### PR TITLE
Make the cursor used for the permalink a text cursor.

### DIFF
--- a/static/gcc.css
+++ b/static/gcc.css
@@ -3,6 +3,13 @@ body {
     padding-bottom: 40px;
 }
 
+/* Override the cursor that Bootstrap defines for readonly inputs, as it looks
+ * very odd on IE (and 'text' makes it clearer that it's copyable everywhere).
+ */
+#permalink {
+    cursor: text;
+}
+
 .sideBySide {
 }
 


### PR DESCRIPTION
The default cursor value assigned by Bootstrap for readonly text fields is "not-allowed", which is rendered as a pointer on Chrome (which isn't great), but as an "unavailable" icon on Internet Explorer, which is pretty terrible.

This switches to "text" (i.e. an I-beam), which makes it much more obvious that the text is selectable anyway.
