### PR TITLE
Fix zig 0.2.0 compilation failures

### DIFF
--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -10,6 +10,7 @@ compiler.trunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.trunk.semver=trunk
 compiler.z020.exe=/opt/compiler-explorer/zig-0.2.0/zig
 compiler.z020.semver=0.2.0
+compiler.z020.options=--zig-install-prefix /opt/compiler-explorer/zig-0.2.0
 compiler.z030.exe=/opt/compiler-explorer/zig-0.3.0/zig
 compiler.z030.semver=0.3.0
 

--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -33,12 +33,21 @@ class ZigCompiler extends BaseCompiler {
     }
 
     preProcess(source) {
-        source += '\n';
-        source += 'extern fn zig_panic() noreturn;\n';
-        source += 'pub inline fn panic(msg: []const u8, error_return_trace: ' +
-                  '?*@import("builtin").StackTrace) noreturn {\n';
-        source += '    zig_panic();\n';
-        source += '}\n';
+        if (this.compiler.semver == '0.2.0') {
+            source += '\n';
+            source += 'extern fn zig_panic() noreturn;\n';
+            source += 'pub inline fn panic(msg: []const u8, error_return_trace: ' +
+                      '?&@import("builtin").StackTrace) noreturn {\n';
+            source += '    zig_panic();\n';
+            source += '}\n';
+        } else {
+            source += '\n';
+            source += 'extern fn zig_panic() noreturn;\n';
+            source += 'pub inline fn panic(msg: []const u8, error_return_trace: ' +
+                      '?*@import("builtin").StackTrace) noreturn {\n';
+            source += '    zig_panic();\n';
+            source += '}\n';
+        }
 
         return source;
     }


### PR DESCRIPTION
This fixes the main incompatibilities resulting from the earlier compiler.

There is a bug in the zig 0.2.0 compiler when emitting an explicit
assembly output file. Binary dumping using objdump is required.

This is as good as possible without patching the binary, which I don't think is worthwhile considering this specific compiler version is out of date.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
