### PR TITLE
Enable pahole for D compilers

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -114,10 +114,15 @@ libs.mir_glas.versions.trunk.path=/opt/compiler-explorer/libs/d/mir-glas-trunk/s
 #################################
 # Installed tools
 
-tools=llvm-mcatrunk
+tools=llvm-mcatrunk:pahole
 
 tools.llvm-mcatrunk.name=llvm-mca
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
+
+tools.pahole.name=pahole
+tools.pahole.exe=/opt/compiler-explorer/pahole/bin/pahole
+tools.pahole.type=postcompilation
+tools.pahole.class=pahole-tool


### PR DESCRIPTION
Great to see pahole added to CE!
I'd very much like to see its output for D.
Untested, but D compilers' debug output should be similar enough to C++ such that pahole shows _some_ correct values.