### PR TITLE
Avoid parsing version properties as numbers

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -68,8 +68,15 @@ function parseProperties(blob, name) {
             logger.error(`Bad line: ${line} in ${name}: ${index + 1}`);
             return;
         }
-        props[split[1].trim()] = toProperty(split[2].trim());
-        debug(`${split[1].trim()} = ${split[2].trim()}`);
+        let prop = split[1].trim();
+        let val = split[2].trim();
+        // hack to avoid applying toProperty to version properties
+        // so that they're not parsed as numbers
+        if (!prop.endsWith('.version') && !prop.endsWith('.semver')) {
+            val = toProperty(val);
+        }
+        props[prop] = val;
+        debug(`${prop} = ${val}`);
     });
     return props;
 }

--- a/test/example-config/cases.test.properties
+++ b/test/example-config/cases.test.properties
@@ -20,3 +20,5 @@ stringPropertyFalse=False
 badLineIfYouSeeThisWithAnErrorItsOk
 001string=001
 0985string=0985
+compiler.example110.semver=1.10
+libs.example.versions.010.version=0.10 

--- a/test/properties-test.js
+++ b/test/properties-test.js
@@ -151,6 +151,12 @@ describe('Properties', () => {
         compilerProps.get(languages, 'bar', true, undefined).should.deep.equal({a: false});
         compilerProps.propsByLangId[languages.a.id] = undefined;
     });
+    it('should not parse version properies as numbers', () => {
+        should.equal(casesProps('libs.example.versions.010.version'), '0.10');
+    });
+    it('should not parse semver properies as numbers', () => {
+        should.equal(casesProps('compiler.example110.semver'), '1.10');
+    });
 });
 
 describe('Properties blob parsing', () => {


### PR DESCRIPTION
Parsing versions such as "1.10" results in a "1.1" float, incorrectly
changing the value.

Fixes #1980
