### PR TITLE
Fix asm parser to recognize SPARC function definitions

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -40,7 +40,7 @@ class AsmParser extends AsmRegex {
         this.instructionRe = /^\s*[a-zA-Z]+/;
         this.identifierFindRe = /[.a-zA-Z_$@][a-zA-z0-9_]*/g;
         this.hasNvccOpcodeRe = /^\s*[a-zA-Z|@]/;
-        this.definesFunction = /^\s*\.(type.*,\s*[@%]function|proc\s+[.a-zA-Z_][a-zA-Z0-9$_.]*:.*)$/;
+        this.definesFunction = /^\s*\.(type.*,\s*[@%#]function|proc\s+[.a-zA-Z_][a-zA-Z0-9$_.]*:.*)$/;
         this.definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_][a-zA-Z0-9$_.]*)/;
         this.indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
         this.assignmentDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]+)\s*=/;

--- a/test/cases/bug-1989_sparc.asm
+++ b/test/cases/bug-1989_sparc.asm
@@ -1,0 +1,18 @@
+        .file   "example.d"
+        .section        ".text"
+        .align 4
+        .weak   issue1989
+        .type   issue1989, #function
+        .proc   00
+issue1989:
+.LFB0:
+        add     %o1, %o0, %o1
+        mov     0, %g1
+        cmp     %o1, %o0
+        movg    %icc, 1, %g1
+        jmp     %o7+8
+         mov    %g1, %o0
+.LFE0:
+        .size   issue1989, .-issue1989
+        .ident  "GCC: (GNU) 9.0.1 20190425 (experimental)"
+        .section        .note.GNU-stack,"",@progbits

--- a/test/cases/bug-1989_sparc.asm.directives.labels
+++ b/test/cases/bug-1989_sparc.asm.directives.labels
@@ -1,0 +1,7 @@
+issue1989:
+        add     %o1, %o0, %o1
+        mov     0, %g1
+        cmp     %o1, %o0
+        movg    %icc, 1, %g1
+        jmp     %o7+8
+         mov    %g1, %o0


### PR DESCRIPTION
Refs #1989

This only affected weak symbols as normal functions are caught by `definesGlobal`.  Perhaps there should probably be a `definesWeak` regex as well for catching `.weak myfunc` too.

See, for example, the difference between https://godbolt.org/z/rLvijD