### PR TITLE
Pass -fsyntax-only when getting GCC options and test that -masm= is really supported

### DIFF
--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -82,9 +82,9 @@ class BaseParser {
 class GCCParser extends BaseParser {
     static async parse(compiler) {
         const results = await Promise.all([
-            GCCParser.getOptions(compiler, "--target-help"),
-            GCCParser.getOptions(compiler, "--help=common"),
-            GCCParser.getOptions(compiler, "--help=optimizers")
+            GCCParser.getOptions(compiler, "-fsyntax-only --target-help"),
+            GCCParser.getOptions(compiler, "-fsyntax-only --help=common"),
+            GCCParser.getOptions(compiler, "-fsyntax-only --help=optimizers")
         ]);
         const options = Object.assign({}, ...results);
         const keys = _.keys(options);
@@ -102,6 +102,15 @@ class GCCParser extends BaseParser {
             compiler.compiler.supportsGccDump = true;
         }
         return compiler;
+    }
+
+    static async getOptions(compiler, helpArg) {
+        const optionFinder = /^\s*(--?[a-z0-9=+,[\]<>|-]*)\s*(.*)/i;
+        const result = await compiler.execCompilerCached(compiler.compiler.exe, helpArg.split(' '));
+        const options = result.code === 0
+            ? BaseParser.parseLines(result.stdout + result.stderr, optionFinder) : {};
+        compiler.possibleArguments.populateOptions(options);
+        return options;
     }
 }
 

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -90,8 +90,14 @@ class GCCParser extends BaseParser {
         const keys = _.keys(options);
         logger.debug(`gcc-like compiler options: ${keys.join(" ")}`);
         if (BaseParser.hasSupport(options, "-masm=")) {
-            compiler.compiler.intelAsm = "-masm=intel";
-            compiler.compiler.supportsIntel = true;
+            // -masm= may be available but unsupported by the compiler.
+            compiler.exec(compiler.compiler.exe, ["-fsyntax-only", "--target-help", "-masm=intel"])
+                .then(result => {
+                    if (result.code === 0) {
+                        compiler.compiler.intelAsm = "-masm=intel";
+                        compiler.compiler.supportsIntel = true;
+                    }
+                });
         }
         if (BaseParser.hasSupport(options, "-fdiagnostics-color")) {
             if (compiler.compiler.options) compiler.compiler.options += " ";


### PR DESCRIPTION
Hosting on a site with nearly 200 cross compilers, pretty much all are without a capable assembler installed.  One bug I ran into was that when invoking `gcc --target-help` and others, the compiler still creates a dummy file to which the driver attempts to assemble it.  This naturally fails and so the GCC Tree/RTL feature is not picked up.

A few of the cross compilers are for Darwin i686/x86_64.  For both of these targets, `-masm=` is available as an option (it is picked up from the i386 target options).  But the darwin support code will reject it if present on the command-line.  So in order to properly disable, gcc needs to be ran again with `-masm=intel` passed, and if there's an error, we know it is really unsupported.