### PR TITLE
Turn on the automatic PVS-Studio.cfg generation

### DIFF
--- a/lib/tooling/PVS-Studio-tool.js
+++ b/lib/tooling/PVS-Studio-tool.js
@@ -29,29 +29,12 @@ const
     exec = require('../exec'),
     utils = require('../utils'),
     logger = require('../logger').logger,
-    _ = require('underscore'),
     fs = require('fs-extra');
 
 class PVSStudioTool extends BaseTool {
     constructor(toolInfo, env) {
         super(toolInfo, env);
         this.plogConverterPath = this.env.compilerProps("plogConverter", "/usr/bin/plog-converter");
-
-        this.cfgFileContents = [
-            "exclude-path = /opt",
-            "exclude-path = /usr"
-        ];
-    }
-
-    async writeCfgFile(filepath) {
-        const specificConfiguration = [
-            "analysis-mode = 4",
-            "platform = x64"
-        ];
-
-        const configdata = _.union(this.cfgFileContents, specificConfiguration);
-
-        return fs.writeFile(filepath, configdata.join("\n"));
     }
 
     async runTool(compilationInfo, inputFilepath, args) {
@@ -66,9 +49,6 @@ class PVSStudioTool extends BaseTool {
         const manualCompileFlags = compilationInfo.options.filter(option => (option !== inputFilepath));
         compileFlags = compileFlags.concat(manualCompileFlags);
 
-        const cfgfilepath = path.join(sourceDir, 'PVS-Studio.cfg');
-        const cfgfile = this.writeCfgFile(cfgfilepath);
-
         // Deal with args
         args = [];
 
@@ -77,7 +57,8 @@ class PVSStudioTool extends BaseTool {
         args.push("--source-file", inputFilepath);
         const outputFilePath = path.join(sourceDir, "pvs-studio-log.log");
         args.push("--output-file", outputFilePath);
-        args.push("--cfg", cfgfilepath);
+
+        args.push("--pvs-studio-path", path.dirname(this.tool.exe) + "/pvs-studio");
 
         // TODO: expand this to switch() for all supported compilers:
         // visualcpp, clang, gcc, bcc, bcc_clang64, iar, keil5, keil5_gnu
@@ -101,8 +82,6 @@ class PVSStudioTool extends BaseTool {
         // Let the tool know the compilation options
         args.push("--cl-params");
         args = args.concat(compileFlags);
-
-        await cfgfile;
 
         // If you are to modify this code,
         // don't forget that super.runTool() does args.push(inputFilepath) inside.


### PR DESCRIPTION
To support different platform options it's better the let pvs-studio-analyzer make the .cfg file by itself.