### PR TITLE
Exclude directories for analysis

### DIFF
--- a/lib/tooling/PVS-Studio-tool.js
+++ b/lib/tooling/PVS-Studio-tool.js
@@ -58,6 +58,10 @@ class PVSStudioTool extends BaseTool {
         const outputFilePath = path.join(sourceDir, "pvs-studio-log.log");
         args.push("--output-file", outputFilePath);
 
+        // Exclude directories from analysis
+        args.push("-e", "/opt");
+        args.push("-e", "/usr");
+
         args.push("--pvs-studio-path", path.dirname(this.tool.exe) + "/pvs-studio");
 
         // TODO: expand this to switch() for all supported compilers:


### PR DESCRIPTION
Exclude /opt and /usr for not analyzing the unnecessary files