### PR TITLE
Tools includeKey

### DIFF
--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -77,7 +77,7 @@ class CompilerFinder {
                         }
                     }, res => {
                         let error;
-                        const {statusCode} = res;
+                        const { statusCode } = res;
                         const contentType = res.headers['content-type'];
 
                         if (statusCode !== 200) {
@@ -280,9 +280,12 @@ class CompilerFinder {
             isSemVer: isSemVer,
             semver: semverVer,
             libs: supportedLibraries,
-            tools: _.omit(this.optionsHandler.get().tools[langId], tool => tool.isCompilerExcluded(compilerName)),
+            tools: _.omit(
+                this.optionsHandler.get().tools[langId],
+                tool => tool.isCompilerExcluded(compilerName, props)),
             unwiseOptions: props("unwiseOptions", "").split("|")
         };
+
         logger.debug("Found compiler", compilerInfo);
         return compilerInfo;
     }
@@ -336,7 +339,7 @@ class CompilerFinder {
                     _.map(list, o => `lang:${o.lang} name:${o.name}`).join(', ')}`);
             }
         });
-        return {compilers, foundClash};
+        return { compilers, foundClash };
     }
 
     async retryPromise(promiseFunc, name, maxFails, retryMs) {
@@ -385,7 +388,7 @@ class CompilerFinder {
         let compilers = (await this.getCompilers()).flat(Infinity);
         compilers = await this.compileHandler.setCompilers(compilers);
         const result = this.ensureDistinct(_.compact(compilers));
-        return {foundClash: result.foundClash, compilers: _.sortBy(result.compilers, "name")};
+        return { foundClash: result.foundClash, compilers: _.sortBy(result.compilers, "name") };
     }
 }
 

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -137,6 +137,7 @@ class ClientOptionsHandler {
                         type: this.compilerProps(lang, toolBaseName + '.type'),
                         exe: this.compilerProps(lang, toolBaseName + '.exe'),
                         exclude: this.compilerProps(lang, toolBaseName + '.exclude'),
+                        includeKey: this.compilerProps(lang, toolBaseName +'.includeKey'),
                         options: this.compilerProps(lang, toolBaseName + '.options'),
                         languageId: this.compilerProps(lang, toolBaseName + '.languageId'),
                         stdinHint: this.compilerProps(lang, toolBaseName + '.stdinHint')

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -45,7 +45,14 @@ class BaseTool {
         return this.tool.type || "independent";
     }
 
-    isCompilerExcluded(compilerId) {
+    isCompilerExcluded(compilerId, compilerProps) {
+        if (this.tool.includeKey) {
+            // If the includeKey is set, we only support compilers that have a truthy 'includeKey'.
+            if (!compilerProps(this.tool.includeKey)) {
+                return true;
+            }
+            // Even if the include key is truthy, we fall back to the exclusion list.
+        }
         return this.tool.exclude.find((excl) => compilerId.includes(excl));
     }
 


### PR DESCRIPTION
If a tool has an includeKey set, then for each compiler, this key is
looked up, and if not 'truthy', then the tool is disabled for that
compiler.
