### PR TITLE
Wsl fixes

### DIFF
--- a/lib/compilers/wsl-vc.js
+++ b/lib/compilers/wsl-vc.js
@@ -28,6 +28,7 @@
 
 const Win32VcCompiler = require('./win32-vc'),
     AsmParser = require('../asm-parser-vc'),
+    path = require('path'),
     temp = require('temp');
 
 class WslVcCompiler extends Win32VcCompiler {
@@ -72,6 +73,21 @@ class WslVcCompiler extends Win32VcCompiler {
         options.env['WSLENV'] = 'INCLUDE:LIB' + old_env;
 
         return super.exec(compiler, args, options);
+    }
+
+    runCompiler(compiler, options, inputFilename, execOptions) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+
+        // inputFilename is guaranteed to be Windows formatted (e.g. c:/) but
+        // Node.js needs the Unix syntax
+        const inputDirectory = path.dirname(inputFilename);
+        const driveLetter = inputDirectory.substring(0, 1).toLowerCase();
+        const directoryPath = inputDirectory.substring(2).trim();
+        execOptions.customCwd = path.join("/mnt", driveLetter, directoryPath);
+
+        return super.runCompiler(compiler, options, inputFilename, execOptions);
     }
 }
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -360,7 +360,7 @@ function applyWineEnv(env) {
 }
 
 function needsWine(command) {
-    return command.match(/\.exe$/i) && process.platform === 'linux';
+    return command.match(/\.exe$/i) && process.platform === 'linux' && !process.env.wsl;
 }
 
 function executeWineDirect(command, args, options) {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Encountered two small problems when running Compiler Explorer from within WSL and trying to add `cl.exe` to `c++.defaults.properties`, like so:

```
# Default settings for C++
compilers=&gcc:&clang:&cl19
[...]
group.cl19.compilers=clx64
group.cl19.compilerType=wsl-vc
group.cl19.includeFlag=/I
group.cl19.versionFlag=/?
group.cl19.versionRe=^Microsoft \(R\) C/C\+\+.*$
group.cl19.demanglerClassFile=./demangler-win32
group.cl19.supportsBinary=false
compiler.clx64.exe=/mnt/c/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe
compiler.clx64.name=msvc 2019 x64
compiler.clx64.demangler=/mnt/c/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/undname.exe
[...]
```

The first problem was that CE thought WINE was needed, and the second problem was that the working directory for spawning process was Windows formatted (i.e. `C:\...`) and not `/mnt/c/...`.

I am putting it out here in case someone finds it useful. Huge fan of Compiler Explorer 😄 keep up the good work!
