### PR TITLE
Add backend option skipAsm

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -788,18 +788,20 @@ class BaseCompiler {
                 fs.remove(result.dirPath);
                 result.dirPath = undefined;
             }
-            if (result.okToCache) {
-                const res = this.processAsm(result, filters, options);
-                result.asm = res.asm;
-                result.labelDefinitions = res.labelDefinitions;
-            } else {
-                result.asm = [{text: result.asm}];
-            }
-            // TODO rephrase this so we don't need to reassign
-            result = filters.demangle ? await this.postProcessAsm(result, filters) : result;
-            if (this.compiler.supportsCfg && backendOptions && backendOptions.produceCfg) {
-                result.cfg = cfg.generateStructure(this.compiler.compilerType,
-                    this.compiler.version, result.asm);
+            if (!backendOptions || !backendOptions.skipAsm) {
+                if (result.okToCache) {
+                    const res = this.processAsm(result, filters, options);
+                    result.asm = res.asm;
+                    result.labelDefinitions = res.labelDefinitions;
+                } else {
+                    result.asm = [{text: result.asm}];
+                }
+                // TODO rephrase this so we don't need to reassign
+                result = filters.demangle ? await this.postProcessAsm(result, filters) : result;
+                if (this.compiler.supportsCfg && backendOptions && backendOptions.produceCfg) {
+                    result.cfg = cfg.generateStructure(this.compiler.compilerType,
+                        this.compiler.version, result.asm);
+                }
             }
             result.popularArguments = this.possibleArguments.getPopularArguments(options);
             if (result.okToCache) {

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -235,6 +235,11 @@ class CompileHandler {
             _.each((req.query.removeFilters || "").split(","), filter => {
                 if (filter) delete filters[filter];
             });
+            // Ask for asm not to be returned
+            if (req.query.skipAsm === "true") {
+                backendOptions = { skipAsm: true };
+            }
+
         }
         options = this.splitArguments(options);
         if (!Array.isArray(executionParameters.args)) {

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -294,7 +294,8 @@ Conformance.prototype.compileChild = function (child) {
                 userArguments: child.find(".options").val() || "",
                 filters: {},
                 compilerOptions: {produceAst: false, produceOptInfo: false},
-                libraries: []
+                libraries: [],
+                skipAsm: true
             }
         };
 


### PR DESCRIPTION
It avoids processing the asm parts if the user does not need it

Maybe another approach would be to always process it and delete it
 from the served result, that way we could cache both versions
 under the same key.


Test coming tomorrow before merging :)

Closes #2017 