### PR TITLE
Add more steps to utilize free space.

### DIFF
--- a/static/explorer.css
+++ b/static/explorer.css
@@ -554,11 +554,23 @@ div.populararguments div.dropdown-menu {
 
 @media (min-height: 700px) {
     .ces-content-root {
-        max-height: 500px;
+        max-height: 400px;
     }
     /* Scales on the top-level object to try and fit enough in shorter screens*/
     .ces-top {
         font-size: 75%;
+    }
+}
+
+@media (min-height: 800px) {
+    .ces-content-root {
+        max-height: 500px;
+    }
+}
+
+@media (min-height: 900px) {
+    .ces-content-root {
+        max-height: 600px;
     }
 }
 

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -548,10 +548,15 @@ div.populararguments div.dropdown-menu {
 }
 
 .ces-content-root {
-    max-height: calc(100vh - 300px);
+    max-height: 150px;
     overflow-y: scroll;
 }
 
+@media (min-height: 450px) {
+    .ces-content-root {
+    max-height: calc(100vh - 300px);
+    }
+}
 @media (min-height: 700px) {
     /* Scales on the top-level object to try and fit enough in shorter screens*/
     .ces-top {

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -548,51 +548,21 @@ div.populararguments div.dropdown-menu {
 }
 
 .ces-content-root {
-    max-height: 200px;
+    max-height: calc(100vh - 300px);
     overflow-y: scroll;
 }
 
 @media (min-height: 700px) {
-    .ces-content-root {
-        max-height: 400px;
-    }
     /* Scales on the top-level object to try and fit enough in shorter screens*/
     .ces-top {
         font-size: 75%;
     }
 }
 
-@media (min-height: 800px) {
-    .ces-content-root {
-        max-height: 500px;
-    }
-}
-
-@media (min-height: 900px) {
-    .ces-content-root {
-        max-height: 600px;
-    }
-}
-
 @media (min-height: 1000px) {
-    .ces-content-root {
-        max-height: 700px;
-    }
     /* Scales on the top-level object to try and fit enough in shorter screens*/
     .ces-top {
         font-size: 90%;
-    }
-}
-
-@media (min-height: 1200px) {
-    .ces-content-root {
-        max-height: 900px;
-    }
-}
-
-@media (min-height: 1800px) {
-    .ces-content-root {
-        max-height: 1200px;
     }
 }
 


### PR DESCRIPTION
This is how I'd utilize the available space for the sponsors popup.

I did not change the font-sizes as the preset is already pretty readable.

I understand if these are too many steps, I consider the `800px` step optional.