### PR TITLE
Mobile context menu bugfix

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -299,6 +299,7 @@ Editor.prototype.initCallbacks = function () {
     }, this));
 
     if (window.compilerExplorerOptions.mobileViewer) {
+        // bugfix for issue with contextmenu not going away when clicking somewhere else on the screen
         this.editor.onDidChangeCursorSelection(_.bind(function () {
             var contextmenu = $("div.context-view.monaco-menu-container");
             if (contextmenu.css("display") !== "none") {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -299,7 +299,7 @@ Editor.prototype.initCallbacks = function () {
     }, this));
 
     if (window.compilerExplorerOptions.mobileViewer) {
-        // bugfix for issue with contextmenu not going away when clicking somewhere else on the screen
+        // workaround for issue with contextmenu not going away when tapping somewhere else on the screen
         this.editor.onDidChangeCursorSelection(_.bind(function () {
             var contextmenu = $("div.context-view.monaco-menu-container");
             if (contextmenu.css("display") !== "none") {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -108,15 +108,6 @@ function Editor(hub, state, container) {
     });
     this.editor.getModel().setEOL(monaco.editor.EndOfLineSequence.LF);
 
-    if (window.compilerExplorerOptions.mobileViewer) {
-        this.editor.onDidChangeCursorSelection(_.bind(function() {
-            var contextmenu = $("div.context-view.monaco-menu-container");
-            if (contextmenu.css("display") !== "none") {
-                contextmenu.hide();
-            }
-        }, this));
-    }
-
     if (state.source !== undefined) {
         this.setSource(state.source);
     } else {
@@ -306,6 +297,15 @@ Editor.prototype.initCallbacks = function () {
     this.editor.onMouseMove(_.bind(function (e) {
         this.mouseMoveThrottledFunction(e);
     }, this));
+
+    if (window.compilerExplorerOptions.mobileViewer) {
+        this.editor.onDidChangeCursorSelection(_.bind(function () {
+            var contextmenu = $("div.context-view.monaco-menu-container");
+            if (contextmenu.css("display") !== "none") {
+                contextmenu.hide();
+            }
+        }, this));
+    }
 
     this.cursorSelectionThrottledFunction =
         _.throttle(_.bind(this.onDidChangeCursorSelection, this), 500);

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -108,6 +108,15 @@ function Editor(hub, state, container) {
     });
     this.editor.getModel().setEOL(monaco.editor.EndOfLineSequence.LF);
 
+    if (window.compilerExplorerOptions.mobileViewer) {
+        this.editor.onDidChangeCursorSelection(_.bind(function() {
+            var contextmenu = $("div.context-view.monaco-menu-container");
+            if (contextmenu.css("display") !== "none") {
+                contextmenu.hide();
+            }
+        }, this));
+    }
+
     if (state.source !== undefined) {
         this.setSource(state.source);
     } else {


### PR DESCRIPTION
Hides the context menu when clicking somewhere else in the editor.

Will not hide when you click somewhere within the line number margin. There might be another event for that.

I think this only applies to the Touch interface, as touch/gestures is implemented separately (so they did try to make something out of mobile at some point ;-))