### PR TITLE
Make url hash a base32 encode

### DIFF
--- a/lib/storage/storage.js
+++ b/lib/storage/storage.js
@@ -31,7 +31,7 @@ const logger = require('../logger').logger,
     profanities = require('profanities');
 
 const FILE_HASH_VERSION = 'Compiler Explorer Config Hasher 2';
-/* How long a string to check for possible unusbale hashes (Profanities or confusing text)
+/* How long a string to check for possible unusable hashes (Profanities or confusing text)
 Note that a Hash might end up being longer than this!
  */
 const USABLE_HASH_CHECK_LENGTH = 9; // Quite generous

--- a/lib/storage/storage.js
+++ b/lib/storage/storage.js
@@ -24,15 +24,17 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 const logger = require('../logger').logger,
-    hash = require('../utils').getBinaryHash,
+    utils = require('../utils'),
     /***
      * @type {string[]}
      */
     profanities = require('profanities');
 
-const FILE_HASH_VERSION = 'Compiler Explorer Config Hasher';
-const USABLE_NAME_MAX_LENGTH = 9; // Quite generous
-const ILLEGIBLE_LETERS = ['l', 'I', 'O', '0', '1']; // L i and o are allowed. Readable if the others are not present
+const FILE_HASH_VERSION = 'Compiler Explorer Config Hasher 2';
+/* How long a string to check for possible unusbale hashes (Profanities or confusing text)
+Note that a Hash might end up being longer than this!
+ */
+const USABLE_HASH_CHECK_LENGTH = 9; // Quite generous
 const MAX_TRIES = 4;
 
 class StorageBase {
@@ -46,39 +48,32 @@ class StorageBase {
      * @param {Buffer} buffer
      * @returns {string}
      */
-    static safe64Encoded(buffer) {
-        return buffer.toString('base64')
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-    }
-
-    static isLegibleText(text) {
-        return !ILLEGIBLE_LETERS.some(letter => text.includes(letter));
+    static encodeBuffer(buffer) {
+        return utils.base32Encode(buffer);
     }
 
     static isCleanText(text) {
-        return !profanities.some(badWord => text.includes(badWord));
+        const lowercased = text.toLowerCase();
+        return !profanities.some(badWord => lowercased.includes(badWord));
     }
 
-    static isUsableText(text) {
-        const lowercasedText = text.toLowerCase();
-        return StorageBase.isLegibleText(text) && StorageBase.isCleanText(lowercasedText);
+    static getRawConfigHash(config) {
+        return StorageBase.encodeBuffer(utils.getBinaryHash(JSON.stringify(config), FILE_HASH_VERSION));
     }
 
     static getSafeHash(config) {
         // Keep rehashing until a usable text is found
-        let configHash = StorageBase.safe64Encoded(hash(JSON.stringify(config), FILE_HASH_VERSION));
+        let configHash = StorageBase.getRawConfigHash(config);
         let tries = 1;
-        while (!StorageBase.isUsableText(configHash.substr(0, USABLE_NAME_MAX_LENGTH))) {
+        while (!StorageBase.isCleanText(configHash.substr(0, USABLE_HASH_CHECK_LENGTH))) {
             // Shake up the hash a bit by adding, or incrementing a nonce value.
             config.nonce = tries;
             logger.info(`Unusable text found in full hash ${configHash} - Trying again (${tries})`);
             if (tries <= MAX_TRIES) {
-                configHash = StorageBase.safe64Encoded(hash(JSON.stringify(config), FILE_HASH_VERSION));
+                configHash = StorageBase.getRawConfigHash(config);
                 ++tries;
             } else {
-                logger.warn(`Gave up trying to find usable text for ${configHash}`);
+                logger.warn(`Gave up trying to find clean text for ${configHash}`);
                 break;
             }
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -226,7 +226,8 @@ exports.replaceAll = function replaceAll(line, oldValue, newValue) {
 
 const BASE32_ALPHABET = "13456789EGKMPTWYabcdefhjnoqrsvxz";
 /***
- *  A Base32 encoding implementation valid for our needs
+ *  A Base32 encoding implementation valid for our needs.
+ *  Of importance, note that there's no padding
  * @param {Buffer} buffer
  * @returns {string}
  */
@@ -249,7 +250,7 @@ exports.base32Encode = function base32Encode(buffer) {
 
     for (const byte of buffer) {
         // Append current byte to digest
-        digest = ((byte) * Math.pow(2, bits)) | digest;
+        digest = (byte << bits) | digest;
         bits += 8;
 
         // Add characters until we run out of bits

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -221,3 +221,46 @@ exports.replaceAll = function replaceAll(line, oldValue, newValue) {
     }
     return line;
 };
+
+// Initally based on http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
+
+const BASE32_ALPHABET = "13456789EGKMPTWYabcdefhjnoqrsvxz";
+/***
+ *  A Base32 encoding implementation valid for our needs
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
+exports.base32Encode = function base32Encode(buffer) {
+    let output = "";
+    // This can grow up to 12 bits
+    let digest = 0;
+    // How many bits are we actually using from digest
+    let bits = 0;
+
+    function encodeNewWord() {
+        // Get first 5 bits
+        const word = digest & 0b11111;
+        const character = BASE32_ALPHABET[word];
+        output += character;
+        bits -= 5;
+        // Shift out the newly processed word
+        digest = (digest >>> 5);
+    }
+
+    for (const byte of buffer) {
+        // Append current byte to digest
+        digest = ((byte) * Math.pow(2, bits)) | digest;
+        bits += 8;
+
+        // Add characters until we run out of bits
+        while (bits >= 5) {
+            encodeNewWord();
+        }
+    }
+    // Do we need a last pass?
+    if (bits !== 0) {
+        encodeNewWord();
+    }
+
+    return output;
+};

--- a/test/storage/storage-tests.js
+++ b/test/storage/storage-tests.js
@@ -33,7 +33,7 @@ describe('Hash tests', () => {
     it('should never generate invalid characters', () => {
         for (let i = 0; i < 256; ++i) {
             const buf = Buffer.of(i);
-            const as64 = StorageBase.safe64Encoded(buf);
+            const as64 = StorageBase.encodeBuffer(buf);
             as64.should.not.contain("/");
             as64.should.not.contain("+");
         }
@@ -50,7 +50,7 @@ describe('Hash tests', () => {
             .onFirstCall().returns(badResult)
             .onSecondCall().returns(badResult) // force nonce to update a couple of times
             .returns(goodResult);
-        sinon.replace(StorageBase, 'safe64Encoded', callback);
+        sinon.replace(StorageBase, 'encodeBuffer', callback);
         const {config, configHash} = StorageBase.getSafeHash(testCase);
         configHash.should.not.equal(badResult);
         configHash.should.equal(goodResult);
@@ -58,13 +58,10 @@ describe('Hash tests', () => {
         should.exist(asObj.nonce);
         asObj.nonce.should.equal(2);
     });
-    it('should detect illegible characters in hashes', () => {
-        StorageBase.isLegibleText("three").should.be.true;
-        StorageBase.isLegibleText(badResult).should.be.false;
-    });
+
     it('should not modify ok hashes', () => {
         const testCase = {some: "test"};
-        const {config, configHash} = StorageBase.getSafeHash(testCase); // L in 13th place: OK
+        const {config, configHash} = StorageBase.getSafeHash(testCase);
         const asObj = JSON.parse(config);
         should.not.exist(asObj.nonce);
     });

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -350,3 +350,20 @@ describe('replaces all substrings', () => {
             .should.equal("babababababababa");
     });
 });
+
+describe('encodes in our version of base32', () => {
+    function doTest(original, expected) {
+        utils.base32Encode(Buffer.from(original)).should.equal(expected);
+    }
+
+   it('returns what we expect', () => {
+       // Done by hand to check that they are valid
+       doTest("", "");
+
+       doTest("a", "35");
+
+       doTest("foo", "8rrx8");
+
+       doTest("foobar", "8rrx8b7Pc5");
+   })
+});

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -356,14 +356,34 @@ describe('encodes in our version of base32', () => {
         utils.base32Encode(Buffer.from(original)).should.equal(expected);
     }
 
-   it('returns what we expect', () => {
-       // Done by hand to check that they are valid
-       doTest("", "");
+    // Done by hand to check that they are valid
 
-       doTest("a", "35");
+    it('works for empty strings', () => {
+        doTest("", "");
+    });
 
-       doTest("foo", "8rrx8");
+    it('works for lengths multiple of 5 bits', () => {
+        doTest("aaaaa", "3Mn4ha7P");
+    });
 
-       doTest("foobar", "8rrx8b7Pc5");
-   })
+    it('works for lengths not multiple of 5 bits', () => {
+        // 3
+        doTest("a", "35");
+
+        // 1
+        doTest("aa", "3Mn1");
+
+        // 4
+        doTest("aaa", "3Mn48");
+
+        // 2
+        doTest("aaaa", "3Mn4ha3");
+    });
+
+    it('works for some random strings', () => {
+        // I also calculated this ones so lets put them
+        doTest("foo", "8rrx8");
+
+        doTest("foobar", "8rrx8b7Pc5");
+    });
 });


### PR DESCRIPTION
Avoids most of the problems present with the current base64 implementation
Closes #1902 
