### PR TITLE
[feature] Basic support for LLVM flang compiler.

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gfortran_86:&ifort:&cross
+compilers=&gfortran_86:&ifort:&cross:&clang_llvmflang
 defaultCompiler=gfortran93
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
@@ -117,6 +117,13 @@ compiler.farmg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnu
 compiler.farmg730.name=ARM gfortran 7.3
 compiler.farmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
 compiler.farmg820.name=ARM gfortran 8.2
+
+###############################
+# LLVM Flang for X86
+group.clang_llvmflang.compilers=flang
+group.clang_llvmflang.groupName= LLVM-FLANG X86-64
+compiler.flang.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
+compiler.flang.name=flang (experimental)
 
 ###############################
 # GCC for ARM 64bit

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -120,10 +120,10 @@ compiler.farmg820.name=ARM gfortran 8.2
 
 ###############################
 # LLVM Flang for X86
-group.clang_llvmflang.compilers=flang
+group.clang_llvmflang.compilers=flangtrunk
 group.clang_llvmflang.groupName= LLVM-FLANG X86-64
-compiler.flang.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
-compiler.flang.name=flang (experimental)
+compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
+compiler.flangtrunk.name=flang-trunk (experimental)
 
 ###############################
 # GCC for ARM 64bit


### PR DESCRIPTION
This is an effort to support LLVM flang compiler which is merged in LLVM project as of now.
The compiler has mostly support till semantic checks.So I think no assembly would be generated as of date.
The codegen to LLVM IR is a work in progress in another github repo, which is planned to be pushed here
in successive PR once the flang works well, and of course first PR.
The FIR branch would help in actual use of godbolt to developers, people interested in learning FIR/MLIR representations
and could help in doing some optimizations studying the IR.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
