### PR TITLE
Add SIMDe library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -741,7 +741,7 @@ compiler.djggp494.semver=4.9.4
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:tomlplusplus:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:spy:libuv
+libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:tomlplusplus:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:spy:libuv:simde
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172:173
 libs.boost.url=https://www.boost.org
@@ -1323,6 +1323,14 @@ libs.libuv.versions=1370
 libs.libuv.url=https://github.com/libuv/libuv
 libs.libuv.versions.1370.version=1.37.0
 libs.libuv.versions.1370.path=/opt/compiler-explorer/libs/libuv/v1.37.0/
+
+libs.simde.name=SIMDe
+libs.simde.description=Implementations of SIMD instruction sets for systems which don't natively support them.
+libs.simde.versions=trunk
+libs.simde.url=https://github.com/simd-everywhere/simde
+libs.simde.versions.trunk.version=trunk
+libs.simde.versions.trunk.path=/opt/compiler-explorer/libs/simde
+
 
 #################################
 #################################

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -589,7 +589,7 @@ compiler.sdcc400.semver=4.0.0
 #################################
 # Libraries
 
-libs=openssl:cs50:hedley:libuv
+libs=openssl:cs50:hedley:libuv:simde
 
 libs.openssl.name=OpenSSL
 libs.openssl.versions=111c
@@ -618,6 +618,13 @@ libs.libuv.versions=1370
 libs.libuv.url=https://github.com/libuv/libuv
 libs.libuv.versions.1370.version=1.37.0
 libs.libuv.versions.1370.path=/opt/compiler-explorer/libs/libuv/v1.37.0/
+
+libs.simde.name=SIMDe
+libs.simde.description=Implementations of SIMD instruction sets for systems which don't natively support them.
+libs.simde.versions=trunk
+libs.simde.url=https://github.com/simd-everywhere/simde
+libs.simde.versions.trunk.version=trunk
+libs.simde.versions.trunk.path=/opt/compiler-explorer/libs/simde
 
 
 #################################


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This adds the [SIMDe](https://github.com/simd-everywhere/simde) library for C and C++. It is a header-only library. Note that I am not affiliated with the simde project. I'm just adding the library, because it would be useful for me and hopefully others too.

Please let me know if there is anything else I have to do.