### PR TITLE
[ISSUE-2030] Fix modal padding and margin to properly centre dialogs

### DIFF
--- a/static/explorer.css
+++ b/static/explorer.css
@@ -222,13 +222,14 @@ pre.content.wrap {
 }
 
 .modal { /* maximum for all modal dialogs */
-width: 100%; 
-height: 100%;
+    width: 100%;
+    height: 100%;
+    padding: 1.75rem;
 }
 
 .modal-dialog {
     max-width: max-content; /* override bootstrap width */
-    margin: 1.75rem; /* global margin for all dialogs */
+    margin: 0 auto;
 }
 
 .modal-content { 


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

[Issue 2030](https://github.com/compiler-explorer/compiler-explorer/issues/2030) pointed out that modals are not centred. This pull request fixes that problem by applying `margin: 0 auto;` to the main modal element. In order to maintain the previous 1.75rem spacing around the dialog that stops it running up against the window border, I've added 1.75rem of padding around the parent element.

![ss-responsive](https://user-images.githubusercontent.com/20519886/87250808-d083bb80-c4aa-11ea-81c3-d3c4ebf15b51.png)

![ss-responsive-large](https://user-images.githubusercontent.com/20519886/87250813-d8dbf680-c4aa-11ea-9069-9b9ead324c9a.png)
