### PR TITLE
Add GCC 10.2

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -21,7 +21,7 @@ compiler.nasm21402.semver=2.14.02
 compiler.nasm21402.exe=/opt/compiler-explorer/nasm-2.14.02/nasm
 
 
-group.gnuas.compilers=gnuas510:gnuas520:gnuas530:gnuas540:gnuas6:gnuas62:gnuas63:gnuas71:gnuas72:gnuas73:gnuas81:gnuas82:gnuas83:gnuas91:gnuas92:gnuas93:gnuas101:gnuassnapshot
+group.gnuas.compilers=gnuas510:gnuas520:gnuas530:gnuas540:gnuas6:gnuas62:gnuas63:gnuas71:gnuas72:gnuas73:gnuas81:gnuas82:gnuas83:gnuas91:gnuas92:gnuas93:gnuas101:gnuas102:gnuassnapshot
 group.gnuas.versionFlag=--version
 group.gnuas.options=-g
 group.gnuas.isSemVer=true
@@ -60,6 +60,8 @@ compiler.gnuas93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/as
 compiler.gnuas93.semver=9.3
 compiler.gnuas101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/as
 compiler.gnuas101.semver=10.1
+compiler.gnuas102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/as
+compiler.gnuas102.semver=10.2
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&gcc86:&icc:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64
-defaultCompiler=g101
+defaultCompiler=g102
 demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
 needsMulti=false
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:g102:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.baseName=x86-64 gcc
 group.gcc86.isSemVer=true
@@ -105,6 +105,8 @@ compiler.g93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/g++
 compiler.g93.semver=9.3
 compiler.g101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 compiler.g101.semver=10.1
+compiler.g102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/g++
+compiler.g102.semver=10.2
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&ppci:&cicc:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc
-defaultCompiler=cg101
+defaultCompiler=cg102
 demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
 needsMulti=false
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cg93:cg101:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cg93:cg101:cg102:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.isSemVer=true
 group.cgcc86.baseName=x86-64 gcc
@@ -84,6 +84,8 @@ compiler.cg93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gcc
 compiler.cg93.semver=9.3
 compiler.cg101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gcc
 compiler.cg101.semver=10.1
+compiler.cg102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gcc
+compiler.cg102.semver=10.2
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -6,7 +6,7 @@ compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550:gfortran6:gfortran62:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran91:gfortran92:gfortran93:gfortran101:gfortransnapshot
+group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550:gfortran6:gfortran62:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran91:gfortran92:gfortran93:gfortran101:gfortran102:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 compiler.gfortran412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/gfortran
 compiler.gfortran412.name=x86-64 gfortran 4.1.2
@@ -80,6 +80,8 @@ compiler.gfortran93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gfortran
 compiler.gfortran93.name=x86-64 gfortran 9.3
 compiler.gfortran101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gfortran
 compiler.gfortran101.name=x86-64 gfortran 10.1
+compiler.gfortran102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gfortran
+compiler.gfortran102.name=x86-64 gfortran 10.2
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gfortransnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&gfortran_86:&ifort:&cross:&clang_llvmflang
-defaultCompiler=gfortran93
+defaultCompiler=gfortran102
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
 compilerType=fortran

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -3,7 +3,7 @@ objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
 
 compilers=&gccgo:&gl:&cross:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl
 
-group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo101
+group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo101:gccgo102
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -20,6 +20,8 @@ compiler.gccgo930.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gccgo
 compiler.gccgo930.semver=9.3.0
 compiler.gccgo101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gccgo
 compiler.gccgo101.semver=10.1.0
+compiler.gccgo102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gccgo
+compiler.gccgo102.semver=10.2.0
 
 group.gl.compilers=6g141:gl172:gl185:gl187:gl192:gl194:gl1100:gl1101:gl1110:gl1120:gl1130:gl1140:386_gl114:gltip:386_gltip
 group.gl.versionFlag=version


### PR DESCRIPTION
Note: untested.
See https://github.com/compiler-explorer/infra/pull/375

I have not updated the default for Fortran since it was not pointing to the latest, is that an omission or intended?