### PR TITLE
Enforce trailing commas in javascript arrays, objects, import, and exports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,12 @@
       "named": "never",
       "asyncArrow": "always"
     }],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline"
+    }],
     "quote-props": ["error", "as-needed"]
   },
   "parserOptions": {

--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ const opts = nopt({
     ensureNoIdClash: [Boolean],
     logHost: [String],
     logPort: [Number],
-    suppressConsoleLog: [Boolean]
+    suppressConsoleLog: [Boolean],
 });
 
 if (opts.debug) logger.level = 'debug';
@@ -137,7 +137,7 @@ const defArgs = {
     doCache: !opts.noCache,
     fetchCompilersFromRemote: !opts.noRemoteFetch,
     ensureNoCompilerClash: opts.ensureNoIdClash,
-    suppressConsoleLog: opts.suppressConsoleLog || false
+    suppressConsoleLog: opts.suppressConsoleLog || false,
 };
 
 if (opts.logHost && opts.logPort) {
@@ -265,7 +265,7 @@ function setupWebPackDevMiddleware(router) {
 
     router.use(webpackDevMiddleware(webpackCompiler, {
         publicPath: '/static',
-        logger: logger
+        logger: logger,
     }));
 
     pugRequireHandler = (path) => urljoin(httpRoot, 'static', path);
@@ -280,7 +280,7 @@ function setupStaticMiddleware(router) {
         const staticPath = path.join(distPath, 'static');
         logger.info(`  serving static files from '${staticPath}'`);
         router.use('/static', express.static(staticPath, {
-            maxAge: staticMaxAgeSecs * 1000
+            maxAge: staticMaxAgeSecs * 1000,
         }));
     }
 
@@ -326,7 +326,7 @@ function oldGoogleUrlHandler(req, res, next) {
             }
             res.writeHead(301, {
                 Location: resultObj.longUrl,
-                'Cache-Control': 'public'
+                'Cache-Control': 'public',
             });
             res.end();
         })
@@ -383,7 +383,7 @@ function setupSentry(sentryDsn) {
                 event.request.data = JSON.stringify({redacted: true});
             }
             return event;
-        }
+        },
     });
     logger.info(`Configured with Sentry endpoint ${sentryDsn}`);
 }
@@ -508,7 +508,7 @@ async function main() {
     const sponsorConfig = sponsors.loadFromString(fs.readFileSync(configDir + '/sponsors.yaml', 'utf-8'));
     function renderConfig(extra, urlOptions) {
         const urlOptionsAllowed = [
-            'readOnly', 'hideEditorToolbars'
+            'readOnly', 'hideEditorToolbars',
         ];
         const filteredUrlOptions = _.mapObject(
             _.pick(urlOptions, urlOptionsAllowed),
@@ -550,7 +550,7 @@ async function main() {
             embedded: false,
             mobileViewer: isMobileViewer(req),
             config: config,
-            metadata: metadata
+            metadata: metadata,
         }, req.query));
     }
 
@@ -559,7 +559,7 @@ async function main() {
         contentPolicyHeader(res);
         res.render('embed', renderConfig({
             embedded: true,
-            mobileViewer: isMobileViewer(req)
+            mobileViewer: isMobileViewer(req),
         }, req.query));
     };
     if (isDevMode()) {
@@ -615,17 +615,17 @@ async function main() {
         .use(morgan(morganFormat, {
             stream: logger.stream,
             // Skip for non errors (2xx, 3xx)
-            skip: (req, res) => res.statusCode >= 400
+            skip: (req, res) => res.statusCode >= 400,
         }))
         .use(morgan(morganFormat, {
             stream: logger.warnStream,
             // Skip for non user errors (4xx)
-            skip: (req, res) => res.statusCode < 400 || res.statusCode >= 500
+            skip: (req, res) => res.statusCode < 400 || res.statusCode >= 500,
         }))
         .use(morgan(morganFormat, {
             stream: logger.errStream,
             // Skip for non server errors (5xx)
-            skip: (req, res) => res.statusCode < 500
+            skip: (req, res) => res.statusCode < 500,
         }))
         .use(compression())
         .get('/', (req, res) => {
@@ -633,7 +633,7 @@ async function main() {
             contentPolicyHeader(res);
             res.render('index', renderConfig({
                 embedded: false,
-                mobileViewer: isMobileViewer(req)
+                mobileViewer: isMobileViewer(req),
             }, req.query));
         })
         .get('/e', embeddedHandler)
@@ -645,7 +645,7 @@ async function main() {
             res.render('embed', renderConfig({
                 embedded: true,
                 readOnly: true,
-                mobileViewer: isMobileViewer(req)
+                mobileViewer: isMobileViewer(req),
             }, req.query));
         })
         .get('/robots.txt', (req, res) => {
@@ -669,7 +669,7 @@ async function main() {
             contentPolicyHeader(res);
             res.render('bits/' + req.params.bits, renderConfig({
                 embedded: false,
-                mobileViewer: isMobileViewer(req)
+                mobileViewer: isMobileViewer(req),
             }, req.query));
         })
         .use(bodyParser.json({limit: ceProps('bodyParserLimit', maxUploadSize)}))

--- a/lib/asm-parser-ewavr.js
+++ b/lib/asm-parser-ewavr.js
@@ -108,7 +108,7 @@ class AsmEWAVRParser extends AsmParserBase {
         let resultObject = {
             prefix: [],    // line array
             labels: [],    // label array
-            postfix: []    // line array
+            postfix: [],    // line array
         };
 
         let currentLabel = null; // func option
@@ -125,7 +125,7 @@ class AsmEWAVRParser extends AsmParserBase {
             if ((hasopc || createsData) && (currentFile || currentLine)) {
                 return {
                     file: (currentFile ? currentFile : null),
-                    line: (currentLine ? currentLine : null)
+                    line: (currentLine ? currentLine : null),
                 };
             }
 
@@ -139,7 +139,7 @@ class AsmEWAVRParser extends AsmParserBase {
                     lines: [],
                     initialLine: currentLine,
                     name: matches[1],
-                    file: currentFile
+                    file: currentFile,
                 };
                 definedLabels[matches[1]] =  currentLine;
                 resultObject.labels.push(currentLabel);
@@ -232,7 +232,7 @@ class AsmEWAVRParser extends AsmParserBase {
             line = utils.expandTabs(line);
             const textAndSource = {
                 text: AsmRegex.filterAsmLine(line, filters),
-                source: createSourceFor(line, currentFile, currentLine)
+                source: createSourceFor(line, currentFile, currentLine),
             };
             if (currentLabel === null) {
                 resultObject.prefix.push(textAndSource);
@@ -302,7 +302,7 @@ class AsmEWAVRParser extends AsmParserBase {
         }
 
         return {
-            asm: result
+            asm: result,
         };
     }
 }

--- a/lib/asm-parser-vc.js
+++ b/lib/asm-parser-vc.js
@@ -121,7 +121,7 @@ class AsmParser extends AsmParserBase {
         let resultObject = {
             prefix: [],    // line array
             functions: [], // func array
-            postfix: null    // line?
+            postfix: null,    // line?
         };
 
         let currentFunction = null; // func option
@@ -137,7 +137,7 @@ class AsmParser extends AsmParserBase {
             if (hasopc && (currentFile || currentLine)) {
                 return {
                     file: (currentFile ? currentFile : null),
-                    line: (currentLine ? currentLine : null)
+                    line: (currentLine ? currentLine : null),
                 };
             }
 
@@ -161,7 +161,7 @@ class AsmParser extends AsmParserBase {
                     lines: [],
                     initialLine: undefined,
                     name: undefined,
-                    file: undefined
+                    file: undefined,
                 };
                 resultObject.functions.push(currentFunction);
             }
@@ -255,7 +255,7 @@ class AsmParser extends AsmParserBase {
             const hasopc = this.hasOpcode(line);
             const textAndSource = {
                 text: AsmRegex.filterAsmLine(line, filters),
-                source: createSourceFor(hasopc, currentFile, currentLine)
+                source: createSourceFor(hasopc, currentFile, currentLine),
             };
             if (currentFunction === null) {
                 resultObject.prefix.push(textAndSource);
@@ -356,7 +356,7 @@ class AsmParser extends AsmParserBase {
         }
 
         return {
-            asm: result
+            asm: result,
         };
     }
 }

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -228,8 +228,8 @@ class AsmParser extends AsmRegex {
                 name: label,
                 range: {
                     startCol: startCol,
-                    endCol: startCol + label.length
-                }
+                    endCol: startCol + label.length,
+                },
             });
         });
 
@@ -289,7 +289,7 @@ class AsmParser extends AsmRegex {
                 if (file) {
                     source = {
                         file: !file.match(stdInLooking) ? file : null,
-                        line: sourceLine
+                        line: sourceLine,
                     };
                 } else {
                     source = null;
@@ -321,7 +321,7 @@ class AsmParser extends AsmRegex {
                 const sourceLine = parseInt(match[2]);
                 source = {
                     file: !file.match(stdInLooking) ? file : null,
-                    line: sourceLine
+                    line: sourceLine,
                 };
             } else if (line.match(source6502DbgEnd)) {
                 source = null;
@@ -428,7 +428,7 @@ class AsmParser extends AsmRegex {
             asm.push({
                 text: text,
                 source: this.hasOpcode(line, inNvccCode) ? source : null,
-                labels: labelsInLine
+                labels: labelsInLine,
             });
         });
 
@@ -436,7 +436,7 @@ class AsmParser extends AsmRegex {
 
         return {
             asm: asm,
-            labelDefinitions: labelDefinitions
+            labelDefinitions: labelDefinitions,
         };
     }
 
@@ -467,7 +467,7 @@ class AsmParser extends AsmRegex {
         // Handle "error" documents.
         if (asmLines.length === 1 && asmLines[0][0] === '<') {
             return {
-                asm: [{text: asmLines[0], source: null}]
+                asm: [{text: asmLines[0], source: null}],
             };
         }
 
@@ -483,7 +483,7 @@ class AsmParser extends AsmRegex {
                     asm.push({
                         text: "[truncated; too many lines]",
                         source: null,
-                        labels: labelsInLine
+                        labels: labelsInLine,
                     });
                 }
                 return;
@@ -501,7 +501,7 @@ class AsmParser extends AsmRegex {
                     asm.push({
                         text: func + ":",
                         source: null,
-                        labels: labelsInLine
+                        labels: labelsInLine,
                     });
                     labelDefinitions[func] = asm.length;
                 }
@@ -535,7 +535,7 @@ class AsmParser extends AsmRegex {
                     links = [{
                         offset: disassembly.indexOf(destMatch[1]),
                         length: destMatch[1].length,
-                        to: parseInt(destMatch[1], 16)
+                        to: parseInt(destMatch[1], 16),
                     }];
 
                     const labelName = destMatch[2];
@@ -544,8 +544,8 @@ class AsmParser extends AsmRegex {
                         name: labelName,
                         range: {
                             startCol: startCol,
-                            endCol: startCol + labelName.length
-                        }
+                            endCol: startCol + labelName.length,
+                        },
                     });
                 }
                 asm.push({
@@ -554,7 +554,7 @@ class AsmParser extends AsmRegex {
                     text: disassembly,
                     source: source,
                     links: links,
-                    labels: labelsInLine
+                    labels: labelsInLine,
                 });
             }
         });
@@ -563,7 +563,7 @@ class AsmParser extends AsmRegex {
 
         return {
             asm: asm,
-            labelDefinitions: labelDefinitions
+            labelDefinitions: labelDefinitions,
         };
     }
 

--- a/lib/asm-raw.js
+++ b/lib/asm-raw.js
@@ -68,7 +68,7 @@ class AsmRaw extends AsmRegex {
                     links = [{
                         offset: disassembly.indexOf(destMatch[1]),
                         length: destMatch[1].length,
-                        to: parseInt(destMatch[1], 16)
+                        to: parseInt(destMatch[1], 16),
                     }];
                 }
                 result.push({opcodes: opcodes, address: address, text: disassembly, source: source, links: links});
@@ -76,7 +76,7 @@ class AsmRaw extends AsmRegex {
         });
 
         return {
-            asm: result
+            asm: result,
         };
     }
 
@@ -86,5 +86,5 @@ class AsmRaw extends AsmRegex {
 }
 
 module.exports = {
-    AsmParser: AsmRaw
+    AsmParser: AsmRaw,
 };

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -82,5 +82,5 @@ function getConfig(name) {
 module.exports = {
     InstanceFetcher: InstanceFetcher,
     initConfig: initConfig,
-    getConfig: getConfig
+    getConfig: getConfig,
 };

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -138,7 +138,7 @@ class BaseCompiler {
             timeoutMs: this.env.ceProps("compileTimeoutMs", 7500),
             maxErrorOutput: this.env.ceProps("max-error-output", 5000),
             env: this.env.getEnv(this.compiler.needsMulti),
-            wrapper: this.compilerProps("compiler-wrapper")
+            wrapper: this.compilerProps("compiler-wrapper"),
         };
     }
 
@@ -186,7 +186,7 @@ class BaseCompiler {
                 maxOutput: maxSize,
                 timeoutMs: timeoutMs,
                 ldPath: _.union(this.compiler.ldPath, executeParameters.ldPath).join(":"),
-                input: executeParameters.stdin
+                input: executeParameters.stdin,
             });
             execResult.stdout = utils.parseOutput(execResult.stdout);
             execResult.stderr = utils.parseOutput(execResult.stderr);
@@ -197,7 +197,7 @@ class BaseCompiler {
             return {
                 stdout: err.stdout ? utils.parseOutput(err.stdout) : [],
                 stderr: err.stderr ? utils.parseOutput(err.stderr) : [],
-                code: err.code !== undefined ? err.code : -1
+                code: err.code !== undefined ? err.code : -1,
             };
         }
     }
@@ -233,7 +233,7 @@ class BaseCompiler {
 
         return {
             id: foundLib,
-            version: "autodetect"
+            version: "autodetect",
         };
     }
 
@@ -352,7 +352,7 @@ class BaseCompiler {
         if (this.toolchainPath) {
             toolchainLibraryPaths = [
                 path.join(this.toolchainPath, '/lib64'),
-                path.join(this.toolchainPath, '/lib32')
+                path.join(this.toolchainPath, '/lib32'),
             ];
         }
 
@@ -455,7 +455,7 @@ class BaseCompiler {
         }
         return {
             asm: [{text: 'Internal error; unable to open output path'}],
-            labelDefinitions: {}
+            labelDefinitions: {},
         };
     }
 
@@ -591,7 +591,7 @@ class BaseCompiler {
                     code: 0,
                     inputFilename: path.join(dirPath, this.compileFilename),
                     dirPath: dirPath,
-                    executableFilename: this.getExecutableFilename(dirPath, this.outputFilebase)
+                    executableFilename: this.getExecutableFilename(dirPath, this.outputFilebase),
                 });
             }
             logger.debug("Tried to get executable from cache, but got a cache miss");
@@ -631,7 +631,7 @@ class BaseCompiler {
                 didExecute: false,
                 buildResult,
                 stderr: [],
-                stdout: []
+                stdout: [],
             };
         } else {
             if (!fs.existsSync(buildResult.executableFilename)) {
@@ -640,7 +640,7 @@ class BaseCompiler {
                     didExecute: false,
                     buildResult,
                     stderr: [],
-                    stdout: []
+                    stdout: [],
                 };
 
                 verboseResult.buildResult.stderr.push({text:"Compiler did not produce an executable"});
@@ -723,8 +723,8 @@ class BaseCompiler {
             Promise.all(this.runToolsOfType(tools, "independent", this.getCompilationInfo(key, {
                 inputFilename,
                 dirPath,
-                outputFilename
-            })))
+                outputFilename,
+            }))),
         ]);
         asmResult.dirPath = dirPath;
         asmResult.compilationOptions = options;
@@ -777,7 +777,7 @@ class BaseCompiler {
         }
         const executeParameters = {
             args: executionParameters.args || [],
-            stdin: executionParameters.stdin || ""
+            stdin: executionParameters.stdin || "",
         };
         const key = this.getCacheKey(source, options, backendOptions, filters, tools, libraries);
 
@@ -982,7 +982,7 @@ class BaseCompiler {
                 all: [],
                 selectedPass: "",
                 currentPassOutput: 'Nothing selected for dump:\nselect at least one of Tree/RTL filter',
-                syntaxHighlight: false
+                syntaxHighlight: false,
             };
         }
 
@@ -990,7 +990,7 @@ class BaseCompiler {
             all: [],
             selectedPass: opts.pass,
             currentPassOutput: '<No pass selected>',
-            syntaxHighlight: false
+            syntaxHighlight: false,
         };
         let passFound = false;
         // Phase letter is one of {i, l, r, t}
@@ -1156,7 +1156,7 @@ Please select another pass or change filters.`;
             commentOnly: true,
             directives: true,
             labels: true,
-            optOutput: false
+            optOutput: false,
         };
     }
 }

--- a/lib/buildenvsetup/buildenvsetup-ceconan.js
+++ b/lib/buildenvsetup/buildenvsetup-ceconan.js
@@ -50,7 +50,7 @@ class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
             const url = `${this.host}/v1/conans/${encLibid}/${encVersion}/${encLibid}/${encVersion}/search`;
             const settings = {
                 method: "GET",
-                json: true
+                json: true,
             };
 
             request(url, settings, (err, res, body) => {
@@ -76,7 +76,7 @@ class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
 
             const settings = {
                 method: "GET",
-                json: true
+                json: true,
             };
 
             request(url, settings, (err, res, body) => {
@@ -111,7 +111,7 @@ class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
 
             const settings = {
                 method: 'GET',
-                encoding: null
+                encoding: null,
             };
 
             request(packageUrl, settings).pipe(gunzip);
@@ -132,7 +132,7 @@ class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
             "compiler.libcxx": libcxx,
             arch: arch,
             stdver: stdver,
-            flagcollection: flagcollection
+            flagcollection: flagcollection,
         };
 
         return buildProperties;
@@ -157,7 +157,7 @@ class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
                     id: libId,
                     version: details.version,
                     lookupversion: details.lookupversion,
-                    possibleBuilds: this.getAllPossibleBuilds(libId, lookupversion).catch(() => false)
+                    possibleBuilds: this.getAllPossibleBuilds(libId, lookupversion).catch(() => false),
                 });
             }
         });

--- a/lib/cache/in-memory.js
+++ b/lib/cache/in-memory.js
@@ -31,7 +31,7 @@ class InMemoryCache extends BaseCache {
         this.cacheMb = cacheMb;
         this.cache = new LRU({
             max: cacheMb * 1024 * 1024,
-            length: n => n.length
+            length: n => n.length,
         });
     }
 
@@ -43,7 +43,7 @@ class InMemoryCache extends BaseCache {
         const cached = this.cache.get(key);
         return Promise.resolve({
             hit: !!cached,
-            data: cached
+            data: cached,
         });
     }
 

--- a/lib/cache/on-disk.js
+++ b/lib/cache/on-disk.js
@@ -50,7 +50,7 @@ class OnDiskCache extends BaseCache {
             noDisposeOnSet: true,
             dispose: (key, n) => {
                 fs.unlink(n.path, () => {});
-            }
+            },
         });
         fs.mkdirSync(path, { recursive: true });
         const info = getAllFiles(path).map(({name, fullPath}) => {
@@ -60,8 +60,8 @@ class OnDiskCache extends BaseCache {
                 sort: stat.ctimeMs,
                 data: {
                     path: fullPath,
-                    size: stat.size
-                }
+                    size: stat.size,
+                },
             };
         });
         // Sort oldest first
@@ -92,7 +92,7 @@ class OnDiskCache extends BaseCache {
     async putInternal(key, value) {
         const info = {
             path: path.join(this.path, key),
-            size: value.length
+            size: value.length,
         };
         await fs.writeFile(info.path, value);
         return this.cache.set(key, info);

--- a/lib/cache/s3.js
+++ b/lib/cache/s3.js
@@ -52,7 +52,7 @@ class S3Cache extends BaseCache {
     putInternal(key, value, creator) {
         const options = {
             metadata: {},
-            redundancy: 'REDUCED_REDUNDANCY'
+            redundancy: 'REDUCED_REDUNDANCY',
         };
         if (creator) {
             options.metadata.CreatedBy = creator;

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -88,7 +88,7 @@ const gccX86 = {
 
     extractNodeName: inst => inst.match(/\.L\d+/) + ':',
 
-    isJmpInstruction: x => x.trim()[0] === 'j'
+    isJmpInstruction: x => x.trim()[0] === 'j',
 };
 
 const clangX86 = {
@@ -122,7 +122,7 @@ const clangX86 = {
 
     extractNodeName: inst => inst.match(/\.LBB\d+_\d+/) + ':',
 
-    isJmpInstruction: x => x.trim()[0] === 'j'
+    isJmpInstruction: x => x.trim()[0] === 'j',
 };
 
 function splitToFunctions(asmArr, isEnd) {
@@ -188,12 +188,12 @@ function splitToCanonicalBasicBlock(basicBlock) {
         return [{
             nameId: basicBlock.nameId,
             start: basicBlock.start,
-            end: basicBlock.end
+            end: basicBlock.end,
         }];
     else if (actPosSz === 1)
         return [
             {nameId: basicBlock.nameId, start: basicBlock.start, end: actionPos[0] + 1},
-            {nameId: basicBlock.nameId + '@' + (actionPos[0] + 1), start: actionPos[0] + 1, end: basicBlock.end}
+            {nameId: basicBlock.nameId + '@' + (actionPos[0] + 1), start: actionPos[0] + 1, end: basicBlock.end},
         ];
     else {
         let first = 0;
@@ -231,7 +231,7 @@ function makeNodes(asms, arrOfCanonicalBasicBlock) {
             id: e.nameId,
             label: `${e.nameId}${e.nameId.indexOf(':') !== -1 ? '' : ':'}\n${concatInstructions(asms, e.start, e.end)}`,
             color: '#99ccff',
-            shape: 'box'
+            shape: 'box',
         };
     });
 }
@@ -333,7 +333,7 @@ function generateCfgStructure(compilerType, version, asmArr) {
 
         result[code[rng.start].text] = {
             nodes: makeNodes(code, arrOfCanonicalBasicBlock),
-            edges: makeEdges(code, arrOfCanonicalBasicBlock, rules)
+            edges: makeEdges(code, arrOfCanonicalBasicBlock, rules),
         };
     }, this));
 

--- a/lib/clientstate-normalizer.js
+++ b/lib/clientstate-normalizer.js
@@ -110,7 +110,7 @@ class ClientStateNormalizer {
 
             compiler.tools.push({
                 id: component.componentState.toolId,
-                args: component.componentState.args
+                args: component.componentState.args,
             });
         } else if (component.content) {
             this.fromGoldenLayoutContent(component.content);
@@ -132,10 +132,10 @@ class GoldenLayoutComponents {
             componentState: {
                 id: customSessionId ? customSessionId : session.id,
                 source: session.source,
-                lang: session.language
+                lang: session.language,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -145,10 +145,10 @@ class GoldenLayoutComponents {
             componentName: "ast",
             componentState: {
                 id: compilerIndex,
-                editorid: customSessionId ? customSessionId : session.id
+                editorid: customSessionId ? customSessionId : session.id,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -158,10 +158,10 @@ class GoldenLayoutComponents {
             componentName: "opt",
             componentState: {
                 id: compilerIndex,
-                editorid: customSessionId ? customSessionId : session.id
+                editorid: customSessionId ? customSessionId : session.id,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -174,11 +174,11 @@ class GoldenLayoutComponents {
                 editorid: customSessionId ? customSessionId : session.id,
                 options: {
                     navigation: false,
-                    physics: false
-                }
+                    physics: false,
+                },
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -188,10 +188,10 @@ class GoldenLayoutComponents {
             componentName: "gccdump",
             componentState: {
                 _compilerid: compilerIndex,
-                _editorid: customSessionId ? customSessionId : session.id
+                _editorid: customSessionId ? customSessionId : session.id,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -203,10 +203,10 @@ class GoldenLayoutComponents {
                 compiler: compilerIndex,
                 editor: customSessionId ? customSessionId : session.id,
                 wrap: false,
-                fontScale: 14
+                fontScale: 14,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -218,10 +218,10 @@ class GoldenLayoutComponents {
                 editor: customSessionId ? customSessionId : session.id,
                 compiler: compilerIndex,
                 toolId: toolId,
-                args: args
+                args: args,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -233,10 +233,10 @@ class GoldenLayoutComponents {
                 editorid: customSessionId ? customSessionId : session.id,
                 langId: session.language,
                 compilers: [],
-                libs: conformanceview.libs
+                libs: conformanceview.libs,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -256,13 +256,13 @@ class GoldenLayoutComponents {
                     commentOnly: compiler.filters.commentOnly,
                     trim: compiler.filters.trim,
                     intel: compiler.filters.intel,
-                    demangle: compiler.filters.demangle
+                    demangle: compiler.filters.demangle,
                 },
                 libs: compiler.libs,
-                lang: session.language
+                lang: session.language,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -281,10 +281,10 @@ class GoldenLayoutComponents {
                 compilationPanelShown: executor.compilerVisible,
                 compilerOutShown: executor.compilerOutputVisible,
                 argsPanelShown: executor.argumentsVisible,
-                stdinPanelShown: executor.stdinVisible
+                stdinPanelShown: executor.stdinVisible,
             },
             isClosable: true,
-            reorderEnabled: true
+            reorderEnabled: true,
         };
     }
 
@@ -298,8 +298,8 @@ class GoldenLayoutComponents {
                 rhs: right,
                 lhsdifftype: 0,
                 rhsdifftype: 0,
-                fontScale: 14
-            }
+                fontScale: 14,
+            },
         };
     }
 
@@ -331,7 +331,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
         return {
             type: "stack",
             width: width,
-            content: [component]
+            content: [component],
         };
     }
 
@@ -385,7 +385,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
         conformanceview.compilers.forEach((compiler) => {
             const compjson = {
                 compilerId: compiler.id,
-                options: compiler.options
+                options: compiler.options,
             };
 
             stack.content[0].componentState.compilers.push(compjson);
@@ -412,7 +412,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
         } else {
             return [
                 this.createPresentationModeComponents(state.sessions[left.session], 1),
-                this.createPresentationModeComponents(state.sessions[right.session], 2)
+                this.createPresentationModeComponents(state.sessions[right.session], 2),
             ];
         }
     }
@@ -433,7 +433,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                 responsiveMode: "onload",
                 tabOverlapAllowance: 0,
                 reorderOnTabMenuClick: true,
-                tabControlOffset: 10
+                tabControlOffset: 10,
             },
             dimensions:
             {
@@ -443,7 +443,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                 minItemWidth: 10,
                 headerHeight: 20,
                 dragProxyWidth: 300,
-                dragProxyHeight: 200
+                dragProxyHeight: 200,
             },
             labels:
             {
@@ -452,14 +452,14 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                 minimise: "minimise",
                 popout: "open in new window",
                 popin: "pop in",
-                tabDropdown: "additional tabs"
+                tabDropdown: "additional tabs",
             },
             content: [
                 {
                     type: "column",
-                    content: []
-                }
-            ]
+                    content: [],
+                },
+            ],
         };
     }
 
@@ -469,7 +469,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
             {
                 type: "column",
                 width: 100,
-                content: this.createSourceContentArray(state, left, left)
+                content: this.createSourceContentArray(state, left, left),
             }];
 
         return gl;
@@ -481,7 +481,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
             {
                 type: "row",
                 height: 50,
-                content: this.createSourceContentArray(state, left, right)
+                content: this.createSourceContentArray(state, left, right),
             },
             {
                 type: "row",
@@ -491,11 +491,11 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                         type: "stack",
                         width: 100,
                         content: [
-                            this.createDiffComponent(left.compiler + 1, right.compiler + 1)
-                        ]
-                    }
-                ]
-            }
+                            this.createDiffComponent(left.compiler + 1, right.compiler + 1),
+                        ],
+                    },
+                ],
+            },
         ];
 
         return gl;
@@ -507,8 +507,8 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
             width: customWidth ? customWidth : 50,
             activeItemIndex: 0,
             content: [
-                this.createSourceComponent(session, customSessionId)
-            ]
+                this.createSourceComponent(session, customSessionId),
+            ],
         };
 
         for (let idxCompiler = 0; idxCompiler < session.compilers.length; idxCompiler++) {
@@ -545,7 +545,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
         for (var idxSession = 0; idxSession < state.sessions.length; idxSession++) {
             const gl = this.getPresentationModeLayoutForSource(state, {
                 session: idxSession,
-                compiler: 0
+                compiler: 0,
             });
             slides.push(gl);
         }
@@ -569,7 +569,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                 responsiveMode: "onload",
                 tabOverlapAllowance: 0,
                 reorderOnTabMenuClick: true,
-                tabControlOffset: 10
+                tabControlOffset: 10,
             },
             dimensions: {
                 borderWidth: 5,
@@ -578,7 +578,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                 minItemWidth: 10,
                 headerHeight: 20,
                 dragProxyWidth: 300,
-                dragProxyHeight: 200
+                dragProxyHeight: 200,
             },
             labels: {
                 close: "close",
@@ -586,15 +586,15 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                 minimise: "minimise",
                 popout: "open in new window",
                 popin: "pop in",
-                tabDropdown: "additional tabs"
+                tabDropdown: "additional tabs",
             },
             content: [
                 {
                     type: "row",
                     content: [
-                    ]
-                }
-            ]
+                    ],
+                },
+            ],
         };
 
         if (state.sessions.length > 1) {
@@ -612,14 +612,14 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
                         {
                             type: "row",
                             content: [
-                            ]
+                            ],
                         },
                         {
                             type: "row",
                             content: [
-                            ]
-                        }
-                    ]
+                            ],
+                        },
+                    ],
                 };
 
                 let stack = this.newSourceStackFromSession(session, 100.0);
@@ -666,7 +666,7 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
             this.golden.content[0] = {
                 type: "row",
                 content: [
-                ]
+                ],
             };
 
             const width = 100.0 / (1 + session.compilers.length + session.executors.length +
@@ -709,5 +709,5 @@ class ClientStateGoldenifier extends GoldenLayoutComponents {
 
 module.exports = {
     ClientStateNormalizer: ClientStateNormalizer,
-    ClientStateGoldenifier: ClientStateGoldenifier
+    ClientStateGoldenifier: ClientStateGoldenifier,
 };

--- a/lib/clientstate.js
+++ b/lib/clientstate.js
@@ -250,5 +250,5 @@ module.exports = {
     Compiler: ClientStateCompiler,
     Executor: ClientStateExecutor,
     CompilerOptions: ClientStateCompilerOptions,
-    ConformanceView: ClientStateConformanceView
+    ConformanceView: ClientStateConformanceView,
 };

--- a/lib/compilation-queue.js
+++ b/lib/compilation-queue.js
@@ -29,7 +29,7 @@ class CompilationQueue {
         this._queue = new Queue({
             concurrency,
             timeout,
-            throwOnTimeout: true
+            throwOnTimeout: true,
         });
     }
 
@@ -49,7 +49,7 @@ class CompilationQueue {
         return {
             busy: pending > 0 || size > 0,
             pending,
-            size
+            size,
         };
     }
 }

--- a/lib/compiler-arguments.js
+++ b/lib/compiler-arguments.js
@@ -67,7 +67,7 @@ class CompilerArguments {
 
             if (obj.description.includes("optimize") || obj.description.includes("optimization")) {
                 possibleArguments[argKey] = {
-                    description: obj.description
+                    description: obj.description,
                 };
             }
         });
@@ -176,7 +176,7 @@ class CompilerArguments {
 
                     this.possibleArguments[key].specifically.push({
                         arg: option,
-                        timesused: timesUsed
+                        timesused: timesUsed,
                     });
                 }
             }

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -73,8 +73,8 @@ class CompilerFinder {
                         port: port,
                         path: apiPath,
                         headers: {
-                            Accept: 'application/json'
-                        }
+                            Accept: 'application/json',
+                        },
                     }, res => {
                         let error;
                         const { statusCode } = res;
@@ -111,7 +111,7 @@ class CompilerFinder {
                                     compiler.exe = null;
                                     compiler.remote = {
                                         target: `${uriSchema}://${host}:${port}`,
-                                        path: urljoin('/', uriBase, 'api/compiler', compiler.id, 'compile')
+                                        path: urljoin('/', uriBase, 'api/compiler', compiler.id, 'compile'),
                                     };
                                     return compiler;
                                 });
@@ -152,12 +152,12 @@ class CompilerFinder {
             if (match) {
                 return {
                     id: match[1],
-                    version: match[2]
+                    version: match[2],
                 };
             } else {
                 return {
                     id: lib,
-                    version: false
+                    version: false,
                 };
             }
         });
@@ -289,8 +289,8 @@ class CompilerFinder {
                 id: props("buildenvsetup", ""),
                 props: (name, def) => {
                     return props(`buildenvsetup.${name}`, def);
-                }
-            }
+                },
+            },
         };
 
         logger.debug("Found compiler", compilerInfo);

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -55,7 +55,7 @@ class AdaCompiler extends BaseCompiler {
                 '-eS', // commands are not errors
                 '-cargs', // Compiler Switches for gcc.
                 '-o',
-                outputFilename,
+                outputFilename
             );
 
             if (this.compiler.intelAsm && filters.intel) {

--- a/lib/compilers/analysis-tool.js
+++ b/lib/compilers/analysis-tool.js
@@ -40,7 +40,7 @@ class AnalysisTool extends BaseCompiler {
             commentOnly: false,
             directives: false,
             labels: false,
-            optOutput: false
+            optOutput: false,
         };
     }
 }

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -57,7 +57,7 @@ class BaseParser {
             if (previousOption) {
                 options[previousOption] = {
                     description: match[2].trim(),
-                    timesused: 0
+                    timesused: 0,
                 };
             }
         });
@@ -84,7 +84,7 @@ class GCCParser extends BaseParser {
         const results = await Promise.all([
             GCCParser.getOptions(compiler, "-fsyntax-only --target-help"),
             GCCParser.getOptions(compiler, "-fsyntax-only --help=common"),
-            GCCParser.getOptions(compiler, "-fsyntax-only --help=optimizers")
+            GCCParser.getOptions(compiler, "-fsyntax-only --help=optimizers"),
         ]);
         const options = Object.assign({}, ...results);
         const keys = _.keys(options);
@@ -212,7 +212,7 @@ class VCParser extends BaseParser {
             if (previousOption) {
                 options[previousOption] = {
                     description: match[2].trim(),
-                    timesused: 0
+                    timesused: 0,
                 };
             }
         };
@@ -255,7 +255,7 @@ class RustParser extends BaseParser {
         const results = await Promise.all([
             RustParser.getOptions(compiler, "--help"),
             RustParser.getOptions(compiler, "-C help"),
-            RustParser.getOptions(compiler, "--help -v")
+            RustParser.getOptions(compiler, "--help -v"),
         ]);
         const options = Object.assign({}, ...results);
         if (BaseParser.hasSupport(options, "--color")) {
@@ -300,5 +300,5 @@ module.exports = {
     Pascal: PascalParser,
     ISPC: ISPCParser,
     Rust: RustParser,
-    Nim: NimParser
+    Nim: NimParser,
 };

--- a/lib/compilers/ewavr.js
+++ b/lib/compilers/ewavr.js
@@ -54,7 +54,7 @@ class EWAVRCompiler extends BaseCompiler {
         
         return [
             '-lB', this.filename(outputFilename),
-            '-o', this.filename(outputFilename + '.obj')
+            '-o', this.filename(outputFilename + '.obj'),
         ];
     }
 }

--- a/lib/compilers/fake-for-test.js
+++ b/lib/compilers/fake-for-test.js
@@ -29,7 +29,7 @@ class FakeCompiler {
         this.compiler = {
             id: info.id || 'fake-for-test',
             lang: info.lang || 'fake-lang',
-            options: info.options || ''
+            options: info.options || '',
         };
         this.info = info;
     }
@@ -52,8 +52,8 @@ class FakeCompiler {
                 source: source,
                 options: options,
                 backendOptions: backendOptions,
-                filters: filters
-            }
+                filters: filters,
+            },
         }));
     }
 

--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -39,7 +39,7 @@ const jumpPrefixes = [
 
     // s390x
     'cmpb',
-    'cmpub'
+    'cmpub',
 ];
 
 class GolangCompiler extends BaseCompiler {

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -54,7 +54,7 @@ class JavaCompiler extends BaseCompiler {
                 '-c',
                 // Prints out line and local variable tables.
                 '-l',
-                classFile
+                classFile,
             ];
             const objResult = await this.exec(this.compiler.objdumper, args, {maxOutput: maxSize, customCwd: dirPath});
             const oneResult = {};
@@ -82,7 +82,7 @@ class JavaCompiler extends BaseCompiler {
         filters.binary = true;
 
         return [
-            '-Xlint:all'
+            '-Xlint:all',
         ];
     }
 
@@ -108,7 +108,7 @@ class JavaCompiler extends BaseCompiler {
             "-s",
             // --source-path path or -sourcepath path
             // Specifies where to find input source files.
-            "--source-path", "-sourcepath"
+            "--source-path", "-sourcepath",
         ];
 
         for (const userOption of userOptions) {
@@ -156,7 +156,7 @@ class JavaCompiler extends BaseCompiler {
                     }
                     segments.push({
                         text: line,
-                        source: null
+                        source: null,
                     });
                 }
 
@@ -186,7 +186,7 @@ class JavaCompiler extends BaseCompiler {
 
         for (const codeAndLineNumberTable of codeAndLineNumberTables) {
             const method = {
-                instructions: []
+                instructions: [],
             };
             methods.push(method);
 
@@ -201,7 +201,7 @@ class JavaCompiler extends BaseCompiler {
                         instrOffset: instrOffset,
                         // Should an instruction ever not be followed by a line number table,
                         // it might contain a trailing \r on Windows -> trim it, otherwise this would not be necessary
-                        text: codeLineCandidate.trimRight()
+                        text: codeLineCandidate.trimRight(),
                     });
                 } else {
                     break;
@@ -267,7 +267,7 @@ class JavaCompiler extends BaseCompiler {
             // Used for sorting
             firstSourceLine: methods.reduce((p, m) => p === -1 ? m.startLine : Math.min(p, m.startLine), -1),
             methods: methods,
-            textsBeforeMethod
+            textsBeforeMethod,
         };
     }
 }

--- a/lib/compilers/nim.js
+++ b/lib/compilers/nim.js
@@ -33,7 +33,7 @@ const NimCommands = [
     "compileToCpp", "cpp", "cc",
     "compileToOC", "objc",
     "js",
-    "check"
+    "check",
 ];
 
 class NimCompiler extends BaseCompiler {
@@ -50,7 +50,7 @@ class NimCompiler extends BaseCompiler {
         return [
             "-o:" + outputFilename, //output file, only for js mode
             "--nolinking", //disable linking, only compile to nimcache
-            "--nimcache:" + this.cacheDir(outputFilename) //output folder for the nimcache
+            "--nimcache:" + this.cacheDir(outputFilename), //output folder for the nimcache
         ];
     }
 

--- a/lib/compilers/ppci.js
+++ b/lib/compilers/ppci.js
@@ -29,7 +29,7 @@ const BaseCompiler = require('../base-compiler'),
 const forbiddenOptions = [
     '--report',
     '--text-report',
-    '--html-report'
+    '--html-report',
 ];
 
 class PPCICompiler extends BaseCompiler {

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -136,7 +136,7 @@ class Win32Compiler extends BaseCompiler {
                 '/Fa' + this.filename(outputFilename.replace(/\.exe$/, "")),
                 '/Fo' + this.filename(outputFilename.replace(/\.exe$/, "") + '.obj'),
                 '/Fm' + this.filename(mapFilename),
-                '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), "output"))
+                '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), "output")),
             ];
         } else {
             return [
@@ -144,7 +144,7 @@ class Win32Compiler extends BaseCompiler {
                 '/FA',
                 '/c',
                 '/Fa' + this.filename(outputFilename),
-                '/Fo' + this.filename(outputFilename + '.obj')
+                '/Fo' + this.filename(outputFilename + '.obj'),
             ];
         }
     }

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -90,7 +90,7 @@ class WineVcCompiler extends BaseCompiler {
                 '/Fa' + this.filename(outputFilename),
                 '/Fo' + this.filename(outputFilename + '.obj'),
                 '/Fm' + this.filename(mapFilename),
-                '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), "output"))
+                '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), "output")),
             ];
         } else {
             return [
@@ -98,7 +98,7 @@ class WineVcCompiler extends BaseCompiler {
                 '/FA',
                 '/c',
                 '/Fa' + this.filename(outputFilename),
-                '/Fo' + this.filename(outputFilename + '.obj')
+                '/Fo' + this.filename(outputFilename + '.obj'),
             ];
         }
     }

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -45,10 +45,10 @@ const data = {
     'connect-src': ["'self'", '*', 'https://*.godbolt.org', 'localhost:*',
         'https://*.compiler-explorer.com', 'https://api.github.com'],
     'media-src': ["'self'", 'https://ssl.gstatic.com', 'https://*.godbolt.org', 'localhost:*',
-        'https://*.compiler-explorer.com']
+        'https://*.compiler-explorer.com'],
 };
 
 module.exports = {
     data: data,
-    policy: _.map(data, (value, policyKey) => `${policyKey} ${value.join(' ')}`).join(';')
+    policy: _.map(data, (value, policyKey) => `${policyKey} ${value.join(' ')}`).join(';'),
 };

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -32,7 +32,7 @@ const LabelMetadata = [
     {ident: 'C3Ev', description: 'complete object allocating constructor'},
     {ident: 'D0Ev', description: 'deleting destructor'},
     {ident: 'D1Ev', description: 'complete object destructor'},
-    {ident: 'D2Ev', description: 'base object destructor'}
+    {ident: 'D2Ev', description: 'base object destructor'},
 ];
 
 class DemanglerCPP extends Demangler {

--- a/lib/demangler-pascal.js
+++ b/lib/demangler-pascal.js
@@ -53,7 +53,7 @@ class DemanglerPascal extends Demangler {
             "VMT_OUTPUT_", "INIT$_OUTPUT", "RTTI_OUTPUT_", "FINALIZE$_OUTPUT",
             "_$",
             "DEBUGSTART_$", "DEBUGEND_$", "DBG_$", "DBG2_$", "DBGREF_$",
-            "DEBUGSTART_OUTPUT", "DEBUGEND_OUTPUT", "DBG_OUTPUT_", "DBG2_OUTPUT_", "DBGREF_OUTPUT_"
+            "DEBUGSTART_OUTPUT", "DEBUGEND_OUTPUT", "DBG_OUTPUT_", "DBG2_OUTPUT_", "DBGREF_OUTPUT_",
         ];
     }
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -69,7 +69,7 @@ function executeDirect(command, args, options, filenameTransform) {
     const child = child_process.spawn(command, args, {
         cwd: cwd,
         env: env,
-        detached: process.platform === 'linux'
+        detached: process.platform === 'linux',
     });
     let running = true;
 
@@ -80,7 +80,7 @@ function executeDirect(command, args, options, filenameTransform) {
     const streams = {
         stderr: "",
         stdout: "",
-        truncated: false
+        truncated: false,
     };
     let timeout;
     if (timeoutMs) timeout = setTimeout(() => {
@@ -129,7 +129,7 @@ function executeDirect(command, args, options, filenameTransform) {
                 okToCache,
                 filenameTransform,
                 stdout: streams.stdout,
-                stderr: streams.stderr
+                stderr: streams.stderr,
             };
             logger.debug("Execution", {type: "executed", command: command, args: args, result: result});
             resolve(result);
@@ -146,7 +146,7 @@ function withNsjailTimeout(args, options) {
         const ExtraWallClockLeewayMs = 1000;
         return args.concat([
             '--time_limit',
-            `${Math.round((options.timeoutMs + ExtraWallClockLeewayMs) / 1000)}`
+            `${Math.round((options.timeoutMs + ExtraWallClockLeewayMs) / 1000)}`,
         ]);
     }
     return args;
@@ -188,7 +188,7 @@ function withFirejailTimeout(args, options) {
         return args.concat([
             // TODO: reinstate once we work out why this causes a 1s+ delay on every execution!
             // `--timeout=${msToFjTimeout(options.timeoutMs + ExtraWallClockLeewayMs)}`,
-            `--rlimit-cpu=${Math.round((options.timeoutMs + ExtraCpuLeewayMs) / 1000)}`
+            `--rlimit-cpu=${Math.round((options.timeoutMs + ExtraCpuLeewayMs) / 1000)}`,
         ]);
     }
     return args;
@@ -225,7 +225,7 @@ const sandboxDispatchTable = {
         return executeDirect(command, args, options);
     },
     nsjail: sandboxNsjail,
-    firejail: sandboxFirejail
+    firejail: sandboxFirejail,
 };
 
 async function sandbox(command, args, options) {
@@ -281,7 +281,7 @@ function initialiseWine() {
                 "--private",
                 `--name=${wineSandboxName}`,
                 wine,
-                "cmd"
+                "cmd",
             ],
             {env: env, detached: true});
         logger.info(`firejailed pid=${wineServer.pid}`);
@@ -414,7 +414,7 @@ function executeNone(command, args, options) {
 
 const executeDispatchTable = {
     none: executeNone,
-    firejail: executeFirejail
+    firejail: executeFirejail,
 };
 
 async function execute(command, args, options) {
@@ -428,5 +428,5 @@ async function execute(command, args, options) {
 module.exports = {
     execute,
     sandbox,
-    initialiseWine
+    initialiseWine,
 };

--- a/lib/google.js
+++ b/lib/google.js
@@ -41,7 +41,7 @@ class ShortLinkResolver {
                     return;
                 }
                 resolve({
-                    longUrl: targetLocation
+                    longUrl: targetLocation,
                 });
             });
         });

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -44,7 +44,7 @@ class ApiHandler {
                 {
                     "Access-Control-Allow-Origin": "*",
                     "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept",
-                    "Cache-Control": cacheHeader
+                    "Cache-Control": cacheHeader,
                 }
             );
             next();
@@ -93,7 +93,7 @@ class ApiHandler {
                 logger.warn(`Exception thrown when expanding ${id}: `, err);
                 next({
                     statusCode: 404,
-                    message: `ID "${id}" could not be found`
+                    message: `ID "${id}" could not be found`,
                 });
             });
     }
@@ -139,7 +139,7 @@ class ApiHandler {
                 name: language.name,
                 description: language.description,
                 url: language.url,
-                versions: versionArr
+                versions: versionArr,
             };
         });
     }
@@ -151,13 +151,13 @@ class ApiHandler {
             } else {
                 next({
                     statusCode: 404,
-                    message: "Language is required"
+                    message: "Language is required",
                 });
             }
         } else {
             next({
                 statusCode: 500,
-                message: "Internal error"
+                message: "Internal error",
             });
         }
     }
@@ -168,7 +168,7 @@ class ApiHandler {
         } else {
             next({
                 statusCode: 500,
-                message: "Internal error"
+                message: "Internal error",
             });
         }
     }

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -290,7 +290,7 @@ class CompileHandler {
         }
         const {
             source, options, backendOptions, filters,
-            bypassCache, tools, executionParameters, libraries
+            bypassCache, tools, executionParameters, libraries,
         } = this.parseRequest(req, compiler);
         const remote = compiler.getRemote();
         if (remote) {

--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -50,7 +50,7 @@ class Formatter {
                 exe: exe,
                 version: match ? match[0] : result.stdout,
                 name: this.ceProps(`formatter.${formatter}.name`, exe),
-                styles: this.ceProps(`formatter.${formatter}.styles`, "").split(':')
+                styles: this.ceProps(`formatter.${formatter}.styles`, "").split(':'),
             };
         } catch (err) {
             logger.warn(`Error while fetching tool info for ${exe}:`, {err});
@@ -67,7 +67,7 @@ class Formatter {
             res.status(422); // Unprocessable Entity
             res.send({
                 exit: 2,
-                answer: "Tool not supported"
+                answer: "Tool not supported",
             });
             return false;
         }
@@ -75,7 +75,7 @@ class Formatter {
         if (!req.body || !req.body.source) {
             res.send({
                 exit: 0,
-                answer: ""
+                answer: "",
             });
             return false;
         }
@@ -85,7 +85,7 @@ class Formatter {
             res.status(422); // Unprocessable Entity
             res.send({
                 exit: 3,
-                answer: "Base style not supported"
+                answer: "Base style not supported",
             });
             return false;
         }
@@ -101,7 +101,7 @@ class Formatter {
                 {input: req.body.source});
             res.send({
                 exit: result.code,
-                answer: result.stdout || ""
+                answer: result.stdout || "",
             });
         } catch (ex) {
             // Unexpected problem when running the formatter
@@ -109,7 +109,7 @@ class Formatter {
             res.send({
                 exit: 1,
                 thrown: true,
-                answer: ex.message || "Internal server error"
+                answer: ex.message || "Internal server error",
             });
         }
     }

--- a/lib/handlers/route-api.js
+++ b/lib/handlers/route-api.js
@@ -76,7 +76,7 @@ class RouteAPI {
                 logger.debug(`Exception thrown when expanding ${id}: `, err);
                 next({
                     statusCode: 404,
-                    message: `ID "${id}/${sessionid}" could not be found`
+                    message: `ID "${id}/${sessionid}" could not be found`,
                 });
             });
     }
@@ -103,7 +103,7 @@ class RouteAPI {
                 logger.warn(`Could not expand ${id}: ${err}`);
                 next({
                     statusCode: 404,
-                    message: `ID "${id}" could not be found`
+                    message: `ID "${id}" could not be found`,
                 });
             });
     }
@@ -150,7 +150,7 @@ class RouteAPI {
                 logger.debug('Exception value:', err);
                 next({
                     statusCode: 404,
-                    message: `ID "${id}" could not be found`
+                    message: `ID "${id}" could not be found`,
                 });
             });
     }
@@ -186,7 +186,7 @@ class RouteAPI {
         const metadata = {
             ogDescription: null,
             ogAuthor: null,
-            ogTitle: "Compiler Explorer"
+            ogTitle: "Compiler Explorer",
         };
 
         if (link) {

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -49,57 +49,57 @@ const languages = {
         monaco: 'cppp',
         extensions: ['.cpp', '.cxx', '.h', '.hpp', '.hxx', '.c'],
         alias: ['gcc', 'cpp'],
-        previewFilter: /^\s*#include/
+        previewFilter: /^\s*#include/,
     },
     llvm: {
         name: 'LLVM IR',
         monaco: 'llvm-ir',
         extensions: ['.ll'],
-        alias: []
+        alias: [],
     },
     cppx: {
         name: 'Cppx',
         monaco: 'cppp',
         extensions: ['.cpp', '.cxx', '.h', '.hpp', '.hxx', '.c'],
         alias: [],
-        previewFilter: /^\s*#include/
+        previewFilter: /^\s*#include/,
     },
     c: {
         name: 'C',
         monaco: 'nc',
         extensions: ['.c', '.h'],
         alias: [],
-        previewFilter: /^\s*#include/
+        previewFilter: /^\s*#include/,
     },
     rust: {
         name: 'Rust',
         monaco: 'rust',
         extensions: ['.rs'],
-        alias: []
+        alias: [],
     },
     d: {
         name: 'D',
         monaco: 'd',
         extensions: ['.d'],
-        alias: []
+        alias: [],
     },
     go: {
         name: 'Go',
         monaco: 'go',
         extensions: ['.go'],
-        alias: []
+        alias: [],
     },
     ispc: {
         name: 'ispc',
         monaco: 'ispc',
         extensions: ['.ispc'],
-        alias: []
+        alias: [],
     },
     haskell: {
         name: 'Haskell',
         monaco: 'haskell',
         extensions: ['.hs', '.haskell'],
-        alias: []
+        alias: [],
     },
     // Temporarily disabled: see #1438
     // java: {
@@ -112,76 +112,76 @@ const languages = {
         name: 'OCaml',
         monaco: 'ocaml',
         extensions: ['.ml', '.mli'],
-        alias: []
+        alias: [],
     },
     python: {
         name: 'Python',
         monaco: 'python',
         extensions: ['.py'],
-        alias: []
+        alias: [],
     },
     swift: {
         name: 'Swift',
         monaco: 'swift',
         extensions: ['.swift'],
-        alias: []
+        alias: [],
     },
     pascal: {
         name: 'Pascal',
         monaco: 'pascal',
         extensions: ['.pas'],
-        alias: []
+        alias: [],
     },
     fortran: {
         id: 'fortran',
         name: 'Fortran',
         monaco: 'fortran',
         extensions: ['.f90','.F90','.f95','.F95'],
-        alias: []
+        alias: [],
     },
     assembly: {
         name: 'Assembly',
         monaco: 'asm',
         extensions: ['.asm'],
-        alias: ['asm']
+        alias: ['asm'],
     },
     analysis: {
         name: 'Analysis',
         monaco: 'asm',
         extensions: ['.asm'],  // maybe add more? Change to a unique one?
-        alias: ['tool', 'tools']
+        alias: ['tool', 'tools'],
     },
     cuda: {
         name: 'CUDA',
         monaco: 'cuda',
         extensions: ['.cu'],
         alias: ['nvcc'],
-        monacoDisassembly: 'ptx'
+        monacoDisassembly: 'ptx',
     },
     zig: {
         name: 'Zig',
         monaco: 'zig',
         extensions: ['.zig'],
-        alias: []
+        alias: [],
     },
     clean: {
         name: 'Clean',
         monaco: 'clean',
         extensions: ['.icl'],
-        alias: []
+        alias: [],
     },
     ada: {
         name: 'Ada',
         monaco: 'ada',
         extensions: ['.adb', '.ads'],
-        alias: []
+        alias: [],
     },
     nim: {
         name: 'Nim',
         monaco: 'nim',
         extensions: ['.nim'],
-        alias: []
-    }
+        alias: [],
+    },
 };
 
 const fs = require('fs-extra');
@@ -197,5 +197,5 @@ _.each(languages, (lang, key) => {
 });
 
 module.exports = {
-    list: languages
+    list: languages,
 };

--- a/lib/llvm-ir.js
+++ b/lib/llvm-ir.js
@@ -130,7 +130,7 @@ class LlvmIrParser {
                 result.push({
                     text: (filters.trim ? utils.squashHorizontalWhitespace(line) : line),
                     source: source,
-                    scope: match[1]
+                    scope: match[1],
                 });
                 prevLineEmpty = false;
                 return;
@@ -157,13 +157,13 @@ class LlvmIrParser {
             if (!line.scope) return;
             line.source = {
                 file: this.getFileName(debugInfo, line.scope),
-                line: this.getSourceLineNumber(debugInfo, line.scope)
+                line: this.getSourceLineNumber(debugInfo, line.scope),
             };
         });
 
         return {
             asm: result,
-            labelDefinitions: {}
+            labelDefinitions: {},
         };
     }
 
@@ -173,7 +173,7 @@ class LlvmIrParser {
         }
         return {
             asm: [],
-            labelDefinitions: {}
+            labelDefinitions: {},
         };
     }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -34,25 +34,25 @@ const logger = winston.createLogger({
         winston.format.colorize(),
         winston.format.splat(),
         winston.format.simple()),
-    transports: [consoleTransportInstance]
+    transports: [consoleTransportInstance],
 });
 
 logger.stream = {
     write: message => {
         logger.info(message.trim());
-    }
+    },
 };
 
 logger.warnStream = {
     write: message => {
         logger.warn(message.trim());
-    }
+    },
 };
 
 logger.errStream = {
     write: message => {
         logger.error(message.trim());
-    }
+    },
 };
 
 // Our own transport which uses Papertrail under the hood but better adapts it to work
@@ -68,7 +68,7 @@ class MyPapertrailTransport extends TransportStream {
             {
                 host: opts.host,
                 port: opts.port,
-                logFormat: (level, message) => message
+                logFormat: (level, message) => message,
             }
         );
     }
@@ -86,7 +86,7 @@ class MyPapertrailTransport extends TransportStream {
 
 exports.logToPapertrail = (host, port, identifier) => {
     const transport = new MyPapertrailTransport({
-        host: host, port: port, identifier: identifier
+        host: host, port: port, identifier: identifier,
     });
     transport.transport.on('error', (err) => {
         logger.error(err);

--- a/lib/map-file-delphi.js
+++ b/lib/map-file-delphi.js
@@ -61,7 +61,7 @@ class MapFileReaderDelphi extends MapFileReader {
                 segment: matches[1],
                 addressInt: addressWithOffset,
                 address: addressWithOffset.toString(16),
-                segmentLength: parseInt(matches[3], 16)
+                segmentLength: parseInt(matches[3], 16),
             });
         } else {
             matches = line.match(this.regexDelphiCodeSegment);

--- a/lib/map-file-vs.js
+++ b/lib/map-file-vs.js
@@ -89,7 +89,7 @@ class MapFileReaderVS extends MapFileReader {
                 address: addressWithOffset.toString(16),
                 displayName: matches[3],
                 unitName: matches[6],
-                isStaticSymbol: false
+                isStaticSymbol: false,
             };
             this.namedAddresses.push(symbolObject);
 

--- a/lib/map-file.js
+++ b/lib/map-file.js
@@ -128,7 +128,7 @@ class MapFileReader {
             segment: segment,
             addressInt: address,
             address: address.toString(16),
-            segmentLength: 0
+            segmentLength: 0,
         });
     }
 
@@ -310,7 +310,7 @@ class MapFileReader {
             segment: segment,
             addressWithoutOffset: addressWithoutOffset,
             addressInt: addressWithOffset,
-            address: addressWithOffset.toString(16)
+            address: addressWithOffset.toString(16),
         };
     }
 
@@ -338,7 +338,7 @@ class MapFileReader {
         if (matches) {
             this.entryPoint = {
                 segment: matches[1],
-                addressWithoutOffset: matches[2]
+                addressWithoutOffset: matches[2],
             };
         }
     }
@@ -392,7 +392,7 @@ class MapFileReader {
                     address: addressStart.toString(16),
                     endAddress: (addressStart + segmentLen).toString(16),
                     segmentLength: segmentLen,
-                    unitName: currentUnit
+                    unitName: currentUnit,
                 });
 
                 addressStart = symbolObject.addressInt;
@@ -404,7 +404,7 @@ class MapFileReader {
                     addressInt: addressStart,
                     address: addressStart.toString(16),
                     segmentLength: -1,
-                    unitName: symbolObject.unitName
+                    unitName: symbolObject.unitName,
                 });
             }
         }
@@ -425,7 +425,7 @@ class MapFileReader {
                     startAddress: segment.addressInt,
                     startAddressHex: segment.addressInt.toString(16),
                     endAddress: segment.addressInt + segment.segmentLength,
-                    endAddressHex: (segment.addressInt + segment.segmentLength).toString(16)
+                    endAddressHex: (segment.addressInt + segment.segmentLength).toString(16),
                 });
             }
         }

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -107,17 +107,17 @@ class ClientOptionsHandler {
                     enabled: cookiePolicyEnabled,
                     hash: cookiePolicyEnabled ? ClientOptionsHandler.getFileHash(
                         path.resolve(__dirname, '..', 'static', 'policies', 'cookies.html')) : null,
-                    key: 'cookie_status'
+                    key: 'cookie_status',
                 },
                 privacy: {
                     enabled: privacyPolicyEnabled,
                     hash: privacyPolicyEnabled ? ClientOptionsHandler.getFileHash(
                         path.resolve(__dirname, '..', 'static', 'policies', 'privacy.html')) : null,
                     // How we store this privacy hash on the local storage
-                    key: 'privacy_status'
-                }
+                    key: 'privacy_status',
+                },
             },
-            motdUrl: ceProps('motdUrl', '')
+            motdUrl: ceProps('motdUrl', ''),
         };
         this._updateOptionsHash();
     }
@@ -141,11 +141,11 @@ class ClientOptionsHandler {
                         options: this.compilerProps(lang, toolBaseName + '.options'),
                         languageId: this.compilerProps(lang, toolBaseName + '.languageId'),
                         stdinHint: this.compilerProps(lang, toolBaseName + '.stdinHint'),
-                        compilerLanguage: lang
+                        compilerLanguage: lang,
                     },
                     {
                         ceProps: this.ceProps,
-                        compilerProps: (propname) => this.compilerProps(lang, propname)
+                        compilerProps: (propname) => this.compilerProps(lang, propname),
                     });
                 });
             }
@@ -178,7 +178,7 @@ class ClientOptionsHandler {
                             this.compilerProps(lang, libBaseName + '.liblink'), []),
                         dependencies: this.splitIntoArray(
                             this.compilerProps(lang, libBaseName + '.dependencies'), []),
-                        versions: {}
+                        versions: {},
                     };
                     const listedVersions = `${this.compilerProps(lang, libBaseName + '.versions')}`;
                     if (listedVersions) {

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -38,7 +38,7 @@ class Packager {
         return new Promise((resolve, reject) => {
             tarGzip.decompress({
                 source: packageFile,
-                destination: destination
+                destination: destination,
             }, (err) => {
                 if (err) {
                     reject(err);
@@ -57,8 +57,8 @@ class Packager {
                 level: 6,
                 memLevel: 6,
                 options: {
-                    dereference: true
-                }
+                    dereference: true,
+                },
             }, (err) => {
                 if (err) {
                     reject(err);
@@ -71,5 +71,5 @@ class Packager {
 }
 
 module.exports = {
-    Packager: Packager
+    Packager: Packager,
 };

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -187,5 +187,5 @@ module.exports = {
         propDebug = debug;
     },
     fakeProps: fake => (prop, def) => fake[prop] === undefined ? def : fake[prop],
-    parseProperties: parseProperties
+    parseProperties: parseProperties,
 };

--- a/lib/s3-handler.js
+++ b/lib/s3-handler.js
@@ -59,7 +59,7 @@ class S3Bucket {
             Key: `${path}/${key}`,
             Body: value,
             StorageClass: options.redundancy || "STANDARD",
-            Metadata: options.metadata || {}
+            Metadata: options.metadata || {},
         }).promise();
     }
 }

--- a/lib/shortener-tinyurl.js
+++ b/lib/shortener-tinyurl.js
@@ -30,7 +30,7 @@ function handler(req, res) {
     const url = `${req.protocol}://${req.get('host')}#${req.body.config}`;
     const options = {
         url: "https://tinyurl.com/api-create.php?url=" + encodeURIComponent(url),
-        method: "GET"
+        method: "GET",
     };
     const callback = (err, resp, body) => {
         if (!err && resp.statusCode === 200) {

--- a/lib/storage/storage-local.js
+++ b/lib/storage/storage-local.js
@@ -70,7 +70,7 @@ class StorageLocal extends StorageBase {
                     return {
                         prefix: prefix,
                         uniqueSubHash: subHash,
-                        alreadyPresent: false
+                        alreadyPresent: false,
                     };
                 } else {
                     const expectedPath = path.join(this.storageFolder, subHash);
@@ -82,7 +82,7 @@ class StorageLocal extends StorageBase {
                         return {
                             prefix: prefix,
                             uniqueSubHash: subHash,
-                            alreadyPresent: true
+                            alreadyPresent: true,
                         };
                     }
                 }
@@ -104,7 +104,7 @@ class StorageLocal extends StorageBase {
             const item = await fs.readJson(expectedPath);
             return {
                 config: item.config,
-                specialMetadata: null
+                specialMetadata: null,
             };
         } catch (err) {
             // IO error/Logic error, we have no way to store this right now. Please try again? What to do here?

--- a/lib/storage/storage-null.js
+++ b/lib/storage/storage-null.js
@@ -38,14 +38,14 @@ class StorageNull extends StorageBase {
         return {
             prefix: "null",
             uniqueSubHash: "null",
-            alreadyPresent: true
+            alreadyPresent: true,
         };
     }
 
     async expandId() {
         return {
             config: "{}",
-            specialMetadata: null
+            specialMetadata: null,
         };
     }
 

--- a/lib/storage/storage-remote.js
+++ b/lib/storage/storage-remote.js
@@ -35,7 +35,7 @@ class StorageRemote extends StorageBase {
         this.baseUrl = compilerProps.ceProps('remoteStorageServer');
 
         const req = request.defaults({
-            baseUrl: this.baseUrl
+            baseUrl: this.baseUrl,
         });
 
         this.get = util.promisify(req.get);
@@ -47,7 +47,7 @@ class StorageRemote extends StorageBase {
         try {
             resp = await this.post('/shortener', {
                 json: true,
-                body: req.body
+                body: req.body,
             });
         } catch (err) {
             logger.error(err);
@@ -76,7 +76,7 @@ class StorageRemote extends StorageBase {
 
         return {
             config: resp.body,
-            specialMetadata: null
+            specialMetadata: null,
         };
     }
 

--- a/lib/storage/storage-s3.js
+++ b/lib/storage/storage-s3.js
@@ -66,13 +66,13 @@ class StorageS3 extends StorageBase {
                         unique_subhash: {S: item.uniqueSubHash},
                         full_hash: {S: item.fullHash},
                         stats: {
-                            M: {clicks: {N: '0'}}
+                            M: {clicks: {N: '0'}},
                         },
                         creation_ip: {S: ip},
-                        creation_date: {S: now.toISOString()}
-                    }
+                        creation_date: {S: now.toISOString()},
+                    },
                 }).promise(),
-                this.s3.put(item.fullHash, item.config, this.prefix, {})
+                this.s3.put(item.fullHash, item.config, this.prefix, {}),
             ]);
             return item;
         } catch (err) {
@@ -87,7 +87,7 @@ class StorageS3 extends StorageBase {
             TableName: this.table,
             ProjectionExpression: 'unique_subhash, full_hash',
             KeyConditionExpression: 'prefix = :prefix',
-            ExpressionAttributeValues: {':prefix': {S: prefix}}
+            ExpressionAttributeValues: {':prefix': {S: prefix}},
         }).promise();
         const subHashes = _.chain(data.Items)
             .pluck('unique_subhash')
@@ -106,7 +106,7 @@ class StorageS3 extends StorageBase {
                 return {
                     prefix: prefix,
                     uniqueSubHash: subHash,
-                    alreadyPresent: false
+                    alreadyPresent: false,
                 };
             } else {
                 const itemHash = fullHashes[index];
@@ -117,7 +117,7 @@ class StorageS3 extends StorageBase {
                     return {
                         prefix: prefix,
                         uniqueSubHash: subHash,
-                        alreadyPresent: true
+                        alreadyPresent: true,
                     };
                 }
             }
@@ -128,7 +128,7 @@ class StorageS3 extends StorageBase {
     getKeyStruct(id) {
         return {
             prefix: {S: id.substring(0, MIN_STORED_ID_LENGTH)},
-            unique_subhash: {S: id}
+            unique_subhash: {S: id},
         };
     }
 
@@ -137,7 +137,7 @@ class StorageS3 extends StorageBase {
         // for which we have less resources allocated, but get one extra read (But we do have more reserved for it)
         const item = await this.dynamoDb.getItem({
             TableName: this.table,
-            Key: this.getKeyStruct(id)
+            Key: this.getKeyStruct(id),
         }).promise();
 
         const attributes = item.Item;
@@ -150,7 +150,7 @@ class StorageS3 extends StorageBase {
         const metadata = attributes.named_metadata ? attributes.named_metadata.M : null;
         return {
             config: result.data.toString(),
-            specialMetadata: metadata
+            specialMetadata: metadata,
         };
     }
 
@@ -161,9 +161,9 @@ class StorageS3 extends StorageBase {
                 Key: this.getKeyStruct(id),
                 UpdateExpression: 'SET stats.clicks = stats.clicks + :inc',
                 ExpressionAttributeValues: {
-                    ':inc': {N: '1'}
+                    ':inc': {N: '1'},
                 },
-                ReturnValues: 'NONE'
+                ReturnValues: 'NONE',
             }).promise();
         } catch (err) {
             // Swallow up errors

--- a/lib/storage/storage.js
+++ b/lib/storage/storage.js
@@ -110,7 +110,7 @@ class StorageBase {
                         prefix: result.prefix,
                         uniqueSubHash: result.uniqueSubHash,
                         fullHash: configHash,
-                        config: config
+                        config: config,
                     };
 
                     return this.storeItem(storedObject, req);
@@ -152,5 +152,5 @@ function storageFactory(storageSolution, compilerProps, awsProps, httpRootDir) {
 
 module.exports = {
     StorageBase: StorageBase,
-    storageFactory: storageFactory
+    storageFactory: storageFactory,
 };

--- a/lib/toolchain-utils.js
+++ b/lib/toolchain-utils.js
@@ -45,5 +45,5 @@ function getToolchainPath(compilerExe, compilerOptions) {
 }
 
 module.exports = {
-    getToolchainPath: getToolchainPath
+    getToolchainPath: getToolchainPath,
 };

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -64,7 +64,7 @@ class BaseTool {
         return {
             timeoutMs: this.env.ceProps("compileTimeoutMs", 7500),
             maxErrorOutput: this.env.ceProps("max-error-output", 5000),
-            wrapper: this.env.compilerProps("compiler-wrapper")
+            wrapper: this.env.compilerProps("compiler-wrapper"),
         };
     }
 
@@ -74,7 +74,7 @@ class BaseTool {
             name: this.tool.name,
             code: -1,
             languageId: "stderr",
-            stdout: utils.parseOutput(message)
+            stdout: utils.parseOutput(message),
         };
     }
 
@@ -126,7 +126,7 @@ class BaseTool {
             code: result.code,
             languageId: this.tool.languageId,
             stderr: utils.parseOutput(result.stderr, transformedFilepath, exeDir),
-            stdout: utils.parseOutput(result.stdout, transformedFilepath, exeDir)
+            stdout: utils.parseOutput(result.stdout, transformedFilepath, exeDir),
         };
     }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -120,7 +120,7 @@ function parseOutput(lines, inputFilename, pathPrefix) {
                 lineObj.tag = {
                     line: parseInt(match[1]),
                     column: parseInt(match[3] || "0"),
-                    text: match[4].trim()
+                    text: match[4].trim(),
                 };
             }
             result.push(lineObj);

--- a/static/.eslintrc
+++ b/static/.eslintrc
@@ -20,6 +20,12 @@
       "named": "never",
       "asyncArrow": "always"
     }],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline"
+    }],
     "quote-props": ["error", "as-needed"]
   },
   "parserOptions": {

--- a/static/analytics.js
+++ b/static/analytics.js
@@ -30,7 +30,7 @@ if (options.sentryDsn) {
     Sentry.init({
         dsn: options.sentryDsn,
         release: options.release,
-        environment: options.sentryEnvironment
+        environment: options.sentryEnvironment,
     });
 }
 

--- a/static/ansi-to-html.js
+++ b/static/ansi-to-html.js
@@ -33,7 +33,7 @@ var defaults = {
     newline: false,
     escapeXML: false,
     stream: false,
-    colors: getDefaultColors()
+    colors: getDefaultColors(),
 };
 
 function getDefaultColors() {
@@ -53,7 +53,7 @@ function getDefaultColors() {
         12: '#55F',
         13: '#F5F',
         14: '#5FF',
-        15: '#FFF'
+        15: '#FFF',
     };
 
     range(0, 5).forEach(function (red) {
@@ -188,7 +188,7 @@ function handleDisplay(stack, code, options) {
         },
         49: function _() {
             return pushBackgroundColor(stack, options.bg);
-        }
+        },
     };
 
     if (codeMap[code]) {
@@ -396,25 +396,25 @@ function tokenize(text, options, callback) {
     /* eslint no-control-regex:0 */
     var tokens = [{
         pattern: /^\x08+/,
-        sub: remove
+        sub: remove,
     }, {
         pattern: /^\x1b\[[012]?K/,
-        sub: remove
+        sub: remove,
     }, {
         pattern: /^\x1b\[38;5;(\d+)m/,
-        sub: removeXterm256
+        sub: removeXterm256,
     }, {
         pattern: /^\n/,
-        sub: newline
+        sub: newline,
     }, {
         pattern: /^\x1b\[((?:\d{1,3};?)+|)m/,
-        sub: ansiMess
+        sub: ansiMess,
     }, {
         pattern: /^\x1b\[?[\d;]{0,3}/,
-        sub: remove
+        sub: remove,
     }, {
         pattern: /^([^\x1b\x08\n]+)/,
-        sub: realText
+        sub: realText,
     }];
 
     function process(handler, i) {
@@ -518,7 +518,7 @@ Filter.prototype = {
         }
 
         return buf.join('');
-    }
+    },
 };
 
 module.exports = Filter;

--- a/static/codelens-handler.js
+++ b/static/codelens-handler.js
@@ -40,7 +40,7 @@ function registerLensesForCompiler(compilerId, editorModel, lenses) {
         registeredCodelenses.push({
             compilerId: compilerId,
             editorModel: editorModel,
-            lenses: lenses
+            lenses: lenses,
         });
     }
 }
@@ -53,12 +53,12 @@ function provide(model) {
     if (item) {
         return {
             lenses: item.lenses,
-            dispose: function () {}
+            dispose: function () {},
         };
     } else {
         return {
             lenses: [],
-            dispose: function () {}
+            dispose: function () {},
         };
     }
 }
@@ -76,7 +76,7 @@ function unregister(compilerId) {
 function registerProviderForLanguage(language) {
     if (!providersPerLanguage[language]) {
         providersPerLanguage[language] = monaco.languages.registerCodeLensProvider(language, {
-            provideCodeLenses: provide
+            provideCodeLenses: provide,
         });
     }
 }
@@ -84,5 +84,5 @@ function registerProviderForLanguage(language) {
 module.exports = {
     registerLensesForCompiler: registerLensesForCompiler,
     unregister: unregister,
-    registerProviderForLanguage: registerProviderForLanguage
+    registerProviderForLanguage: registerProviderForLanguage,
 };

--- a/static/colour.js
+++ b/static/colour.js
@@ -31,7 +31,7 @@ var schemes = [
     {name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default']},
     {name: 'earth', desc: 'Earth tones (colourblind safe)', count: 9, themes: ['default']},
     {name: 'green-blue', desc: 'Greens and blues (colourblind safe)', count: 4, themes: ['default']},
-    {name: 'gray-shade', desc: 'Gray shades', count: 4, themes: ['dark']}
+    {name: 'gray-shade', desc: 'Gray shades', count: 4, themes: ['dark']},
 ];
 
 function applyColours(editor, colours, schemeName, prevDecorations) {
@@ -45,8 +45,8 @@ function applyColours(editor, colours, schemeName, prevDecorations) {
             range: new monaco.Range(line, 1, line, 1),
             options: {
                 isWholeLine: true,
-                className: "line-linkage " + scheme.name + "-" + (ordinal % scheme.count)
-            }
+                className: "line-linkage " + scheme.name + "-" + (ordinal % scheme.count),
+            },
         };
     });
     return editor.deltaDecorations(prevDecorations, newDecorations);
@@ -54,5 +54,5 @@ function applyColours(editor, colours, schemeName, prevDecorations) {
 
 module.exports = {
     applyColours: applyColours,
-    schemes: schemes
+    schemes: schemes,
 };

--- a/static/compiler-service.js
+++ b/static/compiler-service.js
@@ -37,7 +37,7 @@ function CompilerService(eventHub) {
         max: 200 * 1024,
         length: function (n) {
             return JSON.stringify(n).length;
-        }
+        },
     });
     this.compilersByLang = {};
     _.each(options.compilers, function (compiler) {
@@ -74,7 +74,7 @@ CompilerService.prototype.processFromLangAndCompiler = function (languageId, com
                 if (compiler) {
                     return {
                         langId: lang.id,
-                        compiler: compiler
+                        compiler: compiler,
                     };
                 }
                 return null;
@@ -97,7 +97,7 @@ CompilerService.prototype.processFromLangAndCompiler = function (languageId, com
 
     return {
         langId: langId,
-        compiler: foundCompiler
+        compiler: foundCompiler,
     };
 };
 
@@ -163,7 +163,7 @@ function handleRequestError(request, reject, xhr, textStatus, errorThrown) {
     }
     reject({
         request: request,
-        error: error
+        error: error,
     });
 }
 
@@ -176,7 +176,7 @@ CompilerService.prototype.submit = function (request) {
             return Promise.resolve({
                 request: request,
                 result: cachedResult,
-                localCacheHit: true
+                localCacheHit: true,
             });
         }
     }
@@ -196,10 +196,10 @@ CompilerService.prototype.submit = function (request) {
                 resolve({
                     request: request,
                     result: result,
-                    localCacheHit: false
+                    localCacheHit: false,
                 });
             }, this),
-            error: bindHandler
+            error: bindHandler,
         });
     }, this));
 };
@@ -213,16 +213,16 @@ CompilerService.prototype.requestPopularArguments = function (compilerId, option
             dataType: 'json',
             data: JSON.stringify({
                 usedOptions: options,
-                presplit: false
+                presplit: false,
             }),
             success: _.bind(function (result) {
                 resolve({
                     request: compilerId,
                     result: result,
-                    localCacheHit: false
+                    localCacheHit: false,
                 });
             }, this),
-            error: bindHandler
+            error: bindHandler,
         });
     }, this));
 };
@@ -257,7 +257,7 @@ CompilerService.prototype.getSelectizerOrder = function () {
     return [
         {field: '$order'},
         {field: '$score'},
-        {field: 'name'}
+        {field: 'name'},
     ];
 };
 

--- a/static/components.js
+++ b/static/components.js
@@ -29,7 +29,7 @@ module.exports = {
         return {
             type: 'component',
             componentName: 'compiler',
-            componentState: {source: editorId, lang: lang}
+            componentState: {source: editorId, lang: lang},
         };
     },
     getCompilerWith: function (editorId, filters, options, compilerId, langId, libs) {
@@ -42,36 +42,36 @@ module.exports = {
                 options: options,
                 compiler: compilerId,
                 lang: langId,
-                libs: libs
-            }
+                libs: libs,
+            },
         };
     },
     getExecutor: function (editorId, lang) {
         return {
             type: 'component',
             componentName: 'executor',
-            componentState: {source: editorId, lang: lang}
+            componentState: {source: editorId, lang: lang},
         };
     },
     getEditor: function (id, langId) {
         return {
             type: 'component',
             componentName: 'codeEditor',
-            componentState: {id: id, lang: langId}
+            componentState: {id: id, lang: langId},
         };
     },
     getEditorWith: function (id, source, options) {
         return {
             type: 'component',
             componentName: 'codeEditor',
-            componentState: {id: id, source: source, options: options}
+            componentState: {id: id, source: source, options: options},
         };
     },
     getOutput: function (compiler, editor) {
         return {
             type: 'component',
             componentName: 'output',
-            componentState: {compiler: compiler, editor: editor}
+            componentState: {compiler: compiler, editor: editor},
         };
     },
     getToolViewWith: function (compiler, editor, toolId, args) {
@@ -82,22 +82,22 @@ module.exports = {
                 compiler: compiler,
                 editor: editor,
                 toolId: toolId,
-                args: args
-            }
+                args: args,
+            },
         };
     },
     getDiff: function () {
         return {
             type: 'component',
             componentName: 'diff',
-            componentState: {}
+            componentState: {},
         };
     },
     getOptView: function () {
         return {
             type: 'component',
             componentName: 'opt',
-            componentState: {}
+            componentState: {},
         };
     },
     getOptViewWith: function (id, source, optimization, compilerName, editorid) {
@@ -109,15 +109,15 @@ module.exports = {
                 source: source,
                 optOutput: optimization,
                 compilerName: compilerName,
-                editorid: editorid
-            }
+                editorid: editorid,
+            },
         };
     },
     getAstView: function () {
         return {
             type: 'component',
             componentName: 'ast',
-            componentState: {}
+            componentState: {},
         };
     },
     getAstViewWith: function (id, source, astOutput, compilerName, editorid) {
@@ -129,15 +129,15 @@ module.exports = {
                 source: source,
                 astOutput: astOutput,
                 compilerName: compilerName,
-                editorid: editorid
-            }
+                editorid: editorid,
+            },
         };
     },
     getGccDumpView: function () {
         return {
             type: 'component',
             componentName: 'gccdump',
-            componentState: {}
+            componentState: {},
         };
     },
     getGccDumpViewWith: function (id, compilerName, editorid, gccDumpOutput) {
@@ -147,8 +147,8 @@ module.exports = {
             componentState: {
                 _compilerid: id,
                 _compilerName: compilerName,
-                _editorid: editorid
-            }
+                _editorid: editorid,
+            },
         };
         if (gccDumpOutput) {
             ret.treeDump = gccDumpOutput.treeDump;
@@ -162,7 +162,7 @@ module.exports = {
         return {
             type: 'component',
             componentName: 'cfg',
-            componentState: {}
+            componentState: {},
         };
     },
     getCfgViewWith: function (id, editorid) {
@@ -171,8 +171,8 @@ module.exports = {
             componentName: 'cfg',
             componentState: {
                 id: id,
-                editorid: editorid
-            }
+                editorid: editorid,
+            },
         };
     },
     getConformanceView: function (editorid, source, langId) {
@@ -182,15 +182,15 @@ module.exports = {
             componentState: {
                 editorid: editorid,
                 source: source,
-                langId: langId
-            }
+                langId: langId,
+            },
         };
     },
     getIrView: function () {
         return {
             type: 'component',
             componentName: 'ir',
-            componentState: {}
+            componentState: {},
         };
     },
     getIrViewWith: function (id, source, irOutput, compilerName, editorid) {
@@ -202,8 +202,8 @@ module.exports = {
                 source: source,
                 irOutput: irOutput,
                 compilerName: compilerName,
-                editorid: editorid
-            }
+                editorid: editorid,
+            },
         };
-    }
+    },
 };

--- a/static/fontscale.js
+++ b/static/fontscale.js
@@ -95,7 +95,7 @@ FontScale.prototype.apply = function () {
         this.domRoot.find(this.fontSelectorOrEditor).css('font-size', this.scale + "pt");
     } else {
         this.fontSelectorOrEditor.updateOptions({
-            fontSize: this.scale
+            fontSize: this.scale,
         });
     }
 };

--- a/static/history-widget.js
+++ b/static/history-widget.js
@@ -75,8 +75,8 @@ HistoryWidget.prototype.initializeIfNeeded = function () {
             readOnly: true,
             language: 'c++',
             minimap: {
-                enabled: true
-            }
+                enabled: true,
+            },
         });
 
         this.lhs = new HistoryDiffState(monaco.editor.createModel('', 'c++'));
@@ -86,7 +86,7 @@ HistoryWidget.prototype.initializeIfNeeded = function () {
         this.modal.find('.inline-diff-checkbox').click(_.bind(function (event) {
             var inline = $(event.target).prop('checked');
             this.diffEditor.updateOptions({
-                renderSideBySide: !inline
+                renderSideBySide: !inline,
             });
             this.resizeLayout();
         }, this));
@@ -110,7 +110,7 @@ HistoryWidget.prototype.populateFromLocalStorage = function () {
                 load: _.bind(function () {
                     this.onLoad(data);
                     this.modal.modal('hide');
-                }, this)
+                }, this),
             };
         }, this)));
 };
@@ -210,7 +210,7 @@ HistoryWidget.prototype.resizeLayout = function () {
     var tabcontent = this.modal.find('div.tab-content');
     this.diffEditor.layout({
         width: tabcontent.width(),
-        height: tabcontent.height() - 20
+        height: tabcontent.height() - 20,
     });
 };
 
@@ -228,10 +228,10 @@ HistoryWidget.prototype.run = function (onLoad) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenModalPane',
-        eventAction: 'History'
+        eventAction: 'History',
     });
 };
 
 module.exports = {
-    HistoryWidget: HistoryWidget
+    HistoryWidget: HistoryWidget,
 };

--- a/static/history.js
+++ b/static/history.js
@@ -42,7 +42,7 @@ function extractEditorSources(content) {
         } else if (component.componentName === 'codeEditor') {
             sources.push({
                 lang: component.componentState.lang,
-                source: component.componentState.source
+                source: component.componentState.source,
             });
         }
     }
@@ -90,7 +90,7 @@ function push(stringifiedConfig) {
             completeHistory.push({
                 dt: Date.now(),
                 sources: sources,
-                config: config
+                config: config,
             });
         } else {
             var entry = completeHistory[duplicateIdx];
@@ -118,7 +118,7 @@ function sources(language) {
             if (source.lang === language) {
                 sourcelist.push({
                     dt: entry.dt,
-                    source: source.source
+                    source: source.source,
                 });
             }
         });
@@ -131,5 +131,5 @@ module.exports = {
     push: _.debounce(push, 500),
     list: list,
     sortedList: sortedList,
-    sources: sources
+    sources: sources,
 };

--- a/static/hub.js
+++ b/static/hub.js
@@ -286,7 +286,7 @@ Hub.prototype.addAtRoot = function (newElem) {
     } else {
         this.layout.root.addChild({
             type: 'row',
-            content: [newElem]
+            content: [newElem],
         });
     }
 };

--- a/static/libs-widget.js
+++ b/static/libs-widget.js
@@ -147,13 +147,13 @@ LibsWidget.prototype.lazyDropdownLoad = function () {
                 .prop('id', id)
                 .append($('<option>', {
                     value: '-',
-                    text: '-'
+                    text: '-',
                 }));
             _.each(libEntry.versions, _.bind(function (version, versionId) {
                 select.append($('<option>', {
                     value: versionId,
                     text: version.version,
-                    selected: libsInUse[id] && libsInUse[id] === versionId
+                    selected: libsInUse[id] && libsInUse[id] === versionId,
                 }));
             }, this));
             label.toggleClass('bg-success text-white', select.val() !== '-');
@@ -187,7 +187,7 @@ LibsWidget.prototype.updateLibsDropdown = function () {
         trigger: 'click',
         template: '<div class="popover libs-popover" role="tooltip"><div class="arrow"></div>' +
             '<h3 class="popover-header"></h3>' +
-            '<div class="popover-body"></div></div>'
+            '<div class="popover-body"></div></div>',
     });
 };
 
@@ -253,5 +253,5 @@ LibsWidget.prototype.getLibsInUse = function () {
 };
 
 module.exports = {
-    Widget: LibsWidget
+    Widget: LibsWidget,
 };

--- a/static/loadSave.js
+++ b/static/loadSave.js
@@ -83,7 +83,7 @@ LoadSave.prototype.populateBuiltins = function () {
                         name: elem.name,
                         load: _.bind(function () {
                             this.doLoad(elem);
-                        }, this)
+                        }, this),
                     };
                 }, this))
             );
@@ -99,7 +99,7 @@ LoadSave.prototype.populateLocalStorage = function () {
                 load: _.bind(function () {
                     this.onLoad(data);
                     this.modal.modal('hide');
-                }, this)
+                }, this),
             };
         }, this)));
 };
@@ -114,7 +114,7 @@ LoadSave.prototype.populateLocalHistory = function () {
                 load: _.bind(function () {
                     this.onLoad(data.source);
                     this.modal.modal('hide');
-                }, this)
+                }, this),
             };
         }, this)));
 };
@@ -161,7 +161,7 @@ LoadSave.prototype.run = function (onLoad, editorText, currentLanguage) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenModalPane',
-        eventAction: 'LoadSave'
+        eventAction: 'LoadSave',
     });
 };
 
@@ -206,7 +206,7 @@ LoadSave.prototype.onSaveToFile = function (fileEditor) {
         this.alertSystem.notify('Error while saving your code. Use the clipboard instead.', {
             group: "savelocalerror",
             alertClass: "notification-error",
-            dismissTime: 5000
+            dismissTime: 5000,
         });
         return false;
     }

--- a/static/local.js
+++ b/static/local.js
@@ -59,5 +59,5 @@ function remove(key) {
 module.exports = {
     set: set,
     get: get,
-    remove: remove
+    remove: remove,
 };

--- a/static/main.js
+++ b/static/main.js
@@ -81,7 +81,7 @@ if (!String.prototype.includes) {
 function setupSettings(hub) {
     var eventHub = hub.layout.eventHub;
     var defaultSettings = {
-        defaultLanguage: hub.defaultLangId
+        defaultLanguage: hub.defaultLangId,
     };
     var currentSettings = JSON.parse(local.get('settings', null)) || defaultSettings;
 
@@ -90,14 +90,14 @@ function setupSettings(hub) {
             analytics.proxy('send', {
                 hitType: 'event',
                 eventCategory: 'ThemeChange',
-                eventAction: newSettings.theme
+                eventAction: newSettings.theme,
             });
         }
         if (currentSettings.colourScheme !== newSettings.colourScheme) {
             analytics.proxy('send', {
                 hitType: 'event',
                 eventCategory: 'ColourSchemeChange',
-                eventAction: newSettings.colourScheme
+                eventAction: newSettings.colourScheme,
             });
         }
         currentSettings = newSettings;
@@ -159,7 +159,7 @@ function setupButtons(options) {
                 no: function () {
                     simpleCooks.callDontConsent.apply(simpleCooks);
                 },
-                noHtml: 'Do NOT consent'
+                noHtml: 'Do NOT consent',
             });
         });
     }
@@ -186,7 +186,7 @@ function setupButtons(options) {
                 analytics.proxy('send', {
                     hitType: 'event',
                     eventCategory: 'Sponsors',
-                    eventAction: 'open'
+                    eventAction: 'open',
                 });
             })
             .fail(function (err) {
@@ -249,8 +249,8 @@ function findConfig(defaultConfig, options) {
             settings: {
                 showMaximiseIcon: false,
                 showCloseIcon: false,
-                hasHeaders: false
-            }
+                hasHeaders: false,
+            },
         }, sharing.configFromEmbedded(window.location.hash.substr(1)));
     }
     return config;
@@ -274,7 +274,7 @@ function initPolicies(options) {
     if (options.policies.privacy.enabled &&
         options.policies.privacy.hash !== jsCookie.get(options.policies.privacy.key)) {
         $('#privacy').trigger('click', {
-            title: 'New Privacy Policy. Please take a moment to read it'
+            title: 'New Privacy Policy. Please take a moment to read it',
         });
     }
     simpleCooks.onDoConsent = function () {
@@ -394,9 +394,9 @@ function start() {
             type: 'row',
             content: [
                 Components.getEditor(1, defaultLangId),
-                Components.getCompiler(1, defaultLangId)
-            ]
-        }]
+                Components.getCompiler(1, defaultLangId),
+            ],
+        }],
     };
 
     $(window).bind('hashchange', function () {
@@ -521,7 +521,7 @@ function start() {
             },
             function () {
                 hub.layout.eventHub.emit('modifySettings', {
-                    enableCommunityAds: false
+                    enableCommunityAds: false,
                 });
             });
 
@@ -544,7 +544,7 @@ function start() {
             eventCategory: 'Sponsors',
             eventAction: 'click',
             eventLabel: sponsor.url,
-            transport: 'beacon'
+            transport: 'beacon',
         });
         window.open(sponsor.url);
     };

--- a/static/modes/ada-mode.js
+++ b/static/modes/ada-mode.js
@@ -101,7 +101,7 @@ function definition() {
             'not',
             'and',
             'or',
-            'xor'
+            'xor',
         ],
         standardTypes :[
             // Defined in the package Standard
@@ -122,18 +122,18 @@ function definition() {
             'Constraint_Error',
             'Program_Error',
             'Storage_Error',
-            'Tasking_Error'
+            'Tasking_Error',
         ],
 
         operators: [
             '+', '-', '*', '/', 'div', 'mod',
             'shl', 'shr', 'and', 'or', 'xor', 'not',
             '<', '>', '<=', '>=', '==', '<>',
-            '+=', '-=', '*=', '/='
+            '+=', '-=', '*=', '/=',
         ],
         brackets: [
             ['(', ')', 'delimiter.parenthesis'],
-            ['[', ']', 'delimiter.square']
+            ['[', ']', 'delimiter.square'],
         ],
         symbols: /[=><!~&|+\-*/^]+/,
         delimiters: /[;=.:,`]/,
@@ -146,8 +146,8 @@ function definition() {
                     cases: {
                         '@standardTypes': 'type',
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
                 // Whitespace
                 {include: '@whitespace'},
@@ -165,8 +165,8 @@ function definition() {
                 [/@delimiters/, {
                     cases: {
                         '@keywords': 'keyword',
-                        '@default': 'delimiter'
-                    }
+                        '@default': 'delimiter',
+                    },
                 }],
                 // strings
                 [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-teminated string
@@ -175,21 +175,21 @@ function definition() {
                 // characters
                 [/'[^\\']'/, 'string'],
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-                [/'/, 'string.invalid']
+                [/'/, 'string.invalid'],
             ],
             
             // Whitespace and comments
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
-                [/--.*$/, 'comment']
+                [/--.*$/, 'comment'],
             ],
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, 'string', '@pop']
-            ]
-        }
+                [/"/, 'string', '@pop'],
+            ],
+        },
     };
 }
 monaco.languages.register({id: 'ada'});

--- a/static/modes/asm-mode.js
+++ b/static/modes/asm-mode.js
@@ -55,7 +55,7 @@ function definition() {
                 [/[(){}]/, {token: 'operator', next: '@rest'}],
 
                 // whitespace
-                {include: '@whitespace'}
+                {include: '@whitespace'},
             ],
 
             rest: [
@@ -93,30 +93,30 @@ function definition() {
                 [/%?[.?_$a-zA-Z@][.?_$a-zA-Z0-9@]*/, 'type.identifier'],
 
                 // whitespace
-                {include: '@whitespace'}
+                {include: '@whitespace'},
             ],
 
             comment: [
                 [/[^/*]+/, 'comment'],
                 [/\/\*/, 'comment', '@push'],    // nested comment
                 ["\\*/", 'comment', '@pop'],
-                [/[/*]/, 'comment']
+                [/[/*]/, 'comment'],
             ],
 
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, {token: 'string.quote', bracket: '@close', next: '@pop'}]
+                [/"/, {token: 'string.quote', bracket: '@close', next: '@pop'}],
             ],
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
                 [/\/\*/, 'comment', '@comment'],
                 [/\/\/.*$/, 'comment'],
-                [/[#;\\@].*$/, 'comment']
-            ]
-        }
+                [/[#;\\@].*$/, 'comment'],
+            ],
+        },
     };
 }
 

--- a/static/modes/asm6502-mode.js
+++ b/static/modes/asm6502-mode.js
@@ -34,13 +34,13 @@ function definition() {
                 [/^\s+/, { token: 'whitespace', next: '@opcode' }],
                 [/^\.[a-zA-Z]+\s*/, { token: 'type.identifier', next: '@arguments' }],
                 [/;.*$/, { token: 'comment', next: '@root' }],
-                [/\s*,\s*/, { token: 'delimiter', next: '@arguments' }]
+                [/\s*,\s*/, { token: 'delimiter', next: '@arguments' }],
             ],
 
             opcode: [
                 [/[a-zA-Z]+$/, { token: 'keyword', next: '@root' }],
                 [/[a-zA-Z]+\s*/, { token: 'keyword', next: '@arguments' }],
-                [/;.*$/, { token: 'comment', next: '@root' }]
+                [/;.*$/, { token: 'comment', next: '@root' }],
             ],
 
             arguments: [
@@ -55,9 +55,9 @@ function definition() {
                 [/#[0-9]+/, { token: 'number', next: '@root' }],
                 [/[a-zA-Z_][a-zA-Z_0-9]*/, { token: 'type.identifier', next: '@root' }],
                 [/[0-9]+/, { token: 'number', next: '@root' }],
-                [/;.*$/, { token: 'comment', next: '@root' }]
-            ]
-        }
+                [/;.*$/, { token: 'comment', next: '@root' }],
+            ],
+        },
     };
 }
 

--- a/static/modes/clean-mode.js
+++ b/static/modes/clean-mode.js
@@ -29,15 +29,15 @@ function definition() {
         keywords: [
             'module', 'import', 'Start', 'where', 'otherwise',
             'definition', 'implementation', 'from', 'class', 'instance', 'abort',
-            'infix', 'infixl', 'infixr', 'if', 'True', 'False'
+            'infix', 'infixl', 'infixr', 'if', 'True', 'False',
         ],
 
         builtintypes: [
-            'Int', 'Real', 'String', 'Char', 'Complex', 'Bool'
+            'Int', 'Real', 'String', 'Char', 'Complex', 'Bool',
         ],
 
         operators: [
-            '=', '==', '>=', '<=', '+', '-', '*', '/', '::', ':==', '->', '=:', '=>', '|', '\\\\'
+            '=', '==', '>=', '<=', '+', '-', '*', '/', '::', ':==', '->', '=:', '=>', '|', '\\\\',
         ],
 
         numbers: /-?[0-9.]/,
@@ -58,29 +58,29 @@ function definition() {
                     cases: {
                         '@builtintypes': 'type',
                         '@keywords': 'keyword',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 [/[()[\],:]/, 'delimiter'],
 
                 [/@numbers/, 'number'],
 
-                [/(")(.*)(")/, ['string', 'string', 'string']]
+                [/(")(.*)(")/, ['string', 'string', 'string']],
             ],
 
             comment: [
                 [/[^/*]+/, 'comment'],
                 [/\*\//, 'comment', '@pop'],
-                [/[/*]/, 'comment']
+                [/[/*]/, 'comment'],
             ],
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
                 [/\/\*/, 'comment', '@comment'],
-                [/\/\/.*$/, 'comment']
-            ]
-        }
+                [/\/\/.*$/, 'comment'],
+            ],
+        },
     };
 }
 

--- a/static/modes/cuda-mode.js
+++ b/static/modes/cuda-mode.js
@@ -44,7 +44,7 @@ function definition() {
 
     // Keywords for CUDA
     addKeywords([
-        "__host__", "__global__", "__device__", "__shared__", "__noinline__", "__forceinline__", "__restrict__"
+        "__host__", "__global__", "__device__", "__shared__", "__noinline__", "__forceinline__", "__restrict__",
     ]);
 
     return cuda;

--- a/static/modes/d-mode.js
+++ b/static/modes/d-mode.js
@@ -144,7 +144,7 @@ function definition() {
 
         typeKeywords: [
             'bool', 'byte', 'ubyte', 'short', 'ushort', 'int', 'uint', 'long', 'ulong', 'char', 'wchar', 'dchar',
-            'float', 'double', 'real', 'ifloat', 'idouble', 'ireal', 'cfloat', 'cdouble', 'creal', 'void'
+            'float', 'double', 'real', 'ifloat', 'idouble', 'ireal', 'cfloat', 'cdouble', 'creal', 'void',
         ],
 
         operators: [
@@ -152,7 +152,7 @@ function definition() {
             '==', '<=', '>=', '!=', '&&', '||', '++', '--',
             '+', '-', '*', '/', '&', '|', '^', '%', '<<',
             '>>', '>>>', '+=', '-=', '*=', '/=', '&=', '|=',
-            '^=', '%=', '<<=', '>>=', '>>>='
+            '^=', '%=', '<<=', '>>=', '>>>=',
         ],
 
         // we include these common regular expressions
@@ -167,8 +167,8 @@ function definition() {
                     cases: {
                         '@typeKeywords': 'keyword',
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
                 [/[A-Z][\w$]*/, 'type.identifier'],  // to show class names nicely
 
@@ -181,8 +181,8 @@ function definition() {
                 [/@symbols/, {
                     cases: {
                         '@operators': 'operator',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 // numbers
@@ -203,20 +203,20 @@ function definition() {
                 // characters
                 [/'[^\\']'/, 'string'],
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-                [/'/, 'string.invalid']
+                [/'/, 'string.invalid'],
             ],
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
                 [/\/\*/, 'comment', '@comment'],
                 [/\/\+/, 'comment', '@nestingcomment'],
-                [/\/\/.*$/, 'comment']
+                [/\/\/.*$/, 'comment'],
             ],
 
             comment: [
                 [/[^/*]+/, 'comment'],
                 [/\*\//, 'comment', '@pop'],
-                [/[/*]/, 'comment']
+                [/[/*]/, 'comment'],
             ],
 
             nestingcomment: [
@@ -224,21 +224,21 @@ function definition() {
                 [/\/\+/, 'comment', '@push'],
                 [/\/\+/, 'comment.invalid'],
                 [/\+\//, 'comment', '@pop'],
-                [/[/+]/, 'comment']
+                [/[/+]/, 'comment'],
             ],
 
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, 'string', '@pop']
+                [/"/, 'string', '@pop'],
             ],
 
             rawstring: [
                 [/[^`]/, "string"],
-                [/`/, "string", "@pop"]
-            ]
-        }
+                [/`/, "string", "@pop"],
+            ],
+        },
     };
 }
 
@@ -246,13 +246,13 @@ function configuration() {
     return {
         comments: {
             lineComment: '//',
-            blockComment: ['/*', '*/']
+            blockComment: ['/*', '*/'],
         },
 
         brackets: [
             ['{', '}'],
             ['[', ']'],
-            ['(', ')']
+            ['(', ')'],
         ],
 
         autoClosingPairs: [
@@ -261,7 +261,7 @@ function configuration() {
             {open: '(', close: ')'},
             {open: '`', close: '`', notIn: ['string']},
             {open: '"', close: '"', notIn: ['string']},
-            {open: '\'', close: '\'', notIn: ['string', 'comment']}
+            {open: '\'', close: '\'', notIn: ['string', 'comment']},
         ],
 
         surroundingPairs: [
@@ -270,8 +270,8 @@ function configuration() {
             {open: '(', close: ')'},
             {open: '`', close: '`'},
             {open: '"', close: '"'},
-            {open: '\'', close: '\''}
-        ]
+            {open: '\'', close: '\''},
+        ],
     };
 }
 

--- a/static/modes/fortran-mode.js
+++ b/static/modes/fortran-mode.js
@@ -161,7 +161,7 @@ function definition() {
             'wait',
             'where',
             'while',
-            'write'
+            'write',
         ],
 
         typeKeywords: [
@@ -178,7 +178,7 @@ function definition() {
             'allocatable',
             'parameter',
             'private',
-            'public'
+            'public',
         ],
 
         operators: [
@@ -206,7 +206,7 @@ function definition() {
             '.ne.',
             '.neqv.',
             '.not.',
-            '.or.'
+            '.or.',
         ],
 
         functions: [
@@ -400,7 +400,7 @@ function definition() {
             'ubound',
             'ucobound',
             'unpack',
-            'verify'
+            'verify',
         ],
 
         subroutines: [
@@ -426,7 +426,7 @@ function definition() {
             'mvbits',
             'random_number',
             'random_seed',
-            'system_clock'
+            'system_clock',
         ],
 
         // we include these common regular expressions
@@ -441,8 +441,8 @@ function definition() {
                     cases: {
                         '@typeKeywords': 'type.identifier',
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
                 // identifiers and keywords
                 [/[a-zA-Z][\w$]*/, {
@@ -450,8 +450,8 @@ function definition() {
                         '@keywords': 'keyword',
                         '@functions': 'keyword',
                         '@subroutines': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
 
                 // comments
@@ -466,8 +466,8 @@ function definition() {
                 [/@symbols/, {
                     cases: {
                         '@operators': 'operator',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 // numbers
@@ -487,24 +487,24 @@ function definition() {
                 // characters
                 [/'[^\\']'/, 'string'],
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-                [/'/, 'string.invalid']
+                [/'/, 'string.invalid'],
             ],
 
             whitespace: [
-                [/[ \t\r\n]+/, 'white']
+                [/[ \t\r\n]+/, 'white'],
             ],
 
             comment: [
-                [/!/, 'comment']
+                [/!/, 'comment'],
             ],
 
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, 'string', '@pop']
+                [/"/, 'string', '@pop'],
             ],
-        }
+        },
     };
 }
 
@@ -517,7 +517,7 @@ function configuration() {
         brackets: [
             ['(/', '/)'],
             ['[', ']'],
-            ['(', ')']
+            ['(', ')'],
         ],
 
         autoClosingPairs: [
@@ -525,7 +525,7 @@ function configuration() {
             {open: '(', close: ')'},
             {open: '`', close: '`', notIn: ['string','comment']},
             {open: "'", close: "'", notIn: ['string','comment']},
-            {open: '"', close: '"', notIn: ['string']}
+            {open: '"', close: '"', notIn: ['string']},
         ],
 
         surroundingPairs: [
@@ -533,14 +533,14 @@ function configuration() {
             {open: '(', close: ')'},
             {open: '`', close: '`'},
             {open: "'", close: "'"},
-            {open: '"', close: '"'}
+            {open: '"', close: '"'},
         ],
 
         indentationRules: {
             decreaseIndentPattern: /(end\s*(do|if|function|subroutine|program|module|block|associate|forall|select))|else|(^((?!select).)*(case))/,
             increaseIndentPattern: /(^((?!end).)*(do\s|if(\s|\().*then|function\s|subroutine\s|program\s|module\s|block\s*|associate(\s|\()|forall|case)|else)/,
-            unIndentedLinePattern: null
-        }
+            unIndentedLinePattern: null,
+        },
     };
 }
 

--- a/static/modes/gccdump-rtl-gimple-mode.js
+++ b/static/modes/gccdump-rtl-gimple-mode.js
@@ -196,18 +196,18 @@ function definition() {
             "var_location",
             "debug_implicit_ptr",
             "entry_value",
-            "debug_parameter_ref"
+            "debug_parameter_ref",
         ],
 
         typeKeywords: [
-            'boolean', 'double', 'byte', 'int', 'short', 'char', 'void', 'long', 'float'
+            'boolean', 'double', 'byte', 'int', 'short', 'char', 'void', 'long', 'float',
         ],
 
         operators: [
             '=', '>', '<', '!', '~', '?', ':', '==', '<=', '>=', '!=',
             '&&', '||', '++', '--', '+', '-', '*', '/', '&', '|', '^', '%',
             '<<', '>>', '>>>', '+=', '-=', '*=', '/=', '&=', '|=', '^=',
-            '%=', '<<=', '>>=', '>>>='
+            '%=', '<<=', '>>=', '>>>=',
         ],
 
         // we include these common regular expressions
@@ -224,8 +224,8 @@ function definition() {
                     cases: {
                         '@typeKeywords': 'keyword',
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
                 [/[A-Z][\w$]*/, 'type.identifier'],  // to show class names nicely
 
@@ -238,8 +238,8 @@ function definition() {
                 [/@symbols/, {
                     cases: {
                         '@operators': 'operator',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 // @ annotations.
@@ -262,31 +262,31 @@ function definition() {
                 // characters
                 [/'[^\\']'/, 'string'],
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-                [/'/, 'string.invalid']
+                [/'/, 'string.invalid'],
             ],
 
             comment: [
                 [/[^/*]+/, 'comment'],
                 [/\/\*/, 'comment', '@push'],    // nested comment
                 ["\\*/", 'comment', '@pop'],
-                [/[/*]/, 'comment']
+                [/[/*]/, 'comment'],
             ],
 
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, {token: 'string.quote', bracket: '@close', next: '@pop'}]
+                [/"/, {token: 'string.quote', bracket: '@close', next: '@pop'}],
             ],
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
                 [/\/\*/, 'comment', '@comment'],
                 [/\/\/.*$/, 'comment'],
-                [/^;;.*$/, 'comment']
+                [/^;;.*$/, 'comment'],
 
-            ]
-        }
+            ],
+        },
     };
 }
 

--- a/static/modes/haskell-mode.js
+++ b/static/modes/haskell-mode.js
@@ -28,15 +28,15 @@ function definition() {
     return {
         keywords: [
             'module', 'import', 'main', 'where', 'otherwise', 'newtype',
-            'definition', 'implementation', 'from', 'class', 'instance', 'abort'
+            'definition', 'implementation', 'from', 'class', 'instance', 'abort',
         ],
 
         builtintypes: [
-            'Int', 'Real', 'String'
+            'Int', 'Real', 'String',
         ],
 
         operators: [
-            '=', '==', '>=', '<=', '+', '-', '*', '/', '::', '->', '=:', '=>', '|', '$'
+            '=', '==', '>=', '<=', '+', '-', '*', '/', '::', '->', '=:', '=>', '|', '$',
         ],
 
         numbers: /-?[0-9.]/,
@@ -57,30 +57,30 @@ function definition() {
                     cases: {
                         '@builtintypes': 'type',
                         '@keywords': 'keyword',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 [/[()[\],:]/, 'delimiter'],
 
                 [/@numbers/, 'number'],
 
-                [/(")(.*)(")/, ['string', 'string', 'string']]
+                [/(")(.*)(")/, ['string', 'string', 'string']],
             ],
 
             comment: [
                 [/[^/*]+/, 'comment'],
                 [/\*\//, 'comment', '@pop'],
-                [/[/*]/, 'comment']
+                [/[/*]/, 'comment'],
             ],
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
                 [/\/\*/, 'comment', '@comment'],
                 [/\/\/.*$/, 'comment'],
-                [/--.*$/, 'comment']
-            ]
-        }
+                [/--.*$/, 'comment'],
+            ],
+        },
     };
 }
 

--- a/static/modes/llvm-ir-mode.js
+++ b/static/modes/llvm-ir-mode.js
@@ -34,7 +34,7 @@ function definition() {
         types: [
             'void', 'half', 'float', 'double', 'x86_fp80', 'fp128', 'ppc_fp128',
             'label', 'metadata', 'x86_mmx',
-            'type', 'label', 'opaque', 'token'
+            'type', 'label', 'opaque', 'token',
         ],
         // llvmStatement
         statements: [
@@ -50,7 +50,7 @@ function definition() {
             'sext', 'sge', 'sgt', 'shl', 'shufflevector', 'sitofp', 'sle', 'slt', 'srem',
             'store', 'sub', 'switch', 'trunc', 'udiv', 'ueq', 'uge', 'ugt', 'uitofp', 'ule', 'ult',
             'umax', 'umin', 'une', 'uno', 'unreachable', 'unwind', 'urem', 'va_arg',
-            'xchg', 'xor', 'zext'
+            'xchg', 'xor', 'zext',
         ],
         // llvmKeyword
         keywords: [
@@ -74,7 +74,7 @@ function definition() {
             'sspreq', 'sspstrong', 'strictfp', 'swiftcc', 'tail', 'target', 'thread_local',
             'to', 'triple', 'unnamed_addr', 'unordered', 'uselistorder', 'uselistorder_bb',
             'uwtable', 'volatile', 'weak', 'weak_odr', 'within', 'writeonly', 'x86_64_sysvcc',
-            'win64cc', 'x86_fastcallcc', 'x86_stdcallcc', 'x86_thiscallcc', 'zeroext'
+            'win64cc', 'x86_fastcallcc', 'x86_stdcallcc', 'x86_thiscallcc', 'zeroext',
         ],
 
         escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
@@ -121,19 +121,19 @@ function definition() {
                         '@statements': 'operators',
                         '@keywords': 'keyword',
                         '@types': 'type',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
-                [/[ \t\r\n]+/, 'white']
+                [/[ \t\r\n]+/, 'white'],
 
             ],
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, 'string', '@pop']
-            ]
-        }
+                [/"/, 'string', '@pop'],
+            ],
+        },
     };
 }
 

--- a/static/modes/nc-mode.js
+++ b/static/modes/nc-mode.js
@@ -36,7 +36,7 @@ function definition() {
         'int', 'long', 'register', 'restrict', 'return', 'short', 'signed', 'sizeof', 'static',
         'struct', 'switch', 'typedef', 'union', 'unsigned', 'void', 'volatile', 'while',
         '_Alignas', '_Alignof', '_Atomic', '_Bool', '_Complex', '_Generic', '_Imaginary',
-        '_Noreturn', '_Static_assert', '_Thread_local'
+        '_Noreturn', '_Static_assert', '_Thread_local',
     ];
     return nc;
 }

--- a/static/modes/nim-mode.js
+++ b/static/modes/nim-mode.js
@@ -49,15 +49,15 @@ function definition() {
             "var",
             "when", "while",
             "yield",
-            "push", "pop"
+            "push", "pop",
         ],
         operators: [
             '=', '+', '-', '*', '/', '<', '>',
             '@', '$', '~', '&', '%', '|',
-            '!', '?', '^', '.', ':', '\\'
+            '!', '?', '^', '.', ':', '\\',
         ],
         wordOperators: [
-            'and', 'or', 'not', 'xor', 'shl', 'shr', 'div', 'mod', 'in', 'notin', 'is', 'isnot', 'of'
+            'and', 'or', 'not', 'xor', 'shl', 'shr', 'div', 'mod', 'in', 'notin', 'is', 'isnot', 'of',
         ],
         symbols: /[=><!~&|+\-*/^%]+/,
         escapes: /\\(p|r|c|n|l|f|t|v|a|b|e|\\|"|'|\d+|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]+\})/,
@@ -76,7 +76,7 @@ function definition() {
             ['[.','.]','delimiter.square'],
             ['(',')','delimiter.parenthesis'],
             ['(.','.)','delimiter.parenthesis'],
-            ['<','>','delimiter.angle']
+            ['<','>','delimiter.angle'],
         ],
 
         // The main tokenizer for our languages
@@ -86,16 +86,16 @@ function definition() {
                     cases: {
                         '@keywords': 'keyword',
                         '@wordOperators': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
                 {include: '@whitespace'},
                 [/([:|[[{(]\.|\.[\]})]|[[\]{}()])/, '@brackets'],
                 [/@symbols/, {
                     cases: {
                         '@operators': 'operator',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 // number literals
@@ -117,32 +117,32 @@ function definition() {
                 // strings
                 [/(r|R)"/, 'string', '@rawString'],
                 [/"""/, 'string', '@tripleQuoteString'],
-                [/"(?!")/, 'string', '@string']
+                [/"(?!")/, 'string', '@string'],
             ],
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
                 [/#\[/, 'comment', '@comment'],
-                [/#.*$/, 'comment']
+                [/#.*$/, 'comment'],
             ],
             comment: [
                 [/[^\]#]/, 'comment'],
-                [/\]#/, 'comment', '@pop']
+                [/\]#/, 'comment', '@pop'],
             ],
             string: [
                 [/@escapes/, 'string.escape'],
-                [/"/, 'string', '@pop']
+                [/"/, 'string', '@pop'],
             ],
             tripleQuoteString: [
-                [/"""/, 'string', '@pop']
+                [/"""/, 'string', '@pop'],
             ],
             rawString: [
-                [/"/, 'string', '@pop']
+                [/"/, 'string', '@pop'],
             ],
             character: [
                 [/@charEscapes/, 'string.escape'],
-                [/'/, 'string', '@pop']
-            ]
-        }
+                [/'/, 'string', '@pop'],
+            ],
+        },
     };
 }
 

--- a/static/modes/ocaml-mode.js
+++ b/static/modes/ocaml-mode.js
@@ -104,8 +104,8 @@ function definition() {
                     cases: {
                         '@typeKeywords': 'keyword',
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
 
                 { include: '@whitespace' },
@@ -114,7 +114,7 @@ function definition() {
 
                 [/[+\-*/=<>$@]/, 'operators'],
 
-                [/(")(.*)(")/, ['string', 'string', 'string']]
+                [/(")(.*)(")/, ['string', 'string', 'string']],
             ],
 
             comment: [
@@ -126,7 +126,7 @@ function definition() {
                 [/[ \t\r\n]+/, 'white'],
                 [/\(\*/, 'comment', '@comment'],
             ],
-        }
+        },
     };
 }
 

--- a/static/modes/ptx-mode.js
+++ b/static/modes/ptx-mode.js
@@ -41,7 +41,7 @@ function definition() {
         [/[ \t\r\n]+/, 'white'],
         [/\/\*/, 'comment', '@comment'],
         [/\/\/.*$/, 'comment'],
-        [/[#;\\].*$/, 'comment']
+        [/[#;\\].*$/, 'comment'],
     ];
 
     // Add predicated instructions to the list of root tokens. Search for an opcode next, which is also a root token.

--- a/static/modes/zig-mode.js
+++ b/static/modes/zig-mode.js
@@ -44,13 +44,13 @@ function definition() {
         typeKeywords: [
             'bool', 'f32', 'f64', 'f128', 'void', 'noreturn', 'type', 'error', 'anyerror', 'promise', 'anyframe',
             'isize', 'usize', 'c_short', 'c_ushort', 'c_int', 'c_uint', 'c_long', 'c_ulong',
-            'c_longlong', 'c_ulonglong', 'c_longdouble', 'c_void'
+            'c_longlong', 'c_ulonglong', 'c_longdouble', 'c_void',
         ],
         operators: [
             '+', '+%', '-', '-%', '/', '*', '*%', '=', '^', '&', '?', '|',
             '!', '>', '<', '%', '<<', '<<%', '>>',
             '+=', '+%=', '-=', '-%=', '/=', '*=', '*%=', '==', '^=', '&=',
-            '?=', '|=', '!=', '>=', '<=', '%=', '<<=', '<<%=', '>>='
+            '?=', '|=', '!=', '>=', '<=', '%=', '<<=', '<<%=', '>>=',
         ],
 
         symbols: /[=><!~?:&|+\-*/^%]+/,
@@ -67,8 +67,8 @@ function definition() {
                     cases: {
                         '@typeKeywords': 'keyword',
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
-                    }
+                        '@default': 'identifier',
+                    },
                 }],
 
                 [/@[a-zA-Z_$]*/, 'builtin.identifier'],
@@ -84,8 +84,8 @@ function definition() {
                 [/@symbols/, {
                     cases: {
                         '@operators': 'operator',
-                        '@default': ''
-                    }
+                        '@default': '',
+                    },
                 }],
 
                 // numbers
@@ -106,7 +106,7 @@ function definition() {
                 // characters
                 [/'[^\\']'/, 'string'],
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-                [/'/, 'string.invalid']
+                [/'/, 'string.invalid'],
             ],
 
             whitespace: [
@@ -114,22 +114,22 @@ function definition() {
                 [/\/\*/, 'comment', '@comment'],
                 [/\/\+/, 'comment', '@comment'],
                 [/\/\/.*$/, 'comment'],
-                [/\t/, 'comment.invalid']
+                [/\t/, 'comment.invalid'],
             ],
 
             comment: [
                 [/[^/*]+/, 'comment'],
                 [/\/\*/, 'comment.invalid'],
-                [/[/*]/, 'comment']
+                [/[/*]/, 'comment'],
             ],
 
             string: [
                 [/[^\\"]+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
-                [/"/, 'string', '@pop']
-            ]
-        }
+                [/"/, 'string', '@pop'],
+            ],
+        },
     };
 }
 

--- a/static/motd.js
+++ b/static/motd.js
@@ -49,7 +49,7 @@ function handleMotd(motd, motdNode, subLang, adsEnabled, onHide) {
                     hitType: 'event',
                     eventCategory: 'Ads',
                     eventLabel: 'Visibility',
-                    eventAction: 'Hide'
+                    eventAction: 'Hide',
                 });
                 motdNode.addClass('d-none');
                 onHide();
@@ -59,7 +59,7 @@ function handleMotd(motd, motdNode, subLang, adsEnabled, onHide) {
                     hitType: 'event',
                     eventCategory: 'Ads',
                     eventAction: 'Click',
-                    eventLabel: this.href
+                    eventLabel: this.href,
                 });
             });
             motdNode.removeClass('d-none');
@@ -80,5 +80,5 @@ function initialise(url, motdNode, defaultLanguage, adsEnabled, onMotd, onHide) 
 }
 
 module.exports = {
-    initialise: initialise
+    initialise: initialise,
 };

--- a/static/panes/ast-view.js
+++ b/static/panes/ast-view.js
@@ -44,9 +44,9 @@ function Ast(hub, container, state) {
         quickSuggestions: false,
         fixedOverflowWidgets: true,
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
-        lineNumbersMinChars: 3
+        lineNumbersMinChars: 3,
     });
 
     this._compilerid = state.id;
@@ -67,7 +67,7 @@ function Ast(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Ast'
+        eventAction: 'Ast',
     });
 }
 
@@ -104,7 +104,7 @@ Ast.prototype.resize = function () {
     var topBarHeight = this.topBar.outerHeight(true);
     this.astEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight
+        height: this.domRoot.height() - topBarHeight,
     });
 };
 
@@ -180,7 +180,7 @@ Ast.prototype.currentState = function () {
     var state = {
         id: this._compilerid,
         editorid: this._editorid,
-        selection: this.selection
+        selection: this.selection,
     };
     this.fontScale.addState(state);
     return state;
@@ -201,10 +201,10 @@ Ast.prototype.onSettingsChange = function (newSettings) {
     this.astEditor.updateOptions({
         contextmenu: newSettings.useCustomContextMenu,
         minimap: {
-            enabled: newSettings.showMinimap
+            enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
-        fontLigatures: newSettings.editorsFLigatures
+        fontLigatures: newSettings.editorsFLigatures,
     });
 };
 
@@ -222,5 +222,5 @@ Ast.prototype.close = function () {
 };
 
 module.exports = {
-    Ast: Ast
+    Ast: Ast,
 };

--- a/static/panes/cfg-view.js
+++ b/static/panes/cfg-view.js
@@ -42,8 +42,8 @@ function Cfg(hub, container, state) {
         nodes: [{
             id: 0,
             shape: 'box',
-            label: 'Cfg mode cannot be used when the binary filter is set'
-        }], edges: []
+            label: 'Cfg mode cannot be used when the binary filter is set',
+        }], edges: [],
     };
     // Note that this might be outdated if no functions were present when creating the link, but that's handled
     // by selectize
@@ -62,35 +62,35 @@ function Cfg(hub, container, state) {
             smooth: {
                 enabled: true,
                 type: "dynamic",
-                roundness: 1
+                roundness: 1,
             },
-            physics: true
+            physics: true,
         },
         nodes: {
-            font: {face: 'Consolas, "Liberation Mono", Courier, monospace', align: 'left'}
+            font: {face: 'Consolas, "Liberation Mono", Courier, monospace', align: 'left'},
         },
         layout: {
             hierarchical: {
                 enabled: true,
                 direction: 'UD',
                 nodeSpacing: 100,
-                levelSeparation: 150
-            }
+                levelSeparation: 150,
+            },
         },
         physics: {
             enabled: !!state.options.physics,
             hierarchicalRepulsion: {
-                nodeDistance: 160
-            }
+                nodeDistance: 160,
+            },
         },
         interaction: {
             navigationButtons: !!state.options.navigation,
             keyboard: {
                 enabled: true,
                 speed: {x: 10, y: 10, zoom: 0.03},
-                bindToWindow: false
-            }
-        }
+                bindToWindow: false,
+            },
+        },
     };
 
     this.cfgVisualiser = new vis.Network(this.domRoot.find('.graph-placeholder')[0],
@@ -107,14 +107,14 @@ function Cfg(hub, container, state) {
         valueField: 'name',
         labelField: 'name',
         searchField: ['name'],
-        dropdownParent: 'body'
+        dropdownParent: 'body',
     }).on('change', _.bind(function (e) {
         var selectedFn = this.functions[e.target.value];
         if (selectedFn) {
             this.currentFunc = e.target.value;
             this.showCfgResults({
                 nodes: selectedFn.nodes,
-                edges: selectedFn.edges
+                edges: selectedFn.edges,
             });
             this.cfgVisualiser.selectNodes([selectedFn.nodes[0].id]);
             this.resize();
@@ -133,7 +133,7 @@ function Cfg(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Cfg'
+        eventAction: 'Cfg',
     });
 }
 
@@ -148,7 +148,7 @@ Cfg.prototype.onCompileResult = function (id, compiler, result) {
             }
             this.showCfgResults({
                 nodes: this.functions[this.currentFunc].nodes,
-                edges: this.functions[this.currentFunc].edges
+                edges: this.functions[this.currentFunc].edges,
             });
             this.cfgVisualiser.selectNodes([this.functions[this.currentFunc].nodes[0].id]);
         } else {
@@ -215,14 +215,14 @@ Cfg.prototype.initCallbacks = function () {
         this.networkOpts.physics.enabled = this.togglePhysicsButton.hasClass('active');
         // change only physics.enabled option to preserve current node locations
         this.cfgVisualiser.setOptions({
-            physics: {enabled: this.networkOpts.physics.enabled}
+            physics: {enabled: this.networkOpts.physics.enabled},
         });
     }, this));
 
     this.toggleNavigationButton.on('click', _.bind(function () {
         this.networkOpts.interaction.navigationButtons = this.toggleNavigationButton.hasClass('active');
         this.cfgVisualiser.setOptions({interaction: {
-            navigationButtons: this.networkOpts.interaction.navigationButtons}
+            navigationButtons: this.networkOpts.interaction.navigationButtons},
         });
     }, this));
     this.toggles.on('change', _.bind(function () {
@@ -265,7 +265,7 @@ Cfg.prototype.assignLevels = function (data) {
             id: node.id,
             level: 0,
             state: 0,
-            inCount: 0
+            inCount: 0,
         });
     }
     var isEdgeValid = function (edge) {
@@ -337,7 +337,7 @@ Cfg.prototype.showCfgResults = function (data) {
         this.cfgVisualiser.moveTo({
             position: this.savedPos,
             animation: false,
-            scale: this.savedScale
+            scale: this.savedScale,
         });
         this.needsMove = false;
     }
@@ -375,10 +375,10 @@ Cfg.prototype.currentState = function () {
         selectedFn: this.currentFunc,
         pos: this.cfgVisualiser.getViewPosition(),
         scale: this.cfgVisualiser.getScale(),
-        options: this.getEffectiveOptions()
+        options: this.getEffectiveOptions(),
     };
 };
 
 module.exports = {
-    Cfg: Cfg
+    Cfg: Cfg,
 };

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -48,7 +48,7 @@ var OpcodeCache = new LruCache({
     max: 64 * 1024,
     length: function (n) {
         return JSON.stringify(n).length;
-    }
+    },
 });
 
 function patchOldFilters(filters) {
@@ -123,11 +123,11 @@ function Compiler(hub, container, state) {
         glyphMargin: !options.embedded,
         fixedOverflowWidgets: true,
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
         lineNumbersMinChars: 1,
         renderIndentGuides: false,
-        fontLigatures: this.settings.editorsFLigatures
+        fontLigatures: this.settings.editorsFLigatures,
     });
 
     this.fontScale = new FontScale(this.domRoot, state, this.outputEditor);
@@ -145,14 +145,14 @@ function Compiler(hub, container, state) {
         }),
         items: this.compiler ? [this.compiler.id] : [],
         dropdownParent: 'body',
-        closeAfterSelect: true
+        closeAfterSelect: true,
     }).on('change', _.bind(function (e) {
         var val = $(e.target).val();
         if (val) {
             ga.proxy('send', {
                 hitType: 'event',
                 eventCategory: 'SelectCompiler',
-                eventAction: val
+                eventAction: val,
             });
             this.onCompilerChange(val);
         }
@@ -175,7 +175,7 @@ function Compiler(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Compiler'
+        eventAction: 'Compiler',
     });
 }
 
@@ -214,7 +214,7 @@ Compiler.prototype.initPanerButtons = function () {
         return {
             type: 'component',
             componentName: 'compiler',
-            componentState: currentState
+            componentState: currentState,
         };
     }, this);
     var createOptView = _.bind(function () {
@@ -336,7 +336,7 @@ Compiler.prototype.resize = function () {
     var bottomBarHeight = this.bottomBar.outerHeight(true);
     this.outputEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight - bottomBarHeight
+        height: this.domRoot.height() - topBarHeight - bottomBarHeight,
     });
 };
 
@@ -399,7 +399,7 @@ Compiler.prototype.initEditorActions = function () {
         contextMenuOrder: 1.5,
         run: _.bind(function (ed) {
             this.jumpToLabel(ed.getPosition());
-        }, this)
+        }, this),
     });
 
     // Hiding the 'Jump to label' context menu option if no label can be found
@@ -428,7 +428,7 @@ Compiler.prototype.initEditorActions = function () {
                 // a null file means it was the user's source
                 this.eventHub.emit('editorLinkLine', this.sourceEditorId, source.line, -1, true);
             }
-        }, this)
+        }, this),
     });
 
     this.outputEditor.addAction({
@@ -438,7 +438,7 @@ Compiler.prototype.initEditorActions = function () {
         keybindingContext: null,
         contextMenuGroupId: 'help',
         contextMenuOrder: 1.5,
-        run: _.bind(this.onAsmToolTip, this)
+        run: _.bind(this.onAsmToolTip, this),
     });
 
     this.outputEditor.addAction({
@@ -448,9 +448,9 @@ Compiler.prototype.initEditorActions = function () {
         keybindingContext: null,
         run: _.bind(function () {
             this.eventHub.emit('modifySettings', {
-                colouriseAsm: !this.settings.colouriseAsm
+                colouriseAsm: !this.settings.colouriseAsm,
             });
-        }, this)
+        }, this),
     });
 
 };
@@ -462,7 +462,7 @@ Compiler.prototype.initEditorCommands = function () {
         run: _.bind(function () {
             // eslint-disable-next-line no-console
             console.log(this.assembly);
-        }, this)
+        }, this),
     });
 };
 
@@ -496,7 +496,7 @@ Compiler.prototype.findTools = function (content, tools) {
             tools.push({
                 id: content.componentState.toolId,
                 args: content.componentState.args,
-                stdin: content.componentState.stdin
+                stdin: content.componentState.stdin,
             });
         }
     } else if (content.content) {
@@ -516,7 +516,7 @@ Compiler.prototype.getActiveTools = function (newToolSettings) {
         tools.push({
             id: newToolSettings.toolId,
             args: newToolSettings.args,
-            stdin: newToolSettings.stdin
+            stdin: newToolSettings.stdin,
         });
     }
 
@@ -549,21 +549,21 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
                 opened: this.gccDumpViewOpen,
                 pass: this.gccDumpPassSelected,
                 treeDump: this.treeDumpEnabled,
-                rtlDump: this.rtlDumpEnabled
+                rtlDump: this.rtlDumpEnabled,
             },
             produceOptInfo: this.wantOptInfo,
             produceCfg: this.cfgViewOpen,
-            produceIr: this.irViewOpen
+            produceIr: this.irViewOpen,
         },
         filters: this.getEffectiveFilters(),
         tools: this.getActiveTools(newTools),
-        libraries: []
+        libraries: [],
     };
 
     _.each(this.libsWidget.getLibsInUse(), function (item) {
         options.libraries.push({
             id: item.libId,
-            version: item.versionId
+            version: item.versionId,
         });
     });
 
@@ -572,7 +572,7 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
             source: expanded || '',
             compiler: this.compiler ? this.compiler.id : '',
             options: options,
-            lang: this.currentLangId
+            lang: this.currentLangId,
         };
         if (bypassCache) request.bypassCache = true;
         if (!this.compiler) {
@@ -622,14 +622,14 @@ Compiler.prototype.sendCompile = function (request) {
 Compiler.prototype.setNormalMargin = function () {
     this.outputEditor.updateOptions({
         lineNumbers: true,
-        lineNumbersMinChars: 1
+        lineNumbersMinChars: 1,
     });
 };
 
 Compiler.prototype.setBinaryMargin = function () {
     this.outputEditor.updateOptions({
         lineNumbersMinChars: 6,
-        lineNumbers: _.bind(this.getBinaryForLine, this)
+        lineNumbers: _.bind(this.getBinaryForLine, this),
     });
 };
 
@@ -671,8 +671,8 @@ Compiler.prototype.setAssembly = function (asm) {
                 range: new monaco.Range(line + 1, label.range.startCol,
                     line + 1, label.range.endCol),
                 options: {
-                    inlineClassName: 'asm-label-link'
-                }
+                    inlineClassName: 'asm-label-link',
+                },
             });
         }, this);
     }, this));
@@ -689,12 +689,12 @@ Compiler.prototype.setAssembly = function (asm) {
                         startLineNumber: line + 1,
                         startColumn: 1,
                         endLineNumber: line + 2,
-                        endColumn: 1
+                        endColumn: 1,
                     },
                     id: address,
                     command: {
-                        title: obj.opcodes.join(' ')
-                    }
+                        title: obj.opcodes.join(' '),
+                    },
                 });
             }
         }, this));
@@ -735,13 +735,13 @@ Compiler.prototype.onCompileResponse = function (request, result, cached) {
         eventCategory: 'Compile',
         eventAction: request.compiler,
         eventLabel: request.options.userArguments,
-        eventValue: cached ? 1 : 0
+        eventValue: cached ? 1 : 0,
     });
     ga.proxy('send', {
         hitType: 'timing',
         timingCategory: 'Compile',
         timingVar: request.compiler,
-        timingValue: timeTaken
+        timingValue: timeTaken,
     });
 
     this.labelDefinitions = result.labelDefinitions || {};
@@ -1365,7 +1365,7 @@ Compiler.prototype.updateCompilerInfo = function () {
             this.alertSystem.notify(this.compiler.notification, {
                 group: 'compilerwarning',
                 alertClass: 'notification-info',
-                dismissTime: 5000
+                dismissTime: 5000,
             });
         }
         this.prependOptions.data('content', this.compiler.options);
@@ -1427,7 +1427,7 @@ Compiler.prototype.currentState = function () {
         wantOptInfo: this.wantOptInfo,
         libs: this.libsWidget.get(),
         lang: this.currentLangId,
-        selection: this.selection
+        selection: this.selection,
     };
     this.fontScale.addState(state);
     return state;
@@ -1513,8 +1513,8 @@ Compiler.prototype.onPanesLinkLine = function (compilerId, lineNumber, revealLin
                 options: {
                     isWholeLine: true,
                     linesDecorationsClassName: 'linked-code-decoration-margin',
-                    className: lineClass
-                }
+                    className: lineClass,
+                },
             };
         });
         if (this.linkedFadeTimeoutId !== -1) {
@@ -1537,8 +1537,8 @@ Compiler.prototype.onCompilerSetDecorations = function (id, lineNums, revealLine
                 options: {
                     isWholeLine: true,
                     linesDecorationsClassName: 'linked-code-decoration-margin',
-                    inlineClassName: 'linked-code-decoration-inline'
-                }
+                    inlineClassName: 'linked-code-decoration-inline',
+                },
             };
         });
         this.updateDecorations();
@@ -1552,7 +1552,7 @@ Compiler.prototype.setCompilationOptionsPopover = function (content) {
         template: '<div class="popover' +
             (content ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +
-            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>',
     });
 };
 
@@ -1563,7 +1563,7 @@ Compiler.prototype.setCompilerVersionPopover = function (version) {
         template: '<div class="popover' +
             (version ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +
-            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>',
     });
 };
 
@@ -1582,10 +1582,10 @@ Compiler.prototype.onSettingsChange = function (newSettings) {
     this.outputEditor.updateOptions({
         contextmenu: this.settings.useCustomContextMenu,
         minimap: {
-            enabled: this.settings.showMinimap && !options.embedded
+            enabled: this.settings.showMinimap && !options.embedded,
         },
         fontFamily: this.settings.editorsFFont,
-        fontLigatures: this.settings.editorsFLigatures
+        fontLigatures: this.settings.editorsFLigatures,
     });
 };
 
@@ -1630,7 +1630,7 @@ function getAsmInfo(opcode) {
             error: function (result) {
                 reject(result);
             },
-            cache: true
+            cache: true,
         });
     });
 }
@@ -1685,9 +1685,9 @@ Compiler.prototype.onMouseMove = function (e) {
                 range: currentWord.range,
                 options: {
                     isWholeLine: false, hoverMessage: [{
-                        value: '`' + numericToolTip + '`'
-                    }]
-                }
+                        value: '`' + numericToolTip + '`',
+                    }],
+                },
             };
             this.updateDecorations();
         }
@@ -1713,9 +1713,9 @@ Compiler.prototype.onMouseMove = function (e) {
                             isWholeLine: false,
                             hoverMessage: [{
                                 value: response.tooltip + '\n\nMore information available in the context menu.',
-                                isTrusted: true
-                            }]
-                        }
+                                isTrusted: true,
+                            }],
+                        },
                     };
                     this.updateDecorations();
                 }, this));
@@ -1728,7 +1728,7 @@ Compiler.prototype.onAsmToolTip = function (ed) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenModalPane',
-        eventAction: 'AsmDocs'
+        eventAction: 'AsmDocs',
     });
     if (!this.getEffectiveFilters().intel) return;
     var pos = ed.getPosition();
@@ -1762,7 +1762,7 @@ Compiler.prototype.onAsmToolTip = function (ed) {
             this.alertSystem.notify('This token was not found in the documentation. Sorry!', {
                 group: 'notokenindocs',
                 alertClass: 'notification-error',
-                dismissTime: 3000
+                dismissTime: 3000,
             });
         }
     }, this), _.bind(function (rejection) {
@@ -1770,7 +1770,7 @@ Compiler.prototype.onAsmToolTip = function (ed) {
             .notify('There was an error fetching the documentation for this opcode (' + rejection + ').', {
                 group: 'notokenindocs',
                 alertClass: 'notification-error',
-                dismissTime: 3000
+                dismissTime: 3000,
             });
     }, this));
 };
@@ -1837,7 +1837,7 @@ Compiler.prototype.onLanguageChange = function (editorId, newLangId) {
         // Store the current selected stuff to come back to it later in the same session (Not state stored!)
         this.infoByLang[oldLangId] = {
             compiler: this.compiler && this.compiler.id ? this.compiler.id : options.defaultCompiler[oldLangId],
-            options: this.options
+            options: this.options,
         };
         var info = this.infoByLang[this.currentLangId] || {};
         this.initLangAndCompiler({lang: newLangId, compiler: info.compiler});
@@ -1867,5 +1867,5 @@ Compiler.prototype.updateCompilersSelector = function (info) {
 };
 
 module.exports = {
-    Compiler: Compiler
+    Compiler: Compiler,
 };

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -50,7 +50,7 @@ function Conformance(hub, container, state) {
 
     this.status = {
         allowCompile: false,
-        allowAdd: true
+        allowAdd: true,
     };
     this.stateByLang = {};
 
@@ -62,7 +62,7 @@ function Conformance(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Conformance'
+        eventAction: 'Conformance',
     });
 
     // Dismiss the popover on escape.
@@ -138,7 +138,7 @@ Conformance.prototype.addCompilerSelector = function (config) {
             // Compiler id which is being used
             compilerId: "",
             // Options which are in use
-            options: options.compileOptions[this.langId]
+            options: options.compileOptions[this.langId],
         };
     }
 
@@ -187,7 +187,7 @@ Conformance.prototype.addCompilerSelector = function (config) {
         }),
         items: config.compilerId ? [config.compilerId] : [],
         dropdownParent: 'body',
-        closeAfterSelect: true
+        closeAfterSelect: true,
     }).on('change', _.bind(function (e) {
         onCompilerChange($(e.target).val());
         this.compileChild(newEntry);
@@ -224,7 +224,7 @@ Conformance.prototype.setCompilationOptionsPopover = function (element, content)
         template: '<div class="popover' +
             (content ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +
-            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>',
     });
 };
 
@@ -295,14 +295,14 @@ Conformance.prototype.compileChild = function (child) {
                 filters: {},
                 compilerOptions: {produceAst: false, produceOptInfo: false},
                 libraries: [],
-                skipAsm: true
-            }
+                skipAsm: true,
+            },
         };
 
         _.each(this.libsWidget.getLibsInUse(), function (item) {
             request.options.libraries.push({
                 id: item.libId,
-                version: item.versionId
+                version: item.versionId,
             });
         });
 
@@ -316,7 +316,7 @@ Conformance.prototype.compileChild = function (child) {
                     asm: "",
                     code: -1,
                     stdout: "",
-                    stderr: x.error
+                    stderr: x.error,
                 });
             }, this));
     }, this));
@@ -393,14 +393,14 @@ Conformance.prototype.currentState = function () {
         child = $(child);
         return {
             compilerId: child.find('.compiler-picker').val() || "",
-            options: child.find(".options").val() || ""
+            options: child.find(".options").val() || "",
         };
     });
     return {
         editorid: this.editorId,
         langId: this.langId,
         compilers: compilers,
-        libs: this.libsWidget.get()
+        libs: this.libsWidget.get(),
     };
 };
 
@@ -504,5 +504,5 @@ Conformance.prototype.initFromState = function (state) {
 };
 
 module.exports = {
-    Conformance: Conformance
+    Conformance: Conformance,
 };

--- a/static/panes/diff.js
+++ b/static/panes/diff.js
@@ -106,7 +106,7 @@ function Diff(hub, container, state) {
         fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
         scrollBeyondLastLine: false,
         readOnly: true,
-        language: 'asm'
+        language: 'asm',
     });
 
     this.lhs = new State(state.lhs, monaco.editor.createModel('', 'asm'), state.lhsdifftype || DiffType_ASM);
@@ -123,15 +123,15 @@ function Diff(hub, container, state) {
             { id: DiffType_CompilerStdOut, name: 'Compiler stdout' },
             { id: DiffType_CompilerStdErr, name: 'Compiler stderr' },
             { id: DiffType_ExecStdOut, name: 'Execution stdout' },
-            { id: DiffType_ExecStdErr, name: 'Execution stderr' }
+            { id: DiffType_ExecStdErr, name: 'Execution stderr' },
         ],
         items: [],
         render: {
             option: function (item, escape) {
                 return '<div>' + escape(item.name) + '</div>';
-            }
+            },
         },
-        dropdownParent: 'body'
+        dropdownParent: 'body',
     }).on('change', _.bind(function (e) {
         var target = $(e.target);
         if (target.hasClass('lhsdifftype')) {
@@ -160,9 +160,9 @@ function Diff(hub, container, state) {
                     '<li class="editor">Editor #' + escape(item.editorId) + '</li>' +
                     '<li class="compilerId">' + escape(getItemDisplayTitle(item)) + '</li>' +
                     '</ul></div>';
-            }
+            },
         },
-        dropdownParent: 'body'
+        dropdownParent: 'body',
     }).on('change', _.bind(function (e) {
         var target = $(e.target);
         var compiler = this.compilers[target.val()];
@@ -179,7 +179,7 @@ function Diff(hub, container, state) {
 
     this.selectize = {
         lhs: selectize[0].selectize, rhs: selectize[1].selectize,
-        lhsdifftype: selectizeType[0].selectize, rhsdifftype: selectizeType[1].selectize
+        lhsdifftype: selectizeType[0].selectize, rhsdifftype: selectizeType[1].selectize,
     };
 
     this.initButtons(state);
@@ -190,7 +190,7 @@ function Diff(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Diff'
+        eventAction: 'Diff',
     });
 }
 
@@ -199,7 +199,7 @@ Diff.prototype.resize = function () {
     var topBarHeight = this.topBar.outerHeight(true);
     this.outputEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight
+        height: this.domRoot.height() - topBarHeight,
     });
 };
 
@@ -290,7 +290,7 @@ Diff.prototype.onCompiler = function (id, compiler, options, editorId) {
         name: name,
         options: options,
         editorId: editorId,
-        compiler: compiler
+        compiler: compiler,
     };
     if (!this.lhs.id) {
         this.lhs.compiler = this.compilers[id];
@@ -347,7 +347,7 @@ Diff.prototype.updateState = function () {
         lhs: this.lhs.id,
         rhs: this.rhs.id,
         lhsdifftype: this.lhs.difftype,
-        rhsdifftype: this.rhs.difftype
+        rhsdifftype: this.rhs.difftype,
     };
     this.fontScale.addState(state);
     this.container.setState(state);
@@ -361,10 +361,10 @@ Diff.prototype.onThemeChange = function (newTheme) {
 Diff.prototype.onSettingsChange = function (newSettings) {
     this.outputEditor.updateOptions({
         minimap: {
-            enabled: newSettings.showMinimap
+            enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
-        fontLigatures: newSettings.editorsFLigatures
+        fontLigatures: newSettings.editorsFLigatures,
     });
 };
 
@@ -374,7 +374,7 @@ module.exports = {
         return {
             type: 'component',
             componentName: 'diff',
-            componentState: { lhs: lhs, rhs: rhs }
+            componentState: { lhs: lhs, rhs: rhs },
         };
-    }
+    },
 };

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -97,14 +97,14 @@ function Editor(hub, state, container) {
         quickSuggestions: false,
         fixedOverflowWidgets: true,
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
         folding: true,
         lineNumbersMinChars: 1,
         emptySelectionClipboard: true,
         autoIndent: this.settings.autoIndent ? "advanced" : "none",
         vimInUse: this.settings.useVim,
-        fontLigatures: this.settings.editorsFLigatures
+        fontLigatures: this.settings.editorsFLigatures,
     });
     this.editor.getModel().setEOL(monaco.editor.EndOfLineSequence.LF);
 
@@ -145,7 +145,7 @@ function Editor(hub, state, container) {
         searchField: ['name'],
         options: _.map(usableLanguages, _.identity),
         items: [this.currentLanguage.id],
-        dropdownParent: 'body'
+        dropdownParent: 'body',
     }).on('change', _.bind(function (e) {
         this.onLanguageChange($(e.target).val());
     }, this));
@@ -169,12 +169,12 @@ function Editor(hub, state, container) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Editor'
+        eventAction: 'Editor',
     });
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'LanguageChange',
-        eventAction: this.currentLanguage.id
+        eventAction: this.currentLanguage.id,
     });
 }
 
@@ -189,7 +189,7 @@ Editor.prototype.updateExtraDecorations = function () {
         if (decoration.filter && decoration.filter.indexOf(this.currentLanguage.name.toLowerCase()) < 0) return;
         var match = this.editor.getModel().findNextMatch(decoration.regex, {
             column: 1,
-            lineNumber: 1
+            lineNumber: 1,
         }, true, true, null, false);
         if (match !== this.decorations[decoration.name]) {
             decorationsDirty = true;
@@ -216,7 +216,7 @@ Editor.prototype.updateState = function () {
         id: this.id,
         source: this.getSource(),
         lang: this.currentLanguage.id,
-        selection: this.selection
+        selection: this.selection,
     };
     this.fontScale.addState(state);
     this.container.setState(state);
@@ -562,7 +562,7 @@ Editor.prototype.cleanupSemVer = function (semver) {
 
 Editor.prototype.updateOpenInQuickBench = function () {
     var quickBenchState = {
-        text: this.getSource()
+        text: this.getSource(),
     };
 
     var compilers = this.getCompilerStates();
@@ -652,7 +652,7 @@ Editor.prototype.initEditorActions = function () {
             // This change request is mostly superfluous
             this.maybeEmitChange();
             this.requestCompilation();
-        }, this)
+        }, this),
     });
 
     this.editor.addAction({
@@ -662,15 +662,15 @@ Editor.prototype.initEditorActions = function () {
         keybindingContext: null,
         run: _.bind(function () {
             this.eventHub.emit('modifySettings', {
-                compileOnChange: !this.settings.compileOnChange
+                compileOnChange: !this.settings.compileOnChange,
             });
             this.alertSystem
                 .notify('Compile on change has been toggled ' + (this.settings.compileOnChange ? 'ON' : 'OFF'), {
                     group: "togglecompile",
                     alertClass: this.settings.compileOnChange ? "notification-on" : "notification-off",
-                    dismissTime: 3000
+                    dismissTime: 3000,
                 });
-        }, this)
+        }, this),
     });
 
     this.editor.addAction({
@@ -680,7 +680,7 @@ Editor.prototype.initEditorActions = function () {
         keybindingContext: null,
         contextMenuGroupId: 'help',
         contextMenuOrder: 1.5,
-        run: _.bind(this.formatCurrentText, this)
+        run: _.bind(this.formatCurrentText, this),
     });
 
     this.editor.addAction({
@@ -690,9 +690,9 @@ Editor.prototype.initEditorActions = function () {
         keybindingContext: null,
         run: _.bind(function () {
             this.eventHub.emit('modifySettings', {
-                colouriseAsm: !this.settings.colouriseAsm
+                colouriseAsm: !this.settings.colouriseAsm,
             });
-        }, this)
+        }, this),
     });
 
     this.editor.addAction({
@@ -704,7 +704,7 @@ Editor.prototype.initEditorActions = function () {
         contextMenuOrder: 1.5,
         run: _.bind(function (ed) {
             this.tryPanesLinkLine(ed.getPosition().lineNumber, true);
-        }, this)
+        }, this),
     });
 
     this.isCpp = this.editor.createContextKey('isCpp', true);
@@ -718,7 +718,7 @@ Editor.prototype.initEditorActions = function () {
         contextMenuGroupId: 'help',
         contextMenuOrder: 1.5,
         precondition: 'isCpp',
-        run: _.bind(this.searchOnCppreference, this)
+        run: _.bind(this.searchOnCppreference, this),
     });
 };
 
@@ -746,7 +746,7 @@ Editor.prototype.updateSource = function (newSource) {
     var operation = {
         range: this.editor.getModel().getFullModelRange(),
         forceMoveMarkers: true,
-        text: newSource
+        text: newSource,
     };
     var nullFn = function () {
         return null;
@@ -778,7 +778,7 @@ Editor.prototype.formatCurrentText = function () {
         contentType: 'application/json',  // Sent
         data: JSON.stringify({
             source: previousSource,
-            base: this.settings.formatBase
+            base: this.settings.formatBase,
         }),
         success: _.bind(function (result) {
             if (result.exit === 0) {
@@ -793,7 +793,7 @@ Editor.prototype.formatCurrentText = function () {
                 // Ops, the formatter itself failed!
                 this.alertSystem.notify("We encountered an error formatting your code: " + result.answer, {
                     group: "formatting",
-                    alertClass: "notification-error"
+                    alertClass: "notification-error",
                 });
             }
         }, this),
@@ -810,10 +810,10 @@ Editor.prototype.formatCurrentText = function () {
             error = error || "Unknown error";
             this.alertSystem.notify("We ran into some issues while formatting your code: " + error, {
                 group: "formatting",
-                alertClass: "notification-error"
+                alertClass: "notification-error",
             });
         }, this),
-        cache: true
+        cache: true,
     });
 };
 
@@ -822,12 +822,12 @@ Editor.prototype.resize = function () {
 
     this.editor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight
+        height: this.domRoot.height() - topBarHeight,
     });
     // Only update the options if needed
     if (this.settings.wordWrap) {
         this.editor.updateOptions({
-            wordWrapColumn: this.editor.getLayoutInfo().viewportColumn
+            wordWrapColumn: this.editor.getLayoutInfo().viewportColumn,
         });
     }
 };
@@ -871,12 +871,12 @@ Editor.prototype.onSettingsChange = function (newSettings) {
         quickSuggestions: this.settings.showQuickSuggestions,
         contextmenu: this.settings.useCustomContextMenu,
         minimap: {
-            enabled: this.settings.showMinimap && !options.embedded
+            enabled: this.settings.showMinimap && !options.embedded,
         },
         fontFamily: this.settings.editorsFFont,
         fontLigatures: this.settings.editorsFLigatures,
         wordWrap: this.settings.wordWrap ? 'bounded' : 'off',
-        wordWrapColumn: this.editor.getLayoutInfo().viewportColumn // Ensure the column count is up to date
+        wordWrapColumn: this.editor.getLayoutInfo().viewportColumn, // Ensure the column count is up to date
     });
 
     // Unconditionally send editor changes. The compiler only compiles when needed
@@ -897,7 +897,7 @@ Editor.prototype.onSettingsChange = function (newSettings) {
     if (this.editor.getModel()) {
         this.editor.getModel().updateOptions({
             tabSize: this.settings.tabWidth,
-            insertSpaces: this.settings.useSpaces
+            insertSpaces: this.settings.useSpaces,
         });
     }
 
@@ -996,7 +996,7 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
             startLineNumber: obj.tag.line,
             startColumn: obj.tag.column || 0,
             endLineNumber: obj.tag.line,
-            endColumn: obj.tag.column ? -1 : Infinity
+            endColumn: obj.tag.column ? -1 : Infinity,
         };
     }, this));
     monaco.editor.setModelMarkers(this.editor.getModel(), compilerId, widgets);
@@ -1005,8 +1005,8 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
             range: new monaco.Range(tag.startLineNumber, tag.startColumn, tag.startLineNumber + 1, 1),
             options: {
                 isWholeLine: false,
-                inlineClassName: "error-code"
-            }
+                inlineClassName: "error-code",
+            },
         };
     }, this);
     this.updateDecorations();
@@ -1028,8 +1028,8 @@ Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnNum, reve
             options: {
                 isWholeLine: true,
                 linesDecorationsClassName: 'linked-code-decoration-margin',
-                className: 'linked-code-decoration-line'
-            }
+                className: 'linked-code-decoration-line',
+            },
         }];
 
         if (lineNum > 0 && columnNum !== -1) {
@@ -1037,8 +1037,8 @@ Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnNum, reve
                 range: new monaco.Range(lineNum, columnNum, lineNum, columnNum + 1),
                 options: {
                     isWholeLine: false,
-                    inlineClassName: 'linked-code-decoration-column'
-                }
+                    inlineClassName: 'linked-code-decoration-column',
+                },
             });
         }
 
@@ -1062,8 +1062,8 @@ Editor.prototype.onEditorSetDecoration = function (id, lineNum, reveal) {
             options: {
                 isWholeLine: true,
                 linesDecorationsClassName: 'linked-code-decoration-margin',
-                inlineClassName: 'linked-code-decoration-inline'
-            }
+                inlineClassName: 'linked-code-decoration-inline',
+            },
         }];
         this.updateDecorations();
     }
@@ -1125,7 +1125,7 @@ Editor.prototype.onLanguageChange = function (newLangId) {
             ga.proxy('send', {
                 hitType: 'event',
                 eventCategory: 'LanguageChange',
-                eventAction: newLangId
+                eventAction: newLangId,
             });
         }
         this.waitingForLanguage = false;
@@ -1152,5 +1152,5 @@ Editor.prototype.close = function () {
 };
 
 module.exports = {
-    Editor: Editor
+    Editor: Editor,
 };

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -46,7 +46,7 @@ function makeAnsiToHtml(color) {
         fg: color ? color : '#333',
         bg: '#f5f5f5',
         stream: true,
-        escapeXML: true
+        escapeXML: true,
     });
 }
 
@@ -94,14 +94,14 @@ function Executor(hub, container, state) {
         options: _.map(this.getCurrentLangCompilers(), _.identity),
         items: this.compiler ? [this.compiler.id] : [],
         dropdownParent: 'body',
-        closeAfterSelect: true
+        closeAfterSelect: true,
     }).on('change', _.bind(function (e) {
         var val = $(e.target).val();
         if (val) {
             ga.proxy('send', {
                 hitType: 'event',
                 eventCategory: 'SelectCompiler',
-                eventAction: val
+                eventAction: val,
             });
             this.onCompilerChange(val);
         }
@@ -118,7 +118,7 @@ function Executor(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Executor'
+        eventAction: 'Executor',
     });
 }
 
@@ -188,20 +188,20 @@ Executor.prototype.compile = function (bypassCache) {
         userArguments: this.options,
         executeParameters: {
             args: this.executionArguments,
-            stdin: this.executionStdin
+            stdin: this.executionStdin,
         },
         compilerOptions: {
-            executorRequest: true
+            executorRequest: true,
         },
         filters: {execute: true},
         tools: [],
-        libraries: []
+        libraries: [],
     };
 
     _.each(this.libsWidget.getLibsInUse(), function (item) {
         options.libraries.push({
             id: item.libId,
-            version: item.versionId
+            version: item.versionId,
         });
     });
 
@@ -210,7 +210,7 @@ Executor.prototype.compile = function (bypassCache) {
             source: expanded || '',
             compiler: this.compiler ? this.compiler.id : '',
             options: options,
-            lang: this.currentLangId
+            lang: this.currentLangId,
         };
         if (bypassCache) request.bypassCache = true;
         if (!this.compiler) {
@@ -291,13 +291,13 @@ Executor.prototype.onCompileResponse = function (request, result, cached) {
         eventCategory: 'Compile',
         eventAction: request.compiler,
         eventLabel: request.options.userArguments,
-        eventValue: cached ? 1 : 0
+        eventValue: cached ? 1 : 0,
     });
     ga.proxy('send', {
         hitType: 'timing',
         timingCategory: 'Compile',
         timingVar: request.compiler,
-        timingValue: timeTaken
+        timingValue: timeTaken,
     });
 
     this.clearPreviousOutput();
@@ -599,7 +599,7 @@ Executor.prototype.initCallbacks = function () {
 
     if (MutationObserver !== undefined) {
         new MutationObserver(_.bind(this.resize, this)).observe(this.execStdinField[0], {
-            attributes: true, attributeFilter: ["style"]
+            attributes: true, attributeFilter: ["style"],
         });
     }
 };
@@ -635,7 +635,7 @@ Executor.prototype.updateCompilerInfo = function () {
             this.alertSystem.notify(this.compiler.notification, {
                 group: 'compilerwarning',
                 alertClass: 'notification-info',
-                dismissTime: 5000
+                dismissTime: 5000,
             });
         }
         this.prependOptions.data('content', this.compiler.options);
@@ -685,7 +685,7 @@ Executor.prototype.currentState = function () {
         compilationPanelShown: !this.panelCompilation.hasClass('d-none'),
         compilerOutShown: !this.compilerOutputSection.hasClass('d-none'),
         argsPanelShown: !this.panelArgs.hasClass('d-none'),
-        stdinPanelShown: !this.panelStdin.hasClass('d-none')
+        stdinPanelShown: !this.panelStdin.hasClass('d-none'),
     };
     this.fontScale.addState(state);
     return state;
@@ -726,7 +726,7 @@ Executor.prototype.setCompilationOptionsPopover = function (content) {
         template: '<div class="popover' +
             (content ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +
-            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>',
     });
 };
 
@@ -737,7 +737,7 @@ Executor.prototype.setCompilerVersionPopover = function (version) {
         template: '<div class="popover' +
             (version ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +
-            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<h3 class="popover-header"></h3><div class="popover-body"></div></div>',
     });
 };
 
@@ -790,7 +790,7 @@ Executor.prototype.onLanguageChange = function (editorId, newLangId) {
             compiler: this.compiler && this.compiler.id ? this.compiler.id : options.defaultCompiler[oldLangId],
             options: this.options,
             execArgs: this.executionArguments,
-            execStdin: this.executionStdin
+            execStdin: this.executionStdin,
         };
         var info = this.infoByLang[this.currentLangId] || {};
         this.initLangAndCompiler({lang: newLangId, compiler: info.compiler});
@@ -823,5 +823,5 @@ Executor.prototype.updateCompilersSelector = function (info) {
 };
 
 module.exports = {
-    Executor: Executor
+    Executor: Executor,
 };

--- a/static/panes/gccdump-view.js
+++ b/static/panes/gccdump-view.js
@@ -49,10 +49,10 @@ function GccDump(hub, container, state) {
         fixedOverflowWidgets: true,
         fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
         lineNumbersMinChars: 3,
-        dropdownParent: 'body'
+        dropdownParent: 'body',
     });
 
     this.initButtons(state);
@@ -63,7 +63,7 @@ function GccDump(hub, container, state) {
         labelField: 'name',
         searchField: ['name'],
         options: [],
-        items: []
+        items: [],
     });
 
     this.selectize = selectize[0].selectize;
@@ -101,7 +101,7 @@ function GccDump(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'GccDump'
+        eventAction: 'GccDump',
     });
 }
 
@@ -166,7 +166,7 @@ GccDump.prototype.resize = function () {
     var topBarHeight = this.topBar.outerHeight(true);
     this.gccDumpEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight
+        height: this.domRoot.height() - topBarHeight,
     });
 };
 
@@ -187,7 +187,7 @@ GccDump.prototype.updatePass = function (filters, selectize, gccDumpOutput) {
 
     _.each(passes, function (p) {
         selectize.addOption({
-            name: p
+            name: p,
         });
     }, this);
 
@@ -305,7 +305,7 @@ GccDump.prototype.currentState = function () {
         selectedPass: this.state.selectedPass,
         treeDump: filters.treeDump,
         rtlDump: filters.rtlDump,
-        selection: this.selection
+        selection: this.selection,
     };
 };
 
@@ -313,10 +313,10 @@ GccDump.prototype.onSettingsChange = function (newSettings) {
     this.gccDumpEditor.updateOptions({
         contextmenu: newSettings.useCustomContextMenu,
         minimap: {
-            enabled: newSettings.showMinimap
+            enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
-        fontLigatures: newSettings.editorsFLigatures
+        fontLigatures: newSettings.editorsFLigatures,
     });
 };
 
@@ -334,5 +334,5 @@ GccDump.prototype.close = function () {
 };
 
 module.exports = {
-    GccDump: GccDump
+    GccDump: GccDump,
 };

--- a/static/panes/ir-view.js
+++ b/static/panes/ir-view.js
@@ -51,9 +51,9 @@ function Ir(hub, container, state) {
         quickSuggestions: false,
         fixedOverflowWidgets: true,
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
-        lineNumbersMinChars: 3
+        lineNumbersMinChars: 3,
     });
 
     this._compilerid = state.id;
@@ -82,7 +82,7 @@ function Ir(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Ir'
+        eventAction: 'Ir',
     });
 }
 
@@ -101,7 +101,7 @@ Ir.prototype.initEditorActions = function () {
                 // a null file means it was the user's source
                 this.eventHub.emit('editorLinkLine', this._editorid, source.line, -1, true);
             }
-        }, this)
+        }, this),
     });
 };
 
@@ -146,7 +146,7 @@ Ir.prototype.resize = function () {
     var topBarHeight = this.topBar.outerHeight(true);
     this.irEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight
+        height: this.domRoot.height() - topBarHeight,
     });
 };
 
@@ -230,7 +230,7 @@ Ir.prototype.currentState = function () {
     var state = {
         id: this._compilerid,
         editorid: this._editorid,
-        selection: this.selection
+        selection: this.selection,
     };
     this.fontScale.addState(state);
     return state;
@@ -252,10 +252,10 @@ Ir.prototype.onSettingsChange = function (newSettings) {
     this.irEditor.updateOptions({
         contextmenu: newSettings.useCustomContextMenu,
         minimap: {
-            enabled: newSettings.showMinimap
+            enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
-        fontLigatures: newSettings.editorsFLigatures
+        fontLigatures: newSettings.editorsFLigatures,
     });
 };
 
@@ -308,8 +308,8 @@ Ir.prototype.onPanesLinkLine = function (compilerId, lineNumber, revealLine, sen
                 options: {
                     isWholeLine: true,
                     linesDecorationsClassName: 'linked-code-decoration-margin',
-                    className: lineClass
-                }
+                    className: lineClass,
+                },
             };
         });
         if (this.linkedFadeTimeoutId !== -1) {
@@ -330,5 +330,5 @@ Ir.prototype.close = function () {
 };
 
 module.exports = {
-    Ir: Ir
+    Ir: Ir,
 };

--- a/static/panes/opt-view.js
+++ b/static/panes/opt-view.js
@@ -50,9 +50,9 @@ function Opt(hub, container, state) {
         fixedOverflowWidgets: true,
         fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
-        lineNumbersMinChars: 1
+        lineNumbersMinChars: 1,
     });
 
     this._compilerid = state.id;
@@ -75,7 +75,7 @@ function Opt(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Opt'
+        eventAction: 'Opt',
     });
 }
 
@@ -141,7 +141,7 @@ Opt.prototype.setTitle = function () {
 Opt.prototype.getDisplayableOpt = function (optResult) {
     return {
         value: "**" + optResult.optType + "** - " + optResult.displayString,
-        isTrusted: false
+        isTrusted: false,
     };
 };
 
@@ -173,8 +173,8 @@ Opt.prototype.showOptResults = function (results) {
                 isWholeLine: true,
                 glyphMarginClassName: "opt-decoration." + className.toLowerCase(),
                 hoverMessage: contents,
-                glyphMarginHoverMessage: contents
-            }
+                glyphMarginHoverMessage: contents,
+            },
         });
     }, this);
 
@@ -196,7 +196,7 @@ Opt.prototype.resize = function () {
     var topBarHeight = this.topBar.outerHeight(true);
     this.optEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight
+        height: this.domRoot.height() - topBarHeight,
     });
 };
 
@@ -208,7 +208,7 @@ Opt.prototype.currentState = function () {
     var state = {
         id: this._compilerid,
         editorid: this._editorid,
-        selection: this.selection
+        selection: this.selection,
     };
     this.fontScale.addState(state);
     return state;
@@ -235,10 +235,10 @@ Opt.prototype.onSettingsChange = function (newSettings) {
     this.optEditor.updateOptions({
         contextmenu: newSettings.useCustomContextMenu,
         minimap: {
-            enabled: newSettings.showMinimap
+            enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
-        fontLigatures: newSettings.editorsFLigatures
+        fontLigatures: newSettings.editorsFLigatures,
     });
 };
 
@@ -250,5 +250,5 @@ Opt.prototype.onDidChangeCursorSelection = function (e) {
 };
 
 module.exports = {
-    Opt: Opt
+    Opt: Opt,
 };

--- a/static/panes/output.js
+++ b/static/panes/output.js
@@ -36,7 +36,7 @@ function makeAnsiToHtml(color) {
         fg: color ? color : '#333',
         bg: '#f5f5f5',
         stream: true,
-        escapeXML: true
+        escapeXML: true,
     });
 }
 
@@ -65,7 +65,7 @@ function Output(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Output'
+        eventAction: 'Output',
     });
 }
 
@@ -109,7 +109,7 @@ Output.prototype.currentState = function () {
     var state = {
         compiler: this.compilerId,
         editor: this.editorId,
-        wrap: options.wrap
+        wrap: options.wrap,
     };
     this.fontScale.addState(state);
     return state;
@@ -235,5 +235,5 @@ Output.prototype.setCompileStatus = function (isCompiling) {
 };
 
 module.exports = {
-    Output: Output
+    Output: Output,
 };

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -38,7 +38,7 @@ function makeAnsiToHtml(color) {
         fg: color ? color : '#333',
         bg: '#f5f5f5',
         stream: true,
-        escapeXML: true
+        escapeXML: true,
     });
 }
 
@@ -70,10 +70,10 @@ function Tool(hub, container, state) {
         glyphMargin: true,
         fixedOverflowWidgets: true,
         minimap: {
-            maxColumn: 80
+            maxColumn: 80,
         },
         lineNumbersMinChars: 5,
-        renderIndentGuides: false
+        renderIndentGuides: false,
     });
 
     this.fontScale = new FontScale(this.domRoot, state, ".content");
@@ -94,7 +94,7 @@ function Tool(hub, container, state) {
     ga.proxy('send', {
         hitType: 'event',
         eventCategory: 'OpenViewPane',
-        eventAction: 'Tool'
+        eventAction: 'Tool',
     });
 
     this.eventHub.emit('toolOpened', this.compilerId, this.currentState());
@@ -120,7 +120,7 @@ Tool.prototype.initCallbacks = function () {
 
     if (MutationObserver !== undefined) {
         new MutationObserver(_.bind(this.resize, this)).observe(this.stdinField[0], {
-            attributes: true, attributeFilter: ["style"]
+            attributes: true, attributeFilter: ["style"],
         });
     }
 };
@@ -129,10 +129,10 @@ Tool.prototype.onSettingsChange = function (newSettings) {
     this.outputEditor.updateOptions({
         contextmenu: newSettings.useCustomContextMenu,
         minimap: {
-            enabled: newSettings.showMinimap
+            enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
-        fontLigatures: newSettings.editorsFLigatures
+        fontLigatures: newSettings.editorsFLigatures,
     });
 };
 
@@ -195,7 +195,7 @@ Tool.prototype.resize = function () {
 
     this.outputEditor.layout({
         width: this.domRoot.width(),
-        height: this.domRoot.height() - barsHeight
+        height: this.domRoot.height() - barsHeight,
     });
 
     this.plainContentRoot.height(this.domRoot.height() - barsHeight);
@@ -263,7 +263,7 @@ Tool.prototype.currentState = function () {
         args: this.getInputArgs(),
         stdin: this.getInputStdin(),
         stdinPanelShown: !this.panelStdin.hasClass('d-none'),
-        argsPanelShow: !this.panelArgs.hasClass('d-none')
+        argsPanelShow: !this.panelArgs.hasClass('d-none'),
     };
     this.fontScale.addState(state);
     return state;
@@ -390,7 +390,7 @@ Tool.prototype.setEditorContent = function (content) {
 Tool.prototype.setNormalContent = function () {
     this.outputEditor.updateOptions({
         lineNumbers: true,
-        codeLens: false
+        codeLens: false,
     });
     if (this.codeLensProvider) {
         this.codeLensProvider.dispose();
@@ -419,5 +419,5 @@ Tool.prototype.close = function () {
 };
 
 module.exports = {
-    Tool: Tool
+    Tool: Tool,
 };

--- a/static/presentation.js
+++ b/static/presentation.js
@@ -117,5 +117,5 @@ module.exports = {
     next: next,
     prev: prev,
     getCurrentSlide: getCurrentSlide,
-    setCurrentSlide: setCurrentSlide
+    setCurrentSlide: setCurrentSlide,
 };

--- a/static/settings.js
+++ b/static/settings.js
@@ -158,7 +158,7 @@ function setupSettings(root, settings, onChange, subLangId) {
         min: 250,
         formatter: function (x) {
             return (x / 1000.0).toFixed(2) + "s";
-        }
+        },
     });
     add(root.find('.enableCommunityAds'), 'enableCommunityAds', true, Checkbox);
     add(root.find('.hoverShowSource'), 'hoverShowSource', true, Checkbox);

--- a/static/sharing.js
+++ b/static/sharing.js
@@ -39,7 +39,7 @@ var shareServices = {
             return "https://twitter.com/intent/tweet?text=" +
                 encodeURIComponent(title) + '&url=' + encodeURIComponent(url) + '&via=CompileExplore';
         },
-        text: 'Tweet'
+        text: 'Tweet',
     },
     reddit: {
         embedValid: false,
@@ -49,8 +49,8 @@ var shareServices = {
             return 'http://www.reddit.com/submit?url=' +
                 encodeURIComponent(url) + '&title=' + encodeURIComponent(title);
         },
-        text: 'Share on Reddit'
-    }
+        text: 'Share on Reddit',
+    },
 };
 
 function configFromEmbedded(embeddedUrl) {
@@ -74,10 +74,10 @@ function configFromEmbedded(embeddedUrl) {
                     type: 'row',
                     content: [
                         Components.getEditorWith(1, params.source, filters),
-                        Components.getCompilerWith(1, filters, params.options, params.compiler)
-                    ]
-                }
-            ]
+                        Components.getCompilerWith(1, filters, params.options, params.compiler),
+                    ],
+                },
+            ],
         };
     } else {
         return url.deserialiseState(embeddedUrl);
@@ -125,14 +125,14 @@ function initShareButton(getLink, layout, noteNewState) {
         html: true,
         placement: 'bottom',
         trigger: 'manual',
-        sanitize: false
+        sanitize: false,
     }).click(function () {
         getLink.popover('toggle');
     }).on('inserted.bs.popover', function () {
         ga.proxy('send', {
             hitType: 'event',
             eventCategory: 'OpenModalPane',
-            eventAction: 'Sharing'
+            eventAction: 'Sharing',
         });
         var popoverElement = $($(this).data('bs.popover').tip);
         var socialSharingElements = popoverElement.find('.socialsharing');
@@ -201,7 +201,7 @@ function initShareButton(getLink, layout, noteNewState) {
                         urls[cacheLinkId] = {
                             updateState: updateState,
                             extra: extra,
-                            url: newUrl
+                            url: newUrl,
                         };
                         onUpdate(socialSharing, config, currentBind, urls[cacheLinkId]);
                     }
@@ -290,7 +290,7 @@ function getShortLink(config, root, done) {
     var data = JSON.stringify({
         config: useExternalShortener
             ? url.serialiseState(config)
-            : config
+            : config,
     });
     $.ajax({
         type: 'POST',
@@ -306,7 +306,7 @@ function getShortLink(config, root, done) {
             // Notify the user that we ran into trouble?
             done(err.statusText, null, false);
         }, this),
-        cache: true
+        cache: true,
     });
 }
 
@@ -335,5 +335,5 @@ function getLinks(config, currentBind, done) {
 
 module.exports = {
     initShareButton: initShareButton,
-    configFromEmbedded: configFromEmbedded
+    configFromEmbedded: configFromEmbedded,
 };

--- a/static/themes.js
+++ b/static/themes.js
@@ -31,15 +31,15 @@ var themes = {
         id: "default",
         name: "Default",
         "main-color": "#f2f2f2",
-        monaco: "vs" // Optional field
+        monaco: "vs", // Optional field
     },
     dark: {
         path: "dark",
         id: "dark",
         name: "Dark",
         "main-color": "#333333",
-        monaco: "vs-dark"
-    }
+        monaco: "vs-dark",
+    },
 };
 
 function Themer(eventHub, initialSettings) {
@@ -73,5 +73,5 @@ function Themer(eventHub, initialSettings) {
 
 module.exports = {
     themes: themes,
-    Themer: Themer
+    Themer: Themer,
 };

--- a/static/toggles.js
+++ b/static/toggles.js
@@ -43,11 +43,11 @@ function Togglesv2(root, state) {
             bind = $button.data('bind'),
             settings = {
                 on: {
-                    icon: 'far fa-check-square'
+                    icon: 'far fa-check-square',
                 },
                 off: {
-                    icon: 'far fa-square'
-                }
+                    icon: 'far fa-square',
+                },
             };
 
         // Event Handlers

--- a/static/url.js
+++ b/static/url.js
@@ -119,5 +119,5 @@ module.exports = {
     deserialiseState: deserialiseState,
     serialiseState: serialiseState,
     unrisonify: unrisonify,
-    risonify: risonify
+    risonify: risonify,
 };


### PR DESCRIPTION
This is more of an RFC than anything else - just interested in seeing opinions.

The rational here is to make git diffs less noisy when appending something to the end of an array or object literal.


This shouldn't introduce any compatibility issues in browsers, as its been supported for objects/arrays since almost forever:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas