### PR TITLE
Allow changing the detail level of GCC dumps in TREE and RTL view

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -476,11 +476,49 @@ class BaseCompiler {
         const addOpts = [];
         /* if not defined, consider it true */
 
+        // Build dump options to append to the end of the -fdump command-line flag.
+        // GCC accepts these options as a list of '-' separated names that may
+        // appear in any order.
+        var flags = '';
+        if (gccDumpOptions.dumpFlags.address !== false) {
+            flags += '-address';
+        }
+        if (gccDumpOptions.dumpFlags.slim !== false) {
+            flags += '-slim';
+        }
+        if (gccDumpOptions.dumpFlags.raw !== false) {
+            flags += '-raw';
+        }
+        if (gccDumpOptions.dumpFlags.details !== false) {
+            flags += '-details';
+        }
+        if (gccDumpOptions.dumpFlags.stats !== false) {
+            flags += '-stats';
+        }
+        if (gccDumpOptions.dumpFlags.blocks !== false) {
+            flags += '-blocks';
+        }
+        if (gccDumpOptions.dumpFlags.vops !== false) {
+            flags += '-vops';
+        }
+        if (gccDumpOptions.dumpFlags.lineno !== false) {
+            flags += '-lineno';
+        }
+        if (gccDumpOptions.dumpFlags.uid !== false) {
+            flags += '-uid';
+        }
+        if (gccDumpOptions.dumpFlags.all !== false) {
+            flags += '-all';
+        }
+
         if (gccDumpOptions.treeDump !== false) {
-            addOpts.push('-fdump-tree-all');
+            addOpts.push('-fdump-tree-all' + flags);
         }
         if (gccDumpOptions.rtlDump !== false) {
-            addOpts.push('-fdump-rtl-all');
+            addOpts.push('-fdump-rtl-all' + flags);
+        }
+        if (gccDumpOptions.ipaDump !== false) {
+            addOpts.push('-fdump-ipa-all' + flags);
         }
 
         const newOptions = options.concat(addOpts);
@@ -979,7 +1017,7 @@ class BaseCompiler {
         const rootDir = path.dirname(result.inputFilename);
         const allFiles = await fs.readdir(rootDir);
 
-        if (opts.treeDump === false && opts.rtlDump === false) {
+        if (opts.treeDump === false && opts.rtlDump === false && opts.ipaDump === false) {
             return {
                 all: [],
                 selectedPass: '',

--- a/static/components.js
+++ b/static/components.js
@@ -153,6 +153,17 @@ module.exports = {
         if (gccDumpOutput) {
             ret.treeDump = gccDumpOutput.treeDump;
             ret.rtlDump = gccDumpOutput.rtlDump;
+            ret.ipaDump = gccDumpOutput.ipaDump;
+            ret.addressOption = gccDumpOutput.addressOption;
+            ret.slimOption = gccDumpOutput.slimOption;
+            ret.rawOption = gccDumpOutput.rawOption;
+            ret.detailsOption = gccDumpOutput.detailsOption;
+            ret.statsOption = gccDumpOutput.statsOption;
+            ret.blocksOption = gccDumpOutput.blocksOption;
+            ret.vopsOption = gccDumpOutput.vopsOption;
+            ret.linenoOption = gccDumpOutput.linenoOption;
+            ret.uidOption = gccDumpOutput.uidOption;
+            ret.allOption = gccDumpOutput.allOption;
             ret.selectedPass = gccDumpOutput.selectedPass;
         }
         return ret;

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -550,6 +550,8 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
                 pass: this.gccDumpPassSelected,
                 treeDump: this.treeDumpEnabled,
                 rtlDump: this.rtlDumpEnabled,
+                ipaDump: this.ipaDumpEnabled,
+                dumpFlags: this.dumpFlags,
             },
             produceOptInfo: this.wantOptInfo,
             produceCfg: this.cfgViewOpen,
@@ -914,6 +916,19 @@ Compiler.prototype.onGccDumpFiltersChanged = function (id, filters, reqCompile) 
     if (this.id === id) {
         this.treeDumpEnabled = (filters.treeDump !== false);
         this.rtlDumpEnabled = (filters.rtlDump !== false);
+        this.ipaDumpEnabled = (filters.ipaDump !== false);
+        this.dumpFlags = {
+            address: filters.addressOption !== false,
+            slim: filters.slimOption !== false,
+            raw: filters.rawOption !== false,
+            details: filters.detailsOption !== false,
+            stats: filters.statsOption !== false,
+            blocks: filters.blocksOption !== false,
+            vops: filters.vopsOption !== false,
+            lineno: filters.linenoOption !== false,
+            uid: filters.uidOption !== false,
+            all: filters.allOption !== false,
+        };
 
         if (reqCompile) {
             this.compile();
@@ -946,6 +961,8 @@ Compiler.prototype.onGccDumpViewClosed = function (id) {
         delete this.gccDumpPassSelected;
         delete this.treeDumpEnabled;
         delete this.rtlDumpEnabled;
+        delete this.ipaDumpEnabled;
+        delete this.dumpFlags;
     }
 };
 

--- a/static/panes/gccdump-view.js
+++ b/static/panes/gccdump-view.js
@@ -92,6 +92,7 @@ function GccDump(hub, container, state) {
 
     this.eventHub.emit('gccDumpFiltersChanged', this.state._compilerid, this.getEffectiveFilters(), false);
 
+    this.updateButtons();
     this.saveState();
     this.setTitle();
 
@@ -111,6 +112,45 @@ GccDump.prototype.initButtons = function (state) {
 
     this.topBar = this.domRoot.find('.top-bar');
     this.dumpFiltersButtons = this.domRoot.find('.dump-filters .btn');
+
+    this.dumpTreesButton = this.domRoot.find("[data-bind='treeDump']");
+    this.dumpTreesTitle = this.dumpTreesButton.prop('title');
+
+    this.dumpRtlButton = this.domRoot.find("[data-bind='rtlDump']");
+    this.dumpRtlTitle = this.dumpRtlButton.prop('title');
+
+    this.dumpIpaButton = this.domRoot.find("[data-bind='ipaDump']");
+    this.dumpIpaTitle = this.dumpIpaButton.prop('title');
+
+    this.optionAddressButton = this.domRoot.find("[data-bind='addressOption']");
+    this.optionAddressTitle = this.optionAddressButton.prop('title');
+
+    this.optionSlimButton = this.domRoot.find("[data-bind='slimOption']");
+    this.optionSlimTitle = this.optionSlimButton.prop('title');
+
+    this.optionRawButton = this.domRoot.find("[data-bind='rawOption']");
+    this.optionRawTitle = this.optionRawButton.prop('title');
+
+    this.optionDetailsButton = this.domRoot.find("[data-bind='detailsOption']");
+    this.optionDetailsTitle = this.optionDetailsButton.prop('title');
+
+    this.optionStatsButton = this.domRoot.find("[data-bind='statsOption']");
+    this.optionStatsTitle = this.optionStatsButton.prop('title');
+
+    this.optionBlocksButton = this.domRoot.find("[data-bind='blocksOption']");
+    this.optionBlocksTitle = this.optionBlocksButton.prop('title');
+
+    this.optionVopsButton = this.domRoot.find("[data-bind='vopsOption']");
+    this.optionVopsTitle = this.optionVopsButton.prop('title');
+
+    this.optionLinenoButton = this.domRoot.find("[data-bind='linenoOption']");
+    this.optionLinenoTitle = this.optionLinenoButton.prop('title');
+
+    this.optionUidButton = this.domRoot.find("[data-bind='uidOption']");
+    this.optionUidTitle = this.optionUidButton.prop('title');
+
+    this.optionAllButton = this.domRoot.find("[data-bind='allOption']");
+    this.optionAllTitle = this.optionAllButton.prop('title');
 };
 
 GccDump.prototype.initCallbacks = function () {
@@ -136,6 +176,25 @@ GccDump.prototype.initCallbacks = function () {
     this.gccDumpEditor.onDidChangeCursorSelection(_.bind(function (e) {
         this.cursorSelectionThrottledFunction(e);
     }, this));
+};
+
+GccDump.prototype.updateButtons = function () {
+    var formatButtonTitle = function (button, title) {
+        button.prop('title', '[' + (button.hasClass('active') ? 'ON' : 'OFF') + '] ' + title);
+    };
+    formatButtonTitle(this.dumpTreesButton, this.dumpTreesTitle);
+    formatButtonTitle(this.dumpRtlButton, this.dumpRtlTitle);
+    formatButtonTitle(this.dumpIpaButton, this.dumpIpaTitle);
+    formatButtonTitle(this.optionAddressButton, this.optionAddressTitle);
+    formatButtonTitle(this.optionSlimButton, this.optionSlimTitle);
+    formatButtonTitle(this.optionRawButton, this.optionRawTitle);
+    formatButtonTitle(this.optionDetailsButton, this.optionDetailsTitle);
+    formatButtonTitle(this.optionStatsButton, this.optionStatsTitle);
+    formatButtonTitle(this.optionBlocksButton, this.optionBlocksTitle);
+    formatButtonTitle(this.optionVopsButton, this.optionVopsTitle);
+    formatButtonTitle(this.optionLinenoButton, this.optionLinenoTitle);
+    formatButtonTitle(this.optionUidButton, this.optionUidTitle);
+    formatButtonTitle(this.optionAllButton, this.optionAllTitle);
 };
 
 // Disable view's menu when invalid compiler has been
@@ -285,6 +344,7 @@ GccDump.prototype.getEffectiveFilters = function () {
 
 GccDump.prototype.onFilterChange = function () {
     this.saveState();
+    this.updateButtons();
 
     if (this.inhibitPassSelect !== true) {
         this.eventHub.emit('gccDumpFiltersChanged', this.state._compilerid, this.getEffectiveFilters(), true);
@@ -305,6 +365,17 @@ GccDump.prototype.currentState = function () {
         selectedPass: this.state.selectedPass,
         treeDump: filters.treeDump,
         rtlDump: filters.rtlDump,
+        ipaDump: filters.ipaDump,
+        addressOption: filters.addressOption,
+        slimOption: filters.slimOption,
+        rawOption: filters.rawOption,
+        detailsOption: filters.detailsOption,
+        statsOption: filters.statsOption,
+        blocksOption: filters.blocksOption,
+        vopsOption: filters.vopsOption,
+        linenoOption: filters.linenoOption,
+        uidOption: filters.uidOption,
+        allOption: filters.allOption,
         selection: this.selection,
     };
 };

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -294,14 +294,68 @@
       .btn-group.btn-group-sm(role="group")
         select.gccdump-pass-picker(placeholder="Select a pass...")
       .btn-group.btn-group-sm.dump-filters
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active(type="button" title="Show Tree pass" data-bind="treeDump" aria-pressed="true")
-            span Tree pass
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active(type="button" title="Show RTL pass" data-bind="rtlDump" aria-pressed="true")
-            span RTL pass
-          input.d-none(type="checkbox" checked=true)
+        button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Dump passes" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Available dump passes")
+          span.fas.fa-compass
+          span.hideable &nbsp;Passes
+        .dropdown-menu
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Show Tree passes" data-bind="treeDump" aria-pressed="true")
+              span Tree pass
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Show RTL passes" data-bind="rtlDump" aria-pressed="true")
+              span RTL pass
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Show IPA passes" data-bind="ipaDump" aria-pressed="false")
+              span IPA pass
+            input.d-none(type="checkbox")
+      .btn-group.btn-group-sm.dump-filters
+        button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Dump pass options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Control the details of the dump")
+          span.fas.fa-microchip
+          span.hideable &nbsp;Options
+        .dropdown-menu
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Print raw representation of the tree" data-bind="rawOption" aria-pressed="false")
+              span Raw Dump
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Print condensed intermediate representations" data-bind="slimOption" aria-pressed="false")
+              span Slim Dump
+            input.d-none(type="checkbox")
+          div.dropdown-divider
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Turn on all options (except raw, slim, and lineno)" data-bind="allOption" aria-pressed="false")
+              span All Options
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable printing the address of each tree node" data-bind="addressOption" aria-pressed="true")
+              span Addresses
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable showing basic block boundaries (disabled in raw dumps)" data-bind="blocksOption" aria-pressed="false")
+              span Basic Blocks
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable showing line numbers" data-bind="linenoOption" aria-pressed="false")
+              span Line Numbers
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable more detailed dumps (not honored by every dump option)" data-bind="detailsOption" aria-pressed="false")
+              span Pass Details
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable dumping statistics (not honored by every dump option)" data-bind="statsOption" aria-pressed="false")
+              span Pass Stats
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable showing variable UIDs" data-bind="uidOption" aria-pressed="false")
+              span Unique IDs
+            input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Enable showing virtual operands" data-bind="vopsOption" aria-pressed="false")
+              span Virtual Operands
+            input.d-none(type="checkbox")
     .monaco-placeholder
 
   #cfg


### PR DESCRIPTION
1. This Implements all options that are common for all versions of GCC between 4.0 and 10.2.
These are available in a "Options" drop-down menu on the GCC Tree Viewer pane.
   - address
   - slim
   - raw
   - details
   - stats
   - blocks
   - vops
   - lineno
   - uid
   - all

2. Dump passes have been moved into a drop-down menu "Passes" to keep the row tidy.

3. Add inter-procedural analysis dumps to GCC Tree Viewer.  The option -fdump-ipa-all has been around since GCC 4.0, though leaving it default unchecked in the UI.

4. Adds [ON] or [OFF] to the titles of all filter buttons by implementing GccDump.prototype.updateButtons.

Icons have been half randomly chosen.  For the Passes drop-down have used [fa-compass](https://fontawesome.com/v4.7.0/icon/compass), and for Options [fa-microchip](https://fontawesome.com/v4.7.0/icon/microchip).  If anyone has any better suggestions, I'm all ears.

Similarly, this lacks any tests, so if there's any suggestions on how best to add then, will have a look if it might be possible to add later to this pull.

Fixes #2130