### PR TITLE
Filter compilers in execution panel

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -284,11 +284,13 @@ group.armclang32.groupName=Arm 32-bit clang
 group.armclang32.compilers=armv7-clang-9:armv7-clang-10:armv7-clang-trunk
 group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
+group.armclang32.supportsExecute=false
 
 group.armclang64.groupName=Arm 64-bit clang
 group.armclang64.compilers=armv8-clang-9:armv8-clang-10:armv8-clang-trunk:armv8.5-clang-trunk
 group.armclang64.isSemVer=true
 group.armclang64.compilerType=clang
+group.armclang64.supportsExecute=false
 
 compiler.armv7-clang-10.name=armv7-a clang 10.0.0
 compiler.armv7-clang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -107,6 +107,8 @@ group.cgcc-classic.compilers=cg127
 group.cgcc-classic.groupName=GCC x86
 group.cgcc-classic.isSemVer=true
 group.cgcc-classic.baseName=x86 gcc
+group.cgcc-classic.supportsExecute=false
+group.cgcc-classic.supportsBinary=false
 compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -189,11 +189,13 @@ group.armcclang32.groupName=Arm 32-bit clang
 group.armcclang32.compilers=armv7-cclang-9:armv7-cclang-10:armv7-cclang-trunk
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
+group.armcclang32.supportsExecute=false
 
 group.armcclang64.groupName=Arm 64-bit clang
 group.armcclang64.compilers=armv8-cclang-9:armv8-cclang-10:armv8-cclang-trunk:armv8.5-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
+group.armcclang64.supportsExecute=false
 
 compiler.armv7-cclang-10.name=armv7-a clang 10.0.0
 compiler.armv7-cclang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -686,6 +686,16 @@ class BaseCompiler {
             }
         }
 
+        if (!this.compiler.supportsExecute) {
+            return {
+                code: -1,
+                didExecute: false,
+                buildResult,
+                stderr: [{text: 'Compiler does not support execution'}],
+                stdout: [],
+            };
+        }
+
         executeParameters.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths(key.libraries);
         const result = await this.runExecutable(buildResult.executableFilename, executeParameters);
         result.didExecute = true;

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -73,6 +73,10 @@ class WineVcCompiler extends BaseCompiler {
         return result;
     }
 
+    getSharedLibraryPathsAsArguments() {
+        return [];
+    }
+
     optionsForFilter(filters, outputFilename) {
         if (filters.binary) {
             const mapFilename = outputFilename + '.map';

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -794,8 +794,18 @@ Executor.prototype.onLanguageChange = function (editorId, newLangId) {
 };
 
 Executor.prototype.getCurrentLangCompilers = function () {
+    var allCompilers = this.compilerService.getCompilersForLang(this.currentLangId);
+    var hasAtLeastOneExecuteSupported = _.any(allCompilers, function (compiler) {
+        return (compiler.supportsExecute !== false);
+    });
+
+    if (!hasAtLeastOneExecuteSupported) {
+        this.compiler = null;
+        return [];
+    }
+
     return _.filter(
-        this.compilerService.getCompilersForLang(this.currentLangId),
+        allCompilers,
         _.bind(function (compiler) {
             return (compiler.supportsExecute !== false) ||
                    (this.compiler && compiler.id === this.compiler.id);

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -796,9 +796,10 @@ Executor.prototype.onLanguageChange = function (editorId, newLangId) {
 Executor.prototype.getCurrentLangCompilers = function () {
     return _.filter(
         this.compilerService.getCompilersForLang(this.currentLangId),
-        function (compiler) {
-            return compiler.supportsExecute !== false;
-        });
+        _.bind(function (compiler) {
+            return (compiler.supportsExecute !== false) ||
+                   (this.compiler && compiler.id === this.compiler.id);
+        }, this));
 };
 
 Executor.prototype.updateCompilersSelector = function (info) {

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -794,7 +794,11 @@ Executor.prototype.onLanguageChange = function (editorId, newLangId) {
 };
 
 Executor.prototype.getCurrentLangCompilers = function () {
-    return this.compilerService.getCompilersForLang(this.currentLangId);
+    return _.filter(
+        this.compilerService.getCompilersForLang(this.currentLangId),
+        function (compiler) {
+            return compiler.supportsExecute !== false;
+        });
 };
 
 Executor.prototype.updateCompilersSelector = function (info) {


### PR DESCRIPTION
Fixes #2180
Fixes #2026 
Fixes #1506

- [x] Doesn't show compilers that don't have supportsExecute=true
- [x] Links should still work if something was selected that doesn't supportExecute
- [x] Block execution serverside when !supportsExecute
