### PR TITLE
Add WASM variants for GO

### DIFF
--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -1,7 +1,7 @@
 defaultCompiler=gl1150
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
 
-compilers=&gccgo:&gl:&cross:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl
+compilers=&gccgo:&gl:&cross:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl
 
 group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo101:gccgo102
 group.gccgo.isSemVer=true
@@ -246,6 +246,31 @@ compiler.s390x_gltip.exe=/opt/compiler-explorer/go-tip/bin/go
 compiler.s390x_gltip.semver=(tip)
 compiler.s390x_gltip.goarch=s390x
 compiler.s390x_gltip.name=S390X gc (tip)
+
+###############################
+# WASM GO
+group.wasmgl.compilers=wasm_gltip:wasm_gl115:wasm_gl114
+group.wasmgl.versionFlag=version
+group.wasmgl.compilerType=golang
+group.wasmgl.supportsBinary=false
+group.wasmgl.compilerName=GoLang
+group.wasmgl.isSemVer=true
+group.wasmgl.groupName=GC WASM
+compiler.wasm_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
+compiler.wasm_gl114.semver=1.14
+compiler.wasm_gl114.goarch=wasm
+compiler.wasm_gl114.goos=js
+compiler.wasm_gl114.name=WASM gc 1.14
+compiler.wasm_gl115.exe=/opt/compiler-explorer/golang-1.15/go/bin/go
+compiler.wasm_gl115.semver=1.15
+compiler.wasm_gl115.goarch=wasm
+compiler.wasm_gl115.goos=js
+compiler.wasm_gl115.name=WASM gc 1.15
+compiler.wasm_gltip.exe=/opt/compiler-explorer/go-tip/bin/go
+compiler.wasm_gltip.semver=(tip)
+compiler.wasm_gltip.goarch=wasm
+compiler.wasm_gltip.goos=js
+compiler.wasm_gltip.name=WASM gc (tip)
 
 ###############################
 # Cross GO

--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -219,6 +219,10 @@ class GolangCompiler extends BaseCompiler {
         if (goarch) {
             execOptions.env.GOARCH = goarch;
         }
+        const goos = this.compilerProps(`compiler.${this.compiler.id}.goos`);
+        if (goos) {
+            execOptions.env.GOOS = goos;
+        }
         return execOptions;
     }
 


### PR DESCRIPTION
Fixes #2145 

(Not really sure why you have to repeat the .name properties for Go compilers, but they ain't pretty if you don't supply them a name)
