### PR TITLE
Stop using exe field in compilers api

### DIFF
--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -126,7 +126,7 @@ class ApiHandler {
             if (req.query.fields === 'all') {
                 res.send(list);
             } else {
-                const defaultfields = ['id', 'name', 'lang', 'compilerType', 'semver', 'extensions', 'monaco', 'exe'];
+                const defaultfields = ['id', 'name', 'lang', 'compilerType', 'semver', 'extensions', 'monaco'];
                 if (req.query.fields) {
                     const filteredList = this.filterCompilerProperties(list, req.query.fields.split(','));
                     res.send(filteredList);


### PR DESCRIPTION
This is something to be merged in a month or so. (will break clion plugin if user has not upgraded)
But I wanted to create the PR in case I forgot.
