### PR TITLE
[WIP] Preprocess tool

### DIFF
--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -34,7 +34,11 @@ class BaseTool {
     constructor(toolInfo, env) {
         this.tool = toolInfo;
         this.env = env;
-        this.tool.exclude = this.tool.exclude ? this.tool.exclude.split(':') : [];
+        if (typeof this.tool.exclude === 'string') {
+            this.tool.exclude = this.tool.exclude.split(':');
+        } else if (!this.tool.exclude) {
+            this.tool.exclude = [];
+        }
     }
 
     getId() {

--- a/lib/tooling/preprocessor-tool.js
+++ b/lib/tooling/preprocessor-tool.js
@@ -34,21 +34,22 @@ class PreprocessorTool extends BaseTool {
     constructor(toolInfo, env) {
         super(toolInfo, env);
 
+        this.reLine = /^#\s(\d*)\s(.*)\s?(\d*)/;
+
         this.clangformat = new ClangFormatTool(toolInfo, env);
     }
 
-    async runCompiler(compilationInfo, inputFilepath, args, stdin) {
+    async runCompiler(compilationInfo, inputFilepath, args) {
         let execOptions = this.getDefaultExecOptions();
         if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);
-        execOptions.input = stdin;
 
         args = args ? args : [];
         if (inputFilepath) args.push(inputFilepath);
 
-        const exeDir = path.dirname(compilationInfo.exe);
+        const exeDir = path.dirname(compilationInfo.compiler.exe);
 
         try {
-            const result = await this.exec(compilationInfo.exe, args, execOptions);
+            const result = await this.exec(compilationInfo.compiler.exe, args, execOptions);
             return this.convertResult(result, inputFilepath, exeDir);
         } catch (e) {
             logger.error('Error while running tool: ', e);
@@ -56,17 +57,41 @@ class PreprocessorTool extends BaseTool {
         }
     }
 
+    async enrich(result) {
+        for (let line of result.stdout) {
+            const match = line.text.match(this.reLine);
+            if (match) {
+                if (match[2].includes('example.cpp')) {
+                    line.source = {
+                        file: null,
+                        line: parseInt(match[1]),
+                    };
+                }
+            }
+        }
+
+        return result;
+    }
+
     async runTool(compilationInfo, inputFilepath, args) {
-        const preprocessArgs = ['-E'];
+        const sourceDir = path.dirname(inputFilepath);
+        const outputFilename = 'preprocessor_output.txt';
+        let preprocessArgs = ['-E', '-o', outputFilename];
         const filteredCompilerArgs = _.filter(compilationInfo.options, (arg) => {
             return (arg !== '-S');
         });
-        preprocessArgs.concat(filteredCompilerArgs);
-        preprocessArgs.concat(args);
+        const includeArgs = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        preprocessArgs = preprocessArgs.concat(filteredCompilerArgs, includeArgs, args);
 
-        //const compilerResult = await runCompiler(compilationInfo, inputFilepath, args, stdin);
-
-        //this.clangformat.runTool(compilationInfo, )
+        const compilerResult = await this.runCompiler(compilationInfo, inputFilepath, preprocessArgs);
+        if (compilerResult.code !== 0) {
+            return compilerResult;
+        } else {
+            compilerResult.filenameTransform = () => inputFilepath;
+            const formatResult = await this.clangformat.runTool(
+                compilationInfo, path.join(sourceDir, outputFilename), [], '');
+            return this.enrich(formatResult);
+        }
     }
 }
 

--- a/lib/tooling/preprocessor-tool.js
+++ b/lib/tooling/preprocessor-tool.js
@@ -1,0 +1,73 @@
+// Copyright (c) 2020, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+'use strict';
+
+const
+    _ = require('underscore'),
+    path = require('path'),
+    logger = require('../logger'),
+    ClangFormatTool = require('./clang-format-tool'),
+    BaseTool = require('./base-tool');
+
+class PreprocessorTool extends BaseTool {
+    constructor(toolInfo, env) {
+        super(toolInfo, env);
+
+        this.clangformat = new ClangFormatTool(toolInfo, env);
+    }
+
+    async runCompiler(compilationInfo, inputFilepath, args, stdin) {
+        let execOptions = this.getDefaultExecOptions();
+        if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);
+        execOptions.input = stdin;
+
+        args = args ? args : [];
+        if (inputFilepath) args.push(inputFilepath);
+
+        const exeDir = path.dirname(compilationInfo.exe);
+
+        try {
+            const result = await this.exec(compilationInfo.exe, args, execOptions);
+            return this.convertResult(result, inputFilepath, exeDir);
+        } catch (e) {
+            logger.error('Error while running tool: ', e);
+            return this.createErrorResponse('Error while running tool');
+        }
+    }
+
+    async runTool(compilationInfo, inputFilepath, args) {
+        const preprocessArgs = ['-E'];
+        const filteredCompilerArgs = _.filter(compilationInfo.options, (arg) => {
+            return (arg !== '-S');
+        });
+        preprocessArgs.concat(filteredCompilerArgs);
+        preprocessArgs.concat(args);
+
+        //const compilerResult = await runCompiler(compilationInfo, inputFilepath, args, stdin);
+
+        //this.clangformat.runTool(compilationInfo, )
+    }
+}
+
+module.exports = PreprocessorTool;


### PR DESCRIPTION
Aims to be "better" than just adding -E to compiler parameters.
Executes the selected compiler's -E and clang-formats the output.

Would fix #1177 and #1380 and #1672

**Todo**
- [ ] Maybe this should be a compiler-mode instead of a tool, maybe we can make it automatic by detecting -E (or whatever the equivalent for the compiler is)

Otherwise:
- [ ] Support line annotation on the client-side
- [ ] Filename filter
- [ ] Hide things that are from library headers


![image](https://user-images.githubusercontent.com/442630/92925484-d9f1bb80-f43a-11ea-9236-5f2f05f68ec7.png)
