### PR TITLE
Add Enoki library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -758,7 +758,7 @@ compiler.djggp494.semver=4.9.4
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:tomlplusplus:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer
+libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:tomlplusplus:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer:enoki
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172:173:174
 libs.boost.url=https://www.boost.org
@@ -1445,6 +1445,12 @@ libs.immer.url=https://github.com/arximboldi/immer
 libs.immer.versions=trunk
 libs.immer.versions.trunk.version=trunk
 libs.immer.versions.trunk.path=/opt/compiler-explorer/libs/immer/trunk
+
+libs.enoki.name=Enoki
+libs.enoki.url=https://github.com/mitsuba-renderer/enoki
+libs.enoki.versions=trunk
+libs.enoki.versions.trunk.version=trunk
+libs.enoki.versions.trunk.path=/opt/compiler-explorer/libs/enoki/trunk/include
 
 #################################
 #################################


### PR DESCRIPTION
This PR adds the excellent Enoki library to CE.

Enoki is a library for writing scalable, vectorised code. It's an interesting alternative to the already established libraries like xsimd or VCL. Adding it to CE will make it easier to publicly discuss (dis)advantages in the Codegen of the different SIMD libraries.

There's also a infrastructure PR here: https://github.com/compiler-explorer/infra/pull/402
