### PR TITLE
Support library options to be passed on to the compiler

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -383,6 +383,15 @@ class BaseCompiler {
         }));
     }
 
+    getLibraryOptions(libraries) {
+        return _.flatten(_.map(libraries, (selectedLib) => {
+            const foundVersion = this.findLibVersion(selectedLib);
+            if (!foundVersion) return false;
+
+            return foundVersion.options;
+        }));
+    }
+
     prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
         backendOptions = backendOptions || {};
@@ -396,6 +405,7 @@ class BaseCompiler {
         }
 
         const libIncludes = this.getIncludeArguments(libraries);
+        const libOptions = this.getLibraryOptions(libraries);
         let libLinks = [];
         let libPaths = [];
         let staticLibLinks = [];
@@ -407,7 +417,7 @@ class BaseCompiler {
         }
 
         userOptions = this.filterUserOptions(userOptions) || [];
-        return options.concat(libIncludes, libPaths, libLinks, userOptions,
+        return options.concat(libIncludes, libOptions, libPaths, libLinks, userOptions,
             [this.filename(inputFilename)], staticLibLinks);
     }
 

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -102,6 +102,7 @@ class Win32Compiler extends BaseCompiler {
         }
 
         const libIncludes = this.getIncludeArguments(libraries);
+        const libOptions = this.getLibraryOptions(libraries);
         let libLinks = [];
         let libPaths = [];
         let preLink = [];
@@ -115,7 +116,7 @@ class Win32Compiler extends BaseCompiler {
         }
 
         userOptions = this.filterUserOptions(userOptions) || [];
-        return options.concat(libIncludes, userOptions, [this.filename(inputFilename)], preLink, libPaths,
+        return options.concat(libIncludes, libOptions, userOptions, [this.filename(inputFilename)], preLink, libPaths,
             libLinks, staticlibLinks);
     }
 

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -26,7 +26,6 @@ const temp = require('temp'),
     fs = require('fs-extra'),
     path = require('path'),
     httpProxy = require('http-proxy'),
-    quote = require('shell-quote'),
     _ = require('underscore'),
     logger = require('../logger').logger,
     utils = require('../utils'),
@@ -262,23 +261,16 @@ class CompileHandler {
             backendOptions.skipAsm = req.query.skipAsm === 'true';
 
         }
-        options = this.splitArguments(options);
+        options = utils.splitArguments(options);
         if (!Array.isArray(executionParameters.args)) {
-            executionParameters.args = this.splitArguments(executionParameters.args);
+            executionParameters.args = utils.splitArguments(executionParameters.args);
         }
 
         tools = tools || [];
         tools.forEach((tool) => {
-            tool.args = this.splitArguments(tool.args);
+            tool.args = utils.splitArguments(tool.args);
         });
         return {source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries};
-    }
-
-    splitArguments(options) {
-        return _.chain(quote.parse(options || '')
-            .map(x => typeof (x) === 'string' ? x : x.pattern))
-            .compact()
-            .value();
     }
 
     handlePopularArguments(req, res, next) {
@@ -300,7 +292,7 @@ class CompileHandler {
             if (data.presplit) {
                 return data.usedOptions;
             } else {
-                return this.splitArguments(data.usedOptions);
+                return utils.splitArguments(data.usedOptions);
             }
         }
         return false;

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -27,6 +27,7 @@ const _ = require('underscore'),
     logger = require('./logger').logger,
     semverParser = require('semver'),
     path = require('path'),
+    splitArguments = require('./utils').splitArguments,
     getHash = require('./utils').getHash,
     fs = require('fs-extra');
 
@@ -179,6 +180,8 @@ class ClientOptionsHandler {
                         dependencies: this.splitIntoArray(
                             this.compilerProps(lang, libBaseName + '.dependencies'), []),
                         versions: {},
+                        options: splitArguments(
+                            this.compilerProps(lang, libBaseName + '.options', '')),
                     };
                     const listedVersions = `${this.compilerProps(lang, libBaseName + '.versions')}`;
                     if (listedVersions) {
@@ -226,6 +229,13 @@ class ClientOptionsHandler {
                             libraries[lang][lib].versions[version].liblink = this.splitIntoArray(
                                 this.compilerProps(lang, libVersionName + '.liblink'),
                                 libraries[lang][lib].liblink);
+
+                            const options = this.compilerProps(lang, libVersionName + '.options');
+                            if (options !== undefined) {
+                                libraries[lang][lib].versions[version].options = splitArguments(options);
+                            } else {
+                                libraries[lang][lib].versions[version].options = libraries[lang][lib].options;
+                            }
                         });
                     } else {
                         logger.warn(`No versions found for ${lib} library`);

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -98,6 +98,15 @@ class BaseTool {
         }));
     }
 
+    getLibraryOptions(libraries, compiler) {
+        return _.flatten(_.map(libraries, (selectedLib) => {
+            const foundVersion = this.findLibVersion(selectedLib, compiler);
+            if (!foundVersion) return false;
+
+            return foundVersion.options;
+        }));
+    }
+
     async runTool(compilationInfo, inputFilepath, args, stdin) {
         let execOptions = this.getDefaultExecOptions();
         if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -34,6 +34,7 @@ class ClangTidyTool extends BaseTool {
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
         const includeflags = super.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        const libOptions = super.getLibraryOptions(compilationInfo.libraries, compilationInfo.compiler);
 
         let source;
         const wantsFix = args.find(option => option.includes('-fix'));
@@ -53,6 +54,7 @@ class ClangTidyTool extends BaseTool {
         //  *) indepenent are `args` from the clang-tidy tab
         let compileFlags = compilationInfo.compiler.options.split(' ');
         compileFlags = compileFlags.concat(includeflags);
+        compileFlags = compileFlags.concat(libOptions);
 
         const manualCompileFlags = options.filter(option => (option !== sourcefile));
         compileFlags = compileFlags.concat(manualCompileFlags);

--- a/lib/tooling/compiler-dropin-tool.js
+++ b/lib/tooling/compiler-dropin-tool.js
@@ -33,7 +33,7 @@ class CompilerDropinTool extends BaseTool {
         return toolchainUtils.getToolchainPath(compilationInfo.compiler.exe, compilationInfo.compiler.options);
     }
 
-    getOrderedArguments(compilationInfo, includeflags, args, sourcefile) {
+    getOrderedArguments(compilationInfo, includeflags, libOptions, args, sourcefile) {
         // order should be:
         //  1) options from the compiler config (compilationInfo.compiler.options)
         //  2) includes from the libraries (includeflags)
@@ -69,6 +69,7 @@ class CompilerDropinTool extends BaseTool {
         compileFlags = compileFlags.concat(manualCompileFlags);
         const toolOptions = this.tool.options ? this.tool.options.split(' ') : [];
         compileFlags = compileFlags.concat(toolOptions);
+        compileFlags = compileFlags.concat(libOptions);
         args ? args : [];
         compileFlags = compileFlags.concat(args);
 
@@ -89,8 +90,9 @@ class CompilerDropinTool extends BaseTool {
         const sourcefile = inputFilepath;
 
         const includeflags = super.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        const libOptions = super.getLibraryOptions(compilationInfo.libraries, compilationInfo.compiler);
 
-        const compileFlags = this.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const compileFlags = this.getOrderedArguments(compilationInfo, includeflags, libOptions, args, sourcefile);
         if (!compileFlags) {
             return new Promise((resolve) => {
                 resolve(this.createErrorResponse('Unable to run tool with selected compiler'));

--- a/lib/tooling/pvs-studio-tool.js
+++ b/lib/tooling/pvs-studio-tool.js
@@ -50,6 +50,9 @@ class PvsStudioTool extends BaseTool {
         const includeflags = super.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
         compileFlags = compileFlags.concat(includeflags);
 
+        const libOptions = super.getLibraryOptions(compilationInfo.libraries, compilationInfo.compiler);
+        compileFlags = compileFlags.concat(libOptions);
+
         const manualCompileFlags = compilationInfo.options.filter(option => (option !== inputFilepath));
         compileFlags = compileFlags.concat(manualCompileFlags);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 const _ = require('underscore'),
-    crypto = require('crypto');
+    crypto = require('crypto'),
+    quote = require('shell-quote');
 
 const tabsRe = /\t/g;
 const lineRe = /\r?\n/;
@@ -375,3 +376,12 @@ function base32Encode(buffer) {
 }
 
 exports.base32Encode = base32Encode;
+
+function splitArguments(options) {
+    return _.chain(quote.parse(options || '')
+        .map(x => typeof (x) === 'string' ? x : x.pattern))
+        .compact()
+        .value();
+}
+
+exports.splitArguments = splitArguments;

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -55,6 +55,7 @@ const libProps = {
     'libs.fakelib.versions.noPaths.version': 'no paths',
     'libs.fakelib.versions.noPaths.path': '',
     'libs.fakelib.versions.noPaths.lookupversion': 'no-paths123',
+    'libs.fakelib.versions.noPaths.options' : '-DHELLO123 -DETC "--some thing with spaces"',
     'libs.fs.versions': 'std',
     'libs.fs.versions.std.version': 'std',
     'libs.fs.versions.std.staticliblink': 'c++fs:rt',
@@ -140,15 +141,20 @@ describe('Options handler', () => {
                 dependencies: [],
                 liblink: [],
                 staticliblink: [],
+                options: [],
                 versions: {
                     noPaths: {path: [], version: 'no paths', liblink: [], libpath: [], staticliblink: [], dependencies: [], alias: [],
-                        lookupversion: 'no-paths123'},
+                        lookupversion: 'no-paths123',
+                        options: [
+                            '-DHELLO123',
+                            '-DETC',
+                            '--some thing with spaces']},
                     onePath: {path: ['/dev/null'], version: 'one path', staticliblink: [], dependencies: [],
                         liblink: ['hello'],
-                        libpath: ['/lib/null'], alias: []},
+                        libpath: ['/lib/null'], alias: [], options: []},
                     twoPaths: {path: ['/dev/null', '/dev/urandom'], staticliblink: [], dependencies: [],
                         liblink: ['hello1', 'hello2'],
-                        libpath: ['/lib/null', '/lib/urandom'], version: 'two paths', alias: []},
+                        libpath: ['/lib/null', '/lib/urandom'], version: 'two paths', alias: [], options: []},
                 },
             },
             fs: {
@@ -158,6 +164,7 @@ describe('Options handler', () => {
                 dependencies: [],
                 liblink: [],
                 staticliblink: [],
+                options: [],
                 versions: {
                     std: {
                         libpath: [],
@@ -167,6 +174,7 @@ describe('Options handler', () => {
                         liblink: [],
                         staticliblink: ['c++fs', 'rt'],
                         dependencies: ['pthread'],
+                        options: [],
                     },
                 },
             },
@@ -177,6 +185,7 @@ describe('Options handler', () => {
                 dependencies: [],
                 liblink: [],
                 staticliblink: [],
+                options: [],
                 versions: {
                     trunk: {
                         libpath: [],
@@ -186,6 +195,7 @@ describe('Options handler', () => {
                         liblink: [],
                         staticliblink: ['someotherlib'],
                         dependencies: ['c++fs'],
+                        options: [],
                     },
                 },
             },

--- a/test/tool-tests.js
+++ b/test/tool-tests.js
@@ -44,7 +44,7 @@ describe('CompilerDropInTool', () => {
         const args = [];
         const sourcefile = 'example.cpp';
 
-        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, [], args, sourcefile);
         orderedArgs.should.deep.equal(
             [
                 '--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0',
@@ -67,7 +67,7 @@ describe('CompilerDropInTool', () => {
         const args = [];
         const sourcefile = 'example.cpp';
 
-        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, [], args, sourcefile);
         orderedArgs.should.deep.equal(
             [
                 '--gcc-toolchain=' + path.resolve('/opt/compiler-explorer/gcc-8.0'),
@@ -90,7 +90,7 @@ describe('CompilerDropInTool', () => {
         const args = [];
         const sourcefile = 'example.cpp';
 
-        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, [], args, sourcefile);
         orderedArgs.should.deep.equal(false);
     });
 
@@ -108,7 +108,7 @@ describe('CompilerDropInTool', () => {
         const args = [];
         const sourcefile = 'example.cpp';
 
-        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, [], args, sourcefile);
         orderedArgs.should.deep.equal(
             [
                 '--gcc-toolchain=' + path.resolve('/opt/compiler-explorer/gcc-8.2.0'),
@@ -136,7 +136,7 @@ describe('CompilerDropInTool', () => {
         const args = ['/MD', '/STD:c++latest', '/Ox'];
         const sourcefile = 'example.cpp';
 
-        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, [], args, sourcefile);
         orderedArgs.should.deep.equal(false);
     });
 
@@ -157,7 +157,36 @@ describe('CompilerDropInTool', () => {
         const args = [];
         const sourcefile = 'example.cpp';
 
-        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, args, sourcefile);
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, [], args, sourcefile);
         orderedArgs.should.deep.equal(false);
+    });
+
+    it('Should support library options', () => {
+        const tool = new CompilerDropinTool({}, {});
+
+        const compilationInfo = {
+            compiler: {
+                exe: '/opt/compiler-explorer/clang-concepts-trunk/bin/clang++',
+                options: '--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0',
+                internalIncludePaths: [
+                    '/opt/compiler-explorer/clang-concepts-trunk/something/etc/include',
+                ],
+            },
+            options: [],
+        };
+        const includeflags = [];
+        const args = [];
+        const sourcefile = 'example.cpp';
+        const libOptions = ['-DMYLIBDEF', '-pthread'];
+
+        const orderedArgs = tool.getOrderedArguments(compilationInfo, includeflags, libOptions, args, sourcefile);
+        orderedArgs.should.deep.equal(
+            [
+                '--gcc-toolchain=' + path.resolve('/opt/compiler-explorer/gcc-8.2.0'),
+                '--gcc-toolchain=' + path.resolve('/opt/compiler-explorer/gcc-8.2.0'),
+                '-DMYLIBDEF',
+                '-pthread',
+            ],
+        );
     });
 });


### PR DESCRIPTION
Would enable #2212 to pass -DSPDLOG_COMPILED_LIB

Via adding
`libs.spdlog.options=-DSPDLOG_COMPILED_LIB`
at
https://github.com/compiler-explorer/compiler-explorer/pull/2212/files#diff-abd4fce8d3b41fa3f0e7581f14099250R1468