### PR TITLE
Add libcudacxx CUDA library

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -61,4 +61,4 @@ libs.cudacxx.name=libcudacxx
 libs.cudacxx.versions=trunk
 libs.cudacxx.url=https://github.com/nvidia/libcudacxx
 libs.cudacxx.versions.trunk.version=trunk
-libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/include/trunk/include
+libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/trunk/include

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -41,7 +41,7 @@ compiler.cltrunk.semver=trunk
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 
-libs=cueigen:cucub
+libs=cueigen:cucub:cudacxx
 
 libs.cueigen.name=Eigen
 libs.cueigen.versions=trunk:334
@@ -56,3 +56,9 @@ libs.cucub.versions=180
 libs.cucub.url=http://nvlabs.github.io/cub/index.html
 libs.cucub.versions.180.version=1.8.0
 libs.cucub.versions.180.path=/opt/compiler-explorer/libs/cub/1.8.0
+
+libs.cudacxx.name=libcudacxx
+libs.cudacxx.versions=trunk
+libs.cudacxx.url=https://github.com/nvidia/libcudacxx
+libs.cudacxx.versions.trunk.version=trunk
+libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/include

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -61,4 +61,4 @@ libs.cudacxx.name=libcudacxx
 libs.cudacxx.versions=trunk
 libs.cudacxx.url=https://github.com/nvidia/libcudacxx
 libs.cudacxx.versions.trunk.version=trunk
-libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/include
+libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/include/trunk

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -61,4 +61,4 @@ libs.cudacxx.name=libcudacxx
 libs.cudacxx.versions=trunk
 libs.cudacxx.url=https://github.com/nvidia/libcudacxx
 libs.cudacxx.versions.trunk.version=trunk
-libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/include/trunk
+libs.cudacxx.versions.trunk.path=/opt/compiler-explorer/libs/libcudacxx/include/trunk/include


### PR DESCRIPTION
See also https://github.com/compiler-explorer/infra/pull/408

Adds [libcudacxx](https://github.com/nvidia/libcudacxx) as an optional library when using CUDA. 
