### PR TITLE
Organize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,21 @@
-*code-workspace
-*.swp
-/node_modules
-newrelic_agent.log
-/.npm-updated
+# build generated files
 /.node-bin
-*.vscode
-/out
-*.heapsnapshot
-etc/config/*.local.properties
-.travis-compilers
-/nbproject
-*.bundle*.js
-*.map
-static/dist
-static/vs
-lib/storage/data
-f.out
+/.npm-updated
 /.nyc_output
-/coverage
-/dist
+/node_modules
+/out
+
+# user local customizations
+/etc/config/*.local.properties
+/lib/storage/data
+
+# IDE project files
+/nbproject
+*.vscode
+*.code-workspace
+
+# random bits
+f.out
+newrelic_agent.log
+*.heapsnapshot
+*.swp


### PR DESCRIPTION
Took the opportunity to organize and comment it a bit, so its not super clear what was removed in the diff.

## Removals:
```
*.bundle*.js
*.map
.travis-compilers
/coverage
/dist
static/dist
static/vs
```

Pretty much all of them now live under `/out`, (besides `.travis-compilers`, which just appears to be stale)

Due to recent changes in eslint configuration the existence of some of the above (stale) files can cause issues, and because they are still in .gitignore its very not-obvious that they should no longer exist in your working tree.