### PR TITLE
Disable webpack development middleware statistic logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -281,6 +281,7 @@ async function setupWebPackDevMiddleware(router) {
     router.use(webpackDevMiddleware(webpackCompiler, {
         publicPath: '/static',
         logger: logger,
+        stats: 'errors-only',
     }));
 
     pugRequireHandler = (path) => urljoin(httpRoot, 'static', path);


### PR DESCRIPTION
Trivial change, but I am making this a PR since the old behavior may be desirable to others.

When running `make dev` webpack will now only print
```
info: Compiled successfully.
```
instead of the wall of output it normally prints.

If things go wrong it will still print diagnostics.