### PR TITLE
Update Zig to use the new CLI

### DIFF
--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -65,11 +65,28 @@ export class ZigCompiler extends BaseCompiler {
 
     optionsForFilter(filters, outputFilename, userOptions) {
         let options = [filters.execute ? 'build-exe' : 'build-obj'];
-        if (this.compiler.semver === 'trunk' || (this.compiler.semver && Semver.gt(this.compiler.semver, '0.3.0'))) {
+
+        let self_hosted_cli = this.compiler.semver === 'trunk' || (this.compiler.semver && Semver.gt(this.compiler.semver, '0.6.0'));
+        const desiredName = path.basename(outputFilename);
+        // strip '.s' if we aren't executing
+        const name = filters.execute ? desiredName : desiredName.slice(0, -2);
+
+        if (self_hosted_cli) {
+            // Versions after 0.6.0 use a different command line interface.
             const outputDir = path.dirname(outputFilename);
-            const desiredName = path.basename(outputFilename);
-            // strip '.s' if we aren't executing
-            const name = filters.execute ? desiredName : desiredName.slice(0, -2);
+            options.push('--cache-dir', outputDir,
+                '--name', name);
+
+            if (!filters.binary) {
+                options.push('-fno-emit-bin', '-femit-asm=' + desiredName);
+            } else {
+                options.push('-femit-bin=' + desiredName);
+            }
+            return options;
+        }
+
+        if (this.compiler.semver && Semver.gt(this.compiler.semver, '0.3.0')) {
+            const outputDir = path.dirname(outputFilename);
             options.push('--cache-dir', outputDir,
                 '--output-dir', outputDir,
                 '--name', name);
@@ -96,7 +113,7 @@ export class ZigCompiler extends BaseCompiler {
     }
 
     filterUserOptions(userOptions) {
-        const forbiddenOptions = /^(((--(cache-dir|name|output|verbose))|(-mllvm)).*)$/;
+        const forbiddenOptions = /^(((--(cache-dir|name|output|verbose))|(-mllvm|-fno-emit-bin|-femit-bin)).*)$/;
         return _.filter(userOptions, option => !forbiddenOptions.test(option));
     }
 

--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -66,7 +66,8 @@ export class ZigCompiler extends BaseCompiler {
     optionsForFilter(filters, outputFilename, userOptions) {
         let options = [filters.execute ? 'build-exe' : 'build-obj'];
 
-        let self_hosted_cli = this.compiler.semver === 'trunk' || (this.compiler.semver && Semver.gt(this.compiler.semver, '0.6.0'));
+        let self_hosted_cli = this.compiler.semver === 'trunk' ||
+            (this.compiler.semver && Semver.gt(this.compiler.semver, '0.6.0'));
         const desiredName = path.basename(outputFilename);
         // strip '.s' if we aren't executing
         const name = filters.execute ? desiredName : desiredName.slice(0, -2);


### PR DESCRIPTION
Hi.  
This PR updates Zig to use the newest command line interface introduced in ziglang/zig#6250 when running the trunk version as well as tagged versions greater than 0.6.0 (aka future releases).  

Please let me know if any changes are required, I have been testing this locally and it works like a charm.  
