### PR TITLE
Update the CUDA Thrust/CUB libraries.

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -51,7 +51,7 @@ compiler.cltrunk.semver=trunk
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 
-libs=cueigen:cucub:cudacxx
+libs=cueigen:thrustcub:cucub:cudacxx
 
 libs.cueigen.name=Eigen
 libs.cueigen.versions=trunk:334
@@ -61,7 +61,21 @@ libs.cueigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
 libs.cueigen.versions.334.version=3.3.4
 libs.cueigen.versions.334.path=/opt/compiler-explorer/libs/eigen/v3.3.4
 
-libs.cucub.name=CUB
+libs.thrustcub.name=Thrust+CUB
+libs.thrustcub.versions=trunk:109090:109100:109101:110000
+libs.thrustcub.url=http://www.github.com/NVIDIA/thrust
+libs.thrustcub.versions.109090.version=1.9.9
+libs.thrustcub.versions.109090.path=/opt/compiler-explorer/libs/thrustcub/1.9.9:/opt/compiler-explorer/libs/thrustcub/1.9.9/dependencies/cub
+libs.thrustcub.versions.109100.version=1.9.10
+libs.thrustcub.versions.109100.path=/opt/compiler-explorer/libs/thrustcub/1.9.10:/opt/compiler-explorer/libs/thrustcub/1.9.10/dependencies/cub
+libs.thrustcub.versions.109101.version=1.9.10-1
+libs.thrustcub.versions.109101.path=/opt/compiler-explorer/libs/thrustcub/1.9.10-1:/opt/compiler-explorer/libs/thrustcub/1.9.10-1/dependencies/cub
+libs.thrustcub.versions.110000.version=1.10.0
+libs.thrustcub.versions.110000.path=/opt/compiler-explorer/libs/thrustcub/1.10.0:/opt/compiler-explorer/libs/thrustcub/1.10.0/dependencies/cub
+libs.thrustcub.versions.trunk.version=trunk
+libs.thrustcub.versions.trunk.path=/opt/compiler-explorer/libs/thrustcub/trunk:/opt/compiler-explorer/libs/thrustcub/trunk/dependencies/cub
+
+libs.cucub.name=CUB (Legacy)
 libs.cucub.versions=180
 libs.cucub.url=http://nvlabs.github.io/cub/index.html
 libs.cucub.versions.180.version=1.8.0


### PR DESCRIPTION
Add new versions of the Thrust/CUB libraries for CUDA.

These libraries are now distributed together and version locked, so this PR adds both under a `Thrust + CUB` label. The old standalone 1.8.0 version of CUB is now explicitly labeled as legacy.

See also compiler-explorer/infra#413.