### PR TITLE
Fixes to Armv7 and Armv8 Clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -296,25 +296,25 @@ compiler.armv7-clang-10.name=armv7-a clang 10.0.0
 compiler.armv7-clang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.armv7-clang-10.semver=10.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-clang-10.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+compiler.armv7-clang-10.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv8-clang-10.name=armv8-a clang 10.0.0
 compiler.armv8-clang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.armv8-clang-10.semver=10.0.0
 # Arm v8-a
-compiler.armv8-clang-10.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+compiler.armv8-clang-10.options=-target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-clang-9.name=armv7-a clang 9.0.0
 compiler.armv7-clang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.armv7-clang-9.semver=9.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-clang-9.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+compiler.armv7-clang-9.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv8-clang-9.name=armv8-a clang 9.0.0
 compiler.armv8-clang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.armv8-clang-9.semver=9.0.0
 # Arm v8-a
-compiler.armv8-clang-9.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+compiler.armv8-clang-9.options=-target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-clang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
@@ -322,7 +322,7 @@ compiler.armv7-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++
 compiler.armv7-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-clang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-clang-trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv8-clang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
@@ -330,7 +330,7 @@ compiler.armv8-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++
 compiler.armv8-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-clang-trunk.semver=(trunk)
 # Arm v8-a
-compiler.armv8-clang-trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+compiler.armv8-clang-trunk.options=-target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8.5-clang-trunk.name=armv8.5-a clang (trunk, all architectural features)
 compiler.armv8.5-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
@@ -338,7 +338,7 @@ compiler.armv8.5-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c
 compiler.armv8.5-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8.5-clang-trunk.semver=(trunk allfeats)
 # Arm v8.5-a with all supported architectural features
-compiler.armv8.5-clang-trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android -mtune=cortex-a53 -march=armv8.5-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8.5-clang-trunk.options=-target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -mtune=cortex-a53 -march=armv8.5-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 
 
 # Clang for RISC-V


### PR DESCRIPTION
The previous invocations of these compilers used an x86_64 gcc toolchain,
which prevented Clang from finding suitable headers and libs (eg stdlibc++),
which presented as bugs such as failures to find some C++ headers, and in
incorrect type sizes.

I've also added a sysroot option to the commandline.  This probably isn't
strictly neccessary right now, but it would be necessary if/when execution
support is added.

Change-Id: If6bc3c3d7eb548cd249850ca2992fc28ceb56559

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
