### PR TITLE
[untested] Some tiny refactoring for building executables

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -631,6 +631,21 @@ export class BaseCompiler {
 
     async getOrBuildExecutable(key) {
         const dirPath = await this.newTempDir();
+
+        const buildResults = await this.loadPackageWithExecutable(key, dirPath);
+        if (buildResults) return buildResults;
+
+        const compilationResult = await this.buildExecutableInFolder(key, dirPath);
+        if (compilationResult.code !== 0) {
+            return compilationResult;
+        }
+
+        await this.storePackageWithExecutable(key, dirPath, compilationResult);
+
+        return compilationResult;
+    }
+
+    async loadPackageWithExecutable(key, dirPath) {
         const compilationResultFilename = 'compilation-result.json';
         try {
             const outputFilename = await this.env.executableGet(key, dirPath);
@@ -649,11 +664,11 @@ export class BaseCompiler {
         } catch (err) {
             logger.error('Tried to get executable from cache, but got an error:', {err});
         }
-        const compilationResult = await this.buildExecutableInFolder(key, dirPath);
-        compilationResult.dirPath = dirPath;
-        if (compilationResult.code !== 0) {
-            return compilationResult;
-        }
+        return false;
+    }
+
+    async storePackageWithExecutable(key, dirPath, compilationResult) {
+        const compilationResultFilename = 'compilation-result.json';
 
         const packDir = await this.newTempDir();
         const packagedFile = path.join(packDir, 'package.tgz');
@@ -666,7 +681,6 @@ export class BaseCompiler {
         } finally {
             fs.remove(packDir);
         }
-        return compilationResult;
     }
 
     runExecutable(executable, executeParameters) {
@@ -892,52 +906,60 @@ export class BaseCompiler {
             let [result, optOutput] = await this.doCompilation(
                 inputFilename, dirPath, key, options, filters, backendOptions, libraries, tools);
 
-            // Start the execution as soon as we can, but only await it at the end.
-            const execPromise = doExecute ? this.handleExecution(key, executeParameters) : null;
-
-            if (result.hasOptOutput) {
-                delete result.optPath;
-                result.optOutput = optOutput;
-            }
-            result.tools = _.union(result.tools, await Promise.all(this.runToolsOfType(tools, 'postcompilation',
-                this.getCompilationInfo(key, result))));
-
-            this.doTempfolderCleanup(result);
-            if (result.buildResult) {
-                this.doTempfolderCleanup(result.buildResult);
-            }
-
-            if (!backendOptions.skipAsm) {
-                if (result.okToCache) {
-                    const res = this.processAsm(result, filters, options);
-                    result.asm = res.asm;
-                    result.labelDefinitions = res.labelDefinitions;
-                } else {
-                    result.asm = [{text: result.asm}];
-                }
-                // TODO rephrase this so we don't need to reassign
-                result = filters.demangle ? await this.postProcessAsm(result, filters) : result;
-                if (this.compiler.supportsCfg && backendOptions.produceCfg) {
-                    result.cfg = cfg.generateStructure(this.compiler.compilerType,
-                        this.compiler.version, result.asm);
-                }
-            } else {
-                result.asm = [];
-            }
-            result.popularArguments = this.possibleArguments.getPopularArguments(options);
-            if (result.okToCache) {
-                await this.env.cachePut(key, result);
-            }
-
-            if (doExecute) {
-                result.execResult = await execPromise;
-
-                if (result.execResult.buildResult) {
-                    this.doTempfolderCleanup(result.execResult.buildResult);
-                }
-            }
-            return result;
+            return await this.afterCompilation(result, doExecute, key, executeParameters, tools, backendOptions,
+                filters, options, optOutput);
         });
+    }
+
+    async afterCompilation(result, doExecute, key, executeParameters, tools, backendOptions, filters, options,
+        optOutput) {
+        // Start the execution as soon as we can, but only await it at the end.
+        const execPromise = doExecute ? this.handleExecution(key, executeParameters) : null;
+
+        if (result.hasOptOutput) {
+            delete result.optPath;
+            result.optOutput = optOutput;
+        }
+        result.tools = _.union(result.tools, await Promise.all(this.runToolsOfType(tools, 'postcompilation',
+            this.getCompilationInfo(key, result))));
+
+        this.doTempfolderCleanup(result);
+        if (result.buildResult) {
+            this.doTempfolderCleanup(result.buildResult);
+        }
+
+        if (!backendOptions.skipAsm) {
+            if (result.okToCache) {
+                const res = this.processAsm(result, filters, options);
+                result.asm = res.asm;
+                result.labelDefinitions = res.labelDefinitions;
+            } else {
+                result.asm = [{text: result.asm}];
+            }
+            // TODO rephrase this so we don't need to reassign
+            result = filters.demangle ? await this.postProcessAsm(result, filters) : result;
+            if (this.compiler.supportsCfg && backendOptions.produceCfg) {
+                result.cfg = cfg.generateStructure(this.compiler.compilerType,
+                    this.compiler.version, result.asm);
+            }
+        } else {
+            result.asm = [];
+        }
+
+        if (!backendOptions.skipPopArgs) result.popularArguments = this.possibleArguments.getPopularArguments(options);
+
+        if (result.okToCache) {
+            await this.env.cachePut(key, result);
+        }
+
+        if (doExecute) {
+            result.execResult = await execPromise;
+
+            if (result.execResult.buildResult) {
+                this.doTempfolderCleanup(result.execResult.buildResult);
+            }
+        }
+        return result;
     }
 
     processAsm(result, filters, options) {


### PR DESCRIPTION
Pulled this out of my cmakeapi branch.
Needs some testing as it was amidst/before all kinds of other changes in our codebase.

Will also need to gather my thoughts as to what the strategy is here.

Primarily pulls out the `afterCompilation` steps, and some separate steps for building of executable, storing and loading from s3.
