### PR TITLE
NFC: semantic names for the armv7 and armv8 clang config file entries

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -284,40 +284,52 @@ compiler.clang_embed.notification=Experimental <code>std::embed</code> Support; 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9, clang-10 and trunk
 group.armclang32.groupName=Arm 32-bit clang
-group.armclang32.compilers=armv7-clang-9:armv7-clang-10:armv7-clang-trunk
+group.armclang32.compilers=armv7-clang900:armv7-clang1000:armv7-clang-trunk
 group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
 
 group.armclang64.groupName=Arm 64-bit clang
-group.armclang64.compilers=armv8-clang-9:armv8-clang-10:armv8-clang-trunk:armv8.5-clang-trunk
+group.armclang64.compilers=armv8-clang900:armv8-clang1000:armv8-clang-trunk:armv8.5-clang-trunk
 group.armclang64.isSemVer=true
 group.armclang64.compilerType=clang
 group.armclang64.supportsExecute=false
 
-compiler.armv7-clang-10.name=armv7-a clang 10.0.0
-compiler.armv7-clang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
-compiler.armv7-clang-10.semver=10.0.0
+compiler.armv7-clang1000.name=armv7-a clang 10.0.0
+compiler.armv7-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
+compiler.armv7-clang1000.semver=10.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-clang-10.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-clang1000.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv7-clang1000.alias=armv7-clang-10
 
-compiler.armv8-clang-10.name=armv8-a clang 10.0.0
-compiler.armv8-clang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
-compiler.armv8-clang-10.semver=10.0.0
+compiler.armv8-clang1000.name=armv8-a clang 10.0.0
+compiler.armv8-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
+compiler.armv8-clang1000.semver=10.0.0
 # Arm v8-a
-compiler.armv8-clang-10.options=--target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1000.options=--target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv8-clang1000.alias=armv8-clang-10
 
-compiler.armv7-clang-9.name=armv7-a clang 9.0.0
-compiler.armv7-clang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
-compiler.armv7-clang-9.semver=9.0.0
+compiler.armv7-clang900.name=armv7-a clang 9.0.0
+compiler.armv7-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
+compiler.armv7-clang900.semver=9.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-clang-9.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-clang900.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv7-clang900.alias=armv7-clang-9
 
-compiler.armv8-clang-9.name=armv8-a clang 9.0.0
-compiler.armv8-clang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
-compiler.armv8-clang-9.semver=9.0.0
+compiler.armv8-clang900.name=armv8-a clang 9.0.0
+compiler.armv8-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
+compiler.armv8-clang900.semver=9.0.0
 # Arm v8-a
-compiler.armv8-clang-9.options=--target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang900.options=--target=aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv8-clang900.alias=armv8-clang-9
 
 compiler.armv7-clang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -191,40 +191,52 @@ compiler.cclang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk
 group.armcclang32.groupName=Arm 32-bit clang
-group.armcclang32.compilers=armv7-cclang-9:armv7-cclang-10:armv7-cclang-trunk
+group.armcclang32.compilers=armv7-cclang900:armv7-cclang1000:armv7-cclang-trunk
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
 group.armcclang32.supportsExecute=false
 
 group.armcclang64.groupName=Arm 64-bit clang
-group.armcclang64.compilers=armv8-cclang-9:armv8-cclang-10:armv8-cclang-trunk
+group.armcclang64.compilers=armv8-cclang900:armv8-cclang1000:armv8-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
 
-compiler.armv7-cclang-10.name=armv7-a clang 10.0.0
-compiler.armv7-cclang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
-compiler.armv7-cclang-10.semver=10.0.0
+compiler.armv7-cclang1000.name=armv7-a clang 10.0.0
+compiler.armv7-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.armv7-cclang1000.semver=10.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cclang-10.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+compiler.armv7-cclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv7-cclang1000.alias=armv7-cclang-10
 
-compiler.armv8-cclang-10.name=armv8-a clang 10.0.0
-compiler.armv8-cclang-10.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
-compiler.armv8-cclang-10.semver=10.0.0
+compiler.armv8-cclang1000.name=armv8-a clang 10.0.0
+compiler.armv8-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.armv8-cclang1000.semver=10.0.0
 # Arm v8-a
-compiler.armv8-cclang-10.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+compiler.armv8-cclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv8-cclang1000.alias=armv8-cclang-10
 
-compiler.armv7-cclang-9.name=armv7-a clang 9.0.0
-compiler.armv7-cclang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
-compiler.armv7-cclang-9.semver=9.0.0
+compiler.armv7-cclang900.name=armv7-a clang 9.0.0
+compiler.armv7-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.armv7-cclang900.semver=9.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cclang-9.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+compiler.armv7-cclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv7-cclang900.alias=armv7-cclang-9
 
-compiler.armv8-cclang-9.name=armv8-a clang 9.0.0
-compiler.armv8-cclang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
-compiler.armv8-cclang-9.semver=9.0.0
+compiler.armv8-cclang900.name=armv8-a clang 9.0.0
+compiler.armv8-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.armv8-cclang900.semver=9.0.0
 # Arm v8-a
-compiler.armv8-cclang-9.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+compiler.armv8-cclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv8-cclang900.alias=armv8-cclang-9
 
 compiler.armv7-cclang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang


### PR DESCRIPTION
The previous names only used the major versions.
This is in preparation for a change to add Arm Clang 10.0.1 and 11.0.0

Change-Id: Ie29e8690c3978fd002532d7020371d7c96b735d6

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
