### PR TITLE
[riscv] Enable More RISC-V Targets

### DIFF
--- a/etc/config/c++.default.properties
+++ b/etc/config/c++.default.properties
@@ -383,7 +383,7 @@ compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchai
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 # Clang for RISC-V
-group.rvclang.compilers=rv32-clang:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang900:rv64-clang:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang900
+group.rvclang.compilers=rv32-clang:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang-900:rv64-clang:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang900
 group.rvclang.groupName=Clang RISC-V
 group.rvclang.supportsBinary=false
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -290,19 +290,82 @@ compiler.armv8-full-cclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-lin
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 
 # Clang for RISC-V
-group.rvcclang.compilers=rv32cclang:rv64cclang
+group.rvcclang.compilers=rv32-cclang:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang900:rv64-cclang:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang900
 group.rvcclang.groupName=Clang RISC-V
 group.rvcclang.supportsBinary=false
-compiler.rv32cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.rv32cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32cclang.name=RISC-V rv32gc clang (trunk)
-compiler.rv32cclang.options=-target riscv32 -march=rv32gc -mabi=ilp32
-compiler.rv64cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.rv64cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv64cclang.name=RISC-V rv64gc clang (trunk)
-compiler.rv64cclang.options=-target riscv64 -march=rv64gc -mabi=lp64
+
+compiler.rv32-cclang.name=RISC-V rv32gc clang (trunk)
+compiler.rv32-cclang.alias=rv32cclang
+compiler.rv32-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.rv32-cclang.semver=(trunk)
+compiler.rv32-cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv32-cclang.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+
+compiler.rv32-cclang1100.name=RISC-V rv32gc clang 11.0.0
+compiler.rv32-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.rv32-cclang1100.semver=11.0.0
+compiler.rv32-cclang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang1100.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv32-cclang1100.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+
+compiler.rv32-cclang1001.name=RISC-V rv32gc clang 10.0.1
+compiler.rv32-cclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.rv32-cclang1001.semver=10.0.1
+compiler.rv32-cclang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang1001.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv32-cclang1001.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+
+compiler.rv32-cclang1000.name=RISC-V rv32gc clang 10.0.0
+compiler.rv32-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.rv32-cclang1000.semver=10.0.0
+compiler.rv32-cclang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang1000.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv32-cclang1000.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+
+compiler.rv32-cclang900.name=RISC-V rv32gc clang 9.0.0
+compiler.rv32-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.rv32-cclang900.semver=9.0.0
+compiler.rv32-cclang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang900.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv32-cclang900.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+
+compiler.rv64-cclang.name=RISC-V rv64gc clang (trunk)
+compiler.rv64-cclang.alias=rv64cclang
+compiler.rv64-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.rv64-cclang.semver=(trunk)
+compiler.rv64-cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+
+compiler.rv64-cclang1100.name=RISC-V rv64gc clang 11.0.0
+compiler.rv64-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.rv64-cclang1100.semver=11.0.0
+compiler.rv64-cclang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang1100.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang1100.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+
+compiler.rv64-cclang1001.name=RISC-V rv64gc clang 10.0.1
+compiler.rv64-cclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.rv64-cclang1001.semver=10.0.1
+compiler.rv64-cclang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang1001.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+
+compiler.rv64-cclang1000.name=RISC-V rv64gc clang 10.0.0
+compiler.rv64-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.rv64-cclang1000.semver=10.0.0
+compiler.rv64-cclang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang1000.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+
+compiler.rv64-cclang900.name=RISC-V rv64gc clang 9.0.0
+compiler.rv64-cclang900.semver=9.0.0
+compiler.rv64-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.rv64-cclang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang900.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+
 
 # ppci for various architectures
 group.ppci.compilers=ppci055

--- a/test/example-states/default-state.json
+++ b/test/example-states/default-state.json
@@ -341,7 +341,7 @@
                   "type": "component",
                   "componentName": "compiler",
                   "componentState": {
-                    "compiler": "rv32clang",
+                    "compiler": "rv32-clang",
                     "source": 4,
                     "options": "",
                     "filters": {

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -299,7 +299,7 @@ describe('GoldenLayout utils', () => {
                 {compiler: 'gsnapshot'},
                 {compiler: 'clang_trunk'},
                 {compiler: 'gsnapshot'},
-                {compiler: 'rv32clang'},
+                {compiler: 'rv32-clang'},
             ],
         });
     });


### PR DESCRIPTION
RISC-V became a default backend in Clang 9.0. This commit enables the
use of the RISC-V backend for Clang in versions:
- 9.0.0
- 10.0.0
- 10.0.1
- 11.0.0

I also did a few other tidy-ups:
- I ensured that these could use more headers for rv64, by adding the
  `--gcc-toolchain` and `--sysroot` args to point to the rv64 8.2.0
  cross-compiled gcc toolchain (which is what seems to be done for arm).
- I updated the `-mabi` for rv-64 so it matches what that toolchain is
  likely to have chosen as a default. I should check this, but I'm not
  sure how I can (help?).
- I changed the config keys to introduce a hyphen, to match the arm
  compiler keys.
- I'm not sure if older versions of CE-built clang also have RISC-V,
  given that the clang-builder repo has `RISCV` in the experimental
  targets to build. (PR incoming to remove that, as it's no longer
  needed, as RISC-V is no longer experimental).

I haven't been able to test this, partially because it depends on the
exact compiler-explorer setup on amazon, but I gleaned these details
from code in the compiler-explorer/infra repository.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
