### PR TITLE
[riscv] Add RISC-V 32-bit Compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -384,80 +384,91 @@ compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 # Clang for RISC-V
 group.rvclang.compilers=rv32-clang:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang900:rv64-clang:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang900
-group.rvclang.groupName=Clang RISC-V
+group.rvclang.groupName=RISC-V Clang
 group.rvclang.supportsBinary=false
+group.rvclang.supportsExecute=false
 
 compiler.rv32-clang.name=RISC-V rv32gc clang (trunk)
 compiler.rv32-clang.alias=rv32clang
 compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv32-clang.semver=(trunk)
 compiler.rv32-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-clang.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang.supportsBinary=true
 
 compiler.rv32-clang1100.name=RISC-V rv32gc clang 11.0.0
 compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv32-clang1100.semver=11.0.0
 compiler.rv32-clang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1100.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-clang1100.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-clang1100.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang1100.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1100.supportsBinary=true
 
 compiler.rv32-clang1001.name=RISC-V rv32gc clang 10.0.1
 compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv32-clang1001.semver=10.0.1
 compiler.rv32-clang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-clang1001.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1001.supportsBinary=true
 
 compiler.rv32-clang1000.name=RISC-V rv32gc clang 10.0.0
 compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv32-clang1000.semver=10.0.0
 compiler.rv32-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-clang1000.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1000.supportsBinary=true
 
 compiler.rv32-clang900.name=RISC-V rv32gc clang 9.0.0
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-clang900.semver=9.0.0
 compiler.rv32-clang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang900.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-clang900.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-clang900.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang900.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang900.supportsBinary=true
 
 compiler.rv64-clang.name=RISC-V rv64gc clang (trunk)
 compiler.rv64-clang.alias=rv64clang
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv64-clang.semver=(trunk)
 compiler.rv64-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang.supportsBinary=true
 
 compiler.rv64-clang1100.name=RISC-V rv64gc clang 11.0.0
 compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv64-clang1100.semver=11.0.0
 compiler.rv64-clang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1100.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-clang1100.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1100.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1100.supportsBinary=true
 
 compiler.rv64-clang1001.name=RISC-V rv64gc clang 10.0.1
 compiler.rv64-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv64-clang1001.semver=10.0.1
 compiler.rv64-clang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1001.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-clang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1001.supportsBinary=true
 
 compiler.rv64-clang1000.name=RISC-V rv64gc clang 10.0.0
 compiler.rv64-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv64-clang1000.semver=10.0.0
 compiler.rv64-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1000.supportsBinary=true
 
 compiler.rv64-clang900.name=RISC-V rv64gc clang 9.0.0
 compiler.rv64-clang900.semver=9.0.0
 compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv64-clang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang900.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-clang900.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang900.supportsBinary=true
 
 
 # Clang for WebAssembly
@@ -522,7 +533,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&riscv:&platspec:&kalray
+group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&rvgcc:&platspec:&kalray
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -768,13 +779,23 @@ compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-
 
 ###############################
 # GCC for RISC-V
-group.riscv.compilers=riscv820
-group.riscv.groupName=RISC-V GCC
-group.riscv.isSemVer=true
-compiler.riscv820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
-compiler.riscv820.name=RISC-V gcc 8.2.0
-compiler.riscv820.semver=8.2.0
-compiler.riscv820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+group.rvgcc.compilers=rv64-gcc820:rv32-gcc820
+group.rvgcc.groupName=RISC-V GCC
+group.rvgcc.supportsExecute=false
+
+compiler.rv64-gcc820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc820.name=RISC-V rv64gc gcc 8.2.0
+compiler.rv64-gcc820.alias=riscv820
+compiler.rv64-gcc820.semver=8.2.0
+compiler.rv64-gcc820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc820.supportsBinary=true
+
+compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
+compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
+compiler.rv32-gcc820.semver=8.2.0
+compiler.rv32-gcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv64-gcc820.supportsBinary=true
+
 
 ################################
 # Windows Compilers

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -291,80 +291,91 @@ compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 
 # Clang for RISC-V
 group.rvcclang.compilers=rv32-cclang:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang900:rv64-cclang:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang900
-group.rvcclang.groupName=Clang RISC-V
+group.rvcclang.groupName=RISC-V Clang
 group.rvcclang.supportsBinary=false
+group.rvcclang.supportsExecute=false
 
 compiler.rv32-cclang.name=RISC-V rv32gc clang (trunk)
 compiler.rv32-cclang.alias=rv32cclang
 compiler.rv32-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv32-cclang.semver=(trunk)
 compiler.rv32-cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-cclang.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang.supportsBinary=true
 
 compiler.rv32-cclang1100.name=RISC-V rv32gc clang 11.0.0
 compiler.rv32-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv32-cclang1100.semver=11.0.0
 compiler.rv32-cclang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-cclang1100.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-cclang1100.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-cclang1100.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang1100.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang1100.supportsBinary=true
 
 compiler.rv32-cclang1001.name=RISC-V rv32gc clang 10.0.1
 compiler.rv32-cclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv32-cclang1001.semver=10.0.1
 compiler.rv32-cclang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-cclang1001.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-cclang1001.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-cclang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang1001.supportsBinary=true
 
 compiler.rv32-cclang1000.name=RISC-V rv32gc clang 10.0.0
 compiler.rv32-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv32-cclang1000.semver=10.0.0
 compiler.rv32-cclang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-cclang1000.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-cclang1000.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-cclang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang1000.supportsBinary=true
 
 compiler.rv32-cclang900.name=RISC-V rv32gc clang 9.0.0
 compiler.rv32-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-cclang900.semver=9.0.0
 compiler.rv32-cclang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-cclang900.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.rv32-cclang900.options=-target riscv32 -march=rv32gc -mabi=ilp32d
+compiler.rv32-cclang900.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang900.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang900.supportsBinary=true
 
 compiler.rv64-cclang.name=RISC-V rv64gc clang (trunk)
 compiler.rv64-cclang.alias=rv64cclang
 compiler.rv64-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv64-cclang.semver=(trunk)
 compiler.rv64-cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang.supportsBinary=true
 
 compiler.rv64-cclang1100.name=RISC-V rv64gc clang 11.0.0
 compiler.rv64-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv64-cclang1100.semver=11.0.0
 compiler.rv64-cclang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-cclang1100.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang1100.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang1100.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang1100.supportsBinary=true
 
 compiler.rv64-cclang1001.name=RISC-V rv64gc clang 10.0.1
 compiler.rv64-cclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv64-cclang1001.semver=10.0.1
 compiler.rv64-cclang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-cclang1001.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang1001.supportsBinary=true
 
 compiler.rv64-cclang1000.name=RISC-V rv64gc clang 10.0.0
 compiler.rv64-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv64-cclang1000.semver=10.0.0
 compiler.rv64-cclang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-cclang1000.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang1000.supportsBinary=true
 
 compiler.rv64-cclang900.name=RISC-V rv64gc clang 9.0.0
 compiler.rv64-cclang900.semver=9.0.0
 compiler.rv64-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv64-cclang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-cclang900.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.rv64-cclang900.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang900.supportsBinary=true
 
 
 # ppci for various architectures
@@ -407,7 +418,7 @@ compiler.cicc191.options=-x c -gcc-name=/opt/compiler-explorer/gcc-8.2.0/bin/gcc
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr:&criscv:&cplatspec:&ckalray
+group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr:&rvcgcc:&cplatspec:&ckalray
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
@@ -604,13 +615,23 @@ compiler.cmips564el.semver=5.4
 
 ###############################
 # GCC for RISC-V
-group.criscv.compilers=criscv820
-group.criscv.groupName=RISC-V GCC
-group.criscv.isSemVer=true
-compiler.criscv820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
-compiler.criscv820.name=RISC-V gcc 8.2.0
-compiler.criscv820.semver=8.2.0
-compiler.criscv820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+group.rvcgcc.compilers=rv64-cgcc820:rv32-cgcc820
+group.rvcgcc.groupName=RISC-V GCC
+group.rvcgcc.supportsExecute=false
+
+compiler.rv64-cgcc820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc820.name=RISC-V rv64gc gcc 8.2.0
+compiler.rv64-cgcc820.alias=criscv820
+compiler.rv64-cgcc820.semver=8.2.0
+compiler.rv64-cgcc820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc820.supportsBinary=true
+
+compiler.rv32-cgcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
+compiler.rv32-cgcc820.name=RISC-V rv32gc gcc 8.2.0
+compiler.rv32-cgcc820.semver=8.2.0
+compiler.rv32-cgcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv64-cgcc820.supportsBinary=true
+
 
 ###############################
 # ARM HPC (disabled)


### PR DESCRIPTION
This change also enables `supportsBinary` (but not `supportsExecutable`)
on all the RISC-V targets (switching to the required objdump).

---

This depends on https://github.com/compiler-explorer/infra/pull/439