### PR TITLE
Enable "libraryCode" Filter by Default

### DIFF
--- a/views/options-filters.pug
+++ b/views/options-filters.pug
@@ -14,7 +14,7 @@ mixin filteroption(name, longdescription, shortdescription, defaultchecked)
       input.d-none(type="checkbox" checked=defaultchecked)
 
 +filteroption('labels', 'Filter unused labels from the output', 'Unused labels', true)
-+filteroption('libraryCode', 'Filter functions from other libraries from the output', 'Library functions', false)
++filteroption('libraryCode', 'Filter functions from other libraries from the output', 'Library functions', true)
 +filteroption('directives', 'Filter all assembler directives from the output', 'Directives', true)
 +filteroption('commentOnly', 'Remove all lines which are only comments from the output', 'Comments', true)
 +filteroption('trim', 'Trim intra-line whitespace', 'Horizontal whitespace', false)


### PR DESCRIPTION
I'm proposing setting the "Library Code" filter be enabled by default (I believe this is the correct change to make this happen). 

This change will improve the output of the MSVC compilers as they include a lot of 'external' code in their ASM output. 

To see the impact of this change toggle the "library code" filter with the following C++ using any of the MSVC compilers (e.g. "x64 MSVC v19.28")

```C++
#include <string>
void foo() { std::string s; }
```
