### PR TITLE
Eigen 3.3.9

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1092,10 +1092,12 @@ libs.tts.versions.trunk.path=/opt/compiler-explorer/libs/tts/trunk/include
 libs.tts.versions.v01.version=v0.1
 libs.tts.versions.v01.path=/opt/compiler-explorer/libs/tts/0.1/include
 libs.eigen.name=Eigen
-libs.eigen.versions=trunk:337:335:334
+libs.eigen.versions=trunk:339:337:335:334
 libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
 libs.eigen.versions.trunk.version=trunk
 libs.eigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.eigen.versions.339.version=3.3.9
+libs.eigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
 libs.eigen.versions.337.version=3.3.7
 libs.eigen.versions.337.path=/opt/compiler-explorer/libs/eigen/v3.3.7
 libs.eigen.versions.335.version=3.3.5

--- a/etc/config/c++.default.properties
+++ b/etc/config/c++.default.properties
@@ -1069,10 +1069,12 @@ libs.tts.versions.trunk.path=/opt/compiler-explorer/libs/tts/trunk/include
 libs.tts.versions.v01.version=v0.1
 libs.tts.versions.v01.path=/opt/compiler-explorer/libs/tts/0.1/include
 libs.eigen.name=Eigen
-libs.eigen.versions=trunk:337:335:334
+libs.eigen.versions=trunk:339:337:335:334
 libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
 libs.eigen.versions.trunk.version=trunk
 libs.eigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.eigen.versions.339.version=3.3.9
+libs.eigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
 libs.eigen.versions.337.version=3.3.7
 libs.eigen.versions.337.path=/opt/compiler-explorer/libs/eigen/v3.3.7
 libs.eigen.versions.335.version=3.3.5

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -72,10 +72,16 @@ compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --c
 libs=cueigen:thrustcub:cucub:cudacxx:nvtx
 
 libs.cueigen.name=Eigen
-libs.cueigen.versions=trunk:334
+libs.cueigen.versions=trunk:339:337:335:334
 libs.cueigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
 libs.cueigen.versions.trunk.version=trunk
 libs.cueigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.cueigen.versions.339.version=3.3.9
+libs.cueigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
+libs.cueigen.versions.337.version=3.3.7
+libs.cueigen.versions.337.path=/opt/compiler-explorer/libs/eigen/v3.3.7
+libs.cueigen.versions.335.version=3.3.5
+libs.cueigen.versions.335.path=/opt/compiler-explorer/libs/eigen/v3.3.5
 libs.cueigen.versions.334.version=3.3.4
 libs.cueigen.versions.334.path=/opt/compiler-explorer/libs/eigen/v3.3.4
 


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

@partouf As requested in https://github.com/compiler-explorer/infra/pull/452#issuecomment-748670710 I have added Eigen 3.3.9 *only* to all properties files where older versions have already been configured. This affects
- `c++.default.properties`
- `c++.amazon.properties`

You also asked about `cuda.amazon.properties`, where only `trunk` and `v3.3.4` had been configured. I have added the same versions as to the other files now, but be aware that I am not using CUDA with Eigen (and I am just a user of Eigen). I could not find any issues with CUDA mentioned in the change log, but I have *not tested this at all*.