### PR TITLE
Add text wrapping toggle to executor pane

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -163,6 +163,11 @@ pre.content.wrap {
     white-space: pre-wrap;
 }
 
+pre.content.wrap * {
+    word-wrap: break-word;
+    white-space: pre-wrap; /* Preserve sequences of white space */
+}
+
 .compile-time {
     font-size: x-small;
     font-style: italic;

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -58,6 +58,7 @@ function Executor(hub, container, state) {
     this.compilerService = hub.compilerService;
     this.domRoot = container.getElement();
     this.domRoot.html($('#executor').html());
+    this.contentRoot = this.domRoot.find('.content');
     this.sourceEditorId = state.source || 1;
     this.id = state.id || hub.nextExecutorId();
     this.settings = JSON.parse(local.get('settings', '{}'));
@@ -392,7 +393,7 @@ Executor.prototype.onEditorChange = function (editor, source, langId, compilerId
 
 Executor.prototype.initButtons = function (state) {
     this.filters = new Toggles(this.domRoot.find('.filters'), state.filters);
-
+    this.toggleWrapButton = new Toggles(this.domRoot.find('.options'), state);
     this.compileClearCache = this.domRoot.find('.clear-cache');
     this.outputContentRoot = this.domRoot.find('pre.content');
     this.executionStatusSection = this.outputContentRoot.find('.execution-status');
@@ -441,6 +442,9 @@ Executor.prototype.initButtons = function (state) {
     this.panelArgs = this.domRoot.find('.panel-args');
     this.panelStdin = this.domRoot.find('.panel-stdin');
 
+    this.wrapButton = this.domRoot.find('.wrap-lines');
+    this.wrapTitle = this.wrapButton.prop('title');
+
     this.initToggleButtons(state);
 };
 
@@ -465,6 +469,14 @@ Executor.prototype.initToggleButtons = function (state) {
     if (state.compilerOutShown === false) {
         this.hidePanel(this.toggleCompilerOut, this.compilerOutputSection);
     }
+
+    if (state.wrap === true) {
+        this.contentRoot.addClass('wrap');
+        this.wrapButton.prop('title', '[ON] ' + this.wrapTitle);
+    } else {
+        this.contentRoot.removeClass('wrap');
+        this.wrapButton.prop('title', '[OFF] ' + this.wrapTitle);
+    }
 };
 
 Executor.prototype.onLibsChanged = function () {
@@ -484,6 +496,7 @@ Executor.prototype.onFontScale = function () {
 Executor.prototype.initListeners = function () {
     // this.filters.on('change', _.bind(this.onFilterChange, this));
     this.fontScale.on('change', _.bind(this.onFontScale, this));
+    this.toggleWrapButton.on('change', _.bind(this.onToggleWrapChange, this));
 
     this.container.on('destroy', this.close, this);
     this.container.on('resize', this.resize, this);
@@ -498,7 +511,6 @@ Executor.prototype.initListeners = function () {
     this.eventHub.on('resendExecution', this.onResendExecutionResult, this);
     this.eventHub.on('resize', this.resize, this);
     this.eventHub.on('findExecutors', this.sendExecutor, this);
-
     this.eventHub.on('languageChange', this.onLanguageChange, this);
 };
 
@@ -650,6 +662,13 @@ Executor.prototype.onCompilerChange = function (value) {
     this.updateCompilerUI();
 };
 
+Executor.prototype.onToggleWrapChange = function () {
+    var state = this.currentState();
+    this.contentRoot.toggleClass('wrap',state.wrap);
+    this.wrapButton.prop('title', '['+(state.wrap ? 'ON' : 'OFF')+'] '+ this.wrapTitle);
+    this.saveState();
+};
+
 Executor.prototype.sendExecutor = function () {
     this.eventHub.emit('executor', this.id, this.compiler, this.options, this.sourceEditorId);
 };
@@ -679,6 +698,7 @@ Executor.prototype.currentState = function () {
         compilerOutShown: !this.compilerOutputSection.hasClass('d-none'),
         argsPanelShown: !this.panelArgs.hasClass('d-none'),
         stdinPanelShown: !this.panelStdin.hasClass('d-none'),
+        wrap: this.toggleWrapButton.get().wrap,
     };
     this.fontScale.addState(state);
     return state;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -153,6 +153,11 @@
   #executor
     .top-bar.btn-toolbar.bg-light(role="toolbar")
       include font-size
+      .btn-group.btn-group-sm.options(role="group" aria-label="Output options")
+        .button-checkbox
+          button.btn.btn-sm.btn-light.wrap-lines(type="button" title="Wrap lines" data-bind="wrap" aria-pressed="false" aria-label="Wrap lines")
+            span Wrap lines
+          input.d-none(type="checkbox" checked=false)
         button.btn.btn-sm.btn-light.show-libs(title="Include libs" aria-label="Toggle libraries dropdown")
           span.fas.fa-book
           span.hideable &nbsp;Libraries


### PR DESCRIPTION
Closes #2358

- [x] pass local eslint checks (`make check`)
- [x] ensure feature works as expected:
  - [x] allow user to enable/disable text wrapping in execution only panels
  - [x] button state and relevant css restored after page reloads 