### PR TITLE
TinyC support

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -744,7 +744,7 @@ compiler.ctendrax86trunk.semver=(trunk)
 
 #################################
 # TinyC compiler
-group.tinycc.compilers=tinycc0927
+group.tinycc.compilers=tinycc0927:tinycctrunk
 group.tinycc.groupName=Tiny C compiler
 group.tinycc.baseName=TCC
 group.tinycc.supportsPVS=false
@@ -752,6 +752,9 @@ group.tinycc.isSemVer=true
 group.tinycc.versionFlag=-v
 group.tinycc.supportsBinary=true
 group.tinycc.compilerType=tinyc
+
+compiler.tinycctrunk.exe=/opt/compiler-explorer/tinycc-trunk/bin/tcc
+compiler.tinycctrunk.semver=(trunk)
 
 compiler.tinycc0927.exe=/opt/compiler-explorer/tinycc-0.9.27/bin/tcc
 compiler.tinycc0927.semver=0.9.27

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&ppci:&cicc:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&ppci:&cicc:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc
 defaultCompiler=cg102
 demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
@@ -740,6 +740,21 @@ group.ctendrax86.supportsBinary=false
 
 compiler.ctendrax86trunk.exe=/opt/compiler-explorer/tendra-trunk/bin/tcc
 compiler.ctendrax86trunk.semver=(trunk)
+
+
+#################################
+# TinyC compiler
+group.tinycc.compilers=tinycc0927
+group.tinycc.groupName=Tiny C compiler
+group.tinycc.baseName=TCC
+group.tinycc.supportsPVS=false
+group.tinycc.isSemVer=true
+group.tinycc.versionFlag=-v
+group.tinycc.supportsBinary=true
+group.tinycc.compilerType=tinyc
+
+compiler.tinycc0927.exe=/opt/compiler-explorer/tinycc-0.9.27/bin/tcc
+compiler.tinycc0927.semver=0.9.27
 
 
 #################################

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -61,3 +61,4 @@ export { Win32VcCompiler } from './win32-vc';
 export { WineVcCompiler } from './wine-vc';
 export { WslVcCompiler } from './wsl-vc';
 export { ZigCompiler } from './zig';
+export { TinyCCompiler } from './tinyc';

--- a/lib/compilers/tinyc.js
+++ b/lib/compilers/tinyc.js
@@ -29,11 +29,14 @@ export class TinyCCompiler extends BaseCompiler {
     static get key() { return 'tinyc'; }
 
     optionsForFilter(filters, outputFilename, userOptions) {
-        if (!_.find(userOptions, (opt) => opt === '-E')) {
-            filters.binary = true;
+        if (_.some(userOptions, (opt) => opt === '--help' || opt === '-h' || opt === '-hh')) {
+            return [];
+        } else {
+            if (!_.some(userOptions, (opt) => opt === '-E')) {
+                filters.binary = true;
+            }
+            return ['-o', this.filename(outputFilename)];
         }
-
-        return ['-o', this.filename(outputFilename)];
     }
 
     filterUserOptions(userOptions) {

--- a/lib/compilers/tinyc.js
+++ b/lib/compilers/tinyc.js
@@ -28,9 +28,12 @@ import _ from 'underscore';
 export class TinyCCompiler extends BaseCompiler {
     static get key() { return 'tinyc'; }
 
-    optionsForFilter(filters, outputFilename) {
-        filters.binary = true;
-        return ['-g', '-o', this.filename(outputFilename)];
+    optionsForFilter(filters, outputFilename, userOptions) {
+        if (!_.find(userOptions, (opt) => opt === '-E')) {
+            filters.binary = true;
+        }
+
+        return ['-o', this.filename(outputFilename)];
     }
 
     filterUserOptions(userOptions) {

--- a/lib/compilers/tinyc.js
+++ b/lib/compilers/tinyc.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2020, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { BaseCompiler } from '../base-compiler';
+import _ from 'underscore';
+
+export class TinyCCompiler extends BaseCompiler {
+    static get key() { return 'tinyc'; }
+
+    optionsForFilter(filters, outputFilename) {
+        filters.binary = true;
+        return ['-g', '-o', this.filename(outputFilename)];
+    }
+
+    filterUserOptions(userOptions) {
+        return _.filter(userOptions, (opt) => opt !== '-run');
+    }
+}


### PR DESCRIPTION
Would fix #246

Some things of note:
- [x] Disabled `-run`, because that would run under a different jail
- [ ] `-m32` doesn't work, seems this was not built, probably need to pass something to `configure`
- [x] `-g` is something else than in most compilers, wondering if we should leave it out?
- [x] We can maybe enable trunk (the mob branch @ https://repo.or.cz/w/tinycc.git) ?
