### PR TITLE
Fix regex for .weak and .weakext detection

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -43,7 +43,7 @@ export class AsmParser extends AsmRegex {
         this.hasNvccOpcodeRe = /^\s*[@A-Za-z|]/;
         this.definesFunction = /^\s*\.(type.*,\s*[#%@]function|proc\s+[.A-Z_a-z][\w$.]*:.*)$/;
         this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*)/;
-        this.definesWeak = /^\s*\.(?:weak|weakext)\s*([.A-Z_a-z][\w$.]*)/;
+        this.definesWeak = /^\s*\.(?:weakext|weak)\s*([.A-Z_a-z][\w$.]*)/;
         this.indentedLabelDef = /^\s*([$.A-Z_a-z][\w$.]*):/;
         this.assignmentDef = /^\s*([$.A-Z_a-z][\w$.]+)\s*=/;
         this.directive = /^\s*\..*$/;


### PR DESCRIPTION
Doesn't affect much in our parsing, but regex is incorrect and returned the wrong label name in case of `.weakext` (returned "ext" as labelname)
