### PR TITLE
Add clang compilers to the defaults file

### DIFF
--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -23,12 +23,19 @@ compiler.g8.name=g++ 8.x
 compiler.gdefault.exe=/usr/bin/g++
 compiler.gdefault.name=g++ default
 
-group.clang.compilers=clang7:clangdefault
+group.clang.compilers=clang7:clang8:clang9:clang10:clangdefault
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 compiler.clang7.exe=/usr/bin/clang++-7
 compiler.clang7.name=clang 7
+compiler.clang8.exe=/usr/bin/clang++-8
+compiler.clang8.name=clang 8
+compiler.clang9.exe=/usr/bin/clang++-9
+compiler.clang9.name=clang 9
+compiler.clang10.exe=/usr/bin/clang++-10
+compiler.clang10.name=clang 10
 compiler.clangdefault.exe=/usr/bin/clang++
 compiler.clangdefault.name=clang default
+
 defaultCompiler=gdefault
 postProcess=
 demangler=c++filt


### PR DESCRIPTION
On ubuntu, you can install specific versions of the clang compiler and they
will be named similarly to the gcc compilers. Add these to the defaults file
so if they are there, they will be made available.


<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
