### PR TITLE
Add default installation locations for more C compilers

### DIFF
--- a/etc/config/c.defaults.properties
+++ b/etc/config/c.defaults.properties
@@ -1,11 +1,48 @@
 # Default settings for C
-compilers=/usr/bin/gcc-4.4:/usr/bin/gcc-4.5:/usr/bin/gcc-4.6:/usr/bin/gcc-4.7:/usr/bin/gcc-4.8:/usr/bin/clangcc:/usr/bin/gcc-5:/usr/bin/gcc-7:/usr/bin/gcc-6:/usr/bin/gcc
-defaultCompiler=/usr/bin/gcc
-postProcess=
+compilers=:&gcc:&clang
+defaultCompiler=gdefault
 demangler=c++filt
 objdumper=objdump
+postProcess=
 supportsBinary=true
 binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*)$
 stubRe=\bmain\b
 stubText=int main(void){return 0;/*stub provided by Compiler Explorer*/}
 supportsLibraryCodeFilter=true
+
+group.gcc.compilers=cg44:cg45:cg46:cg47:cg48:cg5:cg6:cg7:cg8:cgdefault
+compiler.cg44.exe=/usr/bin/gcc-4.4
+compiler.cg44.name=gcc 4.4
+compiler.cg45.exe=/usr/bin/gcc-4.5
+compiler.cg45.name=gcc 4.5
+compiler.cg46.exe=/usr/bin/gcc-4.6
+compiler.cg46.name=gcc 4.6
+compiler.cg47.exe=/usr/bin/gcc-4.7
+compiler.cg47.name=gcc 4.7
+compiler.cg48.exe=/usr/bin/gcc-4.8
+compiler.cg48.name=gcc 4.8
+compiler.cg5.exe=/usr/bin/gcc-5
+compiler.cg5.name=gcc 5
+compiler.cg6.exe=/usr/bin/gcc-6
+compiler.cg6.name=gcc 6
+compiler.cg7.exe=/usr/bin/gcc-7
+compiler.cg7.name=gcc 7
+compiler.cg8.exe=/usr/bin/gcc-8
+compiler.cg8.name=gcc 8
+compiler.cgdefault.exe=/usr/bin/gcc
+compiler.cgdefault.name=gcc default
+
+group.clang.compilers=cclang7:cclang8:cclang9:cclang10:cclangdefault:cclangccdefault
+group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
+compiler.cclang7.exe=/usr/bin/clang-7
+compiler.cclang7.name=clang 7
+compiler.cclang8.exe=/usr/bin/clang-8
+compiler.cclang8.name=clang 8
+compiler.cclang9.exe=/usr/bin/clang-9
+compiler.cclang9.name=clang 9
+compiler.cclang10.exe=/usr/bin/clang-10
+compiler.cclang10.name=clang 10
+compiler.cclangdefault.exe=/usr/bin/clang
+compiler.cclangdefault.name=clang default
+compiler.cclangccdefault.exe=/usr/bin/clangcc
+compiler.cclangccdefault.name=clang default


### PR DESCRIPTION
This converts the file to the new config format (AIUI) and adds more C
compilers commonly provided by package managers.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
