### PR TITLE
Make the input file to clang-query unique so you can run multiple clang query tools

### DIFF
--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -45,6 +45,12 @@ export class BaseTool {
         return this.tool.type || 'independent';
     }
 
+    getUniqueFilePrefix() {
+        const timestamp = process.hrtime();
+        const timestamp_str = '_' + timestamp[0] * 1000000 + timestamp[1] / 1000;
+        return this.tool.id.replace(/[^a-z0-9]/gi, '_') + timestamp_str + '_';
+    }
+
     isCompilerExcluded(compilerId, compilerProps) {
         if (this.tool.includeKey) {
             // If the includeKey is set, we only support compilers that have a truthy 'includeKey'.

--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -42,10 +42,12 @@ export class ClangQueryTool extends BaseTool {
             compileFlags.push(this.tool.options);
         }
 
+        const query_commands_file = this.getUniqueFilePrefix() + 'query_commands.txt';
+
         await fs.writeFile(path.join(dir, 'compile_flags.txt'), compileFlags.join('\n'));
-        await fs.writeFile(path.join(dir, 'query_commands.txt'), stdin);
+        await fs.writeFile(path.join(dir, query_commands_file), stdin);
         args.push('-f');
-        args.push('query_commands.txt');
+        args.push(query_commands_file);
         const toolResult = await super.runTool(compilationInfo, sourcefile, args);
 
         if (toolResult.stdout.length > 0) {


### PR DESCRIPTION
I fought with this for a while. I tried executing the tool in a subdirectory; but this failed because it expects a compilation database where it can find it. I tried telling it where that was, but that didn't work.  I tried putting only the query_commands file in a subdirectory but I got some inexplicable errors.  So I went back to a unique filename per invocation.

I looked for other tools that would suffer the same problem, but I actually couldn't find any by looking at the usages of `writeFile`.  Other tools do write a file, but the contents comes from the compilatioInfo which would be identical for all tools running for that compiler. This is also the case with the compile_commands file in clang-query.

So while this isn't as robust as it could be, I think it fixes the immediate bug, and there may not be a similar bug that happens until we get a tool that e.g. inadvertently stomps over other invocations' intermediary files.  (Or someone repeats writing this bug.)