### PR TITLE
Add some default C++ tools that are commonly found

### DIFF
--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -37,6 +37,52 @@ compiler.clang10.name=clang 10
 compiler.clangdefault.exe=/usr/bin/clang++
 compiler.clangdefault.name=clang default
 
+tools=clangquerydefault:clangquery7:clangquery8:clangquery9:clangquery10:strings:ldd
+
+tools.clangquerydefault.exe=/usr/bin/clang-query
+tools.clangquerydefault.name=clang-query (default)
+tools.clangquerydefault.type=independent
+tools.clangquerydefault.class=clang-query-tool
+tools.clangquerydefault.stdinHint=Query commands
+
+tools.clangquery7.exe=/usr/bin/clang-query-7
+tools.clangquery7.name=clang-query 7
+tools.clangquery7.type=independent
+tools.clangquery7.class=clang-query-tool
+tools.clangquery7.stdinHint=Query commands
+
+tools.clangquery8.exe=/usr/bin/clang-query-8
+tools.clangquery8.name=clang-query 8
+tools.clangquery8.type=independent
+tools.clangquery8.class=clang-query-tool
+tools.clangquery8.stdinHint=Query commands
+
+tools.clangquery9.exe=/usr/bin/clang-query-9
+tools.clangquery9.name=clang-query 9
+tools.clangquery9.type=independent
+tools.clangquery9.class=clang-query-tool
+tools.clangquery9.stdinHint=Query commands
+
+tools.clangquery10.exe=/usr/bin/clang-query-10
+tools.clangquery10.name=clang-query 10
+tools.clangquery10.type=independent
+tools.clangquery10.class=clang-query-tool
+tools.clangquery10.stdinHint=Query commands
+
+tools.ldd.name=ldd
+tools.ldd.exe=/usr/bin/ldd
+tools.ldd.type=postcompilation
+tools.ldd.class=readelf-tool
+tools.ldd.exclude=djggp
+tools.ldd.stdinHint=disabled
+
+tools.strings.exe=/usr/bin/strings
+tools.strings.name=strings
+tools.strings.type=postcompilation
+tools.strings.class=strings-tool
+tools.strings.exclude=djggp
+tools.strings.stdinHint=disabled
+
 defaultCompiler=gdefault
 postProcess=
 demangler=c++filt


### PR DESCRIPTION
These tool names are not unique; but I gather that - unlike compiler names - they don't need to be? I found lots of `tools.strings...` in the config files.