### PR TITLE
If an stdinHint is specified on a tool, when the tool opens, default to showing the stdin input

### DIFF
--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -339,6 +339,8 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
                 this.stdinField.prop('placeholder', toolInfo.tool.stdinHint);
                 if (toolInfo.tool.stdinHint === 'disabled') {
                     this.toggleStdin.prop('disabled', true);
+                } else {
+                    this.showPanel(this.toggleStdin, this.panelStdin);
                 }
             } else {
                 this.stdinField.prop('placeholder', 'Tool stdin...');


### PR DESCRIPTION
FWIW clang-query is the only tool in the repo that uses stdinHint
