### PR TITLE
Allow to listen on unix socket instead of port

### DIFF
--- a/app.js
+++ b/app.js
@@ -627,7 +627,7 @@ async function main() {
         await setupStaticMiddleware(router);
     }
 
-    morgan.token('gdpr_ip', req => utils.anonymizeIp(req.ip));
+    morgan.token('gdpr_ip', req => req.ip ? utils.anonymizeIp(req.ip) : '');
 
     // Based on combined format, but: GDPR compliant IP, no timestamp & no unused fields for our usecase
     const morganFormat = isDevMode() ? 'dev' : ':gdpr_ip ":method :url" :status';

--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ const opts = nopt({
     env: [String, Array],
     rootDir: [String],
     host: [String],
-    port: [Number],
+    port: [String, Number],
     propDebug: [Boolean],
     debug: [Boolean],
     dist: [Boolean],
@@ -382,10 +382,20 @@ function startListening(server) {
     }
 
     const startupDurationMs = Math.floor(process.uptime() * 1000);
-    logger.info(`  Listening on http://${defArgs.hostname || 'localhost'}:${_port}/`);
-    logger.info(`  Startup duration: ${startupDurationMs}ms`);
-    logger.info('=======================================');
-    server.listen(_port, defArgs.hostname);
+    if (isNaN(parseInt(_port))) {
+        // unix socket, not a port number...
+        logger.info(`  Listening on socket: //${_port}/`);
+        logger.info(`  Startup duration: ${startupDurationMs}ms`);
+        logger.info('=======================================');
+        server.listen(_port);
+    }
+    else {
+        // normal port number
+        logger.info(`  Listening on http://${defArgs.hostname || 'localhost'}:${_port}/`);
+        logger.info(`  Startup duration: ${startupDurationMs}ms`);
+        logger.info('=======================================');
+        server.listen(_port, defArgs.hostname);
+    }
 }
 
 function setupSentry(sentryDsn, expressApp) {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Dear compiler-explorer team

I tried to run compiler explorer on a linux machine and listen on unix socket instead of a port.
Works basically fine but I needed the changes below to be able to configure it properly.

**I don't know if this messes with some systemd integration (`systemdSocket` function call in `startListening`)**

Another problem occurs during logging (I assume) in production mode (works fine in dev-mode):
```
error: Internal server error: Cannot read property 'includes' of undefined {"domainThrown":true,"stack":"TypeError: Cannot read property 'includes' of undefined\n    at Proxy.anonymizeIp (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/lib/utils.js:161:12)\n    at Function.gdpr_ip (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/app.js:632:42)\n    at eval (eval at compile (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/morgan/index.js:411:10), <anonymous>:5:23)\n    at Array.logRequest (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/morgan/index.js:122:18)\n    at listener (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/on-finished/index.js:169:15)\n    at onFinish (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/on-finished/index.js:100:5)\n    at callback (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/ee-first/index.js:55:10)\n    at ServerResponse.onevent (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/ee-first/index.js:93:5)\n    at ServerResponse.emit (events.js:327:22)\n    at ServerResponse.EventEmitter.emit (domain.js:529:15)"}
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:558:11)
    at ServerResponse.header (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/response.js:771:10)
    at ServerResponse.contentType (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/response.js:599:15)
    at ServerResponse.send (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/response.js:145:14)
    at done (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/response.js:1008:10)
    at Object.exports.renderFile (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/pug/lib/index.js:421:12)
    at View.exports.__express [as engine] (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/pug/lib/index.js:464:11)
    at View.render (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/view.js:135:8)
    at tryRender (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/application.js:640:10)
    at Function.render (/home/zoel_ml/test/compiler-explorer-script/compiler-explorer/node_modules/express/lib/application.js:592:3)
```

Any thoughts on this?