### PR TITLE
WIP: Add support for Elbrus 2000 C++ & Fortran compilers

### DIFF
--- a/etc/firejail/execute.profile
+++ b/etc/firejail/execute.profile
@@ -13,3 +13,5 @@ whitelist /opt/intel
 read-only /opt/intel
 whitelist /opt/arm
 read-only /opt/arm
+whitelist /opt/mcst
+read-only /opt/mcst

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -65,11 +65,12 @@ export class AsmParser extends AsmRegex {
             this.maxAsmLines = compilerProps('maxLinesOfAsm', this.maxAsmLines);
         }
 
+        this.lccLineCommentRe = /(\s+!.*)$/;
         this.asmOpcodeRe = /^\s*([\da-f]+):\s*(([\da-f]{2} ?)+)\s*(.*)/;
         this.lineRe = /^(\/[^:]+):(\d+).*/;
         this.labelRe = /^([\da-f]+)\s+<([^>]+)>:$/;
         this.destRe = /\s([\da-f]+)\s+<([^+>]+)(\+0x[\da-f]+)?>$/;
-        this.commentRe = /[#;]/;
+        this.commentRe = /[#;!]/;
         this.instOpcodeRe = /(\.inst\.?\w?)\s*(.*)/;
     }
 
@@ -262,9 +263,9 @@ export class AsmParser extends AsmRegex {
         let prevLabel = '';
 
         // Lines matching the following pattern are considered comments:
-        // - starts with '#', '@', '//' or a single ';' (non repeated)
+        // - starts with '!', '#', '@', '//' or a single ';' (non repeated)
         // - starts with ';;' and has non-whitespace before end of line
-        const commentOnly = /^\s*(((#|@|\/\/).*)|(\/\*.*\*\/)|(;\s*)|(;[^;].*)|(;;.*\S.*))$/;
+        const commentOnly = /^\s*(((!|#|@|\/\/).*)|(\/\*.*\*\/)|(;\s*)|(;[^;].*)|(;;.*\S.*))$/;
 
         const commentOnlyNvcc = /^\s*(((#|;|\/\/).*)|(\/\*.*\*\/))$/;
         const sourceTag = /^\s*\.loc\s+(\d+)\s+(\d+).*/;
@@ -272,6 +273,8 @@ export class AsmParser extends AsmRegex {
         const source6502Dbg = /^\s*\.dbg\s+line,\s*"([^"]+)",\s*(\d+)/;
         const source6502DbgEnd = /^\s*\.dbg\s+line[^,]/;
         const sourceStab = /^\s*\.stabn\s+(\d+),0,(\d+),.*/;
+        const sourceE2K = /!\s+(.+)\s+:\s+(\d+)$/;
+        const sourceE2Kold = /!.*line=(\d+)$/;
         const stdInLooking = /<stdin>|^-$|example\.[^/]+$|<source>/;
         const endBlock = /\.(cfi_endproc|data|text|section)/;
         let source = null;
@@ -341,6 +344,29 @@ export class AsmParser extends AsmRegex {
             }
         }
 
+        function handleE2K(line) {
+            const match = line.match(sourceE2K)
+            if (match) {
+                const file = match[1];
+                const sourceLine = parseInt(match[2]);
+                source = {
+                    file: !file.match(stdInLooking) ? file : null,
+                    line: sourceLine,
+                };
+                return true;
+            } else {
+                const matchold = line.match(sourceE2Kold)
+                if (matchold) {
+                    source = {
+                        file: null,
+                        line: parseInt(match[1]),
+                    };
+                    return true;
+                }
+            }
+            return false;
+        }
+
         let inNvccDef = false;
         let inNvccCode = false;
 
@@ -357,6 +383,11 @@ export class AsmParser extends AsmRegex {
             handleSource(line);
             handleStabs(line);
             handle6502(line);
+
+            // strip file line comment
+            if(handleE2K(line)) {
+                line = line.split(this.lccLineCommentRe, 1)[0]
+            }
 
             if (source && source.file === null) {
                 lastOwnSource = source;

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -70,7 +70,7 @@ export class AsmParser extends AsmRegex {
         this.lineRe = /^(\/[^:]+):(\d+).*/;
         this.labelRe = /^([\da-f]+)\s+<([^>]+)>:$/;
         this.destRe = /\s([\da-f]+)\s+<([^+>]+)(\+0x[\da-f]+)?>$/;
-        this.commentRe = /[#;!]/;
+        this.commentRe = /[!#;]/;
         this.instOpcodeRe = /(\.inst\.?\w?)\s*(.*)/;
     }
 
@@ -345,7 +345,7 @@ export class AsmParser extends AsmRegex {
         }
 
         function handleE2K(line) {
-            const match = line.match(sourceE2K)
+            const match = line.match(sourceE2K);
             if (match) {
                 const file = match[1];
                 const sourceLine = parseInt(match[2]);
@@ -355,7 +355,7 @@ export class AsmParser extends AsmRegex {
                 };
                 return true;
             } else {
-                const matchold = line.match(sourceE2Kold)
+                const matchold = line.match(sourceE2Kold);
                 if (matchold) {
                     source = {
                         file: null,
@@ -386,7 +386,7 @@ export class AsmParser extends AsmRegex {
 
             // strip file line comment
             if(handleE2K(line)) {
-                line = line.split(this.lccLineCommentRe, 1)[0]
+                line = line.split(this.lccLineCommentRe, 1)[0];
             }
 
             if (source && source.file === null) {

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -40,6 +40,7 @@ export { GolangCompiler } from './golang';
 export { HaskellCompiler } from './haskell';
 export { ISPCCompiler } from './ispc';
 export { JavaCompiler } from './java';
+export { LFortranCompiler } from './lfortran';
 export { LCCCompiler } from './lcc';
 export { LDCCompiler } from './ldc';
 export { LLCCompiler } from './llc';

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -40,6 +40,7 @@ export { GolangCompiler } from './golang';
 export { HaskellCompiler } from './haskell';
 export { ISPCCompiler } from './ispc';
 export { JavaCompiler } from './java';
+export { LCCCompiler } from './lcc';
 export { LDCCompiler } from './ldc';
 export { LLCCompiler } from './llc';
 export { LLVMmcaTool } from './llvm-mca';

--- a/lib/compilers/lcc.js
+++ b/lib/compilers/lcc.js
@@ -22,31 +22,31 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BaseCompiler } from '../base-compiler';
 import path from 'path';
+
+import { BaseCompiler } from '../base-compiler';
 
 export class LCCCompiler extends BaseCompiler {
     static get key() { return 'lcc'; }
 
     optionsForFilter(filters, outputFilename) {
-        let args = []
+        let args = [];
         if(!filters.binary) args = args.concat('-fverbose-asm');
-        args = args.concat(super.optionsForFilter(filters, outputFilename))
-        return args
+        args = args.concat(super.optionsForFilter(filters, outputFilename));
+        return args;
     }
 
     async objdump(outputFilename, result, maxSize, intelAsm, demangle) {
         let args = [];
-	if (demangle) args = args.concat('--demangle');
+        if (demangle) args = args.concat('--demangle');
         args = args.concat(outputFilename);
 
         const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
-	console.log(this.compiler.objdumper, args);
         const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
         result.asm = objResult.stdout;
-        /*if (objResult.code !== 0) {
+        if (objResult.code !== 0) {
             result.asm = `<No output: objdump returned ${objResult.code}>`;
-        }*/
+        }
         return result;
     }
 }

--- a/lib/compilers/lcc.js
+++ b/lib/compilers/lcc.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { BaseCompiler } from '../base-compiler';
+import path from 'path';
+
+export class LCCCompiler extends BaseCompiler {
+    static get key() { return 'lcc'; }
+
+    optionsForFilter(filters, outputFilename) {
+        let args = []
+        if(!filters.binary) args = args.concat('-fverbose-asm');
+        args = args.concat(super.optionsForFilter(filters, outputFilename))
+        return args
+    }
+
+    async objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+        let args = [];
+	if (demangle) args = args.concat('--demangle');
+        args = args.concat(outputFilename);
+
+        const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
+	console.log(this.compiler.objdumper, args);
+        const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
+        result.asm = objResult.stdout;
+        /*if (objResult.code !== 0) {
+            result.asm = `<No output: objdump returned ${objResult.code}>`;
+        }*/
+        return result;
+    }
+}

--- a/lib/compilers/lfortran.js
+++ b/lib/compilers/lfortran.js
@@ -22,26 +22,26 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { FortranCompiler } from './fortran.js';
 import path from 'path';
+
+import { FortranCompiler } from './fortran';
 
 export class LFortranCompiler extends FortranCompiler {
     static get key() { return 'lfortran'; }
 
     optionsForFilter(filters, outputFilename) {
-        let args = []
+        let args = [];
         if(!filters.binary) args = args.concat('-fverbose-asm');
-        args = args.concat(super.optionsForFilter(filters, outputFilename))
-        return args
+        args = args.concat(super.optionsForFilter(filters, outputFilename));
+        return args;
     }
 
     async objdump(outputFilename, result, maxSize, intelAsm, demangle) {
         let args = [];
-	if (demangle) args = args.concat('--demangle');
+        if (demangle) args = args.concat('--demangle');
         args = args.concat(outputFilename);
 
         const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
-	console.log(this.compiler.objdumper, args);
         const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
         result.asm = objResult.stdout;
         if (objResult.code !== 0) {

--- a/lib/compilers/lfortran.js
+++ b/lib/compilers/lfortran.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { FortranCompiler } from './fortran.js';
+import path from 'path';
+
+export class LFortranCompiler extends FortranCompiler {
+    static get key() { return 'lfortran'; }
+
+    optionsForFilter(filters, outputFilename) {
+        let args = []
+        if(!filters.binary) args = args.concat('-fverbose-asm');
+        args = args.concat(super.optionsForFilter(filters, outputFilename))
+        return args
+    }
+
+    async objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+        let args = [];
+	if (demangle) args = args.concat('--demangle');
+        args = args.concat(outputFilename);
+
+        const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
+	console.log(this.compiler.objdumper, args);
+        const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
+        result.asm = objResult.stdout;
+        if (objResult.code !== 0) {
+            result.asm = `<No output: objdump returned ${objResult.code}>`;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This PR adds basic support for compiling and asm highlighting for Elbrus 2000 compilers.

Elbrus 2000 is Russian original VLIW/EPIC architecture. [Wikipedia page](https://en.wikipedia.org/wiki/Elbrus_2000)

Compilers for this platform unfortunately closed source and available only for MCST clients. [MCST webpage (in Russian)](http://mcst.ru/lcc)

Marked as WIP, as there is no tests and I also have plans on integrating ldis (Elbrus disassembler) tool and custom tool https://github.com/numas13/e2k-explore that better explains architecture encoding.