### PR TITLE
Clang Patch Support

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -147,7 +147,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 # Clang for x86
-group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang600:clang700:clang800:clang900:clang1000:clang1001:clang1100:clang_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_embed
+group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_embed
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang.groupName=Clang x86-64
@@ -216,19 +216,40 @@ compiler.clang401.semver=4.0.1
 compiler.clang500.exe=/opt/compiler-explorer/clang-5.0.0/bin/clang++
 compiler.clang500.semver=5.0.0
 compiler.clang500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
+compiler.clang501.exe=/opt/compiler-explorer/clang-5.0.1/bin/clang++
+compiler.clang501.semver=5.0.1
+compiler.clang501.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
+compiler.clang502.exe=/opt/compiler-explorer/clang-5.0.2/bin/clang++
+compiler.clang502.semver=5.0.2
+compiler.clang502.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
 compiler.clang600.exe=/opt/compiler-explorer/clang-6.0.0/bin/clang++
 compiler.clang600.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
 compiler.clang600.semver=6.0.0
+compiler.clang601.exe=/opt/compiler-explorer/clang-6.0.1/bin/clang++
+compiler.clang601.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
+compiler.clang601.semver=6.0.1
 # Clang 7 and above: let's try the latest stable GCC as of the time of build
 compiler.clang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
 compiler.clang700.semver=7.0.0
 compiler.clang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.clang701.exe=/opt/compiler-explorer/clang-7.0.1/bin/clang++
+compiler.clang701.semver=7.0.1
+compiler.clang701.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.clang710.exe=/opt/compiler-explorer/clang-7.1.0/bin/clang++
+compiler.clang710.semver=7.1.0
+compiler.clang710.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
 compiler.clang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang++
 compiler.clang800.semver=8.0.0
 compiler.clang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
+compiler.clang801.exe=/opt/compiler-explorer/clang-8.0.1/bin/clang++
+compiler.clang801.semver=8.0.1
+compiler.clang801.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
 compiler.clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.clang900.semver=9.0.0
 compiler.clang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
+compiler.clang901.semver=9.0.1
+compiler.clang901.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
 compiler.clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.clang1000.semver=10.0.0
 compiler.clang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
@@ -238,6 +259,9 @@ compiler.clang1001.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
 compiler.clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.clang1100.semver=11.0.0
 compiler.clang1100.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0
+compiler.clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
+compiler.clang1101.semver=11.0.1
+compiler.clang1101.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0
 compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.clang_trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.clang_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -284,16 +308,28 @@ compiler.clang_embed.notification=Experimental <code>std::embed</code> Support; 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9, clang-10 and trunk
 group.armclang32.groupName=Arm 32-bit clang
-group.armclang32.compilers=armv7-clang900:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang-trunk
+group.armclang32.compilers=armv7-clang900:armv7-clang901:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang1101:armv7-clang-trunk
 group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
 
 group.armclang64.groupName=Arm 64-bit clang
-group.armclang64.compilers=armv8-clang900:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang-trunk:armv8-full-clang-trunk
+group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang-trunk:armv8-full-clang-trunk
 group.armclang64.isSemVer=true
 group.armclang64.compilerType=clang
 group.armclang64.supportsExecute=false
+
+compiler.armv7-clang1101.name=armv7-a clang 11.0.1
+compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
+compiler.armv7-clang1101.semver=11.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-clang1101.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-clang1101.name=armv8-a clang 11.0.1
+compiler.armv8-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
+compiler.armv8-clang1101.semver=11.0.1
+# Arm v8-a
+compiler.armv8-clang1101.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-clang1100.name=armv7-a clang 11.0.0
 compiler.armv7-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
@@ -336,6 +372,18 @@ compiler.armv8-clang1000.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/
 # This compiler was originally named with only a major version number.  An alias
 # of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv8-clang1000.alias=armv8-clang-10
+
+compiler.armv7-clang901.name=armv7-a clang 9.0.1
+compiler.armv7-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
+compiler.armv7-clang901.semver=9.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-clang901.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-clang901.name=armv8-a clang 9.0.1
+compiler.armv8-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
+compiler.armv8-clang901.semver=9.0.1
+# Arm v8-a
+compiler.armv8-clang901.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-clang900.name=armv7-a clang 9.0.0
 compiler.armv7-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
@@ -383,7 +431,7 @@ compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchai
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 # Clang for RISC-V
-group.rvclang.compilers=rv32-clang:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang900:rv64-clang:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang900
+group.rvclang.compilers=rv32-clang:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900:rv64-clang:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
 group.rvclang.groupName=RISC-V Clang
 group.rvclang.supportsBinary=false
 group.rvclang.supportsExecute=false
@@ -396,6 +444,14 @@ compiler.rv32-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang.supportsBinary=true
+
+compiler.rv32-clang1101.name=RISC-V rv32gc clang 11.0.1
+compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv32-clang1101.semver=11.0.1
+compiler.rv32-clang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-clang1101.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang1101.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1101.supportsBinary=true
 
 compiler.rv32-clang1100.name=RISC-V rv32gc clang 11.0.0
 compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
@@ -421,6 +477,14 @@ compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv
 compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang1000.supportsBinary=true
 
+compiler.rv32-clang901.name=RISC-V rv32gc clang 9.0.1
+compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv32-clang901.semver=9.0.1
+compiler.rv32-clang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-clang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang901.supportsBinary=true
+
 compiler.rv32-clang900.name=RISC-V rv32gc clang 9.0.0
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-clang900.semver=9.0.0
@@ -437,6 +501,14 @@ compiler.rv64-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.supportsBinary=true
+
+compiler.rv64-clang1101.name=RISC-V rv64gc clang 11.0.1
+compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv64-clang1101.semver=11.0.1
+compiler.rv64-clang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-clang1101.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-clang1101.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1101.supportsBinary=true
 
 compiler.rv64-clang1100.name=RISC-V rv64gc clang 11.0.0
 compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
@@ -461,6 +533,14 @@ compiler.rv64-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang1000.supportsBinary=true
+
+compiler.rv64-clang901.name=RISC-V rv64gc clang 9.0.1
+compiler.rv64-clang901.semver=9.0.1
+compiler.rv64-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv64-clang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-clang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-clang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang901.supportsBinary=true
 
 compiler.rv64-clang900.name=RISC-V rv64gc clang 9.0.0
 compiler.rv64-clang900.semver=9.0.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -113,7 +113,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang600:cclang700:cclang800:cclang900:cclang1000:cclang1001:cclang1100:cclang_trunk
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang_trunk
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -161,18 +161,36 @@ compiler.cclang401.exe=/opt/compiler-explorer/clang-4.0.1/bin/clang
 compiler.cclang401.semver=4.0.1
 compiler.cclang500.exe=/opt/compiler-explorer/clang-5.0.0/bin/clang
 compiler.cclang500.semver=5.0.0
+compiler.cclang501.exe=/opt/compiler-explorer/clang-5.0.1/bin/clang
+compiler.cclang501.semver=5.0.1
+compiler.cclang502.exe=/opt/compiler-explorer/clang-5.0.2/bin/clang
+compiler.cclang502.semver=5.0.2
 compiler.cclang600.exe=/opt/compiler-explorer/clang-6.0.0/bin/clang
 compiler.cclang600.semver=6.0.0
+compiler.cclang601.exe=/opt/compiler-explorer/clang-6.0.1/bin/clang
+compiler.cclang601.semver=6.0.1
 # Clang 7 and above: let's try the latest stable GCC as of the time of build
 compiler.cclang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang
 compiler.cclang700.semver=7.0.0
 compiler.cclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.cclang701.exe=/opt/compiler-explorer/clang-7.0.1/bin/clang
+compiler.cclang701.semver=7.0.1
+compiler.cclang701.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.cclang710.exe=/opt/compiler-explorer/clang-7.1.0/bin/clang
+compiler.cclang710.semver=7.1.0
+compiler.cclang710.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
 compiler.cclang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang
 compiler.cclang800.semver=8.0.0
 compiler.cclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
+compiler.cclang801.exe=/opt/compiler-explorer/clang-8.0.1/bin/clang
+compiler.cclang801.semver=8.0.1
+compiler.cclang801.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
 compiler.cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.cclang900.semver=9.0.0
 compiler.cclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.cclang901.semver=9.0.1
+compiler.cclang901.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
 compiler.cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.cclang1000.semver=10.0.0
 compiler.cclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
@@ -182,6 +200,9 @@ compiler.cclang1001.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
 compiler.cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.cclang1100.semver=11.0.0
 compiler.cclang1100.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0
+compiler.cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.cclang1101.semver=11.0.1
+compiler.cclang1101.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0
 compiler.cclang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cclang_trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -191,16 +212,28 @@ compiler.cclang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk
 group.armcclang32.groupName=Arm 32-bit clang
-group.armcclang32.compilers=armv7-cclang900:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang-trunk
+group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang-trunk
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
 group.armcclang32.supportsExecute=false
 
 group.armcclang64.groupName=Arm 64-bit clang
-group.armcclang64.compilers=armv8-cclang900:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang-trunk:armv8-full-cclang-trunk
+group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang-trunk:armv8-full-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
+
+compiler.armv7-cclang1101.name=armv7-a clang 11.0.1
+compiler.armv7-cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.armv7-cclang1101.semver=11.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cclang1101.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cclang1101.name=armv8-a clang 11.0.1
+compiler.armv8-cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.armv8-cclang1101.semver=11.0.1
+# Arm v8-a
+compiler.armv8-cclang1101.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-cclang1100.name=armv7-a clang 11.0.0
 compiler.armv7-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
@@ -243,6 +276,18 @@ compiler.armv8-cclang1000.options=-target aarch64-linux-gnu --gcc-toolchain=/opt
 # This compiler was originally named with only a major version number.  An alias
 # of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv8-cclang1000.alias=armv8-cclang-10
+
+compiler.armv7-cclang901.name=armv7-a clang 9.0.1
+compiler.armv7-cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.armv7-cclang901.semver=9.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cclang901.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cclang901.name=armv8-a clang 9.0.1
+compiler.armv8-cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.armv8-cclang901.semver=9.0.1
+# Arm v8-a
+compiler.armv8-cclang901.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-cclang900.name=armv7-a clang 9.0.0
 compiler.armv7-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
@@ -290,7 +335,7 @@ compiler.armv8-full-cclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-lin
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 
 # Clang for RISC-V
-group.rvcclang.compilers=rv32-cclang:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang900:rv64-cclang:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang900
+group.rvcclang.compilers=rv32-cclang:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900:rv64-cclang:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang900
 group.rvcclang.groupName=RISC-V Clang
 group.rvcclang.supportsBinary=false
 group.rvcclang.supportsExecute=false
@@ -303,6 +348,14 @@ compiler.rv32-cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cclang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-cclang.supportsBinary=true
+
+compiler.rv32-cclang1101.name=RISC-V rv32gc clang 11.0.1
+compiler.rv32-cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv32-cclang1101.semver=11.0.1
+compiler.rv32-cclang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang1101.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang1101.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang1101.supportsBinary=true
 
 compiler.rv32-cclang1100.name=RISC-V rv32gc clang 11.0.0
 compiler.rv32-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
@@ -328,6 +381,14 @@ compiler.rv32-cclang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/risc
 compiler.rv32-cclang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-cclang1000.supportsBinary=true
 
+compiler.rv32-cclang901.name=RISC-V rv32gc clang 9.0.1
+compiler.rv32-cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv32-cclang901.semver=9.0.1
+compiler.rv32-cclang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-cclang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cclang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-cclang901.supportsBinary=true
+
 compiler.rv32-cclang900.name=RISC-V rv32gc clang 9.0.0
 compiler.rv32-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-cclang900.semver=9.0.0
@@ -344,6 +405,14 @@ compiler.rv64-cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv64-cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-cclang.supportsBinary=true
+
+compiler.rv64-cclang1101.name=RISC-V rv64gc clang 11.0.1
+compiler.rv64-cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv64-cclang1101.semver=11.0.1
+compiler.rv64-cclang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang1101.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cclang1101.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang1101.supportsBinary=true
 
 compiler.rv64-cclang1100.name=RISC-V rv64gc clang 11.0.0
 compiler.rv64-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
@@ -368,6 +437,14 @@ compiler.rv64-cclang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fi
 compiler.rv64-cclang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-cclang1000.supportsBinary=true
+
+compiler.rv64-cclang901.name=RISC-V rv64gc clang 9.0.1
+compiler.rv64-cclang901.semver=9.0.1
+compiler.rv64-cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv64-cclang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-cclang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cclang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-cclang901.supportsBinary=true
 
 compiler.rv64-cclang900.name=RISC-V rv64gc clang 9.0.0
 compiler.rv64-cclang900.semver=9.0.0


### PR DESCRIPTION
Adding the following LLVM/Clang versions (in reverse semver order):
- 11.0.1
- 9.0.1
- 8.0.1
- 7.1.0
- 7.0.1
- 6.0.1
- 5.0.2
- 5.0.2

This follows up on:
- https://github.com/compiler-explorer/infra/pull/440
- https://github.com/compiler-explorer/infra/pull/455 (in progress)

Signed-off-by: Sam Elliott <sam@lenary.co.uk>


