### PR TITLE
Clang Experimental Pattern Matching Support

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -147,7 +147,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 # Clang for x86
-group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_embed
+group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_patmat:clang_embed
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang.groupName=Clang x86-64
@@ -297,6 +297,12 @@ compiler.clang_parmexpr.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdum
 compiler.clang_parmexpr.semver=(experimental P1221)
 compiler.clang_parmexpr.options=-std=c++2a -stdlib=libc++
 compiler.clang_parmexpr.notification=Experimental Parametric Expressions; see <a href="https://github.com/ricejasonf/parametric_expressions/blob/master/d1221.md" target="_blank" rel="noopener noreferrer">P1221<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_patmat.exe=/opt/compiler-explorer/clang-patmat-trunk/bin/clang++
+compiler.clang_patmat.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.clang_patmat.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.clang_patmat.semver=(experimental pattern matching)
+compiler.clang_patmat.options=-std=c++2a -stdlib=libc++ -fpattern-matching
+compiler.clang_patmat.notification=Experimental Pattern Matching; see <a href="https://wg21.link/p1371" target="_blank" rel="noopener noreferrer">P1371 <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_embed.exe=/opt/compiler-explorer/clang-embed-trunk/bin/clang++
 compiler.clang_embed.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.clang_embed.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
This is the last of the config for https://github.com/compiler-explorer/infra/pull/442 to expose it on the main site.