### PR TITLE
Add RISC-V 64 Clang 11.0.1 and 9.0.1

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -335,7 +335,7 @@ compiler.armv8-full-cclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-lin
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 
 # Clang for RISC-V
-group.rvcclang.compilers=rv32-cclang:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900:rv64-cclang:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang900
+group.rvcclang.compilers=rv32-cclang:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900:rv64-cclang:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
 group.rvcclang.groupName=RISC-V Clang
 group.rvcclang.supportsBinary=false
 group.rvcclang.supportsExecute=false


### PR DESCRIPTION
I missed these in a previous PR.