### PR TITLE
Add Notification to Compiler Info Popup

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1081,7 +1081,7 @@ Compiler.prototype.initButtons = function (state) {
 
     this.shortCompilerName = this.domRoot.find('.short-compiler-name');
     this.compilerPicker = this.domRoot.find('.compiler-picker');
-    this.setCompilerVersionPopover('');
+    this.setCompilerVersionPopover('', '');
 
     this.topBar = this.domRoot.find('.top-bar');
     this.bottomBar = this.domRoot.find('.bottom-bar');
@@ -1515,9 +1515,10 @@ Compiler.prototype.getPaneName = function () {
 Compiler.prototype.updateCompilerName = function () {
     var compilerName = this.getCompilerName();
     var compilerVersion = this.compiler ? this.compiler.version : '';
+    var compilerNotification = this.compiler ? this.compiler.notification : '';
     this.container.setTitle(this.getPaneName());
     this.shortCompilerName.text(compilerName);
-    this.setCompilerVersionPopover(compilerVersion);
+    this.setCompilerVersionPopover(compilerVersion, compilerNotification);
 };
 
 Compiler.prototype.resendResult = function () {
@@ -1603,10 +1604,14 @@ Compiler.prototype.setCompilationOptionsPopover = function (content) {
     });
 };
 
-Compiler.prototype.setCompilerVersionPopover = function (version) {
+Compiler.prototype.setCompilerVersionPopover = function (version, notification) {
     this.fullCompilerName.popover('dispose');
+    // `notification` contains HTML from a config file, so is 'safe'.
+    // `version` comes from compiler output, so isn't, and is escaped.
     this.fullCompilerName.popover({
-        content: version || '',
+        html: true,
+        title: notification ? $.parseHTML('<span>Compiler Version: ' + notification + '</span>')[0] : 'Full compiler version',
+        content: _.escape(version) || '',
         template: '<div class="popover' +
             (version ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -429,7 +429,7 @@ Executor.prototype.initButtons = function (state) {
 
     this.shortCompilerName = this.domRoot.find('.short-compiler-name');
     this.compilerPicker = this.domRoot.find('.compiler-picker');
-    this.setCompilerVersionPopover('');
+    this.setCompilerVersionPopover('', '');
 
     this.topBar = this.domRoot.find('.top-bar');
     this.bottomBar = this.domRoot.find('.bottom-bar');
@@ -727,9 +727,10 @@ Executor.prototype.getPaneName = function () {
 Executor.prototype.updateCompilerName = function () {
     var compilerName = this.getCompilerName();
     var compilerVersion = this.compiler ? this.compiler.version : '';
+    var compilerNotification = this.compiler ? this.compiler.notification : '';
     this.container.setTitle(this.getPaneName());
     this.shortCompilerName.text(compilerName);
-    this.setCompilerVersionPopover(compilerVersion);
+    this.setCompilerVersionPopover(compilerVersion, compilerNotification);
 };
 
 Executor.prototype.setCompilationOptionsPopover = function (content) {
@@ -743,10 +744,14 @@ Executor.prototype.setCompilationOptionsPopover = function (content) {
     });
 };
 
-Executor.prototype.setCompilerVersionPopover = function (version) {
+Executor.prototype.setCompilerVersionPopover = function (version, notification) {
     this.fullCompilerName.popover('dispose');
+    // `notification` contains HTML from a config file, so is 'safe'.
+    // `version` comes from compiler output, so isn't, and is escaped.
     this.fullCompilerName.popover({
-        content: version || '',
+        html: true,
+        title: notification ? $.parseHTML('<span>Compiler Version: ' + notification + '</span>')[0] : 'Full compiler version',
+        content: _.escape(version) || '',
         template: '<div class="popover' +
             (version ? ' compiler-options-popover' : '') +
             '" role="tooltip"><div class="arrow"></div>' +

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -147,7 +147,7 @@
                   | 0
                 | )
         span.short-compiler-name
-        button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button" title="Full compiler version")
+        button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button")
         span.compile-time(title="Compilation time (Result size)")
 
   #executor
@@ -193,7 +193,7 @@
       .execution-output
     .bottom-bar.bg-light
       span.short-compiler-name
-      button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button" title="Full compiler version")
+      button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button")
       span.compile-time(title="Compilation time (Result size)")
 
   #compiler-output


### PR DESCRIPTION
This should make the information (including links) in the compiler `notification` field more easy to discover and use.

It adds the info to the `i` popup below the compiler output, as shown:
<img width="344" alt="Screen Shot 2021-01-20 at 11 16 53 pm" src="https://user-images.githubusercontent.com/14548/105252570-99871480-5b75-11eb-9063-6686474cdfae.png">

Opinions welcome on whether the info should be in the title or the body. I put it in the title but if it's multiple lines with links, the body might be better?

This came from a request to expose the issue tracker for the clang experimental pattern matching compiler, so people could file issues if they came across them in the prototype. 


