### PR TITLE
Make codelens font follow settings

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -24,6 +24,17 @@
     cursor: pointer;
 }
 
+// The :root and .monaco-editor .codelens-decoration are used to set the codelens font
+// Official support using the IEditorOptions.codeLensFontFamily property has landed in vscode
+// These blocks should be removed once a downstream release of monaco is cut
+:root {
+    // updated at runtime
+    --user-selected-font-stack: Consolas, "Liberation Mono", Courier, monospace; 
+}
+.monaco-editor .codelens-decoration {
+    font-family: var(--user-selected-font-stack);
+}
+
 body {
     overflow: hidden;
 }

--- a/static/themes.js
+++ b/static/themes.js
@@ -60,6 +60,11 @@ function Themer(eventHub, initialSettings) {
         if (!newTheme.monaco)
             newTheme.monaco = 'vs';
         this.setTheme(newTheme);
+
+        // This line is used to set thet codelens font
+        // Official support using the IEditorOptions.codeLensFontFamily property has landed in vscode
+        // It should be removed once a downstream release of monaco is cut
+        document.querySelector(':root').style.setProperty('--user-selected-font-stack', newSettings.editorsFFont);
     };
     this.onSettingsChange(initialSettings);
 


### PR DESCRIPTION
The default codelens font stack is proportional which gets really irritating when counting bytes.
![CE-before](https://user-images.githubusercontent.com/6844979/105802315-e188ab80-5f68-11eb-9cfd-c4ad0a42f09b.png)
I've updated it so that is follows the font stack specified in settings (which is default monospace!)
![CE-after](https://user-images.githubusercontent.com/6844979/105802376-054bf180-5f69-11eb-98da-223558ffe01b.png)
