### PR TITLE
docs/API.md: Mention Emacs client

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -279,3 +279,4 @@ Here are some examples of projects using the Compiler Explorer API:
 * [QTCreator Plugin by dobokirisame](https://github.com/dobokirisame/CompilerExplorer) (C++)
 * [CLion plugin by ogrebenyuk](https://github.com/ogrebenyuk/compilerexplorer) (Java)
 * [QCompilerExplorer - frontend in Qt](https://github.com/Waqar144/QCompilerExplorer) (C++)
+* [Emacs client - compiler-explorer.el](https://github.com/mkcms/compiler-explorer.el)


### PR DESCRIPTION
This patch mentions my Emacs client for the API in the docs: https://github.com/mkcms/compiler-explorer.el
