### PR TITLE
Fully update the lib UI when a library is removed

### DIFF
--- a/static/libs-widget-ext.js
+++ b/static/libs-widget-ext.js
@@ -197,6 +197,8 @@ LibsWidgetExt.prototype.newSelectedLibDiv = function (libId, versionId, lib, ver
         libDiv.remove();
         this.showSelectedLibs();
         this.onChangeCallback();
+        // We need to refresh the library lists, or the selector will still show up with the old library version
+        this.startSearching();
     }, this));
 
     return libDiv;


### PR DESCRIPTION
The select on the library was not being updated if a library was deleted from the selected list.
I feel the solution is too hacky, so I wanted to see if @partouf came up with a better idea before merging this :)