### PR TITLE
Add ARM gcc 10.2.1 (arm-none-eabi)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -668,7 +668,7 @@ compiler.ppc64leclang.supportsBinary=false
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=armg454:armg464:aarchg54:armhfg54:arm541:armg630:arm710:arm64g630:armg640:armg730:armg820:arm64g640:arm64g730:arm64g820:armce820:arm831:arm921
+group.gccarm.compilers=armg454:armg464:aarchg54:armhfg54:arm541:armg630:arm710:arm64g630:armg640:armg730:armg820:arm64g640:arm64g730:arm64g820:armce820:arm831:arm921:arm1021
 group.gccarm.groupName=ARM GCC
 group.gccarm.isSemVer=true
 # Some of the compiler don't like -isystem (as they assume the code must be C).
@@ -746,6 +746,10 @@ compiler.arm921.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-9-2019-q4-major
 compiler.arm921.name=ARM gcc 9.2.1 (none)
 compiler.arm921.semver=9.2.1
 compiler.arm921.supportsBinary=false
+compiler.arm1021.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-g++
+compiler.arm1021.name=ARM gcc 10.2.1 (none)
+compiler.arm1021.semver=10.2.1
+compiler.arm1021.supportsBinary=false
 
 ###############################
 # GCC for Kalray


### PR DESCRIPTION
Adds a gcc version 10.2.1 option for embedded ARM (arm-none-eabi) targets, which corresponds to the 2020-q4-major release from ARM.

I have also opened a request for the infra project repository to add upstream's tarball URL and matching path.


<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
