### PR TITLE
Add ThePhD's text encoding library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1793,7 +1793,7 @@ libs.nsimd.versions.22-arm64.path=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aar
 libs.nsimd.versions.22-arm64.libpath=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aarch64/lib
 libs.nsimd.versions.22-arm64.liblink=nsimd_aarch64
 
-libs.ztdtext.name=zstd.text
+libs.ztdtext.name=ztd.text
 libs.ztdtext.url=https://github.com/soasis/text
 libs.ztdtext.description=Text encoding library
 libs.ztdtext.versions=trunk

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -995,7 +995,7 @@ compiler.djggp494.semver=4.9.4
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:cppitertools:ctbignum:gsl:expected_lite:nlohmann_json:tomlplusplus:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer:enoki:spdlog:python:tts:lexy:eve:nsimd
+libs=boost:brigand:kvasir:cmcstl2:mp-units:cppitertools:ctbignum:gsl:expected_lite:nlohmann_json:tomlplusplus:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer:enoki:spdlog:python:tts:lexy:eve:nsimd:ztdtext
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172:173:174:175
 libs.boost.url=https://www.boost.org
@@ -1792,6 +1792,13 @@ libs.nsimd.versions.22-arm64.version=2.2 (arm64)
 libs.nsimd.versions.22-arm64.path=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aarch64/include
 libs.nsimd.versions.22-arm64.libpath=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aarch64/lib
 libs.nsimd.versions.22-arm64.liblink=nsimd_aarch64
+
+libs.ztdtext.name=zstd.text
+libs.ztdtext.url=https://github.com/soasis/text
+libs.ztdtext.description=Text encoding library
+libs.ztdtext.versions=trunk
+libs.ztdtext.versions.trunk.version=trunk
+libs.ztdtext.versions.trunk.path=/opt/compiler-explorer/libs/ztdtext/trunk/include
 
 #################################
 #################################


### PR DESCRIPTION
Library: https://github.com/soasis/text

I offered @ThePhD to make a PR.
ZSTD is a text encoding library for C++ that will serve as the basis
for a standard text encoding proposal.
As such availability on CE would increase usage experience !

Infra PR : https://github.com/compiler-explorer/infra/pull/466