### PR TITLE
add latest icc/icx/ifort/ifx

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -93,3 +93,4 @@ From oldest to newest contributor, we would like to thank:
 - [Krists Niedritis](https://github.com/JesusKrists)
 - [Julian Hammer](https://github.com/cod3monk)
 - [Peter Schussheim](https://github.com/peterschussheim)
+- [Robert Cohn](https://github.com/rscohn2)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64
+compilers=&gcc86:&icc:&icx:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64
 defaultCompiler=g102
 demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
@@ -568,7 +568,7 @@ compiler.wasm32clang.name=WebAssembly clang (trunk)
 compiler.wasm32clang.options=-target wasm32
 
 # icc for x86
-group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202118:icc202119
+group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112
 group.icc.intelAsm=-masm=intel
 group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
@@ -600,15 +600,23 @@ compiler.icc191.exe=/opt/compiler-explorer/intel-2019.1/bin/icc
 compiler.icc191.semver=19.0.1
 compiler.icc191.options=-gxx-name=/opt/compiler-explorer/gcc-8.2.0/bin/g++
 
-compiler.icc202118.exe=/opt/compiler-explorer/intel-2021.1.8.1883/compiler/latest/linux/bin/intel64/icc
-compiler.icc202118.ldPath=/opt/compiler-explorer/intel-2021.1.8.1883/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.8.1883/compiler/latest/linux/compiler/lib/ia32_lin
-compiler.icc202118.semver=21.1.8
-compiler.icc202118.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+compiler.icc202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/intel64/icc
+compiler.icc202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc202112.semver=2021.1.2
+compiler.icc202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
-compiler.icc202119.exe=/opt/compiler-explorer/intel-2021.1.9.2205/compiler/latest/linux/bin/intel64/icc
-compiler.icc202119.ldPath=/opt/compiler-explorer/intel-2021.1.9.2205/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.9.2205/compiler/latest/linux/compiler/lib/ia32_lin
-compiler.icc202119.semver=21.1.9
-compiler.icc202119.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+# icx for x86
+group.icx.compilers=icx202112
+group.icx.intelAsm=-masm=intel
+group.icx.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+group.icx.groupName=ICX x86-64
+group.icx.baseName=x86-64 icx
+group.icx.isSemVer=true
+
+compiler.icx202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/icx
+compiler.icx202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icx202112.semver=2021.1.2
+compiler.icx202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
 # zapcc
 group.zapcc.compilers=zapcc190308

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -604,6 +604,8 @@ compiler.icc202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/lat
 compiler.icc202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icc202112.semver=2021.1.2
 compiler.icc202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+# Alias the betas to the product compiler
+compiler.icc202112.alias=icc202118:icc202119
 
 # icx for x86
 group.icx.compilers=icx202112

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -601,7 +601,8 @@ compiler.icc191.semver=19.0.1
 compiler.icc191.options=-gxx-name=/opt/compiler-explorer/gcc-8.2.0/bin/g++
 
 compiler.icc202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/intel64/icc
-compiler.icc202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icc202112.libPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icc202112.semver=2021.1.2
 compiler.icc202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 # Alias the betas to the product compiler
@@ -610,15 +611,15 @@ compiler.icc202112.alias=icc202118:icc202119
 # icx for x86
 group.icx.compilers=icx202112
 group.icx.intelAsm=-masm=intel
-group.icx.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+group.icx.options=
 group.icx.groupName=ICX x86-64
 group.icx.baseName=x86-64 icx
 group.icx.isSemVer=true
 
 compiler.icx202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/icx
-compiler.icx202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icx202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icx202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icx202112.semver=2021.1.2
-compiler.icx202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
 # zapcc
 group.zapcc.compilers=zapcc190308

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gfortran_86:&ifort:&cross:&clang_llvmflang
+compilers=&gfortran_86:&ifort:&ifx:&cross:&clang_llvmflang
 defaultCompiler=gfortran102
 demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
@@ -43,7 +43,7 @@ compiler.gfortransnapshot.name=x86-64 gfortran (trunk)
 
 ###############################
 # Intel Parallel Studio XE for x86
-group.ifort.compilers=ifort19:ifort202118:ifort202119
+group.ifort.compilers=ifort19:ifort202112
 group.ifort.intelAsm=-masm=intel
 group.ifort.groupName=IFORT x86-64
 group.ifort.isSemVer=true
@@ -57,15 +57,23 @@ compiler.ifort18.semver=18.0.0
 compiler.ifort19.exe=/opt/compiler-explorer/intel-2019/bin/ifort
 compiler.ifort19.semver=19.0.0
 
-compiler.ifort202118.exe=/opt/compiler-explorer/intel-2021.1.8.1883/compiler/latest/linux/bin/intel64/ifort
-compiler.ifort202118.ldPath=/opt/compiler-explorer/intel-2021.1.8.1883/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.8.1883/compiler/latest/linux/compiler/lib/ia32_lin
-compiler.ifort202118.semver=21.1.8
-compiler.ifort202118.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+compiler.ifort202112.exe=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/bin/intel64/ifort
+compiler.ifort202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifort202112.semver=2021.1.2
+compiler.ifort202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
-compiler.ifort202119.exe=/opt/compiler-explorer/intel-2021.1.9.2205/compiler/latest/linux/bin/intel64/ifort
-compiler.ifort202119.ldPath=/opt/compiler-explorer/intel-2021.1.9.2205/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.9.2205/compiler/latest/linux/compiler/lib/ia32_lin
-compiler.ifort202119.semver=21.1.9
-compiler.ifort202119.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+###############################
+# Intel oneAPI for x86
+group.ifx.compilers=ifx202112
+group.ifx.intelAsm=-masm=intel
+group.ifx.groupName=IFX x86-64
+group.ifx.isSemVer=true
+group.ifx.baseName=x86-64 ifx
+
+compiler.ifx202112.exe=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/bin/ifx
+compiler.ifx202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202112.semver=2021.1.2
+compiler.ifx202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
 ###############################
 # GCC Cross-Compilers

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -58,7 +58,8 @@ compiler.ifort19.exe=/opt/compiler-explorer/intel-2019/bin/ifort
 compiler.ifort19.semver=19.0.0
 
 compiler.ifort202112.exe=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/bin/intel64/ifort
-compiler.ifort202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifort202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifort202112.libPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifort202112.semver=2021.1.2
 compiler.ifort202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 compiler.ifort202112.alias=ifort202118:ifort202119
@@ -70,11 +71,12 @@ group.ifx.intelAsm=-masm=intel
 group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
 group.ifx.baseName=x86-64 ifx
+group.ifx.options=
 
 compiler.ifx202112.exe=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/bin/ifx
-compiler.ifx202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifx202112.libPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifx202112.semver=2021.1.2
-compiler.ifx202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
 ###############################
 # GCC Cross-Compilers

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -61,6 +61,7 @@ compiler.ifort202112.exe=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compil
 compiler.ifort202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifort202112.semver=2021.1.2
 compiler.ifort202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+compiler.ifort202112.alias=ifort202118:ifort202119
 
 ###############################
 # Intel oneAPI for x86


### PR DESCRIPTION
Add latest icc/icx/ifort/ifx

Delete the 2021.1.8, 2021.1.9 which were betas.

icc works, but the rest do not work because they require LD_LIBRARY_PATH set to:
/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:

I could not see how to do it.

Requires https://github.com/compiler-explorer/infra/pull/470 to install the compilers.
