### PR TITLE
Attempt at refactoring to better separate ldpaths and libpaths

### DIFF
--- a/docs/AboutLibraryPaths.md
+++ b/docs/AboutLibraryPaths.md
@@ -77,4 +77,4 @@ This will result in the following situations if we want to compile some code wit
     * `-L/home/ubuntu/mylib/lib` (mylib library path used to find `libmylib.a`)
     * `-lmylib` (mylib library name)
 * Running the executable
-  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64:/home/ubuntu/mylib/lib`
+  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64:/home/ubuntu/mycl/lib/lib32:/home/ubuntu/mylib/lib`

--- a/docs/AboutLibraryPaths.md
+++ b/docs/AboutLibraryPaths.md
@@ -21,7 +21,7 @@ We have a couple of seperate stages where we use and mix different techniques to
   * We always add '.' as a path as well because that's where we put libraries that are downloaded from our Conan server.
   * We use `-l` (or equivalent `linkFlag`) to say we want to statically or dynamically link to a named library binary (the compiler and linker decide if it's gonna be static or dynamic).
 * Running the executable
-  * We use `LD_LIBRARY_PATH` just in case these are dependencies inherited from the compiler.
+  * We use `LD_LIBRARY_PATH` just in case these are dependencies inherited from the compiler - and for the libraries that are used (also just in case).
 
 
 ## Specific properties that are used in certain situations
@@ -35,7 +35,7 @@ We have a couple of seperate stages where we use and mix different techniques to
   * is used for `LD_LIBRARY_PATH` to enable the users's executable to find `.so` files
 * Library .libPath
   * is used for linking (`-Wl,-rpath=` and/or `-L`) during building binaries
-  * is used for `LD_LIBRARY_PATH` to enable the users's executable to find `.so` files
+  * is used for `LD_LIBRARY_PATH` to enable the users's executable to find `.so` files (just in case)
 
 
 ## Example
@@ -77,4 +77,4 @@ This will result in the following situations if we want to compile some code wit
     * `-L/home/ubuntu/mylib/lib` (mylib library path used to find `libmylib.a`)
     * `-lmylib` (mylib library name)
 * Running the executable
-  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64`
+  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64:/home/ubuntu/mylib/lib`

--- a/docs/AboutLibraryPaths.md
+++ b/docs/AboutLibraryPaths.md
@@ -1,0 +1,80 @@
+# About LD_LIBRARY_PATH and library paths
+
+## Background
+
+Libraries are hard. Libraries can be needed for user code, but also to run compilers.
+
+For CE we use a lot of different compilers and environments that need to be separated from the OS's installation, and that makes things more complicated than just building with your standard OS's compiler.
+
+Including header files or equivalent is usually the easy part. If there are binaries involved, things get complicated.
+
+We have a couple of seperate stages where we use and mix different techniques to be able to produce the right assembly or executables.
+
+* Compilation without linking
+  * The `LD_LIBRARY_PATH` environment variable is used here to enable the compiler to find the `.so` files that they need to run.
+  * If you're running a local installation, this is usually your own systems' `LD_LIBRARY_PATH` plus extra things that CE adds through properties.
+  * On godbolt.org we always start with an empty `LD_LIBRARY_PATH` and add what is set in the properties.
+* Building an executable or binary
+  * We use `-Wl,-rpath=` (or equivalent `rpathFlag`) to force library paths into the executable so that they will always find the same `.so` files no matter where they are run. Usually this also includes lib64 and lib folders that the compiler offers for standard libraries that the toolchain offers.
+  * Library paths supplied through `-Wl,-rpath=` for shared libraries will be able to dynamically link to the right architecture's `.so` even if multiple paths are given that contain the same `.so` file.
+  * We use `-L` (or equivalent `libpathFlag`) to enable the compiler to find both static (`.a`) and shared (`.so`) libraries.
+  * We always add '.' as a path as well because that's where we put libraries that are downloaded from our Conan server.
+  * We use `-l` (or equivalent `linkFlag`) to say we want to statically or dynamically link to a named library binary (the compiler and linker decide if it's gonna be static or dynamic).
+* Running the executable
+  * We use `LD_LIBRARY_PATH` just in case these are dependencies inherited from the compiler.
+
+
+## Specific properties that are used in certain situations
+
+* Compiler .ldPath
+  * is used for `LD_LIBRARY_PATH` to support running the compiler
+  * is used for linking (`-Wl,-rpath=` and/or `-L`) during building binaries
+  * is used for `LD_LIBRARY_PATH` to enable the users's executable to find `.so` files
+* Compiler .libPath
+  * is used for linking (`-Wl,-rpath=` and/or `-L`) during building binaries
+  * is used for `LD_LIBRARY_PATH` to enable the users's executable to find `.so` files
+* Library .libPath
+  * is used for linking (`-Wl,-rpath=` and/or `-L`) during building binaries
+  * is used for `LD_LIBRARY_PATH` to enable the users's executable to find `.so` files
+
+
+## Example
+
+Say we have the following things in a `c++.local.properties` file:
+
+```
+compilers=mycl
+compiler.mycl.exe=/home/ubuntu/mycl/bin
+compiler.mycl.ldPath=/home/ubuntu/mycl/lib/lib64
+compiler.mycl.libPath=/home/ubuntu/mycl/lib/lib64:/home/ubuntu/mycl/lib/lib32
+compiler.mycl.options=--gcc-toolchain=/home/ubuntu/gcc10
+compiler.mycl.includeFlag=-I
+
+libs=mylib
+libs.mylib.name=My library
+libs.mylib.path=/home/ubuntu/mylib/include
+libs.mylib.libpath=/home/ubuntu/mylib/lib
+libs.mylib.staticliblink=mylib
+```
+
+This will result in the following situations if we want to compile some code with both the mycl compiler and the mylib library:
+
+* Compilation without linking
+  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64`
+  * `-I/home/ubuntu/mylib/include` is added to the compilation arguments
+* Building an executable or binary
+  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64`
+  * The following are added to the compilation arguments
+    * `-I/home/ubuntu/mylib/include` (library include path)
+    * `-Wl,-rpath=/home/ubuntu/mycl/lib/lib64` (compiler library paths)
+    * `-Wl,-rpath=/home/ubuntu/mycl/lib/lib32`
+    * `-Wl,-rpath=.` (conan library path)
+    * `-L.`
+    * `-Wl,-rpath=/home/ubuntu/gcc10/lib/lib` (gcc toolchain library paths)
+    * `-Wl,-rpath=/home/ubuntu/gcc10/lib/lib32`
+    * `-Wl,-rpath=/home/ubuntu/gcc10/lib/lib64`
+    * `-Wl,-rpath=/home/ubuntu/mylib/lib` (mylib library path - just in case there are `.so` files used)
+    * `-L/home/ubuntu/mylib/lib` (mylib library path used to find `libmylib.a`)
+    * `-lmylib` (mylib library name)
+* Running the executable
+  * `LD_LIBRARY_PATH` is set to `/home/ubuntu/mycl/lib/lib64`

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1237,6 +1237,7 @@ Please select another pass or change filters.`;
         const execOptions = this.getDefaultExecOptions();
         const versionFlag = this.compiler.versionFlag || '--version';
         execOptions.timeoutMs = 0; // No timeout for --version. A sort of workaround for slow EFS/NFS on the prod site
+        execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         try {
             return this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions, true);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -365,18 +365,31 @@ export class BaseCompiler {
         return _.union(
             [libPathFlag + '.'],
             [pathFlag + '.'],
-            this.compiler.ldPath.map(path => pathFlag + path),
+            this.compiler.libPath.map(path => pathFlag + path),
             toolchainLibraryPaths.map(path => pathFlag + path),
             this.getSharedLibraryPaths(libraries).map(path => pathFlag + path),
             this.getSharedLibraryPaths(libraries).map(path => libPathFlag + path));
     }
 
-    getSharedLibraryPathsAsLdLibraryPaths(/*libraries*/) {
-        if (this.alwaysResetLdPath) {
-            return [];
-        } else {
-            return process.env.LD_LIBRARY_PATH ? process.env.LD_LIBRARY_PATH : [];
+    getSharedLibraryPathsAsLdLibraryPaths(libraries) {
+        let paths = [];
+        if (!this.alwaysResetLdPath) {
+            paths = process.env.LD_LIBRARY_PATH ? process.env.LD_LIBRARY_PATH : [];
         }
+        return _.union(paths,
+            this.compiler.ldPath,
+            this.getSharedLibraryPaths(libraries));
+    }
+
+    getSharedLibraryPathsAsLdLibraryPathsForExecution(libraries) {
+        let paths = [];
+        if (!this.alwaysResetLdPath) {
+            paths = process.env.LD_LIBRARY_PATH ? process.env.LD_LIBRARY_PATH : [];
+        }
+        return _.union(paths,
+            this.compiler.ldPath,
+            this.compiler.libPath,
+            this.getSharedLibraryPaths(libraries));
     }
 
     getIncludeArguments(libraries) {
@@ -734,7 +747,7 @@ export class BaseCompiler {
             };
         }
 
-        executeParameters.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths(key.libraries);
+        executeParameters.ldPath = this.getSharedLibraryPathsAsLdLibraryPathsForExecution(key.libraries);
         const result = await this.runExecutable(buildResult.executableFilename, executeParameters);
         result.didExecute = true;
         result.buildResult = buildResult;
@@ -792,7 +805,7 @@ export class BaseCompiler {
         );
 
         const execOptions = this.getDefaultExecOptions();
-        execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths(key.libraries);
+        execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         const makeAst = backendOptions.produceAst && this.compiler.supportsAstView;
         const makeIr = backendOptions.produceIr && this.compiler.supportsIrView;

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -301,6 +301,12 @@ export class CompilerFinder {
             return [];
         }
 
+        if (process.platform === 'win32') {
+            compilerInfo.libPath = compilerInfo.libPath.split(';').filter((p) => p !== '');
+        } else {
+            compilerInfo.libPath = compilerInfo.libPath.split(':').filter((p) => p !== '');
+        }
+
         logger.debug('Found compiler', compilerInfo);
         return compilerInfo;
     }

--- a/lib/compilers/clean.js
+++ b/lib/compilers/clean.js
@@ -82,7 +82,7 @@ export class CleanCompiler extends BaseCompiler {
         execOptions = this.getDefaultExecOptions();
         execOptions.customCwd = tmpDir;
         execOptions.env.CLEANLIB = path.join(compilerPath, '../exe');
-        execOptions.env.CLEANPATH = this.compiler.libPath;
+        execOptions.env.CLEANPATH = this.compiler.libPath.join(':');
         options.pop();
         options.push(moduleName);
 

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -163,7 +163,7 @@ export class Win32Compiler extends BaseCompiler {
             options.env['INCLUDE'] = this.compiler.includePath;
         }
         if (this.compiler.libPath) {
-            options.env['LIB'] = this.compiler.libPath;
+            options.env['LIB'] = this.compiler.libPath.join(';');
         }
         for (const [env, to] of this.compiler.envVars) {
             options.env[env] = to;

--- a/test/base-compiler-tests.js
+++ b/test/base-compiler-tests.js
@@ -91,6 +91,7 @@ describe('Compiler execution', function () {
         remote: true,
         lang: languages['c++'].id,
         ldPath: [],
+        libPath: [],
         supportsExecute: true,
         supportsBinary: true,
     };
@@ -99,6 +100,7 @@ describe('Compiler execution', function () {
         remote: true,
         lang: languages['c++'].id,
         ldPath: [],
+        libPath: [],
     };
 
     before(() => {


### PR DESCRIPTION
Due to complications arising from compilers added in PR #2450 

The situation being that the compiler needed certain library paths, but only the 64 bit path as `LD_LIBRARY_PATH` - and during linking it would need both 64 and 32 for regular `-Wl,-rpath` library paths (to support `-m32`).

It turned out we mixed up some ldPath and libPath usages in the code that needed fixing.

Also included a doc, but not sure if it makes anything any clearer...

Todo:
* [x] Check and fix MSVC and perhaps other broken compilers
* [x] Use compiler ldPath also during version check
