### PR TITLE
.gitattributes: ignore assembly tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 docs/*  linguist-documentation
 *.s linguist-generated
 lib/handlers/asm-docs.js linguist-generated
-test/cases/* linguist-generated
+test/* linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 docs/*  linguist-documentation
 *.s linguist-generated
 lib/handlers/asm-docs.js linguist-generated
-test/* linguist-generated
+test/*-cases/* linguist-generated


### PR DESCRIPTION
This should remove assembly test files from language stats leaving the project's main language as JavaScript.