### PR TITLE
Time all the things

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -243,6 +243,8 @@ export class AsmParser extends AsmRegex {
     processAsm(asmResult, filters) {
         if (filters.binary) return this.processBinaryAsm(asmResult, filters);
 
+        const startTime = process.hrtime.bigint();
+
         if (filters.commentOnly) {
             // Remove any block comments that start and end on a line if we're removing comment-only lines.
             const blockComments = /^[\t ]*\/\*(\*(?!\/)|[^*])*\*\/\s*/gm;
@@ -448,9 +450,12 @@ export class AsmParser extends AsmRegex {
 
         this.removeLabelsWithoutDefinition(asm, labelDefinitions);
 
+        const endTime = process.hrtime.bigint();
+
         return {
             asm: asm,
             labelDefinitions: labelDefinitions,
+            parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
         };
     }
 
@@ -470,6 +475,7 @@ export class AsmParser extends AsmRegex {
     }
 
     processBinaryAsm(asmResult, filters) {
+        const startTime = process.hrtime.bigint();
         const asm = [];
         const labelDefinitions = {};
 
@@ -567,9 +573,12 @@ export class AsmParser extends AsmRegex {
 
         this.removeLabelsWithoutDefinition(asm, labelDefinitions);
 
+        const endTime = process.hrtime.bigint();
+
         return {
             asm: asm,
             labelDefinitions: labelDefinitions,
+            parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
         };
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -666,16 +666,19 @@ export class BaseCompiler {
     async loadPackageWithExecutable(key, dirPath) {
         const compilationResultFilename = 'compilation-result.json';
         try {
+            const startTime = process.hrtime.bigint();
             const outputFilename = await this.env.executableGet(key, dirPath);
             if (outputFilename) {
                 logger.debug(`Using cached package ${outputFilename}`);
                 await this.packager.unpack(outputFilename, dirPath);
                 const buildResults = JSON.parse(await fs.readFile(path.join(dirPath, compilationResultFilename)));
+                const endTime = process.hrtime.bigint();
                 return Object.assign({}, buildResults, {
                     code: 0,
                     inputFilename: path.join(dirPath, this.compileFilename),
                     dirPath: dirPath,
                     executableFilename: this.getExecutableFilename(dirPath, this.outputFilebase),
+                    packageDownloadAndUnzipTime: ((endTime - startTime) / BigInt(1000000)).toString(),
                 });
             }
             logger.debug('Tried to get executable from cache, but got a cache miss');

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -817,7 +817,7 @@ export class BaseCompiler {
         const makeGccDump = backendOptions.produceGccDump && backendOptions.produceGccDump.opened
             && this.compiler.supportsGccDump;
 
-        await buildEnvironment;
+        const downloads = await buildEnvironment;
         const [asmResult, astResult, gccDumpResult, irResult, toolsResult] = await Promise.all([
             this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
             (makeAst ? this.generateAST(inputFilename, options) : ''),
@@ -831,6 +831,7 @@ export class BaseCompiler {
         ]);
         asmResult.dirPath = dirPath;
         asmResult.compilationOptions = options;
+        asmResult.downloads = downloads;
         // Here before the check to ensure dump reports even on failure cases
         if (this.compiler.supportsGccDump && gccDumpResult) {
             asmResult.gccDumpOutput = gccDumpResult;

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -968,6 +968,7 @@ export class BaseCompiler {
                 const res = this.processAsm(result, filters, options);
                 result.asm = res.asm;
                 result.labelDefinitions = res.labelDefinitions;
+                result.parsingTime = res.parsingTime;
             } else {
                 result.asm = [{text: result.asm}];
             }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -179,6 +179,8 @@ export class BaseCompiler {
         result.asm = objResult.stdout;
         if (objResult.code !== 0) {
             result.asm = `<No output: objdump returned ${objResult.code}>`;
+        } else {
+            result.objdumpTime = objResult.execTime;
         }
         return result;
     }
@@ -897,8 +899,13 @@ export class BaseCompiler {
         filters.execute = false;
 
         if (!bypassCache) {
+            const cacheRetreiveTimeStart = process.hrtime.bigint();
             const result = await this.env.cacheGet(key);
             if (result) {
+                const cacheRetreiveTimeEnd = process.hrtime.bigint();
+                result.retreivedFromCacheTime = ((cacheRetreiveTimeEnd - cacheRetreiveTimeStart) /
+                    BigInt(1000000)).toString();
+                result.retreivedFromCache = true;
                 if (doExecute) {
                     result.execResult = await this.env.enqueue(async () => {
                         return this.handleExecution(key, executeParameters);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -623,9 +623,11 @@ export class BaseCompiler {
         execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths(key.libraries);
 
         await writerOfSource;
-        await buildEnvironment;
+        const downloads = await buildEnvironment;
         const result = await this.buildExecutable(key.compiler.exe, compilerArguments, inputFilename,
             execOptions);
+
+        result.downloads = downloads;
 
         result.executableFilename = outputFilename;
         result.compilationOptions = compilerArguments;

--- a/lib/buildenvsetup/ceconan.js
+++ b/lib/buildenvsetup/ceconan.js
@@ -91,8 +91,9 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
         });
     }
 
-    async downloadAndExtractPackage(downloadPath, packageUrl) {
+    async downloadAndExtractPackage(libId, version, downloadPath, packageUrl) {
         return new Promise((resolve) => {
+            const startTime = process.hrtime.bigint();
             const extract = tar.extract();
             const gunzip = zlib.createGunzip();
 
@@ -105,7 +106,12 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
             });
 
             extract.on('finish', () => {
-                resolve();
+                const endTime = process.hrtime.bigint();
+                resolve({
+                    step: `Download of ${libId} ${version}`,
+                    packageUrl: packageUrl,
+                    time: ((endTime - startTime) / BigInt(1000000)).toString(),
+                });
             });
 
             gunzip.pipe(extract);
@@ -173,7 +179,7 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
                     logger.debug(`Found conan hash ${hash} for ${libVer}`);
                     allDownloads.push(
                         this.getPackageUrl(libVerBuilds.id, lookupversion, hash).then((downloadUrl) => {
-                            return this.downloadAndExtractPackage(dirPath, downloadUrl);
+                            return this.downloadAndExtractPackage(libVerBuilds.id, lookupversion, dirPath, downloadUrl);
                         }),
                     );
                 } else {

--- a/lib/compilers/assembly.js
+++ b/lib/compilers/assembly.js
@@ -95,6 +95,8 @@ export class AssemblyCompiler extends BaseCompiler {
         result.asm = objResult.stdout;
         if (objResult.code !== 0) {
             result.asm = '<No output: objdump returned ' + objResult.code + '>';
+        } else {
+            result.objdumpTime = objResult.execTime;
         }
         return result;
     }

--- a/lib/compilers/dmd.js
+++ b/lib/compilers/dmd.js
@@ -72,6 +72,8 @@ export class DMDCompiler extends BaseCompiler {
         result.asm = objResult.stdout;
         if (objResult.code !== 0) {
             result.asm = `<No output: objdump returned ${objResult.code}>`;
+        } else {
+            result.objdumpTime = objResult.execTime;
         }
         return result;
     }

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -68,6 +68,8 @@ export class JavaCompiler extends BaseCompiler {
 
             if (objResult.code !== 0) {
                 oneResult.asm = '<No output: javap returned ' + objResult.code + '>';
+            } else {
+                oneResult.objdumpTime = objResult.execTime;
             }
             return oneResult;
         }));

--- a/lib/compilers/nvcc.js
+++ b/lib/compilers/nvcc.js
@@ -61,6 +61,8 @@ export class NvccCompiler extends BaseCompiler {
         result.asm = objResult.stdout;
         if (objResult.code !== 0) {
             result.asm = `<No output: nvdisasm returned ${objResult.code}>`;
+        } else {
+            result.objdumpTime = objResult.execTime;
         }
         return result;
     }

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -115,6 +115,7 @@ export class FPCCompiler extends BaseCompiler {
         if (objResult.code !== 0) {
             result.asm = '<No output: objdump returned ' + objResult.code + '>';
         } else {
+            result.objdumpTime = objResult.execTime;
             result.asm = FPCCompiler.preProcessBinaryAsm(objResult.stdout);
         }
         return result;

--- a/lib/compilers/ptxas.js
+++ b/lib/compilers/ptxas.js
@@ -115,6 +115,8 @@ export class PtxAssembler extends BaseCompiler {
         result.asm = objResult.stdout;
         if (objResult.code !== 0) {
             result.asm = '<No output: objdump returned ' + objResult.code + '>';
+        } else {
+            result.objdumpTime = objResult.execTime;
         }
         return result;
     }

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -60,6 +60,7 @@ export class Win32Compiler extends BaseCompiler {
         if (objResult.code !== 0) {
             result.asm = '<No output: objdump returned ' + objResult.code + '>';
         } else {
+            result.objdumpTime = objResult.execTime;
             result.asm = objResult.stdout;
         }
 

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -72,6 +72,7 @@ export class WineVcCompiler extends BaseCompiler {
         if (objResult.code !== 0) {
             result.asm = '<No output: objdump returned ' + objResult.code + '>';
         } else {
+            result.objdumpTime = objResult.execTime;
             result.asm = objResult.stdout;
         }
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -69,6 +69,8 @@ function executeDirect(command, args, options, filenameTransform) {
         (command.startsWith('/mnt') && process.env.wsl) ? process.env.winTmp : process.env.tmpDir
     );
     logger.debug('Execution', {type: 'executing', command: command, args: args, env: env, cwd: cwd});
+    const startTime = process.hrtime.bigint();
+
     // AP: Run Windows-volume executables in winTmp. Otherwise, run in tmpDir (which may be undefined).
     // https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
     const child = child_process.spawn(command, args, {
@@ -129,12 +131,14 @@ function executeDirect(command, args, options, filenameTransform) {
             // Being killed externally gives a NULL error code. Synthesize something different here.
             if (code === null) code = -1;
             if (timeout !== undefined) clearTimeout(timeout);
+            const endTime = process.hrtime.bigint();
             const result = {
                 code,
                 okToCache,
                 filenameTransform,
                 stdout: streams.stdout,
                 stderr: streams.stderr,
+                execTime: ((endTime - startTime) / BigInt(1000000)).toString(),
             };
             logger.debug('Execution', {type: 'executed', command: command, args: args, result: result});
             resolve(result);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3358,6 +3358,32 @@
         "is-regex": "^1.0.3"
       }
     },
+    "chart.js": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "body-parser": "^1.18.2",
     "bootstrap": "^4.5.2",
     "bootstrap-slider": "^10.6.2",
+    "chart.js": "^2.9.4",
     "clipboard": "^2.0.6",
     "compiler-opt-info": "0.0.4",
     "compression": "^1.7.1",

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -729,6 +729,11 @@ div.populararguments div.dropdown-menu {
     display: none;
 }
 
+#timing-info .modal-content {
+    min-width: 500px;
+    min-height: 400px;
+}
+
 html[data-theme=default] {
     @import "themes/default-theme";
 }

--- a/static/timing-info-widget.js
+++ b/static/timing-info-widget.js
@@ -63,51 +63,87 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
         'violet',
     ];
 
-    if (compileResult.packageDownloadAndUnzipTime) {
+    if (compileResult.retreivedFromCache) {
         timings.push({
-            step: 'Download from cache',
-            time: compileResult.execTime,
+            step: 'Retreive ASM from cache',
+            time: compileResult.retreivedFromCacheTime,
         });
+
+        if (compileResult.packageDownloadAndUnzipTime) {
+            timings.push({
+                step: 'Download binary from cache',
+                time: compileResult.execTime,
+            });
+        }
+
+        if (compileResult.execResult && compileResult.execResult.execTime) {
+            timings.push({
+                step: 'Execution',
+                time: compileResult.execResult.execTime,
+            });
+        }
     } else {
 
-        if (compileResult.execResult) {
-            if (compileResult.execResult.buildResult) {
-                if (compileResult.execResult.buildResult.packageDownloadAndUnzipTime) {
-                    timings.push({
-                        step: 'Download from cache',
-                        time: compileResult.execResult.buildResult.packageDownloadAndUnzipTime,
-                    });
-                } else {
-                    if (compileResult.execResult.buildResult.downloads) {
-                        timings = timings.concat(compileResult.execResult.buildResult.downloads);
-                    }
+        if (compileResult.packageDownloadAndUnzipTime) {
+            timings.push({
+                step: 'Download binary from cache',
+                time: compileResult.execTime,
+            });
+        } else {
 
-                    if (compileResult.execResult.buildResult.execTime) {
+            if (compileResult.execResult) {
+                if (compileResult.execResult.buildResult) {
+                    if (compileResult.execResult.buildResult.packageDownloadAndUnzipTime) {
                         timings.push({
-                            step: 'Compilation',
-                            time: compileResult.execTime,
+                            step: 'Download binary from cache',
+                            time: compileResult.execResult.buildResult.packageDownloadAndUnzipTime,
                         });
+                    } else {
+                        if (compileResult.execResult.buildResult.downloads) {
+                            timings = timings.concat(compileResult.execResult.buildResult.downloads);
+                        }
+
+                        if (compileResult.execResult.buildResult.execTime) {
+                            timings.push({
+                                step: 'Compilation',
+                                time: compileResult.execResult.buildResult.execTime,
+                            });
+                        }
                     }
                 }
-            }
 
-            if (compileResult.execResult.execTime) {
-                timings.push({
-                    step: 'Execution',
-                    time: compileResult.execResult.execTime,
-                });
-            }
+                if (compileResult.objdumpTime) {
+                    timings.push({
+                        step: 'Disassembly',
+                        time: compileResult.objdumpTime,
+                    });
+                }
 
-        } else {
-            if (compileResult.downloads) {
-                timings = timings.concat(compileResult.downloads);
-            }
+                if (compileResult.execResult.execTime) {
+                    timings.push({
+                        step: 'Execution',
+                        time: compileResult.execResult.execTime,
+                    });
+                }
 
-            if (compileResult.execTime) {
-                timings.push({
-                    step: 'Compilation',
-                    time: compileResult.execTime,
-                });
+            } else {
+                if (compileResult.downloads) {
+                    timings = timings.concat(compileResult.downloads);
+                }
+
+                if (compileResult.execTime) {
+                    timings.push({
+                        step: 'Compilation',
+                        time: compileResult.execTime,
+                    });
+                }
+
+                if (compileResult.objdumpTime) {
+                    timings.push({
+                        step: 'Disassembly',
+                        time: compileResult.objdumpTime,
+                    });
+                }
             }
         }
     }

--- a/static/timing-info-widget.js
+++ b/static/timing-info-widget.js
@@ -137,7 +137,7 @@ TimingInfo.prototype.initializeIfNeeded = function () {
 
     this.ctx = canvas[0].getContext('2d');
     this.chart = new Chart(this.ctx, {
-        type: 'doughnut',
+        type: 'bar',
         data: this.data,
         options: {
             scales: {

--- a/static/timing-info-widget.js
+++ b/static/timing-info-widget.js
@@ -43,6 +43,15 @@ function TimingInfo() {
             label: 'time in ms',
             data: [12, 19, 3, 5, 2, 3],
             borderWidth: 1,
+            backgroundColor: [
+                'red',
+                'orange',
+                'yellow',
+                'green',
+                'blue',
+                'indigo',
+                'violet',
+            ],
         }],
     };
 }
@@ -53,15 +62,6 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
     this.data.labels = [];
     this.data.datasets[0].barThickness = 20;
     this.data.datasets[0].data = [];
-    this.data.datasets[0].backgroundColor = [
-        'red',
-        'orange',
-        'yellow',
-        'green',
-        'blue',
-        'indigo',
-        'violet',
-    ];
 
     if (compileResult.retreivedFromCache) {
         timings.push({
@@ -197,9 +197,12 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
         stepsTotal += parseInt(timing.time, 10);
     }, this));
 
-    if (totalTime > 0) {
-        this.data.labels.push('Network, JS, waiting, etc.');
-        this.data.datasets[0].data.push(totalTime - stepsTotal);
+    this.data.labels.push('Network, JS, waiting, etc.');
+    this.data.datasets[0].data.push(totalTime - stepsTotal);
+
+    if (totalTime - stepsTotal < 0) {
+        this.data.datasets[0].data = [totalTime];
+        this.data.labels = ['Browser cache'];
     }
 };
 

--- a/static/timing-info-widget.js
+++ b/static/timing-info-widget.js
@@ -1,0 +1,160 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+var $ = require('jquery');
+var _ = require('underscore');
+var Alert = require('./alert');
+
+// eslint-disable-next-line
+var Chart = require('chart.js');
+
+function TimingInfo() {
+    this.modal = null;
+    this.alertSystem = new Alert();
+    this.onLoad = _.identity;
+    this.base = window.httpRoot;
+    this.ctx = null;
+
+    this.data = {
+        labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+        datasets: [{
+            label: 'time in ms',
+            data: [12, 19, 3, 5, 2, 3],
+            borderWidth: 1,
+        }],
+    };
+}
+
+TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, totalTime) {
+    var timings = [];
+
+    this.data.labels = [];
+    this.data.datasets[0].barThickness = 20;
+    this.data.datasets[0].data = [];
+    this.data.datasets[0].backgroundColor = [
+        'red',
+        'orange',
+        'yellow',
+        'green',
+        'blue',
+        'indigo',
+        'violet',
+    ];
+
+    if (compileResult.packageDownloadAndUnzipTime) {
+        timings.push({
+            step: 'Download from cache',
+            time: compileResult.execTime,
+        });
+    } else {
+
+        if (compileResult.execResult) {
+            if (compileResult.execResult.buildResult) {
+                if (compileResult.execResult.buildResult.packageDownloadAndUnzipTime) {
+                    timings.push({
+                        step: 'Download from cache',
+                        time: compileResult.execResult.buildResult.packageDownloadAndUnzipTime,
+                    });
+                } else {
+                    if (compileResult.execResult.buildResult.downloads) {
+                        timings = timings.concat(compileResult.execResult.buildResult.downloads);
+                    }
+
+                    if (compileResult.execResult.buildResult.execTime) {
+                        timings.push({
+                            step: 'Compilation',
+                            time: compileResult.execTime,
+                        });
+                    }
+                }
+            }
+
+            if (compileResult.execResult.execTime) {
+                timings.push({
+                    step: 'Execution',
+                    time: compileResult.execResult.execTime,
+                });
+            }
+
+        } else {
+            if (compileResult.downloads) {
+                timings = timings.concat(compileResult.downloads);
+            }
+
+            if (compileResult.execTime) {
+                timings.push({
+                    step: 'Compilation',
+                    time: compileResult.execTime,
+                });
+            }
+        }
+    }
+
+    var stepsTotal = 0;
+    timings.forEach(_.bind(function (timing) {
+        this.data.labels.push(timing.step);
+        this.data.datasets[0].data.push(timing.time);
+
+        stepsTotal += parseInt(timing.time, 10);
+    }, this));
+
+    this.data.labels.push('Network, JS, waiting, etc.');
+    this.data.datasets[0].data.push(totalTime - stepsTotal);
+};
+
+TimingInfo.prototype.initializeIfNeeded = function () {
+    if ((this.modal === null) || (this.modal.length === 0)) {
+        this.modal = $('#timing-info');
+    }
+
+    var chartDiv = this.modal.find('#chart');
+    chartDiv.html('');
+
+    var canvas = $('<canvas id="timing-chart" width="400" height="400"></canvas>');
+    chartDiv.append(canvas);
+
+    this.ctx = canvas[0].getContext('2d');
+    this.chart = new Chart(this.ctx, {
+        type: 'doughnut',
+        data: this.data,
+        options: {
+            scales: {
+                xAxes: [{
+                    ticks: {
+                        beginAtZero: true,
+                    },
+                }],
+            },
+        },
+    });
+};
+
+TimingInfo.prototype.run = function (onLoad, compileResult, totalTime) {
+    this.initializeChartDataFromResult(compileResult, totalTime);
+    this.initializeIfNeeded();
+    this.modal.modal('show');
+};
+
+module.exports = { TimingInfo: TimingInfo };

--- a/static/timing-info-widget.js
+++ b/static/timing-info-widget.js
@@ -65,7 +65,7 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
 
     if (compileResult.retreivedFromCache) {
         timings.push({
-            step: 'Retreive ASM from cache',
+            step: 'Retreive result from cache',
             time: compileResult.retreivedFromCacheTime,
         });
 
@@ -119,6 +119,13 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
                     });
                 }
 
+                if (compileResult.parsingTime) {
+                    timings.push({
+                        step: 'ASM parsing',
+                        time: compileResult.parsingTime,
+                    });
+                }
+
                 if (compileResult.execResult.execTime) {
                     timings.push({
                         step: 'Execution',
@@ -142,6 +149,13 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
                     timings.push({
                         step: 'Disassembly',
                         time: compileResult.objdumpTime,
+                    });
+                }
+
+                if (compileResult.parsingTime) {
+                    timings.push({
+                        step: 'ASM parsing',
+                        time: compileResult.parsingTime,
                     });
                 }
             }

--- a/static/timing-info-widget.js
+++ b/static/timing-info-widget.js
@@ -169,11 +169,17 @@ TimingInfo.prototype.initializeChartDataFromResult = function (compileResult, to
                     step: 'Download binary from cache',
                     time: compileResult.buildResult.packageDownloadAndUnzipTime,
                 });
-            } else if (compileResult.buildResult.execTime) {
-                timings.push({
-                    step: 'Compilation',
-                    time: compileResult.buildResult.execTime,
-                });
+            } else {
+                if (compileResult.buildResult.downloads) {
+                    timings = timings.concat(compileResult.buildResult.downloads);
+                }
+
+                if (compileResult.buildResult.execTime) {
+                    timings.push({
+                        step: 'Compilation',
+                        time: compileResult.buildResult.execTime,
+                    });
+                }
             }
         }
 

--- a/test/exec-tests.js
+++ b/test/exec-tests.js
@@ -29,6 +29,7 @@ function testExecOutput(x) {
     // Work around chai not being able to deepEquals with a function
     x.filenameTransform.should.be.a('function');
     delete x.filenameTransform;
+    delete x.execTime;
     return x;
 }
 

--- a/test/filter-tests.js
+++ b/test/filter-tests.js
@@ -117,6 +117,7 @@ function testFilter(filename, suffix, filters) {
     }
 
     it(filename, () => {
+        delete result.parsingTime;
         if (json) {
             result.should.deep.equal(file, `${filename} case error`);
         } else {

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -317,3 +317,16 @@
                 .libs-favorites-col.col-md
                   h6 Favorites
                   .lib-favorites
+
+#timing-info.modal.fade.gl_keep(tabindex="-1" role="dialog")
+  .modal-dialog.modal-lg
+    .modal-content
+      .modal-header
+        h5.modal-title Timing
+        button.close(type="button" data-dismiss="modal" aria-hidden="true" aria-label="Close")
+          span(aria-hidden="true")
+            | &times;
+      .modal-body
+        #chart
+      .modal-footer
+        button.btn.btn-light(type="button" data-dismiss="modal" aria-label="Close") Close

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -196,6 +196,7 @@
       span.short-compiler-name
       button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button")
       span.compile-time(title="Compilation time (Result size)")
+      button.btn.btn-sm.btn-light.fas.fa-signal.full-timing-info(data-trigger="click" style="cursor: pointer;" role="button")
 
   #compiler-output
     .top-bar.btn-toolbar.options-toolbar.bg-light(role="toolbar")

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -149,6 +149,7 @@
         span.short-compiler-name
         button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button")
         span.compile-time(title="Compilation time (Result size)")
+        button.btn.btn-sm.btn-light.fas.fa-signal.full-timing-info(data-trigger="click" style="cursor: pointer;" role="button")
 
   #executor
     .top-bar.btn-toolbar.bg-light(role="toolbar")


### PR DESCRIPTION
API Request timing is displayed in the UI, but there have been some requests in the past to display more exact timings for the execution of user code (e.g. https://github.com/compiler-explorer/compiler-explorer/issues/2337)

Timing
- [x] Compiler
- [x] Executable
- [x] Library download
- [x] Binary from S3 cache

Display in UI
- [x] Compiler
- [x] Executable
- [x] Library download
