### PR TITLE
fix lib paths for cpp

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -601,8 +601,8 @@ compiler.icc191.semver=19.0.1
 compiler.icc191.options=-gxx-name=/opt/compiler-explorer/gcc-8.2.0/bin/g++
 
 compiler.icc202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/intel64/icc
-compiler.icc202112.ldPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
-compiler.icc202112.libPath=/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icc202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icc202112.semver=2021.1.2
 compiler.icc202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 # Alias the betas to the product compiler


### PR DESCRIPTION
I got the paths wrong in an earlier PR. I could not find anything that is broken because of this, but the paths are not valid.
