### PR TITLE
Add p2320 cppx label

### DIFF
--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -5,7 +5,7 @@ demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
 group.cppx.groupName=Clang
-group.cppx.compilers=cppx010:cppx_20180922:cppx_p1240r1:cppx_p1240r2
+group.cppx.compilers=cppx010:cppx_20180922:cppx_p2320:cppx_p1240r1:cppx_p1240r2
 compiler.cppx010.exe=/opt/compiler-explorer/cppx/current/bin/clang++
 compiler.cppx010.name=CppCon 2017
 compiler.cppx010.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++1z -Xclang -freflection -I/opt/compiler-explorer/cppx/current/include -stdlib=libc++ -include cppx/meta -include cppx/compiler
@@ -13,6 +13,10 @@ compiler.cppx010.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -st
 compiler.cppx_20180922.exe=/opt/compiler-explorer/clang-cppx-pinned-20180922/bin/clang++
 compiler.cppx_20180922.name=CppCon 2018
 compiler.cppx_20180922.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++1z -Xclang -freflection -I/opt/compiler-explorer/cppx/current/include -stdlib=libc++ -include cppx/meta -include cppx/compiler
+
+compiler.cppx_p2320.exe=/opt/compiler-explorer/clang-cppx-p2320-trunk/bin/clang++
+compiler.cppx_p2320.name=p2320 trunk
+compiler.cppx_p2320.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++1z -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-p2320-trunk/current/include -stdlib=libc++ -include cppx/meta -include cppx/compiler
 
 compiler.cppx_p1240r1.exe=/opt/compiler-explorer/clang-cppx-p1240r1/bin/clang++
 compiler.cppx_p1240r1.name=p1240r1


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This is the sister PR to https://github.com/compiler-explorer/clang-builder/pull/20, adding the label for "p2320 trunk"