### PR TITLE
Add arm gnuas compilers

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&nasm:&gnuas:&llvmas:&ptxas
+compilers=&nasm:&gnuas:&llvmas:&ptxas:&gnuasarm:&gnuasarm64
 compilerType=assembly
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
 supportsBinary=true
@@ -65,6 +65,71 @@ compiler.gnuas102.semver=10.2
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)
+
+
+group.gnuasarm.compilers=gnuasarmhfg54:gnuasarmg454:gnuasarmg464:gnuasarmg630:gnuasarmg640:gnuasarmg730:gnuasarmg820:gnuasarm930:gnuasarm1020
+group.gnuasarm.versionFlag=--version
+group.gnuasarm.options=-g
+group.gnuasarm.isSemVer=true
+group.gnuasarm.baseName=ARM gcc
+
+compiler.gnuasarmhfg54.exe=/opt/compiler-explorer/arm/gcc-5.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
+compiler.gnuasarmhfg54.name=ARM gcc 5.4 (linux)
+compiler.gnuasarmhfg54.semver=5.4
+compiler.gnuasarmg454.exe=/opt/compiler-explorer/arm/gcc-4.5.4/bin/arm-unknown-linux-gnueabi-as
+compiler.gnuasarmg454.name=ARM gcc 4.5.4 (linux)
+compiler.gnuasarmg454.semver=4.5.4
+compiler.gnuasarmg464.exe=/opt/compiler-explorer/arm/gcc-4.6.4/bin/arm-unknown-linux-gnueabi-as
+compiler.gnuasarmg464.name=ARM gcc 4.6.4 (linux)
+compiler.gnuasarmg464.semver=4.6.4
+compiler.gnuasarmg630.exe=/opt/compiler-explorer/arm/gcc-6.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-as
+compiler.gnuasarmg630.name=ARM gcc 6.3.0 (linux)
+compiler.gnuasarmg630.semver=6.3.0
+compiler.gnuasarmg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-as
+compiler.gnuasarmg640.name=ARM gcc 6.4 (linux)
+compiler.gnuasarmg640.semver=6.4.0
+compiler.gnuasarmg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-as
+compiler.gnuasarmg730.name=ARM gcc 7.3 (linux)
+compiler.gnuasarmg730.semver=7.3.0
+compiler.gnuasarmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-as
+compiler.gnuasarmg820.name=ARM gcc 8.2 (linux)
+compiler.gnuasarmg820.semver=8.2.0
+compiler.gnuasarm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
+compiler.gnuasarm930.name=ARM gcc 9.3 (linux)
+compiler.gnuasarm930.semver=9.3.0
+compiler.gnuasarm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
+compiler.gnuasarm1020.name=ARM gcc 10.2 (linux)
+compiler.gnuasarm1020.semver=10.2.0
+
+
+group.gnuasarm64.compilers=gnuasarm6454:gnuasarm64g630:gnuasarm64g640:gnuasarm64g730:gnuasarm64g820:gnuasarm64g930:gnuasarm64g1020
+group.gnuasarm64.versionFlag=--version
+group.gnuasarm64.options=-g
+group.gnuasarm64.isSemVer=true
+group.gnuasarm64.baseName=AARCH64 gcc
+
+compiler.gnuasarm6454.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-as
+compiler.gnuasarm6454.name=ARM64 gcc 5.4
+compiler.gnuasarm6454.semver=5.4
+compiler.gnuasarm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-as
+compiler.gnuasarm64g630.name=ARM64 gcc 6.3
+compiler.gnuasarm64g630.semver=6.3
+compiler.gnuasarm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g640.name=ARM64 gcc 6.4
+compiler.gnuasarm64g640.semver=6.4.0
+compiler.gnuasarm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g730.name=ARM64 gcc 7.3
+compiler.gnuasarm64g730.semver=7.3.0
+compiler.gnuasarm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g820.name=ARM64 gcc 8.2
+compiler.gnuasarm64g820.semver=8.2.0
+compiler.gnuasarm64g930.exe=/opt/compiler-explorer/arm64/gcc-9.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g930.name=ARM64 gcc 9.3
+compiler.gnuasarm64g930.semver=9.3.0
+compiler.gnuasarm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g1020.name=ARM64 gcc 10.2
+compiler.gnuasarm64g1020.semver=10.2.0
+
 
 group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas_trunk
 group.llvmas.versionFlag=--version


### PR DESCRIPTION
Fixes #2387

Untested !

Note: I did not copy all arm compilers from c++.amazon.properties as some did not support binary mode, which is required for ASM language.