### PR TITLE
Add C compilers for intel 2021.1.2 release

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&ppci:&cicc:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc
 defaultCompiler=cg102
 demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
@@ -467,7 +467,7 @@ compiler.ppci055.semver=0.5.5
 compiler.ppci055.exe=/opt/compiler-explorer/ppci-0.5.5/ppci/cli/cc.py
 
 # icc for x86
-group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191
+group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112
 group.cicc.intelAsm=-masm=intel
 group.cicc.options=-x c -gcc-name=/opt/compiler-explorer/gcc-4.7.1/bin/gcc
 group.cicc.groupName=ICC x86-64
@@ -492,6 +492,26 @@ compiler.cicc19.options=-x c -gcc-name=/opt/compiler-explorer/gcc-8.2.0/bin/gcc
 compiler.cicc191.exe=/opt/compiler-explorer/intel-2019.1/bin/icc
 compiler.cicc191.semver=19.0.1
 compiler.cicc191.options=-x c -gcc-name=/opt/compiler-explorer/gcc-8.2.0/bin/gcc
+
+compiler.cicc202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/intel64/icc
+compiler.cicc202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc202112.semver=2021.1.2
+compiler.cicc202112.options=-gcc-name=/opt/compiler-explorer/gcc-10.1.0/bin/gcc
+
+# icx for x86
+group.cicx.compilers=cicx202112
+group.cicx.intelAsm=-masm=intel
+group.cicx.options=
+group.cicx.groupName=ICX x86-64
+group.cicx.baseName=x86-64 icx
+group.cicx.isSemVer=true
+
+compiler.cicx202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/icx
+compiler.cicx202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicx202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202112.semver=2021.1.2
+compiler.cicx202112.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC


### PR DESCRIPTION
Add C compilers for intel 2021.1.2
C++ compilers were added in #2450 
