### PR TITLE
Allow other nasm inputformat, add readelf to assembly

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -8,9 +8,10 @@ defaultCompiler=nasm21402
 
 group.nasm.compilers=nasm21202:nasm21302:nasm21303:nasm21402
 group.nasm.versionFlag=-v
-group.nasm.options=-f elf -g -F stabs
+group.nasm.options=
 group.nasm.isSemVer=true
 group.nasm.baseName=NASM
+group.nasm.compilerType=nasm
 compiler.nasm21202.semver=2.12.02
 compiler.nasm21202.exe=/opt/compiler-explorer/nasm-2.12.02/nasm
 compiler.nasm21302.semver=2.13.02
@@ -167,4 +168,11 @@ compiler.ptxasnvcc102.exe=/opt/compiler-explorer/cuda/10.2.89/bin/ptxas
 #################################
 # Installed tools
 
-tools=
+tools=readelf
+
+tools.readelf.name=readelf (trunk)
+tools.readelf.exe=/opt/compiler-explorer/gcc-snapshot/bin/readelf
+tools.readelf.type=postcompilation
+tools.readelf.class=readelf-tool
+tools.readelf.exclude=
+tools.readelf.stdinHint=disabled

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -25,6 +25,7 @@
 export { AdaCompiler } from './ada';
 export { AnalysisTool } from './analysis-tool';
 export { AssemblyCompiler } from './assembly';
+export { NasmCompiler } from './nasm';
 export { Cc65Compiler } from './cc65';
 export { ClangCompiler } from './clang';
 export { CleanCompiler } from './clean';

--- a/lib/compilers/assembly.js
+++ b/lib/compilers/assembly.js
@@ -52,6 +52,24 @@ export class AssemblyCompiler extends BaseCompiler {
         return [];
     }
 
+    getGeneratedOutputFilename(fn) {
+        const outputFolder = path.dirname(fn);
+        const files = fs.readdirSync(outputFolder);
+
+        let outputFilename = super.filename(fn);
+        files.forEach(file => {
+            if (file[0] !== '.' && file !== this.compileFilename) {
+                outputFilename = path.join(outputFolder, file);
+            }
+        });
+
+        return outputFilename;
+    }
+
+    getOutputFilename(dirPath) {
+        return this.getGeneratedOutputFilename(path.join(dirPath, 'example.asm'));
+    }
+
     async runCompiler(compiler, options, inputFilename, execOptions) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
@@ -69,23 +87,8 @@ export class AssemblyCompiler extends BaseCompiler {
         return this.postProcess(asmResult, outputFilename, filters);
     }
 
-    getGeneratedOutputFilename(inputFilename) {
-        const outputFolder = path.dirname(inputFilename);
-
-        return new Promise((resolve, reject) => {
-            fs.readdir(outputFolder, (err, files) => {
-                files.forEach(file => {
-                    if (file[0] !== '.' && file !== this.compileFilename) {
-                        resolve(path.join(outputFolder, file));
-                    }
-                });
-                reject('No output file was generated');
-            });
-        });
-    }
-
     async objdump(outputFilename, result, maxSize, intelAsm, demangle) {
-        const realOutputFilename = await this.getGeneratedOutputFilename(outputFilename);
+        const realOutputFilename = this.getGeneratedOutputFilename(outputFilename);
         const dirPath = path.dirname(realOutputFilename);
         let args = ['-d', realOutputFilename, '-l', '--insn-width=16'];
         if (demangle) args = args.concat('-C');

--- a/lib/compilers/nasm.js
+++ b/lib/compilers/nasm.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import * as utils from '../utils';
+
+import { AssemblyCompiler } from './assembly';
+
+export class NasmCompiler extends AssemblyCompiler {
+    static get key() { return 'nasm'; }
+
+    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
+        let options = super.prepareArguments(userOptions, filters, backendOptions, inputFilename,
+            outputFilename, libraries);
+
+        let fmode;
+        if (options.includes('-felf')) {
+            fmode = 'elf';
+        } else if (options.includes('-felf64')) {
+            fmode = 'elf64';
+        } else if (options.includes('-fbin')) {
+            fmode = 'bin';
+        } else if (options.includes('-f')) {
+            const idx = options.indexOf('-f');
+            fmode = options[idx+1];
+        }
+
+        if (!fmode) {
+            options = ['-g','-f','elf','-F','stabs'].concat(options);
+        }
+
+        return options;
+    }
+
+    async runCompiler(compiler, options, inputFilename, execOptions) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+        execOptions.customCwd = path.dirname(inputFilename);
+
+        const result = await this.exec(compiler, options, execOptions);
+        result.inputFilename = inputFilename;
+        result.stdout = utils.parseOutput(result.stdout, inputFilename);
+        result.stderr = utils.parseOutput(result.stderr, inputFilename);
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes #2221

Doesn't show assembly for non-elf binaries because objdump does not seem to support it, but it compiles and I've added readelf to see at least "something" about the contents.

Also fixes #1804 
