### PR TITLE
Update language levels for active cppx reflection/meta branches

### DIFF
--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -16,7 +16,7 @@ compiler.cppx_20180922.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapsh
 
 compiler.cppx_p2320.exe=/opt/compiler-explorer/clang-cppx-p2320-trunk/bin/clang++
 compiler.cppx_p2320.name=p2320 trunk
-compiler.cppx_p2320.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++1z -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-p2320-trunk/include -stdlib=libc++ -include experimental/meta -include experimental/compiler
+compiler.cppx_p2320.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++20 -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-p2320-trunk/include -stdlib=libc++ -include experimental/meta -include experimental/compiler
 
 compiler.cppx_p1240r1.exe=/opt/compiler-explorer/clang-cppx-p1240r1/bin/clang++
 compiler.cppx_p1240r1.name=p1240r1
@@ -26,7 +26,7 @@ compiler.cppx_p1240r1.alias=cppx_trunk
 
 compiler.cppx_p1240r2.exe=/opt/compiler-explorer/clang-cppx-trunk/bin/clang++
 compiler.cppx_p1240r2.name=p1240r2 trunk
-compiler.cppx_p1240r2.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++2a -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-trunk/include -stdlib=libc++ -include experimental/meta -include experimental/compiler
+compiler.cppx_p1240r2.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++20 -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-trunk/include -stdlib=libc++ -include experimental/meta -include experimental/compiler
 
 #################################
 #################################


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Fix for https://github.com/compiler-explorer/compiler-explorer/pull/2473#issuecomment-794883932, plus a switch to `c++20` instead of `c++2a` for `p12402` 