### PR TITLE
enable optimization output for icx/icpx

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1236,7 +1236,9 @@ Please select another pass or change filters.`;
 
     getArgumentParser() {
         let exe = this.compiler.exe.toLowerCase();
-        if (exe.includes('clang')) {  // check this first as "clang++" matches "g++"
+        if (exe.includes('clang')
+            || exe.includes('icpx')
+            || exe.includes('icx')) {  // check this first as "clang++" matches "g++"
             return ClangParser;
         } else if (exe.includes('g++') || exe.includes('gcc')) {
             return GCCParser;


### PR DESCRIPTION
icx/icpx are clang-based and the optimization output works for these compilers, too.
ifx does not accept -fsave-optmization-output. Need to check if they renamed the switch

compilerType=clang
isn't need, so I did not include in this commit

Addresses #2484 
