### PR TITLE
Mg/asm tweaks

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -11,6 +11,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 # GCC for x86
 group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:g102:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
+group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
 group.gcc86.isSemVer=true
 group.gcc86.unwiseOptions=-march=native
@@ -151,6 +152,7 @@ group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang.groupName=Clang x86-64
+group.clang.instructionSet=amd64
 group.clang.baseName=x86-64 clang
 group.clang.isSemVer=true
 group.clang.compilerType=clang
@@ -325,6 +327,7 @@ group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-c
 group.armclang64.isSemVer=true
 group.armclang64.compilerType=clang
 group.armclang64.supportsExecute=false
+group.armclang64.instructionSet=aarch64
 
 compiler.armv7-clang1101.name=armv7-a clang 11.0.1
 compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
@@ -753,6 +756,7 @@ group.gcc64arm.groupName=Arm 64-bit GCC
 group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g820:arm64g930:arm64g1020
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
+group.gcc64arm.instructionSet=aarch64
 
 compiler.aarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
 compiler.aarchg54.name=ARM64 gcc 5.4
@@ -979,6 +983,7 @@ compiler.cl_new_arm32.instructionSet=arm32
 compiler.cl_new_arm64.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/arm64/cl.exe
 compiler.cl_new_arm64.name=ARM64 msvc v19.14 (WINE)
 compiler.cl_new_arm64.semver=19.14.26423
+compiler.cl_new_arm64.instructionSet=aarch64
 
 #################################
 # ELLCC

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -218,14 +218,14 @@ group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:arm
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
 group.armcclang32.supportsExecute=false
-group.armcclang32.instructionSet = arm32
+group.armcclang32.instructionSet=arm32
 
 group.armcclang64.groupName=Arm 64-bit clang
 group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang-trunk:armv8-full-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
-group.armcclang64.instructionSet = aarch64
+group.armcclang64.instructionSet=aarch64
 
 compiler.armv7-cclang1101.name=armv7-a clang 11.0.1
 compiler.armv7-cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -8,6 +8,7 @@ needsMulti=false
 # GCC for x86
 group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cg93:cg101:cg102:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
+group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
 group.cgcc86.baseName=x86-64 gcc
 group.cgcc86.supportsPVS-Studio=true
@@ -117,6 +118,7 @@ group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:c
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
+group.cclang.instructionSet=amd64
 group.cclang.isSemVer=true
 group.cclang.baseName=x86-64 clang
 group.cclang.compilerType=clang
@@ -223,6 +225,7 @@ group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:arm
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
+group.armcclang64.instructionSet = aarch64
 
 compiler.armv7-cclang1101.name=armv7-a clang 11.0.1
 compiler.armv7-cclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
@@ -628,6 +631,7 @@ group.cgcc64arm.groupName=Arm 64-bit GCC
 group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g820:carm64g930:carm64g1020
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
+group.cgcc64arm.instructionSet=aarch64
 
 compiler.caarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-gcc
 compiler.caarchg54.name=ARM64 gcc 5.4
@@ -846,10 +850,12 @@ compiler.ccl_new_arm32.instructionSet=arm32
 compiler.ccl_new_arm64.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/arm64/cl.exe
 compiler.ccl_new_arm64.name=ARM64 msvc v19.14 (WINE)
 compiler.ccl_new_arm64.semver=19.14.26423
+compiler.ccl_new_arm64.instructionSet=aarch64
 
 #################################
 # cc65 compilers
 group.cc65.compilers=cc65_217:cc65_218:cc65_219:cc65_trunk
+group.cc65.instructionSet=6502
 group.cc65.supportsBinary=false
 group.cc65.groupName=cc65
 group.cc65.compilerType=cc65

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -31,11 +31,13 @@ import _ from 'underscore';
 
 import { AsmParser } from './asm-parser';
 import { getBuildEnvTypeByKey } from './buildenvsetup';
+import { BuildEnvSetupBase } from './buildenvsetup/base';
 import * as cfg from './cfg';
 import { CompilerArguments } from './compiler-arguments';
 import { ClangParser, GCCParser } from './compilers/argument-parsers';
 import { getDemanglerTypeByKey } from './demangler';
 import * as exec from './exec';
+import { InstructionSets } from './instructionsets';
 import { languages } from './languages';
 import { LlvmIrParser } from './llvm-ir';
 import { logger } from './logger';
@@ -90,6 +92,21 @@ export class BaseCompiler {
             this.buildenvsetup = new buildenvsetupclass(this.compiler, this.env, async (compiler, args, options) => {
                 return this.execCompilerCached(compiler, args, options);
             });
+
+        }
+
+        if (!this.compiler.instructionSet) {
+            const isets = new InstructionSets();
+            if (this.buildenvsetup) {
+                isets.getCompilerInstructionSetHint(this.buildenvsetup.compilerArch, this.compiler.exe).then(
+                    (res) => this.compiler.instructionSet = res,
+                ).catch(() => {});
+            } else {
+                const temp = new BuildEnvSetupBase(this.compiler, this.env);
+                isets.getCompilerInstructionSetHint(temp.compilerArch, this.compiler.exe).then(
+                    (res) => this.compiler.instructionSet = res,
+                ).catch(() => {});
+            }
         }
 
         this.packager = new Packager();

--- a/lib/buildenvsetup/base.js
+++ b/lib/buildenvsetup/base.js
@@ -43,7 +43,7 @@ export class BuildEnvSetupBase {
 
         if (this.compilerArch) {
             this.compilerSupportsX86 = false;
-        } else {
+        } else if (execCompilerCachedFunc) {
             this.hasSupportForArch('x86')
                 .then(res => this.compilerSupportsX86 = res)
                 .catch(error => {
@@ -94,14 +94,34 @@ export class BuildEnvSetupBase {
             return  option.startsWith('-march=');
         });
 
-        if (arch) return arch.substr(7);
-
         let target = _.find(this.compilerOptionsArr, (option) => {
             option.startsWith('-target=') ||
             option.startsWith('--target=');
         });
 
-        if (target) return target.substr(target.indexOf('=') + 1);
+        if (target) {
+            target = target.substr(target.indexOf('=') + 1);
+        } else {
+            let targetIdx = this.compilerOptionsArr.indexOf('-target');
+            if (targetIdx !== false) {
+                target = this.compilerOptionsArr[targetIdx + 1];
+            }
+        }
+
+        if (arch) {
+            arch = arch.substr(7);
+        }
+
+        if (target && arch) {
+            if (arch.length < target.length) {
+                return arch;
+            } else {
+                return target;
+            }
+        } else {
+            if (target) return target;
+            if (arch) return arch;
+        }
 
         return false;
     }

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -151,7 +151,8 @@ export class ApiHandler {
             if (req.query.fields === 'all') {
                 res.send(list);
             } else {
-                const defaultfields = ['id', 'name', 'lang', 'compilerType', 'semver', 'extensions', 'monaco'];
+                const defaultfields = ['id', 'name', 'lang', 'compilerType', 'semver', 'extensions', 'monaco',
+                    'instructionSet'];
                 if (req.query.fields) {
                     const filteredList = this.filterCompilerProperties(list, req.query.fields.split(','));
                     res.send(filteredList);

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -28,9 +28,11 @@ import _ from 'underscore';
 
 import { ClientStateNormalizer } from '../clientstate-normalizer';
 import { logger } from '../logger';
+import * as props from '../properties';
 import { getShortenerTypeByKey } from '../shortener';
 import * as utils from '../utils';
 
+import { AsmDocsHandler as AsmDocsHandlerAarch64 } from './asm-docs-api-aarch64';
 import { AsmDocsHandler as AsmDocsHandlerAmd64 } from './asm-docs-api-amd64';
 import { AsmDocsHandler as AsmDocsHandlerArm32 } from './asm-docs-api-arm32';
 import { Formatter } from './formatting';
@@ -60,10 +62,23 @@ export class ApiHandler {
         this.handle.get('/libraries/:language', this.handleLangLibraries.bind(this));
         this.handle.get('/libraries', this.handleAllLibraries.bind(this));
 
-        const asmDocsHandlerAmd64 = new AsmDocsHandlerAmd64();
-        this.handle.get('/asm/:opcode', asmDocsHandlerAmd64.handle.bind(asmDocsHandlerAmd64));
-        const asmDocsHandlerArm32 = new AsmDocsHandlerArm32();
-        this.handle.get('/asm/arm32/:opcode', asmDocsHandlerArm32.handle.bind(asmDocsHandlerArm32));
+        const asmStaticAge = props.propsFor('asm-docs')('staticMaxAgeSecs', 10);
+        const asmArch = {
+            amd64: new AsmDocsHandlerAmd64(),
+            arm32: new AsmDocsHandlerArm32(),
+            aarch64: new AsmDocsHandlerAarch64(),
+        };
+        this.handle.get('/asm/:arch/:opcode', (req, res) => {
+            const handler = asmArch[req.params.arch];
+            if (handler)
+                return handler.handle(req, res);
+            res.setHeader('Cache-Control', 'public, max-age=' + asmStaticAge);
+            res.send('Unknown architecture');
+        });
+        // Legacy binding for old clients.
+        this.handle.get('/asm/:opcode',
+            (req, res) => res.redirect(`amd64/${req.params.opcode}`),
+        );
 
         const maxUploadSize = ceProps('maxUploadSize', '1mb');
         const textParser = bodyParser.text({limit: ceProps('bodyParserLimit', maxUploadSize), type: () => true});

--- a/lib/handlers/asm-docs-api-aarch64.js
+++ b/lib/handlers/asm-docs-api-aarch64.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as props from '../properties';
+
+export class AsmDocsHandler {
+    constructor() {
+        const asmProps = props.propsFor('asm-docs');
+        this.staticMaxAgeSecs = asmProps('staticMaxAgeSecs', 10);
+    }
+
+    handle(req, res) {
+        if (this.staticMaxAgeSecs) {
+            res.setHeader('Cache-Control', 'public, max-age=' + this.staticMaxAgeSecs);
+        }
+
+        res.send('Unknown opcode');
+    }
+}

--- a/lib/handlers/asm-docs-api-arm32.js
+++ b/lib/handlers/asm-docs-api-arm32.js
@@ -58,7 +58,7 @@ export class AsmDocsHandler {
         const matches = opcode.match(this.conditionalRe);
         if (matches) {
             let opcodeDescription = getAsmOpcode(matches[1]);
-            if(!opcodeDescription) return;
+            if (!opcodeDescription) return;
 
             let conditionalText = conditionals[matches[2]] || '';
 
@@ -70,16 +70,13 @@ export class AsmDocsHandler {
     }
 
     handle(req, res) {
-        let opcode = req.params.opcode.toUpperCase();
-        let info = getAsmOpcode(opcode);
-        if (!info) {
-            info = this.getOpcodeConditional(opcode);
-        }
+        const opcode = req.params.opcode.toUpperCase();
+        const info = getAsmOpcode(opcode) || this.getOpcodeConditional(opcode);
         if (this.staticMaxAgeSecs) {
             res.setHeader('Cache-Control', 'public, max-age=' + this.staticMaxAgeSecs);
         }
         if (req.accepts(['text', 'json']) === 'json') {
-            res.send({ found: !!info, result: info });
+            res.send({found: !!info, result: info});
         } else {
             if (info)
                 res.send(info.html);

--- a/lib/instructionsets.js
+++ b/lib/instructionsets.js
@@ -1,0 +1,106 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import _ from 'underscore';
+
+export class InstructionSets {
+    constructor() {
+        this.default = 'amd64';
+
+        this.supported = {
+            aarch64: {
+                target: ['aarch64'],
+                path: ['/aarch64-'],
+            },
+            arm32: {
+                target: ['arm'],
+                path: ['/arm-'],
+            },
+            riscv64: {
+                target: ['rv64'],
+                path: ['/riscv64-'],
+            },
+            riscv32: {
+                target: ['rv32'],
+                path: ['/riscv32-'],
+            },
+            avr: {
+                target: ['avr'],
+                path: ['/avr-'],
+            },
+            msp430: {
+                target: ['msp430'],
+                path: ['/msp430-'],
+            },
+            mips: {
+                target: ['mips'],
+                path: ['/mips-'],
+            },
+            wasm32: {
+                target: ['wasm32'],
+                path: [],
+            },
+            wasm64: {
+                target: ['wasm64'],
+                path: [],
+            },
+            6502: {
+                target: [],
+                path: [],
+            },
+            powerpc64le: {
+                target: ['powerpc64le'],
+                path: ['/powerpc64le-'],
+            },
+            powerpc64: {
+                target: ['powerpc64'],
+                path: ['/powerpc64-'],
+            },
+        };
+    }
+
+    async getCompilerInstructionSetHint(compilerArch, exe) {
+        return new Promise((resolve) => {
+            if (compilerArch) {
+                _.each(this.supported, (method, instructionSet) => {
+                    for (let target of method.target) {
+                        if (compilerArch.includes(target)) {
+                            resolve(instructionSet);
+                        }
+                    }
+                });
+            } else {
+                _.each(this.supported, (method, instructionSet) => {
+                    for (let path of method.path) {
+                        if (exe.includes(path)) {
+                            resolve(instructionSet);
+                        }
+                    }
+                });
+            }
+
+            resolve(this.default);
+        });
+    }
+}

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -456,7 +456,7 @@ Compiler.prototype.initEditorActions = function () {
 
     this.outputEditor.addAction({
         id: 'viewasmdoc',
-        label: 'View x86-64 opcode doc',
+        label: 'View assembly documentation',
         keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.F8],
         keybindingContext: null,
         contextMenuGroupId: 'help',


### PR DESCRIPTION
    Tweaks to new ASM stuff
    
    * mounts /asm/:arch/:opcode and handles unknown arch
    * adds dummy aarch64 placeholder
    * tags some stuff as aarch64
    * tags some stuff as amd64
    * uses a redirect from /asm/XXX -> /asm/amd64/XXX
    
    Still needs more work on tagging amd64 compilers; and things
    like MIPS etc. And we might need a "probably-amd64" kind of thing
    and/or start treating the "empty string" as being "please guess
    the architecture". Not sure yet, but this is a start

CC @jovere 