### PR TITLE
Report back an estimate of filtered lines

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -461,7 +461,6 @@ export class AsmParser extends AsmRegex {
         this.removeLabelsWithoutDefinition(asm, labelDefinitions);
 
         const endTime = process.hrtime.bigint();
-
         return {
             asm: asm,
             labelDefinitions: labelDefinitions,

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -255,6 +255,7 @@ export class AsmParser extends AsmRegex {
         const labelDefinitions = {};
 
         let asmLines = utils.splitLines(asmResult);
+        const startingLineCount = asmLines.length;
         if (filters.preProcessLines !== undefined) {
             asmLines = filters.preProcessLines(asmLines);
         }
@@ -348,7 +349,6 @@ export class AsmParser extends AsmRegex {
 
         let inCustomAssembly = 0;
 
-        let filteredCount = 0;
         // TODO: Make this function smaller
         // eslint-disable-next-line max-statements
         asmLines.forEach(line => {
@@ -392,7 +392,6 @@ export class AsmParser extends AsmRegex {
                 }
 
                 if (!keepInlineCode) {
-                    filteredCount++;
                     return;
                 }
             } else {
@@ -403,7 +402,6 @@ export class AsmParser extends AsmRegex {
                 ((line.match(commentOnly) && !inNvccCode) ||
                     (line.match(commentOnlyNvcc) && inNvccCode))
             ) {
-                filteredCount++;
                 return;
             }
 
@@ -424,7 +422,6 @@ export class AsmParser extends AsmRegex {
                 if (labelsUsed[match[1]] === undefined) {
                     // It's an unused label.
                     if (filters.labels) {
-                        filteredCount++;
                         return;
                     }
                 } else {
@@ -444,7 +441,6 @@ export class AsmParser extends AsmRegex {
                 } else {
                     // .inst generates an opcode, so does not count as a directive
                     if (line.match(this.directive) && !line.match(this.instOpcodeRe)) {
-                        filteredCount++;
                         return;
                     }
                 }
@@ -470,7 +466,7 @@ export class AsmParser extends AsmRegex {
             asm: asm,
             labelDefinitions: labelDefinitions,
             parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
-            filteredCount: filteredCount,
+            filteredCount: startingLineCount - asm.length,
         };
     }
 
@@ -495,6 +491,7 @@ export class AsmParser extends AsmRegex {
         const labelDefinitions = {};
 
         let asmLines = asmResult.split('\n');
+        const startingLineCount = asmLines.length;
         let source = null;
         let func = null;
         let mayRemovePreviousLabel = true;
@@ -594,6 +591,7 @@ export class AsmParser extends AsmRegex {
             asm: asm,
             labelDefinitions: labelDefinitions,
             parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
+            filteredCount: startingLineCount - asm.length,
         };
     }
 

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -347,6 +347,10 @@ export class AsmParser extends AsmRegex {
         let inNvccCode = false;
 
         let inCustomAssembly = 0;
+
+        let filteredCount = 0;
+        // TODO: Make this function smaller
+        // eslint-disable-next-line max-statements
         asmLines.forEach(line => {
             if (line.trim() === '') return maybeAddBlank();
 
@@ -387,7 +391,10 @@ export class AsmParser extends AsmRegex {
                     mayRemovePreviousLabel = false;
                 }
 
-                if (!keepInlineCode) return;
+                if (!keepInlineCode) {
+                    filteredCount++;
+                    return;
+                }
             } else {
                 mayRemovePreviousLabel = true;
             }
@@ -396,6 +403,7 @@ export class AsmParser extends AsmRegex {
                 ((line.match(commentOnly) && !inNvccCode) ||
                     (line.match(commentOnlyNvcc) && inNvccCode))
             ) {
+                filteredCount++;
                 return;
             }
 
@@ -415,7 +423,10 @@ export class AsmParser extends AsmRegex {
                 // It's a label definition.
                 if (labelsUsed[match[1]] === undefined) {
                     // It's an unused label.
-                    if (filters.labels) return;
+                    if (filters.labels) {
+                        filteredCount++;
+                        return;
+                    }
                 } else {
                     // A used label.
                     prevLabel = match;
@@ -432,7 +443,10 @@ export class AsmParser extends AsmRegex {
                     // We're defining data that's being used somewhere.
                 } else {
                     // .inst generates an opcode, so does not count as a directive
-                    if (line.match(this.directive) && !line.match(this.instOpcodeRe)) return;
+                    if (line.match(this.directive) && !line.match(this.instOpcodeRe)) {
+                        filteredCount++;
+                        return;
+                    }
                 }
             }
 
@@ -456,6 +470,7 @@ export class AsmParser extends AsmRegex {
             asm: asm,
             labelDefinitions: labelDefinitions,
             parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
+            filteredCount: filteredCount,
         };
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -992,6 +992,7 @@ export class BaseCompiler {
                 result.asm = res.asm;
                 result.labelDefinitions = res.labelDefinitions;
                 result.parsingTime = res.parsingTime;
+                result.filteredCount = res.filteredCount;
             } else {
                 result.asm = [{text: result.asm}];
             }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -988,11 +988,12 @@ export class BaseCompiler {
 
         if (!backendOptions.skipAsm) {
             if (result.okToCache) {
+                const startingLength = result.asm.length;
                 const res = this.processAsm(result, filters, options);
                 result.asm = res.asm;
                 result.labelDefinitions = res.labelDefinitions;
                 result.parsingTime = res.parsingTime;
-                result.filteredCount = res.filteredCount;
+                result.filteredCount = startingLength - res.asm.length;
             } else {
                 result.asm = [{text: result.asm}];
             }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -988,12 +988,11 @@ export class BaseCompiler {
 
         if (!backendOptions.skipAsm) {
             if (result.okToCache) {
-                const startingLength = result.asm.length;
                 const res = this.processAsm(result, filters, options);
                 result.asm = res.asm;
                 result.labelDefinitions = res.labelDefinitions;
                 result.parsingTime = res.parsingTime;
-                result.filteredCount = startingLength - res.asm.length;
+                result.filteredCount = res.filteredCount;
             } else {
                 result.asm = [{text: result.asm}];
             }

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -179,7 +179,7 @@ pre.content.wrap * {
     white-space: pre-wrap; /* Preserve sequences of white space */
 }
 
-.compile-time {
+.compile-info {
     font-size: x-small;
     font-style: italic;
 }

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -563,7 +563,7 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
         return;
     }
     this.needsCompile = false;
-    this.compileTimeLabel.text(' - Compiling...');
+    this.compileInfoLabel.text(' - Compiling...');
     var options = {
         userArguments: this.options,
         compilerOptions: {
@@ -797,18 +797,22 @@ Compiler.prototype.onCompileResponse = function (request, result, cached) {
     } else {
         this.outputBtn.prop('title', allText.replace(/\x1b\[[0-9;]*m(.\[K)?/g, ''));
     }
-    var timeLabelText = '';
+    var infoLabelText = '';
     if (cached) {
-        timeLabelText = ' - cached';
+        infoLabelText = ' - cached';
     } else if (wasRealReply) {
-        timeLabelText = ' - ' + timeTaken + 'ms';
+        infoLabelText = ' - ' + timeTaken + 'ms';
     }
 
     if (result.asmSize !== undefined) {
-        timeLabelText += ' (' + result.asmSize + 'B)';
+        infoLabelText += ' (' + result.asmSize + 'B)';
     }
 
-    this.compileTimeLabel.text(timeLabelText);
+    if (result.filteredCount > 0) {
+        infoLabelText += ' ~'+ result.filteredCount + (result.filteredCount === 1 ? ' line' : ' lines') + ' filtered';
+    }
+
+    this.compileInfoLabel.text(infoLabelText);
 
     this.postCompilationResult(request, result);
     this.eventHub.emit('compileResult', this.id, this.compiler, result, languages[this.currentLangId]);
@@ -1066,7 +1070,7 @@ Compiler.prototype.initButtons = function (state) {
     this.executorButton = this.domRoot.find('.create-executor');
     this.libsButton = this.domRoot.find('.btn.show-libs');
 
-    this.compileTimeLabel = this.domRoot.find('.compile-time');
+    this.compileInfoLabel = this.domRoot.find('.compile-info');
     this.compileClearCache = this.domRoot.find('.clear-cache');
 
     this.outputBtn = this.domRoot.find('.output-btn');

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -781,7 +781,7 @@ Compiler.prototype.onCompileResponse = function (request, result, cached) {
     });
 
     this.labelDefinitions = result.labelDefinitions || {};
-    this.setAssembly(result.asm || fakeAsm('<No output>'), result.filteredCount);
+    this.setAssembly(result.asm || fakeAsm('<No output>'), result.filteredCount || 0);
 
     var stdout = result.stdout || [];
     var stderr = result.stderr || [];

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -808,7 +808,7 @@ Compiler.prototype.onCompileResponse = function (request, result, cached) {
         infoLabelText += ' (' + result.asmSize + 'B)';
     }
 
-    if (result.filteredCount > 0) {
+    if (result.filteredCount && result.filteredCount > 0) {
         infoLabelText += ' ~'+ result.filteredCount + (result.filteredCount === 1 ? ' line' : ' lines') + ' filtered';
     }
 

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -671,16 +671,13 @@ Compiler.prototype.setAssembly = function (asm, filteredCount) {
     this.assembly = asm;
     if (!this.outputEditor || !this.outputEditor.getModel()) return;
     var editorModel = this.outputEditor.getModel();
-    var msg;
+    var msg = '<No assembly generated>';
     if (asm.length) {
         msg = _.pluck(asm, 'text').join('\n');
-    } else {
-        msg = '<No assembly generated';
-        if (filteredCount > 0) {
-            msg += ' (~' + filteredCount + (filteredCount === 1 ? ' line' : ' lines') + ' filtered)';
-        }
-        msg += '>';
+    } else if (filteredCount > 0) {
+        msg = '<No assembly to display (~' + filteredCount + (filteredCount === 1 ? ' line' : ' lines') + ' filtered)>';
     }
+
     editorModel.setValue(msg);
 
     if (!this.awaitingInitialResults) {

--- a/test/filter-tests.js
+++ b/test/filter-tests.js
@@ -118,6 +118,7 @@ function testFilter(filename, suffix, filters) {
 
     it(filename, () => {
         delete result.parsingTime;
+        delete result.filteredCount;
         if (json) {
             result.should.deep.equal(file, `${filename} case error`);
         } else {

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -148,7 +148,7 @@
                 | )
         span.short-compiler-name
         button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button")
-        span.compile-time(title="Compilation time (Result size)")
+        span.compile-info(title="Compilation info")
         button.btn.btn-sm.btn-light.fas.fa-signal.full-timing-info(data-trigger="click" style="cursor: pointer;" role="button")
 
   #executor


### PR DESCRIPTION
Adds an estimate of how many lines were filtered out when the result is empty (Maybe we could also add them for every compilation?)

Looks something like this
![imagen](https://user-images.githubusercontent.com/5364255/111819216-61375480-88e0-11eb-9490-6a6d5af2a4b6.png)


While it's not a fix for #2505 , it implements the suggestion given there by @dkm :)

Note that I had to `--no-verify` the commit because I couldn't bless the filter tests (And the approval PR is not yet merged in). Also, some work needs to be done to reduce the function where most of the edits take place - It has exceeded its max length of 50, but I just added an ingnore for now