### PR TITLE
Add bells to policies when a new version is available

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -738,6 +738,10 @@ div.populararguments div.dropdown-menu {
     margin-right: 2pt;
 }
 
+span.badge.badge-pill {
+    margin-left: 2pt;
+}
+
 html[data-theme=default] {
     @import "themes/default-theme";
 }

--- a/static/main.js
+++ b/static/main.js
@@ -280,11 +280,27 @@ function initPolicies(options) {
 
     jsCookie.remove('fs_uid');
     jsCookie.remove('cookieconsent_status');
-    if (options.policies.privacy.enabled &&
-        options.policies.privacy.hash !== jsCookie.get(options.policies.privacy.key)) {
-        $('#privacy').trigger('click', {
-            title: 'New Privacy Policy. Please take a moment to read it',
-        });
+    var policyBellNotification = $(document).find('#policyBellNotification');
+    var privacyBellNotification = $(document).find('#privacyBellNotification');
+    var cookiesBellNotification = $(document).find('#cookiesBellNotification');
+    if (options.policies.privacy.enabled) {
+        if (jsCookie.get(options.policies.privacy.key) == null) {
+            $('#privacy').trigger('click', {
+                title: 'New Privacy Policy. Please take a moment to read it',
+            });
+        } else if (options.policies.privacy.hash !== jsCookie.get(options.policies.privacy.key)) {
+            // When the user has already accepted the privacy, just show a pretty notification.
+            policyBellNotification.removeClass('d-none');
+            privacyBellNotification.removeClass('d-none');
+            $(document).find('#privacy')
+                .on('click', function () {
+                    // Only hide if the other policy does not also have a bell
+                    if (cookiesBellNotification.hasClass('d-none')) {
+                        policyBellNotification.addClass('d-none');
+                    }
+                    privacyBellNotification.addClass('d-none');
+                });
+        }
     }
     simpleCooks.onDoConsent = function () {
         jsCookie.set(options.policies.cookies.key, options.policies.cookies.hash, {expires: 365});
@@ -299,11 +315,22 @@ function initPolicies(options) {
     };
     // '' means no consent. Hash match means consent of old. Null means new user!
     var storedCookieConsent = jsCookie.get(options.policies.cookies.key);
-    if (options.policies.cookies.enabled && storedCookieConsent !== '' &&
-        options.policies.cookies.hash !== storedCookieConsent) {
-        simpleCooks.show();
-    } else if (options.policies.cookies.enabled && hasCookieConsented(options)) {
-        analytics.initialise();
+    if (options.policies.cookies.enabled) {
+        if (storedCookieConsent !== '' && options.policies.cookies.hash !== storedCookieConsent) {
+            simpleCooks.show();
+
+            policyBellNotification.removeClass('d-none');
+            cookiesBellNotification.removeClass('d-none');
+            $(document).find('#cookies')
+                .on('click', function () {
+                    if (privacyBellNotification.hasClass('d-none')) {
+                        policyBellNotification.addClass('d-none');
+                    }
+                    cookiesBellNotification.addClass('d-none');
+                });
+        } else if (hasCookieConsented(options)) {
+            analytics.initialise();
+        }
     }
 }
 

--- a/static/main.js
+++ b/static/main.js
@@ -286,19 +286,18 @@ function initPolicies(options) {
             });
         } else if (options.policies.privacy.hash !== jsCookie.get(options.policies.privacy.key)) {
             // When the user has already accepted the privacy, just show a pretty notification.
-            var ppolicyBellNotification = $(document).find('#policyBellNotification');
-            var pprivacyBellNotification = $(document).find('#privacyBellNotification');
-            var pcookiesBellNotification = $(document).find('#cookiesBellNotification');
+            var ppolicyBellNotification = $('#policyBellNotification');
+            var pprivacyBellNotification = $('#privacyBellNotification');
+            var pcookiesBellNotification = $('#cookiesBellNotification');
             ppolicyBellNotification.removeClass('d-none');
             pprivacyBellNotification.removeClass('d-none');
-            $(document).find('#privacy')
-                .on('click', function () {
-                    // Only hide if the other policy does not also have a bell
-                    if (pcookiesBellNotification.hasClass('d-none')) {
-                        ppolicyBellNotification.addClass('d-none');
-                    }
-                    pprivacyBellNotification.addClass('d-none');
-                });
+            $('#privacy').on('click', function () {
+                // Only hide if the other policy does not also have a bell
+                if (pcookiesBellNotification.hasClass('d-none')) {
+                    ppolicyBellNotification.addClass('d-none');
+                }
+                pprivacyBellNotification.addClass('d-none');
+            });
         }
     }
     simpleCooks.onDoConsent = function () {
@@ -317,18 +316,17 @@ function initPolicies(options) {
     if (options.policies.cookies.enabled) {
         if (storedCookieConsent !== '' && options.policies.cookies.hash !== storedCookieConsent) {
             simpleCooks.show();
-            var cpolicyBellNotification = $(document).find('#policyBellNotification');
-            var cprivacyBellNotification = $(document).find('#privacyBellNotification');
-            var ccookiesBellNotification = $(document).find('#cookiesBellNotification');
+            var cpolicyBellNotification = $('#policyBellNotification');
+            var cprivacyBellNotification = $('#privacyBellNotification');
+            var ccookiesBellNotification = $('#cookiesBellNotification');
             cpolicyBellNotification.removeClass('d-none');
             ccookiesBellNotification.removeClass('d-none');
-            $(document).find('#cookies')
-                .on('click', function () {
-                    if (cprivacyBellNotification.hasClass('d-none')) {
-                        cpolicyBellNotification.addClass('d-none');
-                    }
-                    ccookiesBellNotification.addClass('d-none');
-                });
+            $('#cookies').on('click', function () {
+                if (cprivacyBellNotification.hasClass('d-none')) {
+                    cpolicyBellNotification.addClass('d-none');
+                }
+                ccookiesBellNotification.addClass('d-none');
+            });
         } else if (hasCookieConsented(options)) {
             analytics.initialise();
         }

--- a/static/main.js
+++ b/static/main.js
@@ -277,12 +277,8 @@ function initializeResetLayoutLink() {
 
 function initPolicies(options) {
     // Ensure old cookies are removed, to avoid user confusion
-
     jsCookie.remove('fs_uid');
     jsCookie.remove('cookieconsent_status');
-    var policyBellNotification = $(document).find('#policyBellNotification');
-    var privacyBellNotification = $(document).find('#privacyBellNotification');
-    var cookiesBellNotification = $(document).find('#cookiesBellNotification');
     if (options.policies.privacy.enabled) {
         if (jsCookie.get(options.policies.privacy.key) == null) {
             $('#privacy').trigger('click', {
@@ -290,6 +286,9 @@ function initPolicies(options) {
             });
         } else if (options.policies.privacy.hash !== jsCookie.get(options.policies.privacy.key)) {
             // When the user has already accepted the privacy, just show a pretty notification.
+            var policyBellNotification = $(document).find('#policyBellNotification');
+            var privacyBellNotification = $(document).find('#privacyBellNotification');
+            var cookiesBellNotification = $(document).find('#cookiesBellNotification');
             policyBellNotification.removeClass('d-none');
             privacyBellNotification.removeClass('d-none');
             $(document).find('#privacy')
@@ -318,7 +317,9 @@ function initPolicies(options) {
     if (options.policies.cookies.enabled) {
         if (storedCookieConsent !== '' && options.policies.cookies.hash !== storedCookieConsent) {
             simpleCooks.show();
-
+            var policyBellNotification = $(document).find('#policyBellNotification');
+            var privacyBellNotification = $(document).find('#privacyBellNotification');
+            var cookiesBellNotification = $(document).find('#cookiesBellNotification');
             policyBellNotification.removeClass('d-none');
             cookiesBellNotification.removeClass('d-none');
             $(document).find('#cookies')

--- a/static/main.js
+++ b/static/main.js
@@ -309,6 +309,14 @@ function initPolicies(options) {
         jsCookie.set(options.policies.cookies.key, '');
     };
     simpleCooks.onHide = function () {
+        var spolicyBellNotification = $('#policyBellNotification');
+        var sprivacyBellNotification = $('#privacyBellNotification');
+        var scookiesBellNotification = $('#cookiesBellNotification');
+        // Only hide if the other policy does not also have a bell
+        if (sprivacyBellNotification.hasClass('d-none')) {
+            spolicyBellNotification.addClass('d-none');
+        }
+        scookiesBellNotification.addClass('d-none');
         $(window).trigger('resize');
     };
     // '' means no consent. Hash match means consent of old. Null means new user!

--- a/static/main.js
+++ b/static/main.js
@@ -286,18 +286,18 @@ function initPolicies(options) {
             });
         } else if (options.policies.privacy.hash !== jsCookie.get(options.policies.privacy.key)) {
             // When the user has already accepted the privacy, just show a pretty notification.
-            var policyBellNotification = $(document).find('#policyBellNotification');
-            var privacyBellNotification = $(document).find('#privacyBellNotification');
-            var cookiesBellNotification = $(document).find('#cookiesBellNotification');
-            policyBellNotification.removeClass('d-none');
-            privacyBellNotification.removeClass('d-none');
+            var ppolicyBellNotification = $(document).find('#policyBellNotification');
+            var pprivacyBellNotification = $(document).find('#privacyBellNotification');
+            var pcookiesBellNotification = $(document).find('#cookiesBellNotification');
+            ppolicyBellNotification.removeClass('d-none');
+            pprivacyBellNotification.removeClass('d-none');
             $(document).find('#privacy')
                 .on('click', function () {
                     // Only hide if the other policy does not also have a bell
-                    if (cookiesBellNotification.hasClass('d-none')) {
-                        policyBellNotification.addClass('d-none');
+                    if (pcookiesBellNotification.hasClass('d-none')) {
+                        ppolicyBellNotification.addClass('d-none');
                     }
-                    privacyBellNotification.addClass('d-none');
+                    pprivacyBellNotification.addClass('d-none');
                 });
         }
     }
@@ -317,17 +317,17 @@ function initPolicies(options) {
     if (options.policies.cookies.enabled) {
         if (storedCookieConsent !== '' && options.policies.cookies.hash !== storedCookieConsent) {
             simpleCooks.show();
-            var policyBellNotification = $(document).find('#policyBellNotification');
-            var privacyBellNotification = $(document).find('#privacyBellNotification');
-            var cookiesBellNotification = $(document).find('#cookiesBellNotification');
-            policyBellNotification.removeClass('d-none');
-            cookiesBellNotification.removeClass('d-none');
+            var cpolicyBellNotification = $(document).find('#policyBellNotification');
+            var cprivacyBellNotification = $(document).find('#privacyBellNotification');
+            var ccookiesBellNotification = $(document).find('#cookiesBellNotification');
+            cpolicyBellNotification.removeClass('d-none');
+            ccookiesBellNotification.removeClass('d-none');
             $(document).find('#cookies')
                 .on('click', function () {
-                    if (privacyBellNotification.hasClass('d-none')) {
-                        policyBellNotification.addClass('d-none');
+                    if (cprivacyBellNotification.hasClass('d-none')) {
+                        cpolicyBellNotification.addClass('d-none');
                     }
-                    cookiesBellNotification.addClass('d-none');
+                    ccookiesBellNotification.addClass('d-none');
                 });
         } else if (hasCookieConsented(options)) {
             analytics.initialise();

--- a/views/index.pug
+++ b/views/index.pug
@@ -65,7 +65,10 @@ block prepend content
             include menu-other.pug
         if policies.cookies.enabled || policies.privacy.enabled
           li.nav-item.dropdown
-            a.nav-link.dropdown-toggle#policiesDropdown(href="javascript:;" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false") Policies
+            a.nav-link.dropdown-toggle#policiesDropdown(href="javascript:;" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false")
+              | &nbsp;Policies
+              span#policyBellNotification.d-none.badge.badge-pill.badge-primary
+                span.fa.fa-bell
             div.dropdown-menu.dropdown-menu-right(aria-labelledby="policiesDropdown")
               include menu-policies.pug
 

--- a/views/menu-policies.pug
+++ b/views/menu-policies.pug
@@ -1,9 +1,9 @@
-a.justify-content-between.align-items-center.dropdown-item#cookies(href="javascript:;")
+a.dropdown-item#cookies(href="javascript:;")
   span.dropdown-icon.fas.fa-cookie-bite
   | Cookie policy&nbsp;
   span#cookiesBellNotification.d-none.badge.badge-pill.badge-primary
     span.fa.fa-bell
-a.justify-content-between.align-items-center.dropdown-item#privacy(href="javascript:;")
+a.dropdown-item#privacy(href="javascript:;")
   span.dropdown-icon.fas.fa-user-lock
   | Privacy policy&nbsp;
   span#privacyBellNotification.d-none.badge.badge-pill.badge-primary

--- a/views/menu-policies.pug
+++ b/views/menu-policies.pug
@@ -1,6 +1,10 @@
-a.dropdown-item#cookies(href="javascript:;")
+a.justify-content-between.align-items-center.dropdown-item#cookies(href="javascript:;")
   span.dropdown-icon.fas.fa-cookie-bite
-  | Cookie policy
-a.dropdown-item#privacy(href="javascript:;")
+  | Cookie policy&nbsp;
+  span#cookiesBellNotification.d-none.badge.badge-pill.badge-primary
+    span.fa.fa-bell
+a.justify-content-between.align-items-center.dropdown-item#privacy(href="javascript:;")
   span.dropdown-icon.fas.fa-user-lock
-  | Privacy policy
+  | Privacy policy&nbsp;
+  span#privacyBellNotification.d-none.badge.badge-pill.badge-primary
+    span.fa.fa-bell

--- a/views/menu-policies.pug
+++ b/views/menu-policies.pug
@@ -1,10 +1,10 @@
 a.dropdown-item#cookies(href="javascript:;")
   span.dropdown-icon.fas.fa-cookie-bite
-  | Cookie policy&nbsp;
+  | Cookie policy
   span#cookiesBellNotification.d-none.badge.badge-pill.badge-primary
     span.fa.fa-bell
 a.dropdown-item#privacy(href="javascript:;")
   span.dropdown-icon.fas.fa-user-lock
-  | Privacy policy&nbsp;
+  | Privacy policy
   span#privacyBellNotification.d-none.badge.badge-pill.badge-primary
     span.fa.fa-bell


### PR DESCRIPTION
This adds some bells to the policies dropdown when a new version of a policy is available.
It was initially made to adress #2464, but currently it still shows the privacy policy on first view, which does not fix the linked issue.

Ideas welcomed :)