### PR TITLE
Propagate cache hits to higher levels in MultiCache

### DIFF
--- a/lib/cache/multi.js
+++ b/lib/cache/multi.js
@@ -39,12 +39,26 @@ export class MultiCache extends BaseCache {
     }
 
     async getInternal(key) {
+        const misses = [];
+
         for (const cache of this.upstream) {
             const result = await cache.get(key);
-            // TODO: could propagate hits to lower-level caches. But that's a lot of work and it's not
-            // clear to me it is better than just serving from the lowest-level cache.
-            if (result.hit) return result;
+
+            // keep track of caches that missed so we can write to them if we do hit
+            if (!result.hit) {
+                misses.push(cache);
+                continue;
+            }
+
+            // propagate hit to any higher level caches which missed
+            for (const miss of misses) {
+                await miss.put(key, result.data);
+            }
+
+            return result;
         }
+
+        // all caches missed
         return {hit: false};
     }
 

--- a/lib/cache/multi.js
+++ b/lib/cache/multi.js
@@ -38,24 +38,23 @@ export class MultiCache extends BaseCache {
         return `${super.statString()}. ${this.upstream.map(c => `${c.details}: ${c.statString()}`).join('. ')}`;
     }
 
+    propagateHitToMissedCaches(caches, key, data) {
+        return Promise.all(caches.map(c => c.put(key, data)));
+    }
+
     async getInternal(key) {
         const misses = [];
 
         for (const cache of this.upstream) {
             const result = await cache.get(key);
 
+            if (result.hit) {
+                await this.propagateHitToMissedCaches(misses, key, result.data);
+                return result;
+            }
+
             // keep track of caches that missed so we can write to them if we do hit
-            if (!result.hit) {
-                misses.push(cache);
-                continue;
-            }
-
-            // propagate hit to any higher level caches which missed
-            for (const miss of misses) {
-                await miss.put(key, result.data);
-            }
-
-            return result;
+            misses.push(cache);
         }
 
         // all caches missed


### PR DESCRIPTION
The motivating factor here is to potentially make our in-memory caching actually useful.

As it stands, our in-memory cache nearly always misses since the only way it will get populated is for unique new requests to an instance.