### PR TITLE
support for arm instructions in graph viewer

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -68,7 +68,7 @@ function filterTextSection(data) {
     return result;
 }
 
-const gccX86 = {
+const gcc = {
     filterData: asmArr => {
         const jmpLabelRegex = /\.L\d+:/;
         const isCode = x => x && x.text && (x.source !== null || jmpLabelRegex.test(x.text) || isFunctionName(x));
@@ -81,27 +81,30 @@ const gccX86 = {
 
     isBasicBlockEnd: (inst, prevInst) => inst[0] === '.' || prevInst.includes(' ret'),
 
+    isJmpInstruction: x => x.trim()[0] === 'j' || x.match(/\bb\.*(eq|ne|cs|hs|cc|lo|hi|ls|ge|lt|gt|le)?\b/),
+
     getInstructionType: inst => {
-        if (inst.includes('jmp')) return InstructionType_jmp;
-        else if (inst.trim()[0] === 'j') return InstructionType_conditionalJmpInst;
+        if (inst.includes('jmp') || inst.includes(' b ')) return InstructionType_jmp;
+        else if (this.isJmpInstruction(inst)) return InstructionType_conditionalJmpInst;
         else if (!inst.includes(' ret')) return InstructionType_notRetInst;
         else return InstructionType_retInst;
     },
 
     extractNodeName: inst => inst.match(/\.L\d+/) + ':',
-
-    isJmpInstruction: x => x.trim()[0] === 'j',
 };
 
-const clangX86 = {
+const clang = {
     filterData: asmArr => {
         const jmpLabelRegex = /\.LBB\d+_\d+:/;
         const isCode = x => x && x.text && (x.source !== null || jmpLabelRegex.test(x.text) || isFunctionName(x));
 
         const removeComments = x => {
-            const pos = x.text.indexOf('#');
-            if (pos !== -1)
-                x.text = utils.trimRight(x.text.substring(0, pos));
+            const pos_x86 = x.text.indexOf('# ');
+            const pos_arm = x.text.indexOf('// ');
+            if (pos_x86 !== -1)
+                x.text = utils.trimRight(x.text.substring(0, pos_x86));
+            if (pos_arm !== -1)
+                x.text = utils.trimRight(x.text.substring(0, pos_arm));
             return x;
         };
 
@@ -115,16 +118,16 @@ const clangX86 = {
 
     isBasicBlockEnd: (inst, prevInst) => inst[0] === '.' || prevInst.includes(' ret'),
 
+    isJmpInstruction: x => x.trim()[0] === 'j' || x.match(/\bb\.*(eq|ne|cs|hs|cc|lo|hi|ls|ge|lt|gt|le)?\b/),
+
     getInstructionType: function (inst) {
-        if (inst.includes('jmp')) return InstructionType_jmp;
-        else if (inst.trim()[0] === 'j') return InstructionType_conditionalJmpInst;
+        if (inst.includes('jmp') || inst.includes(' b ')) return InstructionType_jmp;
+        else if (this.isJmpInstruction(inst)) return InstructionType_conditionalJmpInst;
         else if (!inst.includes(' ret')) return InstructionType_notRetInst;
         else return InstructionType_retInst;
     },
 
     extractNodeName: inst => inst.match(/\.LBB\d+_\d+/) + ':',
-
-    isJmpInstruction: x => x.trim()[0] === 'j',
 };
 
 function splitToFunctions(asmArr, isEnd) {
@@ -318,7 +321,7 @@ function isLLVMBased(compilerType, version) {
 }
 
 export function generateStructure(compilerType, version, asmArr) {
-    const rules = isLLVMBased(compilerType, version) ? clangX86 : gccX86;
+    const rules = isLLVMBased(compilerType, version) ? clang : gcc;
     const code = rules.filterData(asmArr);
     const funcs = splitToFunctions(code, rules.isFunctionEnd);
     if (funcs.length === 0) {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This PR adds support for ARM branch instructions in the graph viewer. (Solution to #2013).
Clang uses `#` to mark immediates in ARM, which meant immediates were previously stripped out of the graph viewer, so comment stripping had to be removed.