### PR TITLE
Remove ref and link to the wiki

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,3 +96,4 @@ From oldest to newest contributor, we would like to thank:
 - [Robert Cohn](https://github.com/rscohn2)
 - [Jeremy Overesch](https://github.com/jovere)
 - [Arseniy Zaostrovnykh](https://github.com/necto)
+- [Dan Okken](https://github.com/okkenator)

--- a/docs/AddingALibrary.md
+++ b/docs/AddingALibrary.md
@@ -168,7 +168,6 @@ compiler.mycompiler.supportedLibraries=fmt:rangesv3.030
 Hopefully that's enough to get an idea. The ideal case should be a pull request to add a couple of
 lines to the `infra` repository to install the library, and a pull request to add a few lines to the `LANG.amazon.properties`
 file in this repository.
-Once that's done, remember to update [the wiki](https://github.com/compiler-explorer/compiler-explorer/wiki/Installed-libraries) with the new library, adding the library in alphabetical order, with newer versions on top.
 
 If you feel like we could improve this document in any way, please contact us. We'd love to hear from you!
 


### PR DESCRIPTION
Remove a reference and a link to the wiki from AddingALibrary.md since it is obsolete and the page does not exist.
