### PR TITLE
Remove additionalEnv. Treat execOptions.env as always 'in addition to…

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -788,11 +788,11 @@ export class BaseCompiler {
         const maxExecOutputSize = this.env.ceProps('max-executable-output-size', 32 * 1024);
         // Hardcoded fix for #2339. Ideally I'd have a config option for this, but for now this is plenty good enough.
         executeParameters.env = {
-            ...executeParameters.env,
             ASAN_OPTIONS: 'color=always',
             UBSAN_OPTIONS: 'color=always',
             MSAN_OPTIONS: 'color=always',
             LSAN_OPTIONS: 'color=always',
+            ...executeParameters.env,
         };
         return this.execBinary(executable, maxExecOutputSize, executeParameters);
     }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -267,7 +267,7 @@ export class BaseCompiler {
                 timeoutMs: timeoutMs,
                 ldPath: _.union(this.compiler.ldPath, executeParameters.ldPath).join(':'),
                 input: executeParameters.stdin,
-                additionalEnv: executeParameters.additionalEnv,
+                env: executeParameters.env,
             });
             execResult.stdout = utils.parseOutput(execResult.stdout);
             execResult.stderr = utils.parseOutput(execResult.stderr);
@@ -787,7 +787,8 @@ export class BaseCompiler {
     runExecutable(executable, executeParameters) {
         const maxExecOutputSize = this.env.ceProps('max-executable-output-size', 32 * 1024);
         // Hardcoded fix for #2339. Ideally I'd have a config option for this, but for now this is plenty good enough.
-        executeParameters.additionalEnv = {
+        executeParameters.env = {
+            ...executeParameters.env,
             ASAN_OPTIONS: 'color=always',
             UBSAN_OPTIONS: 'color=always',
             MSAN_OPTIONS: 'color=always',

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -24,9 +24,9 @@
 
 import child_process from 'child_process';
 import fs from 'fs';
+import path from 'path';
 
 import Graceful from 'node-graceful';
-import path from 'path';
 import treeKill from 'tree-kill';
 import _ from 'underscore';
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -24,9 +24,9 @@
 
 import child_process from 'child_process';
 import fs from 'fs';
-import path from 'path';
 
 import Graceful from 'node-graceful';
+import path from 'path';
 import treeKill from 'tree-kill';
 import _ from 'underscore';
 
@@ -49,8 +49,7 @@ function executeDirect(command, args, options, filenameTransform) {
     options = options || {};
     const maxOutput = options.maxOutput || 1024 * 1024;
     const timeoutMs = options.timeoutMs || 0;
-    const baseEnv = options.env ? options.env : _.clone(process.env);
-    const env = {...baseEnv, ...(options.additionalEnv || {})};
+    const env = {...process.env, ...options.env};
 
     if (options.ldPath) {
         env.LD_LIBRARY_PATH = options.ldPath;
@@ -177,10 +176,10 @@ function sandboxNsjail(command, args, options) {
         delete options.ldPath;
     }
 
-    for (const key of Object.keys(options.additionalEnv || {})) {
-        jailingOptions.push(`--env=${key}=${options.additionalEnv[key]}`);
-        delete options.additionalEnv[key];
+    for (const key of Object.keys(options.env || {})) {
+        jailingOptions.push(`--env=${key}=${options.env[key]}`);
     }
+    delete options.env;
 
     return executeDirect(
         execProps('nsjail'),
@@ -225,10 +224,10 @@ function sandboxFirejail(command, args, options) {
         delete options.ldPath;
     }
 
-    for (const key of Object.keys(options.additionalEnv || {})) {
-        jailingOptions.push(`--env=${key}=${options.additionalEnv[key]}`);
-        delete options.additionalEnv[key];
+    for (const key of Object.keys(options.env || {})) {
+        jailingOptions.push(`--env=${key}=${options.env[key]}`);
     }
+    delete options.env;
 
     return executeDirect(
         execProps('firejail'),
@@ -369,13 +368,13 @@ export function initialiseWine() {
 }
 
 function applyWineEnv(env) {
-    const prefix = execProps('winePrefix');
-    env = _.clone(env) || {};
-    // Force use of wine vcruntime (See change 45106c382)
-    env.WINEDLLOVERRIDES = 'vcruntime140=b';
-    env.WINEDEBUG = '-all';
-    env.WINEPREFIX = prefix;
-    return env;
+    return {
+        ...env,
+        // Force use of wine vcruntime (See change 45106c382)
+        WINEDLLOVERRIDES: 'vcruntime140=b',
+        WINEDEBUG: '-all',
+        WINEPREFIX: execProps('winePrefix'),
+    };
 }
 
 function needsWine(command) {

--- a/lib/tooling/pvs-studio-tool.js
+++ b/lib/tooling/pvs-studio-tool.js
@@ -150,7 +150,6 @@ export class PvsStudioTool extends BaseTool {
 
     getDefaultExecOptions() {
         const execOptions = super.getDefaultExecOptions();
-        execOptions.env = process.env;
         execOptions.env.PATH = process.env.PATH + ':/opt/compiler-explorer/pvs-studio-latest/bin';
 
         return execOptions;

--- a/lib/tooling/pvs-studio-tool.js
+++ b/lib/tooling/pvs-studio-tool.js
@@ -33,7 +33,9 @@ import * as utils from '../utils';
 import { BaseTool } from './base-tool';
 
 export class PvsStudioTool extends BaseTool {
-    static get key() { return 'pvs-studio-tool'; }
+    static get key() {
+        return 'pvs-studio-tool';
+    }
 
     constructor(toolInfo, env) {
         super(toolInfo, env);
@@ -150,7 +152,10 @@ export class PvsStudioTool extends BaseTool {
 
     getDefaultExecOptions() {
         const execOptions = super.getDefaultExecOptions();
-        execOptions.env.PATH = process.env.PATH + ':/opt/compiler-explorer/pvs-studio-latest/bin';
+        execOptions.env = {
+            ...execOptions.env,
+            PATH: process.env.PATH + ':/opt/compiler-explorer/pvs-studio-latest/bin',
+        };
 
         return execOptions;
     }


### PR DESCRIPTION
… base env'. Specifically only pass those env vars through sandboxing.

Based on conversations with @apmorton and to make env vars more useful in execOptions, while keeping the flavour of "no, only the specific vars you pass will make it into the sandbox env"

See #2569 