### PR TITLE
Highlight individual tokens in the source file and the corresponding nodes in the LLVM AST pane

### DIFF
--- a/lib/llvm-ast.js
+++ b/lib/llvm-ast.js
@@ -31,70 +31,63 @@ export class LlvmAstParser {
 
         // Almost every line of AST includes a span of related source lines:
         // In different forms like <line:a:b, line:c:d>
-        this.spanTypes = {
-            NONE: 'none', // No span specified
-            EMPTY: 'empty', // span mentions no lines
-            LEFT: 'left', // span mentions only the starting line
-            RIGHT: 'right', // span mentions only the finishing line
-            FULL: 'full', // span mentions both lines
+        this.locTypes = {
+            NONE: 'none', // No location specified
+            POINT: 'point', // A single location: beginning of a token
+            SPAN: 'span', // Two locations: first token to last token (beginning)
         };
     }
 
-    // Extract one, two, or no line numbers:
-    // <line:a:b, line:c:d> -> [a, b] - FULL
-    // <col:b, line:c:d> -> [-, b] - RIGHT
-    // <line:a:b, col:c> -> [a, -] - LEFT
-    // <col:a, col:b> -> EMPTY
-    // <no source span> -> NONE
-    parseSpan(line) {
-        const spanRegex = /<((?:line|col)[\d ,:ceilno]+)>/;
-        const twoLineRegex = /line:(\d+)[,:].*line:(\d+)[:>]/;
-        const leftLineRegex = /^line:(\d+)/;
-        const rightLineRegex = / line:(\d+):/;
+    // Accepts "line:a:b" and "col:b"
+    parsePoint(ptLine, lastLineNo) {
+        const lineRegex = /line:(\d+):/;
+        const colRegex = /(?:col|\d):(\d+)(?::|$)/;
+        const lineMatch = ptLine.match(lineRegex);
+        const colMatch = ptLine.match(colRegex);
+        const line = lineMatch ? Number(lineMatch[1]) : lastLineNo;
+        const col = colMatch ? Number(colMatch[1]) : null; // Does not happen for well-formed strings
+        return {line, col};
+    }
 
+    // Accepts "<X, X>" and "<X>", where
+    // X can be "col:a" or "line:a:b"
+    // lastLineNo - the line number of the previous node,
+    // reused when only a column specified.
+    parseSpan(line, lastLineNo) {
+        const spanRegex = /<((?:line|col)[\d ,:ceilno]+)>/;
         const m = line.match(spanRegex);
         if (m) {
             const span = m[1];
-            const ll = span.match(twoLineRegex);
-            if (ll) {
-                return { type : this.spanTypes.FULL, left : Number(ll[1]), right: Number(ll[2])};
+            const beginEnd = span.split(',');
+            if (beginEnd.length === 2) {
+                const begin = this.parsePoint(beginEnd[0], lastLineNo);
+                const end = this.parsePoint(beginEnd[1], begin.line);
+                return { type : this.locTypes.SPAN, begin, end };
+            } else {
+                return { type : this.locTypes.POINT, loc : this.parsePoint(span, lastLineNo) };
             }
-            const left = span.match(leftLineRegex);
-            if (left) {
-                return { type : this.spanTypes.LEFT, left : Number(left[1])};
-            }
-            const right = span.match(rightLineRegex);
-            if (right) {
-                return { type : this.spanTypes.RIGHT, right : Number(right[1])};
-            }
-            return { type : this.spanTypes.EMPTY };
         }
-        return { type : this.spanTypes.NONE };
+        return { type : this.locTypes.NONE };
     }
 
-    // Link the AST lines with spans of source lines
+    // Link the AST lines with spans of source locations (lines+columns)
     parseAndSetSourceLines(astDump) {
-        var lfrom, lto;
+        var lfrom = {line:null, loc:null}, lto = {line:null, loc:null};
         for (var line of astDump) {
-            const span = this.parseSpan(line.text);
+            const span = this.parseSpan(line.text, lfrom.line);
             switch(span.type) {
-                case this.spanTypes.NONE:
-                case this.spanTypes.EMPTY:
+                case this.locTypes.NONE:
                     break;
-                case this.spanTypes.LEFT:
-                    lfrom = span.left;
-                    lto = lfrom;
+                case this.locTypes.POINT:
+                    lfrom = span.loc;
+                    lto = span.loc;
                     break;
-                case this.spanTypes.RIGHT:
-                    lfrom = lto;
-                    lto = span.right;
-                    break;
-                case this.spanTypes.FULL:
-                    lfrom = span.left;
-                    lto = span.right;
+                case this.locTypes.SPAN:
+                    lfrom = span.begin;
+                    lto = span.end;
                     break;
             }
-            if (span.type !== this.spanTypes.NONE) {
+            if (span.type !== this.locTypes.NONE) {
                 line.source = { from : lfrom, to : lto };
             }
         }

--- a/static/panes/ast-view.js
+++ b/static/panes/ast-view.js
@@ -193,10 +193,10 @@ Ast.prototype.onColours = function (id, colours, scheme) {
 
         var astColours = {};
         _.each(this.astCode, function (x, index) {
-            if (x.source && x.source.from && x.source.to &&
-                x.source.from <= x.source.to && x.source.to < x.source.from + 100) {
+            if (x.source && x.source.from.line && x.source.to.line &&
+                x.source.from.line <= x.source.to.line && x.source.to.line < x.source.from.line + 100) {
                 var i;
-                for (i = x.source.from; i <= x.source.to; ++i) {
+                for (i = x.source.from.line; i <= x.source.to.line; ++i) {
                     if (colours[i - 1] !== undefined) {
                         astColours[index] = colours[i - 1];
                         break;
@@ -263,8 +263,8 @@ Ast.prototype.onMouseMove = function (e) {
         var hoverCode = this.astCode[e.target.position.lineNumber - 1];
         if (hoverCode) {
             // We check that we actually have something to show at this point!
-            var sourceLine = (hoverCode.source && hoverCode.source.from && hoverCode.source.to)
-                ? hoverCode.source.from
+            var sourceLine = (hoverCode.source && hoverCode.source.from.line && hoverCode.source.to.line)
+                ? hoverCode.source.from.line
                 : -1;
             this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, -1, false);
             this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, false, this.getPaneName());
@@ -293,7 +293,7 @@ Ast.prototype.onPanesLinkLine = function (compilerId, lineNumber, revealLine, se
     if (Number(compilerId) === this._compilerid) {
         var lineNums = [];
         _.each(this.astCode, function (astLine, i) {
-            if (astLine.source && astLine.source.from <= lineNumber && lineNumber <= astLine.source.to) {
+            if (astLine.source && astLine.source.from.line <= lineNumber && lineNumber <= astLine.source.to.line) {
                 var line = i + 1;
                 lineNums.push(line);
             }

--- a/static/panes/ast-view.js
+++ b/static/panes/ast-view.js
@@ -262,11 +262,19 @@ Ast.prototype.onMouseMove = function (e) {
         this.clearLinkedLines();
         var hoverCode = this.astCode[e.target.position.lineNumber - 1];
         if (hoverCode) {
+            var sourceLine = -1;
+            var colBegin = -1;
+            var colEnd = -1;
             // We check that we actually have something to show at this point!
-            var sourceLine = (hoverCode.source && hoverCode.source.from.line && hoverCode.source.to.line)
-                ? hoverCode.source.from.line
-                : -1;
-            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, -1, false);
+            if (hoverCode.source && hoverCode.source.from) {
+                sourceLine = hoverCode.source.from.line;
+                // Highlight part of a line corresponding to the node if it fits on one line
+                if (hoverCode.source.to && hoverCode.source.from.line === hoverCode.source.to.line) {
+                    colBegin = hoverCode.source.from.col;
+                    colEnd = hoverCode.source.to.col;
+                }
+            }
+            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, colBegin, colEnd, false);
             this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, false, this.getPaneName());
         }
     }

--- a/static/panes/ast-view.js
+++ b/static/panes/ast-view.js
@@ -266,7 +266,7 @@ Ast.prototype.onMouseMove = function (e) {
             var sourceLine = (hoverCode.source && hoverCode.source.from && hoverCode.source.to)
                 ? hoverCode.source.from
                 : -1;
-            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, false);
+            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, -1, false);
             this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, false, this.getPaneName());
         }
     }

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1583,7 +1583,7 @@ Compiler.prototype.clearLinkedLines = function () {
     this.updateDecorations();
 };
 
-Compiler.prototype.onPanesLinkLine = function (compilerId, lineNumber, revealLine, sender) {
+Compiler.prototype.onPanesLinkLine = function (compilerId, lineNumber, colBegin, colEnd, revealLine, sender) {
     if (Number(compilerId) === this.id) {
         var lineNums = [];
         _.each(this.assembly, function (asmLine, i) {
@@ -1750,7 +1750,7 @@ Compiler.prototype.onMouseMove = function (e) {
             // We check that we actually have something to show at this point!
             var sourceLine = hoverAsm.source && !hoverAsm.source.file ? hoverAsm.source.line : -1;
             this.eventHub.emit('editorLinkLine', this.sourceEditorId, sourceLine, -1, -1, false);
-            this.eventHub.emit('panesLinkLine', this.id, sourceLine, false, this.getPaneName());
+            this.eventHub.emit('panesLinkLine', this.id, sourceLine, -1, -1, false, this.getPaneName());
         }
     }
     var currentWord = this.outputEditor.getModel().getWordAtPosition(e.target.position);

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -449,7 +449,7 @@ Compiler.prototype.initEditorActions = function () {
             var source = this.assembly[desiredLine].source;
             if (source !== null && source.file === null) {
                 // a null file means it was the user's source
-                this.eventHub.emit('editorLinkLine', this.sourceEditorId, source.line, -1, true);
+                this.eventHub.emit('editorLinkLine', this.sourceEditorId, source.line, -1, -1, true);
             }
         }, this),
     });
@@ -1749,7 +1749,7 @@ Compiler.prototype.onMouseMove = function (e) {
         if (hoverAsm) {
             // We check that we actually have something to show at this point!
             var sourceLine = hoverAsm.source && !hoverAsm.source.file ? hoverAsm.source.line : -1;
-            this.eventHub.emit('editorLinkLine', this.sourceEditorId, sourceLine, -1, false);
+            this.eventHub.emit('editorLinkLine', this.sourceEditorId, sourceLine, -1, -1, false);
             this.eventHub.emit('panesLinkLine', this.id, sourceLine, false, this.getPaneName());
         }
     }

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1029,7 +1029,7 @@ Editor.prototype.onSelectLine = function (id, lineNum) {
     }
 };
 
-Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnNum, reveal) {
+Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnBegin, columnEnd, reveal) {
     if (Number(editorId) === this.id) {
         if (reveal && lineNum) this.editor.revealLineInCenter(lineNum);
         this.decorations.linkedCode = lineNum === -1 || !lineNum ? [] : [{
@@ -1041,9 +1041,9 @@ Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnNum, reve
             },
         }];
 
-        if (lineNum > 0 && columnNum !== -1) {
+        if (lineNum > 0 && columnBegin !== -1) {
             this.decorations.linkedCode.push({
-                range: new monaco.Range(lineNum, columnNum, lineNum, columnNum + 1),
+                range: new monaco.Range(lineNum, columnBegin, lineNum, columnEnd),
                 options: {
                     isWholeLine: false,
                     inlineClassName: 'linked-code-decoration-column',

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1042,6 +1042,12 @@ Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnBegin, co
         }];
 
         if (lineNum > 0 && columnBegin !== -1) {
+            var line = this.editor.getModel().getLineContent(lineNum);
+            // Highlight the entire last token
+            if (0 < columnEnd && columnEnd < line.length) {
+                var tokenLen = line.slice(columnEnd).search(/[^\w]/);
+                columnEnd += tokenLen + 1;
+            }
             this.decorations.linkedCode.push({
                 range: new monaco.Range(lineNum, columnBegin, lineNum, columnEnd),
                 options: {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1002,14 +1002,22 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
         var severity = 3; // error
         if (obj.tag.text.match(/^warning/)) severity = 2;
         if (obj.tag.text.match(/^note/)) severity = 1;
+        var colBegin = 0;
+        var colEnd = Infinity;
+        if (obj.tag.column) {
+            var span = this.getTokenSpan(obj.tag.line, obj.tag.column);
+            colBegin = obj.tag.column;
+            if (span.colEnd === obj.tag.column) colEnd = -1;
+            else colEnd = span.colEnd + 1;
+        }
         return {
             severity: severity,
             message: obj.tag.text,
             source: compiler.name + ' #' + compilerId,
             startLineNumber: obj.tag.line,
-            startColumn: obj.tag.column || 0,
+            startColumn: colBegin,
             endLineNumber: obj.tag.line,
-            endColumn: obj.tag.column ? -1 : Infinity,
+            endColumn: colEnd,
         };
     }, this));
     monaco.editor.setModelMarkers(this.editor.getModel(), compilerId, widgets);

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -319,7 +319,8 @@ Editor.prototype.initCallbacks = function () {
 
 Editor.prototype.onMouseMove = function (e) {
     if (e !== null && e.target !== null && this.settings.hoverShowSource && e.target.position !== null) {
-        this.tryPanesLinkLine(e.target.position.lineNumber, false);
+        var pos = e.target.position;
+        this.tryPanesLinkLine(pos.lineNumber, pos.column, false);
     }
 };
 
@@ -622,9 +623,11 @@ Editor.prototype.clearLinkedLine = function () {
     this.updateDecorations();
 };
 
-Editor.prototype.tryPanesLinkLine = function (thisLineNumber, reveal) {
+Editor.prototype.tryPanesLinkLine = function (thisLineNumber, column, reveal) {
+    var selectedToken = this.getTokenSpan(thisLineNumber, column);
     _.each(this.asmByCompiler, _.bind(function (asms, compilerId) {
-        this.eventHub.emit('panesLinkLine', compilerId, thisLineNumber, reveal);
+        this.eventHub.emit('panesLinkLine', compilerId, thisLineNumber,
+            selectedToken.colBegin, selectedToken.colEnd, reveal);
     }, this));
 };
 
@@ -695,7 +698,8 @@ Editor.prototype.initEditorActions = function () {
         contextMenuGroupId: 'navigation',
         contextMenuOrder: 1.5,
         run: _.bind(function (ed) {
-            this.tryPanesLinkLine(ed.getPosition().lineNumber, true);
+            var pos = ed.getPosition();
+            this.tryPanesLinkLine(pos.lineNumber, pos.column, true);
         }, this),
     });
 
@@ -1029,6 +1033,45 @@ Editor.prototype.onSelectLine = function (id, lineNum) {
     }
 };
 
+// Returns a half-segment [a, b) for the token on the line lineNum
+// that spans across the column.
+// a - colStart points to the first character of the token
+// b - colEnd points to the character immediately following the token
+// e.g.: "this->callableMethod ( x, y );"
+//              ^a   ^column  ^b
+Editor.prototype.getTokenSpan = function (lineNum, column) {
+    var model = this.editor.getModel();
+    var line = model.getLineContent(lineNum);
+    if (0 < column && column < line.length) {
+        var tokens = monaco.editor.tokenize(line, model.getModeId());
+        if (tokens.length > 0) {
+            var lastOffset = 0;
+            var lastWasString = false;
+            for (var i = 0; i < tokens[0].length; ++i) {
+                // Treat all the contiguous string tokens as one,
+                // For example "hello \" world" is treated as one token
+                // instead of 3 "string.cpp", "strign.escape.cpp", "string.cpp"
+                if (tokens[0][i].type.startsWith('string')) {
+                    if (lastWasString) {
+                        continue;
+                    }
+                    lastWasString = true;
+                } else {
+                    lastWasString = false;
+                }
+                var currentOffset = tokens[0][i].offset;
+                if (column <= currentOffset) {
+                    return { colBegin : lastOffset, colEnd : currentOffset };
+                } else {
+                    lastOffset = currentOffset;
+                }
+            }
+            return { colBegin : lastOffset, colEnd : line.length };
+        }
+    }
+    return { colBegin : column, colEnd : column + 1 };
+};
+
 Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnBegin, columnEnd, reveal) {
     if (Number(editorId) === this.id) {
         if (reveal && lineNum) this.editor.revealLineInCenter(lineNum);
@@ -1042,14 +1085,9 @@ Editor.prototype.onEditorLinkLine = function (editorId, lineNum, columnBegin, co
         }];
 
         if (lineNum > 0 && columnBegin !== -1) {
-            var line = this.editor.getModel().getLineContent(lineNum);
-            // Highlight the entire last token
-            if (0 < columnEnd && columnEnd < line.length) {
-                var tokenLen = line.slice(columnEnd).search(/[^\w]/);
-                columnEnd += tokenLen + 1;
-            }
+            var lastTokenSpan = this.getTokenSpan(lineNum, columnEnd);
             this.decorations.linkedCode.push({
-                range: new monaco.Range(lineNum, columnBegin, lineNum, columnEnd),
+                range: new monaco.Range(lineNum, columnBegin, lineNum, lastTokenSpan.colEnd + 1),
                 options: {
                     isWholeLine: false,
                     inlineClassName: 'linked-code-decoration-column',

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -262,14 +262,14 @@ Executor.prototype.addCompilerOutputLine = function (msg, container, lineNum, co
             $('<span class="linked-compiler-output-line"></span>')
                 .html(msg)
                 .click(_.bind(function (e) {
-                    this.eventHub.emit('editorLinkLine', this.sourceEditorId, lineNum, column, true);
+                    this.eventHub.emit('editorLinkLine', this.sourceEditorId, lineNum, column, column + 1, true);
                     // do not bring user to the top of index.html
                     // http://stackoverflow.com/questions/3252730
                     e.preventDefault();
                     return false;
                 }, this))
                 .on('mouseover', _.bind(function () {
-                    this.eventHub.emit('editorLinkLine', this.sourceEditorId, lineNum, column, false);
+                    this.eventHub.emit('editorLinkLine', this.sourceEditorId, lineNum, column, column + 1, false);
                 }, this))
         );
     } else {

--- a/static/panes/ir-view.js
+++ b/static/panes/ir-view.js
@@ -92,7 +92,7 @@ Ir.prototype.initEditorActions = function () {
             var source = this.irCode[desiredLine].source;
             if (source !== null && source.file === null) {
                 // a null file means it was the user's source
-                this.eventHub.emit('editorLinkLine', this._editorid, source.line, -1, true);
+                this.eventHub.emit('editorLinkLine', this._editorid, source.line, -1, -1, true);
             }
         }, this),
     });
@@ -260,7 +260,7 @@ Ir.prototype.onMouseMove = function (e) {
         if (hoverCode) {
             // We check that we actually have something to show at this point!
             var sourceLine = hoverCode.source && !hoverCode.source.file ? hoverCode.source.line : -1;
-            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, false);
+            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, -1, false);
             this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, false, this.getPaneName());
         }
     }

--- a/static/panes/ir-view.js
+++ b/static/panes/ir-view.js
@@ -261,7 +261,7 @@ Ir.prototype.onMouseMove = function (e) {
             // We check that we actually have something to show at this point!
             var sourceLine = hoverCode.source && !hoverCode.source.file ? hoverCode.source.line : -1;
             this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, -1, false);
-            this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, false, this.getPaneName());
+            this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, -1, -1, false, this.getPaneName());
         }
     }
 };
@@ -284,7 +284,7 @@ Ir.prototype.clearLinkedLines = function () {
     this.updateDecorations();
 };
 
-Ir.prototype.onPanesLinkLine = function (compilerId, lineNumber, revealLine, sender) {
+Ir.prototype.onPanesLinkLine = function (compilerId, lineNumber, colBegin, colEnd, revealLine, sender) {
     if (Number(compilerId) === this._compilerid) {
         var lineNums = [];
         _.each(this.irCode, function (irLine, i) {

--- a/static/panes/output.js
+++ b/static/panes/output.js
@@ -193,14 +193,14 @@ Output.prototype.add = function (msg, lineNum, column) {
             $('<span class="linked-compiler-output-line"></span>')
                 .html(msg)
                 .click(_.bind(function (e) {
-                    this.eventHub.emit('editorLinkLine', this.editorId, lineNum, column, true);
+                    this.eventHub.emit('editorLinkLine', this.editorId, lineNum, column, column + 1, true);
                     // do not bring user to the top of index.html
                     // http://stackoverflow.com/questions/3252730
                     e.preventDefault();
                     return false;
                 }, this))
                 .on('mouseover', _.bind(function () {
-                    this.eventHub.emit('editorLinkLine', this.editorId, lineNum, column, false);
+                    this.eventHub.emit('editorLinkLine', this.editorId, lineNum, column, column + 1, false);
                 }, this))
         );
     } else {

--- a/test/llvm-ast-parser-tests.js
+++ b/test/llvm-ast-parser-tests.js
@@ -80,9 +80,15 @@ describe('llvm-ast', function () {
         should.exist(compilerOutput.stdout.find(l => l.text.match(/col:21, line:4:1/)));
         should.exist(compilerOutput.stdout.find(l => l.text.match(/line:3:5, col:18/)));
         let processed = astParser.processAst(cloneDeep(compilerOutput));
-        should.exist(processed.find(l => l.source && 0 < l.source.from));
-        processed.find(l => l.text.match(/col:21, line:4:1/)).source.to.should.equal(4);
-        processed.find(l => l.text.match(/line:3:5, col:18/)).source.from.should.equal(3);
-        processed.find(l => l.text.match(/line:3:5, col:18/)).source.to.should.equal(3);
+        should.exist(processed.find(l => l.source && 0 < l.source.from.line));
+        processed.find(l => l.text.match(/col:21, line:4:1/)).source.to.line.should.equal(4);
+        processed.find(l => l.text.match(/col:21, line:4:1/)).source.to.col.should.equal(1);
+        processed.find(l => l.text.match(/col:21, line:4:1/)).source.from.col.should.equal(21);
+        processed.find(l => l.text.match(/line:3:5, col:18/)).source.from.line.should.equal(3);
+        processed.find(l => l.text.match(/line:3:5, col:18/)).source.from.col.should.equal(5);
+        processed.find(l => l.text.match(/line:3:5, col:18/)).source.to.line.should.equal(3);
+        processed.find(l => l.text.match(/line:3:5, col:18/)).source.to.col.should.equal(18);
+        // Here "from.line" is inherited from the parent "FunctionDecl <<source>:2:1, line:4:1>"
+        processed.find(l => l.text.match(/CompoundStmt.*<col:21, line:4:1>/)).source.from.line.should.equal(2);
     });
 });


### PR DESCRIPTION
Enable highlighting of spans of tokens in the source editor when the corresponding AST node is hovered over.
Enable the symmetric highlighting of the AST nodes corresponding to precisely the token being hovered over in the source editor.
In both cases `linked-code-decoration-column` marks the highlighted regions (in addition to `linked-code-decoration-margin` that works on the LOC granularity level).
Currently the `linked-code-decoration-column` style is "bold", so on the line highlighted with blue background, some tokens also become bold indicating the precise tokens corresponding to the AST node.

Incidentally, this also fixes the display of the span corresponding to a selected warning/error in the compiler output pane. Up until this change, only the first character has been highlighted when a user hovers the pointer over the warning. Now, the entire token is highlighted.