### PR TITLE
Update Kalray MPPA compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -795,10 +795,22 @@ compiler.arm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=kvxg750_v410:kvxg750:k1cg741:k1cg750
+group.kalray.compilers=kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
+compiler.kvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-g++
+compiler.kvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
+compiler.kvxg750_v440.semver=7.5.0
+compiler.kvxg750_v440.objdumper=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-objdump
+compiler.kvxg750_v430.exe=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-g++
+compiler.kvxg750_v430.name=KVX gcc 7.5 (ACB 4.3.0)
+compiler.kvxg750_v430.semver=7.5.0
+compiler.kvxg750_v430.objdumper=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-objdump
+compiler.kvxg750_v420.exe=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-g++
+compiler.kvxg750_v420.name=KVX gcc 7.5 (ACB 4.2.0)
+compiler.kvxg750_v420.semver=7.5.0
+compiler.kvxg750_v420.objdumper=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-objdump
 compiler.kvxg750_v410.exe=/opt/compiler-explorer/kvx-4.1.0-rc6/bin/kvx-elf-g++
 compiler.kvxg750_v410.name=KVX gcc 7.5 (ACB 4.1.0)
 compiler.kvxg750_v410.semver=7.5.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -668,10 +668,22 @@ compiler.carm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
+compiler.ckvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-gcc
+compiler.ckvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
+compiler.ckvxg750_v440.semver=7.5.0
+compiler.ckvxg750_v440.objdumper=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-objdump
+compiler.ckvxg750_v430.exe=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-gcc
+compiler.ckvxg750_v430.name=KVX gcc 7.5 (ACB 4.3.0)
+compiler.ckvxg750_v430.semver=7.5.0
+compiler.ckvxg750_v430.objdumper=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-objdump
+compiler.ckvxg750_v420.exe=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-gcc
+compiler.ckvxg750_v420.name=KVX gcc 7.5 (ACB 4.2.0)
+compiler.ckvxg750_v420.semver=7.5.0
+compiler.ckvxg750_v420.objdumper=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-objdump
 compiler.ckvxg750_v410.exe=/opt/compiler-explorer/kvx-4.1.0-rc6/bin/kvx-elf-gcc
 compiler.ckvxg750_v410.name=KVX gcc 7.5 (ACB 4.1.0)
 compiler.ckvxg750_v410.semver=7.5.0


### PR DESCRIPTION
Add latest release of Kalray MPPA Compiler: ACB 4.2.0, 4.3.0 and 4.4.0 (GCC 7.5
based).

As with previous update (03d9b491f87c9b32a1dfed94173350fd26faf6a8), the 4.2.0-rc5
is really 4.2.0.

Both release are available at :
https://github.com/kalray/build-scripts/releases/download/v4.2.0-rc5/gcc-kalray-kvx-v4.2.0-rc5.tar.gz
https://github.com/kalray/build-scripts/releases/download/v4.3.0/gcc-kalray-kvx-v4.3.0.tar.gz
https://github.com/kalray/build-scripts/releases/download/v4.4.0/gcc-kalray-kvx-v4.4.0.tar.gz

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
