### PR TITLE
Add GCC 10.3

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&nasm:&gnuas:&llvmas:&ptxas:&gnuasarm:&gnuasarm64
 compilerType=assembly
-objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
+objdumper=/opt/compiler-explorer/gcc-10.3.0/bin/objdump
 supportsBinary=true
 supportsExecute=false
 demangler=
@@ -22,7 +22,7 @@ compiler.nasm21402.semver=2.14.02
 compiler.nasm21402.exe=/opt/compiler-explorer/nasm-2.14.02/nasm
 
 
-group.gnuas.compilers=gnuas510:gnuas520:gnuas530:gnuas540:gnuas6:gnuas62:gnuas63:gnuas71:gnuas72:gnuas73:gnuas81:gnuas82:gnuas83:gnuas91:gnuas92:gnuas93:gnuas101:gnuas102:gnuassnapshot
+group.gnuas.compilers=gnuas510:gnuas520:gnuas530:gnuas540:gnuas6:gnuas62:gnuas63:gnuas71:gnuas72:gnuas73:gnuas81:gnuas82:gnuas83:gnuas91:gnuas92:gnuas93:gnuas101:gnuas102:gnuas103:gnuassnapshot
 group.gnuas.versionFlag=--version
 group.gnuas.options=-g
 group.gnuas.isSemVer=true
@@ -63,6 +63,8 @@ compiler.gnuas101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/as
 compiler.gnuas101.semver=10.1
 compiler.gnuas102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/as
 compiler.gnuas102.semver=10.2
+compiler.gnuas103.exe=/opt/compiler-explorer/gcc-10.3.0/bin/as
+compiler.gnuas103.semver=10.3
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gcc86:&icc:&icx:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64
-defaultCompiler=g102
-demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
+defaultCompiler=g103
+demangler=/opt/compiler-explorer/gcc-10.3.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-10.3.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:g102:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:g102:g103:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -108,6 +108,8 @@ compiler.g101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 compiler.g101.semver=10.1
 compiler.g102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/g++
 compiler.g102.semver=10.2
+compiler.g103.exe=/opt/compiler-explorer/gcc-10.3.0/bin/g++
+compiler.g103.semver=10.3
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc
-defaultCompiler=cg102
-demangler=/opt/compiler-explorer/gcc-10.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-10.1.0/bin/objdump
+defaultCompiler=cg103
+demangler=/opt/compiler-explorer/gcc-10.3.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-10.3.0/bin/objdump
 needsMulti=false
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cg93:cg101:cg102:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cg93:cg101:cg102:cg103:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -87,6 +87,8 @@ compiler.cg101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gcc
 compiler.cg101.semver=10.1
 compiler.cg102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gcc
 compiler.cg102.semver=10.2
+compiler.cg103.exe=/opt/compiler-explorer/gcc-10.3.0/bin/gcc
+compiler.cg103.semver=10.3
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&gfortran_86:&ifort:&ifx:&cross:&clang_llvmflang
-defaultCompiler=gfortran102
-demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
+defaultCompiler=gfortran103
+demangler=/opt/compiler-explorer/gcc-10.3.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-10.3.0/bin/objdump
 compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran91:gfortran92:gfortran93:gfortran101:gfortran102:gfortransnapshot
+group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran91:gfortran92:gfortran93:gfortran101:gfortran102:gfortran103:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 compiler.gfortran494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gfortran
 compiler.gfortran494.name=x86-64 gfortran 4.9.4
@@ -36,6 +36,8 @@ compiler.gfortran101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gfortran
 compiler.gfortran101.name=x86-64 gfortran 10.1
 compiler.gfortran102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gfortran
 compiler.gfortran102.name=x86-64 gfortran 10.2
+compiler.gfortran103.exe=/opt/compiler-explorer/gcc-10.3.0/bin/gfortran
+compiler.gfortran103.name=x86-64 gfortran 10.3
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gfortransnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
I skipped Go since it only seems to have one per major version.

I also updated the default compiler; as well as the `demangler` & `objdumper` (I don't recall if changing these is a problem for the old links -- e.g. we didn't change it for 10.2)

`infra`: https://github.com/compiler-explorer/infra/pull/495