### PR TITLE
Check both "9" and "6" length prefixes.

### DIFF
--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -31,10 +31,25 @@ import { anonymizeIp } from '../utils';
 
 import { StorageBase } from './base';
 
-const MIN_STORED_ID_LENGTH = 9;
+const MIN_STORED_ID_LENGTH = 9; // If you change this, add the previous number to the list below.
+// To deal with backward compatibility (for now), we need to check shorter prefixes for older "vanity" link IDs. e.g.
+// originally things were stored as 6 characters long. (This is also true of any collision link ID that was 7 or more
+// longer). A vanity URL of /z/acm19_count4 was stored originally with a prefix of six chars, and a full ID of
+// acm19_count4, so { prefix: 'acm19_', unique_subhash: 'acm19_count4' }. This was ok as when we came to look up the
+// 'acm19_count4' we truncated it to the _current_ MIN_STORED_ID_LENGTH (then also 6). However, when we bumped up to
+// nine, now we look for { prefix: 'acm19_cou', unique_subhash: 'acm_count4' } and thus don't find it. At some point we
+// will want to "fix" this by _not_ truncating the look up at all, and by doing a one-off rewrite of all vanity links to
+// be prefix==unique_subhash (or something cleverer). For now, we will horribly try one after another. There aren't that
+// many vanity links. Regular 6-char /z/abc123 short links don't suffer from this - they're already less than 9-chars.
+const HISTORICAL_MIN_STORED_ID_LENGTHS = [
+    MIN_STORED_ID_LENGTH, // check current first
+    6, // then the older ones
+];
 
 export class StorageS3 extends StorageBase {
-    static get key() { return 's3'; }
+    static get key() {
+        return 's3';
+    }
 
     constructor(httpRootDir, compilerProps, awsProps) {
         super(httpRootDir, compilerProps);
@@ -127,24 +142,32 @@ export class StorageS3 extends StorageBase {
         throw new Error(`Could not find unique subhash for hash "${hash}"`);
     }
 
-    getKeyStruct(id) {
-        return {
-            prefix: {S: id.substring(0, MIN_STORED_ID_LENGTH)},
-            unique_subhash: {S: id},
-        };
+    getKeyStructs(id) {
+        return _.uniq(
+            HISTORICAL_MIN_STORED_ID_LENGTHS.map(len => id.substring(0, len)))
+            .map(prefix => ({
+                prefix: {S: prefix},
+                unique_subhash: {S: id},
+            }));
+    }
+
+    async findFirstMatchingAttributes(id) {
+        const structs = this.getKeyStructs(id);
+        for (const key of structs) {
+            const item = await this.dynamoDb.getItem({
+                TableName: this.table,
+                Key: key,
+            }).promise();
+            if (item.Item)
+                return item.Item;
+        }
+        throw new Error(`Unable to find short id ${id} (tried ${JSON.stringify(structs)})`);
     }
 
     async expandId(id) {
         // By just getting the item and not trying to update it, we save an update when the link does not exist
-        // for which we have less resources allocated, but get one extra read (But we do have more reserved for it)
-        const item = await this.dynamoDb.getItem({
-            TableName: this.table,
-            Key: this.getKeyStruct(id),
-        }).promise();
-
-        const attributes = item.Item;
-        if (!attributes)
-            throw new Error(`Missing attributes on ${id}`);
+        // for which we have less resources allocated, but get one extra read.
+        const attributes = await this.findFirstMatchingAttributes(id);
         const result = await this.s3.get(attributes.full_hash.S, this.prefix);
         // If we're here, we are pretty confident there is a match. But never hurts to double check
         if (!result.hit)
@@ -157,19 +180,28 @@ export class StorageS3 extends StorageBase {
     }
 
     async incrementViewCount(id) {
-        try {
-            await this.dynamoDb.updateItem({
-                TableName: this.table,
-                Key: this.getKeyStruct(id),
-                UpdateExpression: 'SET stats.clicks = stats.clicks + :inc',
-                ExpressionAttributeValues: {
-                    ':inc': {N: '1'},
-                },
-                ReturnValues: 'NONE',
-            }).promise();
-        } catch (err) {
-            // Swallow up errors
-            logger.error(`Error when incrementing view count for ${id}`, err);
+        for (const key of this.getKeyStructs(id)) {
+            try {
+                await this.dynamoDb.updateItem({
+                    TableName: this.table,
+                    Key: key,
+                    UpdateExpression: 'SET stats.clicks = stats.clicks + :inc',
+                    ExpressionAttributeValues: {
+                        ':inc': {N: '1'},
+                    },
+                    ReturnValues: 'NONE',
+                }).promise();
+                return;
+            } catch (err) {
+                if (err.code === 'ValidationException') {
+                    // Expected if we are trying to up the count on the wrong key struct
+                    // (e.g. a vanity URL).
+                } else {
+                    logger.error(`Error when incrementing view count for ${id}`, err);
+                    return;
+                }
+            }
         }
+        logger.error(`Unable to to increment view count for ${id} (no key struct worked)`);
     }
 }

--- a/test/storage/storage-s3-tests.js
+++ b/test/storage/storage-s3-tests.js
@@ -184,3 +184,154 @@ describe('Stores to s3', () => {
         });
     });
 });
+
+describe('Retrieves from s3', () => {
+    const dynamoDbGetItemHandlers = mockerise('DynamoDB', 'getItem');
+    const s3GetObjectHandlers = mockerise('S3', 'getObject');
+    const httpRootDir = '/';
+    const compilerProps = properties.fakeProps({});
+    const awsProps = properties.fakeProps({
+        region: 'not-a-region',
+        storageBucket: 'bucket',
+        storagePrefix: 'prefix',
+        storageDynamoTable: 'table',
+    });
+    it('fetches in the happy path', async () => {
+        const storage = new StorageS3(httpRootDir, compilerProps, awsProps);
+        const ran = {s3: false, dynamo: false};
+        dynamoDbGetItemHandlers.push(q => {
+            q.TableName.should.equals('table');
+            q.Key.should.deep.equals({
+                prefix: {S: 'ABCDEF'},
+                unique_subhash: {S: 'ABCDEF'},
+            });
+            ran.dynamo = true;
+            return {Item: {full_hash: {S: 'ABCDEFGHIJKLMNOP'}}};
+        });
+        s3GetObjectHandlers.push(q => {
+            q.Bucket.should.equal('bucket');
+            q.Key.should.equal('prefix/ABCDEFGHIJKLMNOP');
+            ran.s3 = true;
+            return {
+                Body: 'I am a monkey',
+            };
+        });
+
+        const result = await storage.expandId('ABCDEF');
+        ran.should.deep.equal({s3: true, dynamo: true});
+        result.should.deep.equal({config: 'I am a monkey', specialMetadata: null});
+    });
+    it('works for old-style links', async () => {
+        // This assumes we had a clash on ABCDEF (and thus went to 7 letters). It was stored as 'ABCDEF', but new code
+        // will try ABCDEF first (as we now have up to 9).
+        const storage = new StorageS3(httpRootDir, compilerProps, awsProps);
+        const ran = {s3: false, dynamo: false};
+        // First fetch fails.
+        dynamoDbGetItemHandlers.push(q => {
+            q.TableName.should.equals('table');
+            q.Key.should.deep.equals({
+                prefix: {S: 'ABCDEFGHI'},
+                unique_subhash: {S: 'ABCDEFGHIJKLMN'},
+            });
+            return {};
+        });
+        // Second succeeds.
+        dynamoDbGetItemHandlers.push(q => {
+            q.TableName.should.equals('table');
+            q.Key.should.deep.equals({
+                prefix: {S: 'ABCDEF'},
+                unique_subhash: {S: 'ABCDEFGHIJKLMN'},
+            });
+            ran.dynamo = true;
+            return {Item: {full_hash: {S: 'ABCDEFGHIJKLMNOP'}}};
+        });
+        s3GetObjectHandlers.push(q => {
+            q.Bucket.should.equal('bucket');
+            q.Key.should.equal('prefix/ABCDEFGHIJKLMNOP');
+            ran.s3 = true;
+            return {
+                Body: 'I am a monkey',
+            };
+        });
+
+        const result = await storage.expandId('ABCDEFGHIJKLMN');
+        ran.should.deep.equal({s3: true, dynamo: true});
+        result.should.deep.equal({config: 'I am a monkey', specialMetadata: null});
+    });
+
+    it('should handle failures', async () => {
+        const storage = new StorageS3(httpRootDir, compilerProps, awsProps);
+        for (let i = 0; i < 10; ++i)
+            dynamoDbGetItemHandlers.push(() => ({}));
+        return storage.expandId('ABCDEF').should.be.rejectedWith(Error, 'Unable to find short id ABCDEF');
+    });
+});
+
+describe('Updates counts in s3', async () => {
+    const dynamoDbUpdateItemHandlers = mockerise('DynamoDB', 'updateItem');
+    const httpRootDir = '/';
+    const compilerProps = properties.fakeProps({});
+    const awsProps = properties.fakeProps({
+        region: 'not-a-region',
+        storageBucket: 'bucket',
+        storagePrefix: 'prefix',
+        storageDynamoTable: 'table',
+    });
+    it('should increment for simple cases', async () => {
+        const storage = new StorageS3(httpRootDir, compilerProps, awsProps);
+        let called = false;
+        dynamoDbUpdateItemHandlers.push(q => {
+            q.should.deep.equals(
+                {
+                    ExpressionAttributeValues: {':inc': {N: '1'}},
+                    Key: {
+                        prefix: {S: 'ABCDEF'},
+                        unique_subhash: {S: 'ABCDEF'},
+                    },
+                    ReturnValues: 'NONE',
+                    TableName: 'table',
+                    UpdateExpression: 'SET stats.clicks = stats.clicks + :inc',
+                },
+            );
+            called = true;
+        });
+        await storage.incrementViewCount('ABCDEF');
+        called.should.be.true;
+    });
+    it('should increment for longer values that aren\'t found on the first', async () => {
+        const storage = new StorageS3(httpRootDir, compilerProps, awsProps);
+        let called = false;
+        dynamoDbUpdateItemHandlers.push(q => {
+            q.should.deep.equals(
+                {
+                    ExpressionAttributeValues: {':inc': {N: '1'}},
+                    Key: {
+                        prefix: {S: 'ABCDEFGHI'},
+                        unique_subhash: {S: 'ABCDEFGHIJKLMNO'},
+                    },
+                    ReturnValues: 'NONE',
+                    TableName: 'table',
+                    UpdateExpression: 'SET stats.clicks = stats.clicks + :inc',
+                },
+            );
+            throw {code: 'ValidationException'};
+        });
+        dynamoDbUpdateItemHandlers.push(q => {
+            q.should.deep.equals(
+                {
+                    ExpressionAttributeValues: {':inc': {N: '1'}},
+                    Key: {
+                        prefix: {S: 'ABCDEF'},
+                        unique_subhash: {S: 'ABCDEFGHIJKLMNO'},
+                    },
+                    ReturnValues: 'NONE',
+                    TableName: 'table',
+                    UpdateExpression: 'SET stats.clicks = stats.clicks + :inc',
+                },
+            );
+            called = true;
+        });
+        await storage.incrementViewCount('ABCDEFGHIJKLMNO');
+        called.should.be.true;
+    });
+});


### PR DESCRIPTION
Long story, we used to store everything with a 6 char prefix.
Then we upgraded new links to use 9. That's fine - old 6-char
prefixes were "substring" to their first 9 chars before being
looked up, and that was, still a length six thing, so old links
were found.

However, any "clashing" 6-string, or any "vanity" link (e.g. the
ones _I_ made...), could be longer than 6 chars. They were
originally stored in the DB with prefix 6, but they'd be looked up
with up to 9 chars.

The new links of course are stored with 9 chars of prefix. This is
arguably a mistake, but we're stuck with both 6- and 9- char prefixes
in the database.

For now, we will try looking at the (up to 9) prefix first. If we miss,
we try the 6-prefix (assuming it's different from the up-to-9).

In practice we should _super rarely_ miss, so this shouldn't materially
affect the database access rate.

In future we might want to fix the prefix, and not have it be the same
as the MIN_CHARS thing. And then we should rewrite the entries in
the database.

But for now, this should fix godbolt.org/z/acm19_count4 and similar.

Closes #2582

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
