### PR TITLE
Express the dependency between "onColours" and "onCompileResult" explicitly

### DIFF
--- a/static/hub.js
+++ b/static/hub.js
@@ -260,6 +260,28 @@ WrappedEventHub.prototype.unsubscribe = function () {
     this.subscriptions = [];
 };
 
+WrappedEventHub.prototype.mediateDependentCalls = function (dependent, dependency) {
+    var dependencyExecuted = false;
+    var lastDependentArgs = null;
+    var dependencyProxy = function () {
+        dependency.apply(this, arguments);
+        dependencyExecuted = true;
+        if (lastDependentArgs) {
+            dependent.apply(this, lastDependentArgs);
+            lastDependentArgs = null;
+        }
+    };
+    var dependentProxy = function () {
+        if (dependencyExecuted) {
+            dependent.apply(this, arguments);
+        } else {
+            lastDependentArgs = arguments;
+        }
+    };
+    return {dependencyProxy: dependencyProxy,
+        dependentProxy: dependentProxy};
+};
+
 Hub.prototype.createEventHub = function () {
     return new WrappedEventHub(this, this.layout.eventHub);
 };


### PR DESCRIPTION
This PR addresses #2513: expressing explicitly the dependency between the two callbacks and enforcing the right call order.

I am likely reinventing the wheel with `WrappedEventHub.prototype.mediateDependentCalls`, but I am not very familiar with the JS libraries and couldn't find anything quickly.