### PR TITLE
[NFC] Mention `npm run dev` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ Running with `make EXTRA_ARGS='--language LANG'` will allow you to load
  `LANG` exclusively, where `LANG` is one for the language ids/aliases defined
  in `lib/languages.js`. The `Makefile` will automatically install all the
  third party libraries needed to run; using `npm` to install server-side and
- client side components. So you can also use `npm run dev` to run CE on your 
- local machine.
+ client side components.
 
 For development, we suggest using `make dev` to enable some useful features,
  such as automatic reloading on file changes and shorter startup times.
+
+You can also use `npm run dev` to run if `make dev` doesn't work on your machine.
 
 Some languages need extra tools to demangle them, e.g. `rust`, `d`, or `haskell`.
  Such tools are kept separately in the

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Running with `make EXTRA_ARGS='--language LANG'` will allow you to load
  `LANG` exclusively, where `LANG` is one for the language ids/aliases defined
  in `lib/languages.js`. The `Makefile` will automatically install all the
  third party libraries needed to run; using `npm` to install server-side and
- client side components.
+ client side components. So you can also use `npm run dev` to run CE on your 
+ local machine.
 
 For development, we suggest using `make dev` to enable some useful features,
  such as automatic reloading on file changes and shorter startup times.


### PR DESCRIPTION
On my system running make giving errors and `npm run dev` work perfectly.
