### PR TITLE
Update gcc contracts documentation URL

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -119,7 +119,7 @@ compiler.gcontracts-trunk.exe=/opt/compiler-explorer/gcc-lock3-contracts-trunk/b
 compiler.gcontracts-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gcontracts-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gcontracts-trunk.semver=(contracts)
-compiler.gcontracts-trunk.notification=Experimental Contract Assertions; see <a href="https://gitlab.com/lock3/gcc-new/wikis/contract-assertions" target="_blank" rel="noopener noreferrer">Lock3's repository wiki<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.gcontracts-trunk.notification=Experimental Contract Support; see <a href="https://github.com/lock3/gcc/wiki" target="_blank" rel="noopener noreferrer">Lock3's repository wiki<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.gcxx-modules-trunk.exe=/opt/compiler-explorer/gcc-cxx-modules-trunk/bin/g++
 compiler.gcxx-modules-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gcxx-modules-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
This corresponds to a gcc-builder pull request to update the repo url: https://github.com/compiler-explorer/gcc-builder/pull/3
