### PR TITLE
Add Lock3 gcc contract labels

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:g102:g103:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:g93:g101:g102:g103:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -120,6 +120,11 @@ compiler.gcontracts-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++f
 compiler.gcontracts-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gcontracts-trunk.semver=(contracts)
 compiler.gcontracts-trunk.notification=Experimental Contract Assertions; see <a href="https://gitlab.com/lock3/gcc-new/wikis/contract-assertions" target="_blank" rel="noopener noreferrer">Lock3's repository wiki<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.gcontract-labels-trunk.exe=/opt/compiler-explorer/gcc-lock3-contract-labels-trunk/bin/g++
+compiler.gcontract-labels-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.gcontract-labels-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.gcontract-labels-trunk.semver=(contract labels)
+compiler.gcontract-labels-trunk.notification=Experimental Contract Label Support; see <a href="https://github.com/lock3/gcc/wiki" target="_blank" rel="noopener noreferrer">Lock3's repository wiki<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.gcxx-modules-trunk.exe=/opt/compiler-explorer/gcc-cxx-modules-trunk/bin/g++
 compiler.gcxx-modules-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gcxx-modules-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
This is one of three PRs adding support for the `contract-labels` branch of https://github.com/lock3/gcc . This likely depends on a related PRs in gcc-builder: https://github.com/compiler-explorer/gcc-builder/pull/4 , and infra: https://github.com/compiler-explorer/infra/pull/498 .

Please let me know if anything needs changed! :)
