### PR TITLE
Fix Go assembly to UpperCase

### DIFF
--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -129,7 +129,6 @@ export class GolangCompiler extends BaseCompiler {
                 prevLine = lineMatch;
             }
 
-            ins = ins.toLowerCase();
             args = this.replaceJump(func, funcCollisions[func], ins, args, usedLabels);
             res.push(`\t${ins}${args}`);
             return res;


### PR DESCRIPTION
Fix Go assembly to UpperCase.

Unlink C to assembly, Go(plan9) assembly always UpperCase.

See also:
- https://golang.org/doc/asm