### PR TITLE
Add Swift 5.4

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,9 +1,9 @@
 compilers=&swift
-demangler=/opt/compiler-explorer/swift-5.3/usr/bin/swift-demangle
-defaultCompiler=swift53
+demangler=/opt/compiler-explorer/swift-5.4/usr/bin/swift-demangle
+defaultCompiler=swift54
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
-group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swiftnightly
+group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swiftnightly
 group.swift.isSemVer=true
 group.swift.baseName=x86-64 swiftc
 compiler.swift311.exe=/opt/compiler-explorer/swift-3.1.1/usr/bin/swiftc
@@ -36,6 +36,8 @@ compiler.swift52.exe=/opt/compiler-explorer/swift-5.2/usr/bin/swiftc
 compiler.swift52.semver=5.2
 compiler.swift53.exe=/opt/compiler-explorer/swift-5.3/usr/bin/swiftc
 compiler.swift53.semver=5.3
+compiler.swift54.exe=/opt/compiler-explorer/swift-5.4/usr/bin/swiftc
+compiler.swift54.semver=5.4
 compiler.swiftnightly.exe=/opt/compiler-explorer/swift-nightly/usr/bin/swiftc
 compiler.swiftnightly.semver=nightly
 


### PR DESCRIPTION
Adds Swift 5.4 as a compiler option. Infra PR: https://github.com/compiler-explorer/infra/pull/503