### PR TITLE
Fix #1346: truncating nested top-level declarations

### DIFF
--- a/lib/llvm-ast.js
+++ b/lib/llvm-ast.js
@@ -103,7 +103,7 @@ export class LlvmAstParser {
         const sourceRegex = /<source>/g;
 
         // Refers to whatever the most recent file specified was
-        const lineRegex = /<line:/;
+        const lineRegex = /<(col|line):/;
 
         let mostRecentIsSource = false;
 

--- a/test/ast/bug-1346-typedef-struct.ast
+++ b/test/ast/bug-1346-typedef-struct.ast
@@ -1,0 +1,20 @@
+TranslationUnitDecl 0x602c78 <<invalid sloc>> <invalid sloc>
+|-TypedefDecl 0x603570 <<invalid sloc>> <invalid sloc> implicit __int128_t '__int128'
+| `-BuiltinType 0x603210 '__int128'
+|-TypedefDecl 0x6035e0 <<invalid sloc>> <invalid sloc> implicit __uint128_t 'unsigned __int128'
+| `-BuiltinType 0x603230 'unsigned __int128'
+|-TypedefDecl 0x603958 <<invalid sloc>> <invalid sloc> implicit __NSConstantString '__NSConstantString_tag'
+| `-RecordType 0x6036d0 '__NSConstantString_tag'
+|   `-CXXRecord 0x603638 '__NSConstantString_tag'
+|-TypedefDecl 0x6039f0 <<invalid sloc>> <invalid sloc> implicit __builtin_ms_va_list 'char *'
+| `-PointerType 0x6039b0 'char *'
+|   `-BuiltinType 0x602d10 'char'
+|-TypedefDecl 0x643bc8 <<invalid sloc>> <invalid sloc> implicit __builtin_va_list '__va_list_tag [1]'
+| `-ConstantArrayType 0x643b70 '__va_list_tag [1]' 1
+|   `-RecordType 0x603ae0 '__va_list_tag'
+|     `-CXXRecord 0x603a48 '__va_list_tag'
+|-CXXRecordDecl 0x643c20 <<source>:1:9, col:16> col:16 struct x
+`-TypedefDecl 0x643d28 <col:1, col:18> col:18 y 'struct x':'x'
+  `-ElaboratedType 0x643cd0 'struct x' sugar
+    `-RecordType 0x643cb0 'x'
+      `-CXXRecord 0x643c20 'x'

--- a/test/ast/bug-1346-typedef-struct.cpp
+++ b/test/ast/bug-1346-typedef-struct.cpp
@@ -1,0 +1,1 @@
+typedef struct x y;

--- a/test/llvm-ast-parser-tests.js
+++ b/test/llvm-ast-parser-tests.js
@@ -44,6 +44,7 @@ describe('llvm-ast', function () {
     let astDump;
     let compilerOutput;
     let astDumpWithCTime;
+    let astDumpNestedDecl1346;
 
     before(() => {
         let fakeProps = new properties.CompilerProps(languages, properties.fakeProps({}));
@@ -53,6 +54,7 @@ describe('llvm-ast', function () {
         astDump = utils.splitLines(fs.readFileSync('test/ast/square.ast').toString());
         compilerOutput = mockAstOutput(astDump);
         astDumpWithCTime = utils.splitLines(fs.readFileSync('test/ast/ctime.ast').toString());
+        astDumpNestedDecl1346 = utils.splitLines(fs.readFileSync('test/ast/bug-1346-typedef-struct.ast').toString());
     });
 
     it('keeps fewer lines than the original', () => {
@@ -90,5 +92,17 @@ describe('llvm-ast', function () {
         processed.find(l => l.text.match(/line:3:5, col:18/)).source.to.col.should.equal(18);
         // Here "from.line" is inherited from the parent "FunctionDecl <<source>:2:1, line:4:1>"
         processed.find(l => l.text.match(/CompoundStmt.*<col:21, line:4:1>/)).source.from.line.should.equal(2);
+    });
+
+    it('does not truncate nested declarations', () => {
+        // See https://github.com/compiler-explorer/compiler-explorer/issues/1346
+        let output = mockAstOutput(astDumpNestedDecl1346);
+        let processed = astParser.processAst(output);
+        processed.length.should.be.above(2);
+        should.exist(processed.find(l => l.text.match(/CXXRecordDecl.*struct x/)));
+        should.exist(processed.find(l => l.text.match(/TypedefDecl.*struct x/)));
+        should.exist(processed.find(l => l.text.match(/ElaboratedType/)));
+        should.exist(processed.find(l => l.text.match(/RecordType/)));
+        should.exist(processed.find(l => l.text.match(/CXXRecord/)));
     });
 });


### PR DESCRIPTION
Sometimes top-level declarations contain multiple nested declarations in a single line. For example:

```
typedef struct x y;
```

In such cases some top-level declarations will not be endowed with a "line:" annotation, but have only "col:" specified as their location because they inherit the line from the previous AST node.

This PR extends the filtering regular expression to accept such cases.