### PR TITLE
Add support for Python optimization flags

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,3 +98,4 @@ From oldest to newest contributor, we would like to thank:
 - [Arseniy Zaostrovnykh](https://github.com/necto)
 - [Dan Okken](https://github.com/okkenator)
 - [Shivam Gupta](https://github.com/xgupta)
+- [Tamir Bahar](https://github.com/tmr232)

--- a/etc/scripts/dis_all.py
+++ b/etc/scripts/dis_all.py
@@ -37,6 +37,10 @@ parser.add_argument('-i', '--inputfile', type=str,
 parser.add_argument('-o', '--outputfile', type=str,
                     help='Optional output file to write output (or error message if syntax error).',
                     default='')
+parser.add_argument('-O', action='store_true', dest='optimize_1',
+                    help="Enable Python's -O optimization flag (remove assert and __debug__-dependent statements)")
+parser.add_argument('-OO', action='store_true', dest='optimize_2',
+                    help="Enable Python's -OO optimization flag (do -O changes and also discard docstrings)")
 
 
 def _disassemble_recursive(co, depth=None):
@@ -114,8 +118,15 @@ if __name__ == '__main__':
         source = fp.read()
 
     name = os.path.basename(args.inputfile)
+
+    optimize=0
+    if args.optimize_1:
+        optimize = 1
+    if args.optimize_2:
+        optimize = 2
+
     try:
-        code = compile(source, name, 'exec')
+        code = compile(source, name, 'exec', optimize=optimize)
     except Exception as e:
         # redirect any other by compile(..) to stderr in order to hide traceback of this script
         sys.stderr.write(''.join(traceback.format_exception_only(type(e), e)))


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Adds the option to pass optimization flags to `compile` when using Python in Compiler-Explorer.

This enables showing the removal of assertions from the code when using the `-O` or `-OO` flags in Python.

There are no tests as I failed to find tests for this specific part of the code. I hope this is OK.