### PR TITLE
Create GCCRSCompiler class from GCCCompiler

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -3,6 +3,7 @@ objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-11.1.0/bin/gcc
 defaultCompiler=r1510
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
+group.gccrs.compilerType=gccrs
 group.gccrs.compilers=gccrs-snapshot
 compiler.gccrs-snapshot.exe=/opt/compiler-explorer/gcc-gccrs-master/bin/gccrs
 compiler.gccrs-snapshot.semver=(GCCRS)

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -37,6 +37,7 @@ export { EWAVRCompiler } from './ewavr';
 export { FakeCompiler } from './fake-for-test';
 export { FortranCompiler } from './fortran';
 export { GCCCompiler } from './gcc';
+export { GCCRSCompiler } from './gccrs';
 export { GolangCompiler } from './golang';
 export { HaskellCompiler } from './haskell';
 export { ISPCCompiler } from './ispc';

--- a/lib/compilers/gccrs.js
+++ b/lib/compilers/gccrs.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { GCCCompiler } from '../gcc';
+
+export class GCCRSCompiler extends GCCCompiler {
+    static get key() { return 'gccrs'; }
+}


### PR DESCRIPTION
Use default GCCCompiler values for GCCRS.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
