### PR TITLE
Rename gccrs group id to really make it listed after rustc

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,14 +1,8 @@
-compilers=&rust:&gccrs
+compilers=&rust:&rustgcc
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-11.1.0/bin/gcc
 defaultCompiler=r1510
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
-group.gccrs.compilerType=gccrs
-group.gccrs.compilers=gccrs-snapshot
-group.gccrs.groupName=Rust-GCC
-compiler.gccrs-snapshot.exe=/opt/compiler-explorer/gcc-gccrs-master/bin/gccrs
-compiler.gccrs-snapshot.semver=(GCCRS)
-compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
 group.rust.compilers=r1510:r1500:r1490:r1480:r1470:r1460:r1452:r1450:r1440:r1430:r1420:r1410:r1400:r1390:r1380:r1370:r1360:r1350:r1340:r1330:r1320:r1310:r1300:r1290:r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190:r180:r170:r160:r150:r140:r130:r120:r110:r100:nightly:beta
 group.rust.compilerType=rust
 group.rust.isSemVer=true
@@ -126,6 +120,12 @@ compiler.nightly.semver=nightly
 compiler.beta.exe=/opt/compiler-explorer/rust-beta/bin/rustc
 compiler.beta.semver=beta
 
+compiler.gccrs-snapshot.exe=/opt/compiler-explorer/gcc-gccrs-master/bin/gccrs
+compiler.gccrs-snapshot.semver=(GCCRS)
+compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
+group.rustgcc.compilerType=gccrs
+group.rustgcc.compilers=gccrs-snapshot
+group.rustgcc.groupName=Rust-GCC
 
 #################################
 #################################


### PR DESCRIPTION
Only changing the name attribute was not enough.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
