### PR TITLE
Remove groupname for GCC Rust

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -125,7 +125,6 @@ compiler.gccrs-snapshot.semver=(GCCRS)
 compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
 group.rustgcc.compilerType=gccrs
 group.rustgcc.compilers=gccrs-snapshot
-group.rustgcc.groupName=Rust-GCC
 
 #################################
 #################################


### PR DESCRIPTION
It seems that removing the group name makes the compiler-picker alphabetically
sorted.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
