### PR TITLE
Use case insensitive sort for group names

### DIFF
--- a/static/compiler-service.js
+++ b/static/compiler-service.js
@@ -108,7 +108,11 @@ CompilerService.prototype.getGroupsInUse = function (langId) {
         .map(function (compiler) {
             return {value: compiler.group, label: compiler.groupName || compiler.group};
         })
-        .sortBy('label')
+        .sort(function(a, b){
+            return a.label.localeCompare(b.label,
+                                         undefined /* Ignore language */,
+                                         { sensitivity: 'base' });
+        })
         .value();
 };
 


### PR DESCRIPTION
Group names are upcased when displayed, but sort is still applied before.
Can be misleading when trying to order them (groupid are always lowcase).

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
