### PR TITLE
updated OSACA version to 0.4.2

### DIFF
--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -21,7 +21,7 @@ group.osaca.supportsBinary=false
 group.osaca.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 group.osaca.compilerType=osaca
 
-compiler.osacatrunk.name=OSACA (0.4.0)
-compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+compiler.osacatrunk.name=OSACA (0.4.2)
+compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 # Intel syntax currently unsupported (WIP)
 # compiler.osacatrunk.intelAsm=--intel-syntax

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2007,8 +2007,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1121,8 +1121,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/clean.amazon.properties
+++ b/etc/config/clean.amazon.properties
@@ -41,8 +41,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=_32
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=_32

--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -40,8 +40,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_blue.amazon.properties
+++ b/etc/config/cppx_blue.amazon.properties
@@ -23,8 +23,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_gold.amazon.properties
+++ b/etc/config/cppx_gold.amazon.properties
@@ -22,8 +22,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -242,8 +242,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=dmd

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -161,8 +161,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -367,8 +367,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=gl:6g141
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=gl:6g141

--- a/etc/config/haskell.amazon.properties
+++ b/etc/config/haskell.amazon.properties
@@ -45,8 +45,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -43,8 +43,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -148,8 +148,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=opt
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=opt

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -39,8 +39,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -144,8 +144,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -58,8 +58,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -42,8 +42,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.2)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled


### PR DESCRIPTION
To integrate newer OSACA version since version 0.4.0 has a bug with analyzing hex numbers in ARM assembly.
Also improves runtime and more instruction support

See also [PR in `compiler-explorer/infra`](https://github.com/compiler-explorer/infra/pull/508)
