### PR TITLE
Adjust media queries to avoid jumps in small screens

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -292,8 +292,8 @@ pre.content.wrap * {
 }
 
 .community-advert {
-    display: none;
-    max-width: 300px;
+    display: flex;
+    max-width: 500px;
     height: 44px;
     margin-top: 3px;
     margin-bottom: 3px;
@@ -306,15 +306,9 @@ pre.content.wrap * {
     padding-right: 4px;
 }
 
-@media (min-width: 1000px) {
+@media (max-width: 1200px) {
     .community-advert {
-        display: flex;
-    }
-}
-
-@media (min-width: 1200px) {
-    .community-advert {
-        max-width: 500px;
+        display: none;
     }
 }
 
@@ -586,6 +580,12 @@ div.populararguments div.dropdown-menu {
 @media (max-width: 1000px) {
     .ces-content-root {
         font-size: 60%;
+    }
+}
+
+@media (max-width: 1250px) {
+    #ces-banner-text {
+        display: none;
     }
 }
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -54,7 +54,8 @@ block prepend content
           button.close(type="button" aria-hidden="true") &times;
       ul.navbar-nav.navbar-right
         if showSponsors
-          li.nav-item.btn.btn-outline-primary#ces(data-toggle="modal") Sponsors
+          li.nav-item.btn.btn-outline-primary#ces(data-toggle="modal")
+            span#ces-banner-text Sponsors
             include sponsor-icons.pug
         li.nav-item.dropdown
           a.nav-link.dropdown-toggle#share(href="javascript:;" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false") Share


### PR DESCRIPTION
Inspired by a Twitter screenshot shared from someone who had a small screen size, this should remove the jumps in the navbar at those sizes.
Made it a PR to check that hiding the Sponsor text is actually ok before merging :)