### PR TITLE
Initial support for mrustc

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&rust:&rustgcc
+compilers=&rust:&rustgcc:&mrustc
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-11.1.0/bin/gcc
 defaultCompiler=r1520
@@ -128,6 +128,13 @@ compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
 group.rustgcc.compilerType=gccrs
 group.rustgcc.compilers=gccrs-snapshot
 group.rustgcc.groupName=Rust-GCC
+
+compiler.mrustc-master.exe=/opt/compiler-explorer/mrustc-master/bin/mrustc
+compiler.mrustc-master.semver=(mrustc)
+group.mrustc.compilerType=mrustc
+group.mrustc.compilers=mrustc-master
+group.mrustc.supportsExecute=false
+group.mrustc.supportsBinary=false
 
 #################################
 #################################

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -56,6 +56,7 @@ export { PPCICompiler } from './ppci';
 export { PtxAssembler } from './ptxas';
 export { PythonCompiler } from './python';
 export { RustCompiler } from './rust';
+export { MrustcCompiler } from './mrustc';
 export { SdccCompiler } from './sdcc';
 export { SwiftCompiler } from './swift';
 export { TenDRACompiler } from './tendra';

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -283,6 +283,13 @@ export class RustParser extends BaseParser {
     }
 }
 
+export class MrustcParser extends BaseParser {
+    static async parse(compiler) {
+        await MrustcParser.getOptions(compiler, '--help');
+        return compiler;
+    }
+}
+
 export class NimParser extends BaseParser {
     static async parse(compiler) {
         await NimParser.getOptions(compiler, '-help');

--- a/lib/compilers/mrustc.js
+++ b/lib/compilers/mrustc.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2021, Marc Poulhiès
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import { BaseCompiler } from '../base-compiler';
+
+import { MrustcParser } from './argument-parsers';
+
+export class MrustcCompiler extends BaseCompiler {
+    static get key() { return 'mrustc'; }
+
+    optionsForFilter(filters, outputFilename) {
+        // mrustc always dumps the C code for <baseout> target in the <baseout>.c file.
+        // In our case, the actual file in -o is not even created because we are
+        // faking the last step (C compilation).
+        // Craft the 'outname' to have the intermediate .c file writen in outputFilename.
+        let outname = path.join(path.dirname(this.filename(outputFilename)),
+            path.basename(this.filename(outputFilename), '.c'));
+        return ['-o', outname, '-L', path.join(path.dirname(this.compiler.exe), '..', 'output')];
+    }
+
+    async runCompiler(compiler, options, inputFilename, execOptions) {
+        // mrustc will always invoke a C compiler on its C output to create a final exec/object.
+        // There's no easy way to disable this last step, so simply faking it with 'true' works.
+        execOptions.env.CC = 'true';
+
+        return super.runCompiler(compiler, options, inputFilename, execOptions);
+    }
+
+    getOutputFilename(dirPath) {
+        return path.join(dirPath, `${path.basename(this.compileFilename, this.lang.extensions[0])}.c`);
+    }
+
+    getArgumentParser() {
+        return MrustcParser;
+    }
+
+}


### PR DESCRIPTION
Add the needed base for new mrustc compiler.
https://github.com/thepowersgang/mrustc

mrustc is transpiling Rust to C and is mainly used for bootstraping rustc.

This change treats the C output as the final product (as is assembly for
GCC/clang). It is not easily possible to automatically plug this C to other C
compilers to get assembly or executable.

fixes #2643

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
