### PR TITLE
LDC: use -gline-tables-only instead of -g by default

### DIFF
--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -47,7 +47,7 @@ export class LDCCompiler extends BaseCompiler {
     }
 
     optionsForFilter(filters, outputFilename) {
-        let options = ['-g', '-of', this.filename(outputFilename)];
+        let options = ['-gline-tables-only', '-of', this.filename(outputFilename)];
         if (filters.intel && !filters.binary) options = options.concat('-x86-asm-syntax=intel');
         if (!filters.binary) options = options.concat('-output-s');
         return options;


### PR DESCRIPTION
This changes the default LDC compile flag from `-g` to `-gline-tables-only`, such that the LLVM IR output does not contain `call void @llvm.dbg.declare` calls that (I think) most users are not interested in.  The old behavior can be restored by the user by passing `-g` (I think users are much more familiar with the `-g` option than the `-gline-tables-only` option). Line information is preserved so users can still see what IR lines correspond to user code lines.

I see that `clang` on CE also defaults to `-g`; the same change could be applied there.