### PR TITLE
mrustc: force crate_type to rlib

### DIFF
--- a/lib/compilers/mrustc.js
+++ b/lib/compilers/mrustc.js
@@ -38,7 +38,10 @@ export class MrustcCompiler extends BaseCompiler {
         // Craft the 'outname' to have the intermediate .c file writen in outputFilename.
         let outname = path.join(path.dirname(this.filename(outputFilename)),
             path.basename(this.filename(outputFilename), '.c'));
-        return ['-o', outname, '-L', path.join(path.dirname(this.compiler.exe), '..', 'output')];
+
+        // Currently always targets a rlib, no binary support at the moment.
+        return ['--crate-type', 'rlib',
+            '-o', outname, '-L', path.join(path.dirname(this.compiler.exe), '..', 'output')];
     }
 
     async runCompiler(compiler, options, inputFilename, execOptions) {


### PR DESCRIPTION
Defaults to bin, which will complain when there is no main(). But at the moment
compiler explorer has no way to compile the resulting C and get an executable.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
