### PR TITLE
Create a seperate window for editing compiler flags

### DIFF
--- a/static/components.js
+++ b/static/components.js
@@ -126,6 +126,25 @@ module.exports = {
             },
         };
     },
+    getFlagsView: function () {
+        return {
+            type: 'component',
+            componentName: 'flags',
+            componentState: {},
+        };
+    },
+    getFlagsViewWith: function (id, compilerName, editorid, compilerFlags) {
+        return {
+            type: 'component',
+            componentName: 'flags',
+            componentState: {
+                id: id,
+                compilerName: compilerName,
+                editorid: editorid,
+                compilerFlags: compilerFlags,
+            },
+        };
+    },
     getAstView: function () {
         return {
             type: 'component',

--- a/static/hub.js
+++ b/static/hub.js
@@ -34,6 +34,7 @@ var tool = require('./panes/tool');
 var Components = require('components');
 var diff = require('./panes/diff');
 var optView = require('./panes/opt-view');
+var flagsView = require('./panes/flags-view');
 var astView = require('./panes/ast-view');
 var irView = require('./panes/ir-view');
 var gccDumpView = require('./panes/gccdump-view');
@@ -106,6 +107,10 @@ function Hub(layout, subLangId, defaultLangId) {
     layout.registerComponent(Components.getOptView().componentName,
         function (container, state) {
             return self.optViewFactory(container, state);
+        });
+    layout.registerComponent(Components.getFlagsView().componentName,
+        function (container, state) {
+            return self.flagsViewFactory(container, state);
         });
     layout.registerComponent(Components.getAstView().componentName,
         function (container, state) {
@@ -205,6 +210,10 @@ Hub.prototype.diffFactory = function (container, state) {
 
 Hub.prototype.optViewFactory = function (container, state) {
     return new optView.Opt(this, container, state);
+};
+
+Hub.prototype.flagsViewFactory = function (container, state) {
+    return new flagsView.Flags(this, container, state);
 };
 
 Hub.prototype.astViewFactory = function (container, state) {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -96,6 +96,7 @@ function Compiler(hub, container, state) {
     this.pendingRequestSentAt = 0;
     this.nextRequest = null;
     this.optViewOpen = false;
+    this.flagsViewOpen = false;
     this.cfgViewOpen = false;
     this.wantOptInfo = state.wantOptInfo;
     this.decorations = {};
@@ -197,6 +198,11 @@ Compiler.prototype.initPanerButtons = function () {
             this.sourceEditorId);
     }, this);
 
+    var createFlagsView = _.bind(function () {
+        return Components.getFlagsViewWith(this.id, this.getCompilerName(), this.sourceEditorId,
+            this.optionsField.val());
+    }, this);
+
     var createAstView = _.bind(function () {
         return Components.getAstViewWith(this.id, this.source, this.lastResult.astOutput, this.getCompilerName(),
             this.sourceEditorId);
@@ -255,6 +261,19 @@ Compiler.prototype.initPanerButtons = function () {
             this.container.layoutManager.root.contentItems[0];
         insertPoint.addChild(createOptView);
     }, this));
+
+    var popularArgumentsMenu = this.domRoot.find('div.populararguments div.dropdown-menu');
+    this.container.layoutManager
+        .createDragSource(this.flagsButton, createFlagsView)
+        ._dragListener.on('dragStart', togglePannerAdder);
+
+    this.flagsButton.click(_.bind(function () {
+        var insertPoint = this.hub.findParentRowOrColumn(this.container) ||
+            this.container.layoutManager.root.contentItems[0];
+        insertPoint.addChild(createFlagsView);
+    }, this));
+
+    popularArgumentsMenu.append(this.flagsButton);
 
     this.container.layoutManager
         .createDragSource(this.astButton, createAstView)
@@ -834,6 +853,12 @@ Compiler.prototype.onEditorChange = function (editor, source, langId, compilerId
     }
 };
 
+Compiler.prototype.onCompilerFlagsChange = function (compilerId, compilerFlags) {
+    if (compilerId === this.id) {
+        this.onOptionsChange(compilerFlags);
+    }
+};
+
 Compiler.prototype.onToolOpened = function (compilerId, toolSettings) {
     if (this.id === compilerId) {
         var toolId = toolSettings.toolId;
@@ -886,6 +911,23 @@ Compiler.prototype.onOptViewClosed = function (id) {
         this.wantOptInfo = false;
         this.optViewOpen = false;
         this.optButton.prop('disabled', this.optViewOpen);
+    }
+};
+
+Compiler.prototype.onFlagsViewClosed = function (id, compilerFlags) {
+    if (this.id === id) {
+        this.flagsViewOpen = false;
+        this.optionsField.val(compilerFlags);
+        this.optionsField.prop('disabled', this.flagsViewOpen);
+        this.flagsButton.prop('disabled', this.flagsViewOpen);
+
+        this.compilerService.requestPopularArguments(this.compiler.id, compilerFlags).then(
+            _.bind(function (result) {
+                if (result && result.result) {
+                    this.handlePopularArgumentsResult(result.result);
+                }
+            }, this)
+        );
     }
 };
 
@@ -994,6 +1036,17 @@ Compiler.prototype.onOptViewOpened = function (id) {
     }
 };
 
+Compiler.prototype.onFlagsViewOpened = function (id) {
+    if (this.id === id) {
+        this.flagsViewOpen = true;
+        this.handlePopularArgumentsResult(false);
+        this.optionsField.prop('disabled', this.flagsViewOpen);
+        this.optionsField.val('see detailed flags window');
+        this.flagsButton.prop('disabled', this.flagsViewOpen);
+        this.compile();
+    }
+};
+
 Compiler.prototype.onCfgViewOpened = function (id) {
     if (this.id === id) {
         this.cfgButton.prop('disabled', true);
@@ -1044,6 +1097,7 @@ Compiler.prototype.initButtons = function (state) {
     this.filters = new Toggles(this.domRoot.find('.filters'), patchOldFilters(state.filters));
 
     this.optButton = this.domRoot.find('.btn.view-optimization');
+    this.flagsButton = this.domRoot.find('div.populararguments div.dropdown-menu button');
     this.astButton = this.domRoot.find('.btn.view-ast');
     this.irButton = this.domRoot.find('.btn.view-ir');
     this.gccDumpButton = this.domRoot.find('.btn.view-gccdump');
@@ -1220,6 +1274,9 @@ Compiler.prototype.updateButtons = function () {
     formatFilterTitle(this.filterTrimButton, this.filterTrimTitle);
 
     this.optButton.prop('disabled', this.optViewOpen || !this.compiler.supportsOptOutput);
+    if(this.flagsButton) {
+        this.flagsButton.prop('disabled', this.flagsViewOpen);
+    }
     this.astButton.prop('disabled', this.astViewOpen || !this.compiler.supportsAstView);
     this.irButton.prop('disabled', this.irViewOpen || !this.compiler.supportsIrView);
     this.cfgButton.prop('disabled', this.cfgViewOpen || !this.compiler.supportsCfg);
@@ -1231,12 +1288,13 @@ Compiler.prototype.updateButtons = function () {
 };
 
 Compiler.prototype.handlePopularArgumentsResult = function (result) {
-    var popularArgumentsMenu = this.domRoot.find('div.populararguments div.dropdown-menu');
-    popularArgumentsMenu.html('');
+    var popularArgumentsMenu = $(this.domRoot.find('div.populararguments div.dropdown-menu'));
 
-    if (result) {
-        var addedOption = false;
+    while(popularArgumentsMenu.children().length > 1) {
+        popularArgumentsMenu.children()[1].remove();
+    }
 
+    if (result && !this.flagsViewOpen) {
         _.forEach(result, _.bind(function (arg, key) {
             var argumentButton = $(document.createElement('button'));
             argumentButton.addClass('dropdown-item btn btn-light btn-sm');
@@ -1261,16 +1319,8 @@ Compiler.prototype.handlePopularArgumentsResult = function (result) {
             }, this));
 
             popularArgumentsMenu.append(argumentButton);
-            addedOption = true;
         }, this));
 
-        if (!addedOption) {
-            $('div.populararguments').hide();
-        } else {
-            $('div.populararguments').show();
-        }
-    } else {
-        $('div.populararguments').hide();
     }
 };
 
@@ -1289,6 +1339,7 @@ Compiler.prototype.initListeners = function () {
         this.eventHub.emit('compilerOpen', this.id, this.sourceEditorId);
     }, this);
     this.eventHub.on('editorChange', this.onEditorChange, this);
+    this.eventHub.on('compilerFlagsChange', this.onCompilerFlagsChange, this);
     this.eventHub.on('editorClose', this.onEditorClose, this);
     this.eventHub.on('colours', this.onColours, this);
     this.eventHub.on('resendCompilation', this.onResendCompilation, this);
@@ -1304,6 +1355,8 @@ Compiler.prototype.initListeners = function () {
 
     this.eventHub.on('optViewOpened', this.onOptViewOpened, this);
     this.eventHub.on('optViewClosed', this.onOptViewClosed, this);
+    this.eventHub.on('flagsViewOpened', this.onFlagsViewOpened, this);
+    this.eventHub.on('flagsViewClosed', this.onFlagsViewClosed, this);
     this.eventHub.on('astViewOpened', this.onAstViewOpened, this);
     this.eventHub.on('astViewClosed', this.onAstViewClosed, this);
     this.eventHub.on('irViewOpened', this.onIrViewOpened, this);
@@ -1392,7 +1445,8 @@ Compiler.prototype.initCallbacks = function () {
 };
 
 Compiler.prototype.onOptionsChange = function (options) {
-    if (this.options !== options) {
+    // Check against our placeholder test to avoid a race condition
+    if (this.options !== options && options !== 'see detailed flags window') {
         this.options = options;
         this.saveState();
         this.compile();

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -923,6 +923,7 @@ Compiler.prototype.onFlagsViewClosed = function (id, compilerFlags) {
         this.flagsViewOpen = false;
         this.optionsField.val(compilerFlags);
         this.optionsField.prop('disabled', this.flagsViewOpen);
+        this.optionsField.prop('placeholder', '');
         this.flagsButton.prop('disabled', this.flagsViewOpen);
 
         this.compilerService.requestPopularArguments(this.compiler.id, compilerFlags).then(
@@ -1047,7 +1048,8 @@ Compiler.prototype.onFlagsViewOpened = function (id) {
         this.flagsViewOpen = true;
         this.handlePopularArgumentsResult(false);
         this.optionsField.prop('disabled', this.flagsViewOpen);
-        this.optionsField.val('see detailed flags window');
+        this.optionsField.val('');
+        this.optionsField.prop('placeholder', 'see detailed flags window');
         this.flagsButton.prop('disabled', this.flagsViewOpen);
         this.compile();
         this.saveState();
@@ -1452,8 +1454,7 @@ Compiler.prototype.initCallbacks = function () {
 };
 
 Compiler.prototype.onOptionsChange = function (options) {
-    // Check against our placeholder test to avoid a race condition
-    if (this.options !== options && options !== 'see detailed flags window') {
+    if (this.options !== options) {
         this.options = options;
         this.saveState();
         this.compile();

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -96,7 +96,7 @@ function Compiler(hub, container, state) {
     this.pendingRequestSentAt = 0;
     this.nextRequest = null;
     this.optViewOpen = false;
-    this.flagsViewOpen = false;
+    this.flagsViewOpen = state.flagsViewOpen || false;
     this.cfgViewOpen = false;
     this.wantOptInfo = state.wantOptInfo;
     this.decorations = {};
@@ -202,6 +202,10 @@ Compiler.prototype.initPanerButtons = function () {
         return Components.getFlagsViewWith(this.id, this.getCompilerName(), this.sourceEditorId,
             this.optionsField.val());
     }, this);
+
+    if (this.flagsViewOpen) {
+        createFlagsView();
+    }
 
     var createAstView = _.bind(function () {
         return Components.getAstViewWith(this.id, this.source, this.lastResult.astOutput, this.getCompilerName(),
@@ -928,6 +932,8 @@ Compiler.prototype.onFlagsViewClosed = function (id, compilerFlags) {
                 }
             }, this)
         );
+
+        this.saveState();
     }
 };
 
@@ -1044,6 +1050,7 @@ Compiler.prototype.onFlagsViewOpened = function (id) {
         this.optionsField.val('see detailed flags window');
         this.flagsButton.prop('disabled', this.flagsViewOpen);
         this.compile();
+        this.saveState();
     }
 };
 
@@ -1539,6 +1546,7 @@ Compiler.prototype.currentState = function () {
         libs: this.libsWidget.get(),
         lang: this.currentLangId,
         selection: this.selection,
+        flagsViewOpen: this.flagsViewOpen,
     };
     this.fontScale.addState(state);
     return state;

--- a/static/panes/flags-view.js
+++ b/static/panes/flags-view.js
@@ -1,0 +1,205 @@
+// Copyright (c) 2021, Tom Ritter
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+
+var FontScale = require('../fontscale');
+var monaco = require('monaco-editor');
+var _ = require('underscore');
+var $ = require('jquery');
+var ga = require('../analytics');
+var monacoConfig = require('../monaco-config');
+var local = require('../local');
+
+require('../modes/asm-mode');
+
+function Flags(hub, container, state) {
+    state = state || {};
+    this.container = container;
+    this.eventHub = hub.createEventHub();
+    this.domRoot = container.getElement();
+    this.domRoot.html($('#flags').html());
+    this.source = state.source || '';
+    this._currentDecorations = [];
+    var root = this.domRoot.find('.monaco-placeholder');
+
+    this.settings = JSON.parse(local.get('settings', '{}'));
+
+    this.editor = monaco.editor.create(root[0], monacoConfig.extendConfig({
+        value: state.compilerFlags.replaceAll(' ', '\n'),
+        language: 'plaintext',
+        readOnly: false,
+        glyphMargin: true,
+    }));
+
+    this._compilerid = state.id;
+    this._compilerName = state.compilerName;
+    this._editorid = state.editorid;
+
+    this.awaitingInitialResults = false;
+    this.selection = state.selection;
+
+    this.isCompilerSupported = false;
+
+    this.initButtons(state);
+    this.initCallbacks();
+
+    this.setTitle();
+    this.onSettingsChange(this.settings);
+    this.eventHub.emit('flagsViewOpened', this._compilerid);
+    ga.proxy('send', {
+        hitType: 'event',
+        eventCategory: 'OpenViewPane',
+        eventAction: 'detailedCompilerFlags',
+    });
+}
+
+Flags.prototype.initButtons = function (state) {
+    this.fontScale = new FontScale(this.domRoot, state, this.editor);
+
+    this.topBar = this.domRoot.find('.top-bar');
+};
+
+Flags.prototype.initCallbacks = function () {
+    this.fontScale.on('change', _.bind(this.updateState, this));
+
+    this.eventHub.on('compiler', this.onCompiler, this);
+    this.eventHub.on('compilerClose', this.onCompilerClose, this);
+    this.eventHub.on('settingsChange', this.onSettingsChange, this);
+    this.eventHub.on('resize', this.resize, this);
+    this.container.on('destroy', this.close, this);
+    this.eventHub.emit('requestSettings');
+    this.eventHub.emit('findCompilers');
+
+    this.container.on('resize', this.resize, this);
+    this.container.on('shown', this.resize, this);
+
+    this.container.layoutManager.on('initialised', function () {
+        // Once initialized, let everyone know what text we have.
+        this.maybeEmitChange();
+    }, this);
+    this.eventHub.on('initialised', this.maybeEmitChange, this);
+
+    this.editor.getModel().onDidChangeContent(_.bind(function () {
+        this.debouncedEmitChange();
+        this.updateState();
+    }, this));
+
+    this.cursorSelectionThrottledFunction =
+        _.throttle(_.bind(this.onDidChangeCursorSelection, this), 500);
+    this.editor.onDidChangeCursorSelection(_.bind(function (e) {
+        this.cursorSelectionThrottledFunction(e);
+    }, this));
+};
+
+Flags.prototype.setTitle = function () {
+    this.container.setTitle(
+        this._compilerName + ' Detailed Compiler Flags (Editor #' +
+            this._editorid + ', Compiler #' + this._compilerid + ')');
+};
+
+Flags.prototype.onCompiler = function (id, compiler) {
+    if (id === this._compilerid) {
+        this._compilerName = compiler ? compiler.name : '';
+        this.setTitle();
+    }
+};
+
+Flags.prototype.resize = function () {
+    var topBarHeight = this.topBar.outerHeight(true);
+    this.editor.layout({
+        width: this.domRoot.width(),
+        height: this.domRoot.height() - topBarHeight,
+    });
+};
+
+Flags.prototype.updateState = function () {
+    this.container.setState(this.currentState());
+};
+
+Flags.prototype.currentState = function () {
+    var state = {
+        id: this._compilerid,
+        editorid: this._editorid,
+        selection: this.selection,
+    };
+    this.fontScale.addState(state);
+    return state;
+};
+
+Flags.prototype.close = function () {
+    this.eventHub.unsubscribe();
+    this.eventHub.emit('flagsViewClosed', this._compilerid, this.getOptions());
+    this.editor.dispose();
+};
+
+Flags.prototype.onCompilerClose = function (id) {
+    if (id === this._compilerid) {
+        // We can't immediately close as an outer loop somewhere in GoldenLayout is iterating over
+        // the hierarchy. We can't modify while it's being iterated over.
+        this.close();
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+Flags.prototype.onSettingsChange = function (newSettings) {
+    this.editor.updateOptions({
+        contextmenu: newSettings.useCustomContextMenu,
+        minimap: {
+            enabled: newSettings.showMinimap,
+        },
+        fontFamily: newSettings.editorsFFont,
+        fontLigatures: newSettings.editorsFLigatures,
+    });
+
+    this.debouncedEmitChange = _.debounce(_.bind(function () {
+        this.maybeEmitChange();
+    }, this), newSettings.delayAfterChange);
+};
+
+Flags.prototype.onDidChangeCursorSelection = function (e) {
+    if (this.awaitingInitialResults) {
+        this.selection = e.selection;
+        this.updateState();
+    }
+};
+
+Flags.prototype.getOptions = function () {
+    var lines = this.editor.getModel().getValue();
+    return lines.replaceAll('\n', ' ');
+};
+
+Flags.prototype.maybeEmitChange = function (force) {
+    var options = this.getOptions();
+    if (!force && options === this.lastChangeEmitted) return;
+
+    this.lastChangeEmitted = options;
+    this.eventHub.emit('compilerFlagsChange', this._compilerid, this.lastChangeEmitted);
+};
+
+module.exports = {
+    Flags: Flags,
+};

--- a/static/panes/flags-view.js
+++ b/static/panes/flags-view.js
@@ -47,7 +47,7 @@ function Flags(hub, container, state) {
     this.settings = JSON.parse(local.get('settings', '{}'));
 
     this.editor = monaco.editor.create(root[0], monacoConfig.extendConfig({
-        value: state.compilerFlags.replaceAll(' ', '\n'),
+        value: state.compilerFlags ? state.compilerFlags.replaceAll(' ', '\n') : '',
         language: 'plaintext',
         readOnly: false,
         glyphMargin: true,
@@ -143,6 +143,7 @@ Flags.prototype.currentState = function () {
         id: this._compilerid,
         editorid: this._editorid,
         selection: this.selection,
+        compilerFlags: this.getOptions(),
     };
     this.fontScale.addState(state);
     return state;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -55,6 +55,10 @@
             button.btn.btn-sm.btn-light.btn-outline-secondary.dropdown-toggle.dropdown-toggle-split(type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false")
               span.sr-only Popular arguments
             div.dropdown-menu.dropdown-menu-right
+              button.dropdown-item.btn.btn-light.btn-sm
+                .argmenuitem
+                  span.argtitle Detailed Compiler Flags
+                  span.argdescription Open a new window to edit verbose compiler flags
       include font-size
       .btn-group.btn-group-sm.filters(role="group")
         button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler's output is generated")
@@ -228,6 +232,11 @@
     .monaco-placeholder
 
   #opt
+    .top-bar.btn-toolbar.bg-light(role="toolbar")
+      include font-size.pug
+    .monaco-placeholder
+
+  #flags
     .top-bar.btn-toolbar.bg-light(role="toolbar")
       include font-size.pug
     .monaco-placeholder


### PR DESCRIPTION
If you have a lot of compiler flags, you don't want to be editing
them in the tiny text box. So add a menu option above
'Popular Arguments' that lets you break out the flags into a
separate window, where you can edit them; one-per-line.

When this happens, the regular flags text box becomes disabled,
and the popular arguments dropdown is not populated.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
