### PR TITLE
Corrected trim of the documentation link.

### DIFF
--- a/lib/tooling/pvs-studio-tool.js
+++ b/lib/tooling/pvs-studio-tool.js
@@ -133,9 +133,8 @@ export class PvsStudioTool extends BaseTool {
 
         // Now let's trim the documentation link
         if (result.stdout.length > 0) {
-            result.stdout[0].text
-                = result.stdout[0].text.replace('www.viva64.com/en/w:1:1: error: Help: ', '');
-            result.stdout[0].text = result.stdout[0].text.concat('\n\n');
+            const idx = result.stdout[0].text.indexOf('The documentation for all analyzer warnings is available here:');
+            result.stdout[0].text = result.stdout[0].text.substring(idx).text.concat('\n\n');
         }
 
         // The error output is unnecessary for the user


### PR DESCRIPTION
Hello, 
My name is Maxim Stefanov (PVS-Studio, https://pvs-studio.com)

Recently, we moved to a new domain (www.viva64.com -> pvs-sudio.com)
Hence, we changed all links of the old website, but one link was left here.

I fixed the receiving of the documentation string without prefix linking to the website.

I'm ready to discuss the edits.
