### PR TITLE
Added support for SASS disassembly for clang as a CUDA compiler.

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -10,7 +10,7 @@ group.nvcc.isSemVer=true
 group.nvcc.baseName=NVCC
 group.nvcc.includeFlag=-I
 group.nvcc.supportsBinary=true
-group.nvcc.objdumper=/opt/compiler-explorer/cuda/11.0.3/bin/nvdisasm
+group.nvcc.objdumper=/opt/compiler-explorer/cuda/11.3.1/bin/nvdisasm
 group.nvcc.rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
 compiler.nvcc91.semver=9.1.85
 compiler.nvcc91.exe=/opt/compiler-explorer/cuda/9.1.85/bin/nvcc
@@ -64,6 +64,11 @@ compiler.nvcc113u1.semver=11.3.1
 group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cltrunk
 group.cuclang.isSemVer=true
 group.cuclang.baseName=clang (CUDA 9.1.85)
+group.cuclang.compilerType=clang-cuda
+group.cuclang.supportsBinary=true
+# The most recent nvdisasm works for older CUDA versions
+group.cuclang.objdumper=/opt/compiler-explorer/cuda/11.3.1/bin/nvdisasm
+
 compiler.cuclang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
 compiler.cuclang700.semver=7.0.0
 compiler.cuclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only

--- a/etc/config/cuda.defaults.properties
+++ b/etc/config/cuda.defaults.properties
@@ -1,18 +1,22 @@
 compilers=&nvcc:&clang
 defaultCompiler=nvcc91
-supportsBinary=false
+supportsBinary=true
 demangler=/opt/compiler-explorer/gcc-6.4.0/bin/c++filt
 
 group.nvcc.compilers=nvcc91
 group.nvcc.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
 group.nvcc.versionRe=^Cuda.*
 group.nvcc.compilerType=nvcc
+group.nvcc.objdumper=/opt/compiler-explorer/cuda/9.1.85/bin/nvdisasm
 
 compiler.nvcc91.name=NVCC 9.1
 compiler.nvcc91.exe=/opt/compiler-explorer/cuda/9.1.85/bin/nvcc
 
 group.clang.compilers=cltrunk
 group.clang.options=--cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+group.clang.compilerType=clang-cuda
+group.clang.supportsBinary=true
+group.clang.objdumper=/opt/compiler-explorer/cuda/9.1.85/bin/nvdisasm
 
 compiler.cltrunk.name=clang trunk
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -28,6 +28,7 @@ export { AssemblyCompiler } from './assembly';
 export { NasmCompiler } from './nasm';
 export { Cc65Compiler } from './cc65';
 export { ClangCompiler } from './clang';
+export { ClangCudaCompiler } from './clang';
 export { CleanCompiler } from './clean';
 export { DefaultCompiler } from './default';
 export { DMDCompiler } from './dmd';

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -24,6 +24,7 @@
 
 import path from 'path';
 
+import { SassAsmParser } from '../asm-parser-sass';
 import { BaseCompiler } from '../base-compiler';
 
 export class ClangCompiler extends BaseCompiler {
@@ -37,5 +38,33 @@ export class ClangCompiler extends BaseCompiler {
         execOptions.customCwd = path.dirname(inputFilename);
 
         return super.runCompiler(compiler, options, inputFilename, execOptions);
+    }
+}
+
+export class ClangCudaCompiler extends ClangCompiler {
+    static get key() { return 'clang-cuda'; }
+    constructor(info, env) {
+        super(info, env);
+
+        this.asm = new SassAsmParser();
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        return ['-o', this.filename(outputFilename), '-g1', filters.binary ? '-c' : '-S'];
+    }
+
+    async objdump(outputFilename, result, maxSize) {
+        // For nvdisasm.
+        const args = [outputFilename, '-c', '-g', '-hex'];
+        const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
+
+        const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
+        result.asm = objResult.stdout;
+        if (objResult.code !== 0) {
+            result.asm = `<No output: nvdisasm returned ${objResult.code}>`;
+        } else {
+            result.objdumpTime = objResult.execTime;
+        }
+        return result;
     }
 }


### PR DESCRIPTION
Clang `--cuda-device-only -c` produces the same kind of CUBIN output as `nvcc
-cubin` and can use nvdisasm to disassemble it.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
