### PR TITLE
[fix] Corrected trim of the documentation link.

### DIFF
--- a/lib/tooling/pvs-studio-tool.js
+++ b/lib/tooling/pvs-studio-tool.js
@@ -134,7 +134,7 @@ export class PvsStudioTool extends BaseTool {
         // Now let's trim the documentation link
         if (result.stdout.length > 0) {
             const idx = result.stdout[0].text.indexOf('The documentation for all analyzer warnings is available here:');
-            result.stdout[0].text = result.stdout[0].text.substring(idx).text.concat('\n\n');
+            result.stdout[0].text = result.stdout[0].text.substring(idx).concat('\n\n');
         }
 
         // The error output is unnecessary for the user


### PR DESCRIPTION
Hello Matt,

I've done [PR](https://github.com/compiler-explorer/compiler-explorer/pull/2727) before. 

I apologize for my inattention (((
When receiving the text about PVS documentation, I mistakenly turned to the 'text' field.

Thank you very much for your understanding!