### PR TITLE
Add Highway SIMD library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1123,7 +1123,7 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:cppitertools:ctbignum:gsl:entt:expected_lite:nlohmann_json:jsoncpp:tomlplusplus:trompeloeil:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:pugixml:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer:enoki:spdlog:python:tts:lexy:eve:nsimd:ztdtext:type_safe:lager:zug:ofw:kiwaku
+libs=boost:brigand:kvasir:cmcstl2:mp-units:cppitertools:ctbignum:gsl:entt:expected_lite:highway:nlohmann_json:jsoncpp:tomlplusplus:trompeloeil:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:pugixml:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer:enoki:spdlog:python:tts:lexy:eve:nsimd:ztdtext:type_safe:lager:zug:ofw:kiwaku
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172:173:174:175:176
 libs.boost.url=https://www.boost.org
@@ -1223,6 +1223,15 @@ libs.expected_lite.versions.010.version=0.1.0
 libs.expected_lite.versions.010.path=/opt/compiler-explorer/libs/expected-lite/v0.1.0/include
 libs.expected_lite.versions.trunk.version=trunk
 libs.expected_lite.versions.trunk.path=/opt/compiler-explorer/libs/expected-lite/trunk/include
+libs.highway.name=Highway
+libs.highway.versions=trunk:0.12.2
+libs.highway.url=https://github.com/google/highway
+libs.highway.versions.trunk.version=trunk
+libs.highway.versions.trunk.path=/opt/compiler-explorer/libs/highway/trunk
+libs.highway.versions.trunk.libpath=/opt/compiler-explorer/libs/highway/trunk
+libs.highway.versions.0.12.2.version=0.12.2
+libs.highway.versions.0.12.2.path=/opt/compiler-explorer/libs/highway/0.12.2
+libs.highway.versions.0.12.2.libpath=/opt/compiler-explorer/libs/highway/0.12.2
 libs.nlohmann_json.name=nlohmann::json
 libs.nlohmann_json.versions=trunk:360:312:211
 libs.nlohmann_json.url=https://github.com/nlohmann/json


### PR DESCRIPTION
Thanks for the awesome compiler explorer! Would be nice to add the Highway SIMD library.

make check reports: 918 passing (24s) 9 pending Tests pass

I successfully tested this locally after copying a git clone to /opt/compiler-explorer/libs/highway. The infra pull request is https://github.com/compiler-explorer/infra/pull/531. I am very unfamiliar with this stack, but please let me know if something can be improved.