### PR TITLE
Adding rustc-cg-gcc

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&rust:&rustgcc:&mrustc
+compilers=&rust:&rustgcc:&mrustc:&rustccggcc
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-11.1.0/bin/gcc
 defaultCompiler=r1530
@@ -130,6 +130,12 @@ compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
 group.rustgcc.compilerType=gccrs
 group.rustgcc.compilers=gccrs-snapshot
 group.rustgcc.groupName=Rust-GCC
+
+group.rustccggcc.compilers=rustccggcc-master
+compiler.rustccggcc-master.exe=/opt/compiler-explorer/rustc-cg-gcc-master/bin/rustc
+compiler.rustccggcc-master.semver=(rustc - GCC)
+group.rustccggcc.compilerType=rustc-cg-gcc
+group.rustccggcc.supportsBinary=false
 
 compiler.mrustc-master.exe=/opt/compiler-explorer/mrustc-master/bin/mrustc
 compiler.mrustc-master.semver=(mrustc)

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -59,6 +59,7 @@ export { PPCICompiler } from './ppci';
 export { PtxAssembler } from './ptxas';
 export { PythonCompiler } from './python';
 export { RustCompiler } from './rust';
+export { RustcCgGCCCompiler } from './rustc-cg-gcc';
 export { MrustcCompiler } from './mrustc';
 export { ScalaCompiler } from './scala';
 export { SdccCompiler } from './sdcc';

--- a/lib/compilers/rustc-cg-gcc.js
+++ b/lib/compilers/rustc-cg-gcc.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import { RustCompiler } from './rust';
+
+export class RustcCgGCCCompiler extends RustCompiler {
+    static get key() { return 'rustc-cg-gcc'; }
+
+    constructor(info, env) {
+        super(info, env);
+        this.compiler.supportsIrView = false;
+    }
+
+    optionsForFilter(filters, outputFilename, userOptions) {
+        // these options are direcly taken from rustc_codegen_gcc doc.
+        // See https://github.com/antoyo/rustc_codegen_gcc
+        let toolroot = path.resolve(path.dirname(this.compiler.exe), '..');
+
+        let options = ['-C', 'panic=abort',
+            '-Z', 'codegen-backend=librustc_codegen_gcc.so',
+            '--sysroot', toolroot + '/sysroot' ];
+
+        // rust.js makes the asumption that LLVM is used. This may go away when cranelift is available.
+        // Until this is the case and the super() class is refactored, simply ditch -Cllvm arg.
+        let super_options = super.optionsForFilter(filters, outputFilename, userOptions).filter(arg => !/-Cllvm.*/.test(arg));
+        options = options.concat(super_options);
+        return options;
+    }
+}


### PR DESCRIPTION
GCC backend for rustc is still in a very early state.
It is in the process of being merged in main rustc source:
https://github.com/rust-lang/compiler-team/issues/442

Currently reusing main rust compiler class and simply remove -Cllvm= argument if any (only for intel asm syntax).

Disabling binary until the result is more friendly (currently binary are too big).

refs #2683