### PR TITLE
Limit AWS SSM request to what we actually use

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -55,7 +55,7 @@ async function loadAwsConfig(properties) {
     const ssm = new AWS.SSM({region: region});
     const path = '/compiler-explorer/';
     try {
-        const response = await ssm.getParametersByPath({Path: path}).promise();
+        const response = await ssm.getParametersByPath({Path: path + 'sentryDsn'}).promise();
         const map = {};
         for (const param of response.Parameters) {
             map[param.Name.substr(path.length)] = param.Value;

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -55,7 +55,7 @@ async function loadAwsConfig(properties) {
     const ssm = new AWS.SSM({region: region});
     const path = '/compiler-explorer/';
     try {
-        const response = await ssm.getParametersByPath({Path: path + 'sentryDsn'}).promise();
+        const response = await ssm.GetParameters([path + 'sentryDsn']).promise();
         const map = {};
         for (const param of response.Parameters) {
             map[param.Name.substr(path.length)] = param.Value;

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -55,7 +55,7 @@ async function loadAwsConfig(properties) {
     const ssm = new AWS.SSM({region: region});
     const path = '/compiler-explorer/';
     try {
-        const response = await ssm.GetParameters([path + 'sentryDsn']).promise();
+        const response = await ssm.getParameters({Names: [path + 'sentryDsn']}).promise();
         const map = {};
         for (const param of response.Parameters) {
             map[param.Name.substr(path.length)] = param.Value;

--- a/test/aws-tests.js
+++ b/test/aws-tests.js
@@ -75,7 +75,7 @@ function setup() {
             ],
         });
 
-        AWS.mock('SSM', 'getParametersByPath', {
+        AWS.mock('SSM', 'getParameters', {
             Parameters: [
                 {
                     Name: '/compiler-explorer/configValue',


### PR DESCRIPTION
Note that if we want to use more variables to be loaded with `getConfig`, we'll have to add it to the list of paths in `loadAwsConfig()`.