### PR TITLE
Add OpenCL C language

### DIFF
--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -1,0 +1,146 @@
+compilers=&armoclcclang32:&armoclcclang64
+defaultCompiler=armoclcclang64
+demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
+needsMulti=false
+supportsBinary=false
+
+# Clang for Arm
+# Provides 32- and 64-bit menu items for clang-9, clang-10, clang-11 and trunk
+group.armoclcclang32.groupName=Arm 32-bit clang
+group.armoclcclang32.compilers=armv7-oclcclang900:armv7-oclcclang901:armv7-oclcclang1000:armv7-oclcclang1001:armv7-oclcclang1100:armv7-oclcclang1101:armv7-oclcclang-trunk
+group.armoclcclang32.isSemVer=true
+group.armoclcclang32.compilerType=clang
+group.armoclcclang32.supportsExecute=false
+group.armoclcclang32.instructionSet=arm32
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armoclcclang32.baseOptions=-Dkernel= -D__kernel=
+
+group.armoclcclang64.groupName=Arm 64-bit clang
+group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk
+group.armoclcclang64.isSemVer=true
+group.armoclcclang64.compilerType=clang
+group.armoclcclang64.supportsExecute=false
+group.armoclcclang64.instructionSet=aarch64
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armoclcclang64.baseOptions=-Dkernel= -D__kernel=
+
+compiler.armv7-oclcclang1101.name=armv7-a clang 11.0.1
+compiler.armv7-oclcclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.armv7-oclcclang1101.semver=11.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang1101.options=-Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang1101.name=armv8-a clang 11.0.1
+compiler.armv8-oclcclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.armv8-oclcclang1101.semver=11.0.1
+# Arm v8-a
+compiler.armv8-oclcclang1101.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-oclcclang1100.name=armv7-a clang 11.0.0
+compiler.armv7-oclcclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.armv7-oclcclang1100.semver=11.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang1100.options=-Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang1100.name=armv8-a clang 11.0.0
+compiler.armv8-oclcclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.armv8-oclcclang1100.semver=11.0.0
+# Arm v8-a
+compiler.armv8-oclcclang1100.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-oclcclang1001.name=armv7-a clang 10.0.1
+compiler.armv7-oclcclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.armv7-oclcclang1001.semver=10.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang1001.options=-Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang1001.name=armv8-a clang 10.0.1
+compiler.armv8-oclcclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.armv8-oclcclang1001.semver=10.0.1
+# Arm v8-a
+compiler.armv8-oclcclang1001.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-oclcclang1000.name=armv7-a clang 10.0.0
+compiler.armv7-oclcclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.armv7-oclcclang1000.semver=10.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang1000.options=-Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang1000.name=armv8-a clang 10.0.0
+compiler.armv8-oclcclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.armv8-oclcclang1000.semver=10.0.0
+# Arm v8-a
+compiler.armv8-oclcclang1000.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-oclcclang901.name=armv7-a clang 9.0.1
+compiler.armv7-oclcclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.armv7-oclcclang901.semver=9.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang901.options=-Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang901.name=armv8-a clang 9.0.1
+compiler.armv8-oclcclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.armv8-oclcclang901.semver=9.0.1
+# Arm v8-a
+compiler.armv8-oclcclang901.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-oclcclang900.name=armv7-a clang 9.0.0
+compiler.armv7-oclcclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.armv7-oclcclang900.semver=9.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang900.options=-Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang900.name=armv8-a clang 9.0.0
+compiler.armv8-oclcclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.armv8-oclcclang900.semver=9.0.0
+# Arm v8-a
+compiler.armv8-oclcclang900.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-oclcclang-trunk.name=armv7-a clang (trunk)
+compiler.armv7-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv7-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-oclcclang-trunk.semver=(trunk)
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang-trunk.name=armv8-a clang (trunk)
+compiler.armv8-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv8-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-oclcclang-trunk.semver=(trunk)
+# Arm v8-a
+compiler.armv8-oclcclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv8-full-oclcclang-trunk.name=armv8-a clang (trunk, all architectural features)
+compiler.armv8-full-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv8-full-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
+# Arm v8-a with all supported architectural features
+compiler.armv8-full-oclcclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+
+#################################
+#################################
+# Installed tools
+
+tools=clangtidytrunk:clangformattrunk:clangquerytrunk
+
+tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
+tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.type=independent
+tools.clangtidytrunk.class=clang-tidy-tool
+tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+tools.clangtidytrunk.stdinHint=disabled
+
+tools.clangformattrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
+tools.clangformattrunk.name=clang-format
+tools.clangformattrunk.type=independent
+tools.clangformattrunk.class=clang-format-tool
+
+tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
+tools.clangquerytrunk.name=clang-query (trunk)
+tools.clangquerytrunk.type=independent
+tools.clangquerytrunk.class=clang-query-tool
+tools.clangquerytrunk.stdinHint=Query commands

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -1,0 +1,31 @@
+# Default settings for OpenCL C
+compilers=&clang
+defaultCompiler=clang
+postProcess=
+demangler=c++filt
+supportsBinary=false
+
+group.clang.compilers=openclcclang7:openclcclang8:openclcclang9:openclcclang10:openclcclang11:openclcclang12:openclcclang13:openclcclangdefault
+group.clang.compilerType=clang
+compiler.openclcclang7.exe=/usr/bin/clang-7
+compiler.openclcclang7.name=clang 7
+compiler.openclcclang7.options=-Xclang -finclude-default-header
+compiler.openclcclang8.exe=/usr/bin/clang-8
+compiler.openclcclang8.name=clang 8
+compiler.openclcclang8.options=-Xclang -finclude-default-header
+compiler.openclcclang9.exe=/usr/bin/clang-9
+compiler.openclcclang9.name=clang 9
+compiler.openclcclang8.options=-Xclang -finclude-default-header
+compiler.openclcclang10.exe=/usr/bin/clang-10
+compiler.openclcclang10.name=clang 10
+compiler.openclcclang10.options=-Xclang -finclude-default-header
+compiler.openclcclang11.exe=/usr/bin/clang-11
+compiler.openclcclang11.name=clang 11
+compiler.openclcclang11.options=-Xclang -finclude-default-header
+compiler.openclcclang12.exe=/usr/bin/clang-12
+compiler.openclcclang12.name=clang 12
+compiler.openclcclang12.options=-Xclang -finclude-default-header
+compiler.openclcclang13.exe=/usr/bin/clang-13
+compiler.openclcclang13.name=clang 13
+compiler.openclcclangdefault.exe=/usr/bin/clang
+compiler.openclcclangdefault.name=clang default

--- a/examples/openclc/default.cl
+++ b/examples/openclc/default.cl
@@ -1,0 +1,7 @@
+kernel void do_add_sub(global short4 *add_out, global short4 *sub_out,
+                       global short4 *x, global short4 *y)
+{
+    size_t g = get_global_id(0);
+    add_out[g] = x[g] + y[g];
+    sub_out[g] = x[g] - y[g];
+}

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -88,6 +88,12 @@ export const languages = {
         alias: [],
         previewFilter: /^\s*#include/,
     },
+    openclc: {
+        name: 'OpenCL C',
+        monaco: 'openclc',
+        extensions: ['.cl', '.ocl'],
+        alias: [],
+    },
     rust: {
         name: 'Rust',
         monaco: 'rust',

--- a/static/modes/openclc-mode.js
+++ b/static/modes/openclc-mode.js
@@ -1,0 +1,98 @@
+// Copyright (c) 2018, 2021, Arm Ltd & Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+var $ = require('jquery');
+var monaco = require('monaco-editor');
+var cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
+var nc = require('./nc-mode');
+
+// We need to create a new definition for OpenCL C so we can add keywords
+
+function definition() {
+    var openclc = $.extend(true, {}, nc); // deep copy
+
+    function removeKeyword(keyword) {
+        var index = openclc.keywords.indexOf(keyword);
+        if (index > -1) {
+            openclc.keywords.splice(index, 1);
+        }
+    }
+
+    function removeKeywords(keywords) {
+        for (var i = 0; i < keywords.length; ++i) {
+            removeKeyword(keywords[i]);
+        }
+    }
+
+    function addKeywords(keywords) {
+        // (Ruben) Done one by one as if you just push them all, Monaco complains that they're not strings, but as
+        // far as I can tell, they indeed are all strings. This somehow fixes it. If you know how to fix it, plz go
+        for (var i = 0; i < keywords.length; ++i) {
+            openclc.keywords.push(keywords[i]);
+        }
+    }
+
+    function vectorTypes(basename) {
+        return [basename + '2', basename + '3', basename + '4', basename + '8', basename + '16'];
+    }
+
+    removeKeywords([
+        'auto', 'register', '_Alignas', '_Alignof', '_Atomic', '_Bool', '_Complex', '_Generic', '_Imaginary',
+        '_Noreturn', '_Static_assert', '_Thread_local',
+    ]);
+
+    // Keywords for OpenCL C
+    addKeywords([
+        '__global', 'global', '__local', 'local', '__constant', 'constant', '__private', 'private',
+        '__kernel', 'kernel',
+        'uniform', 'pipe',
+        '__read_only', 'read_only', '__write_only', 'write_only', '__read_write', 'read_write',
+        'bool', 'uchar', 'ushort', 'uint', 'ulong', 'half',
+        'cl_mem_fence_flags', 'event_t', 'reserve_id_t', 'ndrange_t', 'queue_t',
+        'image2d_t', 'image3d_t', 'image2d_array_t', 'image1d_t', 'image1d_array_t',
+        'image2d_depth_t', 'image1d_buffer_t', 'image2d_array_depth_t',
+        'sampler_t',
+        'uintptr_t', 'intptr_t', 'ptrdiff_t',
+        'size_t']);
+    addKeywords(vectorTypes('char'));
+    addKeywords(vectorTypes('short'));
+    addKeywords(vectorTypes('int'));
+    addKeywords(vectorTypes('long'));
+    addKeywords(vectorTypes('uchar'));
+    addKeywords(vectorTypes('ushort'));
+    addKeywords(vectorTypes('uint'));
+    addKeywords(vectorTypes('ulong'));
+    addKeywords(vectorTypes('half'));
+    addKeywords(vectorTypes('float'));
+    addKeywords(vectorTypes('double'));
+
+    openclc.floatsuffix = /[fFdDhH]?/;
+
+    return openclc;
+}
+
+monaco.languages.register({id: 'openclc'});
+monaco.languages.setLanguageConfiguration('openclc', cpp.conf);
+monaco.languages.setMonarchTokensProvider('openclc', definition());

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -48,6 +48,7 @@ require('../modes/ocaml-mode');
 require('../modes/clean-mode');
 require('../modes/cuda-mode');
 require('../modes/fortran-mode');
+require('../modes/openclc-mode');
 require('../modes/zig-mode');
 require('../modes/nc-mode');
 require('../modes/ada-mode');


### PR DESCRIPTION
Closes #2741.

This PR adds support for OpenCL C as a language, with syntax highlighting and compilation using upstream Clang into Arm assembly.

Note that `etc/config/openclc.amazon.properties` adds the base options `-Dkernel- -D__kernel=` for the Arm targets. 
This is a workaround to prevent the Clang crash documented [here](http://llvm.org/PR50841). Once the bug is fixed,
this workaround can be removed.