### PR TITLE
Initial sketch for how we could parse Rust output

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -221,9 +221,13 @@ export class BaseCompiler {
         const result = await this.exec(compiler, options, execOptions);
         result.inputFilename = inputFilename;
         const transformedInput = result.filenameTransform(inputFilename);
-        result.stdout = utils.parseOutput(result.stdout, transformedInput);
-        result.stderr = utils.parseOutput(result.stderr, transformedInput);
+        this.parseCompilationOutput(result, transformedInput);
         return result;
+    }
+
+    parseCompilationOutput(result, inputFilename) {
+        result.stdout = utils.parseOutput(result.stdout, inputFilename);
+        result.stderr = utils.parseOutput(result.stderr, inputFilename);
     }
 
     supportsObjdump() {

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -52,7 +52,7 @@ function parseOutput(lines, inputFilename, pathPrefix) {
             if (match) {
                 const previous = result.pop();
                 previous.tag = {
-                    line:parseInt(match[1]),
+                    line: parseInt(match[1]),
                     column: parseInt(match[3] || '0'),
                     text: previous.text.replace(asciiRe, ''),
                 };

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -27,42 +27,9 @@ import path from 'path';
 import _ from 'underscore';
 
 import { BaseCompiler } from '../base-compiler';
-import { eachLine } from '../utils';
+import { parseRustOutput } from '../utils';
 
 import { RustParser } from './argument-parsers';
-
-function parseOutput(lines, inputFilename, pathPrefix) {
-    const re = /^ --> <source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
-    const result = [];
-    eachLine(lines, function (line) {
-        line = line.split('<stdin>').join('<source>');
-        if (pathPrefix) line = line.replace(pathPrefix, '');
-        if (inputFilename) {
-            line = line.split(inputFilename).join('<source>');
-
-            if (inputFilename.indexOf('./') === 0) {
-                line = line.split('/home/ubuntu/' + inputFilename.substr(2)).join('<source>');
-                line = line.split('/home/ce/' + inputFilename.substr(2)).join('<source>');
-            }
-        }
-        if (line !== null) {
-            const lineObj = {text: line};
-            const asciiRe = /\x1B\[[\d;]*[Km]/g;
-            const match = line.replace(asciiRe, '').match(re);
-            if (match) {
-                const previous = result.pop();
-                previous.tag = {
-                    line: parseInt(match[1]),
-                    column: parseInt(match[3] || '0'),
-                    text: previous.text.replace(asciiRe, ''),
-                };
-                result.push(previous);
-            }
-            result.push(lineObj);
-        }
-    });
-    return result;
-}
 
 export class RustCompiler extends BaseCompiler {
     static get key() { return 'rust'; }
@@ -113,7 +80,7 @@ export class RustCompiler extends BaseCompiler {
     }
 
     parseCompilationOutput(result, inputFilename) {
-        result.stdout = parseOutput(result.stdout, inputFilename);
-        result.stderr = parseOutput(result.stderr, inputFilename);
+        result.stdout = parseRustOutput(result.stdout, inputFilename);
+        result.stderr = parseRustOutput(result.stderr, inputFilename);
     }
 }

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -27,8 +27,42 @@ import path from 'path';
 import _ from 'underscore';
 
 import { BaseCompiler } from '../base-compiler';
+import { eachLine } from '../utils';
 
 import { RustParser } from './argument-parsers';
+
+function parseOutput(lines, inputFilename, pathPrefix) {
+    const re = /^ --> <source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+    const result = [];
+    eachLine(lines, function (line) {
+        line = line.split('<stdin>').join('<source>');
+        if (pathPrefix) line = line.replace(pathPrefix, '');
+        if (inputFilename) {
+            line = line.split(inputFilename).join('<source>');
+
+            if (inputFilename.indexOf('./') === 0) {
+                line = line.split('/home/ubuntu/' + inputFilename.substr(2)).join('<source>');
+                line = line.split('/home/ce/' + inputFilename.substr(2)).join('<source>');
+            }
+        }
+        if (line !== null) {
+            const lineObj = {text: line};
+            const asciiRe = /\x1B\[[\d;]*[Km]/g;
+            const match = line.replace(asciiRe, '').match(re);
+            if (match) {
+                const previous = result.pop();
+                previous.tag = {
+                    line:parseInt(match[1]),
+                    column: parseInt(match[3] || '0'),
+                    text: previous.text.replace(asciiRe, ''),
+                };
+                result.push(previous);
+            }
+            result.push(lineObj);
+        }
+    });
+    return result;
+}
 
 export class RustCompiler extends BaseCompiler {
     static get key() { return 'rust'; }
@@ -76,5 +110,10 @@ export class RustCompiler extends BaseCompiler {
 
     isCfgCompiler(/*compilerVersion*/) {
         return true;
+    }
+
+    parseCompilationOutput(result, inputFilename) {
+        result.stdout = parseOutput(result.stdout, inputFilename);
+        result.stderr = parseOutput(result.stderr, inputFilename);
     }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,6 +91,22 @@ export function expandTabs(line) {
  * @inner
  */
 
+const ansiColoursRe = /\x1B\[[\d;]*[Km]/g;
+
+function _parseOutputLine(line, inputFilename, pathPrefix) {
+    line = line.split('<stdin>').join('<source>');
+    if (pathPrefix) line = line.replace(pathPrefix, '');
+    if (inputFilename) {
+        line = line.split(inputFilename).join('<source>');
+
+        if (inputFilename.indexOf('./') === 0) {
+            line = line.split('/home/ubuntu/' + inputFilename.substr(2)).join('<source>');
+            line = line.split('/home/ce/' + inputFilename.substr(2)).join('<source>');
+        }
+    }
+    return line;
+}
+
 /***
  *
  * @param lines
@@ -101,25 +117,56 @@ export function expandTabs(line) {
 export function parseOutput(lines, inputFilename, pathPrefix) {
     const re = /^\s*<source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
     const result = [];
-    eachLine(lines, function (line) {
-        line = line.split('<stdin>').join('<source>');
-        if (pathPrefix) line = line.replace(pathPrefix, '');
-        if (inputFilename) {
-            line = line.split(inputFilename).join('<source>');
-
-            if (inputFilename.indexOf('./') === 0) {
-                line = line.split('/home/ubuntu/' + inputFilename.substr(2)).join('<source>');
-                line = line.split('/home/ce/' + inputFilename.substr(2)).join('<source>');
-            }
-        }
+    eachLine(lines, line => {
+        line = _parseOutputLine(line, inputFilename, pathPrefix);
         if (line !== null) {
             const lineObj = {text: line};
-            const match = line.replace(/\x1B\[[\d;]*[Km]/g, '').match(re);
+            const match = line.replace(ansiColoursRe, '').match(re);
             if (match) {
                 lineObj.tag = {
                     line: parseInt(match[1]),
                     column: parseInt(match[3] || '0'),
                     text: match[4].trim(),
+                };
+            }
+            result.push(lineObj);
+        }
+    });
+    return result;
+}
+
+/***
+ *
+ * @param lines
+ * @param inputFilename
+ * @param pathPrefix
+ * @returns {lineObj[]}
+ */
+export function parseRustOutput(lines, inputFilename, pathPrefix) {
+    const re = /^ --> <source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+    const result = [];
+    eachLine(lines, line => {
+        line = _parseOutputLine(line, inputFilename, pathPrefix);
+        if (line !== null) {
+            const lineObj = {text: line};
+            const match = line.replace(ansiColoursRe, '').match(re);
+
+            if (match) {
+                const line = parseInt(match[1]);
+                const column = parseInt(match[3] || '0');
+
+                const previous = result.pop();
+                previous.tag = {
+                    line,
+                    column,
+                    text: previous.text.replace(ansiColoursRe, ''),
+                };
+                result.push(previous);
+
+                lineObj.tag = {
+                    line,
+                    column,
+                    text: '', // Left empty so that it does not show up in the editor
                 };
             }
             result.push(lineObj);


### PR DESCRIPTION
I've pushed and opened this as a PR so I can be shown how to best approach some of this changes.

Obviously simply duplicating the parseOutput code is not good, but other than making it a compiler property
 and overriding it in Rust, I could not think of any good solutions to avoid it.

Also, this assumes that the previous message only spans 1 line, which I don't know how good of an asumption it is.
Also, only the message links on mouseover to the code line. Should the `<source>` tag itself also link back?

¿Should the `warning:` prefixes be visible in the UI, or should we remove that bit?

Closes #2757 once it's finished