### PR TITLE
Config changes

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -17,5 +17,6 @@
     </inspection_tool>
     <inspection_tool class="JSLastCommaInArrayLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSLastCommaInObjectLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedProperty" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -16,6 +16,7 @@ group.gcc86.baseName=x86-64 gcc
 group.gcc86.isSemVer=true
 group.gcc86.unwiseOptions=-march=native
 group.gcc86.supportsPVS-Studio=true
+
 compiler.g412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/g++
 compiler.g412.semver=4.1.2
 compiler.g412.supportsBinary=false
@@ -163,6 +164,7 @@ compiler.g63.needsMulti=true
 compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
+################################
 # Clang for x86
 group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang1200:clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_patmat:clang_embed
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
@@ -174,6 +176,7 @@ group.clang.isSemVer=true
 group.clang.compilerType=clang
 group.clang.unwiseOptions=-march=native
 group.clang.supportsPVS-Studio=true
+
 # Ancient clangs don't support GCC toolchain option
 compiler.clang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-11_10/bin/clang++
 compiler.clang30.alias=/usr/bin/clang++
@@ -336,59 +339,30 @@ compiler.clang_embed.semver=(std::embed)
 compiler.clang_embed.options=-std=c++2a -stdlib=libc++
 compiler.clang_embed.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
-
+################################
 # Clang for Arm
-# Provides 32- and 64-bit menu items for clang-9, clang-10 and trunk
+# Provides 32- menu items for clang-9, clang-10 and trunk
 group.armclang32.groupName=Arm 32-bit clang
 group.armclang32.compilers=armv7-clang900:armv7-clang901:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang1101:armv7-clang-trunk
 group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
 group.armclang32.instructionSet=arm32
-
-group.armclang64.groupName=Arm 64-bit clang
-group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang-trunk:armv8-full-clang-trunk
-group.armclang64.isSemVer=true
-group.armclang64.compilerType=clang
-group.armclang64.supportsExecute=false
-group.armclang64.instructionSet=aarch64
-
 compiler.armv7-clang1101.name=armv7-a clang 11.0.1
 compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv7-clang1101.semver=11.0.1
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1101.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-
-compiler.armv8-clang1101.name=armv8-a clang 11.0.1
-compiler.armv8-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
-compiler.armv8-clang1101.semver=11.0.1
-# Arm v8-a
-compiler.armv8-clang1101.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-
 compiler.armv7-clang1100.name=armv7-a clang 11.0.0
 compiler.armv7-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.armv7-clang1100.semver=11.0.0
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1100.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-
-compiler.armv8-clang1100.name=armv8-a clang 11.0.0
-compiler.armv8-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
-compiler.armv8-clang1100.semver=11.0.0
-# Arm v8-a
-compiler.armv8-clang1100.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-
 compiler.armv7-clang1001.name=armv7-a clang 10.0.1
 compiler.armv7-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
 compiler.armv7-clang1001.semver=10.0.1
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1001.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-
-compiler.armv8-clang1001.name=armv8-a clang 10.0.1
-compiler.armv8-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
-compiler.armv8-clang1001.semver=10.0.1
-# Arm v8-a
-compiler.armv8-clang1001.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-
 compiler.armv7-clang1000.name=armv7-a clang 10.0.0
 compiler.armv7-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.armv7-clang1000.semver=10.0.0
@@ -397,28 +371,11 @@ compiler.armv7-clang1000.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/
 # This compiler was originally named with only a major version number.  An alias
 # of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv7-clang1000.alias=armv7-clang-10
-
-compiler.armv8-clang1000.name=armv8-a clang 10.0.0
-compiler.armv8-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
-compiler.armv8-clang1000.semver=10.0.0
-# Arm v8-a
-compiler.armv8-clang1000.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-# This compiler was originally named with only a major version number.  An alias
-# of this name needs to be maintained to allow old URLs to continue to work
-compiler.armv8-clang1000.alias=armv8-clang-10
-
 compiler.armv7-clang901.name=armv7-a clang 9.0.1
 compiler.armv7-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.armv7-clang901.semver=9.0.1
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-clang901.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-
-compiler.armv8-clang901.name=armv8-a clang 9.0.1
-compiler.armv8-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
-compiler.armv8-clang901.semver=9.0.1
-# Arm v8-a
-compiler.armv8-clang901.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-
 compiler.armv7-clang900.name=armv7-a clang 9.0.0
 compiler.armv7-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.armv7-clang900.semver=9.0.0
@@ -427,16 +384,6 @@ compiler.armv7-clang900.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/c
 # This compiler was originally named with only a major version number.  An alias
 # of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv7-clang900.alias=armv7-clang-9
-
-compiler.armv8-clang900.name=armv8-a clang 9.0.0
-compiler.armv8-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
-compiler.armv8-clang900.semver=9.0.0
-# Arm v8-a
-compiler.armv8-clang900.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-# This compiler was originally named with only a major version number.  An alias
-# of this name needs to be maintained to allow old URLs to continue to work
-compiler.armv8-clang900.alias=armv8-clang-9
-
 compiler.armv7-clang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv7-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -445,6 +392,51 @@ compiler.armv7-clang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
+################################
+# Clang for Arm
+# Provides 64- menu items for clang-9, clang-10 and trunk
+group.armclang64.groupName=Arm 64-bit clang
+group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang-trunk:armv8-full-clang-trunk
+group.armclang64.isSemVer=true
+group.armclang64.compilerType=clang
+group.armclang64.supportsExecute=false
+group.armclang64.instructionSet=aarch64
+compiler.armv8-clang1101.name=armv8-a clang 11.0.1
+compiler.armv8-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
+compiler.armv8-clang1101.semver=11.0.1
+# Arm v8-a
+compiler.armv8-clang1101.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1100.name=armv8-a clang 11.0.0
+compiler.armv8-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
+compiler.armv8-clang1100.semver=11.0.0
+# Arm v8-a
+compiler.armv8-clang1100.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1001.name=armv8-a clang 10.0.1
+compiler.armv8-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
+compiler.armv8-clang1001.semver=10.0.1
+# Arm v8-a
+compiler.armv8-clang1001.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1000.name=armv8-a clang 10.0.0
+compiler.armv8-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
+compiler.armv8-clang1000.semver=10.0.0
+# Arm v8-a
+compiler.armv8-clang1000.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv8-clang1000.alias=armv8-clang-10
+compiler.armv8-clang901.name=armv8-a clang 9.0.1
+compiler.armv8-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
+compiler.armv8-clang901.semver=9.0.1
+# Arm v8-a
+compiler.armv8-clang901.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang900.name=armv8-a clang 9.0.0
+compiler.armv8-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
+compiler.armv8-clang900.semver=9.0.0
+# Arm v8-a
+compiler.armv8-clang900.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+# This compiler was originally named with only a major version number.  An alias
+# of this name needs to be maintained to allow old URLs to continue to work
+compiler.armv8-clang900.alias=armv8-clang-9
 compiler.armv8-clang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -452,7 +444,6 @@ compiler.armv8-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/obj
 compiler.armv8-clang-trunk.semver=(trunk)
 # Arm v8-a
 compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-
 compiler.armv8-full-clang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-full-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -464,6 +455,7 @@ compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchai
 # allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
+################################
 # Clang for RISC-V
 group.rvclang.compilers=rv32-clang:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900:rv64-clang:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
 group.rvclang.groupName=RISC-V Clang
@@ -478,7 +470,6 @@ compiler.rv32-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 compiler.rv32-clang.supportsBinary=true
-
 compiler.rv32-clang1101.name=RISC-V rv32gc clang 11.0.1
 compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
 compiler.rv32-clang1101.semver=11.0.1
@@ -486,7 +477,6 @@ compiler.rv32-clang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv32-clang1101.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1101.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 compiler.rv32-clang1101.supportsBinary=true
-
 compiler.rv32-clang1100.name=RISC-V rv32gc clang 11.0.0
 compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv32-clang1100.semver=11.0.0
@@ -494,7 +484,6 @@ compiler.rv32-clang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv32-clang1100.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1100.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 compiler.rv32-clang1100.supportsBinary=true
-
 compiler.rv32-clang1001.name=RISC-V rv32gc clang 10.0.1
 compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv32-clang1001.semver=10.0.1
@@ -502,7 +491,6 @@ compiler.rv32-clang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang1001.supportsBinary=true
-
 compiler.rv32-clang1000.name=RISC-V rv32gc clang 10.0.0
 compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv32-clang1000.semver=10.0.0
@@ -510,7 +498,6 @@ compiler.rv32-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang1000.supportsBinary=true
-
 compiler.rv32-clang901.name=RISC-V rv32gc clang 9.0.1
 compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
 compiler.rv32-clang901.semver=9.0.1
@@ -518,7 +505,6 @@ compiler.rv32-clang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-clang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang901.supportsBinary=true
-
 compiler.rv32-clang900.name=RISC-V rv32gc clang 9.0.0
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-clang900.semver=9.0.0
@@ -526,7 +512,6 @@ compiler.rv32-clang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-clang900.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang900.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang900.supportsBinary=true
-
 compiler.rv64-clang.name=RISC-V rv64gc clang (trunk)
 compiler.rv64-clang.alias=rv64clang
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -535,7 +520,6 @@ compiler.rv64-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.supportsBinary=true
-
 compiler.rv64-clang1101.name=RISC-V rv64gc clang 11.0.1
 compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
 compiler.rv64-clang1101.semver=11.0.1
@@ -543,7 +527,6 @@ compiler.rv64-clang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv64-clang1101.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1101.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang1101.supportsBinary=true
-
 compiler.rv64-clang1100.name=RISC-V rv64gc clang 11.0.0
 compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv64-clang1100.semver=11.0.0
@@ -551,7 +534,6 @@ compiler.rv64-clang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv64-clang1100.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1100.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang1100.supportsBinary=true
-
 compiler.rv64-clang1001.name=RISC-V rv64gc clang 10.0.1
 compiler.rv64-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv64-clang1001.semver=10.0.1
@@ -559,7 +541,6 @@ compiler.rv64-clang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv64-clang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang1001.supportsBinary=true
-
 compiler.rv64-clang1000.name=RISC-V rv64gc clang 10.0.0
 compiler.rv64-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv64-clang1000.semver=10.0.0
@@ -567,7 +548,6 @@ compiler.rv64-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++fil
 compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang1000.supportsBinary=true
-
 compiler.rv64-clang901.name=RISC-V rv64gc clang 9.0.1
 compiler.rv64-clang901.semver=9.0.1
 compiler.rv64-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
@@ -575,7 +555,6 @@ compiler.rv64-clang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv64-clang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang901.supportsBinary=true
-
 compiler.rv64-clang900.name=RISC-V rv64gc clang 9.0.0
 compiler.rv64-clang900.semver=9.0.0
 compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
@@ -584,7 +563,7 @@ compiler.rv64-clang900.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv6
 compiler.rv64-clang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang900.supportsBinary=true
 
-
+################################
 # Clang for WebAssembly
 group.wasmclang.compilers=wasm32clang
 group.wasmclang.groupName=Clang WebAssembly
@@ -595,6 +574,7 @@ compiler.wasm32clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.wasm32clang.name=WebAssembly clang (trunk)
 compiler.wasm32clang.options=-target wasm32
 
+################################
 # icc for x86
 group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120
 group.icc.intelAsm=-masm=intel
@@ -642,6 +622,7 @@ compiler.icc202120.libPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compile
 compiler.icc202120.semver=2021.2.0
 compiler.icc202120.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
+################################
 # icx for x86
 group.icx.compilers=icx202112:icx202120
 group.icx.intelAsm=-masm=intel
@@ -662,6 +643,7 @@ compiler.icx202120.libPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compile
 compiler.icx202120.semver=2021.2.0
 compiler.icx202120.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
+################################
 # zapcc
 group.zapcc.compilers=zapcc190308
 group.zapcc.intelAsm=-mllvm --x86-asm-syntax=intel
@@ -840,6 +822,7 @@ compiler.arm64gtrunk.semver=trunk
 group.kalray.compilers=kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
+
 # kvx versions are different from the GCC they wrap
 compiler.kvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-g++
 compiler.kvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
@@ -878,6 +861,7 @@ group.platspec.compilers=frc2019:frc2020:raspbian9:raspbian10:arduinouno189:ardu
 group.platspec.groupName=Platform Specific Compilers
 group.platspec.isSemVer=true
 group.platspec.includeFlag=-I
+
 compiler.frc2019.exe=/opt/compiler-explorer/arm/frc2019-6.3.0/roborio/bin/arm-frc2019-linux-gnueabi-g++
 compiler.frc2019.name=FRC 2019
 compiler.frc2019.semver=6.3
@@ -912,6 +896,7 @@ group.msp.groupName=MSP GCC
 group.msp.baseName=MSP430 gcc
 group.msp.isSemVer=true
 group.msp.supportsBinary=false
+
 compiler.msp430g453.exe=/opt/compiler-explorer/msp430/gcc-4.5.3/bin/msp430-g++
 compiler.msp430g453.alias=/usr/bin/msp430-g++
 compiler.msp430g453.semver=4.5.3
@@ -927,6 +912,7 @@ group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
 group.avr.supportsBinary=true
+
 compiler.avrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-g++
 compiler.avrg454.alias=avrg453
 compiler.avrg454.semver=4.5.4
@@ -1123,7 +1109,61 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:cppitertools:ctbignum:gsl:entt:expected_lite:highway:nlohmann_json:jsoncpp:tomlplusplus:trompeloeil:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:pugixml:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype:pipes:spy:libuv:simde:fastor:cctz:crosscables:lua:sol2:unifex:immer:enoki:spdlog:python:tts:lexy:eve:nsimd:ztdtext:type_safe:lager:zug:ofw:kiwaku
+libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:glm:gnufs:googletest:gsl:hedley:hfsm:highway:immer:jsoncpp:kiwaku:kvasir:lager:lexy:libguarded:libuv:llvm:llvmfs:lua:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:seastar:simde:sol2:spdlog:spy:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xsimd:xtensor:xtl:ztdtext:zug
+
+libs.abseil.name=Abseil
+libs.abseil.versions=trunk
+libs.abseil.url=https://abseil.io/
+libs.abseil.staticliblink=absl_bad_any_cast_impl:absl_failure_signal_handler:absl_examine_stack:absl_flags_parse:absl_flags_usage:absl_flags_usage_internal:absl_flags:absl_flags_internal:absl_flags_marshalling:absl_flags_reflection:absl_flags_private_handle_accessor:absl_flags_commandlineflag:absl_flags_commandlineflag_internal:absl_flags_config:absl_flags_program_name:absl_leak_check_disable:absl_leak_check:absl_hash:absl_city:absl_periodic_sampler:absl_random_internal_distribution_test_util:absl_random_distributions:absl_random_seed_sequences:absl_random_internal_pool_urbg:absl_random_internal_randen:absl_random_internal_randen_hwaes:absl_random_internal_randen_hwaes_impl:absl_random_internal_randen_slow:absl_random_internal_platform:absl_random_internal_seed_material:absl_random_seed_gen_exception:absl_raw_hash_set:absl_hashtablez_sampler:absl_exponential_biased:absl_scoped_set_env:absl_statusor:absl_status:absl_cord:absl_bad_optional_access:absl_strerror:absl_str_format_internal:absl_synchronization:absl_graphcycles_internal:absl_stacktrace:absl_symbolize:absl_debugging_internal:absl_demangle_internal:absl_malloc_internal:absl_time:absl_civil_time:absl_strings:absl_strings_internal:rt:absl_base:absl_spinlock_wait:absl_int128:absl_throw_delegate:absl_time_zone:absl_bad_variant_access:absl_raw_logging_internal:absl_log_severity:absl_wyhash
+libs.abseil.versions.trunk.version=trunk
+libs.abseil.versions.trunk.path=/opt/compiler-explorer/libs/abseil
+
+libs.benchmark.name=Google Benchmark
+libs.benchmark.versions=trunk:120:130:140:141:150
+libs.benchmark.url=https://github.com/google/benchmark
+libs.benchmark.staticliblink=benchmark
+libs.benchmark.versions.trunk.version=trunk
+libs.benchmark.versions.trunk.path=/opt/compiler-explorer/libs/google-benchmark/trunk/include
+libs.benchmark.versions.120.version=1.2.0
+libs.benchmark.versions.120.path=/opt/compiler-explorer/libs/google-benchmark/v1.2.0/include
+libs.benchmark.versions.130.version=1.3.0
+libs.benchmark.versions.130.path=/opt/compiler-explorer/libs/google-benchmark/v1.3.0/include
+libs.benchmark.versions.140.version=1.4.0
+libs.benchmark.versions.140.path=/opt/compiler-explorer/libs/google-benchmark/v1.4.0/include
+libs.benchmark.versions.141.version=1.4.1
+libs.benchmark.versions.141.path=/opt/compiler-explorer/libs/google-benchmark/v1.4.1/include
+libs.benchmark.versions.150.version=1.5.0
+libs.benchmark.versions.150.path=/opt/compiler-explorer/libs/google-benchmark/v1.5.0/include
+
+libs.benri.name=benri
+libs.benri.description=Compile time checking of physical quantities.
+libs.benri.versions=trunk:201:211
+libs.benri.url=https://github.com/jansende/benri
+libs.benri.versions.trunk.version=trunk
+libs.benri.versions.trunk.path=/opt/compiler-explorer/libs/benri/trunk/include
+libs.benri.versions.201.version=2.0.1
+libs.benri.versions.201.path=/opt/compiler-explorer/libs/benri/v2.0.1/include
+libs.benri.versions.211.version=2.1.1
+libs.benri.versions.211.path=/opt/compiler-explorer/libs/benri/v2.1.1/include
+
+libs.blaze.name=Blaze
+libs.blaze.versions=trunk:33:34:35:36:37:38
+libs.blaze.url=https://bitbucket.org/blaze-lib/blaze
+libs.blaze.versions.trunk.version=trunk
+libs.blaze.versions.trunk.path=/opt/compiler-explorer/libs/blaze/trunk
+libs.blaze.versions.33.version=3.3
+libs.blaze.versions.33.path=/opt/compiler-explorer/libs/blaze/v3.3
+libs.blaze.versions.34.version=3.4
+libs.blaze.versions.34.path=/opt/compiler-explorer/libs/blaze/v3.4
+libs.blaze.versions.35.version=3.5
+libs.blaze.versions.35.path=/opt/compiler-explorer/libs/blaze/v3.5
+libs.blaze.versions.36.version=3.6
+libs.blaze.versions.36.path=/opt/compiler-explorer/libs/blaze/v3.6
+libs.blaze.versions.37.version=3.7
+libs.blaze.versions.37.path=/opt/compiler-explorer/libs/blaze/v3.7
+libs.blaze.versions.38.version=3.8
+libs.blaze.versions.38.path=/opt/compiler-explorer/libs/blaze/v3.8
+
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172:173:174:175:176
 libs.boost.url=https://www.boost.org
@@ -1153,6 +1193,7 @@ libs.boost.versions.175.version=1.75.0
 libs.boost.versions.175.path=/opt/compiler-explorer/libs/boost_1_75_0
 libs.boost.versions.176.version=1.76.0
 libs.boost.versions.176.path=/opt/compiler-explorer/libs/boost_1_76_0
+
 libs.brigand.name=Brigand
 libs.brigand.versions=trunk:130
 libs.brigand.url=https://github.com/edouarda/brigand
@@ -1160,447 +1201,7 @@ libs.brigand.versions.trunk.version=trunk
 libs.brigand.versions.130.version=1.3.0
 libs.brigand.versions.trunk.path=/opt/compiler-explorer/libs/brigand/trunk/include
 libs.brigand.versions.130.path=/opt/compiler-explorer/libs/brigand/1.3.0
-libs.cppitertools.name=cppitertools
-libs.cppitertools.versions=trunk:100:200
-libs.cppitertools.url=https://github.com/ryanhaining/cppitertools
-libs.cppitertools.versions.trunk.version=trunk
-libs.cppitertools.versions.trunk.path=/opt/compiler-explorer/libs/cppitertools/trunk
-libs.cppitertools.versions.100.version=v1.0
-libs.cppitertools.versions.100.path=/opt/compiler-explorer/libs/cppitertools/v1.0
-libs.cppitertools.versions.200.version=v2.0
-libs.cppitertools.versions.200.path=/opt/compiler-explorer/libs/cppitertools/v2.0
-libs.ctbignum.name=ctbignum
-libs.ctbignum.versions=trunk
-libs.ctbignum.url=https://github.com/niekbouman/ctbignum
-libs.ctbignum.versions.trunk.version=trunk
-libs.ctbignum.versions.trunk.path=/opt/compiler-explorer/libs/ctbignum/include
-libs.kvasir.name=Kvasir::mpl
-libs.kvasir.versions=trunk
-libs.kvasir.url=https://github.com/kvasir-io/mpl
-libs.kvasir.versions.trunk.version=trunk
-# compiler-explorer/compiler-explorer/issues/598
-libs.kvasir.versions.trunk.path=/opt/compiler-explorer/libs/kvasir/mpl/trunk/src/kvasir:/opt/compiler-explorer/libs/kvasir/mpl/trunk/src
-libs.cmcstl2.name=cmcstl2
-libs.cmcstl2.versions=trunk
-libs.cmcstl2.url=https://github.com/CaseyCarter/cmcstl2
-libs.cmcstl2.versions.trunk.version=trunk
-libs.cmcstl2.versions.trunk.path=/opt/compiler-explorer/libs/cmcstl2/include
-libs.gsl.name=GSL
-libs.gsl.description=Guidelines Support Library
-libs.gsl.url=https://github.com/Microsoft/GSL
-# Sorry Martin!
-libs.gsl.versions=trunk:lite:100:200:210:300:301
-libs.gsl.versions.trunk.version=trunk
-libs.gsl.versions.trunk.path=/opt/compiler-explorer/libs/GSL/trunk/include
-libs.gsl.versions.100.version=1.0.0
-libs.gsl.versions.100.path=/opt/compiler-explorer/libs/GSL/v1.0.0/include
-libs.gsl.versions.200.version=2.0.0
-libs.gsl.versions.200.path=/opt/compiler-explorer/libs/GSL/v2.0.0/include
-libs.gsl.versions.210.version=2.1.0
-libs.gsl.versions.210.path=/opt/compiler-explorer/libs/GSL/v2.1.0/include
-libs.gsl.versions.300.version=3.0.0
-libs.gsl.versions.300.path=/opt/compiler-explorer/libs/GSL/v3.0.0/include
-libs.gsl.versions.301.version=3.0.1
-libs.gsl.versions.301.path=/opt/compiler-explorer/libs/GSL/v3.0.1/include
-libs.gsl.versions.lite.version=lite
-libs.gsl.versions.lite.path=/opt/compiler-explorer/libs/gsl-lite/include
-libs.entt.name=entt
-libs.entt.url=https://github.com/skypjack/entt
-libs.entt.versions=trunk:350:360
-libs.entt.versions.350.version=3.5.0
-libs.entt.versions.350.path=/opt/compiler-explorer/libs/entt/v3.5.0/src
-libs.entt.versions.360.version=3.6.0
-libs.entt.versions.360.path=/opt/compiler-explorer/libs/entt/v3.6.0/src
-libs.entt.versions.trunk.version=trunk
-libs.entt.versions.trunk.path=/opt/compiler-explorer/libs/entt/trunk/src
-libs.expected_lite.versions=001:010:trunk
-libs.expected_lite.url=https://github.com/martinmoene/expected-lite
-libs.expected_lite.name=expected-lite
-libs.expected_lite.description=Expected for C++11 and greater
-libs.expected_lite.versions.001.version=0.0.1
-libs.expected_lite.versions.001.path=/opt/compiler-explorer/libs/expected-lite/v0.0.1/include
-libs.expected_lite.versions.010.version=0.1.0
-libs.expected_lite.versions.010.path=/opt/compiler-explorer/libs/expected-lite/v0.1.0/include
-libs.expected_lite.versions.trunk.version=trunk
-libs.expected_lite.versions.trunk.path=/opt/compiler-explorer/libs/expected-lite/trunk/include
-libs.highway.name=Highway
-libs.highway.versions=trunk:0_12_2
-libs.highway.url=https://github.com/google/highway
-libs.highway.staticliblink=hwy
-libs.highway.versions.trunk.version=trunk
-libs.highway.versions.trunk.path=/opt/compiler-explorer/libs/highway/trunk
-libs.highway.versions.0_12_2.version=0.12.2
-libs.highway.versions.0_12_2.path=/opt/compiler-explorer/libs/highway/0.12.2
-libs.nlohmann_json.name=nlohmann::json
-libs.nlohmann_json.versions=trunk:360:312:211
-libs.nlohmann_json.url=https://github.com/nlohmann/json
-libs.nlohmann_json.versions.trunk.version=trunk
-libs.nlohmann_json.versions.trunk.path=/opt/compiler-explorer/libs/nlohmann_json/trunk/single_include
-libs.nlohmann_json.versions.360.version=3.6.0
-libs.nlohmann_json.versions.360.path=/opt/compiler-explorer/libs/nlohmann_json/v3.6.0/single_include
-libs.nlohmann_json.versions.312.version=3.1.2
-libs.nlohmann_json.versions.312.path=/opt/compiler-explorer/libs/nlohmann_json/v3.1.2/single_include
-libs.nlohmann_json.versions.211.version=2.1.1
-libs.nlohmann_json.versions.211.path=/opt/compiler-explorer/libs/nlohmann_json/v2.1.1/src
-libs.jsoncpp.name=JsonCpp
-libs.jsoncpp.description=JsonCpp is a C++ library that allows manipulating JSON values, including serialization and deserialization to and from strings
-libs.jsoncpp.examples=o1W1jofna:rfPajea5G
-libs.jsoncpp.versions=194
-libs.jsoncpp.url=https://github.com/open-source-parsers/jsoncpp
-libs.jsoncpp.staticliblink=jsoncpp
-libs.jsoncpp.versions.194.version=1.9.4
-libs.jsoncpp.versions.194.path=/opt/compiler-explorer/libs/jsoncpp/1.9.4/include
-libs.tomlplusplus.name=toml++
-libs.tomlplusplus.versions=trunk:133:124
-libs.tomlplusplus.description=TOML parser and serializer for modern C++
-libs.tomlplusplus.url=https://marzer.github.io/tomlplusplus
-libs.tomlplusplus.versions.trunk.version=trunk
-libs.tomlplusplus.versions.trunk.path=/opt/compiler-explorer/libs/tomlplusplus/trunk/include
-libs.tomlplusplus.versions.133.version=1.3.3
-libs.tomlplusplus.versions.133.path=/opt/compiler-explorer/libs/tomlplusplus/v1.3.3/include
-libs.tomlplusplus.versions.124.version=1.2.4
-libs.tomlplusplus.versions.124.path=/opt/compiler-explorer/libs/tomlplusplus/v1.2.4/include
-libs.trompeloeil.name=trompeloeil
-libs.trompeloeil.versions=41:40:39:38:37:36:35:34:33:32:31:30:29:28
-libs.trompeloeil.url=https://github.com/rollbear/trompeloeil
-libs.trompeloeil.versions.41.path=/opt/compiler-explorer/libs/trompeloeil/v41/include
-libs.trompeloeil.versions.41.version=v41
-libs.trompeloeil.versions.40.path=/opt/compiler-explorer/libs/trompeloeil/v40/include
-libs.trompeloeil.versions.40.version=v40
-libs.trompeloeil.versions.39.path=/opt/compiler-explorer/libs/trompeloeil/v39/include
-libs.trompeloeil.versions.39.version=v39
-libs.trompeloeil.versions.38.path=/opt/compiler-explorer/libs/trompeloeil/v38/include
-libs.trompeloeil.versions.38.version=v38
-libs.trompeloeil.versions.37.path=/opt/compiler-explorer/libs/trompeloeil/v37/include
-libs.trompeloeil.versions.37.version=v37
-libs.trompeloeil.versions.36.path=/opt/compiler-explorer/libs/trompeloeil/v36/include
-libs.trompeloeil.versions.36.version=v36
-libs.trompeloeil.versions.35.path=/opt/compiler-explorer/libs/trompeloeil/v35/include
-libs.trompeloeil.versions.35.version=v35
-libs.trompeloeil.versions.34.path=/opt/compiler-explorer/libs/trompeloeil/v34/include
-libs.trompeloeil.versions.34.version=v34
-libs.trompeloeil.versions.33.path=/opt/compiler-explorer/libs/trompeloeil/v33/include
-libs.trompeloeil.versions.33.version=v33
-libs.trompeloeil.versions.32.path=/opt/compiler-explorer/libs/trompeloeil/v32/include
-libs.trompeloeil.versions.32.version=v32
-libs.trompeloeil.versions.31.path=/opt/compiler-explorer/libs/trompeloeil/v31/include
-libs.trompeloeil.versions.31.version=v31
-libs.trompeloeil.versions.30.path=/opt/compiler-explorer/libs/trompeloeil/v30/include
-libs.trompeloeil.versions.30.version=v30
-libs.trompeloeil.versions.29.path=/opt/compiler-explorer/libs/trompeloeil/v29/include
-libs.trompeloeil.versions.29.version=v29
-libs.trompeloeil.versions.28.path=/opt/compiler-explorer/libs/trompeloeil/v28/include
-libs.trompeloeil.versions.28.version=v28
-# OpenCV disabled for now, needs more installation work, any many more paths
-#libs.opencv.name=OpenCV
-#libs.opencv.versions=trunk
-#libs.opencv.url=https://opencv.org/
-#libs.opencv.versions.trunk.version=trunk
-#libs.opencv.versions.trunk.path=/opt/compiler-explorer/libs/opencv/include
-libs.xtensor.name=xtensor
-libs.xtensor.versions=trunk:0194:0182:0174
-libs.xtensor.url=http://xtensor.readthedocs.io
-libs.xtensor.versions.trunk.version=trunk
-libs.xtensor.versions.trunk.path=/opt/compiler-explorer/libs/xtensor/trunk/include
-libs.xtensor.versions.0194.version=0.19.4
-libs.xtensor.versions.0194.path=/opt/compiler-explorer/libs/xtensor/0.19.4/include
-libs.xtensor.versions.0182.version=0.18.2
-libs.xtensor.versions.0182.path=/opt/compiler-explorer/libs/xtensor/0.18.2/include
-libs.xtensor.versions.0174.version=0.17.4
-libs.xtensor.versions.0174.path=/opt/compiler-explorer/libs/xtensor/0.17.4/include
-libs.xtl.name=xtl
-libs.xtl.versions=trunk:053:0416
-libs.xtl.url=http://xtl.readthedocs.io
-libs.xtl.versions.trunk.version=trunk
-libs.xtl.versions.trunk.path=/opt/compiler-explorer/libs/xtl/trunk/include
-libs.xtl.versions.053.version=0.5.3
-libs.xtl.versions.053.path=/opt/compiler-explorer/libs/xtl/0.5.3/include
-libs.xtl.versions.0416.version=0.4.16
-libs.xtl.versions.0416.path=/opt/compiler-explorer/libs/xtl/0.4.16/include
-libs.xsimd.name=xsimd
-libs.xsimd.versions=trunk:700:614
-libs.xsimd.url=http://xsimd.readthedocs.io
-libs.xsimd.versions.trunk.version=trunk
-libs.xsimd.versions.trunk.path=/opt/compiler-explorer/libs/xsimd/trunk/include
-libs.xsimd.versions.700.version=7.0.0
-libs.xsimd.versions.700.path=/opt/compiler-explorer/libs/xsimd/7.0.0/include
-libs.xsimd.versions.614.version=6.1.4
-libs.xsimd.versions.614.path=/opt/compiler-explorer/libs/xsimd/6.1.4/include
-libs.abseil.name=Abseil
-libs.abseil.versions=trunk
-libs.abseil.url=https://abseil.io/
-libs.abseil.staticliblink=absl_bad_any_cast_impl:absl_failure_signal_handler:absl_examine_stack:absl_flags_parse:absl_flags_usage:absl_flags_usage_internal:absl_flags:absl_flags_internal:absl_flags_marshalling:absl_flags_reflection:absl_flags_private_handle_accessor:absl_flags_commandlineflag:absl_flags_commandlineflag_internal:absl_flags_config:absl_flags_program_name:absl_leak_check_disable:absl_leak_check:absl_hash:absl_city:absl_periodic_sampler:absl_random_internal_distribution_test_util:absl_random_distributions:absl_random_seed_sequences:absl_random_internal_pool_urbg:absl_random_internal_randen:absl_random_internal_randen_hwaes:absl_random_internal_randen_hwaes_impl:absl_random_internal_randen_slow:absl_random_internal_platform:absl_random_internal_seed_material:absl_random_seed_gen_exception:absl_raw_hash_set:absl_hashtablez_sampler:absl_exponential_biased:absl_scoped_set_env:absl_statusor:absl_status:absl_cord:absl_bad_optional_access:absl_strerror:absl_str_format_internal:absl_synchronization:absl_graphcycles_internal:absl_stacktrace:absl_symbolize:absl_debugging_internal:absl_demangle_internal:absl_malloc_internal:absl_time:absl_civil_time:absl_strings:absl_strings_internal:rt:absl_base:absl_spinlock_wait:absl_int128:absl_throw_delegate:absl_time_zone:absl_bad_variant_access:absl_raw_logging_internal:absl_log_severity:absl_wyhash
-libs.abseil.versions.trunk.version=trunk
-libs.abseil.versions.trunk.path=/opt/compiler-explorer/libs/abseil
-libs.blaze.name=Blaze
-libs.blaze.versions=trunk:33:34:35:36:37:38
-libs.blaze.url=https://bitbucket.org/blaze-lib/blaze
-libs.blaze.versions.trunk.version=trunk
-libs.blaze.versions.trunk.path=/opt/compiler-explorer/libs/blaze/trunk
-libs.blaze.versions.33.version=3.3
-libs.blaze.versions.33.path=/opt/compiler-explorer/libs/blaze/v3.3
-libs.blaze.versions.34.version=3.4
-libs.blaze.versions.34.path=/opt/compiler-explorer/libs/blaze/v3.4
-libs.blaze.versions.35.version=3.5
-libs.blaze.versions.35.path=/opt/compiler-explorer/libs/blaze/v3.5
-libs.blaze.versions.36.version=3.6
-libs.blaze.versions.36.path=/opt/compiler-explorer/libs/blaze/v3.6
-libs.blaze.versions.37.version=3.7
-libs.blaze.versions.37.path=/opt/compiler-explorer/libs/blaze/v3.7
-libs.blaze.versions.38.version=3.8
-libs.blaze.versions.38.path=/opt/compiler-explorer/libs/blaze/v3.8
-libs.ctre.name=CTRE
-libs.ctre.description=Compile Time Regular Expressions
-libs.ctre.versions=trunk:ecma-unicode:dfa:v2
-libs.ctre.url=https://github.com/hanickadot/compile-time-regular-expressions
-libs.ctre.examples=5U67_e:x64CVp:PKTiCC
-libs.ctre.versions.ecma-unicode.version=ecma-unicode
-libs.ctre.versions.ecma-unicode.path=/opt/compiler-explorer/libs/ctre/ecma-unicode/include
-libs.ctre.versions.dfa.version=dfa
-libs.ctre.versions.dfa.path=/opt/compiler-explorer/libs/ctre/dfa/include
-libs.ctre.versions.trunk.version=trunk
-libs.ctre.versions.trunk.path=/opt/compiler-explorer/libs/ctre/main/include
-libs.ctre.versions.v2.version=v2
-libs.ctre.versions.v2.path=/opt/compiler-explorer/libs/ctre/v2/include
-libs.spy.name=SPY
-libs.spy.description=C++17 constexpr settings detectors
-libs.spy.versions=trunk:v004:v100
-libs.spy.url=https://github.com/jfalcou/spy
-libs.spy.versions.trunk.version=trunk
-libs.spy.versions.trunk.path=/opt/compiler-explorer/libs/spy/trunk/include
-libs.spy.versions.v004.version=v0.0.4
-libs.spy.versions.v004.path=/opt/compiler-explorer/libs/spy/0.0.4/include
-libs.spy.versions.v004.alias=v003
-libs.spy.versions.v100.version=v1.0.0
-libs.spy.versions.v100.path=/opt/compiler-explorer/libs/spy/1.0.0/include
-libs.tts.name=TTS
-libs.tts.description=C++20 Unit Test Framework for Numerical Applications
-libs.tts.versions=trunk:v01:v02
-libs.tts.url=https://github.com/jfalcou/tts
-libs.tts.versions.trunk.version=trunk
-libs.tts.versions.trunk.path=/opt/compiler-explorer/libs/tts/trunk/include
-libs.tts.versions.v01.version=v0.1
-libs.tts.versions.v01.path=/opt/compiler-explorer/libs/tts/0.1/include
-libs.tts.versions.v02.version=v0.2
-libs.tts.versions.v02.path=/opt/compiler-explorer/libs/tts/0.2/include
-libs.eve.name=EVE
-libs.eve.description=C++20 SIMD wrapper
-libs.eve.versions=trunk
-libs.eve.url=https://github.com/jfalcou/eve
-libs.eve.versions.trunk.version=trunk
-libs.eve.versions.trunk.path=/opt/compiler-explorer/libs/eve/trunk/include
-libs.ofw.name=OFW
-libs.ofw.description=C++20 Single Files Tools
-libs.ofw.versions=trunk
-libs.ofw.url=https://github.com/jfalcou/ofw
-libs.ofw.versions.trunk.version=trunk
-libs.ofw.versions.trunk.path=/opt/compiler-explorer/libs/ofw/trunk/include
-libs.kiwaku.name=KIWAKU
-libs.kiwaku.description=C++20 Single Files Tools
-libs.kiwaku.versions=trunk
-libs.kiwaku.url=https://github.com/jfalcou/kiwaku
-libs.kiwaku.versions.trunk.version=trunk
-libs.kiwaku.versions.trunk.path=/opt/compiler-explorer/libs/kiwaku/trunk/include
-libs.eigen.name=Eigen
-libs.eigen.versions=trunk:339:337:335:334
-libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
-libs.eigen.versions.trunk.version=trunk
-libs.eigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
-libs.eigen.versions.339.version=3.3.9
-libs.eigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
-libs.eigen.versions.337.version=3.3.7
-libs.eigen.versions.337.path=/opt/compiler-explorer/libs/eigen/v3.3.7
-libs.eigen.versions.335.version=3.3.5
-libs.eigen.versions.335.path=/opt/compiler-explorer/libs/eigen/v3.3.5
-libs.eigen.versions.334.version=3.3.4
-libs.eigen.versions.334.path=/opt/compiler-explorer/libs/eigen/v3.3.4
-libs.benchmark.name=Google Benchmark
-libs.benchmark.versions=trunk:120:130:140:141:150
-libs.benchmark.url=https://github.com/google/benchmark
-libs.benchmark.staticliblink=benchmark
-libs.benchmark.versions.trunk.version=trunk
-libs.benchmark.versions.trunk.path=/opt/compiler-explorer/libs/google-benchmark/trunk/include
-libs.benchmark.versions.120.version=1.2.0
-libs.benchmark.versions.120.path=/opt/compiler-explorer/libs/google-benchmark/v1.2.0/include
-libs.benchmark.versions.130.version=1.3.0
-libs.benchmark.versions.130.path=/opt/compiler-explorer/libs/google-benchmark/v1.3.0/include
-libs.benchmark.versions.140.version=1.4.0
-libs.benchmark.versions.140.path=/opt/compiler-explorer/libs/google-benchmark/v1.4.0/include
-libs.benchmark.versions.141.version=1.4.1
-libs.benchmark.versions.141.path=/opt/compiler-explorer/libs/google-benchmark/v1.4.1/include
-libs.benchmark.versions.150.version=1.5.0
-libs.benchmark.versions.150.path=/opt/compiler-explorer/libs/google-benchmark/v1.5.0/include
-libs.rangesv3.name=range-v3
-libs.rangesv3.versions=trunk:030:035:036:091:0100:0110
-libs.rangesv3.url=https://github.com/ericniebler/range-v3
-libs.rangesv3.versions.trunk.version=trunk
-libs.rangesv3.versions.trunk.path=/opt/compiler-explorer/libs/rangesv3/trunk/include
-libs.rangesv3.versions.030.version=0.3.0
-libs.rangesv3.versions.030.path=/opt/compiler-explorer/libs/rangesv3/0.3.0/include
-libs.rangesv3.versions.035.version=0.3.5
-libs.rangesv3.versions.035.path=/opt/compiler-explorer/libs/rangesv3/0.3.5/include
-libs.rangesv3.versions.036.version=0.3.6
-libs.rangesv3.versions.036.path=/opt/compiler-explorer/libs/rangesv3/0.3.6/include
-libs.rangesv3.versions.091.version=0.9.1
-libs.rangesv3.versions.091.path=/opt/compiler-explorer/libs/rangesv3/0.9.1/include
-libs.rangesv3.versions.0100.version=0.10.0
-libs.rangesv3.versions.0100.path=/opt/compiler-explorer/libs/rangesv3/0.10.0/include
-libs.rangesv3.versions.0110.version=0.11.0
-libs.rangesv3.versions.0110.path=/opt/compiler-explorer/libs/rangesv3/0.11.0/include
-libs.mp-units.name=mp-units
-libs.mp-units.versions=trunk:070:060:050:040:031
-libs.mp-units.url=https://github.com/mpusz/units
-libs.mp-units.description=A Physical Units Library for C++<br /><br />Note that in some cases, you also need to add the {fmt} library.
-libs.mp-units.examples=5dvY8Woh1:9fnzfbhb6
-libs.mp-units.versions.trunk.version=trunk
-libs.mp-units.versions.trunk.path=/opt/compiler-explorer/libs/mp-units/trunk/src/core/include:/opt/compiler-explorer/libs/mp-units/trunk/src/core-fmt/include:/opt/compiler-explorer/libs/mp-units/trunk/src/core-io/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/isq/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/isq-iec80000/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/isq-natural/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-cgs/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-fps/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-iau/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-imperial/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-international/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-typographic/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-us/include:/opt/compiler-explorer/libs/fmt/7.1.3/include:/opt/compiler-explorer/libs/gsl-lite/include
-libs.mp-units.versions.070.version=0.7.0
-libs.mp-units.versions.070.path=/opt/compiler-explorer/libs/mp-units/v0.7.0/src/core/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/core-fmt/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/core-io/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/isq/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/isq-iec80000/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/isq-natural/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-cgs/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-fps/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-iau/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-imperial/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-international/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-typographic/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-us/include:/opt/compiler-explorer/libs/fmt/7.1.3/include:/opt/compiler-explorer/libs/gsl-lite/include
-libs.mp-units.versions.060.version=0.6.0
-libs.mp-units.versions.060.path=/opt/compiler-explorer/libs/mp-units/v0.6.0/src/include:/opt/compiler-explorer/libs/fmt/7.0.0/include:/opt/compiler-explorer/libs/GSL/v3.0.1/include
-libs.mp-units.versions.050.version=0.5.0
-libs.mp-units.versions.050.path=/opt/compiler-explorer/libs/mp-units/v0.5.0/src/include:/opt/compiler-explorer/libs/rangesv3/0.10.0/include:/opt/compiler-explorer/libs/fmt/6.2.0/include
-libs.mp-units.versions.040.version=0.4.0
-libs.mp-units.versions.040.path=/opt/compiler-explorer/libs/mp-units/v0.4.0/src/include:/opt/compiler-explorer/libs/rangesv3/0.9.1/include:/opt/compiler-explorer/libs/fmt/6.0.0/include
-libs.mp-units.versions.031.version=0.3.1
-libs.mp-units.versions.031.path=/opt/compiler-explorer/libs/mp-units/v0.3.1/src/include:/opt/compiler-explorer/libs/rangesv3/0.9.1/include
-libs.dlib.name=dlib
-libs.dlib.description=Machine learning algorithms and tools
-libs.dlib.versions=197:199:1910:trunk
-libs.dlib.url=http://dlib.net/
-libs.dlib.staticliblink=dlib
-libs.dlib.versions.trunk.version=trunk
-libs.dlib.versions.trunk.path=/opt/compiler-explorer/libs/dlib/trunk
-libs.dlib.versions.197.version=19.7
-libs.dlib.versions.197.path=/opt/compiler-explorer/libs/dlib/v19.7
-libs.dlib.versions.197.lookupversion=v19.7
-libs.dlib.versions.199.version=19.9
-libs.dlib.versions.199.path=/opt/compiler-explorer/libs/dlib/v19.9
-libs.dlib.versions.199.lookupversion=v19.9
-libs.dlib.versions.1910.version=19.10
-libs.dlib.versions.1910.path=/opt/compiler-explorer/libs/dlib/v19.10
-libs.dlib.versions.1910.lookupversion=v19.10
-libs.libguarded.name=CsLibGuarded
-libs.libguarded.versions=trunk:110
-libs.libguarded.url=https://github.com/copperspice/cs_libguarded
-libs.libguarded.versions.trunk.version=trunk
-libs.libguarded.versions.trunk.path=/opt/compiler-explorer/libs/libguarded/trunk/src
-libs.libguarded.versions.110.version=1.1.0
-libs.libguarded.versions.110.path=/opt/compiler-explorer/libs/libguarded/libguarded-1.1.0/src
-libs.cppcoro.name=cppcoro
-libs.cppcoro.description=Coroutine abstractions for the Coroutines TS
-libs.cppcoro.versions=trunk
-libs.cppcoro.url=https://github.com/lewissbaker/cppcoro
-libs.cppcoro.versions.trunk.version=trunk
-libs.cppcoro.versions.trunk.path=/opt/compiler-explorer/libs/cppcoro/include
-libs.fmt.name={fmt}
-libs.fmt.description=A modern formatting library
-libs.fmt.versions=trunk:400:410:500:510:520:530:600:610:611:612:620:621:700:713
-libs.fmt.url=https://fmt.dev/
-libs.fmt.staticliblink=fmtd
-libs.fmt.examples=Tevcjh:oK8h33:Yn7Txe:Yn7Txe:K8s4Mc:MjsY7c
-libs.fmt.versions.trunk.version=trunk
-libs.fmt.versions.trunk.path=/opt/compiler-explorer/libs/fmt/trunk/include
-libs.fmt.versions.400.version=4.0.0
-libs.fmt.versions.400.path=/opt/compiler-explorer/libs/fmt/4.0.0
-libs.fmt.versions.400.staticliblink=fmt
-libs.fmt.versions.410.version=4.1.0
-libs.fmt.versions.410.path=/opt/compiler-explorer/libs/fmt/4.1.0
-libs.fmt.versions.410.staticliblink=fmt
-libs.fmt.versions.500.version=5.0.0
-libs.fmt.versions.500.path=/opt/compiler-explorer/libs/fmt/5.0.0/include
-libs.fmt.versions.510.version=5.1.0
-libs.fmt.versions.510.path=/opt/compiler-explorer/libs/fmt/5.1.0/include
-libs.fmt.versions.520.version=5.2.0
-libs.fmt.versions.520.path=/opt/compiler-explorer/libs/fmt/5.2.0/include
-libs.fmt.versions.530.version=5.3.0
-libs.fmt.versions.530.path=/opt/compiler-explorer/libs/fmt/5.3.0/include
-libs.fmt.versions.600.version=6.0.0
-libs.fmt.versions.600.path=/opt/compiler-explorer/libs/fmt/6.0.0/include
-libs.fmt.versions.610.version=6.1.0
-libs.fmt.versions.610.path=/opt/compiler-explorer/libs/fmt/6.1.0/include
-libs.fmt.versions.611.version=6.1.1
-libs.fmt.versions.611.path=/opt/compiler-explorer/libs/fmt/6.1.1/include
-libs.fmt.versions.612.version=6.1.2
-libs.fmt.versions.612.path=/opt/compiler-explorer/libs/fmt/6.1.2/include
-libs.fmt.versions.620.version=6.2.0
-libs.fmt.versions.620.path=/opt/compiler-explorer/libs/fmt/6.2.0/include
-libs.fmt.versions.621.version=6.2.1
-libs.fmt.versions.621.path=/opt/compiler-explorer/libs/fmt/6.2.1/include
-libs.fmt.versions.700.version=7.0.0
-libs.fmt.versions.700.path=/opt/compiler-explorer/libs/fmt/7.0.0/include
-libs.fmt.versions.713.version=7.1.3
-libs.fmt.versions.713.path=/opt/compiler-explorer/libs/fmt/7.1.3/include
-libs.hfsm.name=HFSM
-libs.hfsm.description=Hierarchical Finite State Machine Framework
-libs.hfsm.versions=trunk:08:010
-libs.hfsm.url=https://github.com/andrew-gresyk/HFSM
-libs.hfsm.versions.trunk.version=trunk
-libs.hfsm.versions.trunk.path=/opt/compiler-explorer/libs/hfsm/trunk:/opt/compiler-explorer/libs/hfsm/trunk/include
-libs.hfsm.versions.08.version=0.8
-libs.hfsm.versions.08.path=/opt/compiler-explorer/libs/hfsm/0.8
-libs.hfsm.versions.010.version=0.10
-libs.hfsm.versions.010.path=/opt/compiler-explorer/libs/hfsm/0.10
-libs.glm.name=GLM
-libs.glm.description=OpenGL Mathematics
-libs.glm.versions=trunk:0985:0990:0991:0992:0993:0994:0995:0996:0997:0998
-libs.glm.url=https://glm.g-truc.net/
-libs.glm.versions.trunk.version=trunk
-libs.glm.versions.trunk.path=/opt/compiler-explorer/libs/glm/trunk
-libs.glm.versions.0985.version=0.9.8.5
-libs.glm.versions.0985.path=/opt/compiler-explorer/libs/glm/0.9.8.5
-libs.glm.versions.0990.version=0.9.9.0
-libs.glm.versions.0990.path=/opt/compiler-explorer/libs/glm/0.9.9.0
-libs.glm.versions.0991.version=0.9.9.1
-libs.glm.versions.0991.path=/opt/compiler-explorer/libs/glm/0.9.9.1
-libs.glm.versions.0992.version=0.9.9.2
-libs.glm.versions.0992.path=/opt/compiler-explorer/libs/glm/0.9.9.2
-libs.glm.versions.0993.version=0.9.9.3
-libs.glm.versions.0993.path=/opt/compiler-explorer/libs/glm/0.9.9.3
-libs.glm.versions.0994.version=0.9.9.4
-libs.glm.versions.0994.path=/opt/compiler-explorer/libs/glm/0.9.9.4
-libs.glm.versions.0995.version=0.9.9.5
-libs.glm.versions.0995.path=/opt/compiler-explorer/libs/glm/0.9.9.5
-libs.glm.versions.0996.version=0.9.9.6
-libs.glm.versions.0996.path=/opt/compiler-explorer/libs/glm/0.9.9.6
-libs.glm.versions.0997.version=0.9.9.7
-libs.glm.versions.0997.path=/opt/compiler-explorer/libs/glm/0.9.9.7
-libs.glm.versions.0998.version=0.9.9.8
-libs.glm.versions.0998.path=/opt/compiler-explorer/libs/glm/0.9.9.8
-libs.llvm.name=LLVM
-libs.llvm.description=LLVM
-libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000:1001:1100:1200
-libs.llvm.url=https://llvm.org/
-libs.llvm.versions.trunk.version=trunk
-libs.llvm.versions.trunk.path=/opt/compiler-explorer/libs/llvm/trunk/include
-libs.llvm.versions.401.version=4.0.1
-libs.llvm.versions.401.path=/opt/compiler-explorer/libs/llvm/4.0.1/include
-libs.llvm.versions.500.version=5.0.0
-libs.llvm.versions.500.path=/opt/compiler-explorer/libs/llvm/5.0.0/include
-libs.llvm.versions.501.version=5.0.1
-libs.llvm.versions.501.path=/opt/compiler-explorer/libs/llvm/5.0.1/include
-libs.llvm.versions.502.version=5.0.2
-libs.llvm.versions.502.path=/opt/compiler-explorer/libs/llvm/5.0.2/include
-libs.llvm.versions.600.version=6.0.0
-libs.llvm.versions.600.path=/opt/compiler-explorer/libs/llvm/6.0.0/include
-libs.llvm.versions.601.version=6.0.1
-libs.llvm.versions.601.path=/opt/compiler-explorer/libs/llvm/6.0.1/include
-libs.llvm.versions.700.version=7.0.0
-libs.llvm.versions.700.path=/opt/compiler-explorer/libs/llvm/7.0.0/include
-libs.llvm.versions.701.version=7.0.1
-libs.llvm.versions.701.path=/opt/compiler-explorer/libs/llvm/7.0.1/include
-libs.llvm.versions.800.version=8.0.0
-libs.llvm.versions.800.path=/opt/compiler-explorer/libs/llvm/8.0.0/include
-libs.llvm.versions.900.version=9.0.0
-libs.llvm.versions.900.path=/opt/compiler-explorer/libs/llvm/9.0.0/include
-libs.llvm.versions.1000.version=10.0.0
-libs.llvm.versions.1000.path=/opt/compiler-explorer/libs/llvm/10.0.0/include
-libs.llvm.versions.1001.version=10.0.1
-libs.llvm.versions.1001.path=/opt/compiler-explorer/libs/llvm/10.0.1/include
-libs.llvm.versions.1100.version=11.0.0
-libs.llvm.versions.1100.path=/opt/compiler-explorer/libs/llvm/11.0.0/include
-libs.llvm.versions.1200.version=12.0.0
-libs.llvm.versions.1200.path=/opt/compiler-explorer/libs/llvm/12.0.0/include
+
 libs.catch2.name=Catch2
 libs.catch2.description=Catch2
 libs.catch2.url=https://github.com/catchorg/Catch2
@@ -1664,6 +1265,95 @@ libs.catch2.versions.300-preview2.staticliblink=Catch2
 libs.catch2.versions.300-preview3.version=3.0.0-preview3
 libs.catch2.versions.300-preview3.path=/opt/compiler-explorer/libs/catch2/v3.0.0-preview3/src
 libs.catch2.versions.300-preview3.staticliblink=Catch2
+
+libs.cctz.name=CCTZ
+libs.cctz.url=https://github.com/google/cctz
+libs.cctz.versions=23
+libs.cctz.staticliblink=cctz
+libs.cctz.versions.23.version=2.3
+libs.cctz.versions.23.path=/opt/compiler-explorer/libs/cctz/v2.3/include
+
+libs.cmcstl2.name=cmcstl2
+libs.cmcstl2.versions=trunk
+libs.cmcstl2.url=https://github.com/CaseyCarter/cmcstl2
+libs.cmcstl2.versions.trunk.version=trunk
+libs.cmcstl2.versions.trunk.path=/opt/compiler-explorer/libs/cmcstl2/include
+
+libs.cnl.name=CNL
+libs.cnl.description=Compositional Numeric Library
+libs.cnl.url=https://github.com/johnmcfarlane/cnl
+libs.cnl.versions=1x:100:115:trunk
+libs.cnl.versions.trunk.version=trunk
+libs.cnl.versions.trunk.path=/opt/compiler-explorer/libs/cnl/trunk/include
+libs.cnl.versions.1x.version=1.x
+libs.cnl.versions.1x.path=/opt/compiler-explorer/libs/cnl/v1.x/include
+libs.cnl.versions.100.version=1.0.0
+libs.cnl.versions.100.path=/opt/compiler-explorer/libs/cnl/v1.0.0/include
+libs.cnl.versions.115.version=1.1.5
+libs.cnl.versions.115.path=/opt/compiler-explorer/libs/cnl/v1.1.5/include
+
+libs.cppcoro.name=cppcoro
+libs.cppcoro.description=Coroutine abstractions for the Coroutines TS
+libs.cppcoro.versions=trunk
+libs.cppcoro.url=https://github.com/lewissbaker/cppcoro
+libs.cppcoro.versions.trunk.version=trunk
+libs.cppcoro.versions.trunk.path=/opt/compiler-explorer/libs/cppcoro/include
+
+libs.cppitertools.name=cppitertools
+libs.cppitertools.versions=trunk:100:200
+libs.cppitertools.url=https://github.com/ryanhaining/cppitertools
+libs.cppitertools.versions.trunk.version=trunk
+libs.cppitertools.versions.trunk.path=/opt/compiler-explorer/libs/cppitertools/trunk
+libs.cppitertools.versions.100.version=v1.0
+libs.cppitertools.versions.100.path=/opt/compiler-explorer/libs/cppitertools/v1.0
+libs.cppitertools.versions.200.version=v2.0
+libs.cppitertools.versions.200.path=/opt/compiler-explorer/libs/cppitertools/v2.0
+
+libs.crosscables.name=Crosscables
+libs.crosscables.url=https://github.com/partouf/Crosscables
+libs.crosscables.description=A statically linked C++98 cross-platform and multi-purpose library. Includes templates, classes and functions for custom strings, encoding, containers, threading, filesystem and networking.
+libs.crosscables.versions=trunk
+libs.crosscables.staticliblink=Jumpropes:Groundfloor
+libs.crosscables.versions.trunk.version=trunk
+libs.crosscables.versions.trunk.path=/opt/compiler-explorer/libs/crosscables/trunk/include
+
+libs.ctbignum.name=ctbignum
+libs.ctbignum.versions=trunk
+libs.ctbignum.url=https://github.com/niekbouman/ctbignum
+libs.ctbignum.versions.trunk.version=trunk
+libs.ctbignum.versions.trunk.path=/opt/compiler-explorer/libs/ctbignum/include
+
+libs.ctre.name=CTRE
+libs.ctre.description=Compile Time Regular Expressions
+libs.ctre.versions=trunk:ecma-unicode:dfa:v2
+libs.ctre.url=https://github.com/hanickadot/compile-time-regular-expressions
+libs.ctre.examples=5U67_e:x64CVp:PKTiCC
+libs.ctre.versions.ecma-unicode.version=ecma-unicode
+libs.ctre.versions.ecma-unicode.path=/opt/compiler-explorer/libs/ctre/ecma-unicode/include
+libs.ctre.versions.dfa.version=dfa
+libs.ctre.versions.dfa.path=/opt/compiler-explorer/libs/ctre/dfa/include
+libs.ctre.versions.trunk.version=trunk
+libs.ctre.versions.trunk.path=/opt/compiler-explorer/libs/ctre/main/include
+libs.ctre.versions.v2.version=v2
+libs.ctre.versions.v2.path=/opt/compiler-explorer/libs/ctre/v2/include
+
+libs.dlib.name=dlib
+libs.dlib.description=Machine learning algorithms and tools
+libs.dlib.versions=197:199:1910:trunk
+libs.dlib.url=http://dlib.net/
+libs.dlib.staticliblink=dlib
+libs.dlib.versions.trunk.version=trunk
+libs.dlib.versions.trunk.path=/opt/compiler-explorer/libs/dlib/trunk
+libs.dlib.versions.197.version=19.7
+libs.dlib.versions.197.path=/opt/compiler-explorer/libs/dlib/v19.7
+libs.dlib.versions.197.lookupversion=v19.7
+libs.dlib.versions.199.version=19.9
+libs.dlib.versions.199.path=/opt/compiler-explorer/libs/dlib/v19.9
+libs.dlib.versions.199.lookupversion=v19.9
+libs.dlib.versions.1910.version=19.10
+libs.dlib.versions.1910.path=/opt/compiler-explorer/libs/dlib/v19.10
+libs.dlib.versions.1910.lookupversion=v19.10
+
 libs.doctest.name=Doctest
 libs.doctest.description=The fastest feature-rich C++11 single-header testing framework for unit tests and TDD
 libs.doctest.url=https://github.com/onqtam/doctest
@@ -1704,6 +1394,7 @@ libs.doctest.versions.237.version=2.3.7
 libs.doctest.versions.237.path=/opt/compiler-explorer/libs/doctest/2.3.7/doctest
 libs.doctest.versions.238.version=2.3.8
 libs.doctest.versions.238.path=/opt/compiler-explorer/libs/doctest/2.3.8/doctest
+
 libs.eastl.name=EASTL
 libs.eastl.description=The Electronic Arts Standard Template Library. It is an extensive and robust implementation that has an emphasis on high performance.
 libs.eastl.url=https://github.com/electronicarts/EASTL
@@ -1746,34 +1437,141 @@ libs.eastl.versions.3_16_01.version=3.16.01
 libs.eastl.versions.3_16_01.path=/opt/compiler-explorer/libs/eastl/3.16.01/include:/opt/compiler-explorer/libs/eastl/3.16.01/test/packages/EABase/include/Common
 libs.eastl.versions.3_16_05.version=3.16.05
 libs.eastl.versions.3_16_05.path=/opt/compiler-explorer/libs/eastl/3.16.05/include:/opt/compiler-explorer/libs/eastl/3.16.05/test/packages/EABase/include/Common
-libs.vcl.name=VCL
-libs.vcl.description=Agner Fog's vector class library
-libs.vcl.versions=130:200:201
-libs.vcl.url=https://github.com/vectorclass
-libs.vcl.versions.130.version=1.30
-libs.vcl.versions.130.path=/opt/compiler-explorer/libs/vcl/v1.30
-libs.vcl.versions.200.version=2.00
-libs.vcl.versions.200.path=/opt/compiler-explorer/libs/vcl/v2.00.01
-libs.vcl.versions.201.version=2.01
-libs.vcl.versions.201.path=/opt/compiler-explorer/libs/vcl/v2.01.03
-libs.outcome.versions=trunk
-libs.outcome.url=https://ned14.github.io/outcome/
-libs.outcome.name=outcome
-libs.outcome.description=Provides very lightweight outcome<T> and result<T> (non-Boost edition)
-libs.outcome.versions.trunk.version=trunk
-libs.outcome.versions.trunk.path=/opt/compiler-explorer/libs/outcome/single-header
-libs.cnl.name=CNL
-libs.cnl.description=Compositional Numeric Library
-libs.cnl.url=https://github.com/johnmcfarlane/cnl
-libs.cnl.versions=1x:100:115:trunk
-libs.cnl.versions.trunk.version=trunk
-libs.cnl.versions.trunk.path=/opt/compiler-explorer/libs/cnl/trunk/include
-libs.cnl.versions.1x.version=1.x
-libs.cnl.versions.1x.path=/opt/compiler-explorer/libs/cnl/v1.x/include
-libs.cnl.versions.100.version=1.0.0
-libs.cnl.versions.100.path=/opt/compiler-explorer/libs/cnl/v1.0.0/include
-libs.cnl.versions.115.version=1.1.5
-libs.cnl.versions.115.path=/opt/compiler-explorer/libs/cnl/v1.1.5/include
+
+libs.eigen.name=Eigen
+libs.eigen.versions=trunk:339:337:335:334
+libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
+libs.eigen.versions.trunk.version=trunk
+libs.eigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.eigen.versions.339.version=3.3.9
+libs.eigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
+libs.eigen.versions.337.version=3.3.7
+libs.eigen.versions.337.path=/opt/compiler-explorer/libs/eigen/v3.3.7
+libs.eigen.versions.335.version=3.3.5
+libs.eigen.versions.335.path=/opt/compiler-explorer/libs/eigen/v3.3.5
+libs.eigen.versions.334.version=3.3.4
+libs.eigen.versions.334.path=/opt/compiler-explorer/libs/eigen/v3.3.4
+
+libs.enoki.name=Enoki
+libs.enoki.url=https://github.com/mitsuba-renderer/enoki
+libs.enoki.versions=trunk
+libs.enoki.versions.trunk.version=trunk
+libs.enoki.versions.trunk.path=/opt/compiler-explorer/libs/enoki/trunk/include
+
+libs.entt.name=entt
+libs.entt.url=https://github.com/skypjack/entt
+libs.entt.versions=trunk:350:360
+libs.entt.versions.350.version=3.5.0
+libs.entt.versions.350.path=/opt/compiler-explorer/libs/entt/v3.5.0/src
+libs.entt.versions.360.version=3.6.0
+libs.entt.versions.360.path=/opt/compiler-explorer/libs/entt/v3.6.0/src
+libs.entt.versions.trunk.version=trunk
+libs.entt.versions.trunk.path=/opt/compiler-explorer/libs/entt/trunk/src
+
+libs.etl.name=etl
+libs.etl.versions=trunk
+libs.etl.url=https://github.com/ETLCPP/etl
+libs.etl.versions.trunk.version=trunk
+libs.etl.versions.trunk.path=/opt/compiler-explorer/libs/etl/include:/opt/compiler-explorer/libs/etl/include/etl/profiles
+
+libs.eve.name=EVE
+libs.eve.description=C++20 SIMD wrapper
+libs.eve.versions=trunk
+libs.eve.url=https://github.com/jfalcou/eve
+libs.eve.versions.trunk.version=trunk
+libs.eve.versions.trunk.path=/opt/compiler-explorer/libs/eve/trunk/include
+
+libs.expected_lite.versions=001:010:trunk
+libs.expected_lite.url=https://github.com/martinmoene/expected-lite
+libs.expected_lite.name=expected-lite
+libs.expected_lite.description=Expected for C++11 and greater
+libs.expected_lite.versions.001.version=0.0.1
+libs.expected_lite.versions.001.path=/opt/compiler-explorer/libs/expected-lite/v0.0.1/include
+libs.expected_lite.versions.010.version=0.1.0
+libs.expected_lite.versions.010.path=/opt/compiler-explorer/libs/expected-lite/v0.1.0/include
+libs.expected_lite.versions.trunk.version=trunk
+libs.expected_lite.versions.trunk.path=/opt/compiler-explorer/libs/expected-lite/trunk/include
+
+libs.fastor.name=Fastor
+libs.fastor.description=Fastor is a high performance stack-based tensor (fixed multi-dimensional array) library for modern C++.
+libs.fastor.versions=trunk:063
+libs.fastor.url=https://github.com/romeric/Fastor
+libs.fastor.versions.trunk.version=trunk
+libs.fastor.versions.trunk.path=/opt/compiler-explorer/libs/fastor/trunk
+libs.fastor.versions.063.version=0.6.3
+libs.fastor.versions.063.path=/opt/compiler-explorer/libs/fastor/V0.6.3/
+
+libs.fmt.name={fmt}
+libs.fmt.description=A modern formatting library
+libs.fmt.versions=trunk:400:410:500:510:520:530:600:610:611:612:620:621:700:713
+libs.fmt.url=https://fmt.dev/
+libs.fmt.staticliblink=fmtd
+libs.fmt.examples=Tevcjh:oK8h33:Yn7Txe:Yn7Txe:K8s4Mc:MjsY7c
+libs.fmt.versions.trunk.version=trunk
+libs.fmt.versions.trunk.path=/opt/compiler-explorer/libs/fmt/trunk/include
+libs.fmt.versions.400.version=4.0.0
+libs.fmt.versions.400.path=/opt/compiler-explorer/libs/fmt/4.0.0
+libs.fmt.versions.400.staticliblink=fmt
+libs.fmt.versions.410.version=4.1.0
+libs.fmt.versions.410.path=/opt/compiler-explorer/libs/fmt/4.1.0
+libs.fmt.versions.410.staticliblink=fmt
+libs.fmt.versions.500.version=5.0.0
+libs.fmt.versions.500.path=/opt/compiler-explorer/libs/fmt/5.0.0/include
+libs.fmt.versions.510.version=5.1.0
+libs.fmt.versions.510.path=/opt/compiler-explorer/libs/fmt/5.1.0/include
+libs.fmt.versions.520.version=5.2.0
+libs.fmt.versions.520.path=/opt/compiler-explorer/libs/fmt/5.2.0/include
+libs.fmt.versions.530.version=5.3.0
+libs.fmt.versions.530.path=/opt/compiler-explorer/libs/fmt/5.3.0/include
+libs.fmt.versions.600.version=6.0.0
+libs.fmt.versions.600.path=/opt/compiler-explorer/libs/fmt/6.0.0/include
+libs.fmt.versions.610.version=6.1.0
+libs.fmt.versions.610.path=/opt/compiler-explorer/libs/fmt/6.1.0/include
+libs.fmt.versions.611.version=6.1.1
+libs.fmt.versions.611.path=/opt/compiler-explorer/libs/fmt/6.1.1/include
+libs.fmt.versions.612.version=6.1.2
+libs.fmt.versions.612.path=/opt/compiler-explorer/libs/fmt/6.1.2/include
+libs.fmt.versions.620.version=6.2.0
+libs.fmt.versions.620.path=/opt/compiler-explorer/libs/fmt/6.2.0/include
+libs.fmt.versions.621.version=6.2.1
+libs.fmt.versions.621.path=/opt/compiler-explorer/libs/fmt/6.2.1/include
+libs.fmt.versions.700.version=7.0.0
+libs.fmt.versions.700.path=/opt/compiler-explorer/libs/fmt/7.0.0/include
+libs.fmt.versions.713.version=7.1.3
+libs.fmt.versions.713.path=/opt/compiler-explorer/libs/fmt/7.1.3/include
+
+libs.glm.name=GLM
+libs.glm.description=OpenGL Mathematics
+libs.glm.versions=trunk:0985:0990:0991:0992:0993:0994:0995:0996:0997:0998
+libs.glm.url=https://glm.g-truc.net/
+libs.glm.versions.trunk.version=trunk
+libs.glm.versions.trunk.path=/opt/compiler-explorer/libs/glm/trunk
+libs.glm.versions.0985.version=0.9.8.5
+libs.glm.versions.0985.path=/opt/compiler-explorer/libs/glm/0.9.8.5
+libs.glm.versions.0990.version=0.9.9.0
+libs.glm.versions.0990.path=/opt/compiler-explorer/libs/glm/0.9.9.0
+libs.glm.versions.0991.version=0.9.9.1
+libs.glm.versions.0991.path=/opt/compiler-explorer/libs/glm/0.9.9.1
+libs.glm.versions.0992.version=0.9.9.2
+libs.glm.versions.0992.path=/opt/compiler-explorer/libs/glm/0.9.9.2
+libs.glm.versions.0993.version=0.9.9.3
+libs.glm.versions.0993.path=/opt/compiler-explorer/libs/glm/0.9.9.3
+libs.glm.versions.0994.version=0.9.9.4
+libs.glm.versions.0994.path=/opt/compiler-explorer/libs/glm/0.9.9.4
+libs.glm.versions.0995.version=0.9.9.5
+libs.glm.versions.0995.path=/opt/compiler-explorer/libs/glm/0.9.9.5
+libs.glm.versions.0996.version=0.9.9.6
+libs.glm.versions.0996.path=/opt/compiler-explorer/libs/glm/0.9.9.6
+libs.glm.versions.0997.version=0.9.9.7
+libs.glm.versions.0997.path=/opt/compiler-explorer/libs/glm/0.9.9.7
+libs.glm.versions.0998.version=0.9.9.8
+libs.glm.versions.0998.path=/opt/compiler-explorer/libs/glm/0.9.9.8
+
+libs.gnufs.name=Filesystem (GNU)
+libs.gnufs.versions=autodetect
+libs.gnufs.versions.autodetect.version=autodetect
+libs.gnufs.versions.autodetect.staticliblink=stdc++fs
+
 libs.googletest.name=Google Test
 libs.googletest.versions=trunk:110
 libs.googletest.url=https://github.com/google/googletest
@@ -1783,62 +1581,27 @@ libs.googletest.versions.trunk.path=/opt/compiler-explorer/libs/googletest/trunk
 libs.googletest.versions.110.version=1.10.0
 libs.googletest.versions.110.path=/opt/compiler-explorer/libs/googletest/release-1.10.0/googletest/include:/opt/compiler-explorer/libs/googletest/release-1.10.0/googlemock/include
 libs.googletest.versions.110.lookupversion=release-1.10.0
-libs.tbb.name=Intel TBB
-libs.tbb.versions=20202:20203
-libs.tbb.liblink=tbb
-libs.tbb.url=https://www.threadingbuildingblocks.org/
-libs.tbb.versions.20202.version=2020.2
-libs.tbb.versions.20202.path=/opt/compiler-explorer/libs/tbb/2020.2/include
-libs.tbb.versions.20203.version=2020.3
-libs.tbb.versions.20203.path=/opt/compiler-explorer/libs/tbb/2020.3/include
-libs.tbb.versions.20203.alias=trunk
-libs.seastar.name=Seastar
-libs.seastar.description=SeaStar is an event-driven framework allowing you to write non-blocking, asynchronous code in a relatively straightforward manner.
-libs.seastar.versions=180
-libs.seastar.url=http://seastar.io
-libs.seastar.versions.180.version=18.08.0
-libs.seastar.versions.180.path=/opt/compiler-explorer/libs/seastar/seastar-18.08.0
-libs.pegtl.name=PEGTL
-libs.pegtl.description=Parsing Expression Grammar Template Library
-libs.pegtl.versions=trunk:280
-libs.pegtl.url=https://github.com/taocpp/PEGTL
-libs.pegtl.versions.trunk.version=trunk
-libs.pegtl.versions.trunk.path=/opt/compiler-explorer/libs/PEGTL/trunk/include
-libs.pegtl.versions.280.version=2.8.0
-libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
-libs.pugixml.name=pugixml
-libs.pugixml.description=pugixml is a light-weight C++ XML processing library
-libs.pugixml.examples=bE3WPhMYq
-libs.pugixml.versions=1114
-libs.pugixml.url=https://pugixml.org/
-libs.pugixml.staticliblink=pugixml
-libs.pugixml.versions.1114.version=1.11.4
-libs.pugixml.versions.1114.path=/opt/compiler-explorer/libs/pugixml/v1.11.4/src/
-libs.openssl.name=OpenSSL
-libs.openssl.liblink=ssl:crypto
-libs.openssl.url=https://www.openssl.org
-libs.openssl.versions=111c:111g
-libs.openssl.versions.111c.version=1.1.1c
-libs.openssl.versions.111c.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/include
-libs.openssl.versions.111c.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86/opt/lib
-libs.openssl.versions.111g.version=1.1.1g
-libs.openssl.versions.111g.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/include
-libs.openssl.versions.111g.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86/opt/lib
-libs.nanorange.name=NanoRange
-libs.nanorange.versions=trunk
-libs.nanorange.url=https://github.com/tcbrindle/NanoRange
-libs.nanorange.versions.trunk.version=trunk
-libs.nanorange.versions.trunk.path=/opt/compiler-explorer/libs/nanorange/include
-libs.benri.name=benri
-libs.benri.description=Compile time checking of physical quantities.
-libs.benri.versions=trunk:201:211
-libs.benri.url=https://github.com/jansende/benri
-libs.benri.versions.trunk.version=trunk
-libs.benri.versions.trunk.path=/opt/compiler-explorer/libs/benri/trunk/include
-libs.benri.versions.201.version=2.0.1
-libs.benri.versions.201.path=/opt/compiler-explorer/libs/benri/v2.0.1/include
-libs.benri.versions.211.version=2.1.1
-libs.benri.versions.211.path=/opt/compiler-explorer/libs/benri/v2.1.1/include
+
+libs.gsl.name=GSL
+libs.gsl.description=Guidelines Support Library
+libs.gsl.url=https://github.com/Microsoft/GSL
+# Sorry Martin!
+libs.gsl.versions=trunk:lite:100:200:210:300:301
+libs.gsl.versions.trunk.version=trunk
+libs.gsl.versions.trunk.path=/opt/compiler-explorer/libs/GSL/trunk/include
+libs.gsl.versions.100.version=1.0.0
+libs.gsl.versions.100.path=/opt/compiler-explorer/libs/GSL/v1.0.0/include
+libs.gsl.versions.200.version=2.0.0
+libs.gsl.versions.200.path=/opt/compiler-explorer/libs/GSL/v2.0.0/include
+libs.gsl.versions.210.version=2.1.0
+libs.gsl.versions.210.path=/opt/compiler-explorer/libs/GSL/v2.1.0/include
+libs.gsl.versions.300.version=3.0.0
+libs.gsl.versions.300.path=/opt/compiler-explorer/libs/GSL/v3.0.0/include
+libs.gsl.versions.301.version=3.0.1
+libs.gsl.versions.301.path=/opt/compiler-explorer/libs/GSL/v3.0.1/include
+libs.gsl.versions.lite.version=lite
+libs.gsl.versions.lite.path=/opt/compiler-explorer/libs/gsl-lite/include
+
 libs.hedley.name=hedley
 libs.hedley.description=A C/C++ header to help move ifdefs out of your code
 libs.hedley.versions=v12
@@ -1846,32 +1609,75 @@ libs.hedley.url=https://github.com/nemequ/hedley
 libs.hedley.versions.v12.version=12.0.0
 libs.hedley.versions.v12.path=/opt/compiler-explorer/libs/hedley/v12/
 
-libs.gnufs.name=Filesystem (GNU)
-libs.gnufs.versions=autodetect
-libs.gnufs.versions.autodetect.version=autodetect
-libs.gnufs.versions.autodetect.staticliblink=stdc++fs
-libs.llvmfs.name=Filesystem (LLVM)
-libs.llvmfs.versions=autodetect
-libs.llvmfs.versions.autodetect.version=autodetect
-libs.llvmfs.versions.autodetect.staticliblink=c++fs
+libs.hfsm.name=HFSM
+libs.hfsm.description=Hierarchical Finite State Machine Framework
+libs.hfsm.versions=trunk:08:010
+libs.hfsm.url=https://github.com/andrew-gresyk/HFSM
+libs.hfsm.versions.trunk.version=trunk
+libs.hfsm.versions.trunk.path=/opt/compiler-explorer/libs/hfsm/trunk:/opt/compiler-explorer/libs/hfsm/trunk/include
+libs.hfsm.versions.08.version=0.8
+libs.hfsm.versions.08.path=/opt/compiler-explorer/libs/hfsm/0.8
+libs.hfsm.versions.010.version=0.10
+libs.hfsm.versions.010.path=/opt/compiler-explorer/libs/hfsm/0.10
 
-libs.etl.name=etl
-libs.etl.versions=trunk
-libs.etl.url=https://github.com/ETLCPP/etl
-libs.etl.versions.trunk.version=trunk
-libs.etl.versions.trunk.path=/opt/compiler-explorer/libs/etl/include:/opt/compiler-explorer/libs/etl/include/etl/profiles
+libs.highway.name=Highway
+libs.highway.versions=trunk:0_12_2
+libs.highway.url=https://github.com/google/highway
+libs.highway.staticliblink=hwy
+libs.highway.versions.trunk.version=trunk
+libs.highway.versions.trunk.path=/opt/compiler-explorer/libs/highway/trunk
+libs.highway.versions.0_12_2.version=0.12.2
+libs.highway.versions.0_12_2.path=/opt/compiler-explorer/libs/highway/0.12.2
 
-libs.namedtype.name=NamedType
-libs.namedtype.versions=trunk
-libs.namedtype.url=https://github.com/joboccara/NamedType
-libs.namedtype.versions.trunk.version=trunk
-libs.namedtype.versions.trunk.path=/opt/compiler-explorer/libs/NamedType/include:/opt/compiler-explorer/libs/NamedType/include/NamedType
+libs.immer.name=immer
+libs.immer.url=https://github.com/arximboldi/immer
+libs.immer.versions=trunk
+libs.immer.versions.trunk.version=trunk
+libs.immer.versions.trunk.path=/opt/compiler-explorer/libs/immer/trunk
 
-libs.pipes.name=Pipes
-libs.pipes.versions=trunk
-libs.pipes.url=https://github.com/joboccara/Pipes
-libs.pipes.versions.trunk.version=trunk
-libs.pipes.versions.trunk.path=/opt/compiler-explorer/libs/pipes/include
+libs.jsoncpp.name=JsonCpp
+libs.jsoncpp.description=JsonCpp is a C++ library that allows manipulating JSON values, including serialization and deserialization to and from strings
+libs.jsoncpp.examples=o1W1jofna:rfPajea5G
+libs.jsoncpp.versions=194
+libs.jsoncpp.url=https://github.com/open-source-parsers/jsoncpp
+libs.jsoncpp.staticliblink=jsoncpp
+libs.jsoncpp.versions.194.version=1.9.4
+libs.jsoncpp.versions.194.path=/opt/compiler-explorer/libs/jsoncpp/1.9.4/include
+
+libs.kiwaku.name=KIWAKU
+libs.kiwaku.description=C++20 Single Files Tools
+libs.kiwaku.versions=trunk
+libs.kiwaku.url=https://github.com/jfalcou/kiwaku
+libs.kiwaku.versions.trunk.version=trunk
+libs.kiwaku.versions.trunk.path=/opt/compiler-explorer/libs/kiwaku/trunk/include
+
+libs.kvasir.name=Kvasir::mpl
+libs.kvasir.versions=trunk
+libs.kvasir.url=https://github.com/kvasir-io/mpl
+libs.kvasir.versions.trunk.version=trunk
+# compiler-explorer/compiler-explorer/issues/598
+libs.kvasir.versions.trunk.path=/opt/compiler-explorer/libs/kvasir/mpl/trunk/src/kvasir:/opt/compiler-explorer/libs/kvasir/mpl/trunk/src
+
+libs.lager.name=lager
+libs.lager.url=https://github.com/arximboldi/lager
+libs.lager.versions=trunk
+libs.lager.versions.trunk.version=trunk
+libs.lager.versions.trunk.path=/opt/compiler-explorer/libs/lager/trunk
+
+libs.lexy.name=lexy
+libs.lexy.url=https://github.com/foonathan/lexy
+libs.lexy.description=C++ parser combinator library
+libs.lexy.versions=trunk
+libs.lexy.versions.trunk.version=trunk
+libs.lexy.versions.trunk.path=/opt/compiler-explorer/libs/lexy/trunk/include
+
+libs.libguarded.name=CsLibGuarded
+libs.libguarded.versions=trunk:110
+libs.libguarded.url=https://github.com/copperspice/cs_libguarded
+libs.libguarded.versions.trunk.version=trunk
+libs.libguarded.versions.trunk.path=/opt/compiler-explorer/libs/libguarded/trunk/src
+libs.libguarded.versions.110.version=1.1.0
+libs.libguarded.versions.110.path=/opt/compiler-explorer/libs/libguarded/libguarded-1.1.0/src
 
 libs.libuv.name=libuv
 libs.libuv.description=Cross-platform asynchronous I/O
@@ -1885,36 +1691,45 @@ libs.libuv.versions.1381.version=1.38.1
 libs.libuv.versions.1381.path=/opt/compiler-explorer/libs/libuv/v1.38.1/include
 libs.libuv.versions.1381.libpath=/opt/compiler-explorer/libs/libuv/v1.38.1/x86_64/lib:/opt/compiler-explorer/libs/libuv/v1.38.1/x86/lib
 
-libs.simde.name=SIMDe
-libs.simde.description=Implementations of SIMD instruction sets for systems which don't natively support them.
-libs.simde.versions=trunk
-libs.simde.url=https://github.com/simd-everywhere/simde
-libs.simde.versions.trunk.version=trunk
-libs.simde.versions.trunk.path=/opt/compiler-explorer/libs/simde/trunk
+libs.llvm.name=LLVM
+libs.llvm.description=LLVM
+libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000:1001:1100:1200
+libs.llvm.url=https://llvm.org/
+libs.llvm.versions.trunk.version=trunk
+libs.llvm.versions.trunk.path=/opt/compiler-explorer/libs/llvm/trunk/include
+libs.llvm.versions.401.version=4.0.1
+libs.llvm.versions.401.path=/opt/compiler-explorer/libs/llvm/4.0.1/include
+libs.llvm.versions.500.version=5.0.0
+libs.llvm.versions.500.path=/opt/compiler-explorer/libs/llvm/5.0.0/include
+libs.llvm.versions.501.version=5.0.1
+libs.llvm.versions.501.path=/opt/compiler-explorer/libs/llvm/5.0.1/include
+libs.llvm.versions.502.version=5.0.2
+libs.llvm.versions.502.path=/opt/compiler-explorer/libs/llvm/5.0.2/include
+libs.llvm.versions.600.version=6.0.0
+libs.llvm.versions.600.path=/opt/compiler-explorer/libs/llvm/6.0.0/include
+libs.llvm.versions.601.version=6.0.1
+libs.llvm.versions.601.path=/opt/compiler-explorer/libs/llvm/6.0.1/include
+libs.llvm.versions.700.version=7.0.0
+libs.llvm.versions.700.path=/opt/compiler-explorer/libs/llvm/7.0.0/include
+libs.llvm.versions.701.version=7.0.1
+libs.llvm.versions.701.path=/opt/compiler-explorer/libs/llvm/7.0.1/include
+libs.llvm.versions.800.version=8.0.0
+libs.llvm.versions.800.path=/opt/compiler-explorer/libs/llvm/8.0.0/include
+libs.llvm.versions.900.version=9.0.0
+libs.llvm.versions.900.path=/opt/compiler-explorer/libs/llvm/9.0.0/include
+libs.llvm.versions.1000.version=10.0.0
+libs.llvm.versions.1000.path=/opt/compiler-explorer/libs/llvm/10.0.0/include
+libs.llvm.versions.1001.version=10.0.1
+libs.llvm.versions.1001.path=/opt/compiler-explorer/libs/llvm/10.0.1/include
+libs.llvm.versions.1100.version=11.0.0
+libs.llvm.versions.1100.path=/opt/compiler-explorer/libs/llvm/11.0.0/include
+libs.llvm.versions.1200.version=12.0.0
+libs.llvm.versions.1200.path=/opt/compiler-explorer/libs/llvm/12.0.0/include
 
-libs.fastor.name=Fastor
-libs.fastor.description=Fastor is a high performance stack-based tensor (fixed multi-dimensional array) library for modern C++.
-libs.fastor.versions=trunk:063
-libs.fastor.url=https://github.com/romeric/Fastor
-libs.fastor.versions.trunk.version=trunk
-libs.fastor.versions.trunk.path=/opt/compiler-explorer/libs/fastor/trunk
-libs.fastor.versions.063.version=0.6.3
-libs.fastor.versions.063.path=/opt/compiler-explorer/libs/fastor/V0.6.3/
-
-libs.cctz.name=CCTZ
-libs.cctz.url=https://github.com/google/cctz
-libs.cctz.versions=23
-libs.cctz.staticliblink=cctz
-libs.cctz.versions.23.version=2.3
-libs.cctz.versions.23.path=/opt/compiler-explorer/libs/cctz/v2.3/include
-
-libs.crosscables.name=Crosscables
-libs.crosscables.url=https://github.com/partouf/Crosscables
-libs.crosscables.description=A statically linked C++98 cross-platform and multi-purpose library. Includes templates, classes and functions for custom strings, encoding, containers, threading, filesystem and networking.
-libs.crosscables.versions=trunk
-libs.crosscables.staticliblink=Jumpropes:Groundfloor
-libs.crosscables.versions.trunk.version=trunk
-libs.crosscables.versions.trunk.path=/opt/compiler-explorer/libs/crosscables/trunk/include
+libs.llvmfs.name=Filesystem (LLVM)
+libs.llvmfs.versions=autodetect
+libs.llvmfs.versions.autodetect.version=autodetect
+libs.llvmfs.versions.autodetect.staticliblink=c++fs
 
 libs.lua.name=Lua
 libs.lua.url=https://lua.org
@@ -1927,67 +1742,47 @@ libs.lua.versions.540.version=5.4.0
 libs.lua.versions.540.path=/opt/compiler-explorer/libs/lua/v5.4.0/include
 libs.lua.versions.540.libpath=/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86_64:/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86
 
-libs.sol2.name=sol2
-libs.sol2.url=https://github.com/ThePhD/sol2
-libs.sol2.versions=trunk:321
-libs.sol2.versions.trunk.version=trunk
-libs.sol2.versions.trunk.path=/opt/compiler-explorer/libs/sol2/trunk/include
-libs.sol2.versions.321.version=3.2.1
-libs.sol2.versions.321.path=/opt/compiler-explorer/libs/sol2/v3.2.1/include
+libs.mp-units.name=mp-units
+libs.mp-units.versions=trunk:070:060:050:040:031
+libs.mp-units.url=https://github.com/mpusz/units
+libs.mp-units.description=A Physical Units Library for C++<br /><br />Note that in some cases, you also need to add the {fmt} library.
+libs.mp-units.examples=5dvY8Woh1:9fnzfbhb6
+libs.mp-units.versions.trunk.version=trunk
+libs.mp-units.versions.trunk.path=/opt/compiler-explorer/libs/mp-units/trunk/src/core/include:/opt/compiler-explorer/libs/mp-units/trunk/src/core-fmt/include:/opt/compiler-explorer/libs/mp-units/trunk/src/core-io/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/isq/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/isq-iec80000/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/isq-natural/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-cgs/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-fps/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-iau/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-imperial/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-international/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-typographic/include:/opt/compiler-explorer/libs/mp-units/trunk/src/systems/si-us/include:/opt/compiler-explorer/libs/fmt/7.1.3/include:/opt/compiler-explorer/libs/gsl-lite/include
+libs.mp-units.versions.070.version=0.7.0
+libs.mp-units.versions.070.path=/opt/compiler-explorer/libs/mp-units/v0.7.0/src/core/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/core-fmt/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/core-io/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/isq/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/isq-iec80000/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/isq-natural/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-cgs/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-fps/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-iau/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-imperial/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-international/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-typographic/include:/opt/compiler-explorer/libs/mp-units/v0.7.0/src/systems/si-us/include:/opt/compiler-explorer/libs/fmt/7.1.3/include:/opt/compiler-explorer/libs/gsl-lite/include
+libs.mp-units.versions.060.version=0.6.0
+libs.mp-units.versions.060.path=/opt/compiler-explorer/libs/mp-units/v0.6.0/src/include:/opt/compiler-explorer/libs/fmt/7.0.0/include:/opt/compiler-explorer/libs/GSL/v3.0.1/include
+libs.mp-units.versions.050.version=0.5.0
+libs.mp-units.versions.050.path=/opt/compiler-explorer/libs/mp-units/v0.5.0/src/include:/opt/compiler-explorer/libs/rangesv3/0.10.0/include:/opt/compiler-explorer/libs/fmt/6.2.0/include
+libs.mp-units.versions.040.version=0.4.0
+libs.mp-units.versions.040.path=/opt/compiler-explorer/libs/mp-units/v0.4.0/src/include:/opt/compiler-explorer/libs/rangesv3/0.9.1/include:/opt/compiler-explorer/libs/fmt/6.0.0/include
+libs.mp-units.versions.031.version=0.3.1
+libs.mp-units.versions.031.path=/opt/compiler-explorer/libs/mp-units/v0.3.1/src/include:/opt/compiler-explorer/libs/rangesv3/0.9.1/include
 
-libs.unifex.name=libunifex
-libs.unifex.url=https://github.com/facebookexperimental/libunifex
-libs.unifex.versions=trunk
-libs.unifex.staticliblink=unifex
-libs.unifex.versions.trunk.version=trunk
-libs.unifex.versions.trunk.path=/opt/compiler-explorer/libs/unifex/trunk/include
+libs.namedtype.name=NamedType
+libs.namedtype.versions=trunk
+libs.namedtype.url=https://github.com/joboccara/NamedType
+libs.namedtype.versions.trunk.version=trunk
+libs.namedtype.versions.trunk.path=/opt/compiler-explorer/libs/NamedType/include:/opt/compiler-explorer/libs/NamedType/include/NamedType
 
-libs.immer.name=immer
-libs.immer.url=https://github.com/arximboldi/immer
-libs.immer.versions=trunk
-libs.immer.versions.trunk.version=trunk
-libs.immer.versions.trunk.path=/opt/compiler-explorer/libs/immer/trunk
+libs.nanorange.name=NanoRange
+libs.nanorange.versions=trunk
+libs.nanorange.url=https://github.com/tcbrindle/NanoRange
+libs.nanorange.versions.trunk.version=trunk
+libs.nanorange.versions.trunk.path=/opt/compiler-explorer/libs/nanorange/include
 
-libs.enoki.name=Enoki
-libs.enoki.url=https://github.com/mitsuba-renderer/enoki
-libs.enoki.versions=trunk
-libs.enoki.versions.trunk.version=trunk
-libs.enoki.versions.trunk.path=/opt/compiler-explorer/libs/enoki/trunk/include
-
-libs.spdlog.name=spdlog
-libs.spdlog.url=https://github.com/gabime/spdlog
-libs.spdlog.versions=150:160:161:170:180
-libs.spdlog.staticliblink=spdlogd
-libs.spdlog.options=-DSPDLOG_COMPILED_LIB
-libs.spdlog.versions.150.version=1.5.0
-libs.spdlog.versions.150.path=/opt/compiler-explorer/libs/spdlog/1.5.0/include
-libs.spdlog.versions.160.version=1.6.0
-libs.spdlog.versions.160.path=/opt/compiler-explorer/libs/spdlog/1.6.0/include
-libs.spdlog.versions.161.version=1.6.1
-libs.spdlog.versions.161.path=/opt/compiler-explorer/libs/spdlog/1.6.1/include
-libs.spdlog.versions.170.version=1.7.0
-libs.spdlog.versions.170.path=/opt/compiler-explorer/libs/spdlog/1.7.0/include
-libs.spdlog.versions.180.version=1.8.0
-libs.spdlog.versions.180.path=/opt/compiler-explorer/libs/spdlog/1.8.0/include
-
-libs.python.name=Python
-libs.python.url=https://python.org
-libs.python.versions=359:3610:376:381
-libs.python.versions.359.version=3.5.9
-libs.python.versions.359.path=/opt/compiler-explorer/python-3.5.9/include/python3.5
-libs.python.versions.3610.version=3.6.10
-libs.python.versions.3610.path=/opt/compiler-explorer/python-3.6.10/include/python3.6
-libs.python.versions.376.version=3.7.6
-libs.python.versions.376.path=/opt/compiler-explorer/python-3.7.6/include/python3.7
-libs.python.versions.381.version=3.8.1
-libs.python.versions.381.path=/opt/compiler-explorer/python-3.8.1/include/python3.8
-
-libs.lexy.name=lexy
-libs.lexy.url=https://github.com/foonathan/lexy
-libs.lexy.description=C++ parser combinator library
-libs.lexy.versions=trunk
-libs.lexy.versions.trunk.version=trunk
-libs.lexy.versions.trunk.path=/opt/compiler-explorer/libs/lexy/trunk/include
+libs.nlohmann_json.name=nlohmann::json
+libs.nlohmann_json.versions=trunk:360:312:211
+libs.nlohmann_json.url=https://github.com/nlohmann/json
+libs.nlohmann_json.versions.trunk.version=trunk
+libs.nlohmann_json.versions.trunk.path=/opt/compiler-explorer/libs/nlohmann_json/trunk/single_include
+libs.nlohmann_json.versions.360.version=3.6.0
+libs.nlohmann_json.versions.360.path=/opt/compiler-explorer/libs/nlohmann_json/v3.6.0/single_include
+libs.nlohmann_json.versions.312.version=3.1.2
+libs.nlohmann_json.versions.312.path=/opt/compiler-explorer/libs/nlohmann_json/v3.1.2/single_include
+libs.nlohmann_json.versions.211.version=2.1.1
+libs.nlohmann_json.versions.211.path=/opt/compiler-explorer/libs/nlohmann_json/v2.1.1/src
 
 libs.nsimd.name=NSIMD
 libs.nsimd.url=https://github.com/agenium-scale/nsimd/
@@ -2005,12 +1800,205 @@ libs.nsimd.versions.22-arm64.path=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aar
 libs.nsimd.versions.22-arm64.libpath=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aarch64/lib
 libs.nsimd.versions.22-arm64.liblink=nsimd_aarch64
 
-libs.ztdtext.name=ztd.text
-libs.ztdtext.url=https://github.com/soasis/text
-libs.ztdtext.description=Text encoding library
-libs.ztdtext.versions=trunk
-libs.ztdtext.versions.trunk.version=trunk
-libs.ztdtext.versions.trunk.path=/opt/compiler-explorer/libs/ztdtext/trunk/include
+libs.ofw.name=OFW
+libs.ofw.description=C++20 Single Files Tools
+libs.ofw.versions=trunk
+libs.ofw.url=https://github.com/jfalcou/ofw
+libs.ofw.versions.trunk.version=trunk
+libs.ofw.versions.trunk.path=/opt/compiler-explorer/libs/ofw/trunk/include
+
+# OpenCV disabled for now, needs more installation work, any many more paths
+#libs.opencv.name=OpenCV
+#libs.opencv.versions=trunk
+#libs.opencv.url=https://opencv.org/
+#libs.opencv.versions.trunk.version=trunk
+#libs.opencv.versions.trunk.path=/opt/compiler-explorer/libs/opencv/include
+
+libs.openssl.name=OpenSSL
+libs.openssl.liblink=ssl:crypto
+libs.openssl.url=https://www.openssl.org
+libs.openssl.versions=111c:111g
+libs.openssl.versions.111c.version=1.1.1c
+libs.openssl.versions.111c.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/include
+libs.openssl.versions.111c.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86/opt/lib
+libs.openssl.versions.111g.version=1.1.1g
+libs.openssl.versions.111g.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/include
+libs.openssl.versions.111g.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86/opt/lib
+
+libs.outcome.versions=trunk
+libs.outcome.url=https://ned14.github.io/outcome/
+libs.outcome.name=outcome
+libs.outcome.description=Provides very lightweight outcome<T> and result<T> (non-Boost edition)
+libs.outcome.versions.trunk.version=trunk
+libs.outcome.versions.trunk.path=/opt/compiler-explorer/libs/outcome/single-header
+
+libs.pegtl.name=PEGTL
+libs.pegtl.description=Parsing Expression Grammar Template Library
+libs.pegtl.versions=trunk:280
+libs.pegtl.url=https://github.com/taocpp/PEGTL
+libs.pegtl.versions.trunk.version=trunk
+libs.pegtl.versions.trunk.path=/opt/compiler-explorer/libs/PEGTL/trunk/include
+libs.pegtl.versions.280.version=2.8.0
+libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
+
+libs.pipes.name=Pipes
+libs.pipes.versions=trunk
+libs.pipes.url=https://github.com/joboccara/Pipes
+libs.pipes.versions.trunk.version=trunk
+libs.pipes.versions.trunk.path=/opt/compiler-explorer/libs/pipes/include
+
+libs.pugixml.name=pugixml
+libs.pugixml.description=pugixml is a light-weight C++ XML processing library
+libs.pugixml.examples=bE3WPhMYq
+libs.pugixml.versions=1114
+libs.pugixml.url=https://pugixml.org/
+libs.pugixml.staticliblink=pugixml
+libs.pugixml.versions.1114.version=1.11.4
+libs.pugixml.versions.1114.path=/opt/compiler-explorer/libs/pugixml/v1.11.4/src/
+
+libs.python.name=Python
+libs.python.url=https://python.org
+libs.python.versions=359:3610:376:381
+libs.python.versions.359.version=3.5.9
+libs.python.versions.359.path=/opt/compiler-explorer/python-3.5.9/include/python3.5
+libs.python.versions.3610.version=3.6.10
+libs.python.versions.3610.path=/opt/compiler-explorer/python-3.6.10/include/python3.6
+libs.python.versions.376.version=3.7.6
+libs.python.versions.376.path=/opt/compiler-explorer/python-3.7.6/include/python3.7
+libs.python.versions.381.version=3.8.1
+libs.python.versions.381.path=/opt/compiler-explorer/python-3.8.1/include/python3.8
+
+libs.rangesv3.name=range-v3
+libs.rangesv3.versions=trunk:030:035:036:091:0100:0110
+libs.rangesv3.url=https://github.com/ericniebler/range-v3
+libs.rangesv3.versions.trunk.version=trunk
+libs.rangesv3.versions.trunk.path=/opt/compiler-explorer/libs/rangesv3/trunk/include
+libs.rangesv3.versions.030.version=0.3.0
+libs.rangesv3.versions.030.path=/opt/compiler-explorer/libs/rangesv3/0.3.0/include
+libs.rangesv3.versions.035.version=0.3.5
+libs.rangesv3.versions.035.path=/opt/compiler-explorer/libs/rangesv3/0.3.5/include
+libs.rangesv3.versions.036.version=0.3.6
+libs.rangesv3.versions.036.path=/opt/compiler-explorer/libs/rangesv3/0.3.6/include
+libs.rangesv3.versions.091.version=0.9.1
+libs.rangesv3.versions.091.path=/opt/compiler-explorer/libs/rangesv3/0.9.1/include
+libs.rangesv3.versions.0100.version=0.10.0
+libs.rangesv3.versions.0100.path=/opt/compiler-explorer/libs/rangesv3/0.10.0/include
+libs.rangesv3.versions.0110.version=0.11.0
+libs.rangesv3.versions.0110.path=/opt/compiler-explorer/libs/rangesv3/0.11.0/include
+
+libs.seastar.name=Seastar
+libs.seastar.description=SeaStar is an event-driven framework allowing you to write non-blocking, asynchronous code in a relatively straightforward manner.
+libs.seastar.versions=180
+libs.seastar.url=http://seastar.io
+libs.seastar.versions.180.version=18.08.0
+libs.seastar.versions.180.path=/opt/compiler-explorer/libs/seastar/seastar-18.08.0
+
+libs.simde.name=SIMDe
+libs.simde.description=Implementations of SIMD instruction sets for systems which don't natively support them.
+libs.simde.versions=trunk
+libs.simde.url=https://github.com/simd-everywhere/simde
+libs.simde.versions.trunk.version=trunk
+libs.simde.versions.trunk.path=/opt/compiler-explorer/libs/simde/trunk
+
+libs.sol2.name=sol2
+libs.sol2.url=https://github.com/ThePhD/sol2
+libs.sol2.versions=trunk:321
+libs.sol2.versions.trunk.version=trunk
+libs.sol2.versions.trunk.path=/opt/compiler-explorer/libs/sol2/trunk/include
+libs.sol2.versions.321.version=3.2.1
+libs.sol2.versions.321.path=/opt/compiler-explorer/libs/sol2/v3.2.1/include
+
+libs.spdlog.name=spdlog
+libs.spdlog.url=https://github.com/gabime/spdlog
+libs.spdlog.versions=150:160:161:170:180
+libs.spdlog.staticliblink=spdlogd
+libs.spdlog.options=-DSPDLOG_COMPILED_LIB
+libs.spdlog.versions.150.version=1.5.0
+libs.spdlog.versions.150.path=/opt/compiler-explorer/libs/spdlog/1.5.0/include
+libs.spdlog.versions.160.version=1.6.0
+libs.spdlog.versions.160.path=/opt/compiler-explorer/libs/spdlog/1.6.0/include
+libs.spdlog.versions.161.version=1.6.1
+libs.spdlog.versions.161.path=/opt/compiler-explorer/libs/spdlog/1.6.1/include
+libs.spdlog.versions.170.version=1.7.0
+libs.spdlog.versions.170.path=/opt/compiler-explorer/libs/spdlog/1.7.0/include
+libs.spdlog.versions.180.version=1.8.0
+libs.spdlog.versions.180.path=/opt/compiler-explorer/libs/spdlog/1.8.0/include
+
+libs.spy.name=SPY
+libs.spy.description=C++17 constexpr settings detectors
+libs.spy.versions=trunk:v004:v100
+libs.spy.url=https://github.com/jfalcou/spy
+libs.spy.versions.trunk.version=trunk
+libs.spy.versions.trunk.path=/opt/compiler-explorer/libs/spy/trunk/include
+libs.spy.versions.v004.version=v0.0.4
+libs.spy.versions.v004.path=/opt/compiler-explorer/libs/spy/0.0.4/include
+libs.spy.versions.v004.alias=v003
+libs.spy.versions.v100.version=v1.0.0
+libs.spy.versions.v100.path=/opt/compiler-explorer/libs/spy/1.0.0/include
+
+libs.tbb.name=Intel TBB
+libs.tbb.versions=20202:20203
+libs.tbb.liblink=tbb
+libs.tbb.url=https://www.threadingbuildingblocks.org/
+libs.tbb.versions.20202.version=2020.2
+libs.tbb.versions.20202.path=/opt/compiler-explorer/libs/tbb/2020.2/include
+libs.tbb.versions.20203.version=2020.3
+libs.tbb.versions.20203.path=/opt/compiler-explorer/libs/tbb/2020.3/include
+libs.tbb.versions.20203.alias=trunk
+
+libs.tomlplusplus.name=toml++
+libs.tomlplusplus.versions=trunk:133:124
+libs.tomlplusplus.description=TOML parser and serializer for modern C++
+libs.tomlplusplus.url=https://marzer.github.io/tomlplusplus
+libs.tomlplusplus.versions.trunk.version=trunk
+libs.tomlplusplus.versions.trunk.path=/opt/compiler-explorer/libs/tomlplusplus/trunk/include
+libs.tomlplusplus.versions.133.version=1.3.3
+libs.tomlplusplus.versions.133.path=/opt/compiler-explorer/libs/tomlplusplus/v1.3.3/include
+libs.tomlplusplus.versions.124.version=1.2.4
+libs.tomlplusplus.versions.124.path=/opt/compiler-explorer/libs/tomlplusplus/v1.2.4/include
+
+libs.trompeloeil.name=trompeloeil
+libs.trompeloeil.versions=41:40:39:38:37:36:35:34:33:32:31:30:29:28
+libs.trompeloeil.url=https://github.com/rollbear/trompeloeil
+libs.trompeloeil.versions.41.path=/opt/compiler-explorer/libs/trompeloeil/v41/include
+libs.trompeloeil.versions.41.version=v41
+libs.trompeloeil.versions.40.path=/opt/compiler-explorer/libs/trompeloeil/v40/include
+libs.trompeloeil.versions.40.version=v40
+libs.trompeloeil.versions.39.path=/opt/compiler-explorer/libs/trompeloeil/v39/include
+libs.trompeloeil.versions.39.version=v39
+libs.trompeloeil.versions.38.path=/opt/compiler-explorer/libs/trompeloeil/v38/include
+libs.trompeloeil.versions.38.version=v38
+libs.trompeloeil.versions.37.path=/opt/compiler-explorer/libs/trompeloeil/v37/include
+libs.trompeloeil.versions.37.version=v37
+libs.trompeloeil.versions.36.path=/opt/compiler-explorer/libs/trompeloeil/v36/include
+libs.trompeloeil.versions.36.version=v36
+libs.trompeloeil.versions.35.path=/opt/compiler-explorer/libs/trompeloeil/v35/include
+libs.trompeloeil.versions.35.version=v35
+libs.trompeloeil.versions.34.path=/opt/compiler-explorer/libs/trompeloeil/v34/include
+libs.trompeloeil.versions.34.version=v34
+libs.trompeloeil.versions.33.path=/opt/compiler-explorer/libs/trompeloeil/v33/include
+libs.trompeloeil.versions.33.version=v33
+libs.trompeloeil.versions.32.path=/opt/compiler-explorer/libs/trompeloeil/v32/include
+libs.trompeloeil.versions.32.version=v32
+libs.trompeloeil.versions.31.path=/opt/compiler-explorer/libs/trompeloeil/v31/include
+libs.trompeloeil.versions.31.version=v31
+libs.trompeloeil.versions.30.path=/opt/compiler-explorer/libs/trompeloeil/v30/include
+libs.trompeloeil.versions.30.version=v30
+libs.trompeloeil.versions.29.path=/opt/compiler-explorer/libs/trompeloeil/v29/include
+libs.trompeloeil.versions.29.version=v29
+libs.trompeloeil.versions.28.path=/opt/compiler-explorer/libs/trompeloeil/v28/include
+libs.trompeloeil.versions.28.version=v28
+
+libs.tts.name=TTS
+libs.tts.description=C++20 Unit Test Framework for Numerical Applications
+libs.tts.versions=trunk:v01:v02
+libs.tts.url=https://github.com/jfalcou/tts
+libs.tts.versions.trunk.version=trunk
+libs.tts.versions.trunk.path=/opt/compiler-explorer/libs/tts/trunk/include
+libs.tts.versions.v01.version=v0.1
+libs.tts.versions.v01.path=/opt/compiler-explorer/libs/tts/0.1/include
+libs.tts.versions.v02.version=v0.2
+libs.tts.versions.v02.path=/opt/compiler-explorer/libs/tts/0.2/include
 
 libs.type_safe.name=type_safe
 libs.type_safe.url=https://github.com/foonathan/type_safe
@@ -2019,11 +2007,62 @@ libs.type_safe.versions=trunk
 libs.type_safe.versions.trunk.version=trunk
 libs.type_safe.versions.trunk.path=/opt/compiler-explorer/libs/type_safe/trunk/include:/opt/compiler-explorer/libs/type_safe/trunk/external/debug_assert
 
-libs.lager.name=lager
-libs.lager.url=https://github.com/arximboldi/lager
-libs.lager.versions=trunk
-libs.lager.versions.trunk.version=trunk
-libs.lager.versions.trunk.path=/opt/compiler-explorer/libs/lager/trunk
+libs.unifex.name=libunifex
+libs.unifex.url=https://github.com/facebookexperimental/libunifex
+libs.unifex.versions=trunk
+libs.unifex.staticliblink=unifex
+libs.unifex.versions.trunk.version=trunk
+libs.unifex.versions.trunk.path=/opt/compiler-explorer/libs/unifex/trunk/include
+
+libs.vcl.name=VCL
+libs.vcl.description=Agner Fog's vector class library
+libs.vcl.versions=130:200:201
+libs.vcl.url=https://github.com/vectorclass
+libs.vcl.versions.130.version=1.30
+libs.vcl.versions.130.path=/opt/compiler-explorer/libs/vcl/v1.30
+libs.vcl.versions.200.version=2.00
+libs.vcl.versions.200.path=/opt/compiler-explorer/libs/vcl/v2.00.01
+libs.vcl.versions.201.version=2.01
+libs.vcl.versions.201.path=/opt/compiler-explorer/libs/vcl/v2.01.03
+
+libs.xsimd.name=xsimd
+libs.xsimd.versions=trunk:700:614
+libs.xsimd.url=http://xsimd.readthedocs.io
+libs.xsimd.versions.trunk.version=trunk
+libs.xsimd.versions.trunk.path=/opt/compiler-explorer/libs/xsimd/trunk/include
+libs.xsimd.versions.700.version=7.0.0
+libs.xsimd.versions.700.path=/opt/compiler-explorer/libs/xsimd/7.0.0/include
+libs.xsimd.versions.614.version=6.1.4
+libs.xsimd.versions.614.path=/opt/compiler-explorer/libs/xsimd/6.1.4/include
+
+libs.xtensor.name=xtensor
+libs.xtensor.versions=trunk:0194:0182:0174
+libs.xtensor.url=http://xtensor.readthedocs.io
+libs.xtensor.versions.trunk.version=trunk
+libs.xtensor.versions.trunk.path=/opt/compiler-explorer/libs/xtensor/trunk/include
+libs.xtensor.versions.0194.version=0.19.4
+libs.xtensor.versions.0194.path=/opt/compiler-explorer/libs/xtensor/0.19.4/include
+libs.xtensor.versions.0182.version=0.18.2
+libs.xtensor.versions.0182.path=/opt/compiler-explorer/libs/xtensor/0.18.2/include
+libs.xtensor.versions.0174.version=0.17.4
+libs.xtensor.versions.0174.path=/opt/compiler-explorer/libs/xtensor/0.17.4/include
+
+libs.xtl.name=xtl
+libs.xtl.versions=trunk:053:0416
+libs.xtl.url=http://xtl.readthedocs.io
+libs.xtl.versions.trunk.version=trunk
+libs.xtl.versions.trunk.path=/opt/compiler-explorer/libs/xtl/trunk/include
+libs.xtl.versions.053.version=0.5.3
+libs.xtl.versions.053.path=/opt/compiler-explorer/libs/xtl/0.5.3/include
+libs.xtl.versions.0416.version=0.4.16
+libs.xtl.versions.0416.path=/opt/compiler-explorer/libs/xtl/0.4.16/include
+
+libs.ztdtext.name=ztd.text
+libs.ztdtext.url=https://github.com/soasis/text
+libs.ztdtext.description=Text encoding library
+libs.ztdtext.versions=trunk
+libs.ztdtext.versions.trunk.version=trunk
+libs.ztdtext.versions.trunk.path=/opt/compiler-explorer/libs/ztdtext/trunk/include
 
 libs.zug.name=zug
 libs.zug.url=https://github.com/arximboldi/zug
@@ -2034,8 +2073,7 @@ libs.zug.versions.trunk.path=/opt/compiler-explorer/libs/zug/trunk
 #################################
 #################################
 # Installed tools
-
-tools=PVS-Studio:clangtidytrunk:llvm-mcatrunk:osacatrunk:pahole:clangformattrunk:clangquerytrunk:readelf:x86to6502:ldd:iwyu:strings
+tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:iwyu:ldd:llvm-mcatrunk:osacatrunk:pahole:readelf:strings:x86to6502
 
 tools.PVS-Studio.name=PVS-Studio
 tools.PVS-Studio.exe=/opt/compiler-explorer/pvs-studio-latest/bin/pvs-studio-analyzer
@@ -2045,6 +2083,17 @@ tools.PVS-Studio.class=pvs-studio-tool
 tools.PVS-Studio.stdinHint=disabled
 tools.PVS-Studio.includeKey=supportsPVS-Studio
 
+tools.clangformattrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
+tools.clangformattrunk.name=clang-format
+tools.clangformattrunk.type=independent
+tools.clangformattrunk.class=clang-format-tool
+
+tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
+tools.clangquerytrunk.name=clang-query (trunk)
+tools.clangquerytrunk.type=independent
+tools.clangquerytrunk.class=clang-query-tool
+tools.clangquerytrunk.stdinHint=Query commands
+
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
 tools.clangtidytrunk.name=clang-tidy (trunk)
 tools.clangtidytrunk.type=independent
@@ -2053,10 +2102,20 @@ tools.clangtidytrunk.exclude=cl19:cl_new
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
 tools.clangtidytrunk.stdinHint=disabled
 
-tools.clangformattrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
-tools.clangformattrunk.name=clang-format
-tools.clangformattrunk.type=independent
-tools.clangformattrunk.class=clang-format-tool
+tools.iwyu.exe=/opt/compiler-explorer/iwyu/0.12/bin/include-what-you-use
+tools.iwyu.name=include-what-you-use (0.12)
+tools.iwyu.type=independent
+tools.iwyu.class=compiler-dropin-tool
+# e.g.
+# tools.iwyu.options=-Xiwyu --mapping_file=/opt/compiler-explorer/iwyu/share/include-what-you-use/gcc-8.intrinsics.imp
+tools.iwyu.stdinHint=disabled
+
+tools.ldd.name=ldd
+tools.ldd.exe=/usr/bin/ldd
+tools.ldd.type=postcompilation
+tools.ldd.class=readelf-tool
+tools.ldd.exclude=djggp
+tools.ldd.stdinHint=disabled
 
 tools.llvm-mcatrunk.name=llvm-mca (trunk)
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
@@ -2087,18 +2146,12 @@ tools.readelf.class=readelf-tool
 tools.readelf.exclude=djggp
 tools.readelf.stdinHint=disabled
 
-tools.ldd.name=ldd
-tools.ldd.exe=/usr/bin/ldd
-tools.ldd.type=postcompilation
-tools.ldd.class=readelf-tool
-tools.ldd.exclude=djggp
-tools.ldd.stdinHint=disabled
-
-tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
-tools.clangquerytrunk.name=clang-query (trunk)
-tools.clangquerytrunk.type=independent
-tools.clangquerytrunk.class=clang-query-tool
-tools.clangquerytrunk.stdinHint=Query commands
+tools.strings.exe=/opt/compiler-explorer/gcc-snapshot/bin/strings
+tools.strings.name=strings
+tools.strings.type=postcompilation
+tools.strings.class=strings-tool
+tools.strings.exclude=djggp
+tools.strings.stdinHint=disabled
 
 tools.x86to6502.exe=/opt/compiler-explorer/x86-to-6502/lefticus/x86-to-6502
 tools.x86to6502.name=x86-to-6502
@@ -2107,18 +2160,3 @@ tools.x86to6502.class=x86to6502-tool
 tools.x86to6502.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new_arm32:djggp:riscv:wasm:frc2019:raspbian:arduino
 tools.x86to6502.stdinHint=disabled
 tools.x86to6502.languageId=asm6502
-
-tools.iwyu.exe=/opt/compiler-explorer/iwyu/0.12/bin/include-what-you-use
-tools.iwyu.name=include-what-you-use (0.12)
-tools.iwyu.type=independent
-tools.iwyu.class=compiler-dropin-tool
-# e.g.
-# tools.iwyu.options=-Xiwyu --mapping_file=/opt/compiler-explorer/iwyu/share/include-what-you-use/gcc-8.intrinsics.imp
-tools.iwyu.stdinHint=disabled
-
-tools.strings.exe=/opt/compiler-explorer/gcc-snapshot/bin/strings
-tools.strings.name=strings
-tools.strings.type=postcompilation
-tools.strings.class=strings-tool
-tools.strings.exclude=djggp
-tools.strings.stdinHint=disabled

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -461,6 +461,7 @@ group.rvclang.compilers=rv32-clang:rv32-clang1101:rv32-clang1100:rv32-clang1001:
 group.rvclang.groupName=RISC-V Clang
 group.rvclang.supportsBinary=false
 group.rvclang.supportsExecute=false
+hroup.rvclang.isSemVer=true
 
 compiler.rv32-clang.name=RISC-V rv32gc clang (trunk)
 compiler.rv32-clang.alias=rv32clang

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1087,7 +1087,7 @@ compiler.djggp494.semver=4.9.4
 
 #################################
 # Zig c++
-group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxxtrunk
+group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxxtrunk
 group.zigcxx.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcxx.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcxx.options=
@@ -1102,6 +1102,8 @@ compiler.zcxx070.exe=/opt/compiler-explorer/zig-0.7.0/zig
 compiler.zcxx070.semver=0.7.0
 compiler.zcxx071.exe=/opt/compiler-explorer/zig-0.7.1/zig
 compiler.zcxx071.semver=0.7.1
+compiler.zcxx080.exe=/opt/compiler-explorer/zig-0.8.0/zig
+compiler.zcxx080.semver=0.8.0
 compiler.zcxxtrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcxxtrunk.semver=trunk
 

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -432,7 +432,6 @@ compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 ################################
 # Clang for RISC-V
 group.rvclang.compilers=&rv32clang:&rv64clang
-group.rvclang.groupName=RISC-V Clang
 group.rvclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 group.rvclang.supportsBinary=true
 group.rvclang.supportsExecute=false
@@ -442,6 +441,7 @@ group.rv32clang.compilers=rv32-clang:rv32-clang1200:rv32-clang1101:rv32-clang110
 group.rv32clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 group.rv32clang.baseName=RISC-V rv32gc clang
+group.rv32clang.groupName=RISC-V 32 Clang
 
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-clang900.semver=9.0.0
@@ -473,6 +473,7 @@ group.rv64clang.compilers=rv64-clang:rv64-clang1200:rv64-clang1101:rv64-clang110
 group.rv64clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64clang.baseName=RISC-V rv64gc clang
+group.rv64clang.groupName=RISC-V 64 Clang
 
 compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv64-clang900.semver=9.0.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -348,48 +348,36 @@ group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
 group.armclang32.instructionSet=arm32
-compiler.armv7-clang1101.name=armv7-a clang 11.0.1
+group.armclang32.baseName=armv7-a clang
+
 compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv7-clang1101.semver=11.0.1
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1101.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-compiler.armv7-clang1100.name=armv7-a clang 11.0.0
 compiler.armv7-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.armv7-clang1100.semver=11.0.0
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1100.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-compiler.armv7-clang1001.name=armv7-a clang 10.0.1
 compiler.armv7-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
 compiler.armv7-clang1001.semver=10.0.1
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1001.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-compiler.armv7-clang1000.name=armv7-a clang 10.0.0
 compiler.armv7-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.armv7-clang1000.semver=10.0.0
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang1000.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-# This compiler was originally named with only a major version number.  An alias
-# of this name needs to be maintained to allow old URLs to continue to work
+# This compiler was originally named with only a major version number.
+# An alias of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv7-clang1000.alias=armv7-clang-10
-compiler.armv7-clang901.name=armv7-a clang 9.0.1
 compiler.armv7-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.armv7-clang901.semver=9.0.1
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang901.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-compiler.armv7-clang900.name=armv7-a clang 9.0.0
 compiler.armv7-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.armv7-clang900.semver=9.0.0
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang900.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
-# This compiler was originally named with only a major version number.  An alias
-# of this name needs to be maintained to allow old URLs to continue to work
+# This compiler was originally named with only a major version number.
+# An alias of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv7-clang900.alias=armv7-clang-9
-compiler.armv7-clang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv7-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv7-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-clang-trunk.semver=(trunk)
-# Arm v7-a with Neon and VFPv3
 compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 ################################
@@ -532,6 +520,7 @@ group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
 group.icc.baseName=x86-64 icc
 group.icc.isSemVer=true
+
 compiler.icc1301.exe=/opt/compiler-explorer/intel/bin/icc
 compiler.icc1301.alias=/opt/intel/bin/icc
 compiler.icc1301.semver=13.0.1
@@ -557,7 +546,6 @@ compiler.icc19.options=-gxx-name=/opt/compiler-explorer/gcc-8.2.0/bin/g++
 compiler.icc191.exe=/opt/compiler-explorer/intel-2019.1/bin/icc
 compiler.icc191.semver=19.0.1
 compiler.icc191.options=-gxx-name=/opt/compiler-explorer/gcc-8.2.0/bin/g++
-
 compiler.icc202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/intel64/icc
 compiler.icc202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin
 compiler.icc202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
@@ -565,7 +553,6 @@ compiler.icc202112.semver=2021.1.2
 compiler.icc202112.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 # Alias the betas to the product compiler
 compiler.icc202112.alias=icc202118:icc202119
-
 compiler.icc202120.exe=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/bin/intel64/icc
 compiler.icc202120.ldPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin
 compiler.icc202120.libPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/ia32_lin
@@ -601,6 +588,7 @@ group.zapcc.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 compiler.zapcc190308.exe=/opt/compiler-explorer/zapcc-20170226-190308-1.0/bin/zapcc++
 compiler.zapcc190308.name=x86-64 Zapcc 190308
 
+
 ###############################
 # Cross GCC
 group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&rvgcc:&platspec:&kalray
@@ -613,6 +601,7 @@ group.cross.supportsExecute=false
 group.ppc.compilers=ppcg48:ppc64leg630:ppc64leg8:ppc64g8:ppc64leg9:ppc64g9:ppc64clang:ppc64leclang
 group.ppc.groupName=POWER Compilers
 group.ppc.isSemVer=true
+
 compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
 compiler.ppcg48.name=PowerPC gcc 4.8.5
 compiler.ppcg48.semver=4.8.5
@@ -643,18 +632,20 @@ compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.ppc64clang.name=powerpc64 clang (trunk)
 compiler.ppc64clang.options=-target powerpc64
 compiler.ppc64clang.supportsBinary=false
+compiler.ppc64clang.semver=(snapshot)
 compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64leclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.ppc64leclang.name=power64le clang (trunk)
 compiler.ppc64leclang.options=-target powerpc64le
 compiler.ppc64leclang.supportsBinary=false
+compiler.ppc64leclang.semver=(snapshot)
 
 ###############################
 # GCC for ARM
 group.gccarm.compilers=&gcc32arm:&gcc64arm
 # Some of the compilers don't like -isystem (as they assume the code must be C).
-# See https://github.com/compiler-explorer/compiler-explorer/issues/989 for discussion/
+# See https://github.com/compiler-explorer/compiler-explorer/issues/989 for discussion
 group.gccarm.includeFlag=-I
 
 # 32 bit
@@ -734,37 +725,28 @@ group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g820:arm64g
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
+group.gcc64arm.baseName=ARM64 gcc
 
 compiler.aarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
-compiler.aarchg54.name=ARM64 gcc 5.4
 compiler.aarchg54.alias=aarchg48
 compiler.aarchg54.semver=5.4
 compiler.arm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
-compiler.arm64g630.name=ARM64 gcc 6.3
 compiler.arm64g630.semver=6.3
 compiler.arm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g640.name=ARM64 gcc 6.4
-compiler.arm64g640.semver=6.4.0
+compiler.arm64g640.semver=6.4
 compiler.arm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g730.name=ARM64 gcc 7.3
-compiler.arm64g730.semver=7.3.0
+compiler.arm64g730.semver=7.3
 compiler.arm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g820.name=ARM64 gcc 8.2
-compiler.arm64g820.semver=8.2.0
+compiler.arm64g820.semver=8.2
 compiler.arm64g930.exe=/opt/compiler-explorer/arm64/gcc-9.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g930.name=ARM64 gcc 9.3
-compiler.arm64g930.semver=9.3.0
+compiler.arm64g930.semver=9.3
 compiler.arm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g1020.name=ARM64 gcc 10.2
-compiler.arm64g1020.semver=10.2.0
+compiler.arm64g1020.semver=10.2
 compiler.arm64g1030.exe=/opt/compiler-explorer/arm64/gcc-10.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g1030.name=ARM64 gcc 10.3
-compiler.arm64g1030.semver=10.3.0
+compiler.arm64g1030.semver=10.3
 compiler.arm64g1100.exe=/opt/compiler-explorer/arm64/gcc-11.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g1100.name=ARM64 gcc 11.1
-compiler.arm64g1100.semver=11.1.0
+compiler.arm64g1100.semver=11.1
 compiler.arm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64gtrunk.name=ARM64 gcc trunk
 compiler.arm64gtrunk.semver=trunk
 
 ###############################
@@ -861,7 +843,6 @@ group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
-group.avr.supportsBinary=true
 
 compiler.avrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-g++
 compiler.avrg454.alias=avrg453
@@ -891,6 +872,7 @@ compiler.avrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdum
 group.mips.compilers=mips5:mips5el:mips564:mips564el
 group.mips.groupName=MIPS GCC
 group.mips.isSemVer=true
+
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mips5.name=MIPS gcc 5.4
 compiler.mips5.semver=5.4
@@ -913,32 +895,28 @@ compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-
 group.rvgcc.compilers=rv64-gcc1020:rv64-gcc820:rv32-gcc1020:rv32-gcc820
 group.rvgcc.groupName=RISC-V GCC
 group.rvgcc.supportsExecute=false
+group.rvgcc.isSemVer=true
 
 compiler.rv64-gcc820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcc820.name=RISC-V rv64gc gcc 8.2.0
 compiler.rv64-gcc820.alias=riscv820
 compiler.rv64-gcc820.semver=8.2.0
 compiler.rv64-gcc820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-gcc820.supportsBinary=true
 
 compiler.rv64-gcc1020.exe=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcc1020.name=RISC-V rv64gc gcc 10.2.0
 compiler.rv64-gcc1020.semver=10.2.0
 compiler.rv64-gcc1020.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-gcc1020.supportsBinary=true
 
 compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
 compiler.rv32-gcc820.semver=8.2.0
 compiler.rv32-gcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-gcc820.supportsBinary=true
 
 compiler.rv32-gcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc1020.name=RISC-V rv32gc gcc 10.2.0
 compiler.rv32-gcc1020.semver=8.2.0
 compiler.rv32-gcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-gcc1020.supportsBinary=true
-
 
 ################################
 # Windows Compilers
@@ -955,6 +933,7 @@ group.cl.isSemVer=true
 group.cl19.groupName=WINE MSVC 2017
 group.cl19.compilers=cl19_64:cl19_32:cl19_arm
 group.cl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/
+
 compiler.cl19_64.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/cl.exe
 compiler.cl19_64.name=x64 msvc v19.10 (WINE)
 compiler.cl19_64.semver=19.10.25017
@@ -969,6 +948,7 @@ compiler.cl19_arm.instructionSet=arm
 group.cl19_2015_u3.groupName=WINE MSVC 2015
 group.cl19_2015_u3.compilers=cl19_2015_u3_64:cl19_2015_u3_32:cl19_2015_u3_arm
 group.cl19_2015_u3.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.00.24210/include/
+
 compiler.cl19_2015_u3_64.exe=/opt/compiler-explorer/windows/19.00.24210/bin/amd64/cl.exe
 compiler.cl19_2015_u3_64.name=x64 msvc v19.0 (WINE)
 compiler.cl19_2015_u3_64.semver=19.00.24210
@@ -983,6 +963,7 @@ compiler.cl19_2015_u3_arm.instructionSet=arm
 group.cl_new.groupName=WINE MSVC 2017
 group.cl_new.compilers=cl_new_64:cl_new_32:cl_new_arm32:cl_new_arm64
 group.cl_new.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.14.26423/include/
+
 compiler.cl_new_64.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/x64/cl.exe
 compiler.cl_new_64.name=x64 msvc v19.14 (WINE)
 compiler.cl_new_64.semver=19.14.26423
@@ -1006,6 +987,7 @@ group.ellcc.groupName=ELLCC
 group.ellcc.baseName=ellcc
 group.ellcc.isSemVer=true
 group.ellcc.compilerType=ellcc
+
 compiler.ellcc0133.exe=/opt/compiler-explorer/ellcc-0.1.33/bin/ecc++
 compiler.ellcc0133.semver=0.1.33
 compiler.ellcc0134.exe=/opt/compiler-explorer/ellcc-0.1.34/bin/ecc++
@@ -1026,6 +1008,7 @@ group.djggp.baseName=x86 djgpp
 group.djggp.isSemVer=true
 group.djggp.demangler=
 group.djggp.supportsBinary=false
+
 compiler.djggp720.exe=/opt/compiler-explorer/djgpp-7.2.0/bin/i586-pc-msdosdjgpp-g++
 compiler.djggp720.semver=7.2.0
 compiler.djggp640.exe=/opt/compiler-explorer/djgpp-6.4.0/bin/i586-pc-msdosdjgpp-g++
@@ -1046,6 +1029,7 @@ group.zigcxx.isSemVer=true
 group.zigcxx.baseName=zig c++
 group.zigcxx.compilerType=zigcxx
 group.zigcxx.versionFlag=version
+
 compiler.zcxx060.exe=/opt/compiler-explorer/zig-0.6.0/zig
 compiler.zcxx060.semver=0.6.0
 compiler.zcxx070.exe=/opt/compiler-explorer/zig-0.7.0/zig

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -398,66 +398,52 @@ compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/op
 group.armclang64.groupName=Arm 64-bit clang
 group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang-trunk:armv8-full-clang-trunk
 group.armclang64.isSemVer=true
+group.armclang64.baseName=armv8-a clang
 group.armclang64.compilerType=clang
 group.armclang64.supportsExecute=false
 group.armclang64.instructionSet=aarch64
-compiler.armv8-clang1101.name=armv8-a clang 11.0.1
+
 compiler.armv8-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv8-clang1101.semver=11.0.1
-# Arm v8-a
 compiler.armv8-clang1101.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-compiler.armv8-clang1100.name=armv8-a clang 11.0.0
 compiler.armv8-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.armv8-clang1100.semver=11.0.0
-# Arm v8-a
 compiler.armv8-clang1100.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-compiler.armv8-clang1001.name=armv8-a clang 10.0.1
 compiler.armv8-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
 compiler.armv8-clang1001.semver=10.0.1
-# Arm v8-a
 compiler.armv8-clang1001.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-compiler.armv8-clang1000.name=armv8-a clang 10.0.0
 compiler.armv8-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.armv8-clang1000.semver=10.0.0
-# Arm v8-a
 compiler.armv8-clang1000.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-# This compiler was originally named with only a major version number.  An alias
-# of this name needs to be maintained to allow old URLs to continue to work
+# This compiler was originally named with only a major version number.
+# An alias of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv8-clang1000.alias=armv8-clang-10
-compiler.armv8-clang901.name=armv8-a clang 9.0.1
 compiler.armv8-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.armv8-clang901.semver=9.0.1
-# Arm v8-a
 compiler.armv8-clang901.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-compiler.armv8-clang900.name=armv8-a clang 9.0.0
 compiler.armv8-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.armv8-clang900.semver=9.0.0
-# Arm v8-a
 compiler.armv8-clang900.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-# This compiler was originally named with only a major version number.  An alias
-# of this name needs to be maintained to allow old URLs to continue to work
+# This compiler was originally named with only a major version number.
+# An alias of this name needs to be maintained to allow old URLs to continue to work
 compiler.armv8-clang900.alias=armv8-clang-9
-compiler.armv8-clang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-clang-trunk.semver=(trunk)
-# Arm v8-a
 compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
-compiler.armv8-full-clang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-full-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-full-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv8-full-clang-trunk.semver=(trunk allfeats)
+compiler.armv8-full-clang-trunk.semver=(trunk, all architectural features)
 # Arm v8-a with all supported architectural features
 compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
-# An alias of the original name for this compiler needs to be maintained to
-# allow old URLs to continue to work
+# An alias of the original name for this compiler needs to be maintained to allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 ################################
 # Clang for RISC-V
-group.rvclang.compilers=rv32-clang:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900:rv64-clang:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
+group.rvclang.compilers=rv32-clang:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900:rv64-clang:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
 group.rvclang.groupName=RISC-V Clang
 group.rvclang.supportsBinary=false
 group.rvclang.supportsExecute=false
@@ -471,6 +457,11 @@ compiler.rv32-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 compiler.rv32-clang.supportsBinary=true
+compiler.rv32-clang1200.name=RISC-V rv32gc clang 12.0.0
+compiler.rv32-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.rv32-clang1200.semver=12.0.0
+compiler.rv32-clang1200.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv32-clang1200.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1101.name=RISC-V rv32gc clang 11.0.1
 compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
 compiler.rv32-clang1101.semver=11.0.1
@@ -521,6 +512,11 @@ compiler.rv64-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.supportsBinary=true
+compiler.rv64-clang1200.name=RISC-V rv64gc clang 12.0.0
+compiler.rv64-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.rv64-clang1200.semver=12.0.0
+compiler.rv64-clang1200.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-clang1200.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1101.name=RISC-V rv64gc clang 11.0.1
 compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
 compiler.rv64-clang1101.semver=11.0.1

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -431,7 +431,7 @@ compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 ################################
 # Clang for RISC-V
-group.rvclang.compilers=&rv32clang:&rv32clang
+group.rvclang.compilers=&rv32clang:&rv64clang
 group.rvclang.groupName=RISC-V Clang
 group.rvclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 group.rvclang.supportsBinary=true

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -443,128 +443,81 @@ compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 ################################
 # Clang for RISC-V
-group.rvclang.compilers=rv32-clang:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900:rv64-clang:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
+group.rvclang.compilers=&rv32clang:&rv32clang
 group.rvclang.groupName=RISC-V Clang
-group.rvclang.supportsBinary=false
+group.rvclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+group.rvclang.supportsBinary=true
 group.rvclang.supportsExecute=false
-hroup.rvclang.isSemVer=true
+group.rvclang.isSemVer=true
 
-compiler.rv32-clang.name=RISC-V rv32gc clang (trunk)
-compiler.rv32-clang.alias=rv32clang
-compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.rv32-clang.semver=(trunk)
-compiler.rv32-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
-compiler.rv32-clang.supportsBinary=true
-compiler.rv32-clang1200.name=RISC-V rv32gc clang 12.0.0
-compiler.rv32-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
-compiler.rv32-clang1200.semver=12.0.0
-compiler.rv32-clang1200.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1200.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang1101.name=RISC-V rv32gc clang 11.0.1
-compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
-compiler.rv32-clang1101.semver=11.0.1
-compiler.rv32-clang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1101.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang1101.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
-compiler.rv32-clang1101.supportsBinary=true
-compiler.rv32-clang1100.name=RISC-V rv32gc clang 11.0.0
-compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
-compiler.rv32-clang1100.semver=11.0.0
-compiler.rv32-clang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1100.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang1100.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
-compiler.rv32-clang1100.supportsBinary=true
-compiler.rv32-clang1001.name=RISC-V rv32gc clang 10.0.1
-compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
-compiler.rv32-clang1001.semver=10.0.1
-compiler.rv32-clang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang1001.supportsBinary=true
-compiler.rv32-clang1000.name=RISC-V rv32gc clang 10.0.0
-compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
-compiler.rv32-clang1000.semver=10.0.0
-compiler.rv32-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang1000.supportsBinary=true
-compiler.rv32-clang901.name=RISC-V rv32gc clang 9.0.1
-compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
-compiler.rv32-clang901.semver=9.0.1
-compiler.rv32-clang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv32-clang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
-compiler.rv32-clang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang901.supportsBinary=true
-compiler.rv32-clang900.name=RISC-V rv32gc clang 9.0.0
+group.rv32clang.compilers=rv32-clang:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
+group.rv32clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
+group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+group.rv32clang.baseName=RISC-V rv32gc clang
+
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-clang900.semver=9.0.0
-compiler.rv32-clang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.rv32-clang900.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang900.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang900.supportsBinary=true
-compiler.rv64-clang.name=RISC-V rv64gc clang (trunk)
-compiler.rv64-clang.alias=rv64clang
-compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.rv64-clang.semver=(trunk)
-compiler.rv64-clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang.supportsBinary=true
-compiler.rv64-clang1200.name=RISC-V rv64gc clang 12.0.0
-compiler.rv64-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
-compiler.rv64-clang1200.semver=12.0.0
-compiler.rv64-clang1200.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1200.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang1101.name=RISC-V rv64gc clang 11.0.1
-compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
-compiler.rv64-clang1101.semver=11.0.1
-compiler.rv64-clang1101.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1101.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang1101.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1101.supportsBinary=true
-compiler.rv64-clang1100.name=RISC-V rv64gc clang 11.0.0
-compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
-compiler.rv64-clang1100.semver=11.0.0
-compiler.rv64-clang1100.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1100.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang1100.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1100.supportsBinary=true
-compiler.rv64-clang1001.name=RISC-V rv64gc clang 10.0.1
-compiler.rv64-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
-compiler.rv64-clang1001.semver=10.0.1
-compiler.rv64-clang1001.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1001.supportsBinary=true
-compiler.rv64-clang1000.name=RISC-V rv64gc clang 10.0.0
-compiler.rv64-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
-compiler.rv64-clang1000.semver=10.0.0
-compiler.rv64-clang1000.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1000.supportsBinary=true
-compiler.rv64-clang901.name=RISC-V rv64gc clang 9.0.1
-compiler.rv64-clang901.semver=9.0.1
-compiler.rv64-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
-compiler.rv64-clang901.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.rv64-clang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.rv64-clang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang901.supportsBinary=true
-compiler.rv64-clang900.name=RISC-V rv64gc clang 9.0.0
-compiler.rv64-clang900.semver=9.0.0
+compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv32-clang901.semver=9.0.1
+compiler.rv32-clang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.rv32-clang1000.semver=10.0.0
+compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.rv32-clang1001.semver=10.0.1
+compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
+compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.rv32-clang1100.semver=11.0.0
+compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv32-clang1101.semver=11.0.1
+compiler.rv32-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.rv32-clang1200.semver=12.0.0
+compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.rv32-clang.semver=(trunk)
+compiler.rv32-clang.alias=rv32clang
+
+group.rv64clang.compilers=rv64-clang:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
+group.rv64clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+group.rv64clang.baseName=RISC-V rv64gc clang
+
 compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
-compiler.rv64-clang900.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.rv64-clang900.semver=9.0.0
 compiler.rv64-clang900.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang900.supportsBinary=true
+compiler.rv64-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv64-clang901.semver=9.0.1
+compiler.rv64-clang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-clang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.rv64-clang1000.semver=10.0.0
+compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-clang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.rv64-clang1001.semver=10.0.1
+compiler.rv64-clang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-clang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.rv64-clang1100.semver=11.0.0
+compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv64-clang1101.semver=11.0.1
+compiler.rv64-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.rv64-clang1200.semver=12.0.0
+compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.rv64-clang.semver=(trunk)
+compiler.rv64-clang.alias=rv64clang
 
 ################################
 # Clang for WebAssembly
 group.wasmclang.compilers=wasm32clang
 group.wasmclang.groupName=Clang WebAssembly
 group.wasmclang.supportsBinary=false
+
 compiler.wasm32clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.wasm32clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.wasm32clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1000,7 +1000,7 @@ compiler.tinycc0927.semver=0.9.27
 
 #################################
 # Zig cc
-group.zigcc.compilers=zcc060:zcc070:zcc071:zcctrunk
+group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcctrunk
 group.zigcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcc.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcc.options=

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1022,18 +1022,7 @@ compiler.zcctrunk.semver=trunk
 #################################
 #################################
 # Libraries
-
-libs=openssl:cs50:hedley:libuv:simde:lua:python:nsimd
-
-libs.openssl.name=OpenSSL
-libs.openssl.liblink=ssl:crypto
-libs.openssl.versions=111c:111g
-libs.openssl.versions.111c.version=1.1.1c
-libs.openssl.versions.111c.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/include
-libs.openssl.versions.111c.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86/opt/lib
-libs.openssl.versions.111g.version=1.1.1g
-libs.openssl.versions.111g.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/include
-libs.openssl.versions.111g.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86/opt/lib
+libs=cs50:hedley:libuv:lua:nsimd:openssl:python:simde
 
 libs.cs50.name=cs50
 libs.cs50.versions=910
@@ -1049,6 +1038,16 @@ libs.hedley.url=https://github.com/nemequ/hedley
 libs.hedley.versions.v12.version=12.0.0
 libs.hedley.versions.v12.path=/opt/compiler-explorer/libs/hedley/v12/
 
+libs.lua.name=Lua
+libs.lua.versions=535:540
+libs.lua.liblink=lua:dl:m
+libs.lua.versions.535.version=5.3.5
+libs.lua.versions.535.path=/opt/compiler-explorer/libs/lua/v5.3.5/include
+libs.lua.versions.535.libpath=/opt/compiler-explorer/libs/lua/v5.3.5/lib/x86_64:/opt/compiler-explorer/libs/lua/v5.3.5/lib/x86
+libs.lua.versions.540.version=5.4.0
+libs.lua.versions.540.path=/opt/compiler-explorer/libs/lua/v5.4.0/include
+libs.lua.versions.540.libpath=/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86_64:/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86
+
 libs.libuv.name=libuv
 libs.libuv.description=Cross-platform asynchronous I/O
 libs.libuv.liblink=uv
@@ -1060,35 +1059,6 @@ libs.libuv.versions.1370.libpath=/opt/compiler-explorer/libs/libuv/v1.37.0/x86_6
 libs.libuv.versions.1381.version=1.38.1
 libs.libuv.versions.1381.path=/opt/compiler-explorer/libs/libuv/v1.38.1/include
 libs.libuv.versions.1381.libpath=/opt/compiler-explorer/libs/libuv/v1.38.1/x86_64/lib:/opt/compiler-explorer/libs/libuv/v1.38.1/x86/lib
-
-libs.simde.name=SIMDe
-libs.simde.description=Implementations of SIMD instruction sets for systems which don't natively support them.
-libs.simde.versions=trunk
-libs.simde.url=https://github.com/simd-everywhere/simde
-libs.simde.versions.trunk.version=trunk
-libs.simde.versions.trunk.path=/opt/compiler-explorer/libs/simde/trunk
-
-libs.lua.name=Lua
-libs.lua.versions=535:540
-libs.lua.liblink=lua:dl:m
-libs.lua.versions.535.version=5.3.5
-libs.lua.versions.535.path=/opt/compiler-explorer/libs/lua/v5.3.5/include
-libs.lua.versions.535.libpath=/opt/compiler-explorer/libs/lua/v5.3.5/lib/x86_64:/opt/compiler-explorer/libs/lua/v5.3.5/lib/x86
-libs.lua.versions.540.version=5.4.0
-libs.lua.versions.540.path=/opt/compiler-explorer/libs/lua/v5.4.0/include
-libs.lua.versions.540.libpath=/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86_64:/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86
-
-libs.python.name=Python
-libs.python.url=https://python.org
-libs.python.versions=359:3610:376:381
-libs.python.versions.359.version=3.5.9
-libs.python.versions.359.path=/opt/compiler-explorer/python-3.5.9/include/python3.5
-libs.python.versions.3610.version=3.6.10
-libs.python.versions.3610.path=/opt/compiler-explorer/python-3.6.10/include/python3.6
-libs.python.versions.376.version=3.7.6
-libs.python.versions.376.path=/opt/compiler-explorer/python-3.7.6/include/python3.7
-libs.python.versions.381.version=3.8.1
-libs.python.versions.381.path=/opt/compiler-explorer/python-3.8.1/include/python3.8
 
 libs.nsimd.name=NSIMD
 libs.nsimd.url=https://github.com/agenium-scale/nsimd/
@@ -1106,11 +1076,40 @@ libs.nsimd.versions.22-arm64.path=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aar
 libs.nsimd.versions.22-arm64.libpath=/opt/compiler-explorer/libs/nsimd/v2.2/arm/aarch64/lib
 libs.nsimd.versions.22-arm64.liblink=nsimd_aarch64
 
+libs.openssl.name=OpenSSL
+libs.openssl.liblink=ssl:crypto
+libs.openssl.versions=111c:111g
+libs.openssl.versions.111c.version=1.1.1c
+libs.openssl.versions.111c.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/include
+libs.openssl.versions.111c.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86/opt/lib
+libs.openssl.versions.111g.version=1.1.1g
+libs.openssl.versions.111g.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/include
+libs.openssl.versions.111g.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86/opt/lib
+
+libs.python.name=Python
+libs.python.url=https://python.org
+libs.python.versions=359:3610:376:381
+libs.python.versions.359.version=3.5.9
+libs.python.versions.359.path=/opt/compiler-explorer/python-3.5.9/include/python3.5
+libs.python.versions.3610.version=3.6.10
+libs.python.versions.3610.path=/opt/compiler-explorer/python-3.6.10/include/python3.6
+libs.python.versions.376.version=3.7.6
+libs.python.versions.376.path=/opt/compiler-explorer/python-3.7.6/include/python3.7
+libs.python.versions.381.version=3.8.1
+libs.python.versions.381.path=/opt/compiler-explorer/python-3.8.1/include/python3.8
+
+libs.simde.name=SIMDe
+libs.simde.description=Implementations of SIMD instruction sets for systems which don't natively support them.
+libs.simde.versions=trunk
+libs.simde.url=https://github.com/simd-everywhere/simde
+libs.simde.versions.trunk.version=trunk
+libs.simde.versions.trunk.path=/opt/compiler-explorer/libs/simde/trunk
+
+
 #################################
 #################################
 # Installed tools
-
-tools=PVS-Studio:clangtidytrunk:clangformattrunk:clangquerytrunk:llvm-mcatrunk:osacatrunk:pahole:readelf:ldd:strings
+tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:ldd:llvm-mcatrunk:osacatrunk:pahole:readelf:strings
 
 tools.PVS-Studio.name=PVS-Studio
 tools.PVS-Studio.exe=/opt/compiler-explorer/pvs-studio-latest/bin/pvs-studio-analyzer
@@ -1119,13 +1118,6 @@ tools.PVS-Studio.exclude=ccl19:ccl19_2015_u3:ccl_new:armcclang32:armcclang64:rvc
 tools.PVS-Studio.class=pvs-studio-tool
 tools.PVS-Studio.stdinHint=disabled
 tools.PVS-Studio.includeKey=supportsPVS-Studio
-
-tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
-tools.clangtidytrunk.type=independent
-tools.clangtidytrunk.class=clang-tidy-tool
-tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
-tools.clangtidytrunk.stdinHint=disabled
 
 tools.clangformattrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 tools.clangformattrunk.name=clang-format
@@ -1137,6 +1129,20 @@ tools.clangquerytrunk.name=clang-query (trunk)
 tools.clangquerytrunk.type=independent
 tools.clangquerytrunk.class=clang-query-tool
 tools.clangquerytrunk.stdinHint=Query commands
+
+tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
+tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.type=independent
+tools.clangtidytrunk.class=clang-tidy-tool
+tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+tools.clangtidytrunk.stdinHint=disabled
+
+tools.ldd.name=ldd
+tools.ldd.exe=/usr/bin/ldd
+tools.ldd.type=postcompilation
+tools.ldd.class=readelf-tool
+tools.ldd.exclude=
+tools.ldd.stdinHint=disabled
 
 tools.llvm-mcatrunk.name=llvm-mca (trunk)
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
@@ -1166,13 +1172,6 @@ tools.readelf.type=postcompilation
 tools.readelf.class=readelf-tool
 tools.readelf.exclude=
 tools.readelf.stdinHint=disabled
-
-tools.ldd.name=ldd
-tools.ldd.exe=/usr/bin/ldd
-tools.ldd.type=postcompilation
-tools.ldd.class=readelf-tool
-tools.ldd.exclude=
-tools.ldd.stdinHint=disabled
 
 tools.strings.exe=/opt/compiler-explorer/gcc-snapshot/bin/strings
 tools.strings.name=strings

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1015,6 +1015,8 @@ compiler.zcc070.exe=/opt/compiler-explorer/zig-0.7.0/zig
 compiler.zcc070.semver=0.7.0
 compiler.zcc071.exe=/opt/compiler-explorer/zig-0.7.1/zig
 compiler.zcc071.semver=0.7.1
+compiler.zcc080.exe=/opt/compiler-explorer/zig-0.8.0/zig
+compiler.zcc080.semver=0.8.0
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -1,6 +1,7 @@
 compilers=&zig
 defaultCompiler=z080
 
+# When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
 group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 group.zig.isSemVer=true

--- a/lib/compilers/tinyc.js
+++ b/lib/compilers/tinyc.js
@@ -36,7 +36,7 @@ export class TinyCCompiler extends BaseCompiler {
             if (!_.some(userOptions, (opt) => opt === '-E')) {
                 filters.binary = true;
             }
-            return ['-o', this.filename(outputFilename)];
+            return ['-g', '-o', this.filename(outputFilename)];
         }
     }
 


### PR DESCRIPTION
As a PR mainly so I can have another pair of eyes to recheck the config changes.

This PR:
- Sorts the C & C++ libs and tools alphabetically
- Adds missing semver settings for some C++ Compilers
- Adds missing RSIC-V Clang versions
- Fixes how RISC-V Clang is configured. It's now less of a mess
- Adds missing Zig C & C++ compilers, along with Tincy changes

As you can see, I totally forgot to change branches before commiting them, so I had to branch off and now they are here. Sorry about that