### PR TITLE
Fix execution for JVM compilers

### DIFF
--- a/etc/config/java.amazon.properties
+++ b/etc/config/java.amazon.properties
@@ -7,7 +7,8 @@ postProcess=
 options=
 supportsBinary=false
 needsMulti=false
-supportsExecute=false
+supportsExecute=true
+interpreted=true
 isSemVer=true
 baseName=jdk
 

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -103,7 +103,13 @@ export class JavaCompiler extends BaseCompiler {
         ];
     }
 
-    async handleInterpreting(key, executeParameters) {
+    async handleInterpreting(source, executeParameters) {
+        const dirPath = await this.newTempDir();
+        const inputFile = path.join(dirPath, this.compileFilename);
+        await fs.writeFile(inputFile, source);
+        const execOpts = this.getDefaultExecOptions();
+        const compileResult = await this.runCompiler(this.compiler.exe, [inputFile], inputFile, execOpts);
+
         executeParameters.args = [
             '-Xss136K', // Reduce thread stack size
             '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
@@ -113,11 +119,9 @@ export class JavaCompiler extends BaseCompiler {
             this.getMainClassName(),
             ...executeParameters.args,
         ];
-        const buildResult = await this.getOrBuildExecutable(key);
-        const dirPath = path.dirname(buildResult.executableFilename);
         const result = await this.runExecutable(this.javaRuntime, executeParameters, dirPath);
         result.didExecute = true;
-        result.buildResult = buildResult;
+        result.buildResult = compileResult;
         return result;
     }
 

--- a/lib/compilers/kotlin.js
+++ b/lib/compilers/kotlin.js
@@ -46,7 +46,7 @@ export class KotlinCompiler extends JavaCompiler {
 
     filterUserOptions(userOptions) {
         // filter options without extra arguments
-        userOptions = userOptions.filter(option =>
+        userOptions = (userOptions || []).filter(option =>
             option !== '-script' && option !== '-progressive' && !option.startsWith('-Xjavac'));
 
         const oneArgForbiddenList = new Set([


### PR DESCRIPTION
handleInterpreting is now properly overridden for the JVM based compilers.

Execution has been enabled for Java in the Amazon config