### PR TITLE
Better handling of Kalray MPPA comment and bundle separator

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -267,8 +267,8 @@ export class AsmParser extends AsmRegex {
 
         // Lines matching the following pattern are considered comments:
         // - starts with '#', '@', '//' or a single ';' (non repeated)
-        // - starts with ';;' and has non-whitespace before end of line
-        const commentOnly = /^\s*(((#|@|\/\/).*)|(\/\*.*\*\/)|(;\s*)|(;[^;].*)|(;;.*\S.*))$/;
+        // - starts with ';;' and the first non-whitespace before end of line is not #
+        const commentOnly = /^\s*(((#|@|\/\/).*)|(\/\*.*\*\/)|(;\s*)|(;[^;].*)|(;;\s*[^#\s].*))$/;
 
         const commentOnlyNvcc = /^\s*(((#|;|\/\/).*)|(\/\*.*\*\/))$/;
         const sourceTag = /^\s*\.loc\s+(\d+)\s+(\d+)\s+(.*)/;

--- a/test/filters-cases/kalray-hellow.asm
+++ b/test/filters-cases/kalray-hellow.asm
@@ -26,7 +26,7 @@ toto:
 	make $r0 = .LC0
 	;;
 	lw $r1 = 16[$r10]
-	;;
+        ;;      # (end cycle 3)
 	lw $r2 = 20[$r10]
 	;;
 	lw $r6 = 32[$r10]

--- a/test/filters-cases/kalray-hellow.asm.directives.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.directives.approved.txt
@@ -116,7 +116,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],

--- a/test/filters-cases/kalray-hellow.asm.directives.comments.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.directives.comments.approved.txt
@@ -106,7 +106,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],

--- a/test/filters-cases/kalray-hellow.asm.directives.labels.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.directives.labels.approved.txt
@@ -116,7 +116,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],

--- a/test/filters-cases/kalray-hellow.asm.directives.labels.comments.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.directives.labels.comments.approved.txt
@@ -106,7 +106,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],

--- a/test/filters-cases/kalray-hellow.asm.directives.labels.comments.library.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.directives.labels.comments.library.approved.txt
@@ -106,7 +106,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],

--- a/test/filters-cases/kalray-hellow.asm.directives.library.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.directives.library.approved.txt
@@ -116,7 +116,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],

--- a/test/filters-cases/kalray-hellow.asm.none.approved.txt
+++ b/test/filters-cases/kalray-hellow.asm.none.approved.txt
@@ -167,7 +167,7 @@
     {
       "labels": [],
       "source": null,
-      "text": "        ;;"
+      "text": "        ;;      # (end cycle 3)"
     },
     {
       "labels": [],


### PR DESCRIPTION
The KVX assembly uses ;; as the bundle separator, which can be a problem to
parse as ; is also commonly used as a comment marker.

Latest compiler version also add cycle information for opt level >= 1, which
confuses the current comment filter that treats the bundle separator as comment.

Tune the regex to treat the following :

        addd $r12 = $r12, -96
        get $r16 = $ra
        ;;      # (end cycle 0)

as non-comment. The ';;  #' is special-cased as non-comment.