### PR TITLE
Add C++ for OpenCL language

### DIFF
--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -1,0 +1,134 @@
+compilers=&armcpp4oclclang32:&armcpp4oclclang64
+defaultCompiler=armcpp4oclclang64
+demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
+needsMulti=false
+supportsBinary=false
+
+# Clang for Arm
+# Provides 32- and 64-bit menu items for clang-10, clang-11, clang-12 and trunk
+group.armcpp4oclclang32.groupName=Arm 32-bit clang
+group.armcpp4oclclang32.compilers=armv7-cpp4oclclang1000:armv7-cpp4oclclang1001:armv7-cpp4oclclang1100:armv7-cpp4oclclang1101:armv7-cpp4oclclang1200:armv7-cpp4oclclang-trunk
+group.armcpp4oclclang32.isSemVer=true
+group.armcpp4oclclang32.compilerType=clang
+group.armcpp4oclclang32.supportsExecute=false
+group.armcpp4oclclang32.instructionSet=arm32
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armcpp4oclclang32.baseOptions=-Dkernel= -D__kernel=
+
+group.armcpp4oclclang64.groupName=Arm 64-bit clang
+group.armcpp4oclclang64.compilers=armv8-cpp4oclclang1000:armv8-cpp4oclclang1001:armv8-cpp4oclclang1100:armv8-cpp4oclclang1101:armv8-cpp4oclclang1200:armv8-cpp4oclclang-trunk:armv8-full-cpp4oclclang-trunk
+group.armcpp4oclclang64.isSemVer=true
+group.armcpp4oclclang64.compilerType=clang
+group.armcpp4oclclang64.supportsExecute=false
+group.armcpp4oclclang64.instructionSet=aarch64
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armcpp4oclclang64.baseOptions=-Dkernel= -D__kernel=
+
+compiler.armv7-cpp4oclclang1200.name=armv7-a clang 12.0.0
+compiler.armv7-cpp4oclclang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.armv7-cpp4oclclang1200.semver=12.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang1200.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang1200.name=armv8-a clang 12.0.0
+compiler.armv8-cpp4oclclang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.armv8-cpp4oclclang1200.semver=12.0.0
+# Arm v8-a
+compiler.armv8-cpp4oclclang1200.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-cpp4oclclang1101.name=armv7-a clang 11.0.1
+compiler.armv7-cpp4oclclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.armv7-cpp4oclclang1101.semver=11.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang1101.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang1101.name=armv8-a clang 11.0.1
+compiler.armv8-cpp4oclclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.armv8-cpp4oclclang1101.semver=11.0.1
+# Arm v8-a
+compiler.armv8-cpp4oclclang1101.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-cpp4oclclang1100.name=armv7-a clang 11.0.0
+compiler.armv7-cpp4oclclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.armv7-cpp4oclclang1100.semver=11.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang1100.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang1100.name=armv8-a clang 11.0.0
+compiler.armv8-cpp4oclclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.armv8-cpp4oclclang1100.semver=11.0.0
+# Arm v8-a
+compiler.armv8-cpp4oclclang1100.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-cpp4oclclang1001.name=armv7-a clang 10.0.1
+compiler.armv7-cpp4oclclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.armv7-cpp4oclclang1001.semver=10.0.1
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang1001.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang1001.name=armv8-a clang 10.0.1
+compiler.armv8-cpp4oclclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.armv8-cpp4oclclang1001.semver=10.0.1
+# Arm v8-a
+compiler.armv8-cpp4oclclang1001.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-cpp4oclclang1000.name=armv7-a clang 10.0.0
+compiler.armv7-cpp4oclclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.armv7-cpp4oclclang1000.semver=10.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang1000.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang1000.name=armv8-a clang 10.0.0
+compiler.armv8-cpp4oclclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.armv8-cpp4oclclang1000.semver=10.0.0
+# Arm v8-a
+compiler.armv8-cpp4oclclang1000.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv7-cpp4oclclang-trunk.name=armv7-a clang (trunk)
+compiler.armv7-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv7-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-cpp4oclclang-trunk.semver=(trunk)
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang-trunk.name=armv8-a clang (trunk)
+compiler.armv8-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv8-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-cpp4oclclang-trunk.semver=(trunk)
+# Arm v8-a
+compiler.armv8-cpp4oclclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv8-full-cpp4oclclang-trunk.name=armv8-a clang (trunk, all architectural features)
+compiler.armv8-full-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv8-full-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
+# Arm v8-a with all supported architectural features
+compiler.armv8-full-cpp4oclclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+
+#################################
+#################################
+# Installed tools
+
+tools=clangtidytrunk:clangformattrunk:clangquerytrunk
+
+tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
+tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.type=independent
+tools.clangtidytrunk.class=clang-tidy-tool
+tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+tools.clangtidytrunk.stdinHint=disabled
+
+tools.clangformattrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
+tools.clangformattrunk.name=clang-format
+tools.clangformattrunk.type=independent
+tools.clangformattrunk.class=clang-format-tool
+
+tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
+tools.clangquerytrunk.name=clang-query (trunk)
+tools.clangquerytrunk.type=independent
+tools.clangquerytrunk.class=clang-query-tool
+tools.clangquerytrunk.stdinHint=Query commands

--- a/etc/config/cpp_for_opencl.defaults.properties
+++ b/etc/config/cpp_for_opencl.defaults.properties
@@ -1,0 +1,23 @@
+# Default settings for C++ for OpenCL
+compilers=&clang
+defaultCompiler=cppforopenclclangdefault
+postProcess=
+demangler=c++filt
+supportsBinary=false
+
+group.clang.compilers=cppforopenclclangdefault:cppforopenclclang10:cppforopenclclang11:cppforopenclclang12:cppforopenclclang13
+group.clang.compilerType=clang
+compiler.cppforopenclclangdefault.exe=/usr/bin/clang
+compiler.cppforopenclclangdefault.name=clang default
+compiler.cppforopenclclangdefault.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
+compiler.cppforopenclclang10.exe=/usr/bin/clang-10
+compiler.cppforopenclclang10.name=clang 10
+compiler.cppforopenclclang10.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
+compiler.cppforopenclclang11.exe=/usr/bin/clang-11
+compiler.cppforopenclclang11.name=clang 11
+compiler.cppforopenclclang11.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
+compiler.cppforopenclclang12.exe=/usr/bin/clang-12
+compiler.cppforopenclclang12.name=clang 12
+compiler.cppforopenclclang12.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
+compiler.cppforopenclclang13.exe=/usr/bin/clang-13
+compiler.cppforopenclclang13.name=clang 13

--- a/examples/cpp_for_opencl/default.clcpp
+++ b/examples/cpp_for_opencl/default.clcpp
@@ -1,0 +1,8 @@
+template<typename T>
+T add(T a, T b) {
+    return a + b;
+}
+kernel void k(global int* in1, global int* in2, global int* out) {
+    auto index = get_global_id(0);
+    out[index] = add(in1[index], in2[index]);
+}

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -94,6 +94,12 @@ export const languages = {
         extensions: ['.cl', '.ocl'],
         alias: [],
     },
+    cpp_for_opencl: {
+        name: 'C++ for OpenCL',
+        monaco: 'cpp-for-opencl',
+        extensions: ['.clcpp', '.cl', '.ocl'],
+        alias: [],
+    },
     rust: {
         name: 'Rust',
         monaco: 'rust',

--- a/static/modes/cpp-for-opencl-mode.js
+++ b/static/modes/cpp-for-opencl-mode.js
@@ -1,0 +1,79 @@
+// Copyright (c) 2018, 2021, Arm Ltd & Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+var $ = require('jquery');
+var monaco = require('monaco-editor');
+var cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
+var cppp = require('./cppp-mode');
+
+// We need to create a new definition for C++ for OpenCL so we can remove invalid keywords
+
+function definition() {
+    var cppForOpenCL = $.extend(true, {}, cppp); // deep copy
+
+    function addKeywords(keywords) {
+        // (Ruben) Done one by one as if you just push them all, Monaco complains that they're not strings, but as
+        // far as I can tell, they indeed are all strings. This somehow fixes it. If you know how to fix it, plz go
+        for (var i = 0; i < keywords.length; ++i) {
+            cppForOpenCL.keywords.push(keywords[i]);
+        }
+    }
+
+    function vectorTypes(basename) {
+        return [basename + '2', basename + '3', basename + '4', basename + '8', basename + '16'];
+    }
+    // Keywords for C++ for OpenCL
+    addKeywords([
+        '__global', 'global', '__local', 'local', '__constant', 'constant', '__private', 'private',
+        '__kernel', 'kernel',
+        'uniform', 'pipe',
+        '__read_only', 'read_only', '__write_only', 'write_only', '__read_write', 'read_write',
+        'bool', 'uchar', 'ushort', 'uint', 'ulong',
+        'cl_mem_fence_flags', 'event_t', 'reserve_id_t', 'ndrange_t', 'queue_t',
+        'image2d_t', 'image3d_t', 'image2d_array_t', 'image1d_t', 'image1d_array_t',
+        'image2d_depth_t', 'image1d_buffer_t', 'image2d_array_depth_t',
+        'sampler_t',
+        'uintptr_t', 'intptr_t', 'ptrdiff_t',
+        'size_t']);
+    addKeywords(vectorTypes('char'));
+    addKeywords(vectorTypes('short'));
+    addKeywords(vectorTypes('int'));
+    addKeywords(vectorTypes('long'));
+    addKeywords(vectorTypes('uchar'));
+    addKeywords(vectorTypes('ushort'));
+    addKeywords(vectorTypes('uint'));
+    addKeywords(vectorTypes('ulong'));
+    addKeywords(vectorTypes('half'));
+    addKeywords(vectorTypes('float'));
+    addKeywords(vectorTypes('double'));
+
+    cppForOpenCL.floatsuffix = /[fFhH]?/;
+
+    return cppForOpenCL;
+}
+
+monaco.languages.register({id: 'cpp-for-opencl'});
+monaco.languages.setLanguageConfiguration('cpp-for-opencl', cpp.conf);
+monaco.languages.setMonarchTokensProvider('cpp-for-opencl', definition());

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -49,6 +49,7 @@ require('../modes/clean-mode');
 require('../modes/cuda-mode');
 require('../modes/fortran-mode');
 require('../modes/openclc-mode');
+require('../modes/cpp-for-opencl-mode');
 require('../modes/zig-mode');
 require('../modes/nc-mode');
 require('../modes/ada-mode');


### PR DESCRIPTION
Closes #2742 

This PR adds support for C++ for OpenCL as a language, with syntax highlighting and compilation using upstream Clang into Arm assembly.

Note that `etc/config/cpp_for_opencl.amazon.properties` adds the base options `-Dkernel= -D__kernel=` for the Arm targets.
This is a workaround to prevent the Clang crash documented [here](https://llvm.org/PR50841). Once the bug is fixed, this workaround can be removed.