### PR TITLE
Add optional support for noting page loads with which icons are visible

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -20,6 +20,7 @@ formatter.clangformat.name=clang-format
 formatter.clangformat.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit
 motdUrl=/motd/motd-prod.json
+pageloadUrl=https://lambda.compiler-explorer.com/pageload
 storageSolution=s3
 healthCheckFilePath=/efs/.health
 showSponsors=true

--- a/etc/config/sponsors.yaml
+++ b/etc/config/sponsors.yaml
@@ -10,6 +10,7 @@ levels:
         url: https://solidsands.com/
         priority: 100
         topIcon: true
+        statsId: solid_sands
       - name: Stop Bugs
         description: Identify defects, vulnerabilities, unmaintainable code, and more with PC-lint Plus.
         icon: https://static.ce-cdn.net/gimpel/pcl_logo2.png
@@ -17,6 +18,7 @@ levels:
         url: https://gimpel.com/?promo=godbolt
         priority: 200
         topIcon: true
+        statsId: gimpel
       - name: Intel
         description: We engineer solutions for our customers’ greatest challenges with reliable, cloud to edge computing, inspired by Moore’s Law.
         icon: https://static.ce-cdn.net/intel/logo-classicblue-3000px-single-colour.png
@@ -25,6 +27,7 @@ levels:
         priority: 400
         topIcon: true
         sideBySide: true
+        statsId: intel
   - name: Patreon Legends
     description: 'These amazing people have pledged at the highest level of support. Huge thanks to these fine folks:'
     class: legendary

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -116,6 +116,7 @@ export class ClientOptionsHandler {
                 },
             },
             motdUrl: ceProps('motdUrl', ''),
+            pageloadUrl: ceProps('pageloadUrl', ''),
         };
         this._updateOptionsHash();
     }

--- a/static/main.js
+++ b/static/main.js
@@ -384,6 +384,7 @@ function removeOrphanedMaximisedItemFromConfig(config) {
     if (config.maximisedItemId !== '__glMaximised') return;
 
     var found = false;
+
     function impl(component) {
         if (component.id === '__glMaximised') {
             found = true;
@@ -573,6 +574,15 @@ function start() {
         });
         window.open(sponsor.url);
     };
+
+    if (options.pageloadUrl) {
+        setTimeout(function () {
+            var visibleIcons = $('.ces-icon:visible').map(function (index, value) {
+                return value.dataset.statsid;
+            }).get().join(',');
+            $.post(options.pageloadUrl + '?icons=' + encodeURIComponent(visibleIcons));
+        }, 5000);
+    }
 
     sizeRoot();
     new Sharing(layout);

--- a/views/sponsor-icons.pug
+++ b/views/sponsor-icons.pug
@@ -2,7 +2,7 @@
   each icon in sponsors.icons
     if noscript
       a(href=icon.url)
-        img.ces-icon(src=icon.icon alt=icon.name)
+        img.ces-icon(src=icon.icon alt=icon.name data-statsid=icon.statsId)
       span &nbsp;
     else
-      img.ces-icon(src=icon.icon alt=icon.name)
+      img.ces-icon(src=icon.icon alt=icon.name data-statsid=icon.statsId)


### PR DESCRIPTION
Optionally POST to a "pageload" endpoint with visible ces icons after five seconds of the page loading.