### PR TITLE
Add compilers for Kotlin 1.5.21

### DIFF
--- a/etc/config/kotlin.amazon.properties
+++ b/etc/config/kotlin.amazon.properties
@@ -12,7 +12,7 @@ needsMulti=false
 supportsExecute=true
 interpreted=true
 
-group.kotlin.compilers=kotlinc1400:kotlinc1410:kotlinc1420:kotlinc1421:kotlinc1430:kotlinc1431:kotlinc1432:kotlinc1500:kotlinc1510:kotlinc1520
+group.kotlin.compilers=kotlinc1400:kotlinc1410:kotlinc1420:kotlinc1421:kotlinc1430:kotlinc1431:kotlinc1432:kotlinc1500:kotlinc1510:kotlinc1520:kotlinc1521
 group.kotlin.groupName=Kotlin
 group.kotlin.baseName=kotlinc
 group.kotlin.isSemVer=true
@@ -56,3 +56,7 @@ compiler.kotlinc1520.exe=/opt/compiler-explorer/kotlin-jvm-1.5.20/bin/kotlinc-jv
 compiler.kotlinc1520.semver=1.5.20
 compiler.kotlinc1520.java_home=/opt/compiler-explorer/jdk-16.0.1
 compiler.kotlinc1520.runtime=/opt/compiler-explorer/jdk-16.0.1/bin/java
+compiler.kotlinc1521.exe=/opt/compiler-explorer/kotlin-jvm-1.5.21/bin/kotlinc-jvm
+compiler.kotlinc1521.semver=1.5.21
+compiler.kotlinc1521.java_home=/opt/compiler-explorer/jdk-16.0.1
+compiler.kotlinc1521.runtime=/opt/compiler-explorer/jdk-16.0.1/bin/java


### PR DESCRIPTION
Compiler update for the most recent Kotlin release which fixes some compiler bugs. Tested locally.

Infra: https://github.com/compiler-explorer/infra/pull/551