### PR TITLE
Allow a tool to have a separate monaco editor for it's stdinput

### DIFF
--- a/docs/AddingATool.md
+++ b/docs/AddingATool.md
@@ -13,6 +13,7 @@ tools.rewritecpp.type=independent
 tools.rewritecpp.exclude=
 tools.rewritecpp.class=base-tool
 tools.rewritecpp.stdinHint=disabled
+tools.rewritecpp.monacoStdin=false
 tools.rewritecpp.languageId=cppp
 tools.rewritecpp.options=--a
 tools.rewritecpp.args=--b
@@ -33,6 +34,8 @@ Should you want to deviate from the standard behaviour of `base-tool`, which run
 you should add a new class that extends from `base-tool`.
 
 The `stdinHint` is there to show the user a hint as to what the stdin field is used for in the tool. To disable stdin you can use _disabled_ here.
+
+The `monacoStdin` option makes the stdin editor a separate pane containing a monaco editor. This is useful when a tool has complex input spanning multiple lines and it's more friendly to indent it.
 
 The `languageId` can be used to highlight the output of the tool according to a language known within CE. For example `cppp` will highlight c++ output. Leaving `languageId` empty will use the terminal-like output.
 

--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -44,6 +44,7 @@ tools.clangquerydefault.name=clang-query (default)
 tools.clangquerydefault.type=independent
 tools.clangquerydefault.class=clang-query-tool
 tools.clangquerydefault.stdinHint=Query commands
+tools.clangquerydefault.monacoStdin=true
 
 tools.clangquery7.exe=/usr/bin/clang-query-7
 tools.clangquery7.name=clang-query 7

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -144,6 +144,7 @@ export class ClientOptionsHandler {
                             args: this.compilerProps(lang, toolBaseName + '.args'),
                             languageId: this.compilerProps(lang, toolBaseName + '.languageId'),
                             stdinHint: this.compilerProps(lang, toolBaseName + '.stdinHint'),
+                            monacoStdin: this.compilerProps(lang, toolBaseName + '.monacoStdin'),
                             compilerLanguage: lang,
                         },
                         {

--- a/static/components.js
+++ b/static/components.js
@@ -87,7 +87,7 @@ module.exports = {
             componentState: {compiler: compiler, editor: editor},
         };
     },
-    getToolViewWith: function (compiler, editor, toolId, args) {
+    getToolViewWith: function (compiler, editor, toolId, args, monacoStdin) {
         return {
             type: 'component',
             componentName: 'tool',
@@ -96,6 +96,26 @@ module.exports = {
                 editor: editor,
                 toolId: toolId,
                 args: args,
+                monacoStdin: monacoStdin,
+            },
+        };
+    },
+    getToolInputView: function () {
+        return {
+            type: 'component',
+            componentName: 'toolInputView',
+            componentState: {},
+        };
+    },
+    getToolInputViewWith: function (compilerId, editorId, toolId, toolName) {
+        return {
+            type: 'component',
+            componentName: 'toolInputView',
+            componentState: {
+                compilerId: compilerId,
+                editorId: editorId,
+                toolId: toolId,
+                toolName: toolName,
             },
         };
     },

--- a/static/hub.js
+++ b/static/hub.js
@@ -101,7 +101,7 @@ function Hub(layout, subLangId, defaultLangId) {
         function (container, state) {
             return self.toolFactory(container, state);
         });
-    layout.registerComponent(Components.getToolInputViewWith().componentName,
+    layout.registerComponent(Components.getToolInputView().componentName,
         function (container, state) {
             return self.toolInputViewFactory(container, state);
         });

--- a/static/hub.js
+++ b/static/hub.js
@@ -31,6 +31,7 @@ var compiler = require('./panes/compiler');
 var executor = require('./panes/executor');
 var output = require('./panes/output');
 var tool = require('./panes/tool');
+var toolInputView = require('./panes/tool-input-view');
 var Components = require('components');
 var diff = require('./panes/diff');
 var optView = require('./panes/opt-view');
@@ -99,6 +100,10 @@ function Hub(layout, subLangId, defaultLangId) {
     layout.registerComponent(Components.getToolViewWith().componentName,
         function (container, state) {
             return self.toolFactory(container, state);
+        });
+    layout.registerComponent(Components.getToolInputViewWith().componentName,
+        function (container, state) {
+            return self.toolInputViewFactory(container, state);
         });
     layout.registerComponent(diff.getComponent().componentName,
         function (container, state) {
@@ -202,6 +207,10 @@ Hub.prototype.outputFactory = function (container, state) {
 
 Hub.prototype.toolFactory = function (container, state) {
     return new tool.Tool(this, container, state);
+};
+
+Hub.prototype.toolInputViewFactory = function (container, state) {
+    return new toolInputView.ToolInputView(this, container, state);
 };
 
 Hub.prototype.diffFactory = function (container, state) {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1188,11 +1188,17 @@ Compiler.prototype.supportsTool = function (toolId) {
 Compiler.prototype.initToolButton = function (togglePannerAdder, button, toolId) {
     var createToolView = _.bind(function () {
         var args = '';
+        var monacoStdin = false;
         var langTools = options.tools[this.currentLangId];
-        if (langTools && langTools[toolId] && langTools[toolId].tool && langTools[toolId].tool.args !== undefined) {
-            args = langTools[toolId].tool.args;
+        if (langTools && langTools[toolId] && langTools[toolId].tool){
+            if (langTools[toolId].tool.args !== undefined) {
+                args = langTools[toolId].tool.args;
+            }
+            if (langTools[toolId].tool.monacoStdin !== undefined) {
+                monacoStdin = langTools[toolId].tool.monacoStdin;
+            }
         }
-        return Components.getToolViewWith(this.id, this.sourceEditorId, toolId, args);
+        return Components.getToolViewWith(this.id, this.sourceEditorId, toolId, args, monacoStdin);
     }, this);
 
     this.container.layoutManager

--- a/static/panes/tool-input-view.js
+++ b/static/panes/tool-input-view.js
@@ -1,0 +1,223 @@
+// Copyright (c) 2021, Tom Ritter
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+
+var FontScale = require('../fontscale');
+var monaco = require('monaco-editor');
+var _ = require('underscore');
+var $ = require('jquery');
+var ga = require('../analytics');
+var monacoConfig = require('../monaco-config');
+var local = require('../local');
+
+require('../modes/asm-mode');
+
+function ToolInputView(hub, container, state) {
+    state = state || {};
+    this.container = container;
+    this.eventHub = hub.createEventHub();
+    this.domRoot = container.getElement();
+    this.domRoot.html($('#tool-input').html());
+    this.source = state.source || '';
+    this._currentDecorations = [];
+    var root = this.domRoot.find('.monaco-placeholder');
+
+    this.settings = JSON.parse(local.get('settings', '{}'));
+
+    this.editor = monaco.editor.create(root[0], monacoConfig.extendConfig({
+        value: '',
+        language: 'plaintext',
+        readOnly: false,
+        glyphMargin: true,
+    }));
+
+    this._toolId = state.toolId;
+    this._toolName = state.toolName;
+    this._compilerId = state.compilerId;
+    this._editorId = state.editorId;
+
+    this.awaitingInitialResults = false;
+
+    this.initButtons(state);
+    this.initCallbacks();
+
+    this.setTitle();
+    this.onSettingsChange(this.settings);
+    this.eventHub.emit('toolInputViewOpened', this._toolid);
+    ga.proxy('send', {
+        hitType: 'event',
+        eventCategory: 'OpenViewPane',
+        eventAction: 'toolInputView',
+    });
+}
+
+ToolInputView.prototype.initButtons = function (state) {
+    this.fontScale = new FontScale(this.domRoot, state, this.editor);
+
+    this.topBar = this.domRoot.find('.top-bar');
+};
+
+ToolInputView.prototype.initCallbacks = function () {
+    this.fontScale.on('change', _.bind(this.updateState, this));
+
+    this.eventHub.on('compilerClose', this.onCompilerClose, this);
+    this.eventHub.on('toolClosed', this.onToolClose, this);
+    this.eventHub.on('toolInputViewCloseRequest', this.onToolInputViewCloseRequest, this);
+    this.eventHub.on('settingsChange', this.onSettingsChange, this);
+    this.eventHub.on('setToolInput', this.onSetToolInput, this);
+
+    this.container.on('resize', this.resize, this);
+    this.container.on('shown', this.resize, this);
+    this.container.on('destroy', this.close, this);
+
+    this.container.layoutManager.on('initialised', function () {
+        // Once initialized, let everyone know what text we have.
+        this.maybeEmitChange();
+    }, this);
+    this.eventHub.on('initialised', this.maybeEmitChange, this);
+
+    this.editor.getModel().onDidChangeContent(_.bind(function () {
+        this.debouncedEmitChange();
+        this.updateState();
+    }, this));
+
+    this.cursorSelectionThrottledFunction =
+        _.throttle(_.bind(this.onDidChangeCursorSelection, this), 500);
+    this.editor.onDidChangeCursorSelection(_.bind(function (e) {
+        this.cursorSelectionThrottledFunction(e);
+    }, this));
+};
+
+ToolInputView.prototype.setTitle = function () {
+    var name = this._toolName + ' Input #' + this._compilerId;
+    this.container.setTitle(name);
+};
+
+ToolInputView.prototype.resize = function () {
+    var topBarHeight = this.topBar.outerHeight(true);
+    this.editor.layout({
+        width: this.domRoot.width(),
+        height: this.domRoot.height() - topBarHeight,
+    });
+};
+
+ToolInputView.prototype.updateState = function () {
+    this.container.setState(this.currentState());
+};
+
+ToolInputView.prototype.currentState = function () {
+    var state = {
+        toolId: this._toolId,
+        toolName: this._toolName,
+        editorId: this._editorId,
+        compilerId: this._compilerId,
+    };
+    this.fontScale.addState(state);
+    return state;
+};
+
+ToolInputView.prototype.close = function () {
+    this.eventHub.unsubscribe();
+    this.eventHub.emit('toolInputViewClosed', this._compilerId, this._editorId, this._toolId, this.getInput());
+    this.editor.dispose();
+};
+
+ToolInputView.prototype.onToolClose = function (compilerId, toolSettings) {
+    if (this._compilerId === compilerId && this._toolId === toolSettings.toolId) {
+        // We can't immediately close as an outer loop somewhere in GoldenLayout is iterating over
+        // the hierarchy. We can't modify while it's being iterated over.
+        this.close();
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+ToolInputView.prototype.onToolInputViewCloseRequest = function (compilerId, editorId, toolId) {
+    if (this._compilerId === compilerId && this._editorId === editorId && this._toolId === toolId) {
+        this.close();
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+ToolInputView.prototype.onCompilerClose = function (id) {
+    if (id === this._compilerId) {
+        // We can't immediately close as an outer loop somewhere in GoldenLayout is iterating over
+        // the hierarchy. We can't modify while it's being iterated over.
+        this.close();
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+ToolInputView.prototype.onSettingsChange = function (newSettings) {
+    this.editor.updateOptions({
+        contextmenu: newSettings.useCustomContextMenu,
+        minimap: {
+            enabled: newSettings.showMinimap,
+        },
+        fontFamily: newSettings.editorsFFont,
+        fontLigatures: newSettings.editorsFLigatures,
+    });
+
+    this.debouncedEmitChange = _.debounce(_.bind(function () {
+        this.maybeEmitChange();
+    }, this), newSettings.delayAfterChange);
+};
+
+ToolInputView.prototype.onDidChangeCursorSelection = function (e) {
+    if (this.awaitingInitialResults) {
+        this.selection = e.selection;
+        this.updateState();
+    }
+};
+
+ToolInputView.prototype.onSetToolInput = function (compilerId, editorId, toolId, value) {
+    if (this._compilerId === compilerId && this._editorId === editorId && this._toolId === toolId) {
+        return this.editor.getModel().setValue(value);
+    }
+};
+
+ToolInputView.prototype.getInput = function () {
+    if (!this.editor.getModel()) {
+        return '';
+    }
+    return this.editor.getModel().getValue();
+};
+
+ToolInputView.prototype.maybeEmitChange = function (force) {
+    var input = this.getInput();
+    if (!force && input === this.lastChangeEmitted) return;
+
+    this.lastChangeEmitted = input;
+    this.eventHub.emit('toolInputChange', this._compilerId, this._editorId, this._toolId, this.lastChangeEmitted);
+};
+
+module.exports = {
+    ToolInputView: ToolInputView,
+};

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -30,6 +30,7 @@ var FontScale = require('../fontscale');
 var AnsiToHtml = require('../ansi-to-html');
 var Toggles = require('../toggles');
 var ga = require('../analytics');
+var Components = require('../components');
 var monaco = require('monaco-editor');
 var monacoConfig = require('../monaco-config');
 var ceoptions = require('../options');
@@ -45,6 +46,7 @@ function makeAnsiToHtml(color) {
 }
 
 function Tool(hub, container, state) {
+    this.hub = hub;
     this.container = container;
     this.compilerId = state.compiler;
     this.editorId = state.editor;
@@ -59,11 +61,15 @@ function Tool(hub, container, state) {
     this.optionsToolbar = this.domRoot.find('.options-toolbar');
     this.badLangToolbar = this.domRoot.find('.bad-lang');
     this.compilerName = '';
+    this.monacoStdin = false;
+    this.monacoEditorOpen = false;
+    this.monacoEditorHasBeenAutoOpened = state.monacoEditorHasBeenAutoOpened;
+    this.monacoStdinField = '';
     this.normalAnsiToHtml = makeAnsiToHtml();
     this.errorAnsiToHtml = makeAnsiToHtml('red');
 
     this.optionsField = this.domRoot.find('input.options');
-    this.stdinField = this.domRoot.find('textarea.tool-stdin');
+    this.localStdinField = this.domRoot.find('textarea.tool-stdin');
 
     this.outputEditor = monaco.editor.create(this.editorContentRoot[0], monacoConfig.extendConfig({
         readOnly: true,
@@ -77,6 +83,10 @@ function Tool(hub, container, state) {
     this.fontScale.on('change', _.bind(function () {
         this.saveState();
     }, this));
+
+    this.createToolInputView = _.bind(function () {
+        return Components.getToolInputViewWith(this.compilerId, this.editorId, this.toolId, this.toolName);
+    }, this);
 
     this.initButtons(state);
     this.options = new Toggles(this.domRoot.find('.options'), state);
@@ -107,17 +117,29 @@ Tool.prototype.initCallbacks = function () {
     this.eventHub.on('compilerClose', this.onCompilerClose, this);
     this.eventHub.on('settingsChange', this.onSettingsChange, this);
     this.eventHub.on('languageChange', this.onLanguageChange, this);
+    this.eventHub.on('toolInputChange', this.onToolInputChange, this);
+    this.eventHub.on('toolInputViewClosed', this.onToolInputViewClosed, this);
 
     this.toggleArgs.on('click', _.bind(function () {
         this.togglePanel(this.toggleArgs, this.panelArgs);
     }, this));
 
     this.toggleStdin.on('click', _.bind(function () {
-        this.togglePanel(this.toggleStdin, this.panelStdin);
+        if (!this.monacoStdin) {
+            this.togglePanel(this.toggleStdin, this.panelStdin);
+        } else {
+            if (!this.monacoEditorOpen) {
+                this.openMonacoEditor();
+            } else {
+                this.monacoEditorOpen = false;
+                this.toggleStdin.removeClass('active');
+                this.eventHub.emit('toolInputViewCloseRequest', this.compilerId, this.editorId, this.toolId);
+            }
+        }
     }, this));
 
     if (MutationObserver !== undefined) {
-        new MutationObserver(_.bind(this.resize, this)).observe(this.stdinField[0], {
+        new MutationObserver(_.bind(this.resize, this)).observe(this.localStdinField[0], {
             attributes: true, attributeFilter: ['style'],
         });
     }
@@ -170,13 +192,21 @@ Tool.prototype.initArgs = function (state) {
         }
     }
 
-    if (this.stdinField) {
-        this.stdinField
+    this.monacoStdin = state.monacoStdin || false;
+    this.monacoEditorOpen = state.monacoEditorOpen || false;
+    this.monacoEditorHasBeenAutoOpened = state.monacoEditorHasBeenAutoOpened || false;
+
+    if (this.localStdinField) {
+        this.localStdinField
             .on('change', optionsChange)
             .on('keyup', optionsChange);
 
         if (state.stdin) {
-            this.stdinField.val(state.stdin);
+            if (!this.monacoStdin) {
+                this.localStdinField.val(state.stdin);
+            } else {
+                this.eventHub.emit('setToolInput', this.compilerId, this.editorId, this.toolId, state.stdin);
+            }
         }
     }
 };
@@ -189,12 +219,45 @@ Tool.prototype.getInputArgs = function () {
     }
 };
 
-Tool.prototype.getInputStdin = function () {
-    if (this.stdinField) {
-        return this.stdinField.val();
-    } else {
-        return '';
+Tool.prototype.onToolInputChange = function (compilerId, editorId, toolId, input) {
+    if (this.compilerId === compilerId && this.editorId === editorId && this.toolId === toolId) {
+        this.monacoStdinField = input;
+        this.onOptionsChange();
+        this.eventHub.emit('toolSettingsChange', this.compilerId);
     }
+};
+
+Tool.prototype.onToolInputViewClosed = function (compilerId, editorId, toolId, input) {
+    if (this.compilerId === compilerId && this.editorId === editorId && this.toolId === toolId) {
+        this.monacoStdinField = input;
+        this.monacoEditorOpen = false;
+        this.toggleStdin.removeClass('active');
+
+        this.onOptionsChange();
+        this.eventHub.emit('toolSettingsChange', this.compilerId);
+    }
+};
+
+Tool.prototype.getInputStdin = function () {
+    if (!this.monacoStdin) {
+        if (this.localStdinField) {
+            return this.localStdinField.val();
+        } else {
+            return '';
+        }
+    } else {
+        return this.monacoStdinField;
+    }
+};
+
+Tool.prototype.openMonacoEditor = function () {
+    this.monacoEditorHasBeenAutoOpened = true; // just in case we get here in an unexpected way
+    this.monacoEditorOpen = true;
+    this.toggleStdin.addClass('active');
+    var insertPoint = this.hub.findParentRowOrColumn(this.container) ||
+        this.container.layoutManager.root.contentItems[0];
+    insertPoint.addChild(this.createToolInputView);
+    this.onOptionsChange();
 };
 
 Tool.prototype.getEffectiveOptions = function () {
@@ -245,7 +308,13 @@ Tool.prototype.initToggleButtons = function (state) {
     }
 
     if (state.stdinPanelShown === true) {
-        this.showPanel(this.toggleStdin, this.panelStdin);
+        if (!this.monacoStdin) {
+            this.showPanel(this.toggleStdin, this.panelStdin);
+        } else {
+            if (!this.monacoEditorOpen) {
+                this.openMonacoEditor();
+            }
+        }
     }
 };
 
@@ -279,7 +348,11 @@ Tool.prototype.currentState = function () {
         toolId: this.toolId,
         args: this.getInputArgs(),
         stdin: this.getInputStdin(),
-        stdinPanelShown: !this.panelStdin.hasClass('d-none'),
+        stdinPanelShown: (this.monacoStdin && this.monacoEditorOpen) ||
+         (this.panelStdin && !this.panelStdin.hasClass('d-none')),
+        monacoStdin: this.monacoStdin,
+        monacoEditorOpen: this.monacoEditorOpen,
+        monacoEditorHasBeenAutoOpened: this.monacoEditorHasBeenAutoOpened,
         argsPanelShow: !this.panelArgs.hasClass('d-none'),
     };
     this.fontScale.addState(state);
@@ -335,15 +408,18 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
         if (toolInfo) {
             this.toggleStdin.prop('disabled', false);
 
-            if (toolInfo.tool.stdinHint) {
-                this.stdinField.prop('placeholder', toolInfo.tool.stdinHint);
+            if (this.monacoStdin && !this.monacoEditorOpen && !this.monacoEditorHasBeenAutoOpened) {
+                this.monacoEditorHasBeenAutoOpened = true;
+                this.openMonacoEditor();
+            } else if (!this.monacoStdin && toolInfo.tool.stdinHint) {
+                this.localStdinField.prop('placeholder', toolInfo.tool.stdinHint);
                 if (toolInfo.tool.stdinHint === 'disabled') {
                     this.toggleStdin.prop('disabled', true);
                 } else {
                     this.showPanel(this.toggleStdin, this.panelStdin);
                 }
             } else {
-                this.stdinField.prop('placeholder', 'Tool stdin...');
+                this.localStdinField.prop('placeholder', 'Tool stdin...');
             }
         }
 

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -188,6 +188,11 @@
           input.d-none(type="checkbox" checked=false)
     pre.content
 
+  #tool-input
+    .top-bar.btn-toolbar.bg-light(role="toolbar")
+      include font-size.pug
+    .monaco-placeholder
+
   #tool-output
     .top-bar.bad-lang.bg-warning(role="toolbar" style="display: none")
       p The current language or compiler does not support this tool


### PR DESCRIPTION
Similar to my other PR, in that I am adding a new Pane; but generally unrelated.

This makes it possible for a tool (I built this for clang-query) to have a separate Monaco Editor pane as its std input.  This is specified in the config file, and does **not** let the user choose between the old input or the new one.

It is not specified as the default in any of the supplied configs though, so this is latent code. Maybe you don't want to take code that is not used, or maybe you want to enable it for clang-query?