### PR TITLE
Treat data definitions in the middle of functions as "strong"

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -109,6 +109,9 @@ export class AsmParser extends AsmRegex {
         let currentLabelSet = [];
         let inLabelGroup = false;
         let inCustomAssembly = 0;
+        const startBlock = /\.cfi_startproc/;
+        const endBlock = /\.cfi_endproc/;
+        let inFunction = false;
 
         // Scan through looking for definite label usages (ones used by opcodes),
         // and ones that are weakly used: that is, their use is conditional on another label.
@@ -118,12 +121,19 @@ export class AsmParser extends AsmRegex {
         //       mov eax, .baz
         // In this case, the '.baz' is used by an opcode, and so is strongly used.
         // The '.foo' is weakly used by .baz.
+        // Also, if we have random data definitions within a block of a function (between
+        // cfi_startproc and cfi_endproc), we assume they are strong usages. This covers things
+        // like jump tables embedded in ARM code.
+        // See https://github.com/compiler-explorer/compiler-explorer/issues/2788
         for (let line of asmLines) {
             if (this.startAppBlock.test(line) || this.startAsmNesting.test(line)) {
                 inCustomAssembly++;
             } else if (this.endAppBlock.test(line) || this.endAsmNesting.test(line)) {
                 inCustomAssembly--;
-            }
+            } else if (startBlock.test(line))
+                inFunction = true;
+            else if (endBlock.test(line))
+                inFunction = false;
 
             if (inCustomAssembly > 0)
                 line = this.fixLabelIndentation(line);
@@ -155,7 +165,7 @@ export class AsmParser extends AsmRegex {
 
             if (!filterDirectives || this.hasOpcode(line, false) || definesFunction) {
                 // Only count a label as used if it's used by an opcode, or else we're not filtering directives.
-                for (const label of match)  labelsUsed[label] = true;
+                for (const label of match) labelsUsed[label] = true;
             } else {
                 // If we have a current label, then any subsequent opcode or data definition's labels are referred to
                 // weakly by that label.
@@ -163,8 +173,13 @@ export class AsmParser extends AsmRegex {
                 const isOpcode = this.hasOpcode(line, false);
                 if (isDataDefinition || isOpcode) {
                     for (const currentLabel of currentLabelSet) {
-                        if (!weakUsages[currentLabel]) weakUsages[currentLabel] = [];
-                        for (const label of match)  weakUsages[currentLabel].push(label);
+                        if (inFunction && isDataDefinition) {
+                            // Data definitions in the middle of code should be treated as if they were used strongly.
+                            for (const label of match) labelsUsed[label] = true;
+                        } else {
+                            if (!weakUsages[currentLabel]) weakUsages[currentLabel] = [];
+                            for (const label of match) weakUsages[currentLabel].push(label);
+                        }
                     }
                 }
             }

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -130,10 +130,11 @@ export class AsmParser extends AsmRegex {
                 inCustomAssembly++;
             } else if (this.endAppBlock.test(line) || this.endAsmNesting.test(line)) {
                 inCustomAssembly--;
-            } else if (startBlock.test(line))
+            } else if (startBlock.test(line)) {
                 inFunction = true;
-            else if (endBlock.test(line))
+            } else if (endBlock.test(line)) {
                 inFunction = false;
+            }
 
             if (inCustomAssembly > 0)
                 line = this.fixLabelIndentation(line);

--- a/test/filter-tests.js
+++ b/test/filter-tests.js
@@ -81,13 +81,13 @@ function testFilter(filename, suffix, filters) {
 describe('Filter test cases', function () {
 
     describe('No filters', function () {
-        for (const x of cases)  testFilter(x, '.none', {});
+        for (const x of cases) testFilter(x, '.none', {});
     });
     describe('Directive filters', function () {
-        for (const x of cases)  testFilter(x, '.directives', {directives: true});
+        for (const x of cases) testFilter(x, '.directives', {directives: true});
     });
     describe('Directives and labels together', function () {
-        for (const x of cases)  testFilter(x, '.directives.labels', {directives: true, labels: true});
+        for (const x of cases) testFilter(x, '.directives.labels', {directives: true, labels: true});
     });
     describe('Directives, labels and comments', function () {
         for (const x of cases) {
@@ -107,10 +107,10 @@ describe('Filter test cases', function () {
         }
     });
     describe('Directives and comments', function () {
-        for (const x of cases)  testFilter(x, '.directives.comments', {directives: true, commentOnly: true});
+        for (const x of cases) testFilter(x, '.directives.comments', {directives: true, commentOnly: true});
     });
     describe('Directives and library code', function () {
-        for (const x of cases)  testFilter(x, '.directives.library', {directives: true, libraryCode: true});
+        for (const x of cases) testFilter(x, '.directives.library', {directives: true, libraryCode: true});
     });
     describe('Directives, labels, comments and library code', function () {
         for (const x of cases) {

--- a/test/filters-cases/bug-2788.asm
+++ b/test/filters-cases/bug-2788.asm
@@ -1,0 +1,100 @@
+	.cpu arm7tdmi
+	.eabi_attribute 20, 1
+	.eabi_attribute 21, 1
+	.eabi_attribute 23, 3
+	.eabi_attribute 24, 1
+	.eabi_attribute 25, 1
+	.eabi_attribute 26, 1
+	.eabi_attribute 30, 2
+	.eabi_attribute 34, 0
+	.eabi_attribute 18, 4
+	.file	"example.cpp"
+	.text
+.Ltext0:
+	.cfi_sections	.debug_frame
+	.align	2
+	.global	_Z4revcc
+	.arch armv4t
+	.syntax unified
+	.arm
+	.fpu softvfp
+	.type	_Z4revcc, %function
+_Z4revcc:
+	.fnstart
+.LVL0:
+.LFB0:
+	.file 1 "/tmp/example.cpp"
+	.loc 1 1 19 view -0
+	.cfi_startproc
+	@ Function supports interworking.
+	@ args = 0, pretend = 0, frame = 0
+	@ frame_needed = 0, uses_anonymous_args = 0
+	@ link register save eliminated.
+	.loc 1 2 3 view .LVU1
+	sub	r3, r0, #65
+	cmp	r3, #19
+	ldrls	pc, [pc, r3, asl #2]
+	b	.L7
+.L4:
+	.word	.L8
+	.word	.L7
+	.word	.L6
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L5
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L7
+	.word	.L3
+.L8:
+	.loc 1 12 14 is_stmt 0 view .LVU2
+	mov	r0, #84
+.LVL1:
+.L7:
+	.loc 1 14 1 view .LVU3
+	bx	lr
+.LVL2:
+.L3:
+	.loc 1 9 5 is_stmt 1 view .LVU4
+	.loc 1 10 7 view .LVU5
+	.loc 1 10 14 is_stmt 0 view .LVU6
+	mov	r0, #65
+.LVL3:
+	.loc 1 10 14 view .LVU7
+	bx	lr
+.LVL4:
+.L5:
+	.loc 1 7 5 is_stmt 1 view .LVU8
+	.loc 1 8 7 view .LVU9
+	.loc 1 8 14 is_stmt 0 view .LVU10
+	mov	r0, #67
+.LVL5:
+	.loc 1 8 14 view .LVU11
+	bx	lr
+.LVL6:
+.L6:
+	.loc 1 6 14 view .LVU12
+	mov	r0, #71
+.LVL7:
+	.loc 1 6 14 view .LVU13
+	bx	lr
+	.cfi_endproc
+.LFE0:
+	.cantunwind
+	.fnend
+	.size	_Z4revcc, .-_Z4revcc
+.Letext0:
+	.section	.debug_info,"",%progbits
+.Ldebug_info0:
+	.4byte	0x5a
+	.2byte	0x4

--- a/test/filters-cases/bug-2788.asm.binary.directives.labels.comments.approved.txt
+++ b/test/filters-cases/bug-2788.asm.binary.directives.labels.comments.approved.txt
@@ -1,0 +1,4 @@
+{
+  "asm": [],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/bug-2788.asm.directives.approved.txt
+++ b/test/filters-cases/bug-2788.asm.directives.approved.txt
@@ -1,0 +1,508 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ Function supports interworking."
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ args = 0, pretend = 0, frame = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ frame_needed = 0, uses_anonymous_args = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ link register save eliminated."
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L4:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL4:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL6:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 40,
+    ".L5": 45,
+    ".L6": 50,
+    ".L7": 37,
+    ".L8": 34,
+    "_Z4revcc": 2
+  }
+}

--- a/test/filters-cases/bug-2788.asm.directives.comments.approved.txt
+++ b/test/filters-cases/bug-2788.asm.directives.comments.approved.txt
@@ -1,0 +1,488 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB0:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L4:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL4:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL6:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 36,
+    ".L5": 41,
+    ".L6": 46,
+    ".L7": 33,
+    ".L8": 30,
+    "_Z4revcc": 2
+  }
+}

--- a/test/filters-cases/bug-2788.asm.directives.labels.approved.txt
+++ b/test/filters-cases/bug-2788.asm.directives.labels.approved.txt
@@ -1,0 +1,438 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ Function supports interworking."
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ args = 0, pretend = 0, frame = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ frame_needed = 0, uses_anonymous_args = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ link register save eliminated."
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 34,
+    ".L5": 37,
+    ".L6": 40,
+    ".L7": 32,
+    ".L8": 30,
+    "_Z4revcc": 1
+  }
+}

--- a/test/filters-cases/bug-2788.asm.directives.labels.comments.approved.txt
+++ b/test/filters-cases/bug-2788.asm.directives.labels.comments.approved.txt
@@ -1,0 +1,418 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 30,
+    ".L5": 33,
+    ".L6": 36,
+    ".L7": 28,
+    ".L8": 26,
+    "_Z4revcc": 1
+  }
+}

--- a/test/filters-cases/bug-2788.asm.directives.labels.comments.library.approved.txt
+++ b/test/filters-cases/bug-2788.asm.directives.labels.comments.library.approved.txt
@@ -1,0 +1,418 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 30,
+    ".L5": 33,
+    ".L6": 36,
+    ".L7": 28,
+    ".L8": 26,
+    "_Z4revcc": 1
+  }
+}

--- a/test/filters-cases/bug-2788.asm.directives.library.approved.txt
+++ b/test/filters-cases/bug-2788.asm.directives.library.approved.txt
@@ -1,0 +1,508 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ Function supports interworking."
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ args = 0, pretend = 0, frame = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ frame_needed = 0, uses_anonymous_args = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ link register save eliminated."
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L4:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL4:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL6:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 40,
+    ".L5": 45,
+    ".L6": 50,
+    ".L7": 37,
+    ".L8": 34,
+    "_Z4revcc": 2
+  }
+}

--- a/test/filters-cases/bug-2788.asm.none.approved.txt
+++ b/test/filters-cases/bug-2788.asm.none.approved.txt
@@ -1,0 +1,759 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cpu arm7tdmi"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 20, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 21, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 23, 3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 24, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 25, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 26, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 30, 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 34, 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .eabi_attribute 18, 4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .file   \"example.cpp\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .text"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_sections   .debug_frame"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .align  2"
+    },
+    {
+      "labels": [
+        {
+          "name": "_Z4revcc",
+          "range": {
+            "endCol": 25,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .global _Z4revcc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .arch armv4t"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .syntax unified"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .arm"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .fpu softvfp"
+    },
+    {
+      "labels": [
+        {
+          "name": "_Z4revcc",
+          "range": {
+            "endCol": 25,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .type   _Z4revcc, %function"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_Z4revcc:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .fnstart"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .file 1 \"/tmp/example.cpp\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 1 19 view -0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_startproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ Function supports interworking."
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ args = 0, pretend = 0, frame = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ frame_needed = 0, uses_anonymous_args = 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        @ link register save eliminated."
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 2 3 view .LVU1"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        sub     r3, r0, #65"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        cmp     r3, #19"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ldrls   pc, [pc, r3, asl #2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": {
+        "column": 3,
+        "file": null,
+        "line": 2
+      },
+      "text": "        b       .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L4:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L8"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L6",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L6"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L5"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L3",
+          "range": {
+            "endCol": 20,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .word   .L3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 12 14 is_stmt 0 view .LVU2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 12
+      },
+      "text": "        mov     r0, #84"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 14 1 view .LVU3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 14
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L3:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 9 5 is_stmt 1 view .LVU4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 10 7 view .LVU5"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 10 14 is_stmt 0 view .LVU6"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        mov     r0, #65"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 10 14 view .LVU7"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 10
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL4:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 7 5 is_stmt 1 view .LVU8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 8 7 view .LVU9"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 8 14 is_stmt 0 view .LVU10"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        mov     r0, #67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL5:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 8 14 view .LVU11"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 8
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL6:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L6:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 6 14 view .LVU12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        mov     r0, #71"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL7:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 6 14 view .LVU13"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 14,
+        "file": null,
+        "line": 6
+      },
+      "text": "        bx      lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cantunwind"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .fnend"
+    },
+    {
+      "labels": [
+        {
+          "name": "_Z4revcc",
+          "range": {
+            "endCol": 25,
+            "startCol": 17
+          }
+        },
+        {
+          "name": "_Z4revcc",
+          "range": {
+            "endCol": 37,
+            "startCol": 29
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .size   _Z4revcc, .-_Z4revcc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .section        .debug_info,\"\",%progbits"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .4byte  0x5a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .2byte  0x4"
+    }
+  ],
+  "labelDefinitions": {
+    ".L3": 67,
+    ".L5": 76,
+    ".L6": 85,
+    ".L7": 63,
+    ".L8": 59,
+    "_Z4revcc": 22
+  }
+}


### PR DESCRIPTION
Things like ARM jump tables put important data inline within a function. Such
data should be treated as a "strong" reference (e.g. a root use). For example:

```asm
        sub     r3, r0, #65
        cmp     r3, #19
        ldrls   pc, [pc, r3, asl #2]
        b       .L7
        .word   .L8
        .word   .L7
        .word   .L6
        .word   .L7
        ....etc...
.L7: some things
.L8: some other things
```

Without this change, the `.L8` label would be dropped as unused. But it's implicitly used
by the sequence of `.word`s in the middle of the function.

Closes #2788

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
