### PR TITLE
Add hotels-template-library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1064,7 +1064,7 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:glm:gnufs:googletest:gsl:hedley:hfsm:highway:immer:jsoncpp:kiwaku:kvasir:lager:lexy:libguarded:libuv:llvm:llvmfs:lua:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xsimd:xtensor:xtl:ztdtext:zug
+libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:glm:gnufs:googletest:gsl:hedley:hfsm:highway:hotels-template-library:immer:jsoncpp:kiwaku:kvasir:lager:lexy:libguarded:libuv:llvm:llvmfs:lua:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xsimd:xtensor:xtl:ztdtext:zug
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -1593,6 +1593,13 @@ libs.highway.versions.trunk.version=trunk
 libs.highway.versions.trunk.path=/opt/compiler-explorer/libs/highway/trunk
 libs.highway.versions.0_12_2.version=0.12.2
 libs.highway.versions.0_12_2.path=/opt/compiler-explorer/libs/highway/0.12.2
+
+libs.hotels-template-library.name=Hotels Template Library
+libs.hotels-template-library.description=Hotels Template Library contains an open-source collection of C++ template libraries that are developed to make C++ development easier, safer and more efficient.
+libs.hotels-template-library.url=https://github.com/google/hotels-template-library
+libs.hotels-template-library.versions=trunk
+libs.hotels-template-library.versions.trunk.version=trunk
+libs.hotels-template-library.versions.trunk.path=/opt/compiler-explorer/libs/taojson/trunk/
 
 libs.immer.name=immer
 libs.immer.url=https://github.com/arximboldi/immer


### PR DESCRIPTION
Associated infra change compiler-explorer/infra#558

The different sub-libraries under hotels-template-library are still under active development and don't have any version tags, so just trunk is necessary.

Ran `make check` locally and all tests/linters passed.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
