### PR TITLE
Add rustc MIR output view

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -567,8 +567,42 @@ export class BaseCompiler {
         };
     }
 
+    async generateRustMir(inputFilename) {
+        // These arguments make Rustc produce the Rust MIR
+        const execOptions = this.getDefaultExecOptions();
+        // TODO: reconsider this value
+        execOptions.maxOutput = 1024 ** 3;
+        const rustcOptions = [
+            inputFilename,
+            '-o',
+            this.getRustMirOutputFilename(inputFilename),
+            '--emit=mir',
+            '--crate-type',
+            'rlib',
+        ];
+
+        const output = await this.runCompiler(this.compiler.exe, rustcOptions, this.filename(inputFilename),
+            execOptions);
+        if (output.code !== 0) {
+            return [{text: 'Failed to run compiler to get Rust MIR'}];
+        }
+        const mirPath = this.getRustMirOutputFilename(inputFilename);
+        if (await fs.exists(mirPath)) {
+            const content = await fs.readFile(mirPath, 'utf-8');
+            // TODO: process the output
+            return content.split('\n').map((line) => ({
+                text: line,
+            }));
+        }
+        return [{text: 'Internal error; unable to open output path'}];
+    }
+
     getIrOutputFilename(inputFilename) {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
+    }
+
+    getRustMirOutputFilename(inputFilename) {
+        return inputFilename.replace(path.extname(inputFilename), '.mir');
     }
 
     getOutputFilename(dirPath, outputFilebase) {
@@ -930,15 +964,17 @@ export class BaseCompiler {
 
         const makeAst = backendOptions.produceAst && this.compiler.supportsAstView;
         const makeIr = backendOptions.produceIr && this.compiler.supportsIrView;
+        const makeRustMir = backendOptions.produceRustMir && this.compiler.supportsRustMirView;
         const makeGccDump = backendOptions.produceGccDump && backendOptions.produceGccDump.opened
             && this.compiler.supportsGccDump;
 
         const downloads = await buildEnvironment;
-        const [asmResult, astResult, gccDumpResult, irResult, toolsResult] = await Promise.all([
+        const [asmResult, astResult, gccDumpResult, irResult, rustMirResult, toolsResult] = await Promise.all([
             this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
             (makeAst ? this.generateAST(inputFilename, options) : ''),
             (makeGccDump ? this.generateGccDump(inputFilename, options, backendOptions.produceGccDump) : ''),
             (makeIr ? this.generateIR(inputFilename, options, filters) : ''),
+            (makeRustMir ? this.generateRustMir(inputFilename, options) : ''),
             Promise.all(this.runToolsOfType(tools, 'independent', this.getCompilationInfo(key, {
                 inputFilename,
                 dirPath,
@@ -974,6 +1010,10 @@ export class BaseCompiler {
         if (irResult) {
             asmResult.hasIrOutput = true;
             asmResult.irOutput = irResult;
+        }
+        if (rustMirResult) {
+            asmResult.hasRustMirOutput = true;
+            asmResult.rustMirOutput = rustMirResult;
         }
 
         return this.checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters);

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -38,6 +38,7 @@ export class RustCompiler extends BaseCompiler {
         super(info, env);
         this.compiler.supportsIntel = true;
         this.compiler.supportsIrView = true;
+        this.compiler.supportsRustMirView = true;
         this.compiler.irArg = ['--emit', 'llvm-ir'];
         this.linker = this.compilerProps('linker');
     }

--- a/lib/compilers/rustc-cg-gcc.js
+++ b/lib/compilers/rustc-cg-gcc.js
@@ -32,6 +32,7 @@ export class RustcCgGCCCompiler extends RustCompiler {
     constructor(info, env) {
         super(info, env);
         this.compiler.supportsIrView = false;
+        this.compiler.supportsRustMirView = false;
     }
 
     optionsForFilter(filters, outputFilename, userOptions) {

--- a/lib/compilers/rustc-cg-gcc.js
+++ b/lib/compilers/rustc-cg-gcc.js
@@ -32,7 +32,6 @@ export class RustcCgGCCCompiler extends RustCompiler {
     constructor(info, env) {
         super(info, env);
         this.compiler.supportsIrView = false;
-        this.compiler.supportsRustMirView = false;
     }
 
     optionsForFilter(filters, outputFilename, userOptions) {

--- a/static/components.js
+++ b/static/components.js
@@ -269,4 +269,24 @@ module.exports = {
             },
         };
     },
+    getRustMirView: function () {
+        return {
+            type: 'component',
+            componentName: 'rustmir',
+            componentState: {},
+        };
+    },
+    getRustMirViewWith: function (id, source, rustMirOutput, compilerName, editorid) {
+        return {
+            type: 'component',
+            componentName: 'rustmir',
+            componentState: {
+                id: id,
+                source: source,
+                rustMirOutput: rustMirOutput,
+                compilerName: compilerName,
+                editorid: editorid,
+            },
+        };
+    },
 };

--- a/static/hub.js
+++ b/static/hub.js
@@ -38,6 +38,7 @@ var optView = require('./panes/opt-view');
 var flagsView = require('./panes/flags-view');
 var astView = require('./panes/ast-view');
 var irView = require('./panes/ir-view');
+var rustMirView = require('./panes/rustmir-view');
 var gccDumpView = require('./panes/gccdump-view');
 var cfgView = require('./panes/cfg-view');
 var conformanceView = require('./panes/conformance-view');
@@ -124,6 +125,10 @@ function Hub(layout, subLangId, defaultLangId) {
     layout.registerComponent(Components.getIrView().componentName,
         function (container, state) {
             return self.irViewFactory(container, state);
+        });
+    layout.registerComponent(Components.getRustMirView().componentName,
+        function (container, state) {
+            return self.rustMirViewFactory(container, state);
         });
     layout.registerComponent(Components.getGccDumpView().componentName,
         function (container, state) {
@@ -231,6 +236,10 @@ Hub.prototype.astViewFactory = function (container, state) {
 
 Hub.prototype.irViewFactory = function (container, state) {
     return new irView.Ir(this, container, state);
+};
+
+Hub.prototype.rustMirViewFactory = function (container, state) {
+    return new rustMirView.RustMir(this, container, state);
 };
 
 Hub.prototype.gccDumpViewFactory = function (container, state) {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -217,6 +217,11 @@ Compiler.prototype.initPanerButtons = function () {
             this.sourceEditorId);
     }, this);
 
+    var createRustMirView = _.bind(function () {
+        return Components.getRustMirViewWith(this.id, this.source, this.lastResult.rustMirOutput,
+            this.getCompilerName(), this.sourceEditorId);
+    }, this);
+
     var createGccDumpView = _.bind(function () {
         return Components.getGccDumpViewWith(this.id, this.getCompilerName(), this.sourceEditorId,
             this.lastResult.gccDumpOutput);
@@ -297,6 +302,16 @@ Compiler.prototype.initPanerButtons = function () {
         var insertPoint = this.hub.findParentRowOrColumn(this.container) ||
             this.container.layoutManager.root.contentItems[0];
         insertPoint.addChild(createIrView);
+    }, this));
+
+    this.container.layoutManager
+        .createDragSource(this.rustMirButton, createRustMirView)
+        ._dragListener.on('dragStart', togglePannerAdder);
+
+    this.rustMirButton.click(_.bind(function () {
+        var insertPoint = this.hub.findParentRowOrColumn(this.container) ||
+            this.container.layoutManager.root.contentItems[0];
+        insertPoint.addChild(createRustMirView);
     }, this));
 
     this.container.layoutManager
@@ -579,6 +594,7 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
             produceOptInfo: this.wantOptInfo,
             produceCfg: this.cfgViewOpen,
             produceIr: this.irViewOpen,
+            produceRustMir: this.rustMirViewOpen,
         },
         filters: this.getEffectiveFilters(),
         tools: this.getActiveTools(newTools),
@@ -974,6 +990,21 @@ Compiler.prototype.onIrViewClosed = function (id) {
     }
 };
 
+Compiler.prototype.onRustMirViewOpened = function (id) {
+    if (this.id === id) {
+        this.rustMirButton.prop('disabled', true);
+        this.rustMirViewOpen = true;
+        this.compile();
+    }
+};
+
+Compiler.prototype.onRustMirViewClosed = function (id) {
+    if (this.id === id) {
+        this.rustMirButton.prop('disabled', false);
+        this.rustMirViewOpen = false;
+    }
+};
+
 Compiler.prototype.onGccDumpUIInit = function (id) {
     if (this.id === id) {
         this.compile();
@@ -1109,6 +1140,7 @@ Compiler.prototype.initButtons = function (state) {
     this.flagsButton = this.domRoot.find('div.populararguments div.dropdown-menu button');
     this.astButton = this.domRoot.find('.btn.view-ast');
     this.irButton = this.domRoot.find('.btn.view-ir');
+    this.rustMirButton = this.domRoot.find('.btn.view-rustmir');
     this.gccDumpButton = this.domRoot.find('.btn.view-gccdump');
     this.cfgButton = this.domRoot.find('.btn.view-cfg');
     this.executorButton = this.domRoot.find('.create-executor');
@@ -1295,6 +1327,7 @@ Compiler.prototype.updateButtons = function () {
     }
     this.astButton.prop('disabled', this.astViewOpen || !this.compiler.supportsAstView);
     this.irButton.prop('disabled', this.irViewOpen || !this.compiler.supportsIrView);
+    this.rustMirButton.prop('disabled', /* this.rustMirViewOpen || !this.compiler.supportsRustMirView*/ false);
     this.cfgButton.prop('disabled', this.cfgViewOpen || !this.compiler.supportsCfg);
     this.gccDumpButton.prop('disabled', this.gccDumpViewOpen || !this.compiler.supportsGccDump);
 
@@ -1377,6 +1410,8 @@ Compiler.prototype.initListeners = function () {
     this.eventHub.on('astViewClosed', this.onAstViewClosed, this);
     this.eventHub.on('irViewOpened', this.onIrViewOpened, this);
     this.eventHub.on('irViewClosed', this.onIrViewClosed, this);
+    this.eventHub.on('rustMirViewOpened', this.onRustMirViewOpened, this);
+    this.eventHub.on('rustMirViewClosed', this.onRustMirViewClosed, this);
     this.eventHub.on('outputOpened', this.onOutputOpened, this);
     this.eventHub.on('outputClosed', this.onOutputClosed, this);
 

--- a/static/panes/rustmir-view.js
+++ b/static/panes/rustmir-view.js
@@ -1,0 +1,208 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+var FontScale = require('../fontscale');
+var ga = require('../analytics');
+var _ = require('underscore');
+var $ = require('jquery');
+var monaco = require('monaco-editor');
+var monacoConfig = require('../monaco-config');
+
+function RustMir(hub, container, state) {
+    this.container = container;
+    this.eventHub = hub.createEventHub();
+    this.domRoot = container.getElement();
+    this.domRoot.html($('#rustmir').html());
+
+    var root = this.domRoot.find('.monaco-placeholder');
+    this.rustMirEditor = monaco.editor.create(root[0], monacoConfig.extendConfig({
+        language: 'rust',
+        readOnly: true,
+        glyphMargin: true,
+        lineNumbersMinChars: 3,
+    }));
+
+    this._compilerid = state.id;
+    this._compilerName = state.compilerName;
+    this._editorid = state.editorid;
+
+    this.awaitingInitialResults = false;
+    this.selection = state.selection;
+
+    this.settings = {};
+    this.colours = [];
+    this.irCode = [];
+
+    this.initButtons(state);
+    this.initCallbacks();
+
+    if (state && state.rustMirOutput) {
+        this.showRustMirResults(state.rustMirOutput);
+    }
+    this.setTitle();
+
+    ga.proxy('send', {
+        hitType: 'event',
+        eventCategory: 'OpenViewPane',
+        eventAction: 'RustMir',
+    });
+}
+
+RustMir.prototype.initButtons = function (state) {
+    this.fontScale = new FontScale(this.domRoot, state, this.rustMirEditor);
+
+    this.topBar = this.domRoot.find('.top-bar');
+};
+
+RustMir.prototype.initCallbacks = function () {
+    this.fontScale.on('change', this.updateState, this);
+    this.container.on('destroy', this.close, this);
+    this.container.on('resize', this.resize, this);
+
+    this.eventHub.on('compileResult', this.onCompileResult, this);
+    this.eventHub.on('compiler', this.onCompiler, this);
+    this.eventHub.on('compilerClose', this.onCompilerClose, this);
+    this.eventHub.on('settingsChange', this.onSettingsChange, this);
+
+    this.eventHub.emit('rustMirViewOpened', this._compilerid);
+    this.eventHub.emit('requestSettings');
+
+    this.eventHub.on('shown', this.resize, this);
+    this.eventHub.on('resize', this.resize, this);
+
+    this.cursorSelectionThrottledFunction =
+        _.throttle(_.bind(this.onDidChangeCursorSelection, this), 500);
+    this.rustMirEditor.onDidChangeCursorSelection(_.bind(function (e) {
+        this.cursorSelectionThrottledFunction(e);
+    }, this));
+};
+
+// TODO: de-dupe with compiler etc
+RustMir.prototype.resize = function () {
+    var topBarHeight = this.topBar.outerHeight(true);
+    this.rustMirEditor.layout({
+        width: this.domRoot.width(),
+        height: this.domRoot.height() - topBarHeight,
+    });
+};
+
+RustMir.prototype.onCompileResult = function (id, compiler, result) {
+    if (this._compilerid !== id) return;
+    if (result.hasRustMirOutput) {
+        this.showRustMirResults(result.rustMirOutput);
+    } else if (compiler.supportsRustMirView) {
+        this.showRustMirResults([{text: '<No output>'}]);
+    }
+};
+
+RustMir.prototype.getCurrentEditorLanguage = function() {
+    return this.rustMirEditor.getModel().getModeId();
+};
+
+RustMir.prototype.getPaneName = function () {
+    return this._compilerName + ' Rust MIR Viewer (Editor #' + this._editorid + ', Compiler # '
+        + this._compilerid + ')';
+};
+
+RustMir.prototype.setTitle = function () {
+    this.container.setTitle(this.getPaneName());
+};
+
+RustMir.prototype.showRustMirResults = function (rustMirCode) {
+    if (!this.rustMirEditor) return;
+    this.rustMirEditor.getModel().setValue(rustMirCode.length
+        ? _.pluck(rustMirCode, 'text').join('\n')
+        : '<No Rust MIR generated>');
+
+    if (!this.awaitingInitialResults) {
+        if (this.selection) {
+            this.rustMirEditor.setSelection(this.selection);
+            this.rustMirEditor.revealLinesInCenter(this.selection.startLineNumber,
+                this.selection.endLineNumber);
+        }
+        this.awaitingInitialResults = true;
+    }
+};
+
+RustMir.prototype.onCompiler = function (id, compiler, options, editorid) {
+    if (this._compilerid === id) {
+        this._compilerName = compiler ? compiler.name : '';
+        this._editorid = editorid;
+        this.setTitle();
+        if (compiler && !compiler.supportsRustMirView) {
+            this.rustMirEditor.setValue('<Rust MIR output is not supported for this compiler>');
+        }
+    }
+};
+
+RustMir.prototype.onCompilerClose = function (id) {
+    if (this._compilerid === id) {
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+RustMir.prototype.updateState = function () {
+    this.container.setState(this.currentState());
+};
+
+RustMir.prototype.currentState = function () {
+    var state = {
+        id: this._compilerid,
+        editorid: this._editorid,
+        selection: this.selection,
+    };
+    this.fontScale.addState(state);
+    return state;
+};
+
+RustMir.prototype.onDidChangeCursorSelection = function (e) {
+    if (this.awaitingInitialResults) {
+        this.selection = e.selection;
+        this.updateState();
+    }
+};
+
+RustMir.prototype.onSettingsChange = function (newSettings) {
+    this.settings = newSettings;
+    this.rustMirEditor.updateOptions({
+        contextmenu: newSettings.useCustomContextMenu,
+        minimap: {
+            enabled: newSettings.showMinimap,
+        },
+        fontFamily: newSettings.editorFFont,
+        fontLigatures: newSettings.editorsFLigatures,
+    });
+};
+
+RustMir.prototype.close = function () {
+    this.eventHub.unsubscribe();
+    this.eventHub.emit('rustMirViewClosed', this._compilerid);
+    this.rustMirEditor.dispose();
+};
+
+module.exports = {
+    RustMir: RustMir,
+};

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -93,9 +93,12 @@
           button.dropdown-item.btn.btn-sm.btn-light.view-ast(title="Show AST output")
             span.dropdown-icon.fas.fa-leaf
             | AST output
-          button.dropdown-item.btn.btn-sm.btn-light.view-ir(title="Show IR output")
+          button.dropdown-item.btn.btn-sm.btn-light.view-ir(title="Show LLVM IR output")
             span.dropdown-icon.fas.fa-align-center
-            | IR output
+            | LLVM IR output
+          button.dropdown-item.btn.btn-sm.btn-light.view-rustmir(title="Show Rust MIR output")
+            span.dropdown-icon.fas.fa-water
+            | Rust MIR output
           button.dropdown-item.btn.btn-sm.btn-light.view-gccdump(title="Show Tree/RTL dump (GCC only)")
             span.dropdown-icon.fas.fa-tree
             | GCC Tree/RTL output
@@ -252,6 +255,11 @@
     .monaco-placeholder
 
   #ir
+    .top-bar.btn-toolbar.bg-light(role="toolbar")
+      include font-size.pug
+    .monaco-placeholder
+
+  #rustmir
     .top-bar.btn-toolbar.bg-light(role="toolbar")
       include font-size.pug
     .monaco-placeholder


### PR DESCRIPTION
Adds a new pane and processor for generating and showing Rust's MIR. This is my first time hacking on the front end. Let me know if there's anything that's missing.

![image](https://user-images.githubusercontent.com/42585241/126380381-4e65671b-dd3b-4ed7-95ce-8fbec1f2288e.png)

I do not have any tests for this at the moment. I would appreciate some help in how to set up testing for this.

Fixes #2566 

/cc @ojeda 