### PR TITLE
updated OSACA version to 0.4.5

### DIFF
--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -21,7 +21,7 @@ group.osaca.supportsBinary=false
 group.osaca.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 group.osaca.compilerType=osaca
 
-compiler.osacatrunk.name=OSACA (0.4.3)
-compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+compiler.osacatrunk.name=OSACA (0.4.5)
+compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 # Intel syntax currently unsupported (WIP)
 # compiler.osacatrunk.intelAsm=--intel-syntax

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2105,8 +2105,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1162,8 +1162,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/clean.amazon.properties
+++ b/etc/config/clean.amazon.properties
@@ -41,8 +41,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=_32
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=_32

--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -40,8 +40,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_blue.amazon.properties
+++ b/etc/config/cppx_blue.amazon.properties
@@ -23,8 +23,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_gold.amazon.properties
+++ b/etc/config/cppx_gold.amazon.properties
@@ -22,8 +22,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -248,8 +248,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=dmd

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -178,8 +178,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -367,8 +367,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=gl:6g141
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=gl:6g141

--- a/etc/config/haskell.amazon.properties
+++ b/etc/config/haskell.amazon.properties
@@ -48,8 +48,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -45,8 +45,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -154,8 +154,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=opt
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=opt

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -39,8 +39,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -161,8 +161,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -58,8 +58,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -53,8 +53,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.3)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.3/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.5)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Updated OSACA in CE to v0.4.5 to support some new instruction forms.
See also the related [PR #559 in `compiler-explorer/infra`](https://github.com/compiler-explorer/infra/pull/559)