### PR TITLE
Hide panes that are not supported by a compiler

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1321,22 +1321,24 @@ Compiler.prototype.updateButtons = function () {
     this.filterTrimButton.prop('disabled', this.compiler.disabledFilters.indexOf('trim') !== -1);
     formatFilterTitle(this.filterTrimButton, this.filterTrimTitle);
 
-    this.optButton.prop('disabled', this.optViewOpen || !this.compiler.supportsOptOutput);
     if (this.flagsButton) {
         this.flagsButton.prop('disabled', this.flagsViewOpen);
     }
-    this.astButton.prop('disabled', this.astViewOpen || !this.compiler.supportsAstView);
-    this.irButton.prop('disabled', this.irViewOpen || !this.compiler.supportsIrView);
-    this.rustMirButton.prop('disabled', this.rustMirViewOpen || !this.compiler.supportsRustMirView);
-    this.cfgButton.prop('disabled', this.cfgViewOpen || !this.compiler.supportsCfg);
-    this.gccDumpButton.prop('disabled', this.gccDumpViewOpen || !this.compiler.supportsGccDump);
-    this.executorButton.prop('disabled', !this.compiler.supportsExecute);
+    this.optButton.prop('disabled', this.optViewOpen);
+    this.astButton.prop('disabled', this.astViewOpen);
+    this.irButton.prop('disabled', this.irViewOpen);
+    this.rustMirButton.prop('disabled', this.rustMirViewOpen);
+    this.cfgButton.prop('disabled', this.cfgViewOpen);
+    this.gccDumpButton.prop('disabled', this.gccDumpViewOpen);
+    // The executorButton does not need to be changed here, because you can create however
+    // many executors as you want.
 
     this.optButton.toggle(!!this.compiler.supportsOptOutput);
     this.astButton.toggle(!!this.compiler.supportsAstView);
     this.irButton.toggle(!!this.compiler.supportsIrView);
-    this.gccDumpButton.toggle(!!this.compiler.supportsGccDump);
+    this.rustMirButton.toggle(!!this.compiler.supportsRustMirView);
     this.cfgButton.toggle(!!this.compiler.supportsCfg);
+    this.gccDumpButton.toggle(!!this.compiler.supportsGccDump);
     this.executorButton.toggle(!!this.compiler.supportsExecute);
 
     this.enableToolButtons();

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1330,8 +1330,14 @@ Compiler.prototype.updateButtons = function () {
     this.rustMirButton.prop('disabled', this.rustMirViewOpen || !this.compiler.supportsRustMirView);
     this.cfgButton.prop('disabled', this.cfgViewOpen || !this.compiler.supportsCfg);
     this.gccDumpButton.prop('disabled', this.gccDumpViewOpen || !this.compiler.supportsGccDump);
-
     this.executorButton.prop('disabled', !this.compiler.supportsExecute);
+
+    this.optButton.toggle(!!this.compiler.supportsOptOutput);
+    this.astButton.toggle(!!this.compiler.supportsAstView);
+    this.irButton.toggle(!!this.compiler.supportsIrView);
+    this.gccDumpButton.toggle(!!this.compiler.supportsGccDump);
+    this.cfgButton.toggle(!!this.compiler.supportsCfg);
+    this.executorButton.toggle(!!this.compiler.supportsExecute);
 
     this.enableToolButtons();
 };


### PR DESCRIPTION
Follow up to https://github.com/compiler-explorer/compiler-explorer/pull/2795#discussion_r675894577

The buttons for unsupported panes are now hidden in the UI.

This keeps the original behavior of disabling buttons while their views are open (the IR view button is disabled while IR is shown).