### PR TITLE
Fix Rust MIR button bug and remove invalid todo line

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -589,7 +589,6 @@ export class BaseCompiler {
         const mirPath = this.getRustMirOutputFilename(inputFilename);
         if (await fs.exists(mirPath)) {
             const content = await fs.readFile(mirPath, 'utf-8');
-            // TODO: process the output
             return content.split('\n').map((line) => ({
                 text: line,
             }));

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1327,7 +1327,7 @@ Compiler.prototype.updateButtons = function () {
     }
     this.astButton.prop('disabled', this.astViewOpen || !this.compiler.supportsAstView);
     this.irButton.prop('disabled', this.irViewOpen || !this.compiler.supportsIrView);
-    this.rustMirButton.prop('disabled', /* this.rustMirViewOpen || !this.compiler.supportsRustMirView*/ false);
+    this.rustMirButton.prop('disabled', this.rustMirViewOpen || !this.compiler.supportsRustMirView);
     this.cfgButton.prop('disabled', this.cfgViewOpen || !this.compiler.supportsCfg);
     this.gccDumpButton.prop('disabled', this.gccDumpViewOpen || !this.compiler.supportsGccDump);
 


### PR DESCRIPTION
Follow up to #2795

As @mattgodbolt pointed out in the previous PR I left a todo comment which isn't valid anymore.

In addition to that, the rust MIR button wouldn't disable ever. Both of these nits are fixed in this patch.