### PR TITLE
Delay compilation until editor sends compile request on language change

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2020,11 +2020,17 @@ Compiler.prototype.onLanguageChange = function (editorId, newLangId) {
             options: this.options,
         };
         var info = this.infoByLang[this.currentLangId] || {};
+        this.deferCompiles = true;
         this.initLangAndCompiler({lang: newLangId, compiler: info.compiler});
         this.updateCompilersSelector(info);
-        this.updateCompilerUI();
-        this.sendCompiler();
         this.saveState();
+        this.updateCompilerUI();
+
+        // this is a workaround to delay compilation further until the Editor sends a compile request
+        this.needsCompile = false;
+
+        this.undefer();
+        this.sendCompiler();
     }
 };
 


### PR DESCRIPTION
When you change editor language, a compile request would be sent even though the Source had not been changed yet (resulting for example in Java source being compiled with GCC, etc)

Editor will still probably trigger compilation twice depending on settings. (1. Editor code change, 2. Compilation request on language change (event in editor.js)) - but the result will be fetched from browser cache in most situations.
