### PR TITLE
Circle: Add support for Intel ASM syntax

### DIFF
--- a/etc/config/circle.amazon.properties
+++ b/etc/config/circle.amazon.properties
@@ -1,17 +1,21 @@
-compilers=circlelatest:circle128
+compilers=circlelatest:circle129:circle128
 isSemVer=true
 defaultCompiler=circlelatest
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 
-#group.circle.intelAsm=-mllvm --x86-asm-syntax=intel
 compiler.circlelatest.exe=/opt/compiler-explorer/circle-latest/circle
 compiler.circlelatest.name=Latest
 compiler.circlelatest.semver=latest
 
+compiler.circle129.exe=/opt/compiler-explorer/circle-129/circle
+compiler.circle129.name=Build 129
+compiler.circle129.semver=129
+
 compiler.circle128.exe=/opt/compiler-explorer/circle-128/circle
 compiler.circle128.name=Build 128
 compiler.circle128.semver=128
+compiler.circle128.intelAsm=
 
 #################################
 #################################

--- a/etc/config/circle.defaults.properties
+++ b/etc/config/circle.defaults.properties
@@ -4,7 +4,7 @@ supportsExecute=true
 compilerType=circle
 
 group.circle.compilers=circledefault
-#group.circle.intelAsm=-mllvm --x86-asm-syntax=intel
+group.circle.intelAsm=--intel
 compiler.circledefault.exe=circle
 compiler.circledefault.name=circle default
 

--- a/lib/compilers/circle.js
+++ b/lib/compilers/circle.js
@@ -31,8 +31,10 @@ export class CircleCompiler extends BaseCompiler {
 
     optionsForFilter(filters, outputFilename) {
         let options = [`-o=${this.filename(outputFilename)}`];
-        if (!filters.execute && !filters.binary) {
-            //options.push(filters.binary ? '-c' : '-S');
+        if (this.compiler.intelAsm && filters.intel && !filters.binary) {
+            options = options.concat(this.compiler.intelAsm.split(' '));
+        }
+        if (!filters.binary) {
             options.push('-S');
         }
         return options;


### PR DESCRIPTION
This PR add support for Intel ASM syntax, which was added to 129 build of circle.