### PR TITLE
Update to latest zig trunk

### DIFF
--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -72,6 +72,8 @@ export class ZigCompiler extends BaseCompiler {
             source += 'extern fn zig_panic() noreturn;\n';
             source += 'pub fn panic(msg: []const u8, error_return_trace: ' +
                 '?*@import("std").builtin.StackTrace) noreturn {\n';
+            source += '    _ = msg;\n';
+            source += '    _ = error_return_trace;\n';
             source += '    zig_panic();\n';
             source += '}\n';
         }


### PR DESCRIPTION
Unused function parameters (used in the custom panic handler) are now
compile errors.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
