### PR TITLE
Add support for heterogeneous compute

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1279,8 +1279,7 @@ export class BaseCompiler {
         result.tools = _.union(result.tools, await Promise.all(this.runToolsOfType(tools, 'postcompilation',
             this.getCompilationInfo(key, result))));
 
-        const outputFilename = this.getOutputFilename(result.dirPath, this.outputFilebase);
-        result = await this.extractDeviceCode(result, filters, outputFilename);
+        result = this.extractDeviceCode(result, filters);
 
         this.doTempfolderCleanup(result);
         if (result.buildResult) {
@@ -1434,7 +1433,7 @@ Please select another pass or change filters.`;
     }
 
     // eslint-disable-next-line no-unused-vars
-    async extractDeviceCode(result, filters, outputFilename) {
+    extractDeviceCode(result, filters) {
         return result;
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1279,6 +1279,9 @@ export class BaseCompiler {
         result.tools = _.union(result.tools, await Promise.all(this.runToolsOfType(tools, 'postcompilation',
             this.getCompilationInfo(key, result))));
 
+        const outputFilename = this.getOutputFilename(result.dirPath, this.outputFilebase);
+        result = await this.extractDeviceCode(result, filters, outputFilename);
+
         this.doTempfolderCleanup(result);
         if (result.buildResult) {
             this.doTempfolderCleanup(result.buildResult);
@@ -1428,6 +1431,10 @@ Please select another pass or change filters.`;
         }
 
         return output;
+    }
+
+    async extractDeviceCode(result, filters, outputFilename) {
+        return result;
     }
 
     async execPostProcess(result, postProcesses, outputFilename, maxSize) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1433,6 +1433,7 @@ Please select another pass or change filters.`;
         return output;
     }
 
+    // eslint-disable-next-line no-unused-vars
     async extractDeviceCode(result, filters, outputFilename) {
         return result;
     }

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -250,6 +250,7 @@ export class CompilerFinder {
             demangler: demangler,
             demanglerType: props('demanglerType', ''),
             objdumper: props('objdumper', ''),
+            deviceExtractor: props('deviceExtractor', ''),
             objdumperType: props('objdumperType', ''),
             intelAsm: props('intelAsm', ''),
             instructionSet: props('instructionSet', ''),

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -250,7 +250,6 @@ export class CompilerFinder {
             demangler: demangler,
             demanglerType: props('demanglerType', ''),
             objdumper: props('objdumper', ''),
-            deviceExtractor: props('deviceExtractor', ''),
             objdumperType: props('objdumperType', ''),
             intelAsm: props('intelAsm', ''),
             instructionSet: props('instructionSet', ''),

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -26,10 +26,18 @@ import path from 'path';
 
 import { AmdgpuAsmParser } from '../asm-parser-amdgpu';
 import { SassAsmParser } from '../asm-parser-sass';
+import fs from 'fs-extra';
+
 import { BaseCompiler } from '../base-compiler';
 
 export class ClangCompiler extends BaseCompiler {
     static get key() { return 'clang'; }
+
+    constructor(info, env) {
+        super(info, env);
+        if (this.compiler.deviceExtractor)
+            this.compiler.supportsDeviceAsmView = true;
+    }
 
     runCompiler(compiler, options, inputFilename, execOptions) {
         if (!execOptions) {
@@ -39,6 +47,36 @@ export class ClangCompiler extends BaseCompiler {
         execOptions.customCwd = path.dirname(inputFilename);
 
         return super.runCompiler(compiler, options, inputFilename, execOptions);
+    }
+
+    async extractDeviceCode(result, filters, outputFilename) {
+        // Check to see if there is any offload code in the assembly file.
+        const offload_regexp = /__CLANG_OFFLOAD_BUNDLE__/;
+        if (!this.compiler.deviceExtractor || !offload_regexp.exec(result.asm))
+            return result;
+
+        const extractor = this.compiler.deviceExtractor;
+        const extractor_result = await this.exec(extractor,
+            [outputFilename, result.dirPath + '/devices'], {});
+        if (extractor_result.code !== 0) {
+            result.devices = extractor_result.stderr;
+            return result;
+        }
+        const extractor_info = JSON.parse(extractor_result.stdout);
+        result.asm = await fs.readFile(extractor_info.host, 'utf-8');
+        const devices = result.devices = {};
+        for (const device in extractor_info.devices) {
+            const file = extractor_info.devices[device];
+            devices[device] = await this.processDeviceAssembly(device, file, filters);
+        }
+        return result;
+    }
+
+    async processDeviceAssembly(deviceName, deviceFile, filters) {
+        const deviceAsm = await fs.readFile(deviceFile, 'utf-8');
+        return this.llvmIr.isLlvmIr(deviceAsm) ?
+            this.llvmIr.process(deviceAsm, filters) :
+            this.asm.process(deviceAsm, filters);
     }
 }
 

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -24,10 +24,10 @@
 
 import path from 'path';
 
-import { AmdgpuAsmParser } from '../asm-parser-amdgpu';
-import { SassAsmParser } from '../asm-parser-sass';
 import fs from 'fs-extra';
 
+import { AmdgpuAsmParser } from '../asm-parser-amdgpu';
+import { SassAsmParser } from '../asm-parser-sass';
 import { BaseCompiler } from '../base-compiler';
 
 export class ClangCompiler extends BaseCompiler {
@@ -52,7 +52,7 @@ export class ClangCompiler extends BaseCompiler {
     async extractDeviceCode(result, filters, outputFilename) {
         // Check to see if there is any offload code in the assembly file.
         const offload_regexp = /__CLANG_OFFLOAD_BUNDLE__/;
-        if (!this.compiler.deviceExtractor || !offload_regexp.exec(result.asm))
+        if (!this.compiler.deviceExtractor || !offload_regexp.test(result.asm))
             return result;
 
         const extractor = this.compiler.deviceExtractor;

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -24,19 +24,20 @@
 
 import path from 'path';
 
-import fs from 'fs-extra';
-
 import { AmdgpuAsmParser } from '../asm-parser-amdgpu';
 import { SassAsmParser } from '../asm-parser-sass';
 import { BaseCompiler } from '../base-compiler';
 
+const offloadRegexp = /^#\s+__CLANG_OFFLOAD_BUNDLE__(__START__|__END__)\s+(.*)$/gm;
+
 export class ClangCompiler extends BaseCompiler {
-    static get key() { return 'clang'; }
+    static get key() {
+        return 'clang';
+    }
 
     constructor(info, env) {
         super(info, env);
-        if (this.compiler.deviceExtractor)
-            this.compiler.supportsDeviceAsmView = true;
+        this.compiler.supportsDeviceAsmView = true;
     }
 
     runCompiler(compiler, options, inputFilename, execOptions) {
@@ -49,39 +50,69 @@ export class ClangCompiler extends BaseCompiler {
         return super.runCompiler(compiler, options, inputFilename, execOptions);
     }
 
-    async extractDeviceCode(result, filters, outputFilename) {
+    splitDeviceCode(assembly) {
         // Check to see if there is any offload code in the assembly file.
-        const offload_regexp = /__CLANG_OFFLOAD_BUNDLE__/;
-        if (!this.compiler.deviceExtractor || !offload_regexp.test(result.asm))
-            return result;
+        if (!offloadRegexp.test(assembly))
+            return null;
 
-        const extractor = this.compiler.deviceExtractor;
-        const extractor_result = await this.exec(extractor,
-            [outputFilename, result.dirPath + '/devices'], {});
-        if (extractor_result.code !== 0) {
-            result.devices = extractor_result.stderr;
-            return result;
+        offloadRegexp.lastIndex = 0;
+        const matches = assembly.matchAll(offloadRegexp);
+        let prevStart = 0;
+        const devices = {};
+        for (const match of matches) {
+            const [full, startOrEnd, triple] = match;
+            if (startOrEnd === '__START__') {
+                prevStart = match.index + full.length + 1;
+            } else {
+                devices[triple] = assembly.substr(prevStart, match.index - prevStart);
+            }
         }
-        const extractor_info = JSON.parse(extractor_result.stdout);
-        result.asm = await fs.readFile(extractor_info.host, 'utf-8');
-        const devices = result.devices = {};
-        for (const device in extractor_info.devices) {
-            const file = extractor_info.devices[device];
-            devices[device] = await this.processDeviceAssembly(device, file, filters);
-        }
-        return result;
+        return devices;
     }
 
-    async processDeviceAssembly(deviceName, deviceFile, filters) {
-        const deviceAsm = await fs.readFile(deviceFile, 'utf-8');
+    extractDeviceCode(result, filters) {
+        const split = this.splitDeviceCode(result.asm);
+        if (!split)
+            return result;
+
+        const devices = result.devices = {};
+        for (const key of Object.keys(split)) {
+            if (key.indexOf('host-') === 0)
+                result.asm = split[key];
+            else
+                devices[key] = this.processDeviceAssembly(key, split[key], filters);
+        }
+        return result;
+        // //result.asm = ...
+        //
+        // const extractor = this.compiler.deviceExtractor;
+        // const extractor_result = await this.exec(extractor,
+        //     [outputFilename, result.dirPath + '/devices'], {});
+        // if (extractor_result.code !== 0) {
+        //     result.devices = extractor_result.stderr;
+        //     return result;
+        // }
+        // const extractor_info = JSON.parse(extractor_result.stdout);
+        // result.asm = await fs.readFile(extractor_info.host, 'utf-8');
+        // const devices = result.devices = {};
+        // for (const device in extractor_info.devices) {
+        //     const file = extractor_info.devices[device];
+        //     devices[device] = await this.processDeviceAssembly(device, file, filters);
+        // }
+        // return result;
+    }
+
+    processDeviceAssembly(deviceName, deviceAsm, filters) {
         return this.llvmIr.isLlvmIr(deviceAsm) ?
-            this.llvmIr.process(deviceAsm, filters) :
-            this.asm.process(deviceAsm, filters);
+            this.llvmIr.process(deviceAsm, filters) : this.asm.process(deviceAsm, filters);
     }
 }
 
 export class ClangCudaCompiler extends ClangCompiler {
-    static get key() { return 'clang-cuda'; }
+    static get key() {
+        return 'clang-cuda';
+    }
+
     constructor(info, env) {
         super(info, env);
 
@@ -107,8 +138,12 @@ export class ClangCudaCompiler extends ClangCompiler {
         return result;
     }
 }
+
 export class ClangHipCompiler extends ClangCompiler {
-    static get key() { return 'clang-hip'; }
+    static get key() {
+        return 'clang-hip';
+    }
+
     constructor(info, env) {
         super(info, env);
 

--- a/static/components.js
+++ b/static/components.js
@@ -287,4 +287,24 @@ module.exports = {
             },
         };
     },
+    getDeviceView: function () {
+        return {
+            type: 'component',
+            componentName: 'device',
+            componentState: {},
+        };
+    },
+    getDeviceViewWith: function (id, source, deviceOutput, compilerName, editorid) {
+        return {
+            type: 'component',
+            componentName: 'device',
+            componentState: {
+                id: id,
+                source: source,
+                deviceOutput: deviceOutput,
+                compilerName: compilerName,
+                editorid: editorid,
+            },
+        };
+    },
 };

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -95,6 +95,11 @@ body {
     width: 99%;
 }
 
+.change-device {
+    min-width: 20em;
+    width: 99%;
+}
+
 li.tweet {
     padding: 3px 20px;
 }

--- a/static/hub.js
+++ b/static/hub.js
@@ -38,6 +38,7 @@ var optView = require('./panes/opt-view');
 var flagsView = require('./panes/flags-view');
 var astView = require('./panes/ast-view');
 var irView = require('./panes/ir-view');
+var deviceView = require('./panes/device-view');
 var rustMirView = require('./panes/rustmir-view');
 var gccDumpView = require('./panes/gccdump-view');
 var cfgView = require('./panes/cfg-view');
@@ -125,6 +126,10 @@ function Hub(layout, subLangId, defaultLangId) {
     layout.registerComponent(Components.getIrView().componentName,
         function (container, state) {
             return self.irViewFactory(container, state);
+        });
+    layout.registerComponent(Components.getDeviceView().componentName,
+        function (container, state) {
+            return self.deviceViewFactory(container, state);
         });
     layout.registerComponent(Components.getRustMirView().componentName,
         function (container, state) {
@@ -236,6 +241,10 @@ Hub.prototype.astViewFactory = function (container, state) {
 
 Hub.prototype.irViewFactory = function (container, state) {
     return new irView.Ir(this, container, state);
+};
+
+Hub.prototype.deviceViewFactory = function (container, state) {
+    return new deviceView.DeviceAsm(this, container, state);
 };
 
 Hub.prototype.rustMirViewFactory = function (container, state) {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1054,12 +1054,6 @@ Compiler.prototype.onDeviceViewClosed = function (id) {
     }
 };
 
-Compiler.prototype.onDeviceSettingsChanged = function (id) {
-    if (this.id === id) {
-        this.compile();
-    }
-};
-
 Compiler.prototype.onRustMirViewOpened = function (id) {
     if (this.id === id) {
         this.rustMirButton.prop('disabled', true);
@@ -1503,8 +1497,6 @@ Compiler.prototype.initListeners = function () {
     this.eventHub.on('gccDumpViewOpened', this.onGccDumpViewOpened, this);
     this.eventHub.on('gccDumpViewClosed', this.onGccDumpViewClosed, this);
     this.eventHub.on('gccDumpUIInit', this.onGccDumpUIInit, this);
-
-    this.eventHub.on('deviceSettingsChanged', this.onDeviceSettingsChanged, this);
 
     this.eventHub.on('cfgViewOpened', this.onCfgViewOpened, this);
     this.eventHub.on('cfgViewClosed', this.onCfgViewClosed, this);

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1293,7 +1293,7 @@ Compiler.prototype.initToolButton = function (togglePannerAdder, button, toolId)
         var args = '';
         var monacoStdin = false;
         var langTools = options.tools[this.currentLangId];
-        if (langTools && langTools[toolId] && langTools[toolId].tool){
+        if (langTools && langTools[toolId] && langTools[toolId].tool) {
             if (langTools[toolId].tool.args !== undefined) {
                 args = langTools[toolId].tool.args;
             }
@@ -1398,8 +1398,8 @@ Compiler.prototype.updateButtons = function () {
     this.optButton.prop('disabled', this.optViewOpen);
     this.astButton.prop('disabled', this.astViewOpen);
     this.irButton.prop('disabled', this.irViewOpen);
+    this.deviceButton.prop('disabled', this.deviceViewOpen);
     this.rustMirButton.prop('disabled', this.rustMirViewOpen);
-    this.deviceButton.prop('disabled', this.deviceViewOpen || !this.compiler.supportsDeviceAsmView);
     this.cfgButton.prop('disabled', this.cfgViewOpen);
     this.gccDumpButton.prop('disabled', this.gccDumpViewOpen);
     // The executorButton does not need to be changed here, because you can create however
@@ -1408,6 +1408,7 @@ Compiler.prototype.updateButtons = function () {
     this.optButton.toggle(!!this.compiler.supportsOptOutput);
     this.astButton.toggle(!!this.compiler.supportsAstView);
     this.irButton.toggle(!!this.compiler.supportsIrView);
+    this.deviceButton.toggle(!!this.compiler.supportsDeviceAsmView);
     this.rustMirButton.toggle(!!this.compiler.supportsRustMirView);
     this.cfgButton.toggle(!!this.compiler.supportsCfg);
     this.gccDumpButton.toggle(!!this.compiler.supportsGccDump);

--- a/static/panes/device-view.js
+++ b/static/panes/device-view.js
@@ -1,0 +1,379 @@
+// Copyright (c) 2020, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+
+var FontScale = require('../fontscale');
+var monaco = require('monaco-editor');
+var _ = require('underscore');
+var $ = require('jquery');
+var colour = require('../colour');
+var ga = require('../analytics');
+var monacoConfig = require('../monaco-config');
+
+function DeviceAsm(hub, container, state) {
+    this.container = container;
+    this.eventHub = hub.createEventHub();
+    this.domRoot = container.getElement();
+    this.domRoot.html($('#device').html());
+
+    this.decorations = {};
+    this.prevDecorations = [];
+    var root = this.domRoot.find('.monaco-placeholder');
+
+    this.deviceEditor = monaco.editor.create(root[0], monacoConfig.extendConfig({
+        language: 'asm',
+        readOnly: true,
+        glyphMargin: true,
+        lineNumbersMinChars: 3,
+    }));
+
+    this._compilerid = state.id;
+    this._compilerName = state.compilerName;
+    this._editorid = state.editorid;
+
+    this.awaitingInitialResults = false;
+    this.selection = state.selection;
+
+    this.settings = {};
+
+    this.colours = [];
+    this.deviceCode = [];
+    this.lastColours = [];
+    this.lastColourScheme = {};
+
+    var selectize = this.domRoot.find('.change-device').selectize({
+        sortField: 'name',
+        valueField: 'name',
+        labelField: 'name',
+        searchField: ['name'],
+        options: [],
+        items: [],
+    });
+
+    this.selectize = selectize[0].selectize;
+
+    this.initButtons(state);
+    this.initCallbacks();
+    this.initEditorActions();
+
+    if (state && state.irOutput) {
+        this.showDeviceAsmResults(state.irOutput);
+    }
+    this.setTitle();
+
+    ga.proxy('send', {
+        hitType: 'event',
+        eventCategory: 'OpenViewPane',
+        eventAction: 'DeviceAsm',
+    });
+}
+
+DeviceAsm.prototype.initEditorActions = function () {
+    this.deviceEditor.addAction({
+        id: 'viewsource',
+        label: 'Scroll to source',
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.F10],
+        keybindingContext: null,
+        contextMenuGroupId: 'navigation',
+        contextMenuOrder: 1.5,
+        run: _.bind(function (ed) {
+            var desiredLine = ed.getPosition().lineNumber - 1;
+            var source = this.deviceCode[desiredLine].source;
+            if (source !== null && source.file === null) {
+                // a null file means it was the user's source
+                this.eventHub.emit('editorLinkLine', this._editorid, source.line, -1, true);
+            }
+        }, this),
+    });
+};
+
+DeviceAsm.prototype.initButtons = function (state) {
+    this.fontScale = new FontScale(this.domRoot, state, this.deviceEditor);
+
+    this.topBar = this.domRoot.find('.top-bar');
+};
+
+DeviceAsm.prototype.initCallbacks = function () {
+    this.linkedFadeTimeoutId = -1;
+    this.mouseMoveThrottledFunction = _.throttle(_.bind(this.onMouseMove, this), 50);
+    this.deviceEditor.onMouseMove(_.bind(function (e) {
+        this.mouseMoveThrottledFunction(e);
+    }, this));
+
+    this.cursorSelectionThrottledFunction =
+        _.throttle(_.bind(this.onDidChangeCursorSelection, this), 500);
+    this.deviceEditor.onDidChangeCursorSelection(_.bind(function (e) {
+        this.cursorSelectionThrottledFunction(e);
+    }, this));
+
+    this.fontScale.on('change', _.bind(this.updateState, this));
+    this.selectize.on('change', _.bind(this.onDeviceSelect, this));
+
+    this.container.on('destroy', this.close, this);
+
+    this.eventHub.on('compileResult', this.onCompileResponse, this);
+    this.eventHub.on('compiler', this.onCompiler, this);
+    this.eventHub.on('colours', this.onColours, this);
+    this.eventHub.on('panesLinkLine', this.onPanesLinkLine, this);
+    this.eventHub.on('compilerClose', this.onCompilerClose, this);
+    this.eventHub.on('settingsChange', this.onSettingsChange, this);
+    this.eventHub.emit('deviceViewOpened', this._compilerid);
+    this.eventHub.emit('requestSettings');
+
+    this.container.on('resize', this.resize, this);
+    this.container.on('shown', this.resize, this);
+};
+
+// TODO: de-dupe with compiler etc
+DeviceAsm.prototype.resize = function () {
+    var topBarHeight = this.topBar.outerHeight(true);
+    this.deviceEditor.layout({
+        width: this.domRoot.width(),
+        height: this.domRoot.height() - topBarHeight,
+    });
+};
+
+DeviceAsm.prototype.onCompileResponse = function (id, compiler, result) {
+    if (this._compilerid !== id) return;
+    var devices = result.devices;
+    var deviceNames = [];
+    if (!devices) {
+        this.showDeviceAsmResults([{text: '<No output>'}]);
+    } else if (typeof devices == 'string') {
+        this.showDeviceAsmResults([{text: 'Device extraction error:\n' + devices}]);
+    } else {
+        deviceNames = Object.keys(devices);
+    }
+
+    this.makeDeviceSelector(deviceNames);
+    var selectedDevice = this.selectize.getValue();
+    if (selectedDevice)
+        this.showDeviceAsmResults(devices[selectedDevice].asm);
+
+    // Why call this explicitly instead of just listening to the "colours" event?
+    // Because the recolouring happens before this editors value is set using "showDeviceAsmResults".
+    this.onColours(this._compilerid, this.lastColours, this.lastColourScheme);
+};
+
+DeviceAsm.prototype.makeDeviceSelector = function (deviceNames) {
+    var selectize = this.selectize;
+    var selected = this.selectize.getValue();
+
+    _.each(selectize.options, function (p) {
+        if (deviceNames.indexOf(p.name) === -1) {
+            selectize.removeOption(p.name);
+        }
+    }, this);
+
+    _.each(deviceNames, function (p) {
+        selectize.addOption({
+            name: p,
+        });
+    }, this);
+
+    if (!selected && deviceNames.length > 0) {
+        selected = deviceNames[0];
+        selectize.setValue(selected, true);
+    } else if (selected && deviceNames.indexOf(selected) === -1) {
+        selectize.clear(true);
+        this.showDeviceAsmResults(
+            [{text: '<Device ' + selected + ' not found>'}]);
+    }
+};
+
+DeviceAsm.prototype.onDeviceSelect = function () {
+    this.eventHub.emit('deviceSettingsChanged', this._compilerid);
+};
+
+DeviceAsm.prototype.getPaneName = function () {
+    return this._compilerName + ' Device Viewer (Editor #' + this._editorid + ', Compiler #' + this._compilerid + ')';
+};
+
+DeviceAsm.prototype.setTitle = function () {
+    this.container.setTitle(this.getPaneName());
+};
+
+DeviceAsm.prototype.showDeviceAsmResults = function (deviceCode) {
+    if (!this.deviceEditor) return;
+    this.deviceCode = deviceCode;
+    this.deviceEditor.getModel().setValue(
+        deviceCode.length ? _.pluck(deviceCode, 'text').join('\n') : '<No device code>');
+
+    if (!this.awaitingInitialResults) {
+        if (this.selection) {
+            this.deviceEditor.setSelection(this.selection);
+            this.deviceEditor.revealLinesInCenter(this.selection.startLineNumber,
+                this.selection.endLineNumber);
+        }
+        this.awaitingInitialResults = true;
+    }
+};
+
+DeviceAsm.prototype.onCompiler = function (id, compiler, options, editorid) {
+    if (id === this._compilerid) {
+        this._compilerName = compiler ? compiler.name : '';
+        this._editorid = editorid;
+        this.setTitle();
+        if (compiler && !compiler.supportsDeviceAsmView) {
+            this.deviceEditor.setValue('<Device output is not supported for this compiler>');
+        }
+    }
+};
+
+DeviceAsm.prototype.onColours = function (id, colours, scheme) {
+    this.lastColours = colours;
+    this.lastColourScheme = scheme;
+
+    if (id === this._compilerid) {
+        var irColours = {};
+        _.each(this.deviceCode, function (x, index) {
+            if (x.source && x.source.file === null && x.source.line > 0 && colours[x.source.line - 1] !== undefined) {
+                irColours[index] = colours[x.source.line - 1];
+            }
+        });
+        this.colours = colour.applyColours(this.deviceEditor, irColours, scheme, this.colours);
+    }
+};
+
+DeviceAsm.prototype.onCompilerClose = function (id) {
+    if (id === this._compilerid) {
+        // We can't immediately close as an outer loop somewhere in GoldenLayout is iterating over
+        // the hierarchy. We can't modify while it's being iterated over.
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+DeviceAsm.prototype.updateState = function () {
+    this.container.setState(this.currentState());
+};
+
+DeviceAsm.prototype.currentState = function () {
+    var state = {
+        id: this._compilerid,
+        editorid: this._editorid,
+        selection: this.selection,
+    };
+    this.fontScale.addState(state);
+    return state;
+};
+
+DeviceAsm.prototype.onCompilerClose = function (id) {
+    if (id === this._compilerid) {
+        // We can't immediately close as an outer loop somewhere in GoldenLayout is iterating over
+        // the hierarchy. We can't modify while it's being iterated over.
+        this.close();
+        _.defer(function (self) {
+            self.container.close();
+        }, this);
+    }
+};
+
+DeviceAsm.prototype.onSettingsChange = function (newSettings) {
+    this.settings = newSettings;
+    this.deviceEditor.updateOptions({
+        contextmenu: newSettings.useCustomContextMenu,
+        minimap: {
+            enabled: newSettings.showMinimap,
+        },
+        fontFamily: newSettings.editorsFFont,
+        fontLigatures: newSettings.editorsFLigatures,
+    });
+};
+
+DeviceAsm.prototype.onMouseMove = function (e) {
+    if (e === null || e.target === null || e.target.position === null) return;
+    if (this.settings.hoverShowSource === true && this.deviceCode) {
+        this.clearLinkedLines();
+        var hoverCode = this.deviceCode[e.target.position.lineNumber - 1];
+        if (hoverCode) {
+            // We check that we actually have something to show at this point!
+            var sourceLine = hoverCode.source && !hoverCode.source.file ? hoverCode.source.line : -1;
+            this.eventHub.emit('editorLinkLine', this._editorid, sourceLine, -1, false);
+            this.eventHub.emit('panesLinkLine', this._compilerid, sourceLine, false, this.getPaneName());
+        }
+    }
+};
+
+DeviceAsm.prototype.onDidChangeCursorSelection = function (e) {
+    if (this.awaitingInitialResults) {
+        this.selection = e.selection;
+        this.updateState();
+    }
+};
+
+
+DeviceAsm.prototype.updateDecorations = function () {
+    this.prevDecorations = this.deviceEditor.deltaDecorations(
+        this.prevDecorations, _.flatten(_.values(this.decorations)));
+};
+
+DeviceAsm.prototype.clearLinkedLines = function () {
+    this.decorations.linkedCode = [];
+    this.updateDecorations();
+};
+
+DeviceAsm.prototype.onPanesLinkLine = function (compilerId, lineNumber, revealLine, sender) {
+    if (Number(compilerId) === this._compilerid) {
+        var lineNums = [];
+        _.each(this.deviceCode, function (irLine, i) {
+            if (irLine.source && irLine.source.file === null && irLine.source.line === lineNumber) {
+                var line = i + 1;
+                lineNums.push(line);
+            }
+        });
+        if (revealLine && lineNums[0]) this.deviceEditor.revealLineInCenter(lineNums[0]);
+        var lineClass = sender !== this.getPaneName() ? 'linked-code-decoration-line' : '';
+        this.decorations.linkedCode = _.map(lineNums, function (line) {
+            return {
+                range: new monaco.Range(line, 1, line, 1),
+                options: {
+                    isWholeLine: true,
+                    linesDecorationsClassName: 'linked-code-decoration-margin',
+                    className: lineClass,
+                },
+            };
+        });
+        if (this.linkedFadeTimeoutId !== -1) {
+            clearTimeout(this.linkedFadeTimeoutId);
+        }
+        this.linkedFadeTimeoutId = setTimeout(_.bind(function () {
+            this.clearLinkedLines();
+            this.linkedFadeTimeoutId = -1;
+        }, this), 5000);
+        this.updateDecorations();
+    }
+};
+
+DeviceAsm.prototype.close = function () {
+    this.eventHub.unsubscribe();
+    this.eventHub.emit('deviceViewClosed', this._compilerid);
+    this.deviceEditor.dispose();
+};
+
+module.exports = {
+    DeviceAsm: DeviceAsm,
+};

--- a/static/panes/device-view.js
+++ b/static/panes/device-view.js
@@ -32,6 +32,8 @@ var colour = require('../colour');
 var ga = require('../analytics');
 var monacoConfig = require('../monaco-config');
 
+var TomSelect = require('tom-select');
+
 function DeviceAsm(hub, container, state) {
     this.container = container;
     this.eventHub = hub.createEventHub();
@@ -63,16 +65,17 @@ function DeviceAsm(hub, container, state) {
     this.lastColours = [];
     this.lastColourScheme = {};
 
-    var selectize = this.domRoot.find('.change-device').selectize({
+    var changeDeviceEl = this.domRoot[0].querySelector('.change-device');
+    this.selectize = new TomSelect(changeDeviceEl, {
         sortField: 'name',
         valueField: 'name',
         labelField: 'name',
         searchField: ['name'],
         options: [],
         items: [],
+        dropdownParent: 'body',
+        plugins: ['input_autogrow'],
     });
-
-    this.selectize = selectize[0].selectize;
 
     this.initButtons(state);
     this.initCallbacks();

--- a/test/compilers/clang-tests.js
+++ b/test/compilers/clang-tests.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { ClangCompiler } from '../../lib/compilers';
+import { chai, makeCompilationEnvironment } from '../utils';
+
+const expect = chai.expect;
+
+describe('clang tests', () => {
+    const languages = {'c++': {id: 'c++'}};
+
+    const info = {
+        exe: null,
+        remote: true,
+        lang: 'c++',
+        ldPath: [],
+    };
+
+    describe('device code...', async () => {
+        const clang = new ClangCompiler(info, makeCompilationEnvironment({languages}));
+        it('Should return null for non-device code', () => {
+            expect(clang.splitDeviceCode('')).to.be.null;
+            expect(clang.splitDeviceCode('mov eax, 00h\nadd r0, r0, #1\n')).to.be.null;
+        });
+        it('should separate out bundles ', () => {
+            expect(clang.splitDeviceCode(`# __CLANG_OFFLOAD_BUNDLE____START__ openmp-x86_64-unknown-linux-gnu
+    i am some
+    linux remote stuff
+# __CLANG_OFFLOAD_BUNDLE____END__ openmp-x86_64-unknown-linux-gnu
+
+# __CLANG_OFFLOAD_BUNDLE____START__ host-x86_64-unknown-linux-gnu
+    whereas
+    i am host code
+# __CLANG_OFFLOAD_BUNDLE____END__ host-x86_64-unknown-linux-gnu
+`)).to.deep.equal({
+                'host-x86_64-unknown-linux-gnu': '    whereas\n    i am host code\n',
+                'openmp-x86_64-unknown-linux-gnu': '    i am some\n    linux remote stuff\n',
+            });
+        });
+    });
+});

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -266,7 +266,7 @@
     .top-bar.btn-toolbar.bg-light(role="toolbar")
       include font-size.pug
       .btn-group.btn-group-sm(role="group")
-        select.change-device(placholder="Select a device...")
+        select.change-device(placeholder="Select a device...")
     .monaco-placeholder
 
   #rustmir

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -93,9 +93,12 @@
           button.dropdown-item.btn.btn-sm.btn-light.view-ast(title="Show AST output")
             span.dropdown-icon.fas.fa-leaf
             | AST output
-          button.dropdown-item.btn.btn-sm.btn-light.view-ir(title="Show LLVM IR output")
+          button.dropdown-item.btn.btn-sm.btn-light.view-ir(title="Show IR output")
             span.dropdown-icon.fas.fa-align-center
-            | LLVM IR output
+            | IR output
+          button.dropdown-item.btn.btn-sm.btn-light.view-device(title="Show Device output")
+            span.dropdown-icon.fas.fa-tv
+            | Device output
           button.dropdown-item.btn.btn-sm.btn-light.view-rustmir(title="Show Rust MIR output")
             span.dropdown-icon.fas.fa-water
             | Rust MIR output
@@ -257,6 +260,13 @@
   #ir
     .top-bar.btn-toolbar.bg-light(role="toolbar")
       include font-size.pug
+    .monaco-placeholder
+
+  #device
+    .top-bar.btn-toolbar.bg-light(role="toolbar")
+      include font-size.pug
+      .btn-group.btn-group-sm(role="group")
+        select.change-device(placholder="Select a device...")
     .monaco-placeholder
 
   #rustmir


### PR DESCRIPTION
Originall by @jcranmer-intel, submitted as #2306

Rebased and updated after a prolonged period of inactivity.

---

This is an incomplete pull request at the moment, but I feel it would be better to continue the conversation with some actual code behind it. This is to fix issue #2244 .

At the moment, I've tested this with a basic support for clang -fopenmp offload runs. Specifically, the example code I used would be the example here: https://godbolt.org/z/rvGeqc.

Starting with the UX: I implemented the device viewer pane using a slightly-modified copy of the IR viewer. It is insufficient at this moment; I haven't added support for device selection or device-specific arguments. Some of my testing identifies other issues: the same asm filters are applied to both the regular ASM view and the device ASM view, which may not be the best UI. In general, UI is not my strong suit, and I'd personally prefer to focus my efforts on backend implementation issues than UI issues if someone else is willing to pick up the slack.

The backend only adds support for the clang -fopenmp heterogeneous flow, which is probably the simplest flow as you actually get simple assembly files of both host and offload neatly packaged into one. GCC's OpenMP implementation packs it as section data; the SYCL offload embeds a .bc file instead. My plan to support all these flows is to require the use of a device extractor tool (deviceExtractor in the properties files), and this tool would have to live in the tools repository. I've prototyped it as a python script that extracts files into a directory as well as outputting a JSON blob indicating which generated file is the host and which generated outputs correspond to which devices.

The first commit in this PR should have all of the relevant information for understanding the backend portion of the code (except the device extractor code itself), while the second commit is all the necessary changes for a rudimentary UI portion.

Feedback would be greatly appreciated.
