### PR TITLE
Clientstate tweaks

### DIFF
--- a/lib/clientstate-normalizer.js
+++ b/lib/clientstate-normalizer.js
@@ -32,9 +32,12 @@ import {
 export class ClientStateNormalizer {
     constructor() {
         this.normalized = new ClientState();
+        this.rootContent = null;
     }
 
     fromGoldenLayoutContent(content) {
+        if (!this.rootContent) this.rootContent = content;
+
         for (const component of content) {
             this.fromGoldenLayoutComponent(component);
         }
@@ -50,6 +53,36 @@ export class ClientStateNormalizer {
         compiler.filters.demangle = component.componentState.filters.demangle;
     }
 
+    findCompilerInGoldenLayout(content, id) {
+        let result;
+
+        for (const component of content) {
+            if (component.componentName === 'compiler') {
+                if (component.componentState.id === id) {
+                    return component;
+                }
+            } else if (component.content && component.content.length > 0) {
+                result = this.findCompilerInGoldenLayout(component.content, id);
+                if (result) break;
+            }
+        }
+
+        return result;
+    }
+
+    findOrCreateSessionFromEditorOrCompiler(editorId, compilerId) {
+        let session;
+        if (editorId) {
+            session = this.normalized.findOrCreateSession(editorId);
+        } else {
+            const glCompiler = this.findCompilerInGoldenLayout(this.rootContent, compilerId);
+            if (glCompiler) {
+                session = this.normalized.findOrCreateSession(glCompiler.componentState.source);
+            }
+        }
+        return session;
+    }
+
     fromGoldenLayoutComponent(component) {
         if (component.componentName === 'codeEditor') {
             const session = this.normalized.findOrCreateSession(component.componentState.id);
@@ -59,12 +92,16 @@ export class ClientStateNormalizer {
             const session = this.normalized.findOrCreateSession(component.componentState.source);
 
             const compiler = new ClientStateCompiler();
+            if (component.componentState.id) compiler._internalid = component.componentState.id;
             compiler.id = component.componentState.compiler;
             compiler.options = component.componentState.options;
             compiler.libs = component.componentState.libs;
             this.setFilterSettingsFromComponent(compiler, component);
 
             session.compilers.push(compiler);
+            if (!component.componentState.id) {
+                this.normalized.numberCompilersIfNeeded(session, this.normalized.getNextCompilerId());
+            }
         } else if (component.componentName === 'executor') {
             const session = this.normalized.findOrCreateSession(component.componentState.source);
 
@@ -83,35 +120,34 @@ export class ClientStateNormalizer {
 
             session.executors.push(executor);
         } else if (component.componentName === 'ast') {
-            const session = this.normalized.findOrCreateSession(component.componentState.editorid);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid, component.componentState.id);
             const compiler = session.findOrCreateCompiler(component.componentState.id);
 
             compiler.specialoutputs.push('ast');
         } else if (component.componentName === 'opt') {
-            const session = this.normalized.findOrCreateSession(component.componentState.editorid);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid, component.componentState.id);
             const compiler = session.findOrCreateCompiler(component.componentState.id);
 
             compiler.specialoutputs.push('opt');
         } else if (component.componentName === 'cfg') {
-            const session = this.normalized.findOrCreateSession(component.componentState.editorid);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid, component.componentState.id);
             const compiler = session.findOrCreateCompiler(component.componentState.id);
 
             compiler.specialoutputs.push('cfg');
         } else if (component.componentName === 'gccdump') {
-            const session = this.normalized.findOrCreateSession(component.componentState._editorid);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState._editorid, component.componentState._compilerid);
             const compiler = session.findOrCreateCompiler(component.componentState._compilerid);
 
             compiler.specialoutputs.push('gccdump');
         } else if (component.componentName === 'output') {
-            const session = this.normalized.findOrCreateSession(component.componentState.editor);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editor, component.componentState.compiler);
             const compiler = session.findOrCreateCompiler(component.componentState.compiler);
-
             compiler.specialoutputs.push('compilerOutput');
         } else if (component.componentName === 'conformance') {
             const session = this.normalized.findOrCreateSession(component.componentState.editorid);
             session.conformanceview = new ClientStateConformanceView(component.componentState);
         } else if (component.componentName === 'tool') {
-            const session = this.normalized.findOrCreateSession(component.componentState.editor);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editor, component.componentState.compiler);
             const compiler = session.findOrCreateCompiler(component.componentState.compiler);
 
             compiler.tools.push({
@@ -124,6 +160,8 @@ export class ClientStateNormalizer {
     }
 
     fromGoldenLayout(globj) {
+        this.rootContent = globj.content;
+
         if (globj.content) {
             this.fromGoldenLayoutContent(globj.content);
         }

--- a/lib/clientstate-normalizer.js
+++ b/lib/clientstate-normalizer.js
@@ -120,34 +120,40 @@ export class ClientStateNormalizer {
 
             session.executors.push(executor);
         } else if (component.componentName === 'ast') {
-            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid, component.componentState.id);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid,
+                component.componentState.id);
             const compiler = session.findOrCreateCompiler(component.componentState.id);
 
             compiler.specialoutputs.push('ast');
         } else if (component.componentName === 'opt') {
-            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid, component.componentState.id);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid,
+                component.componentState.id);
             const compiler = session.findOrCreateCompiler(component.componentState.id);
 
             compiler.specialoutputs.push('opt');
         } else if (component.componentName === 'cfg') {
-            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid, component.componentState.id);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editorid,
+                component.componentState.id);
             const compiler = session.findOrCreateCompiler(component.componentState.id);
 
             compiler.specialoutputs.push('cfg');
         } else if (component.componentName === 'gccdump') {
-            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState._editorid, component.componentState._compilerid);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState._editorid,
+                component.componentState._compilerid);
             const compiler = session.findOrCreateCompiler(component.componentState._compilerid);
 
             compiler.specialoutputs.push('gccdump');
         } else if (component.componentName === 'output') {
-            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editor, component.componentState.compiler);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editor,
+                component.componentState.compiler);
             const compiler = session.findOrCreateCompiler(component.componentState.compiler);
             compiler.specialoutputs.push('compilerOutput');
         } else if (component.componentName === 'conformance') {
             const session = this.normalized.findOrCreateSession(component.componentState.editorid);
             session.conformanceview = new ClientStateConformanceView(component.componentState);
         } else if (component.componentName === 'tool') {
-            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editor, component.componentState.compiler);
+            const session = this.findOrCreateSessionFromEditorOrCompiler(component.componentState.editor,
+                component.componentState.compiler);
             const compiler = session.findOrCreateCompiler(component.componentState.compiler);
 
             compiler.tools.push({

--- a/lib/clientstate.js
+++ b/lib/clientstate.js
@@ -50,6 +50,8 @@ export class ClientStateCompilerOptions {
 
 export class ClientStateCompiler {
     constructor(jsondata) {
+        this._internalid = undefined;
+
         if (jsondata) {
             this.fromJsonData(jsondata);
         } else {
@@ -63,6 +65,10 @@ export class ClientStateCompiler {
     }
 
     fromJsonData(jsondata) {
+        if (typeof jsondata._internalid !== undefined) {
+            this._internalid = jsondata._internalid;
+        }
+
         if (typeof jsondata.id !== 'undefined') {
             this.id = jsondata.id;
         } else if (typeof jsondata.compilerId !== 'undefined') {
@@ -107,6 +113,8 @@ export class ClientStateExecutor {
             this.compiler = new ClientStateCompiler();
             this.wrap = false;
         }
+
+        delete this.compiler._internalid;
     }
 
     fromJsonData(jsondata) {
@@ -140,7 +148,9 @@ export class ClientStateConformanceView {
     fromJsonData(jsondata) {
         this.libs = jsondata.libs;
         for (const compilerdata of jsondata.compilers) {
-            this.compilers.push(new ClientStateCompiler(compilerdata));
+            const compiler = new ClientStateCompiler(compilerdata);
+            delete compiler._internalid;
+            this.compilers.push(compiler);
         }
     }
 }
@@ -184,18 +194,20 @@ export class ClientStateSession {
     }
 
     findOrCreateCompiler(id) {
-        let compiler = null;
-        if (id <= this.compilers.length) {
-            compiler = this.compilers[id - 1];
-            return compiler;
+        let foundCompiler;
+        for (let compiler of this.compilers) {
+            if (compiler._internalid === id) {
+                foundCompiler = compiler;
+            }
         }
 
-        for (let idx = this.compilers.length; idx < id; idx++) {
-            compiler = new ClientStateCompiler();
-            this.compilers.push(compiler);
+        if (!foundCompiler) {
+            foundCompiler = new ClientStateCompiler();
+            foundCompiler._internalid = id;
+            this.compilers.push(foundCompiler);
         }
 
-        return compiler;
+        return foundCompiler;
     }
 
     countNumberOfSpecialOutputsAndTools() {
@@ -221,15 +233,50 @@ export class ClientState {
 
     fromJsonData(jsondata) {
         for (const sessiondata of jsondata.sessions) {
-            this.sessions.push(new ClientStateSession(sessiondata));
+            const session = new ClientStateSession(sessiondata);
+            this.numberCompilersIfNeeded(session);
+            this.sessions.push(session);
+        }
+    }
+
+    getNextCompilerId() {
+        let nextId = 1;
+        for (const session of this.sessions) {
+            for (const compiler of session.compilers) {
+                if (compiler._internalid && compiler._internalid >= nextId) {
+                    nextId = compiler._internalid + 1;
+                }
+            }
+        }
+        return nextId;
+    }
+
+    numberCompilersIfNeeded(session, startAt) {
+        let id = startAt;
+        let someIdsNeedNumbering = false;
+
+        for (const compiler of session.compilers) {
+            if (compiler._internalid) {
+                if (compiler._internalid >= id) {
+                    id = compiler._internalid + 1;
+                }
+            } else {
+                someIdsNeedNumbering = true;
+            }
+        }
+
+        if (someIdsNeedNumbering) {
+            for (const compiler of session.compilers) {
+                if (!compiler._internalid) {
+                    compiler._internalid = id;
+                    id++;
+                }
+            }
         }
     }
 
     findSessionById(id) {
-        let session = null;
-        for (let idxSession = 0; idxSession < this.sessions.length; idxSession++) {
-            session = this.sessions[idxSession];
-
+        for (const session of this.sessions) {
             if (session.id === id) {
                 return session;
             }

--- a/test/state/andthekitchensink.json.normalized
+++ b/test/state/andthekitchensink.json.normalized
@@ -7,6 +7,7 @@
             "source": "\ntemplate<typename T>\nconcept TheSameAndAddable = requires(T a, T b) {\n    {a+b} -> T;\n};\n\ntemplate<TheSameAndAddable T>\nT sum(T x, T y) {\n    return x + y;\n}\n\n#include <string>\n\nint main() {\n    int z = 0;\n    int w;\n\n    return sum(z, w);\n}\n",
             "compilers": [
                 {
+                    "_internalid": 1,
                     "id": "clang_concepts",
                     "options": "-std=c++1z -Wuninitialized -O3",
                     "filters": {
@@ -29,6 +30,7 @@
                     "tools": []
                 },
                 {
+                    "_internalid": 2,
                     "id": "g82",
                     "options": "",
                     "filters": {

--- a/test/state/conformanceview.json.normalized
+++ b/test/state/conformanceview.json.normalized
@@ -45,6 +45,7 @@
             },
             "compilers": [
                 {
+                    "_internalid": 1,
                     "id": "vc2017_64",
                     "options": "",
                     "filters": {
@@ -62,6 +63,7 @@
                     "tools": []
                 },
                 {
+                    "_internalid": 2,
                     "id": "vc2017_32",
                     "options": "-O3",
                     "filters": {
@@ -79,6 +81,7 @@
                     "tools": []
                 },
                 {
+                    "_internalid": 3,
                     "id": "vc2017_64",
                     "options": "-O2",
                     "filters": {

--- a/test/state/executor.json.normalized
+++ b/test/state/executor.json.normalized
@@ -6,6 +6,7 @@
             "source": "// Type your code here, or load an example.\nint square(int num) {\n    auto x = 344 + 5 + 1;\n    return num * num + 234 + x;\n}\n\nint main() {\n    return square(23);\n}\n",
             "compilers": [
                 {
+                    "_internalid": 1,
                     "filters": {
                         "binary": false,
                         "commentOnly": true,

--- a/test/state/executorwrap.json.normalized
+++ b/test/state/executorwrap.json.normalized
@@ -7,6 +7,7 @@
             "conformanceview": false,
             "compilers": [
                 {
+                    "_internalid": 1,
                     "id": "g111",
                     "options": "",
                     "filters": {

--- a/test/state/output-editor-id.json
+++ b/test/state/output-editor-id.json
@@ -1,0 +1,156 @@
+{
+    "settings": {
+        "hasHeaders": true,
+        "constrainDragToContainer": false,
+        "reorderEnabled": true,
+        "selectionEnabled": false,
+        "popoutWholeStack": false,
+        "blockedPopoutsThrowError": true,
+        "closePopoutsOnUnload": true,
+        "showPopoutIcon": true,
+        "showMaximiseIcon": true,
+        "showCloseIcon": true,
+        "responsiveMode": "onload",
+        "tabOverlapAllowance": 0,
+        "reorderOnTabMenuClick": true,
+        "tabControlOffset": 10,
+        "theme": "dark"
+    },
+    "dimensions": {
+        "borderWidth": 5,
+        "borderGrabWidth": 15,
+        "minItemHeight": 10,
+        "minItemWidth": 10,
+        "headerHeight": 20,
+        "dragProxyWidth": 300,
+        "dragProxyHeight": 200
+    },
+    "labels": {
+        "close": "close",
+        "maximise": "maximise",
+        "minimise": "minimise",
+        "popout": "open in new window",
+        "popin": "pop in",
+        "tabDropdown": "additional tabs"
+    },
+    "content": [
+        {
+            "type": "row",
+            "isClosable": true,
+            "reorderEnabled": true,
+            "title": "",
+            "content": [
+                {
+                    "type": "stack",
+                    "width": 50,
+                    "isClosable": true,
+                    "reorderEnabled": true,
+                    "title": "",
+                    "activeItemIndex": 0,
+                    "content": [
+                        {
+                            "type": "component",
+                            "componentName": "codeEditor",
+                            "componentState": {
+                                "id": 1,
+                                "source": "#include <iostream>\n \nint main() {\n  std::cout << \"Hello CE!\";\n}",
+                                "lang": "c++",
+                                "fontScale": 25,
+                                "fontUsePx": true
+                            },
+                            "isClosable": true,
+                            "reorderEnabled": true,
+                            "title": "C++ source #1"
+                        }
+                    ]
+                },
+                {
+                    "type": "column",
+                    "isClosable": true,
+                    "reorderEnabled": true,
+                    "title": "",
+                    "width": 50,
+                    "content": [
+                        {
+                            "type": "stack",
+                            "height": 50,
+                            "isClosable": true,
+                            "reorderEnabled": true,
+                            "title": "",
+                            "activeItemIndex": 0,
+                            "content": [
+                                {
+                                    "type": "component",
+                                    "componentName": "compiler",
+                                    "componentState": {
+                                        "id": 1,
+                                        "compiler": "g83",
+                                        "source": 1,
+                                        "options": "-O2 -march=haswell -Wall -Wextra -pedantic -Wno-unused-variable -Wno-unused-parameter",
+                                        "filters": {
+                                            "commentOnly": true,
+                                            "directives": true,
+                                            "intel": true,
+                                            "labels": true,
+                                            "trim": true,
+                                            "execute": true,
+                                            "binary": false,
+                                            "demangle": true,
+                                            "libraryCode": true
+                                        },
+                                        "libs": [],
+                                        "lang": "c++",
+                                        "selection": {
+                                            "startLineNumber": 1,
+                                            "startColumn": 1,
+                                            "endLineNumber": 1,
+                                            "endColumn": 1,
+                                            "selectionStartLineNumber": 1,
+                                            "selectionStartColumn": 1,
+                                            "positionLineNumber": 1,
+                                            "positionColumn": 1
+                                        },
+                                        "flagsViewOpen": false,
+                                        "fontScale": 30,
+                                        "fontUsePx": true
+                                    },
+                                    "isClosable": true,
+                                    "reorderEnabled": true,
+                                    "title": "x86-64 gcc 8.3 (Editor #1, Compiler #1) C++"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "stack",
+                            "height": 50,
+                            "isClosable": true,
+                            "reorderEnabled": true,
+                            "title": "",
+                            "activeItemIndex": 0,
+                            "content": [
+                                {
+                                    "type": "component",
+                                    "componentName": "output",
+                                    "componentState": {
+                                        "compiler": 1,
+                                        "wrap": false,
+                                        "fontScale": 14,
+                                        "fontUsePx": true
+                                    },
+                                    "isClosable": true,
+                                    "reorderEnabled": true,
+                                    "title": "Output of x86-64 gcc 8.3 (Compiler #1)"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "isClosable": true,
+    "reorderEnabled": true,
+    "title": "",
+    "openPopouts": [],
+    "maximisedItemId": null
+}

--- a/test/state/output-editor-id.normalized.json
+++ b/test/state/output-editor-id.normalized.json
@@ -1,0 +1,33 @@
+{
+    "sessions": [
+        {
+            "id": 1,
+            "language": "c++",
+            "source": "#include <iostream>\n \nint main() {\n  std::cout << \"Hello CE!\";\n}",
+            "conformanceview": false,
+            "compilers": [
+                {
+                    "_internalid": 1,
+                    "id": "g83",
+                    "options": "-O2 -march=haswell -Wall -Wextra -pedantic -Wno-unused-variable -Wno-unused-parameter",
+                    "filters": {
+                        "binary": false,
+                        "commentOnly": true,
+                        "demangle": true,
+                        "directives": true,
+                        "execute": false,
+                        "intel": true,
+                        "labels": true,
+                        "trim": true
+                    },
+                    "libs": [],
+                    "specialoutputs": [
+                        "compilerOutput"
+                    ],
+                    "tools": []
+                }
+            ],
+            "executors": []
+        }
+    ]
+}

--- a/test/state/twocompilers.json.normalized
+++ b/test/state/twocompilers.json.normalized
@@ -7,6 +7,7 @@
             "source": "// Type your code here, or load an example.\r\nint square(int num) {\r\n    return num * num + 3;\r\n}\r\n\r\n",
             "compilers": [
                 {
+                    "_internalid": 1,
                     "id": "vc2017_64",
                     "options": "-O2",
                     "filters": {
@@ -33,6 +34,7 @@
             "source": "// Type your code here, or load an example.\r\nint square(int num) {\r\n    return num * num;\r\n}",
             "compilers": [
                 {
+                    "_internalid": 2,
                     "id": "vc2017_32",
                     "options": "-O3",
                     "filters": {

--- a/test/statenormalisation-tests.js
+++ b/test/statenormalisation-tests.js
@@ -87,6 +87,16 @@ describe('Normalizing clientstate', () => {
 
         normalizer.normalized.should.deep.equal(resultdata);
     });
+
+    it('Allow output without editor id', () => {
+        const normalizer = new ClientStateNormalizer();
+        const data =  JSON.parse(fs.readFileSync('test/state/output-editor-id.json'));
+        normalizer.fromGoldenLayout(data);
+
+        const resultdata = JSON.parse(fs.readFileSync('test/state/output-editor-id.normalized.json'));
+
+        normalizer.normalized.should.deep.equal(resultdata);
+    });
 });
 
 describe('ClientState parsing', () => {


### PR DESCRIPTION
I tried out a link from reveal-compiler-explorer which sends Rison'd GL to godbolt.org .
It's actually slightly malformed, so it gives two errors. That should probably be fixed on their side.

But there were also some peculiar things going on when making a shortlink and calling /api/clientstateinfo - namely that there seemed to be extra editors and compilers where none were actually there.

It was because the editorId was not set for a compiler output pane. This should be fine in GL, because we don't really do much with the editor there (and am currently also phasing out a lot of instances of that for multifile).

But in the clientstate normalization function the editorid was still required and the compiler id's weren't being recorded, so the information got lost and confused and it started making empty editors. I added _internalId to the clientstate for those cases where it's necessary to do lookups by compiler id.

It's not used/needed in Goldenifier, in ClientState everything's contextual.
