### PR TITLE
Override default compiler flags for OCaml

### DIFF
--- a/lib/compilers/ocaml.js
+++ b/lib/compilers/ocaml.js
@@ -29,6 +29,10 @@ import { BaseCompiler } from '../base-compiler';
 export class OCamlCompiler extends BaseCompiler {
     static get key() { return 'ocaml'; }
 
+    getSharedLibraryPathsAsArguments() {
+        return [];
+    }
+
     optionsForFilter() {
         return ['-S', '-g', '-c'];
     }


### PR DESCRIPTION
This should allow the compiler to actually compile executables
thanks @partouf for basically telling me exactly how to go about this

closes #2848