### PR TITLE
Add Clang assertions trunk for OpenCL C and C++ for OpenCL

### DIFF
--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -8,7 +8,7 @@ supportsBinary=false
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-10, clang-11, clang-12 and trunk
 group.armcpp4oclclang32.groupName=Arm 32-bit clang
-group.armcpp4oclclang32.compilers=armv7-cpp4oclclang1000:armv7-cpp4oclclang1001:armv7-cpp4oclclang1100:armv7-cpp4oclclang1101:armv7-cpp4oclclang1200:armv7-cpp4oclclang-trunk
+group.armcpp4oclclang32.compilers=armv7-cpp4oclclang1000:armv7-cpp4oclclang1001:armv7-cpp4oclclang1100:armv7-cpp4oclclang1101:armv7-cpp4oclclang1200:armv7-cpp4oclclang-trunk:armv7-cpp4oclclang-trunk-assertions
 group.armcpp4oclclang32.isSemVer=true
 group.armcpp4oclclang32.compilerType=clang
 group.armcpp4oclclang32.supportsExecute=false
@@ -17,7 +17,7 @@ group.armcpp4oclclang32.instructionSet=arm32
 group.armcpp4oclclang32.baseOptions=-Dkernel= -D__kernel=
 
 group.armcpp4oclclang64.groupName=Arm 64-bit clang
-group.armcpp4oclclang64.compilers=armv8-cpp4oclclang1000:armv8-cpp4oclclang1001:armv8-cpp4oclclang1100:armv8-cpp4oclclang1101:armv8-cpp4oclclang1200:armv8-cpp4oclclang-trunk:armv8-full-cpp4oclclang-trunk
+group.armcpp4oclclang64.compilers=armv8-cpp4oclclang1000:armv8-cpp4oclclang1001:armv8-cpp4oclclang1100:armv8-cpp4oclclang1101:armv8-cpp4oclclang1200:armv8-cpp4oclclang-trunk:armv8-cpp4oclclang-trunk-assertions:armv8-full-cpp4oclclang-trunk
 group.armcpp4oclclang64.isSemVer=true
 group.armcpp4oclclang64.compilerType=clang
 group.armcpp4oclclang64.supportsExecute=false
@@ -93,6 +93,14 @@ compiler.armv7-cpp4oclclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-cpp4oclclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
+compiler.armv7-cpp4oclclang-trunk-assertions.name=armv7-a clang (trunk, assertions)
+compiler.armv7-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv7-cpp4oclclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
 compiler.armv8-cpp4oclclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -100,6 +108,14 @@ compiler.armv8-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/
 compiler.armv8-cpp4oclclang-trunk.semver=(trunk)
 # Arm v8-a
 compiler.armv8-cpp4oclclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv8-cpp4oclclang-trunk-assertions.name=armv8-a clang (trunk, assertions)
+compiler.armv8-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv8-cpp4oclclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
+# Arm v8-a
+compiler.armv8-cpp4oclclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-full-cpp4oclclang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -8,7 +8,7 @@ supportsBinary=false
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9, clang-10, clang-11, clang-12 and trunk
 group.armoclcclang32.groupName=Arm 32-bit clang
-group.armoclcclang32.compilers=armv7-oclcclang900:armv7-oclcclang901:armv7-oclcclang1000:armv7-oclcclang1001:armv7-oclcclang1100:armv7-oclcclang1101:armv7-oclcclang1200:armv7-oclcclang-trunk
+group.armoclcclang32.compilers=armv7-oclcclang900:armv7-oclcclang901:armv7-oclcclang1000:armv7-oclcclang1001:armv7-oclcclang1100:armv7-oclcclang1101:armv7-oclcclang1200:armv7-oclcclang-trunk:armv7-oclcclang-trunk-assertions
 group.armoclcclang32.isSemVer=true
 group.armoclcclang32.compilerType=clang
 group.armoclcclang32.supportsExecute=false
@@ -17,7 +17,7 @@ group.armoclcclang32.instructionSet=arm32
 group.armoclcclang32.baseOptions=-Dkernel= -D__kernel=
 
 group.armoclcclang64.groupName=Arm 64-bit clang
-group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk
+group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk::armv8-oclcclang-trunk-assertions
 group.armoclcclang64.isSemVer=true
 group.armoclcclang64.compilerType=clang
 group.armoclcclang64.supportsExecute=false
@@ -117,6 +117,14 @@ compiler.armv7-oclcclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-oclcclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
+compiler.armv7-oclcclang-trunk-assertions.name=armv7-a clang (trunk, assertions)
+compiler.armv7-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv7-oclcclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-oclcclang-trunk-assertions.semver=(assertions trunk)
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
 compiler.armv8-oclcclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -124,6 +132,14 @@ compiler.armv8-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.armv8-oclcclang-trunk.semver=(trunk)
 # Arm v8-a
 compiler.armv8-oclcclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+compiler.armv8-oclcclang-trunk-assertions.name=armv8-a clang (trunk, assertions)
+compiler.armv8-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv8-oclcclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-oclcclang-trunk-assertions.semver=(assertions trunk)
+# Arm v8-a
+compiler.armv8-oclcclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-full-oclcclang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang


### PR DESCRIPTION
This PR adds Clang built with assertions enabled for OpenCL C and C++ for OpenCL.