### PR TITLE
Make OCaml examples executable and objdumpable

### DIFF
--- a/etc/config/ocaml.defaults.properties
+++ b/etc/config/ocaml.defaults.properties
@@ -1,6 +1,9 @@
 compilers=/usr/bin/ocamlopt
-supportsBinary=false
+supportsBinary=true
+supportsExecute=true
 compilerType=ocaml
+versionFlag=-v |sed 1q #nicer output than -vnum
+objdumper=objdump
 
 
 #################################

--- a/lib/compilers/ocaml.js
+++ b/lib/compilers/ocaml.js
@@ -33,11 +33,21 @@ export class OCamlCompiler extends BaseCompiler {
         return [];
     }
 
-    optionsForFilter() {
-        return ['-S', '-g', '-c'];
+    optionsForFilter(filters, outputFileName) {
+        let options = ['-g', '-S'];
+        if (filters.binary) {
+            options = options.concat('-o', this.filename(outputFileName));
+        } else {
+            options = options.concat('-c');
+        }
+        return options;
     }
 
     getOutputFilename(dirPath) {
         return path.join(dirPath, `${path.basename(this.compileFilename, this.lang.extensions[0])}.s`);
+    }
+
+    getExecutableFilename(dirPath, outputFilebase) {
+        return path.join(dirPath, outputFilebase);
     }
 }


### PR DESCRIPTION
Hi again! This change should allow CE to execute OCaml code. Tested locally.

Changes:

- ocaml.default.properties:
  - add the relevant flags for execution and emitting binaries
  - add nicer version number reporting
  - let CE know `objdump` can be used on ocaml objects

- ocaml.js:
  - update optionsForFilter for both executable and object handling
  - override the getter for executable to work within ocamlopt context