### PR TITLE
Reorganize CUDA compiler variants.

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -3,6 +3,11 @@ defaultCompiler=nvcc113u1
 supportsBinary=true
 supportsExecute=false
 
+# Compilers target the most recent GPU to allow compilation of largest possible
+# subset of CUDA code.
+# Details of GPUs/features supported by CUDA compilers can be found here:
+# gist.github.com/ax3l/9489132#clang--x-cuda
+
 group.nvcc.compilers=nvcc113u1:nvcc113:nvcc112u2:nvcc112u1:nvcc112:nvcc111u1:nvcc111:nvcc11u1:nvcc11:nvcc102:nvcc101u2:nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
 group.nvcc.versionRe=^Cuda.*
 group.nvcc.compilerType=nvcc
@@ -11,84 +16,93 @@ group.nvcc.baseName=NVCC
 group.nvcc.includeFlag=-I
 group.nvcc.objdumper=/opt/compiler-explorer/cuda/11.3.1/bin/nvdisasm
 group.nvcc.rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
-compiler.nvcc91.semver=9.1.85
+
+# NVCC 9.x
+compiler.nvcc91.semver=9.1.85 sm_70
 compiler.nvcc91.exe=/opt/compiler-explorer/cuda/9.1.85/bin/nvcc
-compiler.nvcc91.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
-compiler.nvcc92.semver=9.2.88
+compiler.nvcc91.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_70
+compiler.nvcc92.semver=9.2.88 sm_70
 compiler.nvcc92.exe=/opt/compiler-explorer/cuda/9.2.88/bin/nvcc
-compiler.nvcc92.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
-compiler.nvcc100.semver=10.0.130
+compiler.nvcc92.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_70
+
+# NVCC 10.x
+compiler.nvcc100.semver=10.0.130 sm_75
 compiler.nvcc100.exe=/opt/compiler-explorer/cuda/10.0.130/bin/nvcc
-compiler.nvcc100.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
-compiler.nvcc101.semver=10.1.105
+compiler.nvcc100.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_75
+compiler.nvcc101.semver=10.1.105 sm_75
 compiler.nvcc101.exe=/opt/compiler-explorer/cuda/10.1.105/bin/nvcc
-compiler.nvcc101.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
-compiler.nvcc101u1.semver=10.1.105
+compiler.nvcc101.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_75
+compiler.nvcc101u1.semver=10.1.168 sm_75
 compiler.nvcc101u1.exe=/opt/compiler-explorer/cuda/10.1.168/bin/nvcc
-compiler.nvcc101u1.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
-compiler.nvcc101u2.semver=10.1.168
+compiler.nvcc101u1.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_75
+compiler.nvcc101u2.semver=10.1.243 sm_75
 compiler.nvcc101u2.exe=/opt/compiler-explorer/cuda/10.1.243/bin/nvcc
-compiler.nvcc101u2.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
+compiler.nvcc101u2.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_75
+compiler.nvcc102.semver=10.2.89 sm_75
 compiler.nvcc102.exe=/opt/compiler-explorer/cuda/10.2.89/bin/nvcc
-compiler.nvcc102.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
-compiler.nvcc102.semver=10.2.89
+compiler.nvcc102.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -arch=sm_75
+
+# NVCC 11.x
+compiler.nvcc11.semver=11.0.2 sm_80
 compiler.nvcc11.exe=/opt/compiler-explorer/cuda/11.0.2/bin/nvcc
-compiler.nvcc11.options=--compiler-bindir /opt/compiler-explorer/gcc-9.3.0/bin
-compiler.nvcc11.semver=11.0.2
+compiler.nvcc11.options=--compiler-bindir /opt/compiler-explorer/gcc-9.3.0/bin -arch=sm_80
+compiler.nvcc11u1.semver=11.0.3 sm_80
 compiler.nvcc11u1.exe=/opt/compiler-explorer/cuda/11.0.3/bin/nvcc
-compiler.nvcc11u1.options=--compiler-bindir /opt/compiler-explorer/gcc-9.3.0/bin
-compiler.nvcc11u1.semver=11.0.3
+compiler.nvcc11u1.options=--compiler-bindir /opt/compiler-explorer/gcc-9.3.0/bin -arch=sm_80
+compiler.nvcc111.semver=11.1.0 sm_86
 compiler.nvcc111.exe=/opt/compiler-explorer/cuda/11.1.0/bin/nvcc
-compiler.nvcc111.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc111.semver=11.1.0
+compiler.nvcc111.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
+compiler.nvcc111u1.semver=11.1.1 sm_86
 compiler.nvcc111u1.exe=/opt/compiler-explorer/cuda/11.1.1/bin/nvcc
-compiler.nvcc111u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc111u1.semver=11.1.1
+compiler.nvcc111u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
+compiler.nvcc112.semver=11.2.0 sm_86
 compiler.nvcc112.exe=/opt/compiler-explorer/cuda/11.2.0/bin/nvcc
-compiler.nvcc112.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc112.semver=11.2.0
+compiler.nvcc112.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
+compiler.nvcc112u1.semver=11.2.1 sm_86
 compiler.nvcc112u1.exe=/opt/compiler-explorer/cuda/11.2.1/bin/nvcc
-compiler.nvcc112u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc112u1.semver=11.2.1
+compiler.nvcc112u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
+compiler.nvcc112u2.semver=11.2.2 sm_86
 compiler.nvcc112u2.exe=/opt/compiler-explorer/cuda/11.2.2/bin/nvcc
-compiler.nvcc112u2.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc112u2.semver=11.2.2
+compiler.nvcc112u2.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
+compiler.nvcc113.semver=11.3.0 sm_86
 compiler.nvcc113.exe=/opt/compiler-explorer/cuda/11.3.0/bin/nvcc
-compiler.nvcc113.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc113.semver=11.3.0
+compiler.nvcc113.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
+compiler.nvcc113u1.semver=11.3.1 sm_86
 compiler.nvcc113u1.exe=/opt/compiler-explorer/cuda/11.3.1/bin/nvcc
-compiler.nvcc113u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
-compiler.nvcc113u1.semver=11.3.1
+compiler.nvcc113u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin -arch=sm_86
 
 group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cltrunk
 group.cuclang.isSemVer=true
-group.cuclang.baseName=clang (CUDA 9.1.85)
+group.cuclang.baseName=clang
 group.cuclang.compilerType=clang-cuda
 # The most recent nvdisasm works for older CUDA versions
 group.cuclang.objdumper=/opt/compiler-explorer/cuda/11.3.1/bin/nvdisasm
 
+# Clang is versioned independently of CUDA. We pick the most recent CUDA version
+# supported by clang and the most recent GPU variant supported by that
+# combination of clang and CUDA versions..
 compiler.cuclang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
-compiler.cuclang700.semver=7.0.0
-compiler.cuclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+compiler.cuclang700.semver=7.0.0 sm_70 CUDA-9.1
+compiler.cuclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_70 --cuda-device-only
 compiler.cuclang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang++
-compiler.cuclang800.semver=8.0.0
-compiler.cuclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+compiler.cuclang800.semver=8.0.0 sm_75 CUDA-10.0
+compiler.cuclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0 --cuda-path=/opt/compiler-explorer/cuda/10.0.130 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
-compiler.cuclang900.semver=9.0.0
-compiler.cuclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+compiler.cuclang900.semver=9.0.0 sm_75 CUDA-10.1
+compiler.cuclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 --cuda-path=/opt/compiler-explorer/cuda/10.1.168 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
-compiler.cuclang1000.semver=10.0.0
-compiler.cuclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+compiler.cuclang1000.semver=10.0.0 sm_75 CUDA-10.2
+compiler.cuclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/10.2.89 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
-compiler.cuclang1001.semver=10.0.1
-compiler.cuclang1001.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+compiler.cuclang1001.semver=10.0.1 sm_75 CUDA-10.2
+compiler.cuclang1001.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/10.2.89 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
-compiler.cuclang1100.semver=11.0.0
-compiler.cuclang1100.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
-compiler.cltrunk.semver=trunk
+compiler.cuclang1100.semver=11.0.0 sm_75 CUDA-10.2
+compiler.cuclang1100.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0 --cuda-path=/opt/compiler-explorer/cuda/10.2.89 --cuda-gpu-arch=sm_75 --cuda-device-only
+compiler.cltrunk.semver=trunk sm_86 CUDA-11.3
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_35 --cuda-device-only
+compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
 
 group.hipclang.compilers=hiptrunk
 group.hipclang.isSemVer=true


### PR DESCRIPTION
Features supported by newer CUDA versions and GPUs are usually a superset of the
features of the older versions. Using the most recent ones allows us to compile more
code.

* For NVCC, use the most recent GPU supported by particular CUDA version.
* For clang, pick the most recent supported CUDA version and GPU.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
