### PR TITLE
* Fixed documentation for executionWrapper

### DIFF
--- a/docs/AddingACompiler.md
+++ b/docs/AddingACompiler.md
@@ -94,7 +94,7 @@ versionFlag | String | The flag to pass to the compiler to make it emit its vers
 versionRe | RegExp | A regular expression used to capture the version from the version output|
 compilerType | String | The name of the class handling this compiler|
 interpreted | Boolean | Whether this is an interpreted language, and so the "compiler" is really an interpreter|
-executionWrapper | Boolean | When executing the compiler's output, run under this script (e.g. could run under `qemu` or `mpi_run` or similar)|
+executionWrapper | Path | Path to script that can execute the compiler's output (e.g. could run under `qemu` or `mpi_run` or similar)|
 
 The `compilerType` option is special: it refers to the Javascript class in `lib/compilers/*.js` which handles running and handling
 output for this compiler type.


### PR DESCRIPTION
> it ain't much but it's honest work

The compiler option documentation for `executionWrapper` is misleading, as turns out now it can allow custom scripts to run the output which is nice.
If I noticed it beforehand it would have saved me some time when configuring custom compiler, hence the PR as may save some time for others :)