### PR TITLE
Add Eigen v3.4.0 release

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1406,10 +1406,12 @@ libs.eastl.versions.3_16_05.version=3.16.05
 libs.eastl.versions.3_16_05.path=/opt/compiler-explorer/libs/eastl/3.16.05/include:/opt/compiler-explorer/libs/eastl/3.16.05/test/packages/EABase/include/Common
 
 libs.eigen.name=Eigen
-libs.eigen.versions=trunk:339:337:335:334
+libs.eigen.versions=trunk:340:339:337:335:334
 libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
 libs.eigen.versions.trunk.version=trunk
 libs.eigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.eigen.versions.340.version=3.4.0
+libs.eigen.versions.340.path=/opt/compiler-explorer/libs/eigen/v3.4.0
 libs.eigen.versions.339.version=3.3.9
 libs.eigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
 libs.eigen.versions.337.version=3.3.7

--- a/etc/config/circle.amazon.properties
+++ b/etc/config/circle.amazon.properties
@@ -360,10 +360,12 @@ libs.eastl.versions.3_16_05.version=3.16.05
 libs.eastl.versions.3_16_05.path=/opt/compiler-explorer/libs/eastl/3.16.05/include:/opt/compiler-explorer/libs/eastl/3.16.05/test/packages/EABase/include/Common
 
 libs.eigen.name=Eigen
-libs.eigen.versions=trunk:339:337:335:334
+libs.eigen.versions=trunk:340:339:337:335:334
 libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
 libs.eigen.versions.trunk.version=trunk
 libs.eigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.eigen.versions.340.version=3.4.0
+libs.eigen.versions.340.path=/opt/compiler-explorer/libs/eigen/v3.4.0
 libs.eigen.versions.339.version=3.3.9
 libs.eigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
 libs.eigen.versions.337.version=3.3.7

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -104,10 +104,12 @@ compiler.hiptrunk.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 libs=cueigen:thrustcub:cucub:cudacxx:nvtx:nsimd:cuco
 
 libs.cueigen.name=Eigen
-libs.cueigen.versions=trunk:339:337:334
+libs.cueigen.versions=trunk:340:339:337:334
 libs.cueigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page
 libs.cueigen.versions.trunk.version=trunk
 libs.cueigen.versions.trunk.path=/opt/compiler-explorer/libs/eigen/vtrunk
+libs.cueigen.versions.340.version=3.4.0
+libs.cueigen.versions.340.path=/opt/compiler-explorer/libs/eigen/v3.4.0
 libs.cueigen.versions.339.version=3.3.9
 libs.cueigen.versions.339.path=/opt/compiler-explorer/libs/eigen/v3.3.9
 libs.cueigen.versions.337.version=3.3.7


### PR DESCRIPTION
Changed all configurations containing Eigen to include the newest upstream release v3.4.0.

I have only adapted the configuration to add the new version and did not run any tests locally.