### PR TITLE
Add generic keywords to OpenCL C and C++ for OpenCL

### DIFF
--- a/static/modes/cpp-for-opencl-mode.js
+++ b/static/modes/cpp-for-opencl-mode.js
@@ -47,6 +47,7 @@ function definition() {
     // Keywords for C++ for OpenCL
     addKeywords([
         '__global', 'global', '__local', 'local', '__constant', 'constant', '__private', 'private',
+        '__generic', 'generic',
         '__kernel', 'kernel',
         'uniform', 'pipe',
         '__read_only', 'read_only', '__write_only', 'write_only', '__read_write', 'read_write',

--- a/static/modes/openclc-mode.js
+++ b/static/modes/openclc-mode.js
@@ -66,6 +66,7 @@ function definition() {
     // Keywords for OpenCL C
     addKeywords([
         '__global', 'global', '__local', 'local', '__constant', 'constant', '__private', 'private',
+        '__generic', 'generic',
         '__kernel', 'kernel',
         'uniform', 'pipe',
         '__read_only', 'read_only', '__write_only', 'write_only', '__read_write', 'read_write',


### PR DESCRIPTION
The generic and __generic keywords are currently reserved in the OpenCL C
specification. They have already been added as keywords in Clang. Without
highlighting, it can seem as if generic is not an address space, as the
other address spaces are highlighted. This can be seen in the AST viewer
on Compiler Explorer. The lack of highlighting makes the AST less convenient
from a user-perspective.

C++ for OpenCL inherits address space behavior from OpenCL C v2.0 s6.5, so
this change applies to both OpenCL C and C++ for OpenCL.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
