### PR TITLE
Add chibicc compiler

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc
 defaultCompiler=cg112
 demangler=/opt/compiler-explorer/gcc-11.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.2.0/bin/objdump
@@ -988,6 +988,18 @@ group.cproc86.compilers=cproc-master
 group.cproc86.instructionSet=amd64
 group.cproc86.compilerType=cproc
 compiler.cproc-master.exe=/opt/compiler-explorer/cproc-master/bin/cproc
+
+################################
+# Chibicc
+group.chibicc.isSemVer=true
+group.chibicc.groupName=Chibicc
+group.chibicc.compilers=chibicc-trunk
+group.chibicc.supportsExecute=true
+group.chibicc.supportsBinary=true
+compiler.chibicc-trunk.name=Chibicc 2020-12-07
+compiler.chibicc-trunk.exe=/opt/compiler-explorer/chibicc-main/chibicc
+compiler.chibicc-trunk.semver=(trunk)
+compiler.chibicc-trunk.explicitVersion=90d1f7f199cc55b13c7fdb5839d1409806633fdb
 
 #################################
 #################################

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1525,6 +1525,10 @@ Please select another pass or change filters.`;
 
     getVersion() {
         logger.info(`Gathering ${this.compiler.id} version information on ${this.compiler.exe}`);
+        if (this.compiler.explicitVersion) {
+            logger.debug(`${this.compiler.id} has forced version output: ${this.compiler.explicitVersion}`);
+            return {stdout: [this.compiler.explicitVersion], stderr: [], code: 0};
+        }
         const execOptions = this.getDefaultExecOptions();
         const versionFlag = this.compiler.versionFlag || '--version';
         execOptions.timeoutMs = 0; // No timeout for --version. A sort of workaround for slow EFS/NFS on the prod site

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -246,6 +246,7 @@ export class CompilerFinder {
             options: actualOptions,
             versionFlag: props('versionFlag'),
             versionRe: props('versionRe'),
+            explicitVersion: props('explicitVersion'),
             compilerType: props('compilerType', ''),
             demangler: demangler,
             demanglerType: props('demanglerType', ''),


### PR DESCRIPTION
Adds https://github.com/rui314/chibicc compiler. As the compiler does not support any version flags, I've added a new `explicitVersion` prop key that has priority over the version checks.

As per its readme, the history of the repo might be rewritten at any time so it was tricky to find a good solution for how to handle versions here, but I think the simplest wins: Having only a main that we update if/when needed