### PR TITLE
Implement code document formatting through monaco

### DIFF
--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import $ from 'jquery';
+import * as monaco from 'monaco-editor';
+import { Promise } from "es6-promise";
+import { Alert } from "./alert";
+
+declare global {
+    interface Window {
+        httpRoot: string;
+    }
+}
+
+const getDocumentFormatter = (language: string, formatter: string, formatBase: string): monaco.languages.DocumentFormattingEditProvider => ({
+    provideDocumentFormattingEdits(
+        model: monaco.editor.ITextModel,
+        options: monaco.languages.FormattingOptions,
+        token: monaco.CancellationToken
+    ): Promise<monaco.languages.TextEdit[]> {
+        const alertSystem = new Alert();
+        return new Promise((resolve, reject) => {
+           const source = model.getValue();
+            $.ajax({
+                type: 'POST',
+                url: `${window.location.origin}${window.httpRoot}api/format/${formatter}`,
+                dataType: 'json',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    source,
+                    base: formatBase,
+                }),
+                success: (result) => {
+                    if (result.exit === 0) {
+                        resolve([{
+                            range: model.getFullModelRange(),
+                            text: result.answer,
+                        }]);
+                    } else {
+                        alertSystem.notify(`We encountered an error formatting your code: ${result.answer}`, {
+                            group: 'formatting',
+                            alertClass: 'notification-error',
+                        });
+                    }
+                },
+                error: (xhr, status, error) => {
+                    // Hopefully we have not exploded!
+                    if (xhr.responseText) {
+                        try {
+                            var res = JSON.parse(xhr.responseText);
+                            error = res.answer || error;
+                        } catch (e) {
+                            // continue regardless of error
+                        }
+                    }
+                    error = error || 'Unknown error';
+                    alertSystem.notify('We ran into some issues while formatting your code: ' + error, {
+                        group: 'formatting',
+                        alertClass: 'notification-error',
+                    });
+                    reject();
+                },
+                cache: true,
+            });
+        });
+    }
+});
+
+monaco.languages.registerDocumentFormattingEditProvider('cppp', getDocumentFormatter('cppp', 'clangformat', 'Google'));

--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -28,12 +28,6 @@ import { Promise } from "es6-promise";
 
 import { Alert } from "./alert";
 
-declare global {
-    interface Window {
-        httpRoot: string;
-    }
-}
-
 const getDocumentFormatter = (
     language: string,
     formatter: string,

--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -25,6 +25,7 @@
 import $ from 'jquery';
 import * as monaco from 'monaco-editor';
 import { Promise } from "es6-promise";
+
 import { Alert } from "./alert";
 
 declare global {
@@ -33,7 +34,11 @@ declare global {
     }
 }
 
-const getDocumentFormatter = (language: string, formatter: string, formatBase: string): monaco.languages.DocumentFormattingEditProvider => ({
+const getDocumentFormatter = (
+    language: string,
+    formatter: string,
+    formatBase: string
+): monaco.languages.DocumentFormattingEditProvider => ({
     provideDocumentFormattingEdits(
         model: monaco.editor.ITextModel,
         options: monaco.languages.FormattingOptions,
@@ -41,7 +46,7 @@ const getDocumentFormatter = (language: string, formatter: string, formatBase: s
     ): Promise<monaco.languages.TextEdit[]> {
         const alertSystem = new Alert();
         return new Promise((resolve, reject) => {
-           const source = model.getValue();
+            const source = model.getValue();
             $.ajax({
                 type: 'POST',
                 url: `${window.location.origin}${window.httpRoot}api/format/${formatter}`,
@@ -75,7 +80,7 @@ const getDocumentFormatter = (language: string, formatter: string, formatBase: s
                         }
                     }
                     error = error || 'Unknown error';
-                    alertSystem.notify('We ran into some issues while formatting your code: ' + error, {
+                    alertSystem.notify(`We ran into some issues while formatting your code: ${error}`, {
                         group: 'formatting',
                         alertClass: 'notification-error',
                     });

--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -87,3 +87,5 @@ const getDocumentFormatter = (
 });
 
 monaco.languages.registerDocumentFormattingEditProvider('cppp', getDocumentFormatter('cppp', 'clangformat', 'Google'));
+monaco.languages.registerDocumentFormattingEditProvider('nc', getDocumentFormatter('nc', 'clangformat', 'Google'));
+monaco.languages.registerDocumentFormattingEditProvider('rust', getDocumentFormatter('rust', 'rustfmt', 'None'));

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -706,16 +706,6 @@ Editor.prototype.initEditorActions = function () {
     });
 
     this.editor.addAction({
-        id: 'format',
-        label: 'Format text',
-        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.F9],
-        keybindingContext: null,
-        contextMenuGroupId: 'help',
-        contextMenuOrder: 1.5,
-        run: _.bind(this.formatCurrentText, this),
-    });
-
-    this.editor.addAction({
         id: 'toggleColourisation',
         label: 'Toggle colourisation',
         keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.F1],
@@ -753,6 +743,10 @@ Editor.prototype.initEditorActions = function () {
         precondition: 'isCpp',
         run: _.bind(this.searchOnCppreference, this),
     });
+
+    this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.F9, _.bind(function () {
+        this.editor.getAction('editor.action.formatDocument').run();
+    }, this));
 };
 
 Editor.prototype.searchOnCppreference = function (ed) {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -37,6 +37,7 @@ var monacoVim = require('monaco-vim');
 var monacoConfig = require('../monaco-config');
 var TomSelect = require('tom-select');
 var Settings = require('../settings');
+require('../formatter-registry');
 require('../modes/_all');
 
 var loadSave = new loadSaveLib.LoadSave();

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -4,7 +4,7 @@
 		"outDir": ".",
 		"sourceMap": true,
 		"rootDir": ".",
-        "esModuleInterop": true
+		"esModuleInterop": true
 	},
 	"files": [
 		"global.ts",
@@ -12,6 +12,7 @@
         "line-colouring.ts",
 		"panes/tree.ts",
 		"alert.ts",
-		"url.ts"
+		"url.ts",
+		"formatter-registry.ts"
 	]
 }


### PR DESCRIPTION
As discussed in #2818 and #2770; Monaco has its own document formatting functionality which does the same thing as our Ctrl + F9 keybinding.

This is an MVP implementation for using Monaco's own FormattingEditProvider.

![Peek 2021-08-26 16-06](https://user-images.githubusercontent.com/42585241/130977545-1754c192-6fef-49b8-949b-9f3f7399a6a4.gif)

The old Ctrl + F9 keybinding is now hidden as a monaco command, which will invoke the `editor.action.formatDocument` action, making the keymap backwards compatible.