### PR TITLE
Move global TypeScript declarations into its own file

### DIFF
--- a/static/global.ts
+++ b/static/global.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+declare global {
+    export interface Window {
+        httpRoot: string | null;
+    }
+}
+
+// Necessary because we're not exporting any actual symbols from this file
+// See https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html
+export {};

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -38,10 +38,6 @@ const options = require('../options');
 const languages = options.languages;
 const saveAs = require('file-saver').saveAs;
 
-declare global {
-    interface Window { httpRoot: any; }
-}
-
 export class TreeState extends MultifileServiceState {
     id: number
     cmakeArgs: string;

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -7,6 +7,7 @@
         "esModuleInterop": true
 	},
 	"files": [
+		"global.ts",
 		"multifile-service.ts",
         "line-colouring.ts",
 		"panes/tree.ts",


### PR DESCRIPTION
Moving `declare global` blocks into their own file, making it easier to maintain them.