### PR TITLE
Fix execution for Java with multifile ui

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1058,7 +1058,7 @@ export class BaseCompiler {
 
     doTempfolderCleanup(buildResult) {
         if (buildResult.dirPath && !this.delayCleanupTemp) {
-            //fs.remove(buildResult.dirPath);
+            fs.remove(buildResult.dirPath);
         }
         buildResult.dirPath = undefined;
     }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -873,7 +873,8 @@ export class BaseCompiler {
         return this.execBinary(executable, maxExecOutputSize, executeParameters, homeDir);
     }
 
-    async handleInterpreting(source, executeParameters) {
+    async handleInterpreting(key, executeParameters) {
+        const source = key.source;
         const dirPath = await this.newTempDir();
         const outputFilename = this.getExecutableFilename(dirPath, this.outputFilebase);
         await fs.writeFile(outputFilename, source);
@@ -886,7 +887,7 @@ export class BaseCompiler {
 
     async handleExecution(key, executeParameters) {
         if (this.compiler.interpreted)
-            return this.handleInterpreting(key.source, executeParameters);
+            return this.handleInterpreting(key, executeParameters);
         const buildResult = await this.getOrBuildExecutable(key);
         if (buildResult.code !== 0) {
             return {
@@ -1057,7 +1058,7 @@ export class BaseCompiler {
 
     doTempfolderCleanup(buildResult) {
         if (buildResult.dirPath && !this.delayCleanupTemp) {
-            fs.remove(buildResult.dirPath);
+            //fs.remove(buildResult.dirPath);
         }
         buildResult.dirPath = undefined;
     }

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -103,13 +103,8 @@ export class JavaCompiler extends BaseCompiler {
         ];
     }
 
-    async handleInterpreting(source, executeParameters) {
-        const dirPath = await this.newTempDir();
-        const inputFile = path.join(dirPath, this.compileFilename);
-        await fs.writeFile(inputFile, source);
-        const execOpts = this.getDefaultExecOptions();
-        const compileResult = await this.runCompiler(this.compiler.exe, [inputFile], inputFile, execOpts);
-
+    async handleInterpreting(key, executeParameters) {
+        const compileResult = await this.getOrBuildExecutable(key);
         executeParameters.args = [
             '-Xss136K', // Reduce thread stack size
             '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
@@ -117,9 +112,11 @@ export class JavaCompiler extends BaseCompiler {
             '-XX:-UseDynamicNumberOfGCThreads',
             '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
             this.getMainClassName(),
+            '-cp',
+            compileResult.dirPath,
             ...executeParameters.args,
         ];
-        const result = await this.runExecutable(this.javaRuntime, executeParameters, dirPath);
+        const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
         result.didExecute = true;
         result.buildResult = compileResult;
         return result;


### PR DESCRIPTION
By refactoring handleInterpreting to receive the entire `key` argument from `handleExecution` we can access all of the files from the multifile-ui tree.

This will make sure the Java execution compiles all of the files and runs using the correct classpath.

Fixes #2877