### PR TITLE
Add tooltips to files in tree view.

### DIFF
--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -22,9 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { MultifileFile, MultifileService, MultifileServiceState } from "../multifile-service";
-import { saveAs } from "file-saver";
-import { LineColouring } from "../line-colouring";
+import {MultifileFile, MultifileService, MultifileServiceState} from '../multifile-service';
+import {LineColouring} from '../line-colouring';
 
 const _ = require('underscore');
 const $ = require('jquery');
@@ -39,7 +38,7 @@ const languages = options.languages;
 const saveAs = require('file-saver').saveAs;
 
 export class TreeState extends MultifileServiceState {
-    id: number
+    id: number;
     cmakeArgs: string;
     customOutputFilename: string;
 }
@@ -179,8 +178,8 @@ export class Tree {
             id: this.id,
             cmakeArgs: this.getCmakeArgs(),
             customOutputFilename: this.getCustomOutputFilename(),
-            ... this.multifileService.getState()
-        }
+            ...this.multifileService.getState(),
+        };
     };
 
     private updateState() {
@@ -317,7 +316,8 @@ export class Tree {
 
     private addRowToTreelist(file: MultifileFile) {
         const item = $(this.rowTemplate.children()[0].cloneNode(true));
-        const stagingButton = item.find('.stage-file');
+        const stageButton = item.find('.stage-file');
+        const unstageButton = item.find('.unstage-file');
         const renameButton = item.find('.rename-file');
         const deleteButton = item.find('.delete-file');
 
@@ -359,21 +359,17 @@ export class Tree {
             }
         });
 
-        if (file.isIncluded) {
-            stagingButton.removeClass('fa-plus').addClass('fa-minus');
-            stagingButton.on('click', async (e) => {
-                const fileId = $(e.currentTarget).parent('li').data('fileId');
-                await this.moveToExclude(fileId);
-            });
-            this.namedItems.append(item);
-        } else {
-            stagingButton.removeClass('fa-minus').addClass('fa-plus');
-            stagingButton.on('click', async (e) => {
-                const fileId = $(e.currentTarget).parent('li').data('fileId');
-                await this.moveToInclude(fileId);
-            });
-            this.unnamedItems.append(item);
-        }
+        stageButton.on('click', async (e) => {
+            const fileId = $(e.currentTarget).parent('li').data('fileId');
+            await this.moveToInclude(fileId);
+        });
+        unstageButton.on('click', async (e) => {
+            const fileId = $(e.currentTarget).parent('li').data('fileId');
+            await this.moveToExclude(fileId);
+        });
+        stageButton.toggle(!file.isIncluded);
+        unstageButton.toggle(file.isIncluded);
+        (file.isIncluded ? this.namedItems : this.unnamedItems).append(item);
     }
 
     private refresh() {

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -478,6 +478,7 @@
   #tree-editor-tpl
     li.list-group-item.tree-editor-file.input-group-append
         span.filename someresource.txt
-        button.btn.delete-file.fa.fa-trash
-        button.btn.rename-file.fa.fa-tag
-        button.btn.stage-file.fa.fa-plus
+        button.btn.delete-file.fa.fa-trash(title="Remove this file" aria-label="Delete")
+        button.btn.rename-file.fa.fa-tag(title="Rename this file" aria-label="Rename")
+        button.btn.stage-file.fa.fa-plus(title="Include this file in the build" aria-label="Include")
+        button.btn.unstage-file.fa.fa-minus(title="Exclude this file from the build" aria-label="Exclude")


### PR DESCRIPTION
* Makes the two buttons (stage/unstage) separate so the template
  file has all the title etc in it.
* Hides/unhides to show the appropriate button only.

I'm not wed to this approach, but it saved putting the descriptions
into the source code.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
