### PR TITLE
OCaml Improvements: objdump and a few refactorings

### DIFF
--- a/etc/config/ocaml.amazon.properties
+++ b/etc/config/ocaml.amazon.properties
@@ -1,5 +1,6 @@
 compilers=&ocaml
 defaultCompiler=ocaml4120flambda
+objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
 group.ocaml.compilers=ocaml4120flambda:ocaml4120:ocaml4112flambda:ocaml4112:ocaml4111flambda:ocaml4111:ocaml4102flambda:ocaml4102:ocaml4101flambda:ocaml4101:ocaml4100flambda:ocaml4100:ocaml4091flambda:ocaml4091:ocaml4090flambda:ocaml4090:ocaml4081flambda:ocaml4081:ocaml4071flambda:ocaml4071:ocaml4061:ocaml4042
 group.ocaml.isSemVer=true

--- a/etc/config/ocaml.defaults.properties
+++ b/etc/config/ocaml.defaults.properties
@@ -1,10 +1,20 @@
-compilers=/usr/bin/ocamlopt
+compilerType=ocaml
 supportsBinary=true
 supportsExecute=true
-compilerType=ocaml
-versionFlag=-v |sed 1q #nicer output than -vnum
-objdumper=objdump
+versionFlag=-v
 
+compilers=&ocamlopt
+defaultCompiler=system
+
+group.ocamlopt.compilers=system:local
+
+compiler.system.baseName=System OCaml
+compiler.system.exe=/usr/bin/ocamlopt
+compiler.system.objdumper=/usr/bin/objdump
+
+compiler.local.baseName=Local Switch
+compiler.local.exe=ocamlopt
+compiler.local.objdumper=objdump
 
 #################################
 #################################

--- a/etc/config/ocaml.defaults.properties
+++ b/etc/config/ocaml.defaults.properties
@@ -4,17 +4,17 @@ supportsExecute=true
 versionFlag=-v
 
 compilers=&ocamlopt
-defaultCompiler=system
+defaultCompiler=ocamlsystem
 
-group.ocamlopt.compilers=system:local
+group.ocamlopt.compilers=ocamlsystem:ocamllocal
 
-compiler.system.baseName=System OCaml
-compiler.system.exe=/usr/bin/ocamlopt
-compiler.system.objdumper=/usr/bin/objdump
+compiler.ocamlsystem.baseName=System OCaml
+compiler.ocamlsystem.exe=/usr/bin/ocamlopt
+compiler.ocamlsystem.objdumper=/usr/bin/objdump
 
-compiler.local.baseName=Local Switch
-compiler.local.exe=ocamlopt
-compiler.local.objdumper=objdump
+compiler.ocamllocal.baseName=Local Switch
+compiler.ocamllocal.exe=ocamlopt
+compiler.ocamllocal.objdumper=objdump
 
 #################################
 #################################

--- a/etc/config/ocaml.defaults.properties
+++ b/etc/config/ocaml.defaults.properties
@@ -11,6 +11,7 @@ group.ocamlopt.compilers=ocamlsystem:ocamllocal
 compiler.ocamlsystem.baseName=System OCaml
 compiler.ocamlsystem.exe=/usr/bin/ocamlopt
 compiler.ocamlsystem.objdumper=/usr/bin/objdump
+compiler.ocamlsystem.alias=/usr/bin/ocamlopt
 
 compiler.ocamllocal.baseName=Local Switch
 compiler.ocamllocal.exe=ocamlopt

--- a/lib/compilers/ocaml.js
+++ b/lib/compilers/ocaml.js
@@ -22,35 +22,32 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import path from 'path';
-
 import { BaseCompiler } from '../base-compiler';
 
 export class OCamlCompiler extends BaseCompiler {
     static get key() { return 'ocaml'; }
+
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+        // override output base because ocaml's -S -o has different semantics.
+        // namely, it outputs a full binary exe to the supposed asm dump.
+        // with this override and optionsForFilter override, that pecularity..
+        // ..is bypassed entirely.
+        this.outputFilebase = 'example';
+    }
 
     getSharedLibraryPathsAsArguments() {
         return [];
     }
 
     optionsForFilter(filters, outputFileName) {
-        let options = ['-g', '-S'];
+        const options = ['-g'];
         if (filters.binary) {
-            options = options.concat('-o', this.filename(outputFileName));
+            options.unshift('-o', outputFileName);
         } else {
-            options = options.concat('-c');
+            options.unshift('-S', '-c');
         }
         return options;
     }
 
-    getOutputFilename(dirPath, outputFilebase, key) {
-        const filename = key.backendOptions.customOutputFilename ||
-            `${path.basename(this.compileFilename, this.lang.extensions[0])}.s`;
-        return path.join(dirPath, filename);
-    }
-
-    getExecutableFilename(dirPath, outputFilebase, key) {
-        const filename = key.backendOptions.customOutputFilename || outputFilebase;
-        return path.join(dirPath, filename);
-    }
 }

--- a/lib/compilers/ocaml.js
+++ b/lib/compilers/ocaml.js
@@ -24,6 +24,8 @@
 
 import { BaseCompiler } from '../base-compiler';
 
+import { PascalParser } from './argument-parsers';
+
 export class OCamlCompiler extends BaseCompiler {
     static get key() { return 'ocaml'; }
 
@@ -50,4 +52,7 @@ export class OCamlCompiler extends BaseCompiler {
         return options;
     }
 
+    getArgumentParser() {
+        return PascalParser;
+    }
 }


### PR DESCRIPTION
This patchset doesn't _add_ much, besides an argument parser derived from Pascal's (for now) for similarities in interface.
Rather, it tries to remove things and give `ocaml.js` better chances at forward compatibility.
It also follows [this](https://github.com/compiler-explorer/compiler-explorer/issues/2855#issuecomment-898939931) comment wrt `*.defaults.properties` preferred minimalism.

To see the work in progress, check #2850