### PR TITLE
 [NFC] Port monaco-config.js to TypeScript

### DIFF
--- a/static/monaco-config.ts
+++ b/static/monaco-config.ts
@@ -25,7 +25,7 @@
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 
-const DEFAULT_MONACO_CONFIG: monaco.editor.IEditorConstructionOptions = {
+const DEFAULT_MONACO_CONFIG = {
     fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
     scrollBeyondLastLine: true,
     quickSuggestions: false,
@@ -38,10 +38,32 @@ const DEFAULT_MONACO_CONFIG: monaco.editor.IEditorConstructionOptions = {
     emptySelectionClipboard: true,
 };
 
-export function extendConfig(
-    overrides: monaco.editor.IEditorConstructionOptions,
-    settings?: any /* SiteSettings #2917 */
-): monaco.editor.IEditorConstructionOptions {
+type EditorKinds =
+    | monaco.editor.IStandaloneDiffEditor
+    | monaco.editor.IStandaloneCodeEditor;
+
+/** Pick consturction options based on editor kind */
+type EditorConstructionType<E extends EditorKinds> =
+    E extends monaco.editor.IStandaloneDiffEditor
+        ? monaco.editor.IDiffEditorConstructionOptions
+        : monaco.editor.IStandaloneEditorConstructionOptions;
+
+/**
+ * Extend the default monaco editor construction options.
+ *
+ * Type parameter E indicates which editor kind you're constructing a config
+ * for. Valid options are EditorKinds, aka monaco.editor.IStandaloneDiffEditor
+ * or monaco.editor.IStandaloneCodeEditor
+ *
+ * TODO(supergrecko): underscore.extend yields any, can we improve the type
+ *  check on this?
+ */
+export function extendConfig<
+    E extends EditorKinds = monaco.editor.IStandaloneCodeEditor,
+    T = EditorConstructionType<E>>(
+    overrides: T,
+    settings?: any, /* SiteSettings #2917 */
+): T {
     if (settings !== undefined) {
         return _.extend({}, DEFAULT_MONACO_CONFIG, {
             fontFamily: settings.editorsFFont,

--- a/static/monaco-config.ts
+++ b/static/monaco-config.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Compiler Explorer Authors
+// Copyright (c) 2021, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -22,11 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
-var _ = require('underscore');
+import _ from 'underscore';
+import * as monaco from 'monaco-editor';
 
-var config = {
-    value: '',
+const DEFAULT_MONACO_CONFIG: monaco.editor.IEditorConstructionOptions = {
     fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
     scrollBeyondLastLine: true,
     quickSuggestions: false,
@@ -39,19 +38,17 @@ var config = {
     emptySelectionClipboard: true,
 };
 
-function extendConfig(options, settings) {
-    var settingsObject = {};
+export function extendConfig(
+    overrides: monaco.editor.IEditorConstructionOptions,
+    settings?: any /* SiteSettings #2917 */
+): monaco.editor.IEditorConstructionOptions {
     if (settings !== undefined) {
-        settingsObject = {
+        return _.extend({}, DEFAULT_MONACO_CONFIG, {
             fontFamily: settings.editorsFFont,
             autoIndent: settings.autoIndent ? 'advanced' : 'none',
             vimInUse: settings.useVim,
             fontLigatures: settings.editorsFLigatures,
-        };
+        }, overrides);
     }
-    return _.extend({}, config, settingsObject, options);
+    return _.extend({}, DEFAULT_MONACO_CONFIG, overrides);
 }
-
-module.exports = {
-    extendConfig: extendConfig,
-};

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -15,6 +15,7 @@
 		"formatter-registry.ts",
 		"sharing.ts",
 		"url.ts",
-		"utils.ts"
+		"utils.ts",
+		"monaco-config.ts"
 	]
 }

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -7,15 +7,15 @@
 		"esModuleInterop": true
 	},
 	"files": [
-		"global.ts",
-		"multifile-service.ts",
-		"line-colouring.ts",
-		"panes/tree.ts",
 		"alert.ts",
 		"formatter-registry.ts",
+		"global.ts",
+		"line-colouring.ts",
+		"monaco-config.ts",
+		"multifile-service.ts",
+		"panes/tree.ts",
 		"sharing.ts",
 		"url.ts",
 		"utils.ts",
-		"monaco-config.ts"
 	]
 }


### PR DESCRIPTION
Ports the extendConfig() utility to TypeScript to ensure proper types are passed in the overrides object. This is a non-functional change, and will only affect TypeScript callers (of which there are none at the time of writing).