### PR TITLE
Add signal string to execution request results

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -126,7 +126,7 @@ export function executeDirect(command, args, options, filenameTransform) {
             logger.debug(`Execution error with ${command} args: ${args}:`, e);
             reject(e);
         });
-        child.on('close', code => {
+        child.on('close', (code, signal) => {
             // Being killed externally gives a NULL error code. Synthesize something different here.
             if (code === null) code = -1;
             if (timeout !== undefined) clearTimeout(timeout);
@@ -134,6 +134,7 @@ export function executeDirect(command, args, options, filenameTransform) {
             const result = {
                 code,
                 okToCache,
+                signal,
                 filenameTransform,
                 stdout: streams.stdout,
                 stderr: streams.stderr,

--- a/test/exec-tests.js
+++ b/test/exec-tests.js
@@ -49,6 +49,7 @@ describe('Execution tests', () => {
                         {
                             code: 0,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: 'hello world\n',
                         });
@@ -60,6 +61,7 @@ describe('Execution tests', () => {
                         {
                             code: 0,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: 'A very ver\n[Truncated]',
                         });
@@ -71,6 +73,7 @@ describe('Execution tests', () => {
                         {
                             code: 1,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: '',
                         });
@@ -82,6 +85,7 @@ describe('Execution tests', () => {
                         {
                             code: -1,
                             okToCache: false,
+                            signal: null,
                             stderr: '\nKilled - processing time exceeded',
                             stdout: '',
                         });
@@ -97,6 +101,7 @@ describe('Execution tests', () => {
                         {
                             code: 0,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: 'this is stdin',
                         });
@@ -112,6 +117,7 @@ describe('Execution tests', () => {
                         {
                             code: 0,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: 'hello world\r\n',
                         });
@@ -123,6 +129,7 @@ describe('Execution tests', () => {
                         {
                             code: 0,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: 'A very ver\n[Truncated]',
                         });
@@ -134,6 +141,7 @@ describe('Execution tests', () => {
                         {
                             code: 1,
                             okToCache: true,
+                            signal: null,
                             stderr: '',
                             stdout: '',
                         });
@@ -145,6 +153,7 @@ describe('Execution tests', () => {
                         {
                             code: 1,
                             okToCache: false,
+                            signal: null,
                             stderr: '\nKilled - processing time exceeded',
                             stdout: '',
                         });


### PR DESCRIPTION
This is a quick patch that adds the signal string into the final json result for API requests. Whether we do anything in the front end to express these signals (i.e. outputting it in the console), I'm not sure about.

I couldn't get my local environment to run Compiler Explorer so I took a swing blind, this may require more work or testing to ensure all is well.