### PR TITLE
Rename CUDA to CUDA C++ in language dropdown

### DIFF
--- a/lib/languages.js
+++ b/lib/languages.js
@@ -195,7 +195,7 @@ export const languages = {
         alias: ['tool', 'tools'],
     },
     cuda: {
-        name: 'CUDA',
+        name: 'CUDA C++',
         monaco: 'cuda',
         extensions: ['.cu'],
         alias: ['nvcc'],


### PR DESCRIPTION
Fixes #2934 

Renamed the dropdown name for CUDA to CUDA C++ as described in #2934

![image](https://user-images.githubusercontent.com/42585241/133448627-67d976a6-4dd8-4e3e-8716-904b32aeba9c.png)
