### PR TITLE
Add support for generating SPIR-V assembly from OpenCL C and C++ for OpenCL

### DIFF
--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -6,7 +6,7 @@ needsMulti=false
 supportsBinary=false
 
 translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
-disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
+disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-10, clang-11, clang-12 and trunk

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -1,9 +1,12 @@
-compilers=&armcpp4oclclang32:&armcpp4oclclang64
+compilers=&armcpp4oclclang32:&armcpp4oclclang64:&armcpp4oclclang32spir:&armcpp4oclclang64spir
 defaultCompiler=armcpp4oclclang64
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 needsMulti=false
 supportsBinary=false
+
+translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
+disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-10, clang-11, clang-12 and trunk
@@ -124,6 +127,51 @@ compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snap
 compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
 compiler.armv8-full-cpp4oclclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+
+# SPIR-V Assembly
+group.armcpp4oclclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)
+group.armcpp4oclclang32spir.compilers=armv7-cpp4oclclang-trunk-spir:armv7-cpp4oclclang-trunk-assertions-spir
+group.armcpp4oclclang32spir.isSemVer=true
+group.armcpp4oclclang32spir.compilerType=spirv
+group.armcpp4oclclang32spir.supportsExecute=false
+group.armcpp4oclclang32spir.instructionSet=arm32
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armcpp4oclclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir-unknown-unknown
+
+group.armcpp4oclclang64spir.groupName=Arm 64-bit clang (SPIR-V asm)
+group.armcpp4oclclang64spir.compilers=armv8-cpp4oclclang-trunk-spir64:armv8-cpp4oclclang-trunk-assertions-spir64
+group.armcpp4oclclang64spir.isSemVer=true
+group.armcpp4oclclang64spir.compilerType=spirv
+group.armcpp4oclclang64spir.supportsExecute=false
+group.armcpp4oclclang64spir.instructionSet=aarch64
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armcpp4oclclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir64-unknown-unknown
+
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang-trunk-spir.name=armv7-a clang (trunk, SPIR-V asm)
+compiler.armv7-cpp4oclclang-trunk-spir.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv7-cpp4oclclang-trunk-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-cpp4oclclang-trunk-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-cpp4oclclang-trunk-spir.semver=(trunk)
+
+compiler.armv7-cpp4oclclang-trunk-assertions-spir.name=armv7-a clang (trunk, assertions, SPIR-V asm)
+compiler.armv7-cpp4oclclang-trunk-assertions-spir.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv7-cpp4oclclang-trunk-assertions-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-cpp4oclclang-trunk-assertions-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-cpp4oclclang-trunk-assertions-spir.semver=(assertions trunk)
+
+# Arm v8-a
+compiler.armv8-cpp4oclclang-trunk-spir64.name=armv8-a clang (trunk, SPIR-V asm)
+compiler.armv8-cpp4oclclang-trunk-spir64.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv8-cpp4oclclang-trunk-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-cpp4oclclang-trunk-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-cpp4oclclang-trunk-spir64.semver=(trunk)
+
+compiler.armv8-cpp4oclclang-trunk-assertions-spir64.name=armv8-a clang (trunk, assertions, SPIR-V asm)
+compiler.armv8-cpp4oclclang-trunk-assertions-spir64.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv8-cpp4oclclang-trunk-assertions-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-cpp4oclclang-trunk-assertions-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-cpp4oclclang-trunk-assertions-spir64.semver=(assertions trunk)
 
 #################################
 #################################

--- a/etc/config/cpp_for_opencl.defaults.properties
+++ b/etc/config/cpp_for_opencl.defaults.properties
@@ -1,9 +1,12 @@
 # Default settings for C++ for OpenCL
-compilers=&clang
+compilers=&clang:&spirv
 defaultCompiler=cppforopenclclangdefault
 postProcess=
 demangler=c++filt
 supportsBinary=false
+
+translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
+disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 group.clang.compilers=cppforopenclclangdefault:cppforopenclclang10:cppforopenclclang11:cppforopenclclang12:cppforopenclclang13
 group.clang.compilerType=clang
@@ -21,3 +24,21 @@ compiler.cppforopenclclang12.name=clang 12
 compiler.cppforopenclclang12.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
 compiler.cppforopenclclang13.exe=/usr/bin/clang-13
 compiler.cppforopenclclang13.name=clang 13
+
+group.spirv.compilers=spirvcppclang13spir:spirvcppclang13spir64:spirvcppclangdefaultspir:spirvcppclangdefaultspir64
+group.spirv.compilerType=spirv
+compiler.spirvcppclangdefaultspir.exe=/usr/bin/clang
+compiler.spirvcppclangdefaultspir.name=clang default (SPIR-V asm, spir triple)
+compiler.spirvcppclangdefaultspir.options=-cl-std=clc++ -x cl -finclude-default-header -triple spir-unknown-unknown
+
+compiler.spirvcppclangdefaultspir64.exe=/usr/bin/clang
+compiler.spirvcppclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
+compiler.spirvcppclangdefaultspir64.options=-cl-std=clc++ -x cl -finclude-default-header -triple spir64-unknown-unknown
+
+compiler.spirvcppclang13spir.exe=/usr/bin/clang-13
+compiler.spirvcppclang13spir.name=clang 13 (SPIR-V asm, spir triple)
+compiler.spirvcppclang13spir.options=-cl-std=clc++ -finclude-default-header -triple spir-unknown-unknown
+
+compiler.spirvcppclang13spir64.exe=/usr/bin/clang-13
+compiler.spirvcppclang13spir64.name=clang 13 (SPIR-V asm, spir64 triple)
+compiler.spirvcppclang13spir64.options=-cl-std=clc++ -finclude-default-header -triple spir64-unknown-unknown

--- a/etc/config/cpp_for_opencl.defaults.properties
+++ b/etc/config/cpp_for_opencl.defaults.properties
@@ -6,7 +6,7 @@ demangler=c++filt
 supportsBinary=false
 
 translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
-disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
+disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 group.clang.compilers=cppforopenclclangdefault:cppforopenclclang10:cppforopenclclang11:cppforopenclclang12:cppforopenclclang13
 group.clang.compilerType=clang

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -6,7 +6,7 @@ needsMulti=false
 supportsBinary=false
 
 translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
-disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
+disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9, clang-10, clang-11, clang-12 and trunk

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -1,9 +1,12 @@
-compilers=&armoclcclang32:&armoclcclang64
+compilers=&armoclcclang32:&armoclcclang64:&armoclcclang32spir:&armoclcclang64spir
 defaultCompiler=armoclcclang64
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 needsMulti=false
 supportsBinary=false
+
+translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
+disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9, clang-10, clang-11, clang-12 and trunk
@@ -17,7 +20,7 @@ group.armoclcclang32.instructionSet=arm32
 group.armoclcclang32.baseOptions=-Dkernel= -D__kernel=
 
 group.armoclcclang64.groupName=Arm 64-bit clang
-group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk::armv8-oclcclang-trunk-assertions
+group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk:armv8-oclcclang-trunk-assertions
 group.armoclcclang64.isSemVer=true
 group.armoclcclang64.compilerType=clang
 group.armoclcclang64.supportsExecute=false
@@ -148,6 +151,51 @@ compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapsho
 compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
 compiler.armv8-full-oclcclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+
+# SPIR-V Assembly
+group.armoclcclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)
+group.armoclcclang32spir.compilers=armv7-oclcclang-trunk-spir:armv7-oclcclang-trunk-assertions-spir
+group.armoclcclang32spir.isSemVer=true
+group.armoclcclang32spir.compilerType=spirv
+group.armoclcclang32spir.supportsExecute=false
+group.armoclcclang32spir.instructionSet=arm32
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armoclcclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir-unknown-unknown
+
+group.armoclcclang64spir.groupName=Arm 64-bit clang (SPIR-V asm)
+group.armoclcclang64spir.compilers=armv8-oclcclang-trunk-spir64:armv8-oclcclang-trunk-assertions-spir64
+group.armoclcclang64spir.isSemVer=true
+group.armoclcclang64spir.compilerType=spirv
+group.armoclcclang64spir.supportsExecute=false
+group.armoclcclang64spir.instructionSet=aarch64
+# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
+group.armoclcclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir64-unknown-unknown
+
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang-trunk-spir.name=armv7-a clang (trunk, SPIR-V asm)
+compiler.armv7-oclcclang-trunk-spir.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv7-oclcclang-trunk-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-oclcclang-trunk-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-oclcclang-trunk-spir.semver=(trunk)
+
+compiler.armv7-oclcclang-trunk-assertions-spir.name=armv7-a clang (trunk, assertions, SPIR-V asm)
+compiler.armv7-oclcclang-trunk-assertions-spir.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv7-oclcclang-trunk-assertions-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv7-oclcclang-trunk-assertions-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-oclcclang-trunk-assertions-spir.semver=(assertions trunk)
+
+# Arm v8-a
+compiler.armv8-oclcclang-trunk-spir64.name=armv8-a clang (trunk, SPIR-V asm)
+compiler.armv8-oclcclang-trunk-spir64.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.armv8-oclcclang-trunk-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-oclcclang-trunk-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-oclcclang-trunk-spir64.semver=(trunk)
+
+compiler.armv8-oclcclang-trunk-assertions-spir64.name=armv8-a clang (trunk, assertions, SPIR-V asm)
+compiler.armv8-oclcclang-trunk-assertions-spir64.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.armv8-oclcclang-trunk-assertions-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.armv8-oclcclang-trunk-assertions-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-oclcclang-trunk-assertions-spir64.semver=(assertions trunk)
 
 #################################
 #################################

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -1,9 +1,12 @@
 # Default settings for OpenCL C
-compilers=&clang
-defaultCompiler=clang
+compilers=&clang:&spirv
+defaultCompiler=openclcclangdefault
 postProcess=
 demangler=c++filt
 supportsBinary=false
+
+translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
+disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 group.clang.compilers=openclcclang7:openclcclang8:openclcclang9:openclcclang10:openclcclang11:openclcclang12:openclcclang13:openclcclangdefault
 group.clang.compilerType=clang
@@ -29,3 +32,21 @@ compiler.openclcclang13.exe=/usr/bin/clang-13
 compiler.openclcclang13.name=clang 13
 compiler.openclcclangdefault.exe=/usr/bin/clang
 compiler.openclcclangdefault.name=clang default
+
+group.spirv.compilers=spirvclang13spir:spirvclang13spir64:spirvclangdefaultspir:spirvclangdefaultspir64
+group.spirv.compilerType=spirv
+compiler.spirvclang13spir.exe=/usr/bin/clang-13
+compiler.spirvclang13spir.name=clang 13 (SPIR-V asm, spir triple)
+compiler.spirvclang13spir.options=-finclude-default-header -triple spir-unknown-unknown
+
+compiler.spirvclang13spir64.exe=/usr/bin/clang-13
+compiler.spirvclang13spir64.name=clang 13 (SPIR-V asm, spir64 triple)
+compiler.spirvclang13spir64.options=-finclude-default-header -triple spir64-unknown-unknown
+
+compiler.spirvclangdefaultspir.exe=/usr/bin/clang
+compiler.spirvclangdefaultspir.name=clang default (SPIR-V asm, spir triple)
+compiler.spirvclangdefaultspir.options=-finclude-default-header -triple spir-unknown-unknown
+
+compiler.spirvclangdefaultspir64.exe=/usr/bin/clang
+compiler.spirvclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
+compiler.spirvclangdefaultspir64.options=-finclude-default-header -triple spir64-unknown-unknown

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -6,7 +6,7 @@ demangler=c++filt
 supportsBinary=false
 
 translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
-disassemblerPath =/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
+disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 group.clang.compilers=openclcclang7:openclcclang8:openclcclang9:openclcclang10:openclcclang11:openclcclang12:openclcclang13:openclcclangdefault
 group.clang.compilerType=clang

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -67,6 +67,7 @@ export { RustcCgGCCCompiler } from './rustc-cg-gcc';
 export { MrustcCompiler } from './mrustc';
 export { ScalaCompiler } from './scala';
 export { SdccCompiler } from './sdcc';
+export { SPIRVCompiler } from './spirv';
 export { SwiftCompiler } from './swift';
 export { TenDRACompiler } from './tendra';
 export { Win32Compiler } from './win32';

--- a/lib/compilers/spirv.js
+++ b/lib/compilers/spirv.js
@@ -1,0 +1,189 @@
+// Copyright (c) 2018, 2021, Compiler Explorer Authors, Arm Ltd
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import _ from 'underscore';
+
+import { BaseCompiler } from '../base-compiler';
+import { logger } from '../logger';
+import * as utils from '../utils';
+
+export class SPIRVCompiler extends BaseCompiler {
+    static get key() { return 'spirv'; }
+
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+
+        this.translatorPath = this.compilerProps('translatorPath');
+        this.disassemblerPath = this.compilerProps('disassemblerPath');
+    }
+
+    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
+        let options = this.optionsForFilter(filters, outputFilename, userOptions);
+        backendOptions = backendOptions || {};
+
+        if (this.compiler.options) {
+            let compilerOptions = _.filter(utils.splitArguments(this.compiler.options), option =>
+                option !== '-fno-crash-diagnostics');
+
+            options = options.concat(compilerOptions);
+        }
+
+        if (this.compiler.supportsOptOutput && backendOptions.produceOptInfo) {
+            options = options.concat(this.compiler.optArg);
+        }
+
+        const libIncludes = this.getIncludeArguments(libraries);
+        const libOptions = this.getLibraryOptions(libraries);
+        let libLinks = [];
+        let libPaths = [];
+        let staticLibLinks = [];
+
+        if (filters.binary) {
+            libLinks = this.getSharedLibraryLinks(libraries);
+            libPaths = this.getSharedLibraryPathsAsArguments(libraries);
+            staticLibLinks = this.getStaticLibraryLinks(libraries);
+        }
+
+        userOptions = this.filterUserOptions(userOptions) || [];
+        return options.concat(libIncludes, libOptions, libPaths, libLinks, userOptions,
+            [this.filename(inputFilename)], staticLibLinks);
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        const sourceDir = path.dirname(outputFilename);
+        const bitcodeFilename = path.join(sourceDir, this.outputFilebase + '.bc');
+        return [
+            '-cc1',
+            '-debug-info-kind=limited',
+            '-dwarf-version=5',
+            '-debugger-tuning=gdb',
+            '-o', bitcodeFilename,
+        ];
+    }
+
+    getPrimaryOutputFilename(dirPath, outputFilebase) {
+        return path.join(dirPath, `${outputFilebase}.bc`);
+    }
+
+    // TODO: Check this to see if it needs key
+    getOutputFilename(dirPath, outputFilebase) {
+        return path.join(dirPath, `${outputFilebase}.spvasm`);
+    }
+
+    async runCompiler(compiler, options, inputFilename, execOptions) {
+        const sourceDir = path.dirname(inputFilename);
+        const bitcodeFilename = path.join(sourceDir, this.outputFilebase + '.bc');
+
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+        execOptions.customCwd = path.dirname(inputFilename);
+
+        let newOptions = options;
+        newOptions.push('-emit-llvm-bc');
+
+        const bitcode = await this.exec(compiler, newOptions, execOptions);
+        if (bitcode.code !== 0) {
+            logger.error('Bitcode compilation failed', bitcode);
+            bitcode.stdout = utils.parseOutput(bitcode.stdout, bitcodeFilename, execOptions.customCwd);
+            bitcode.stderr = utils.parseOutput(bitcode.stderr, bitcodeFilename, execOptions.customCwd);
+            return bitcode;
+        }
+
+        const spvBinFilename = path.join(sourceDir, this.outputFilebase + '.spv');
+        const translatorFlags = ['-spirv-debug', bitcodeFilename, '-o', spvBinFilename];
+
+        const spvBin = await this.exec(this.translatorPath, translatorFlags, execOptions);
+        if (spvBin.code !== 0) {
+            logger.error('LLVM to SPIR-V translation failed', spvBin);
+            spvBin.stdout = utils.parseOutput(spvBin.stdout, spvBinFilename, execOptions.customCwd);
+            spvBin.stderr = utils.parseOutput(spvBin.stderr, spvBinFilename, execOptions.customCwd);
+            return spvBin;
+        }
+
+        const spvasmFilename = path.join(sourceDir, this.outputFilebase + '.spvasm');
+        const disassemblerFlags = [spvBinFilename,  '-o', spvasmFilename];
+
+        const spvasmOutput = await this.exec(this.disassemblerPath, disassemblerFlags, execOptions);
+        if (spvasmOutput.code !== 0) {
+            logger.error('SPIR-V binary to text failed', spvasmOutput);
+        }
+
+        spvasmOutput.stdout = utils.parseOutput(spvasmOutput.stdout, spvasmFilename, execOptions.customCwd);
+        spvasmOutput.stderr = utils.parseOutput(spvasmOutput.stderr, spvasmFilename, execOptions.customCwd);
+        return spvasmOutput;
+    }
+
+    // TODO: Check the next few functions and clean them up
+    async runCompilerForASTOrIR(compiler, options, inputFilename, execOptions) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+
+        execOptions.customCwd = path.dirname(inputFilename);
+
+        const sourceDir = path.dirname(inputFilename);
+        const outputFile = path.join(sourceDir, this.outputFilebase + '.bc');
+
+        let newOptions = options;
+        newOptions.concat('-S');
+
+        let index = newOptions.indexOf(outputFile);
+        if(index !== -1){
+            newOptions[index] = inputFilename.replace(path.extname(inputFilename), '.ll');
+        }
+
+        return super.runCompiler(compiler, newOptions, inputFilename, execOptions);
+    }
+
+    async generateAST(inputFilename, options) {
+        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics')
+            .concat(['-ast-dump']);
+
+        const execOptions = this.getDefaultExecOptions();
+        execOptions.maxOutput = 1024 * 1024 * 1024;
+
+        return this.llvmAst.processAst(
+            await this.runCompilerForASTOrIR(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions));
+    }
+
+    async generateIR(inputFilename, options, filters) {
+        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics')
+            .concat('-emit-llvm');
+
+        const execOptions = this.getDefaultExecOptions();
+        execOptions.maxOutput = 1024 * 1024 * 1024;
+
+        const output = await this.runCompilerForASTOrIR(
+            this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
+        if (output.code !== 0) {
+            logger.error('Failed to run compiler to get IR code');
+            return output.stderr;
+        }
+        const ir = await this.processIrOutput(output, filters);
+        return ir.asm;
+    }
+}


### PR DESCRIPTION
Closes #2743.

This PR requires https://github.com/compiler-explorer/infra/pull/590.