### PR TITLE
Add Java OpenJDK 17

### DIFF
--- a/etc/config/java.amazon.properties
+++ b/etc/config/java.amazon.properties
@@ -1,7 +1,7 @@
-compilers=&java11:&java12:&java13:&java14:&java15:&java16
+compilers=&java11:&java12:&java13:&java14:&java15:&java16:&java17
 compilerType=java
 versionFlag=-version
-defaultCompiler=java1601
+defaultCompiler=java1700
 demangler=
 postProcess=
 options=
@@ -53,3 +53,10 @@ group.java16.objdumper=/opt/compiler-explorer/jdk-16.0.1/bin/javap
 compiler.java1601.exe=/opt/compiler-explorer/jdk-16.0.1/bin/javac
 compiler.java1601.runtime=/opt/compiler-explorer/jdk-16.0.1/bin/java
 compiler.java1601.semver=16.0.1
+
+group.java17.compilers=java1700
+group.java17.groupName=OpenJDK 17
+group.java17.objdumper=/opt/compiler-explorer/jdk-17/bin/javap
+compiler.java1700.exe=/opt/compiler-explorer/jdk-17/bin/javac
+compiler.java1700.runtime=/opt/compiler-explorer/jdk-17/bin/java
+compiler.java1700.semver=17.0.0

--- a/etc/config/java.amazon.properties
+++ b/etc/config/java.amazon.properties
@@ -56,7 +56,7 @@ compiler.java1601.semver=16.0.1
 
 group.java17.compilers=java1700
 group.java17.groupName=OpenJDK 17
-group.java17.objdumper=/opt/compiler-explorer/jdk-17/bin/javap
-compiler.java1700.exe=/opt/compiler-explorer/jdk-17/bin/javac
-compiler.java1700.runtime=/opt/compiler-explorer/jdk-17/bin/java
+group.java17.objdumper=/opt/compiler-explorer/jdk-17.0.0/bin/javap
+compiler.java1700.exe=/opt/compiler-explorer/jdk-17.0.0/bin/javac
+compiler.java1700.runtime=/opt/compiler-explorer/jdk-17.0.0/bin/java
 compiler.java1700.semver=17.0.0

--- a/etc/config/kotlin.amazon.properties
+++ b/etc/config/kotlin.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&kotlin
 compilerType=kotlin
 versionFlag=-version
-objdumper=/opt/compiler-explorer/jdk-17/bin/javap
+objdumper=/opt/compiler-explorer/jdk-17.0.0/bin/javap
 instructionSet=java
 defaultCompiler=kotlinc1530
 demangler=

--- a/etc/config/kotlin.amazon.properties
+++ b/etc/config/kotlin.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&kotlin
 compilerType=kotlin
 versionFlag=-version
-objdumper=/opt/compiler-explorer/jdk-16.0.1/bin/javap
+objdumper=/opt/compiler-explorer/jdk-17/bin/javap
 instructionSet=java
 defaultCompiler=kotlinc1530
 demangler=

--- a/etc/config/scala.amazon.properties
+++ b/etc/config/scala.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&scala
 compilerType=scala
 versionFlag=-version
-objdumper=/opt/compiler-explorer/jdk-16.0.1/bin/javap
+objdumper=/opt/compiler-explorer/jdk-17/bin/javap
 instructionSet=java
 # Scala 3.0 was recently released, so it's a bit early to make it the default
 defaultCompiler=scalac2136

--- a/etc/config/scala.amazon.properties
+++ b/etc/config/scala.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&scala
 compilerType=scala
 versionFlag=-version
-objdumper=/opt/compiler-explorer/jdk-17/bin/javap
+objdumper=/opt/compiler-explorer/jdk-17.0.0/bin/javap
 instructionSet=java
 # Scala 3.0 was recently released, so it's a bit early to make it the default
 defaultCompiler=scalac2136


### PR DESCRIPTION
Adds an installer for the new OpenJDK 17

Looks like they dropped the semver for the version string so it's just `/opt/compiler-explorer/jdk-17`. I wrote it out as `17.0.0` for consistency, but the actual version name is just `17`... Thoughts?

Infra: https://github.com/compiler-explorer/infra/pull/591