### PR TITLE
Fix missing FormatBase variants in settings.interfaces.ts

### DIFF
--- a/static/settings.interfaces.ts
+++ b/static/settings.interfaces.ts
@@ -35,7 +35,9 @@ type FormatBase =
     | 'LLVM'
     | 'Mozilla'
     | 'Chromium'
-    | 'WebKit';
+    | 'WebKit'
+    | 'Microsoft'
+    | 'GNU';
 
 export interface SiteSettings {
     autoCloseBrackets: boolean;


### PR DESCRIPTION
Follow up to #2926 

Extends the FormatBase type to include the new Clang Format base styles.
