### PR TITLE
Bind duplicate selection to Ctrl + D

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -776,6 +776,10 @@ Editor.prototype.initEditorActions = function () {
     this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.F9, _.bind(function () {
         this.editor.getAction('editor.action.formatDocument').run();
     }, this));
+
+    this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_D, _.bind(function () {
+        this.editor.getAction('editor.action.duplicateSelection').run();
+    }, this));
 };
 
 Editor.prototype.searchOnCppreference = function (ed) {


### PR DESCRIPTION
Closes #2955

This re-binds the Monaco duplicate selection (or line) action to Ctrl + D
