### PR TITLE
Respect tab width and tabs/spaces settings for format APIs

### DIFF
--- a/docs/AddingAFormatter.md
+++ b/docs/AddingAFormatter.md
@@ -15,8 +15,8 @@
     ```
   - The value returned by `key` above corresponds to the `type` property you set in the compiler-explorer properties
      configuration file.
-  - Tweak `format(args, source)`, `getDefaultArguments()`, `getStyleArguments(style)` and `isValidStyle(style)` as
-     necessary
+  - Tweak `format(source, options)` and `isValidStyle(style)` as necessary. See the JSDoc for `format` and the
+     implementations for other formatters to get a further understanding of how to implement `format(source, options)`.
 * Add your `TypeFormatter` to `lib/formatters/_all.js` in alphabetical order
 
 * You can check the output of http://localhost:10240/api/formats to be sure your formatter is there.

--- a/lib/base-formatter.js
+++ b/lib/base-formatter.js
@@ -29,23 +29,30 @@ export class BaseFormatter {
         this.formatterInfo = formatterInfo;
     }
 
-    async format(args, source) {
+    /**
+     * Format the provided source code using the formatting tool.
+     *
+     * This function should construct the final arguments passed to the tool
+     * executable.
+     *
+     * Optionally accept a third argument to respect other formatting options.
+     * The possible options passed are as follows:
+     *
+     * interface AdditionalFormatOptions {
+     *     useSpaces: boolean;
+     *     tabWidth: number;
+     *     baseStyle: string;
+     * }
+     */
+    async format(source, options) {
+        const args = [`--style=${options.baseStyle}`];
         return await exec.execute(this.formatterInfo.exe, args, {input: source});
     }
 
-    getDefaultArguments() {
-        return [];
-    }
-
-    getStyleArguments(style) {
-        return [`--style=${style}`];
-    }
-
+    /**
+     * Test if a formatting base style is valid for this formatter
+     */
     isValidStyle(style) {
         return this.formatterInfo.styles.includes(style);
-    }
-
-    isOneTrueStyle() {
-        return this.formatterInfo.styles.length === 0;
     }
 }

--- a/lib/formatters/clang-format.js
+++ b/lib/formatters/clang-format.js
@@ -23,7 +23,16 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import { BaseFormatter } from '../base-formatter';
+import * as exec from '../exec';
 
 export class ClangFormatFormatter extends BaseFormatter {
-    static get key() { return 'clangformat'; }
+    static get key() {
+        return 'clangformat';
+    }
+
+    async format(source, options) {
+        const tabText = options.useSpaces ? 'Never' : 'AlignWithSpaces';
+        const arg = `{BasedOnStyle: ${options.baseStyle}, IndentWidth: ${options.tabWidth}, UseTab: ${tabText}}`;
+        return await exec.execute(this.formatterInfo.exe, [`--style=${arg}`], {input: source});
+    }
 }

--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -68,28 +68,32 @@ export class FormattingHandler {
     async handle(req, res) {
         const name = req.params.tool;
         const formatter = this.formatters[name];
+        // Ensure the formatter exists
         if (!formatter) {
             return res.status(422).send({
                 exit: 2,
                 answer: `Unknown format tool '${name}'`,
             });
         }
+        // Ensure there is source code to format
         if (!req.body || !req.body.source) {
             return res.send({exit: 0, answer: ''});
         }
-        const args = [...formatter.getDefaultArguments()];
-        if (!formatter.isOneTrueStyle()) {
-            const style = req.body.base;
-            if (!formatter.isValidStyle(style)) {
-                return res.status(422).send({
-                    exit: 3,
-                    answer: `Style '${style}' is not supported`,
-                });
-            }
-            args.concat(...formatter.getStyleArguments(style));
+        // Ensure the wanted style is valid for the formatter
+        const style = req.body.base;
+        if (!formatter.isValidStyle(style)) {
+            return res.status(422).send({
+                exit: 3,
+                answer: `Style '${style}' is not supported`,
+            });
         }
         try {
-            const result = await formatter.format(args, req.body.source);
+            // Perform the actual formatting
+            const result = await formatter.format(req.body.source, {
+                useSpaces: req.body.useSpaces,
+                tabWidth: req.body.tabWidth,
+                baseStyle: req.body.base,
+            });
             res.send({
                 exit: result.code,
                 answer: result.stdout || '',

--- a/static/formatter-registry.interfaces.ts
+++ b/static/formatter-registry.interfaces.ts
@@ -22,25 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BaseFormatter } from '../base-formatter';
-import * as exec from '../exec';
-
-export class RustFmtFormatter extends BaseFormatter {
-    static get key() { return 'rustfmt'; }
-
-    async format(source, options) {
-        const args = [
-            '--emit', 'stdout',
-            '--config', `hard_tabs=${options.useSpaces ? 'false' : 'true'}`,
-            '--config', `tab_spaces=${options.tabWidth}`,
-        ];
-        return await exec.execute(this.formatterInfo.exe, args, {input: source});
-    }
-
-    /**
-     * Rust format only has one style.
-     */
-    isValidStyle() {
-        return true;
-    }
+export interface FormatRequestOptions {
+    source: string;
+    formatterId: string;
+    base: string;
+    tabWidth: number;
+    useSpaces: boolean;
 }

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -9,6 +9,7 @@
 	"files": [
 		"alert.interfaces.ts",
 		"alert.ts",
+		"formatter-registry.interfaces.ts",
 		"formatter-registry.ts",
 		"global.ts",
 		"lib-utils.ts",

--- a/test/base-formatter-tests.js
+++ b/test/base-formatter-tests.js
@@ -33,7 +33,6 @@ describe('Basic formatter functionality', () => {
             type: 'foofmt',
             version: 'foobar-format 1.0.0',
         });
-        fmt.isOneTrueStyle().should.equal(true);
         fmt.isValidStyle('foostyle').should.equal(false);
         fmt.formatterInfo.styles.should.deep.equal([]);
     });
@@ -46,9 +45,7 @@ describe('Basic formatter functionality', () => {
             type: 'foofmt',
             version: 'foobar-format 1.0.0',
         });
-        fmt.isOneTrueStyle().should.equal(false);
         fmt.isValidStyle('foostyle').should.equal(true);
         fmt.formatterInfo.styles.should.deep.equal(['foostyle']);
-        fmt.getStyleArguments('foostyle').should.deep.equal(['--style=foostyle']);
     });
 });


### PR DESCRIPTION
Fixes #2770 

Site settings for tab width and tabs vs spaces are now being used when sent to the /api/format APIs.

This patch also includes some tiny internal refactoring on the bits related to the formatting API.