### PR TITLE
Warn if Execution Only is added for compiler without execution

### DIFF
--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -218,6 +218,12 @@ Executor.prototype.compile = function (bypassCache) {
 };
 
 Executor.prototype.compileFromEditorSource = function (options, bypassCache) {
+    if (!this.compiler.supportsExecute) {
+        this.alertSystem.notify('This compiler (' + this.compiler.name + ') does not support execution', {
+            group: 'execution',
+        });
+        return;
+    }
     this.compilerService.expand(this.source).then(_.bind(function (expanded) {
         var request = {
             source: expanded || '',


### PR DESCRIPTION
Partial fix for #2960 

Shows a warning in the alert system and cancels the execution request if the compiler does not support execution.

**As discussed on Discord:**
A more ideal approach would be to completely disable the "Execution only" button from the UI if the compiler doesn't execute.