### PR TITLE
2967: Escape string that gets passed as custom output filename

### DIFF
--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -171,7 +171,7 @@ export class Tree {
     }
 
     private getCustomOutputFilename(): string {
-        return this.customOutputFilenameInput.val();
+        return _.escape(this.customOutputFilenameInput.val());
     }
 
     public currentState(): TreeState {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
This PR fixes #2967 an XSS vulnerability in the custom output file input text, by escaping any html that gets passed in