### PR TITLE
Implement LLVM IR output for ispc

### DIFF
--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -29,12 +29,23 @@ import { ISPCParser } from './argument-parsers';
 export class ISPCCompiler extends BaseCompiler {
     static get key() { return 'ispc'; }
 
+    constructor(info, env) {
+        super(info, env);
+        this.compiler.supportsIrView = true;
+        this.compiler.irArg = ['--emit-llvm-text'];
+    }
+
     optionsForFilter(filters, outputFilename) {
         let options = ['--target=avx2-i32x8', '--emit-asm', '-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary) {
             options = options.concat(this.compiler.intelAsm.split(' '));
         }
         return options;
+    }
+
+    async generateIR(inputFilename, options, filters) {
+        const newOptions = [...options, ...this.compiler.irArg, '-o', this.getIrOutputFilename(inputFilename)];
+        return super.generateIR(inputFilename, newOptions, filters);
     }
 
     getArgumentParser() {


### PR DESCRIPTION
Fixes #2970 

Implements LLVM IR output for the ispc compiler as requested in #2970 

![image](https://user-images.githubusercontent.com/42585241/135239218-250461fd-4aad-43fd-9708-5ced7e292cac.png)
