### PR TITLE
Add new version of KVX compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -774,11 +774,15 @@ compiler.arm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
+group.kalray.compilers=kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
 
 # kvx versions are different from the GCC they wrap
+compiler.kvxg941_v460.exe=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-g++
+compiler.kvxg941_v460.name=KVX gcc 9.4 (ACB 4.6.0)
+compiler.kvxg941_v460.semver=9.4.1
+compiler.kvxg941_v460.objdumper=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-objdump
 compiler.kvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-g++
 compiler.kvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
 compiler.kvxg750_v440.semver=7.5.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -664,10 +664,14 @@ compiler.carm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
+compiler.ckvxg941_v460.exe=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-gcc
+compiler.ckvxg941_v460.name=KVX gcc 9.4 (ACB 4.6.0)
+compiler.ckvxg941_v460.semver=9.4.1
+compiler.ckvxg941_v460.objdumper=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-objdump
 compiler.ckvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-gcc
 compiler.ckvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
 compiler.ckvxg750_v440.semver=7.5.0


### PR DESCRIPTION
KVX GCC is now based on GCC 9.4.1.
Release ACB 4.6.0 available at: https://github.com/kalray/build-scripts/releases/tag/v4.6.0