### PR TITLE
Unconditionally use the compilation queue

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx
+compilers=&gcc86:&icc:&icx:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx
 defaultCompiler=g112
 demangler=/opt/compiler-explorer/gcc-11.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.2.0/bin/objdump

--- a/etc/config/compiler-explorer.beta.properties
+++ b/etc/config/compiler-explorer.beta.properties
@@ -3,6 +3,3 @@ httpRoot=/beta
 storageSolution=s3
 motdUrl=/motd/motd-beta.json
 sentryEnvironment=beta
-cacheConfig=
-executableCacheConfig=
-compilerCacheConfig=

--- a/etc/config/compiler-explorer.beta.properties
+++ b/etc/config/compiler-explorer.beta.properties
@@ -3,3 +3,6 @@ httpRoot=/beta
 storageSolution=s3
 motdUrl=/motd/motd-beta.json
 sentryEnvironment=beta
+cacheConfig=
+executableCacheConfig=
+compilerCacheConfig=

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -234,7 +234,7 @@ export class BaseCompiler {
         return {mtime: this.mtime, compiler, args, options};
     }
 
-    async execCompilerCached(compiler, args, options, useExecutionQueue) {
+    async execCompilerCached(compiler, args, options) {
         if (!options) {
             options = this.getDefaultExecOptions();
             options.timeoutMs = 0;
@@ -244,9 +244,7 @@ export class BaseCompiler {
         const key = this.getCompilerCacheKey(compiler, args, options);
         let result = await this.env.compilerCacheGet(key);
         if (!result) {
-            const doExecute = async () => exec.execute(compiler, args, options);
-
-            result = await (useExecutionQueue ? this.env.enqueue(doExecute) : doExecute());
+            result = await this.env.enqueue(async () => exec.execute(compiler, args, options));
             if (result.okToCache)
                 this.env.compilerCachePut(key, result);
         }
@@ -1723,7 +1721,7 @@ Please select another pass or change filters.`;
     }
 
     getVersion() {
-        logger.info(`Gathering ${this.compiler.id} version information on ${this.compiler.exe}`);
+        logger.info(`Gathering ${this.compiler.id} version information on ${this.compiler.exe}...`);
         if (this.compiler.explicitVersion) {
             logger.debug(`${this.compiler.id} has forced version output: ${this.compiler.explicitVersion}`);
             return {stdout: [this.compiler.explicitVersion], stderr: [], code: 0};
@@ -1734,7 +1732,7 @@ Please select another pass or change filters.`;
         execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         try {
-            return this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions, true);
+            return this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions);
         } catch (err) {
             logger.error(`Unable to get version for compiler '${this.compiler.exe}' - ${err}`);
             return null;
@@ -1782,7 +1780,9 @@ Please select another pass or change filters.`;
 
         this.initialiseLibraries(clientOptions);
 
-        return this.getArgumentParser().parse(this);
+        const initResult = await this.getArgumentParser().parse(this);
+        logger.info(`${compiler} ${version} is ready`);
+        return initResult;
     }
 
     getInfo() {

--- a/lib/compilation-queue.js
+++ b/lib/compilation-queue.js
@@ -22,10 +22,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { default as Queue } from 'p-queue';
+import {executionAsyncId} from 'async_hooks';
+
+import {default as Queue} from 'p-queue';
 
 export class CompilationQueue {
     constructor(concurrency, timeout) {
+        this._running = new Set();
         this._queue = new Queue({
             concurrency,
             timeout,
@@ -40,7 +43,22 @@ export class CompilationQueue {
     }
 
     enqueue(job) {
-        return this._queue.add(job);
+        const enqueueAsyncId = executionAsyncId();
+        // If we're asked to enqueue a job when we're already in a async queued job context, just run it.
+        // This prevents a deadlock.
+        if (this._running.has(enqueueAsyncId))
+            return job();
+        return this._queue.add(() => {
+            const jobAsyncId = executionAsyncId();
+            if (this._running.has(jobAsyncId))
+                throw new Error('somehow we entered the context twice');
+            try {
+                this._running.add(jobAsyncId);
+                return job();
+            } finally {
+                this._running.delete(jobAsyncId);
+            }
+        });
     }
 
     status() {


### PR DESCRIPTION
* Always use the compilation queue, which ensures we don't
  execute more native apps thn are configured, especially while
  we're starting up.
* Guard the compilation queue from enqueueing stuff that was
  already executing in a queue context. This is to prevent deadlock
  though it's not always a problem (it's only if the caller awaits
  the job, which is often the case).

Should mitigate the issues we had on Sep 30 2021, where nodes were
having trouble starting up due to the large amount of JVM-based
compilers. See #2977

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
