### PR TITLE
Enable GCC dump for the GNAT Ada compiler

### DIFF
--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -32,7 +32,6 @@ export class AdaCompiler extends BaseCompiler {
 
     constructor(info, env) {
         super(info, env);
-        this.supportsOptOutput = false;
         this.compiler.supportsGccDump = true;
         this.compiler.supportsIntel = true;
     }

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -33,6 +33,7 @@ export class AdaCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
         this.supportsOptOutput = false;
+        this.compiler.supportsGccDump = true;
         this.compiler.supportsIntel = true;
     }
 


### PR DESCRIPTION
GNAT is part of GCC and can handle the regular GCC options for dump files.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>