### PR TITLE
Convert colour.js to typescript

### DIFF
--- a/static/colour.ts
+++ b/static/colour.ts
@@ -24,11 +24,21 @@
 
 'use strict';
 
-var _ = require('underscore');
-var monaco = require('monaco-editor');
+import _ from 'underscore';
+import * as monaco from 'monaco-editor';
+
+/**
+ * A colour scheme
+ */
+interface ColourScheme {
+    name: string;
+    desc: string;
+    count: number;
+    themes: string[];
+}
 
 // If you want to use an scheme in every theme, set `theme: ['all']`
-var schemes = [
+export const schemes: ColourScheme[] = [
     { name: 'rainbow', desc: 'Rainbow 1', count: 12, themes: ['default'] },
     { name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default'] },
     { name: 'earth', desc: 'Earth tones (colourblind safe)', count: 9, themes: ['default'] },
@@ -37,13 +47,14 @@ var schemes = [
     { name: 'rainbow-dark', desc: 'Dark Rainbow', count: 12, themes: ['dark'] },
 ];
 
-function applyColours(editor, colours, schemeName, prevDecorations) {
-    var scheme = _.findWhere(schemes, { name: schemeName });
+export function applyColours(editor: monaco.editor.ICodeEditor, colours: number[], schemeName: string, prevDecorations: string[]): string[] {
+    let scheme: ColourScheme = _.findWhere(schemes, { name: schemeName });
     if (!scheme) {
         scheme = schemes[0];
     }
-    var newDecorations = _.map(colours, function (ordinal, line) {
-        line = parseInt(line) + 1;
+
+    const newDecorations = _.map(colours, (ordinal: number, _line: number | string) => {
+        const line: number = parseInt(_line as string) + 1;
         return {
             range: new monaco.Range(line, 1, line, 1),
             options: {
@@ -52,10 +63,6 @@ function applyColours(editor, colours, schemeName, prevDecorations) {
             },
         };
     });
+
     return editor.deltaDecorations(prevDecorations, newDecorations);
 }
-
-module.exports = {
-    applyColours: applyColours,
-    schemes: schemes,
-};

--- a/static/colour.ts
+++ b/static/colour.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
-
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -9,6 +9,7 @@
 	"files": [
 		"alert.interfaces.ts",
 		"alert.ts",
+		"colour.ts",
 		"formatter-registry.interfaces.ts",
 		"formatter-registry.ts",
 		"global.ts",


### PR DESCRIPTION
This will convert ``static/colour.js`` to typescript (see #2981)

Changes are pretty much the same as with the other conversions I did.

Assumed that param ``colours`` in ``applyColours`` is of type ``number[]`` as this is the only fitting type.