### PR TITLE
fix(java): show full asm output when using switch expression

### DIFF
--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -236,6 +236,7 @@ export class JavaCompiler extends BaseCompiler {
             for (const codeLineCandidate of utils.splitLines(codeAndLineNumberTable)) {
                 // Match
                 //       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
+                // Or match the "default: <code>" block inside a lookupswitch instruction   
                 const match = codeLineCandidate.match(/\s+(\d+|default): (.*)/);
                 if (match) {
                     const instrOffset = Number.parseInt(match[1]);
@@ -246,6 +247,8 @@ export class JavaCompiler extends BaseCompiler {
                         text: codeLineCandidate.trimEnd(),
                     });
                 } else {
+                    // Attempt to match the closing } of a lookupswitch. If we don't include the closing bracket, then
+                    // the brackets will be misaligned, and it may be confusing to read.
                     const isClosingCurlyBrace = codeLineCandidate.match(/\s+}/);
                     if (isClosingCurlyBrace) {
                         // Put closing curly brace in asm output

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -246,8 +246,9 @@ export class JavaCompiler extends BaseCompiler {
                         text: codeLineCandidate.trimEnd(),
                     });
                 } else {
-                    const isClosingCurlyBrace = codeLineCandidate.match(/\s+}.*/);
+                    const isClosingCurlyBrace = codeLineCandidate.match(/\s+}/);
                     if (isClosingCurlyBrace) {
+                        // Put closing curly brace in asm output
                         method.instructions.push({
                             text: codeLineCandidate.trimEnd(),
                         });

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -236,7 +236,7 @@ export class JavaCompiler extends BaseCompiler {
             for (const codeLineCandidate of utils.splitLines(codeAndLineNumberTable)) {
                 // Match
                 //       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
-                const match = codeLineCandidate.match(/\s+(\d+): (.*)/);
+                const match = codeLineCandidate.match(/\s+(\d+|default): (.*)/);
                 if (match) {
                     const instrOffset = Number.parseInt(match[1]);
                     method.instructions.push({
@@ -246,6 +246,13 @@ export class JavaCompiler extends BaseCompiler {
                         text: codeLineCandidate.trimEnd(),
                     });
                 } else {
+                    const isClosingCurlyBrace = codeLineCandidate.match(/\s+}.*/);
+                    if (isClosingCurlyBrace) {
+                        method.instructions.push({
+                            text: codeLineCandidate.trimEnd(),
+                        });
+                        continue;
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Issue: #2995

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
