### PR TITLE
Fix Rust MIR view to correctly display unsupported compiler

### DIFF
--- a/static/panes/rustmir-view.ts
+++ b/static/panes/rustmir-view.ts
@@ -78,11 +78,11 @@ export class RustMir extends Pane<monaco.editor.IStandaloneCodeEditor> {
         this.eventHub.emit('requestSettings');
     }
 
-    override onCompileResult(id: unknown, compiler: unknown, result: any): void {
+    override onCompileResult(id: unknown, compiler: any, result: any): void {
         if (this.compilerInfo.compilerId !== id) return;
         if (result.hasRustMirOutput) {
             this.showRustMirResults(result.rustMirOutput);
-        } else {
+        } else if (compiler.supportsRustMirView) {
             this.showRustMirResults([{text: '<No output>'}]);
         }
     }
@@ -93,7 +93,7 @@ export class RustMir extends Pane<monaco.editor.IStandaloneCodeEditor> {
             this.compilerInfo.editorId = editorId;
             this.setTitle();
             if (compiler && !compiler.supportsRustMirView) {
-                this.editor.setValue('<Rust MIR output is not supported for this compiler>');
+                this.showRustMirResults([{text: '<Rust MIR output is not supported for this compiler>'}]);
             }
         }
     }


### PR DESCRIPTION
The pane would still show <no output> for unsupported compiler.
Let the onCompiler callback correctly write the message in case the compiler is
not supported.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>