### PR TITLE
Avoid calling compilerProps after compiler object construction

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -62,6 +62,9 @@ export class BaseCompiler {
 
         this.alwaysResetLdPath = this.env.ceProps('alwaysResetLdPath');
         this.delayCleanupTemp = this.env.ceProps('delayCleanupTemp', false);
+        this.stubRe = new RegExp(this.compilerProps('stubRe'));
+        this.stubText = this.compilerProps('stubText');
+        this.compilerWrapper = this.compilerProps('compiler-wrapper');
 
         if (!this.compiler.options) this.compiler.options = '';
         if (!this.compiler.optArg) this.compiler.optArg = '';
@@ -257,7 +260,7 @@ export class BaseCompiler {
             timeoutMs: this.env.ceProps('compileTimeoutMs', 7500),
             maxErrorOutput: this.env.ceProps('max-error-output', 5000),
             env: this.env.getEnv(this.compiler.needsMulti),
-            wrapper: this.compilerProps('compiler-wrapper'),
+            wrapper: this.compilerWrapper,
         };
     }
 
@@ -1642,8 +1645,8 @@ Please select another pass or change filters.`;
     }
 
     preProcess(source, filters) {
-        if (filters.binary && !new RegExp(this.compilerProps('stubRe')).test(source)) {
-            source += '\n' + this.compilerProps('stubText') + '\n';
+        if (filters.binary && !this.stubRe.test(source)) {
+            source += `\n${this.stubText}\n`;
         }
         return source;
     }

--- a/lib/compilers/crystal.js
+++ b/lib/compilers/crystal.js
@@ -39,6 +39,7 @@ export class CrystalCompiler extends BaseCompiler {
         this.asm = new CrystalAsmParser();
         this.compiler.supportsIrView = true;
         this.compiler.irArg = ['--emit', 'llvm-ir'];
+        this.ccPath = this.compilerProps(`compiler.${this.compiler.id}.cc`);
     }
 
     getSharedLibraryPathsAsArguments() {
@@ -47,9 +48,8 @@ export class CrystalCompiler extends BaseCompiler {
 
     getDefaultExecOptions() {
         const execOptions = super.getDefaultExecOptions();
-        const cc = this.compilerProps(`compiler.${this.compiler.id}.cc`);
-        if (cc) {
-            execOptions.env.CC = cc;
+        if (this.ccPath) {
+            execOptions.env.CC = this.ccPath;
         }
         return execOptions;
     }

--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -41,6 +41,13 @@ export class GolangCompiler extends BaseCompiler {
         return 'golang';
     }
 
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+        this.goroot = this.compilerProps(`compiler.${this.compiler.id}.goroot`);
+        this.goarch = this.compilerProps(`compiler.${this.compiler.id}.goarch`);
+        this.goos = this.compilerProps(`compiler.${this.compiler.id}.goos`);
+    }
+
     convertNewGoL(code) {
         const re = /^\s+(0[Xx]?[\dA-Za-z]+)?\s?(\d+)\s*\(([^:]+):(\d+)\)\s*([A-Z]+)(.*)/;
         const reUnknown = /^\s+(0[Xx]?[\dA-Za-z]+)?\s?(\d+)\s*\(<unknown line number>\)\s*([A-Z]+)(.*)/;
@@ -208,17 +215,14 @@ export class GolangCompiler extends BaseCompiler {
 
     getDefaultExecOptions() {
         const execOptions = super.getDefaultExecOptions();
-        const goroot = this.compilerProps(`compiler.${this.compiler.id}.goroot`);
-        if (goroot) {
-            execOptions.env.GOROOT = goroot;
+        if (this.goroot) {
+            execOptions.env.GOROOT = this.goroot;
         }
-        const goarch = this.compilerProps(`compiler.${this.compiler.id}.goarch`);
-        if (goarch) {
-            execOptions.env.GOARCH = goarch;
+        if (this.goarch) {
+            execOptions.env.GOARCH = this.goarch;
         }
-        const goos = this.compilerProps(`compiler.${this.compiler.id}.goos`);
-        if (goos) {
-            execOptions.env.GOOS = goos;
+        if (this.goos) {
+            execOptions.env.GOOS = this.goos;
         }
         return execOptions;
     }

--- a/lib/compilers/kotlin.js
+++ b/lib/compilers/kotlin.js
@@ -30,11 +30,15 @@ export class KotlinCompiler extends JavaCompiler {
         return 'kotlin';
     }
 
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+        this.javaHome = this.compilerProps(`compiler.${this.compiler.id}.java_home`);
+    }
+
     getDefaultExecOptions() {
         const execOptions = super.getDefaultExecOptions();
-        const javaHome = this.compilerProps(`compiler.${this.compiler.id}.java_home`);
-        if (javaHome) {
-            execOptions.env.JAVA_HOME = javaHome;
+        if (this.javaHome) {
+            execOptions.env.JAVA_HOME = this.javaHome;
         }
 
         return execOptions;

--- a/lib/compilers/python.js
+++ b/lib/compilers/python.js
@@ -34,6 +34,8 @@ export class PythonCompiler extends BaseCompiler {
         super(compilerInfo, env);
         this.compiler.demangler = null;
         this.demanglerClass = null;
+        this.disasmScriptPath =
+            this.compilerProps('disasmScript') || resolvePathFromAppRoot('etc', 'scripts', 'dis_all.py');
     }
 
     // eslint-disable-next-line no-unused-vars
@@ -66,15 +68,9 @@ export class PythonCompiler extends BaseCompiler {
         return {asm: bytecodeResult};
     }
 
-    getDisasmScriptPath() {
-        const script = this.compilerProps('disasmScript');
-
-        return script || resolvePathFromAppRoot('etc', 'scripts', 'dis_all.py');
-    }
-
     optionsForFilter(filters, outputFilename) {
         return ['-I',
-            this.getDisasmScriptPath(),
+            this.disasmScriptPath,
             '--outputfile',
             outputFilename,
             '--inputfile'];

--- a/lib/compilers/ruby.js
+++ b/lib/compilers/ruby.js
@@ -36,6 +36,8 @@ export class RubyCompiler extends BaseCompiler {
         super(compilerInfo, env);
         this.compiler.demangler = null;
         this.demanglerClass = null;
+        this.disasmScriptPath =
+            this.compilerProps('disasmScript') || resolvePathFromAppRoot('etc', 'scripts', 'ruby', 'disasm.rb');
     }
 
     processAsm(result) {
@@ -73,15 +75,9 @@ export class RubyCompiler extends BaseCompiler {
         return {asm: bytecodeResult};
     }
 
-    getDisasmScriptPath() {
-        const script = this.compilerProps('disasmScript');
-
-        return script || resolvePathFromAppRoot('etc', 'scripts', 'ruby', 'disasm.rb');
-    }
-
     optionsForFilter(filters, outputFilename) {
         return [
-            this.getDisasmScriptPath(),
+            this.disasmScriptPath,
             '--outputfile',
             outputFilename,
             '--fname',

--- a/lib/compilers/scala.js
+++ b/lib/compilers/scala.js
@@ -30,11 +30,15 @@ export class ScalaCompiler extends JavaCompiler {
         return 'scala';
     }
 
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+        this.javaHome = this.compilerProps(`compiler.${this.compiler.id}.java_home`);
+    }
+
     getDefaultExecOptions() {
         const execOptions = super.getDefaultExecOptions();
-        const javaHome = this.compilerProps(`compiler.${this.compiler.id}.java_home`);
-        if (javaHome) {
-            execOptions.env.JAVA_HOME = javaHome;
+        if (this.javaHome) {
+            execOptions.env.JAVA_HOME = this.javaHome;
         }
 
         return execOptions;


### PR DESCRIPTION
This isn't exhaustive across the codebase, but it removed all property access after construction directly inside BaseCompiler and all subclasses.

One small step in the direction of separating fleet configuration from instance startup.