### PR TITLE
refactor: replace underscore each usage with native for of

### DIFF
--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -123,7 +123,7 @@ export class ClientOptionsHandler {
 
     parseTools(baseTools) {
         const tools = {};
-        Object.entries(baseTools).map(([lang, forLang]) => {
+        for (const [lang, forLang] of Object.entries(baseTools)){
             if (lang && forLang) {
                 tools[lang] = {};
                 for (const tool of forLang.split(':')) {
@@ -156,7 +156,8 @@ export class ClientOptionsHandler {
                     }
                 }
             }
-        });
+
+        }
         return tools;
     }
 
@@ -170,7 +171,7 @@ export class ClientOptionsHandler {
 
     parseLibraries(baseLibs) {
         const libraries = {};
-        Object.entries(baseLibs).map(([lang, forLang]) => {
+        for (const [lang, forLang] of Object.entries(baseLibs)){
             if (lang && forLang) {
                 libraries[lang] = {};
                 for (const lib of forLang.split(':')) {
@@ -249,7 +250,7 @@ export class ClientOptionsHandler {
                     }
                 }
             }
-        });
+        }
         return libraries;
     }
 
@@ -280,9 +281,10 @@ export class ClientOptionsHandler {
         const copiedCompilers = JSON.parse(JSON.stringify(compilers));
         let semverGroups = {};
         // Reset the supportsExecute flag in case critical compilers change
-        Object.keys(this.options.languages).map(key => {
+
+        for (const key of Object.keys(this.options.languages)){
             this.options.languages[key].supportsExecute = false;
-        });
+        }
 
         for (const [compilersKey, compiler] of copiedCompilers.entries()) {
             if (compiler.supportsExecute) {
@@ -296,18 +298,19 @@ export class ClientOptionsHandler {
                 });
                 semverGroups[compiler.group].splice(index, 0, compiler);
             }
-            Object.keys(compiler).map(propKey => {
+
+            for (const propKey of Object.keys(compiler)){
                 if (forbiddenKeys.has(propKey)) {
                     delete copiedCompilers[compilersKey][propKey];
                 }
-            });
+            }
         }
 
-        Object.values(semverGroups).map(group => {
+        for (const group of Object.values(semverGroups)){
             let order = 0;
             // Set $order to -index on array. As group is an array, iteration order is guaranteed.
             for (const compiler of group)  compiler['$order'] = -order++;
-        });
+        }
 
         this.options.compilers = copiedCompilers;
         this._updateOptionsHash();


### PR DESCRIPTION
### Description

The PR replaces instances of `_.each` to `for of` and `Obejct.keys`. Closes https://github.com/compiler-explorer/compiler-explorer/issues/3003

Request to please check the complete functionality of the app.