### PR TITLE
Introduce whatwg-fetch as fetch polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16475,6 +16475,11 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "underscore": "^1.13.1",
     "url-join": "^4.0.1",
     "vis": "4.20.1",
+    "whatwg-fetch": "^3.6.2",
     "which": "^2.0.2",
     "winston": "^3.3.3",
     "winston-loki": "^6.0.2",

--- a/static/main.js
+++ b/static/main.js
@@ -27,6 +27,7 @@
 // setup analytics before anything else so we can capture any future errors in sentry
 var analytics = require('./analytics').ga;
 
+require('whatwg-fetch');
 // eslint-disable-next-line requirejs/no-js-extension
 require('popper.js');
 require('bootstrap');


### PR DESCRIPTION
As previously discussed on Discord, we would like to phase out JQuery's ajax methods for fetch.

For those unaware, fetch is a modern, promise-based API for sending HTTP requests from the browser (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

This patch introduces whatwg-fetch as the polyfill for fetch, as well as installing it inside the main script.