### PR TITLE
Fix ansi-to-html background color regression

### DIFF
--- a/static/ansi-to-html.ts
+++ b/static/ansi-to-html.ts
@@ -156,7 +156,7 @@ function handleDisplay(stack: string[], _code: string | number, options: AnsiToH
         23: () => closeTag(stack, 'i'),
         24: () => closeTag(stack, 'u'),
         39: () => pushForegroundColor(stack, options.fg),
-        49: () => pushForegroundColor(stack, options.bg),
+        49: () => pushBackgroundColor(stack, options.bg),
     };
 
     if (codeMap[code]) {


### PR DESCRIPTION
As reported and verified in #3018, I introduced a regression in the ansi-to-html code which would set the foreground color equal to the background color.

Fixes #3018 