### PR TITLE
Decouple each pane state from the base pane state

### DIFF
--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -38,7 +38,7 @@ import * as utils from '../utils';
  * Type parameter E indicates which monaco editor kind this pane hosts. Common
  * values are monaco.editor.IDiffEditor and monaco.ICodeEditor
  */
-export abstract class Pane<E extends monaco.editor.IEditor> {
+export abstract class Pane<E extends monaco.editor.IEditor, S extends {}> {
     compilerInfo: PaneCompilerState;
     container: Container;
     domRoot: JQuery;
@@ -57,7 +57,7 @@ export abstract class Pane<E extends monaco.editor.IEditor> {
      *
      * Overridable for implementors
      */
-    protected constructor(hub: any /* Hub */, container: Container, state: BasePaneState) {
+    protected constructor(hub: any /* Hub */, container: Container, state: S & BasePaneState) {
         this.container = container;
         this.eventHub = hub.createEventHub();
         this.domRoot = container.getElement();
@@ -120,14 +120,14 @@ export abstract class Pane<E extends monaco.editor.IEditor> {
     abstract registerOpeningAnalyticsEvent(): void
 
     /** Optionally overridable code for initializing pane buttons */
-    registerButtons(state: BasePaneState /* typeof state */): void {}
+    registerButtons(state: S): void {}
 
     /** Optionally overridable code for initializing event callbacks */
     registerCallbacks(): void {}
 
     abstract getPaneName(): string;
     abstract onCompiler(id: number, compiler: any, options: any, editorId: number): void;
-    abstract onCompileResult(id: unknown, compiler: unknown, result: unknown): void;
+    abstract onCompileResult(id: number, compiler: unknown, result: unknown): void;
     abstract close(): void;
 
     /** Initialize standard lifecycle hooks */
@@ -147,7 +147,7 @@ export abstract class Pane<E extends monaco.editor.IEditor> {
         this.container.setTitle(this.getPaneName());
     }
 
-    protected onCompilerClose(id: unknown) {
+    protected onCompilerClose(id: number) {
         if (this.compilerInfo.compilerId === id) {
             _.defer(() => this.container.close());
         }

--- a/static/panes/rustmacroexp-view.interfaces.ts
+++ b/static/panes/rustmacroexp-view.interfaces.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+export interface RustMacroExpState {
+    rustMacroExpOutput: any;
+}

--- a/static/panes/rustmacroexp-view.ts
+++ b/static/panes/rustmacroexp-view.ts
@@ -28,16 +28,13 @@ import { Container } from 'golden-layout';
 
 import { Pane } from './pane';
 import { BasePaneState } from './pane.interfaces';
+import { RustMacroExpState } from './rustmacroexp-view.interfaces';
 
 import ga from '../analytics';
 import { extendConfig } from '../monaco-config';
 
-export interface RustMacroExpState extends BasePaneState {
-    rustMacroExpOutput: any;
-}
-
-export class RustMacroExp extends Pane<monaco.editor.IStandaloneCodeEditor> {
-    constructor(hub: any, container: Container, state: RustMacroExpState) {
+export class RustMacroExp extends Pane<monaco.editor.IStandaloneCodeEditor, RustMacroExpState> {
+    constructor(hub: any, container: Container, state: RustMacroExpState & BasePaneState) {
         super(hub, container, state);
         if (state && state.rustMacroExpOutput) {
             this.showRustMacroExpResults(state.rustMacroExpOutput);
@@ -78,7 +75,7 @@ export class RustMacroExp extends Pane<monaco.editor.IStandaloneCodeEditor> {
         this.eventHub.emit('requestSettings');
     }
 
-    override onCompileResult(id: unknown, compiler: any, result: any): void {
+    override onCompileResult(id: number, compiler: any, result: any): void {
         if (this.compilerInfo.compilerId !== id) return;
         if (result.hasRustMacroExpOutput) {
             this.showRustMacroExpResults(result.rustMacroExpOutput);

--- a/static/panes/rustmir-view.interfaces.ts
+++ b/static/panes/rustmir-view.interfaces.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+export interface RustMirState {
+    rustMirOutput: any;
+}

--- a/static/panes/rustmir-view.ts
+++ b/static/panes/rustmir-view.ts
@@ -28,16 +28,13 @@ import { Container } from 'golden-layout';
 
 import { Pane } from './pane';
 import { BasePaneState } from './pane.interfaces';
+import { RustMirState } from './rustmir-view.interfaces';
 
 import ga from '../analytics';
 import { extendConfig } from '../monaco-config';
 
-export interface RustMirState extends BasePaneState {
-    rustMirOutput: any;
-}
-
-export class RustMir extends Pane<monaco.editor.IStandaloneCodeEditor> {
-    constructor(hub: any, container: Container, state: RustMirState) {
+export class RustMir extends Pane<monaco.editor.IStandaloneCodeEditor, RustMirState> {
+    constructor(hub: any, container: Container, state: RustMirState & BasePaneState) {
         super(hub, container, state);
         if (state && state.rustMirOutput) {
             this.showRustMirResults(state.rustMirOutput);


### PR DESCRIPTION
Decouples the individual initial pane states for each pane from the BasePaneState type.

This will allow easier re-use of the state the various constructors receive (see https://github.com/compiler-explorer/compiler-explorer/pull/2993#issuecomment-940456445)

Non-functional change.