### PR TITLE
Fix IAR EWB implementation to work on Linux and tweak its ARM support

### DIFF
--- a/lib/asm-parser-ewavr.js
+++ b/lib/asm-parser-ewavr.js
@@ -35,11 +35,11 @@ export class AsmEWAVRParser extends AsmParser {
         this.lineNumberComment = /^\/\/\s*(\d+)\s(?!bytes).*/;
 
         // categories of directives. remove if filters.directives set
-        this.segmentBegin = /^\s*(ASEG|ASEGN|COMMON|RSEG|STACK)\s*([A-Z_a-z][\w():]*)/;
-        this.segmentControl = /^\s*(ALIGN|EVEN|ODD|ORG)/;
+        this.segmentBegin = /^\s*(ASEG|ASEGN|COMMON|RSEG|STACK|SECTION)\s*(.[\w():]*)/;
+        this.segmentControl = /^\s*(ALIGN|EVEN|ODD|ORG|SECTION_GROUP|SECTION_TYPE|DATA)/;
         this.definesGlobal = /^\s*(EXTERN|EXTRN|IMPORT|EXPORT|PUBWEAK|PUBLIC)\s+(.+)$/;
         this.definesLocal = /^\s*((ASSIGN|DEFINE|LOCAL|ALIAS|EQU|VAR)|(([A-Z_a-z]\w*)=.+))$/;
-        this.miscDirective = /^\s*(NAME|MODULE|PROGRAM|LIBRARY|ERROR|END|CASEOFF|CASEON|CFI|COL|RADIX)/;
+        this.miscDirective = /^\s*(NAME|MODULE|PROGRAM|LIBRARY|ERROR|END|CASEOFF|CASEON|CFI|COL|RADIX|THUMB)/;
 
         // NOTE: Compiler generated labels can have spaces in them, but are quoted and in <>
         this.labelDef = /^`?\?*<?([A-Z_a-z][\w :]*)>?`?:$/;


### PR DESCRIPTION
This PR on the one hand adds Linux support to the IAR EWB implementation. Previously, it only worked with Windows paths.
On the other hand the PR also tweaks the ARM implementation (e.g. recognizing section and thumb directives).
