### PR TITLE
Add Crystal 1.2.0

### DIFF
--- a/etc/config/crystal.amazon.properties
+++ b/etc/config/crystal.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&crystal
-defaultCompiler=crystal11
+defaultCompiler=crystal12
 
-group.crystal.compilers=crystal11:crystal10:crystal036:crystal035:crystal034:crystal033:crystal032:crystal031:crystal030:crystal029
+group.crystal.compilers=crystal12:crystal11:crystal10:crystal036:crystal035:crystal034:crystal033:crystal032:crystal031:crystal030:crystal029
 group.crystal.isSemVer=true
 group.crystal.baseName=Crystal
 group.crystal.groupName=Crystal x86-64
@@ -10,6 +10,9 @@ group.crystal.supportsExecute=true
 group.crystal.compilerType=crystal
 group.crystal.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
+compiler.crystal12.semver=1.2.0
+compiler.crystal12.exe=/opt/compiler-explorer/crystal-1.2.0/bin/crystal
+compiler.crystal12.cc=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.crystal11.semver=1.1.1
 compiler.crystal11.exe=/opt/compiler-explorer/crystal-1.1.1/bin/crystal
 compiler.crystal11.cc=/opt/compiler-explorer/gcc-snapshot/bin/gcc


### PR DESCRIPTION
Related: compiler-explorer/infra#610

A fully filtered blank file now produces 3203 lines of assembly output, compared to 13397 in the previous compiler version.