### PR TITLE
Make Alert.enterSomething's yes callback's type includes the answer

### DIFF
--- a/static/alert.interfaces.ts
+++ b/static/alert.interfaces.ts
@@ -39,6 +39,11 @@ export interface AlertAskOptions {
     onClose?: () => void;
 }
 
+export type AlertEnterTextOptions = {
+    /** The enter text action returns a value which is captured here */
+    yes?: (answer: string) => void;
+} & Partial<Pick<AlertAskOptions, 'no' | 'yesHtml' | 'yesClass' | 'noHtml' | 'noClass' | 'onClose'>>;
+
 export interface AlertNotifyOptions {
     /**
      * Which group this notification is from. Sets data-group attribute value

--- a/static/alert.ts
+++ b/static/alert.ts
@@ -24,7 +24,7 @@
 
 import $ from 'jquery';
 
-import { AlertAskOptions, AlertNotifyOptions } from "./alert.interfaces";
+import { AlertAskOptions, AlertEnterTextOptions, AlertNotifyOptions } from './alert.interfaces';
 
 export class Alert {
     yesHandler: (answer?: string | string[] | number) => void | null = null;
@@ -137,7 +137,7 @@ export class Alert {
     /**
      * Asks the user a two choice question, where the title, content and buttons are customizable
      */
-    enterSomething(title: string, question: string, defaultValue: string, askOptions: AlertAskOptions) {
+    enterSomething(title: string, question: string, defaultValue: string, askOptions: AlertEnterTextOptions) {
         const modal = $('#enter-something');
         this.yesHandler = askOptions?.yes ?? (() => undefined);
         this.noHandler = askOptions?.no ?? (() => undefined);

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -475,7 +475,7 @@ export class MultifileService {
 
         return new Promise((resolve) => {
             this.alertSystem.enterSomething('Rename file', 'Please enter new filename', suggestedFilename, {
-                yes: (value) => {
+                yes: (value: string) => {
                     if (value !== '' && value[0] !== '/') {
                         if (!this.fileExists(value, file)) {
                             file.filename = value;


### PR DESCRIPTION
(waiting for CppCon to merge)

The Alert component was not typed to have the `yes` callback handler accept the string which was entered by the user.

NFC - TypeScript only change