### PR TITLE
Refactor GCC dump and GNAT expanded code creation

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -359,6 +359,80 @@ export class BaseCompiler {
         return fn;
     }
 
+    // Returns a list of additional options that may be required by some backend options.
+    // Meant to be overloaded by compiler classes.
+    // Default handles the GCC compiler with some debug dump enabled.
+    optionsForBackend(backendOptions){
+        const addOpts = [];
+
+        if (backendOptions.produceGccDump && backendOptions.produceGccDump.opened
+            && this.compiler.supportsGccDump) {
+            addOpts.push('-fdump-passes');
+            const gccDumpOptions = backendOptions.produceGccDump;
+
+            // Build dump options to append to the end of the -fdump command-line flag.
+            // GCC accepts these options as a list of '-' separated names that may
+            // appear in any order.
+            let flags = '';
+            if (gccDumpOptions.dumpFlags.address !== false) {
+                flags += '-address';
+            }
+            if (gccDumpOptions.dumpFlags.slim !== false) {
+                flags += '-slim';
+            }
+            if (gccDumpOptions.dumpFlags.raw !== false) {
+                flags += '-raw';
+            }
+            if (gccDumpOptions.dumpFlags.details !== false) {
+                flags += '-details';
+            }
+            if (gccDumpOptions.dumpFlags.stats !== false) {
+                flags += '-stats';
+            }
+            if (gccDumpOptions.dumpFlags.blocks !== false) {
+                flags += '-blocks';
+            }
+            if (gccDumpOptions.dumpFlags.vops !== false) {
+                flags += '-vops';
+            }
+            if (gccDumpOptions.dumpFlags.lineno !== false) {
+                flags += '-lineno';
+            }
+            if (gccDumpOptions.dumpFlags.uid !== false) {
+                flags += '-uid';
+            }
+            if (gccDumpOptions.dumpFlags.all !== false) {
+                flags += '-all';
+            }
+
+            // If we want to remove the passes that won't produce anything from the
+            // drop down menu, we need to ask for all dump files and see what's
+            // really created. This is currently only possible with regular GCC, not
+            // for compilers that us libgccjit. The later can't easily move dump
+            // files outside of the tempdir created on the fly.
+            if (this.compiler.removeEmptyGccDump){
+                if (gccDumpOptions.treeDump !== false) {
+                    addOpts.push('-fdump-tree-all' + flags);
+                }
+                if (gccDumpOptions.rtlDump !== false) {
+                    addOpts.push('-fdump-rtl-all' + flags);
+                }
+                if (gccDumpOptions.ipaDump !== false) {
+                    addOpts.push('-fdump-ipa-all' + flags);
+                }
+            } else {
+                // If not dumping everything, create a specific command like
+                // -fdump-tree-fixup_cfg1-some-flags=stdout
+                if (gccDumpOptions.pass) {
+                    const dumpCmd = gccDumpOptions.pass.command_prefix + flags + '=stdout';
+                    addOpts.push(dumpCmd);
+                }
+            }
+        }
+
+        return addOpts;
+    }
+
     optionsForFilter(filters, outputFilename) {
         let options = ['-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary) {
@@ -568,6 +642,8 @@ export class BaseCompiler {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
         backendOptions = backendOptions || {};
 
+        options = options.concat(this.optionsForBackend(backendOptions));
+
         if (this.compiler.options) {
             options = options.concat(utils.splitArguments(this.compiler.options));
         }
@@ -730,19 +806,11 @@ export class BaseCompiler {
         return this.getOutputFilename(dirPath, outputFilebase, key);
     }
 
-    async generateGnatDebug(inputFilename, options) {
+    async processGnatDebugOutput(inputFilename, output) {
         const gnatDebugPath = this.getGnatDebugOutputFilename(inputFilename);
 
-        // currently hardcode the flag but should really be a user parameter
-        const newoptions = options.concat (['-gnatDGL']);
-
-        const execOptions = this.getDefaultExecOptions();
-        execOptions.maxOutput = 1024 * 1024 * 1024;
-
-        const output = await this.runCompiler(this.compiler.exe, newoptions, this.filename(inputFilename),
-                                              execOptions);
         if (output.code !== 0) {
-            return [{text: 'Failed to run compiler to get GNAT Debug Tree'}];
+            return [{text: 'Failed to run compiler => no GNAT Expanded code'}];
         }
         if (await fs.exists(gnatDebugPath)) {
             const content = await fs.readFile(gnatDebugPath, 'utf-8');
@@ -776,83 +844,6 @@ export class BaseCompiler {
             };
         else
             return null;
-    }
-
-    getGccDumpOptions(gccDumpOptions, removeEmptyPasses) {
-        const addOpts = ['-fdump-passes'];
-        // Build dump options to append to the end of the -fdump command-line flag.
-        // GCC accepts these options as a list of '-' separated names that may
-        // appear in any order.
-        let flags = '';
-        if (gccDumpOptions.dumpFlags.address !== false) {
-            flags += '-address';
-        }
-        if (gccDumpOptions.dumpFlags.slim !== false) {
-            flags += '-slim';
-        }
-        if (gccDumpOptions.dumpFlags.raw !== false) {
-            flags += '-raw';
-        }
-        if (gccDumpOptions.dumpFlags.details !== false) {
-            flags += '-details';
-        }
-        if (gccDumpOptions.dumpFlags.stats !== false) {
-            flags += '-stats';
-        }
-        if (gccDumpOptions.dumpFlags.blocks !== false) {
-            flags += '-blocks';
-        }
-        if (gccDumpOptions.dumpFlags.vops !== false) {
-            flags += '-vops';
-        }
-        if (gccDumpOptions.dumpFlags.lineno !== false) {
-            flags += '-lineno';
-        }
-        if (gccDumpOptions.dumpFlags.uid !== false) {
-            flags += '-uid';
-        }
-        if (gccDumpOptions.dumpFlags.all !== false) {
-            flags += '-all';
-        }
-
-        // If we want to remove the passes that won't produce anything from the
-        // drop down menu, we need to ask for all dump files and see what's
-        // really created. This is currently only possible with regular GCC, not
-        // for compilers that us libgccjit. The later can't easily move dump
-        // files outside of the tempdir created on the fly.
-        if (removeEmptyPasses){
-            if (gccDumpOptions.treeDump !== false) {
-                addOpts.push('-fdump-tree-all' + flags);
-            }
-            if (gccDumpOptions.rtlDump !== false) {
-                addOpts.push('-fdump-rtl-all' + flags);
-            }
-            if (gccDumpOptions.ipaDump !== false) {
-                addOpts.push('-fdump-ipa-all' + flags);
-            }
-        } else {
-            // If not dumping everything, create a specific command like
-            // -fdump-tree-fixup_cfg1-some-flags=stdout
-            if (gccDumpOptions.pass) {
-                const dumpCmd = gccDumpOptions.pass.command_prefix + flags + '=stdout';
-                addOpts.push(dumpCmd);
-            }
-        }
-
-        return addOpts;
-    }
-
-    async generateGccDump(inputFilename, options, gccDumpOptions, removeEmptyPasses) {
-        const newOptions = options.concat(this.getGccDumpOptions(gccDumpOptions, removeEmptyPasses));
-
-        const execOptions = this.getDefaultExecOptions();
-        // A higher max output is needed for when the user includes headers
-        execOptions.maxOutput = 1024 * 1024 * 1024;
-
-        return this.processGccDumpOutput(
-            gccDumpOptions,
-            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions),
-            removeEmptyPasses);
     }
 
     async checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters) {
@@ -1202,8 +1193,6 @@ export class BaseCompiler {
         const [
             asmResult,
             astResult,
-            gccDumpResult,
-            gnatDebugResult,
             irResult,
             rustMirResult,
             rustMacroExpResult,
@@ -1211,10 +1200,6 @@ export class BaseCompiler {
         ] = await Promise.all([
             this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
             (makeAst ? this.generateAST(inputFilename, options) : ''),
-            (makeGccDump ? this.generateGccDump(inputFilename, options,
-                                                backendOptions.produceGccDump,
-                                                this.compiler.removeEmptyGccDump) : ''),
-            (makeGnatDebug ? this.generateGnatDebug(inputFilename, options) : ''),
             (makeIr ? this.generateIR(inputFilename, options, filters) : ''),
             (makeRustMir ? this.generateRustMir(inputFilename, options) : ''),
             (makeRustMacroExp ? this.generateRustMacroExpansion(inputFilename, options) : ''),
@@ -1224,6 +1209,17 @@ export class BaseCompiler {
                 outputFilename,
             }))),
         ]);
+
+        // Both GNAT and GCC can produce their dump/expanded code files along
+        // with the main compilation command.
+        const gnatDebugResult = (makeGnatDebug ?
+                                 await this.processGnatDebugOutput(inputFilenameSafe, asmResult)
+                                 : '');
+        const gccDumpResult = (makeGccDump ?
+                               await this.processGccDumpOutput(backendOptions.produceGccDump,
+                                                               asmResult, this.compiler.removeEmptyGccDump)
+                               : '');
+
         asmResult.dirPath = dirPath;
         asmResult.compilationOptions = options;
         asmResult.downloads = downloads;

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -46,6 +46,16 @@ export class AdaCompiler extends BaseCompiler {
         return path.join(dirPath, 'example.o');
     }
 
+    optionsForBackend(backendOptions){
+        // super is needed as it handles the GCC Dump files.
+        const opts = super.optionsForBackend (backendOptions);
+
+        if (backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugView)
+            opts.push('-gnatDGL');
+
+        return opts;
+    }
+
     optionsForFilter(filters, outputFilename) {
         let options = [];
 


### PR DESCRIPTION
Instead of having a dedicated invocation of the compilers, inject needed options
in the main compilation command and do everything in one run. This should fix
GNAT race condition on ALI file, save some CPU time and make the latency a bit
better. This can work as long as everything can really be done in one run (eg.
no incompatible options, no clash on stdout/stderr).

Add optionsForBackend in base compiler class that is meant to be overloaded by
compilers for injecting options based on current backend options. Use it for
GCC dumps (BaseCompiler) and GNAT expanded code.

Fixes #3041
References #3029