### PR TITLE
Implemement backwards compatability for Format API after #2957

### DIFF
--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -95,13 +95,13 @@ export class FormattingHandler {
         try {
             // Perform the actual formatting
             const result = await formatter.format(req.body.source, {
-                useSpaces: req.body.useSpaces,
-                tabWidth: req.body.tabWidth,
+                useSpaces: req.body.useSpaces ? req.body.useSpaces : true,
+                tabWidth: req.body.tabWidth ? req.body.tabWidth: 4,
                 baseStyle: req.body.base,
             });
             res.send({
                 exit: result.code,
-                answer: result.stdout || '',
+                answer: result.stdout || result.stderr || '',
             });
         } catch (err) {
             res.status(500).send({

--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -25,8 +25,8 @@
 import _ from 'underscore';
 
 import * as exec from '../exec';
-import { getFormatterTypeByKey } from '../formatters';
-import { logger } from '../logger';
+import {getFormatterTypeByKey} from '../formatters';
+import {logger} from '../logger';
 
 export class FormattingHandler {
     constructor(ceProps) {
@@ -95,8 +95,8 @@ export class FormattingHandler {
         try {
             // Perform the actual formatting
             const result = await formatter.format(req.body.source, {
-                useSpaces: req.body.useSpaces ? req.body.useSpaces : true,
-                tabWidth: req.body.tabWidth ? req.body.tabWidth: 4,
+                useSpaces: req.body.useSpaces !== undefined ? req.body.useSpaces : true,
+                tabWidth: req.body.tabWidth !== undefined ? req.body.tabWidth : 4,
                 baseStyle: req.body.base,
             });
             res.send({

--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -25,8 +25,8 @@
 import _ from 'underscore';
 
 import * as exec from '../exec';
-import {getFormatterTypeByKey} from '../formatters';
-import {logger} from '../logger';
+import { getFormatterTypeByKey } from '../formatters';
+import { logger } from '../logger';
 
 export class FormattingHandler {
     constructor(ceProps) {


### PR DESCRIPTION
Fixes #3065 

The `useSpaces` and `tabWidth` fields now have defaults.