### PR TITLE
    Await for things

### DIFF
--- a/app.js
+++ b/app.js
@@ -557,7 +557,7 @@ async function main() {
         metricsServer.get('/metrics', async (req, res) => {
             try {
                 res.set('Content-Type', PromClient.register.contentType);
-                res.end(await PromClient.register.metrics());
+                res.end(PromClient.register.metrics());
             } catch (ex) {
                 res.status(500).end(ex);
             }

--- a/etc/scripts/docenizer-java.js
+++ b/etc/scripts/docenizer-java.js
@@ -105,4 +105,4 @@ const main = async () => {
     console.log('}');
 };
 
-main();
+main().then(() =>{}).catch(e => console.exception("Caught error", e));

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -248,8 +248,15 @@ export class BaseCompiler {
         let result = await this.env.compilerCacheGet(key);
         if (!result) {
             result = await this.env.enqueue(async () => exec.execute(compiler, args, options));
-            if (result.okToCache)
-                this.env.compilerCachePut(key, result);
+            if (result.okToCache) {
+                this.env.compilerCachePut(key, result)
+                    .then(() => {
+                        // Do nothing, but we don't await here.
+                    })
+                    .catch(e => {
+                        logger.info('Uncaught exception caching compilation results', e);
+                    });
+            }
         }
 
         return result;

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -110,7 +110,7 @@ export class GCCParser extends BaseParser {
             GCCParser.getOptions(compiler, '-fsyntax-only --help=optimizers'),
         ]);
         const options = Object.assign({}, ...results);
-        this.setCompilerSettingsFromOptions(compiler, options);
+        await this.setCompilerSettingsFromOptions(compiler, options);
         return compiler;
     }
 
@@ -147,7 +147,7 @@ export class ClangParser extends BaseParser {
 
     static async parse(compiler) {
         const options = await ClangParser.getOptions(compiler, '--help');
-        this.setCompilerSettingsFromOptions(compiler, options);
+        await this.setCompilerSettingsFromOptions(compiler, options);
         return compiler;
     }
 }
@@ -169,7 +169,7 @@ export class ISPCParser extends BaseParser {
 
     static async parse(compiler) {
         const options = await ISPCParser.getOptions(compiler, '--help');
-        this.setCompilerSettingsFromOptions(compiler, options);
+        await this.setCompilerSettingsFromOptions(compiler, options);
         return compiler;
     }
 
@@ -290,7 +290,7 @@ export class RustParser extends BaseParser {
             RustParser.getOptions(compiler, '--help -v'),
         ]);
         const options = Object.assign({}, ...results);
-        this.setCompilerSettingsFromOptions(compiler, options);
+        await this.setCompilerSettingsFromOptions(compiler, options);
         return compiler;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3737,7 +3737,8 @@
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -16144,9 +16145,16 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
+            "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
             "wrap-ansi": "^5.1.0"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
@@ -16163,6 +16171,17 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -16195,6 +16214,7 @@
             "require-directory": "^2.1.1",
             "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.2"
@@ -16323,6 +16343,7 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
+            "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
             "wrap-ansi": "^5.1.0"
           },
@@ -16352,6 +16373,12 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "fsevents": {
           "version": "1.2.13",
@@ -16413,6 +16440,34 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -16453,6 +16508,7 @@
             "require-directory": "^2.1.1",
             "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.2"

--- a/static/load-save.js
+++ b/static/load-save.js
@@ -50,7 +50,12 @@ function LoadSave() {
     this.editorText = '';
     this.extension = '.txt';
     this.base = window.httpRoot;
-    this.fetchBuiltins();
+    this.fetchBuiltins()
+        .then(function () {
+        })
+        .catch(function () {
+            // swallow up errors
+        });
 }
 
 LoadSave.prototype.initializeIfNeeded = function () {
@@ -179,8 +184,8 @@ LoadSave.prototype.onSaveToBrowserStorage = function () {
         this.modal.modal('hide');
         this.alertSystem.ask(
             'Replace current?',
-            "Do you want to replace the existing saved file '" + name + "'?",
-            { yes: done });
+            'Do you want to replace the existing saved file \'' + name + '\'?',
+            {yes: done});
     } else {
         done();
         this.modal.modal('hide');
@@ -199,7 +204,7 @@ LoadSave.prototype.onSaveToFile = function (fileEditor) {
         var name = fileLang !== undefined && fileEditor !== undefined ?
             (fileLang + ' Editor #' + fileEditor + ' ') : '';
         saveAs(
-            new Blob([this.editorText], { type: 'text/plain;charset=utf-8' }),
+            new Blob([this.editorText], {type: 'text/plain;charset=utf-8'}),
             'Compiler Explorer ' + name + 'Code' + this.extension);
         return true;
     } catch (e) {
@@ -222,4 +227,4 @@ LoadSave.prototype.doLoad = function (element) {
 };
 
 
-module.exports = { LoadSave: LoadSave };
+module.exports = {LoadSave: LoadSave};

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -133,7 +133,7 @@ export class MultifileService {
 
         const zip = await JSZip.loadAsync(f);
 
-        zip.forEach(async (relativePath, zipEntry) => {
+        await Promise.all(zip.map(async (relativePath, zipEntry) => {
             if (!zipEntry.dir) {
                 let removeFromName = 0;
                 if (relativePath.indexOf(zipFilename + '/') === 0) {
@@ -167,7 +167,7 @@ export class MultifileService {
                 this.addFile(file);
                 callback(file);
             }
-        });
+        }));
     }
 
     public async saveProjectToZipfile(callback: (any) => void) {
@@ -389,7 +389,7 @@ export class MultifileService {
         if (file.filename === '') {
             const isRenamed = await this.renameFile(fileId);
             if (isRenamed) {
-                this.includeByFileId(fileId);
+                await this.includeByFileId(fileId);
             } else {
                 file.isIncluded = false;
             }

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -481,19 +481,19 @@ export class Tree {
         const addEditorButton = this.domRoot.find('.add-editor');
         const saveProjectButton = this.domRoot.find('.save-project-to-file');
 
-        saveProjectButton.on('click', () => {
-            this.multifileService.saveProjectToZipfile(Tree.triggerSaveAs.bind(this));
+        saveProjectButton.on('click', async () => {
+            await this.multifileService.saveProjectToZipfile(Tree.triggerSaveAs.bind(this));
         });
 
         const loadProjectFromFile = this.domRoot.find('.load-project-from-file');
-        loadProjectFromFile.on('change', (e) => {
+        loadProjectFromFile.on('change', async (e) => {
             const files = e.target.files;
             if (files.length > 0) {
                 this.multifileService.forEachFile((file: MultifileFile) => {
                     this.removeFile(file.fileId);
                 });
 
-                this.multifileService.loadProjectFromFile(files[0], (file: MultifileFile) => {
+                await this.multifileService.loadProjectFromFile(files[0], (file: MultifileFile) => {
                     this.refresh();
                     if (file.filename === 'CMakeLists.txt') {
                         // todo: find a way to toggle on CMake checkbox...

--- a/test/cache-tests.js
+++ b/test/cache-tests.js
@@ -133,8 +133,8 @@ describe('Multi caches', () => {
         const subCache1 = new InMemoryCache('test', 1);
         const subCache2 = new InMemoryCache('test', 1);
         // Set up caches with deliberately skew values for the same key.
-        subCache1.put('a key', 'cache1');
-        subCache2.put('a key', 'cache2');
+        await subCache1.put('a key', 'cache1');
+        await subCache2.put('a key', 'cache2');
         const cache = new MultiCache('test', subCache1, subCache2);
         await cache.get('a key').should.eventually.eql({hit: true, data: Buffer.from('cache1')});
 


### PR DESCRIPTION
 We had a number of things that aren't await()ing their promises.
 That led to non-deterministic compiler settings like Intel support.
 I used the IDE to find them all and fix the ones that I thought looked
 important.
  
 More generally we should use tslint (once we're all typescript) to
 ensure this more generally. I tried the eslint equivalent but it
 either overreacted or didn't catch anything.
  
 Closes #3085
