### PR TITLE
Actually use the setting style in the format api

### DIFF
--- a/static/formatter-registry.interfaces.ts
+++ b/static/formatter-registry.interfaces.ts
@@ -22,10 +22,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import { FormatBase } from './settings.interfaces';
+
 export interface FormatRequestOptions {
     source: string;
     formatterId: string;
-    base: string;
+    /**
+     * Specifies which formatting preset to use. "__DefaultStyle" means the
+     * formatter doesn't have style presets, and that the backend should
+     * ignore the "base" option.
+     */
+    base: FormatBase | '__DefaultStyle';
     tabWidth: number;
     useSpaces: boolean;
 }

--- a/static/settings.interfaces.ts
+++ b/static/settings.interfaces.ts
@@ -30,7 +30,7 @@ type ColourScheme =
     | 'gray-shade'
     | 'rainbow-dark';
 
-type FormatBase =
+export type FormatBase =
     | 'Google'
     | 'LLVM'
     | 'Mozilla'


### PR DESCRIPTION
Fixes #3089

The formatter-registry will now use the site settings when querying the Format API. For compilers that do not support multiple styles, __DefeaultStyle is passed.