### PR TITLE
Set Java default encoding to UTF-8

### DIFF
--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -100,6 +100,8 @@ export class JavaCompiler extends BaseCompiler {
 
         return [
             '-Xlint:all',
+            '-encoding',
+            'utf8',
         ];
     }
 


### PR DESCRIPTION
Fixes #3093 

The default encoding used for Java is now UTF-8. This did not have to be changed for the Scala or Kotlin compilers as those already default to UTF-8

https://godbolt.org/z/de16Y1TqM (Kotlin)
https://godbolt.org/z/Tf4Po8cf4 (Scala)