### PR TITLE
Honor compiler flags in rustc MIR output view

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -26,6 +26,7 @@ import path from 'path';
 
 import * as compilerOptInfo from 'compiler-opt-info';
 import fs from 'fs-extra';
+import nopt from 'nopt';
 import temp from 'temp';
 import _ from 'underscore';
 
@@ -640,20 +641,12 @@ export class BaseCompiler {
         };
     }
 
-    async generateRustMir(inputFilename) {
-        // These arguments make Rustc produce the Rust MIR
+    async generateRustMir(outputFilename, inputFilename, options) {
         const execOptions = this.getDefaultExecOptions();
         // TODO: reconsider this value
         execOptions.maxOutput = 1024 ** 3;
-        const mirPath = this.getRustMirOutputFilename(inputFilename);
-        const rustcOptions = [
-            inputFilename,
-            '-o',
-            mirPath,
-            '--emit=mir',
-            '--crate-type',
-            'rlib',
-        ];
+        const rustcOptions = [...options, '--emit', 'mir'];
+        const mirPath = this.getRustMirOutputFilename(rustcOptions, outputFilename);
 
         const output = await this.runCompiler(this.compiler.exe, rustcOptions, this.filename(inputFilename),
             execOptions);
@@ -699,8 +692,20 @@ export class BaseCompiler {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
     }
 
-    getRustMirOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.mir');
+    getRustMirOutputFilename(rustcOptions, outputFilename) {
+        // If the `--emit` flag is specified multiple times alongside with `-o`, rustc will "infer"
+        // the name for each output from the provided output name, e.g.:
+        // `rustc -o output.with.ext --emit=mir --emit=asm input.rs`
+        // generates output.mir and output.s
+        let emits = nopt({emit: Array}, {}, rustcOptions, 0).emit;
+        let non_mir_emits = _.filter(emits, emit => emit !== 'mir').length > 0;
+        if (non_mir_emits) {
+            let basename = path.basename(outputFilename).split('.')[0] + '.mir';
+            let dirname = path.dirname(outputFilename);
+            return path.join(dirname, basename);
+        } else {
+            return outputFilename;
+        }
     }
 
     getGnatDebugOutputFilename(inputFilename) {
@@ -1216,7 +1221,7 @@ export class BaseCompiler {
                                                 this.compiler.removeEmptyGccDump) : ''),
             (makeGnatDebug ? this.generateGnatDebug(inputFilename, options) : ''),
             (makeIr ? this.generateIR(inputFilename, options, filters) : ''),
-            (makeRustMir ? this.generateRustMir(inputFilename, options) : ''),
+            (makeRustMir ? this.generateRustMir(outputFilename, inputFilename, options) : ''),
             (makeRustMacroExp ? this.generateRustMacroExpansion(inputFilename, options) : ''),
             Promise.all(this.runToolsOfType(tools, 'independent', this.getCompilationInfo(key, {
                 inputFilename,


### PR DESCRIPTION
There are a bunch of flags that affect the genererated mir (`-Copt-level`, `-Coverflow-checks`, `-Cpanic`, ...).  This PR appends the compiler flags when generating the mir output. Alternatively, one could add a way to add specific flags to the MIR view but I thought honoring the main compiler flags would be more consistent with the way the  LLVM IR view works. On the downside, this could change the behavior of old links.

I didn't add any test, but I'll be happy to with some direction :)
