### PR TITLE
Enable the GCC dump for the rustc using GCC backend

### DIFF
--- a/lib/compilers/rustc-cg-gcc.js
+++ b/lib/compilers/rustc-cg-gcc.js
@@ -32,6 +32,21 @@ export class RustcCgGCCCompiler extends RustCompiler {
     constructor(info, env) {
         super(info, env);
         this.compiler.supportsIrView = false;
+
+        // Enable GCC dump code,
+        this.compiler.supportsGccDump = true;
+
+        // but do not try to filter out empty dumps:
+        // This filtering needs to dump all files but currently libgccjit (used by
+        // this rustc backend) and compiler-explorer's use of jails makes this task a bit tricky.
+        // The user will be presented more dumps than effectively created.
+        // Turning this to 'true' will break the dumps.
+
+        this.compiler.removeEmptyGccDump = false;
+    }
+
+    getGccDumpOptions(gccDumpOptions, removeEmptyPasses){
+        return [ '-C' , 'llvm-args=' + super.getGccDumpOptions(gccDumpOptions, removeEmptyPasses).join(' ')];
     }
 
     optionsForFilter(filters, outputFilename, userOptions) {


### PR DESCRIPTION
Beware that the way it is working causes several dump files to be empty. The
list of potential files is based on `-fdump-passes` output, but during the
actual compilation, some passes may or may not emit something (eg. a passe may
not be executed at all because it's not applicable). The drop down list will
contain some dump names that will simply display message like:

   Pass 'cselim (tree)' was requested
   but nothing was dumped. Possible causes are:
    - pass is not valid in this (maybe you changed the compiler options);
    - pass is valid but did not emit anything (eg. it was not executed).

This is expected and until someone has a better idea, this will be the case :)

fixes: #2868
Signed-off-by: Marc Poulhiès <dkm@kataplop.net>