### PR TITLE
Add Crystal 1.2.2

### DIFF
--- a/etc/config/crystal.amazon.properties
+++ b/etc/config/crystal.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&crystal
-defaultCompiler=crystal12
+defaultCompiler=crystal122
 
-group.crystal.compilers=crystal12:crystal11:crystal10:crystal036:crystal035:crystal034:crystal033:crystal032:crystal031:crystal030:crystal029
+group.crystal.compilers=crystal122:crystal12:crystal11:crystal10:crystal036:crystal035:crystal034:crystal033:crystal032:crystal031:crystal030:crystal029
 group.crystal.isSemVer=true
 group.crystal.baseName=Crystal
 group.crystal.groupName=Crystal x86-64
@@ -10,6 +10,9 @@ group.crystal.supportsExecute=true
 group.crystal.compilerType=crystal
 group.crystal.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
+compiler.crystal122.semver=1.2.2
+compiler.crystal122.exe=/opt/compiler-explorer/crystal-1.2.2/bin/crystal
+compiler.crystal122.cc=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.crystal12.semver=1.2.0
 compiler.crystal12.exe=/opt/compiler-explorer/crystal-1.2.0/bin/crystal
 compiler.crystal12.cc=/opt/compiler-explorer/gcc-snapshot/bin/gcc


### PR DESCRIPTION
Requires compiler-explorer/infra#630. Should also fix the link failures with 1.2.0.