### PR TITLE
Filter fdump-passes output from stderr before displaying

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1690,6 +1690,8 @@ export class BaseCompiler {
         let dumpFileName;
         let passFound = false;
 
+        const filtered_stderr = [];
+        const toRemoveFromStderr = /^\s*((ipa|tree|rtl)-)|(\*)([\w-]+).*(ON|OFF)$/;
         for (const obj of Object.values(result.stderr)) {
             const selectizeObject = this.fromInternalGccDumpName(obj.text, selectedPasses);
             if (selectizeObject){
@@ -1710,7 +1712,12 @@ export class BaseCompiler {
 
                 output.all.push(selectizeObject);
             }
+
+            if (!toRemoveFromStderr.test(obj.text)){
+                filtered_stderr.push(obj);
+            }
         }
+        result.stderr = filtered_stderr;
 
         if (opts.pass && passFound){
             output.currentPassOutput = '';


### PR DESCRIPTION
The refactor from #3024 left all the output from -fdump-passes in
stderr. Filter it out before displaying it in the output pane.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>