### PR TITLE
Honour rustc flags when emitting MIR and emit both assembly and MIR in the same execution

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -26,6 +26,7 @@ import path from 'path';
 
 import * as compilerOptInfo from 'compiler-opt-info';
 import fs from 'fs-extra';
+import nopt from 'nopt';
 import temp from 'temp';
 import _ from 'underscore';
 
@@ -716,20 +717,12 @@ export class BaseCompiler {
         };
     }
 
-    async generateRustMir(inputFilename) {
-        // These arguments make Rustc produce the Rust MIR
+    async generateRustMir(outputFilename, inputFilename, options) {
         const execOptions = this.getDefaultExecOptions();
         // TODO: reconsider this value
         execOptions.maxOutput = 1024 ** 3;
-        const mirPath = this.getRustMirOutputFilename(inputFilename);
-        const rustcOptions = [
-            inputFilename,
-            '-o',
-            mirPath,
-            '--emit=mir',
-            '--crate-type',
-            'rlib',
-        ];
+        const rustcOptions = [...options, '--emit', 'mir'];
+        const mirPath = this.getRustMirOutputFilename(rustcOptions, outputFilename);
 
         const output = await this.runCompiler(this.compiler.exe, rustcOptions, this.filename(inputFilename),
             execOptions);
@@ -775,8 +768,20 @@ export class BaseCompiler {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
     }
 
-    getRustMirOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.mir');
+    getRustMirOutputFilename(rustcOptions, outputFilename) {
+        // If the `--emit` flag is specified multiple times alongside with `-o`, rustc will "infer"
+        // the name for each output from the provided output name, e.g.:
+        // `rustc -o output.with.ext --emit=mir --emit=asm input.rs`
+        // generates output.mir and output.s
+        let emits = nopt({emit: Array}, {}, rustcOptions, 0).emit;
+        let non_mir_emits = _.filter(emits, emit => emit !== 'mir').length > 0;
+        if (non_mir_emits) {
+            let basename = path.basename(outputFilename).split('.')[0] + '.mir';
+            let dirname = path.dirname(outputFilename);
+            return path.join(dirname, basename);
+        } else {
+            return outputFilename;
+        }
     }
 
     getGnatDebugOutputFilename(inputFilename) {
@@ -1201,7 +1206,7 @@ export class BaseCompiler {
             this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
             (makeAst ? this.generateAST(inputFilename, options) : ''),
             (makeIr ? this.generateIR(inputFilename, options, filters) : ''),
-            (makeRustMir ? this.generateRustMir(inputFilename, options) : ''),
+            (makeRustMir ? this.generateRustMir(outputFilename, inputFilename, options) : ''),
             (makeRustMacroExp ? this.generateRustMacroExpansion(inputFilename, options) : ''),
             Promise.all(this.runToolsOfType(tools, 'independent', this.getCompilationInfo(key, {
                 inputFilename,

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -26,7 +26,6 @@ import path from 'path';
 
 import * as compilerOptInfo from 'compiler-opt-info';
 import fs from 'fs-extra';
-import nopt from 'nopt';
 import temp from 'temp';
 import _ from 'underscore';
 
@@ -362,6 +361,7 @@ export class BaseCompiler {
 
     // Returns a list of additional options that may be required by some backend options.
     // Meant to be overloaded by compiler classes.
+    // Called with 2 parameters: backendOptions and outputFilename.
     // Default handles the GCC compiler with some debug dump enabled.
     optionsForBackend(backendOptions){
         const addOpts = [];
@@ -643,7 +643,7 @@ export class BaseCompiler {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
         backendOptions = backendOptions || {};
 
-        options = options.concat(this.optionsForBackend(backendOptions));
+        options = options.concat(this.optionsForBackend(backendOptions, outputFilename));
 
         if (this.compiler.options) {
             options = options.concat(utils.splitArguments(this.compiler.options));
@@ -717,15 +717,8 @@ export class BaseCompiler {
         };
     }
 
-    async generateRustMir(outputFilename, inputFilename, options) {
-        const execOptions = this.getDefaultExecOptions();
-        // TODO: reconsider this value
-        execOptions.maxOutput = 1024 ** 3;
-        const rustcOptions = [...options, '--emit', 'mir'];
-        const mirPath = this.getRustMirOutputFilename(rustcOptions, outputFilename);
-
-        const output = await this.runCompiler(this.compiler.exe, rustcOptions, this.filename(inputFilename),
-            execOptions);
+    async processRustMirOutput(outputFilename, options, output) {
+        const mirPath = this.getRustMirOutputFilename(outputFilename);
         if (output.code !== 0) {
             return [{text: 'Failed to run compiler to get Rust MIR'}];
         }
@@ -766,22 +759,6 @@ export class BaseCompiler {
 
     getIrOutputFilename(inputFilename) {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
-    }
-
-    getRustMirOutputFilename(rustcOptions, outputFilename) {
-        // If the `--emit` flag is specified multiple times alongside with `-o`, rustc will "infer"
-        // the name for each output from the provided output name, e.g.:
-        // `rustc -o output.with.ext --emit=mir --emit=asm input.rs`
-        // generates output.mir and output.s
-        let emits = nopt({emit: Array}, {}, rustcOptions, 0).emit;
-        let non_mir_emits = _.filter(emits, emit => emit !== 'mir').length > 0;
-        if (non_mir_emits) {
-            let basename = path.basename(outputFilename).split('.')[0] + '.mir';
-            let dirname = path.dirname(outputFilename);
-            return path.join(dirname, basename);
-        } else {
-            return outputFilename;
-        }
     }
 
     getGnatDebugOutputFilename(inputFilename) {
@@ -1199,14 +1176,12 @@ export class BaseCompiler {
             asmResult,
             astResult,
             irResult,
-            rustMirResult,
             rustMacroExpResult,
             toolsResult,
         ] = await Promise.all([
             this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
             (makeAst ? this.generateAST(inputFilename, options) : ''),
             (makeIr ? this.generateIR(inputFilename, options, filters) : ''),
-            (makeRustMir ? this.generateRustMir(outputFilename, inputFilename, options) : ''),
             (makeRustMacroExp ? this.generateRustMacroExpansion(inputFilename, options) : ''),
             Promise.all(this.runToolsOfType(tools, 'independent', this.getCompilationInfo(key, {
                 inputFilename,
@@ -1215,7 +1190,7 @@ export class BaseCompiler {
             }))),
         ]);
 
-        // Both GNAT and GCC can produce their dump/expanded code files along
+        // GNAT, GCC and rustc can produce their extra output files along
         // with the main compilation command.
         const gnatDebugResult = (makeGnatDebug ?
                                  await this.processGnatDebugOutput(inputFilenameSafe, asmResult)
@@ -1223,6 +1198,9 @@ export class BaseCompiler {
         const gccDumpResult = (makeGccDump ?
                                await this.processGccDumpOutput(backendOptions.produceGccDump,
                                                                asmResult, this.compiler.removeEmptyGccDump)
+                               : '');
+        const rustMirResult = (makeRustMir ?
+                               await this.processRustMirOutput(outputFilename, options, asmResult)
                                : '');
 
         asmResult.dirPath = dirPath;

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -717,7 +717,7 @@ export class BaseCompiler {
         };
     }
 
-    async processRustMirOutput(outputFilename, options, output) {
+    async processRustMirOutput(outputFilename, output) {
         const mirPath = this.getRustMirOutputFilename(outputFilename);
         if (output.code !== 0) {
             return [{text: 'Failed to run compiler to get Rust MIR'}];
@@ -1200,7 +1200,7 @@ export class BaseCompiler {
                                                                asmResult, this.compiler.removeEmptyGccDump)
                                : '');
         const rustMirResult = (makeRustMir ?
-                               await this.processRustMirOutput(outputFilename, options, asmResult)
+                               await this.processRustMirOutput(outputFilename, asmResult)
                                : '');
 
         asmResult.dirPath = dirPath;

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -46,9 +46,9 @@ export class AdaCompiler extends BaseCompiler {
         return path.join(dirPath, 'example.o');
     }
 
-    optionsForBackend(backendOptions){
+    optionsForBackend(backendOptions, outputFilename){
         // super is needed as it handles the GCC Dump files.
-        const opts = super.optionsForBackend (backendOptions);
+        const opts = super.optionsForBackend (backendOptions, outputFilename);
 
         if (backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugView)
             opts.push('-gnatDGL');

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -45,7 +45,19 @@ export class RustCompiler extends BaseCompiler {
         this.linker = this.compilerProps('linker');
     }
 
+    getRustMirOutputFilename(outputFilename) {
+        return outputFilename.replace(path.extname(outputFilename), '.mir');
+    }
+
     getSharedLibraryPathsAsArguments() {
+        return [];
+    }
+
+    optionsForBackend(backendOptions, outputFilename) {
+        if (backendOptions.produceRustMir && this.compiler.supportsRustMirView) {
+            const of = this.getRustMirOutputFilename(outputFilename);
+            return ['--emit', `mir=${of}`];
+        }
         return [];
     }
 


### PR DESCRIPTION
The initial change from @nilehmann in #3107 has been refactored to simplify the rustc execution. It is now only called once instead of once for each output.