### PR TITLE
Remove unused wolfy87-eventemitter dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16781,11 +16781,6 @@
         }
       }
     },
-    "wolfy87-eventemitter": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
-      "integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw=="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "winston-loki": "6.0.1",
     "winston-papertrail": "^1.0.5",
     "winston-transport": "^4.4.0",
-    "wolfy87-eventemitter": "^5.2.9",
     "yaml": "^1.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This dependency doesn't appear to be used anywhere. It was introduced in 70556a6c6597ac6c112497f1b3c4b07a4a3e1d9c as a event emitter replacement, but we're not using it anywhere in the codebase anymore.