### PR TITLE
Show GNAT expanded code pane even in case of compiler error

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -809,16 +809,22 @@ export class BaseCompiler {
     async processGnatDebugOutput(inputFilename, output) {
         const gnatDebugPath = this.getGnatDebugOutputFilename(inputFilename);
 
-        if (output.code !== 0) {
-            return [{text: 'Failed to run compiler => no GNAT Expanded code'}];
-        }
+        // Do not check compiler result before looking for expanded code. The
+        // compiler may exit with an error after the emission. This file is also
+        // very usefull to debug error message.
         if (await fs.exists(gnatDebugPath)) {
             const content = await fs.readFile(gnatDebugPath, 'utf-8');
             return content.split('\n').map((line) => ({
                 text: line,
             }));
+        } else {
+            // check for possible cause for missing file
+            if (output.code !== 0) {
+                return [{text: 'GNAT exited with an error and did not create the expanded code'}];
+            } else {
+                return [{text: 'GNAT exited successfully but the expanded code is missing, something is wrong'}];
+            }
         }
-        return [{text: 'Internal error; unable to open output path'}];
     }
 
     /**


### PR DESCRIPTION
Even when the compiler exits with an error, try to display the expanded
code.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>