### PR TITLE
update gcc and clang in default properties

### DIFF
--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -1,7 +1,7 @@
 # Default settings for C++
 compilers=&gcc:&clang
 
-group.gcc.compilers=g44:g45:g46:g47:g48:g5:g6:g7:g8:gdefault
+group.gcc.compilers=g44:g45:g46:g47:g48:g5:g6:g7:g8:g9:g10:g11:gdefault
 compiler.g44.exe=/usr/bin/g++-4.4
 compiler.g44.name=g++ 4.4
 compiler.g45.exe=/usr/bin/g++-4.5
@@ -20,10 +20,16 @@ compiler.g7.exe=/usr/bin/g++-7
 compiler.g7.name=g++ 7.x
 compiler.g8.exe=/usr/bin/g++-8
 compiler.g8.name=g++ 8.x
+compiler.g9.exe=/usr/bin/g++-9
+compiler.g9.name=g++ 9.x
+compiler.g10.exe=/usr/bin/g++-10
+compiler.g10.name=g++ 10.x
+compiler.g11.exe=/usr/bin/g++-11
+compiler.g11.name=g++ 11.x
 compiler.gdefault.exe=/usr/bin/g++
 compiler.gdefault.name=g++ default
 
-group.clang.compilers=clang7:clang8:clang9:clang10:clangdefault
+group.clang.compilers=clang7:clang8:clang9:clang10:clang11:clang12:clangdefault
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.compilerType=clang
 compiler.clang7.exe=/usr/bin/clang++-7
@@ -34,10 +40,14 @@ compiler.clang9.exe=/usr/bin/clang++-9
 compiler.clang9.name=clang 9
 compiler.clang10.exe=/usr/bin/clang++-10
 compiler.clang10.name=clang 10
+compiler.clang11.exe=/usr/bin/clang++-11
+compiler.clang11.name=clang 11
+compiler.clang12.exe=/usr/bin/clang++-12
+compiler.clang12.name=clang 12
 compiler.clangdefault.exe=/usr/bin/clang++
 compiler.clangdefault.name=clang default
 
-tools=clangquerydefault:clangquery7:clangquery8:clangquery9:clangquery10:strings:ldd
+tools=clangquerydefault:clangquery7:clangquery8:clangquery9:clangquery10:clangquery11:clangquery12:strings:ldd
 
 tools.clangquerydefault.exe=/usr/bin/clang-query
 tools.clangquerydefault.name=clang-query (default)
@@ -69,6 +79,18 @@ tools.clangquery10.name=clang-query 10
 tools.clangquery10.type=independent
 tools.clangquery10.class=clang-query-tool
 tools.clangquery10.stdinHint=Query commands
+
+tools.clangquery11.exe=/usr/bin/clang-query-11
+tools.clangquery11.name=clang-query 11
+tools.clangquery11.type=independent
+tools.clangquery11.class=clang-query-tool
+tools.clangquery11.stdinHint=Query commands
+
+tools.clangquery12.exe=/usr/bin/clang-query-12
+tools.clangquery12.name=clang-query 12
+tools.clangquery12.type=independent
+tools.clangquery12.class=clang-query-tool
+tools.clangquery12.stdinHint=Query commands
 
 tools.ldd.name=ldd
 tools.ldd.exe=/usr/bin/ldd

--- a/etc/config/c.defaults.properties
+++ b/etc/config/c.defaults.properties
@@ -10,7 +10,7 @@ stubRe=\bmain\b
 stubText=int main(void){return 0;/*stub provided by Compiler Explorer*/}
 supportsLibraryCodeFilter=true
 
-group.gcc.compilers=cg44:cg45:cg46:cg47:cg48:cg5:cg6:cg7:cg8:cgdefault
+group.gcc.compilers=cg44:cg45:cg46:cg47:cg48:cg5:cg6:cg7:cg8:cg9:cg10:cg11:cgdefault
 compiler.cg44.exe=/usr/bin/gcc-4.4
 compiler.cg44.name=gcc 4.4
 compiler.cg45.exe=/usr/bin/gcc-4.5
@@ -29,10 +29,16 @@ compiler.cg7.exe=/usr/bin/gcc-7
 compiler.cg7.name=gcc 7
 compiler.cg8.exe=/usr/bin/gcc-8
 compiler.cg8.name=gcc 8
+compiler.cg9.exe=/usr/bin/gcc-9
+compiler.cg9.name=gcc 9
+compiler.cg10.exe=/usr/bin/gcc-10
+compiler.cg10.name=gcc 10
+compiler.cg11.exe=/usr/bin/gcc-11
+compiler.cg11.name=gcc 11
 compiler.cgdefault.exe=/usr/bin/gcc
 compiler.cgdefault.name=gcc default
 
-group.clang.compilers=cclang7:cclang8:cclang9:cclang10:cclangdefault:cclangccdefault
+group.clang.compilers=cclang7:cclang8:cclang9:cclang10:cclang11:cclang12:cclangdefault:cclangccdefault
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 compiler.cclang7.exe=/usr/bin/clang-7
 compiler.cclang7.name=clang 7
@@ -42,6 +48,10 @@ compiler.cclang9.exe=/usr/bin/clang-9
 compiler.cclang9.name=clang 9
 compiler.cclang10.exe=/usr/bin/clang-10
 compiler.cclang10.name=clang 10
+compiler.cclang11.exe=/usr/bin/clang-11
+compiler.cclang11.name=clang 11
+compiler.cclang12.exe=/usr/bin/clang-12
+compiler.cclang12.name=clang 12
 compiler.cclangdefault.exe=/usr/bin/clang
 compiler.cclangdefault.name=clang default
 compiler.cclangccdefault.exe=/usr/bin/clangcc

--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -7,7 +7,7 @@ compilerType=fortran
 
 ###############################
 # GCC for x86
-group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494:gfortran48:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550:gfortran5:gfortran62:gfortran63:gfortran6:gfortran71:gfortran72:gfortran73:gfortran7:gfortran81:gfortran
+group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494:gfortran48:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550:gfortran5:gfortran62:gfortran63:gfortran6:gfortran71:gfortran72:gfortran73:gfortran7:gfortran8:gfortran81:gfortran9:gfortran10:gfortran11:gfortran
 group.gfortran_86.groupName=GCC x86-64
 compiler.gfortran412.exe=/usr/bin/gfortran-4.1.2
 compiler.gfortran412.name=x86-64 gfortran 4.1.2
@@ -77,7 +77,15 @@ compiler.gfortran73.exe=/usr/bin/gfortran-7.3.0
 compiler.gfortran73.name=x86-64 gfortran 7.3
 compiler.gfortran7.exe=/usr/bin/gfortran-7
 compiler.gfortran7.name=x86-64 gfortran 7
+compiler.gfortran8.exe=/usr/bin/gfortran-8
+compiler.gfortran8.name=x86-64 gfortran 8
 compiler.gfortran81.exe=/usr/bin/gfortran-8.1.0
 compiler.gfortran81.name=x86-64 gfortran 8.1
+compiler.gfortran9.exe=/usr/bin/gfortran-9
+compiler.gfortran9.name=x86-64 gfortran 9
+compiler.gfortran10.exe=/usr/bin/gfortran-10
+compiler.gfortran10.name=x86-64 gfortran 10
+compiler.gfortran11.exe=/usr/bin/gfortran-11
+compiler.gfortran11.name=x86-64 gfortran 11
 compiler.gfortran.exe=/usr/bin/gfortran
 compiler.gfortran.name=x86-64 gfortran


### PR DESCRIPTION
The *.default.properties files list only older C,C++ and Fortran compilers.

update gcc, clang and gfortran in the files: 
etc/config/c.defaults.properties
etc/config/c++.defaults.properties
etc/config/fortran.defaults.properties

gcc & g++: 9,10,11
clang & clang++: 11,12
gfortran: 8,9,10,11

These PR contain only the updates. The files need further cleanups, but this is not part of this PR.
(gcc 10.x vs g++ 10; gfortran contain "x64", but uses the native compiler. This is missing on the other compilers or should be removed for gfortran; ...)  
I can help here (for C, C++ and Fortran), but would like get some feedback first.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
