### PR TITLE
Fix and refactor rustc-cg-gcc GCC dump

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -359,76 +359,84 @@ export class BaseCompiler {
         return fn;
     }
 
+    getGccDumpFileName(outputFilename) {
+        return outputFilename.replace(path.extname(outputFilename), '.dump');
+    }
+
+    getGccDumpOptions(gccDumpOptions, outputFilename) {
+        const addOpts = ['-fdump-passes'];
+
+        // Build dump options to append to the end of the -fdump command-line flag.
+        // GCC accepts these options as a list of '-' separated names that may
+        // appear in any order.
+        let flags = '';
+        if (gccDumpOptions.dumpFlags.address !== false) {
+            flags += '-address';
+        }
+        if (gccDumpOptions.dumpFlags.slim !== false) {
+            flags += '-slim';
+        }
+        if (gccDumpOptions.dumpFlags.raw !== false) {
+            flags += '-raw';
+        }
+        if (gccDumpOptions.dumpFlags.details !== false) {
+            flags += '-details';
+        }
+        if (gccDumpOptions.dumpFlags.stats !== false) {
+            flags += '-stats';
+        }
+        if (gccDumpOptions.dumpFlags.blocks !== false) {
+            flags += '-blocks';
+        }
+        if (gccDumpOptions.dumpFlags.vops !== false) {
+            flags += '-vops';
+        }
+        if (gccDumpOptions.dumpFlags.lineno !== false) {
+            flags += '-lineno';
+        }
+        if (gccDumpOptions.dumpFlags.uid !== false) {
+            flags += '-uid';
+        }
+        if (gccDumpOptions.dumpFlags.all !== false) {
+            flags += '-all';
+        }
+
+        // If we want to remove the passes that won't produce anything from the
+        // drop down menu, we need to ask for all dump files and see what's
+        // really created. This is currently only possible with regular GCC, not
+        // for compilers that us libgccjit. The later can't easily move dump
+        // files outside of the tempdir created on the fly.
+        if (this.compiler.removeEmptyGccDump){
+            if (gccDumpOptions.treeDump !== false) {
+                addOpts.push('-fdump-tree-all' + flags);
+            }
+            if (gccDumpOptions.rtlDump !== false) {
+                addOpts.push('-fdump-rtl-all' + flags);
+            }
+            if (gccDumpOptions.ipaDump !== false) {
+                addOpts.push('-fdump-ipa-all' + flags);
+            }
+        } else {
+            // If not dumping everything, create a specific command like
+            // -fdump-tree-fixup_cfg1-some-flags=somefilename
+            if (gccDumpOptions.pass) {
+                const dumpFile = this.getGccDumpFileName(outputFilename);
+                const dumpCmd = gccDumpOptions.pass.command_prefix + flags + `=${dumpFile}`;
+                addOpts.push(dumpCmd);
+            }
+        }
+        return addOpts;
+    }
+
     // Returns a list of additional options that may be required by some backend options.
     // Meant to be overloaded by compiler classes.
-    // Called with 2 parameters: backendOptions and outputFilename.
     // Default handles the GCC compiler with some debug dump enabled.
-    optionsForBackend(backendOptions){
+    optionsForBackend(backendOptions, outputFilename){
         const addOpts = [];
 
         if (backendOptions.produceGccDump && backendOptions.produceGccDump.opened
             && this.compiler.supportsGccDump) {
-            addOpts.push('-fdump-passes');
-            const gccDumpOptions = backendOptions.produceGccDump;
-
-            // Build dump options to append to the end of the -fdump command-line flag.
-            // GCC accepts these options as a list of '-' separated names that may
-            // appear in any order.
-            let flags = '';
-            if (gccDumpOptions.dumpFlags.address !== false) {
-                flags += '-address';
-            }
-            if (gccDumpOptions.dumpFlags.slim !== false) {
-                flags += '-slim';
-            }
-            if (gccDumpOptions.dumpFlags.raw !== false) {
-                flags += '-raw';
-            }
-            if (gccDumpOptions.dumpFlags.details !== false) {
-                flags += '-details';
-            }
-            if (gccDumpOptions.dumpFlags.stats !== false) {
-                flags += '-stats';
-            }
-            if (gccDumpOptions.dumpFlags.blocks !== false) {
-                flags += '-blocks';
-            }
-            if (gccDumpOptions.dumpFlags.vops !== false) {
-                flags += '-vops';
-            }
-            if (gccDumpOptions.dumpFlags.lineno !== false) {
-                flags += '-lineno';
-            }
-            if (gccDumpOptions.dumpFlags.uid !== false) {
-                flags += '-uid';
-            }
-            if (gccDumpOptions.dumpFlags.all !== false) {
-                flags += '-all';
-            }
-
-            // If we want to remove the passes that won't produce anything from the
-            // drop down menu, we need to ask for all dump files and see what's
-            // really created. This is currently only possible with regular GCC, not
-            // for compilers that us libgccjit. The later can't easily move dump
-            // files outside of the tempdir created on the fly.
-            if (this.compiler.removeEmptyGccDump){
-                if (gccDumpOptions.treeDump !== false) {
-                    addOpts.push('-fdump-tree-all' + flags);
-                }
-                if (gccDumpOptions.rtlDump !== false) {
-                    addOpts.push('-fdump-rtl-all' + flags);
-                }
-                if (gccDumpOptions.ipaDump !== false) {
-                    addOpts.push('-fdump-ipa-all' + flags);
-                }
-            } else {
-                // If not dumping everything, create a specific command like
-                // -fdump-tree-fixup_cfg1-some-flags=stdout
-                if (gccDumpOptions.pass) {
-                    const dumpCmd = gccDumpOptions.pass.command_prefix + flags + '=stdout';
-                    addOpts.push(dumpCmd);
-                }
-            }
+            addOpts.push.apply(addOpts, this.getGccDumpOptions(backendOptions.produceGccDump, outputFilename));
         }
 
         return addOpts;
@@ -1203,7 +1211,8 @@ export class BaseCompiler {
                                  : '');
         const gccDumpResult = (makeGccDump ?
                                await this.processGccDumpOutput(backendOptions.produceGccDump,
-                                                               asmResult, this.compiler.removeEmptyGccDump)
+                                                               asmResult, this.compiler.removeEmptyGccDump,
+                                                               outputFilename)
                                : '');
         const rustMirResult = (makeRustMir ?
                                await this.processRustMirOutput(outputFilename, asmResult)
@@ -1652,7 +1661,7 @@ export class BaseCompiler {
 
     }
 
-    async processGccDumpOutput(opts, result, removeEmptyPasses) {
+    async processGccDumpOutput(opts, result, removeEmptyPasses, outputFilename) {
         const rootDir = path.dirname(result.inputFilename);
 
         if (opts.treeDump === false && opts.rtlDump === false && opts.ipaDump === false) {
@@ -1676,7 +1685,7 @@ export class BaseCompiler {
         if (opts.ipaDump) selectedPasses.push('ipa');
         if (opts.rtlDump) selectedPasses.push('rtl');
 
-        let dumpFileName;
+        let dumpFileName = this.getGccDumpFileName(outputFilename);
         let passFound = false;
 
         const filtered_stderr = [];
@@ -1710,17 +1719,12 @@ export class BaseCompiler {
 
         if (opts.pass && passFound){
             output.currentPassOutput = '';
-            if (removeEmptyPasses) {
-                if (dumpFileName)
-                    output.currentPassOutput = await fs.readFile(dumpFileName, 'utf-8');
-                // else leave the currentPassOutput empty. Can happen when some
-                // UI options are changed and a now disabled pass is still
-                // requested.
-            } else {
-                for (const obj of Object.values(result.stdout)) {
-                    output.currentPassOutput += obj.text + '\n';
-                }
-            }
+
+            if (dumpFileName && await fs.pathExists(dumpFileName))
+                output.currentPassOutput = await fs.readFile(dumpFileName, 'utf-8');
+            // else leave the currentPassOutput empty. Can happen when some
+            // UI options are changed and a now disabled pass is still
+            // requested.
 
             if (/^\s*$/.test(output.currentPassOutput)) {
                 output.currentPassOutput = `Pass '${opts.pass.name}' was requested

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -54,11 +54,15 @@ export class RustCompiler extends BaseCompiler {
     }
 
     optionsForBackend(backendOptions, outputFilename) {
+        // The super class handles the GCC dump files that may be needed by
+        // rustc-cg-gcc subclass.
+        const opts = super.optionsForBackend (backendOptions, outputFilename);
+
         if (backendOptions.produceRustMir && this.compiler.supportsRustMirView) {
             const of = this.getRustMirOutputFilename(outputFilename);
-            return ['--emit', `mir=${of}`];
+            opts.push('--emit', `mir=${of}`);
         }
-        return [];
+        return opts;
     }
 
     optionsForFilter(filters, outputFilename, userOptions) {


### PR DESCRIPTION
Conflicting changes in #3109 and #3064 left the GCC dump of rustc broken.

Reapplied the changes and refactored how the -fdump-foo-pass= option is crafted.
Instead of using stdout, use an explicit file. Beware that this won't work with
older GCC version. Regular GCC is still using the 'dump all files' instead of
the targeted option, so it's not impacted by this limitation. Only rustc-cg-gcc
is currently using this mecanism and it's using a recent libgccjit.

Really fixes #2868

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>