### PR TITLE
Format the output file for Erlang in a nicer way

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -104,3 +104,4 @@ From oldest to newest contributor, we would like to thank:
 - [Oleksandr Muliar](https://github.com/msdinit)
 - [Quinton Miller](https://github.com/HertzDevil)
 - [Kevin Adler](https://github.com/kadler)
+- [Björn Gustavsson](https://github.com/bjorng)

--- a/lib/compilers/erlang.js
+++ b/lib/compilers/erlang.js
@@ -39,8 +39,9 @@ export class ErlangCompiler extends BaseCompiler {
             '-eval',
             '{ok, Input} = init:get_argument(input),' +
                 '{ok, _, Output} = compile:file(Input, [\'S\', binary, no_line_info, report]),' +
-                'Binary = io_lib:format("~p", [Output]),' +
-                `file:write_file("${outputFilename}", list_to_binary(Binary)),` +
+                `{ok,Fd} = file:open("${outputFilename}", [write]),` +
+                'beam_listing:module(Fd, Output),' +
+                'file:close(Fd),' +
                 'halt().',
         ];
     }


### PR DESCRIPTION
For Erlang, format the output in the same way as the 'S' option
does. To achieve this, we use the `beam_listing` module, which is
undocumented but has been stable for many many years.
