### PR TITLE
Add xtensa compilers for ESP32, ESP32-S2, ESP32-S3

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -628,7 +628,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&rvgcc:&platspec:&kalray
+group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -973,6 +973,57 @@ compiler.rv32-gcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unkn
 compiler.rv32-gcc1020.name=RISC-V rv32gc gcc 10.2.0
 compiler.rv32-gcc1020.semver=10.2.0
 compiler.rv32-gcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+
+################################
+# GCC for Xtensa ESP32
+group.xtensaesp32.compilers=esp32g2019r2:esp32g2020r1:esp32g2020r2:esp32g2020r3:esp32g2021r1:esp32g2021r2
+group.xtensaesp32.groupName=Xtensa ESP32 GCC
+group.xtensaesp32.supportsBinary=false
+
+compiler.esp32g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-g++
+compiler.esp32g2019r2.name=Xtensa ESP32 gcc 8.2.0 (2019r2)
+compiler.esp32g2020r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2020r1/bin/xtensa-esp32-elf-g++
+compiler.esp32g2020r1.name=Xtensa ESP32 gcc 8.2.0 (2020r1)
+compiler.esp32g2020r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2020r2/bin/xtensa-esp32-elf-g++
+compiler.esp32g2020r2.name=Xtensa ESP32 gcc 8.2.0 (2020r2)
+compiler.esp32g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32-elf-g++
+compiler.esp32g2020r3.name=Xtensa ESP32 gcc 8.4.0 (2020r3)
+compiler.esp32g2021r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_4_0-esp-2021r1/bin/xtensa-esp32-elf-g++
+compiler.esp32g2021r1.name=Xtensa ESP32 gcc 8.4.0 (2021r1)
+compiler.esp32g2021r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_4_0-esp-2021r2/bin/xtensa-esp32-elf-g++
+compiler.esp32g2021r2.name=Xtensa ESP32 gcc 8.4.0 (2021r2)
+
+################################
+# GCC for Xtensa ESP32-S2
+group.xtensaesp32s2.compilers=esp32s2g2019r2:esp32s2g2020r1:esp32s2g2020r2:esp32s2g2020r3:esp32s2g2021r1:esp32s2g2021r2
+group.xtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
+group.xtensaesp32s2.supportsBinary=false
+
+compiler.esp32s2g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g2019r2.name=Xtensa ESP32-S2 gcc 8.2.0 (2019r2)
+compiler.esp32s2g2020r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2020r1/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g2020r1.name=Xtensa ESP32-S2 gcc 8.2.0 (2020r1)
+compiler.esp32s2g2020r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2020r2/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g2020r2.name=Xtensa ESP32-S2 gcc 8.2.0 (2020r2)
+compiler.esp32s2g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g2020r3.name=Xtensa ESP32-S2 gcc 8.4.0 (2020r3)
+compiler.esp32s2g2021r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_4_0-esp-2021r1/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g2021r1.name=Xtensa ESP32-S2 gcc 8.4.0 (2021r1)
+compiler.esp32s2g2021r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_4_0-esp-2021r2/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g2021r2.name=Xtensa ESP32-S2 gcc 8.4.0 (2021r2)
+
+################################
+# GCC for Xtensa ESP32-S3
+group.xtensaesp32s3.compilers=esp32s3g2020r3:esp32s3g2021r1:esp32s3g2021r2
+group.xtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
+group.xtensaesp32s3.supportsBinary=false
+
+compiler.esp32s3g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-g++
+compiler.esp32s3g2020r3.name=Xtensa ESP32-S3 gcc 8.4.0 (2020r3)
+compiler.esp32s3g2021r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2021r1/bin/xtensa-esp32s3-elf-g++
+compiler.esp32s3g2021r1.name=Xtensa ESP32-S3 gcc 8.4.0 (2021r1)
+compiler.esp32s3g2021r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2021r2/bin/xtensa-esp32s3-elf-g++
+compiler.esp32s3g2021r2.name=Xtensa ESP32-S3 gcc 8.4.0 (2021r2)
 
 ################################
 # Windows Compilers


### PR DESCRIPTION
PR to add compilers is https://github.com/compiler-explorer/infra/pull/639

Tested it locally and `make check` is happy as well.

Fixes #1817