### PR TITLE
rust: HIR dump and small refactor with macro expansion

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -725,6 +725,52 @@ export class BaseCompiler {
         };
     }
 
+    getRustMacroExpansionOutputFilename(inputFilename) {
+        return inputFilename.replace(path.extname(inputFilename), '.expanded.rs');
+    }
+
+    getRustHirOutputFilename(inputFilename) {
+        return inputFilename.replace(path.extname(inputFilename), '.hir');
+    }
+
+    getRustMirOutputFilename(outputFilename) {
+        return outputFilename.replace(path.extname(outputFilename), '.mir');
+    }
+
+    // Currently called for getting macro expansion and HIR.
+    // It returns the content of the output file created after using -Z unpretty=<unprettyOpt>.
+    // The outputFriendlyName is a free form string used in case of error.
+    async generateRustUnprettyOutput(inputFilename, options, unprettyOpt, outputFilename, outputFriendlyName){
+        const execOptions = this.getDefaultExecOptions();
+
+        const rustcOptions = [...options];
+        rustcOptions.splice(options.indexOf('-o', 2));
+        rustcOptions.push(inputFilename, '-o', outputFilename, `-Zunpretty=${unprettyOpt}`);
+
+        const output = await this.runCompiler(this.compiler.exe, rustcOptions, inputFilename,
+                                              execOptions);
+        if (output.code !== 0) {
+            return [{text: `Failed to run compiler to get Rust ${outputFriendlyName}`}];
+        }
+        if (await fs.exists(outputFilename)) {
+            const content = await fs.readFile(outputFilename, 'utf-8');
+            return content.split('\n').map((line) => ({
+                text: line,
+            }));
+        }
+        return [{text: 'Internal error; unable to open output path'}];
+    }
+
+    async generateRustMacroExpansion(inputFilename, options) {
+        const macroExpPath = this.getRustMacroExpansionOutputFilename(inputFilename);
+        return this.generateRustUnprettyOutput(inputFilename, options, 'expanded', macroExpPath, 'Macro Expansion');
+    }
+
+    async generateRustHir(inputFilename, options) {
+        const hirPath = this.getRustHirOutputFilename(inputFilename);
+        return this.generateRustUnprettyOutput(inputFilename, options, 'hir-tree', hirPath, 'HIR');
+    }
+
     async processRustMirOutput(outputFilename, output) {
         const mirPath = this.getRustMirOutputFilename(outputFilename);
         if (output.code !== 0) {
@@ -739,42 +785,12 @@ export class BaseCompiler {
         return [{text: 'Internal error; unable to open output path'}];
     }
 
-    async generateRustMacroExpansion(inputFilename) {
-        const execOptions = this.getDefaultExecOptions();
-        const macroExpPath = this.getRustMacroExpansionOutputFilename(inputFilename);
-        const rustcOptions = [
-            inputFilename,
-            '-o',
-            macroExpPath,
-            '-Zunpretty=expanded',
-            '--crate-type',
-            'rlib',
-        ];
-
-        const output = await this.runCompiler(this.compiler.exe, rustcOptions, this.filename(inputFilename),
-            execOptions);
-        if (output.code !== 0) {
-            return [{text: 'Failed to run compiler to get Rust Macro Expansion'}];
-        }
-        if (await fs.exists(macroExpPath)) {
-            const content = await fs.readFile(macroExpPath, 'utf-8');
-            return content.split('\n').map((line) => ({
-                text: line,
-            }));
-        }
-        return [{text: 'Internal error; unable to open output path'}];
-    }
-
     getIrOutputFilename(inputFilename) {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
     }
 
     getGnatDebugOutputFilename(inputFilename) {
         return inputFilename + '.dg';
-    }
-
-    getRustMacroExpansionOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.expanded.rs');
     }
 
     getOutputFilename(dirPath, outputFilebase, key) {
@@ -1182,6 +1198,7 @@ export class BaseCompiler {
         const makeIr = backendOptions.produceIr && this.compiler.supportsIrView;
         const makeRustMir = backendOptions.produceRustMir && this.compiler.supportsRustMirView;
         const makeRustMacroExp = backendOptions.produceRustMacroExp && this.compiler.supportsRustMacroExpView;
+        const makeRustHir = backendOptions.produceRustHir && this.compiler.supportsRustHirView;
         const makeGccDump = backendOptions.produceGccDump && backendOptions.produceGccDump.opened
             && this.compiler.supportsGccDump;
 
@@ -1190,12 +1207,14 @@ export class BaseCompiler {
             asmResult,
             astResult,
             irResult,
+            rustHirResult,
             rustMacroExpResult,
             toolsResult,
         ] = await Promise.all([
             this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
             (makeAst ? this.generateAST(inputFilename, options) : ''),
             (makeIr ? this.generateIR(inputFilename, options, filters) : ''),
+            (makeRustHir ? this.generateRustHir(inputFilename, options) : ''),
             (makeRustMacroExp ? this.generateRustMacroExpansion(inputFilename, options) : ''),
             Promise.all(this.runToolsOfType(tools, 'independent', this.getCompilationInfo(key, {
                 inputFilename,
@@ -1260,6 +1279,11 @@ export class BaseCompiler {
         if (rustMacroExpResult) {
             asmResult.hasRustMacroExpOutput = true;
             asmResult.rustMacroExpOutput = rustMacroExpResult;
+        }
+
+        if (rustHirResult) {
+            asmResult.hasRustHirOutput = true;
+            asmResult.rustHirOutput = rustHirResult;
         }
 
         return this.checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters);

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -39,14 +39,15 @@ export class RustCompiler extends BaseCompiler {
         this.compiler.supportsIntel = true;
         this.compiler.supportsIrView = true;
         this.compiler.supportsRustMirView = true;
-        // Macro expansion through -Zunpretty=expanded is only available for Nightly
-        this.compiler.supportsRustMacroExpView = info.name === 'nightly' || info.semver === 'nightly';
+
+        const isNightly = info.name === 'nightly' || info.semver === 'nightly';
+        // Macro expansion (-Zunpretty=expanded) and HIR (-Zunpretty=hir-tree)
+        // are only available for Nightly
+        this.compiler.supportsRustMacroExpView = isNightly;
+        this.compiler.supportsRustHirView = isNightly;
+
         this.compiler.irArg = ['--emit', 'llvm-ir'];
         this.linker = this.compilerProps('linker');
-    }
-
-    getRustMirOutputFilename(outputFilename) {
-        return outputFilename.replace(path.extname(outputFilename), '.mir');
     }
 
     getSharedLibraryPathsAsArguments() {

--- a/static/components.js
+++ b/static/components.js
@@ -350,6 +350,26 @@ module.exports = {
             },
         };
     },
+    getRustHirView: function () {
+        return {
+            type: 'component',
+            componentName: 'rusthir',
+            componentState: {},
+        };
+    },
+    getRustHirViewWith: function (id, source, rustHirOutput, compilerName, editorid) {
+        return {
+            type: 'component',
+            componentName: 'rusthir',
+            componentState: {
+                id: id,
+                source: source,
+                rustHirOutput: rustHirOutput,
+                compilerName: compilerName,
+                editorid: editorid,
+            },
+        };
+    },
     getDeviceView: function () {
         return {
             type: 'component',

--- a/static/hub.js
+++ b/static/hub.js
@@ -43,6 +43,7 @@ var deviceView = require('./panes/device-view');
 var rustMirView = require('./panes/rustmir-view');
 var gnatDebugView = require('./panes/gnatdebug-view');
 var rustMacroExpView = require('./panes/rustmacroexp-view');
+var rustHirView = require('./panes/rusthir-view');
 var gccDumpView = require('./panes/gccdump-view');
 var cfgView = require('./panes/cfg-view');
 var conformanceView = require('./panes/conformance-view');
@@ -152,6 +153,10 @@ function Hub(layout, subLangId, defaultLangId) {
     layout.registerComponent(Components.getRustMacroExpView().componentName,
         function (container, state) {
             return self.rustMacroExpViewFactory(container, state);
+        });
+    layout.registerComponent(Components.getRustHirView().componentName,
+        function (container, state) {
+            return self.rustHirViewFactory(container, state);
         });
     layout.registerComponent(Components.getGccDumpView().componentName,
         function (container, state) {
@@ -333,6 +338,10 @@ Hub.prototype.rustMirViewFactory = function (container, state) {
 
 Hub.prototype.rustMacroExpViewFactory = function (container, state) {
     return new rustMacroExpView.RustMacroExp(this, container, state);
+};
+
+Hub.prototype.rustHirViewFactory = function (container, state) {
+    return new rustHirView.RustHir(this, container, state);
 };
 
 Hub.prototype.gccDumpViewFactory = function (container, state) {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -263,6 +263,11 @@ Compiler.prototype.initPanerButtons = function () {
             this.getCompilerName(), this.sourceEditorId);
     }, this);
 
+    var createRustHirView = _.bind(function () {
+        return Components.getRustHirViewWith(this.id, this.source, this.lastResult.rustHirOutput,
+            this.getCompilerName(), this.sourceEditorId);
+    }, this);
+
     var createGccDumpView = _.bind(function () {
         return Components.getGccDumpViewWith(this.id, this.getCompilerName(), this.sourceEditorId,
             this.lastResult.gccDumpOutput);
@@ -379,6 +384,16 @@ Compiler.prototype.initPanerButtons = function () {
         var insertPoint = this.hub.findParentRowOrColumn(this.container) ||
             this.container.layoutManager.root.contentItems[0];
         insertPoint.addChild(createRustMacroExpView);
+    }, this));
+
+    this.container.layoutManager
+        .createDragSource(this.rustHirButton, createRustHirView)
+        ._dragListener.on('dragStart', togglePannerAdder);
+
+    this.rustHirButton.click(_.bind(function () {
+        var insertPoint = this.hub.findParentRowOrColumn(this.container) ||
+            this.container.layoutManager.root.contentItems[0];
+        insertPoint.addChild(createRustHirView);
     }, this));
 
     this.container.layoutManager
@@ -704,6 +719,7 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
             produceDevice: this.deviceViewOpen,
             produceRustMir: this.rustMirViewOpen,
             produceRustMacroExp: this.rustMacroExpViewOpen,
+            produceRustHir: this.rustHirViewOpen,
         },
         filters: this.getEffectiveFilters(),
         tools: this.getActiveTools(newTools),
@@ -1309,6 +1325,21 @@ Compiler.prototype.onRustMacroExpViewClosed = function (id) {
     }
 };
 
+Compiler.prototype.onRustHirViewOpened = function (id) {
+    if (this.id === id) {
+        this.rustHirButton.prop('disabled', true);
+        this.rustHirViewOpen = true;
+        this.compile();
+    }
+};
+
+Compiler.prototype.onRustHirViewClosed = function (id) {
+    if (this.id === id) {
+        this.rustHirButton.prop('disabled', false);
+        this.rustHirViewOpen = false;
+    }
+};
+
 Compiler.prototype.onGccDumpUIInit = function (id) {
     if (this.id === id) {
         this.compile();
@@ -1448,6 +1479,7 @@ Compiler.prototype.initButtons = function (state) {
     this.gnatDebugButton = this.domRoot.find('.btn.view-gnatdebug');
     this.rustMirButton = this.domRoot.find('.btn.view-rustmir');
     this.rustMacroExpButton = this.domRoot.find('.btn.view-rustmacroexp');
+    this.rustHirButton = this.domRoot.find('.btn.view-rusthir');
     this.gccDumpButton = this.domRoot.find('.btn.view-gccdump');
     this.gnatDebugButton = this.domRoot.find('.btn.view-gnatdebug');
     this.cfgButton = this.domRoot.find('.btn.view-cfg');
@@ -1662,6 +1694,7 @@ Compiler.prototype.updateButtons = function () {
     this.deviceButton.prop('disabled', this.deviceViewOpen);
     this.rustMirButton.prop('disabled', this.rustMirViewOpen);
     this.rustMacroExpButton.prop('disabled', this.rustMacroExpViewOpen);
+    this.rustHirButton.prop('disabled', this.rustHirViewOpen);
     this.cfgButton.prop('disabled', this.cfgViewOpen);
     this.gccDumpButton.prop('disabled', this.gccDumpViewOpen);
     this.gnatDebugButton.prop('disabled', this.gnatDebugViewOpen);
@@ -1674,6 +1707,7 @@ Compiler.prototype.updateButtons = function () {
     this.deviceButton.toggle(!!this.compiler.supportsDeviceAsmView);
     this.rustMirButton.toggle(!!this.compiler.supportsRustMirView);
     this.rustMacroExpButton.toggle(!!this.compiler.supportsRustMacroExpView);
+    this.rustHirButton.toggle(!!this.compiler.supportsRustHirView);
     this.cfgButton.toggle(!!this.compiler.supportsCfg);
     this.gccDumpButton.toggle(!!this.compiler.supportsGccDump);
     this.gnatDebugButton.toggle(!!this.compiler.supportsGnatDebugView);
@@ -1766,6 +1800,8 @@ Compiler.prototype.initListeners = function () {
     this.eventHub.on('rustMirViewClosed', this.onRustMirViewClosed, this);
     this.eventHub.on('rustMacroExpViewOpened', this.onRustMacroExpViewOpened, this);
     this.eventHub.on('rustMacroExpViewClosed', this.onRustMacroExpViewClosed, this);
+    this.eventHub.on('rustHirViewOpened', this.onRustHirViewOpened, this);
+    this.eventHub.on('rustHirViewClosed', this.onRustHirViewClosed, this);
     this.eventHub.on('outputOpened', this.onOutputOpened, this);
     this.eventHub.on('outputClosed', this.onOutputClosed, this);
 

--- a/static/panes/rusthir-view.interfaces.ts
+++ b/static/panes/rusthir-view.interfaces.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+export interface RustHirState {
+    rustHirOutput: any;
+}

--- a/static/panes/rusthir-view.ts
+++ b/static/panes/rusthir-view.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import _ from 'underscore';
+import * as monaco from 'monaco-editor';
+import { Container } from 'golden-layout';
+
+import { Pane } from './pane';
+import { BasePaneState } from './pane.interfaces';
+import { RustHirState } from './rusthir-view.interfaces';
+
+import { ga } from '../analytics';
+import { extendConfig } from '../monaco-config';
+
+export class RustHir extends Pane<monaco.editor.IStandaloneCodeEditor, RustHirState> {
+    constructor(hub: any, container: Container, state: RustHirState & BasePaneState) {
+        super(hub, container, state);
+        if (state && state.rustHirOutput) {
+            this.showRustHirResults(state.rustHirOutput);
+        }
+    }
+
+    override getInitialHTML(): string {
+        return $('#rusthir').html();
+    }
+
+    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
+        return monaco.editor.create(editorRoot, extendConfig({
+            language: 'plainText',
+            readOnly: true,
+            glyphMargin: true,
+            lineNumbersMinChars: 3,
+        }));
+    }
+
+    override registerOpeningAnalyticsEvent(): void {
+        ga.proxy('send', {
+            hitType: 'event',
+            eventCategory: 'OpenViewPane',
+            eventAction: 'RustHir',
+        });
+    }
+
+    override getPaneName(): string {
+        return `Rust HIR Viewer ${this.compilerInfo.compilerName}` +
+            `(Editor #${this.compilerInfo.editorId}, ` +
+            `Compiler #${this.compilerInfo.compilerId})`;
+    }
+
+    override registerCallbacks(): void {
+        const throttleFunction = _.throttle((event) => this.onDidChangeCursorSelection(event), 500);
+        this.editor.onDidChangeCursorSelection((event) => throttleFunction(event));
+        this.eventHub.emit('rustHirViewOpened', this.compilerInfo.compilerId);
+        this.eventHub.emit('requestSettings');
+    }
+
+    override onCompileResult(compilerId: number, compiler: any, result: any): void {
+        if (this.compilerInfo.compilerId !== compilerId) return;
+        if (result.hasRustHirOutput) {
+            this.showRustHirResults(result.rustHirOutput);
+        } else if (compiler.supportsRustHirView) {
+            this.showRustHirResults([{text: '<No output>'}]);
+        }
+    }
+
+    override onCompiler(compilerId: number, compiler: any, options: any, editorId: number): void {
+        if (this.compilerInfo.compilerId === compilerId) {
+            this.compilerInfo.compilerName = compiler ? compiler.name : '';
+            this.compilerInfo.editorId = editorId;
+            this.setTitle();
+            if (compiler && !compiler.supportsRustHirView) {
+                this.showRustHirResults([{
+                    text: '<Rust HIR output is not supported for this compiler>'
+                }]);
+            }
+        }
+    }
+
+    showRustHirResults(result: any[]): void {
+        if (!this.editor) return;
+        this.editor.getModel().setValue(result.length
+            ? _.pluck(result, 'text').join('\n')
+            : '<No Rust HIR generated>');
+
+        if (!this.isAwaitingInitialResults) {
+            if (this.selection) {
+                this.editor.setSelection(this.selection);
+                this.editor.revealLinesInCenter(this.selection.selectionStartLineNumber,
+                    this.selection.endLineNumber);
+            }
+            this.isAwaitingInitialResults = true;
+        }
+    }
+
+    override close(): void {
+        this.eventHub.unsubscribe();
+        this.eventHub.emit('rustHirViewClosed', this.compilerInfo.compilerId);
+        this.editor.dispose();
+    }
+}

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -108,6 +108,9 @@
           button.dropdown-item.btn.btn-sm.btn-light.view-rustmacroexp(title="Show Rust Macro Expansion")
             span.dropdown-icon.fas.fa-arrows-alt
             | Rust Macro Expansion output
+          button.dropdown-item.btn.btn-sm.btn-light.view-rusthir(title="Show Rust HIR")
+            span.dropdown-icon.fas.fa-arrows-alt
+            | Rust HIR output
           button.dropdown-item.btn.btn-sm.btn-light.view-gccdump(title="Show Tree/RTL dump (GCC only)")
             span.dropdown-icon.fas.fa-tree
             | GCC Tree/RTL output
@@ -302,6 +305,11 @@
     .monaco-placeholder
 
   #rustmacroexp
+    .top-bar.btn-toolbar.bg-light(role="toolbar")
+      include font-size
+    .monaco-placeholder
+
+  #rusthir
     .top-bar.btn-toolbar.bg-light(role="toolbar")
       include font-size
     .monaco-placeholder


### PR DESCRIPTION
Small refactoring for handling -Zunpretty calls:

- reuse options from main compiler invocation instead of crafting new ones.
- move some rust specific methods from base-compiler.js to rust.js

Now also handles HIR output in a dedicated pane.
Still a lot of copy/pasting from the macro expansion.

fixes #2567

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>