### PR TITLE
Temporarily patch Kotlin runtime execution

### DIFF
--- a/lib/compilers/kotlin.js
+++ b/lib/compilers/kotlin.js
@@ -54,9 +54,6 @@ export class KotlinCompiler extends JavaCompiler {
             option !== '-script' && option !== '-progressive' && !option.startsWith('-Xjavac'));
 
         const oneArgForbiddenList = new Set([
-            // -d directory
-            // Destination for generated class files
-            '-d',
             // -jdk-home path
             // Include a custom JDK from the specified location
             // into the classpath instead of the default JAVA_HOME
@@ -78,6 +75,44 @@ export class KotlinCompiler extends JavaCompiler {
         return [
             '-Xjavac-arguments="-Xlint:all"',
         ];
+    }
+
+    /**
+     * Handle Kotlin execution.
+     *
+     * Kotlin execution differs in the way that Kotlin requires its standard
+     * standard library because that's where the runtime libraries such as
+     * kotlin.jvm.internal.Intrinsics is.
+     *
+     * Therefore, we append the -include-runtime and -d flags to specify where
+     * to output the jarfile which we will run using `java -jar`
+     *
+     * TODO(supergrecko): Find a better fix than this bandaid for execution
+     */
+    async handleInterpreting(key, executeParameters) {
+        const alteredKey = {
+            ...key,
+            options: ['-include-runtime', '-d', 'example.jar'],
+        };
+        const compileResult = await this.getOrBuildExecutable(alteredKey);
+        executeParameters.args = [
+            '-Xss136K', // Reduce thread stack size
+            '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
+            '-XX:-UseDynamicNumberOfCompilerThreads',
+            '-XX:-UseDynamicNumberOfGCThreads',
+            '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
+            '-cp',
+            compileResult.dirPath,
+            '-jar',
+            'example.jar',
+            // -jar <jar> has to be the last java parameter, otherwise it will use
+            // our java parameters as program parameters
+            ...executeParameters.args,
+        ];
+        const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
+        result.didExecute = true;
+        result.buildResult = compileResult;
+        return result;
     }
 
     getArgumentParser() {


### PR DESCRIPTION
Fixes the problem where any (reasonable) Kotlin JVM execution would fail with a NoClassDefFound error with kotlin.jvm.internal.Intrinsics.

The Kotlin execution is now packed into a jar with the Kotlin Standard Library and executed with `java -jar`.