### PR TITLE
Added clang-13 to OpenCL and improved compilation speed.

### DIFF
--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -9,9 +9,9 @@ translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
 disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 # Clang for Arm
-# Provides 32- and 64-bit menu items for clang-10, clang-11, clang-12 and trunk
+# Provides 32- and 64-bit menu items for clang-10, clang-11, clang-12, clang-13 and trunk
 group.armcpp4oclclang32.groupName=Arm 32-bit clang
-group.armcpp4oclclang32.compilers=armv7-cpp4oclclang1000:armv7-cpp4oclclang1001:armv7-cpp4oclclang1100:armv7-cpp4oclclang1101:armv7-cpp4oclclang1200:armv7-cpp4oclclang-trunk:armv7-cpp4oclclang-trunk-assertions
+group.armcpp4oclclang32.compilers=armv7-cpp4oclclang1000:armv7-cpp4oclclang1001:armv7-cpp4oclclang1100:armv7-cpp4oclclang1101:armv7-cpp4oclclang1200:armv7-cpp4oclclang1300:armv7-cpp4oclclang-trunk:armv7-cpp4oclclang-trunk-assertions
 group.armcpp4oclclang32.isSemVer=true
 group.armcpp4oclclang32.compilerType=clang
 group.armcpp4oclclang32.supportsExecute=false
@@ -20,7 +20,7 @@ group.armcpp4oclclang32.instructionSet=arm32
 group.armcpp4oclclang32.baseOptions=-Dkernel= -D__kernel=
 
 group.armcpp4oclclang64.groupName=Arm 64-bit clang
-group.armcpp4oclclang64.compilers=armv8-cpp4oclclang1000:armv8-cpp4oclclang1001:armv8-cpp4oclclang1100:armv8-cpp4oclclang1101:armv8-cpp4oclclang1200:armv8-cpp4oclclang-trunk:armv8-cpp4oclclang-trunk-assertions:armv8-full-cpp4oclclang-trunk
+group.armcpp4oclclang64.compilers=armv8-cpp4oclclang1000:armv8-cpp4oclclang1001:armv8-cpp4oclclang1100:armv8-cpp4oclclang1101:armv8-cpp4oclclang1200:armv8-cpp4oclclang1300:armv8-cpp4oclclang-trunk:armv8-cpp4oclclang-trunk-assertions:armv8-full-cpp4oclclang-trunk
 group.armcpp4oclclang64.isSemVer=true
 group.armcpp4oclclang64.compilerType=clang
 group.armcpp4oclclang64.supportsExecute=false
@@ -28,6 +28,22 @@ group.armcpp4oclclang64.instructionSet=aarch64
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
 group.armcpp4oclclang64.baseOptions=-Dkernel= -D__kernel=
 
+# Specify each Clang version
+
+# version 13
+compiler.armv7-cpp4oclclang1300.name=armv7-a clang 13.0.0
+compiler.armv7-cpp4oclclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.armv7-cpp4oclclang1300.semver=13.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cpp4oclclang1300.options=-cl-std=clc++ -x cl -target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-cpp4oclclang1300.name=armv8-a clang 13.0.0
+compiler.armv8-cpp4oclclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.armv8-cpp4oclclang1300.semver=13.0.0
+# Arm v8-a
+compiler.armv8-cpp4oclclang1300.options=-cl-std=clc++ -x cl -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+#version 12
 compiler.armv7-cpp4oclclang1200.name=armv7-a clang 12.0.0
 compiler.armv7-cpp4oclclang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
 compiler.armv7-cpp4oclclang1200.semver=12.0.0
@@ -40,6 +56,7 @@ compiler.armv8-cpp4oclclang1200.semver=12.0.0
 # Arm v8-a
 compiler.armv8-cpp4oclclang1200.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 11.0.1
 compiler.armv7-cpp4oclclang1101.name=armv7-a clang 11.0.1
 compiler.armv7-cpp4oclclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
 compiler.armv7-cpp4oclclang1101.semver=11.0.1
@@ -52,6 +69,7 @@ compiler.armv8-cpp4oclclang1101.semver=11.0.1
 # Arm v8-a
 compiler.armv8-cpp4oclclang1101.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 11
 compiler.armv7-cpp4oclclang1100.name=armv7-a clang 11.0.0
 compiler.armv7-cpp4oclclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.armv7-cpp4oclclang1100.semver=11.0.0
@@ -64,6 +82,7 @@ compiler.armv8-cpp4oclclang1100.semver=11.0.0
 # Arm v8-a
 compiler.armv8-cpp4oclclang1100.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 10.0.1
 compiler.armv7-cpp4oclclang1001.name=armv7-a clang 10.0.1
 compiler.armv7-cpp4oclclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.armv7-cpp4oclclang1001.semver=10.0.1
@@ -76,6 +95,7 @@ compiler.armv8-cpp4oclclang1001.semver=10.0.1
 # Arm v8-a
 compiler.armv8-cpp4oclclang1001.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 10
 compiler.armv7-cpp4oclclang1000.name=armv7-a clang 10.0.0
 compiler.armv7-cpp4oclclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.armv7-cpp4oclclang1000.semver=10.0.0
@@ -88,6 +108,7 @@ compiler.armv8-cpp4oclclang1000.semver=10.0.0
 # Arm v8-a
 compiler.armv8-cpp4oclclang1000.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#main dev version
 compiler.armv7-cpp4oclclang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv7-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -136,7 +157,7 @@ group.armcpp4oclclang32spir.compilerType=spirv
 group.armcpp4oclclang32spir.supportsExecute=false
 group.armcpp4oclclang32spir.instructionSet=arm32
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armcpp4oclclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir-unknown-unknown
+group.armcpp4oclclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
 group.armcpp4oclclang64spir.groupName=Arm 64-bit clang (SPIR-V asm)
 group.armcpp4oclclang64spir.compilers=armv8-cpp4oclclang-trunk-spir64:armv8-cpp4oclclang-trunk-assertions-spir64
@@ -145,7 +166,7 @@ group.armcpp4oclclang64spir.compilerType=spirv
 group.armcpp4oclclang64spir.supportsExecute=false
 group.armcpp4oclclang64spir.instructionSet=aarch64
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armcpp4oclclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir64-unknown-unknown
+group.armcpp4oclclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-cpp4oclclang-trunk-spir.name=armv7-a clang (trunk, SPIR-V asm)

--- a/etc/config/cpp_for_opencl.defaults.properties
+++ b/etc/config/cpp_for_opencl.defaults.properties
@@ -12,7 +12,7 @@ group.clang.compilers=cppforopenclclangdefault:cppforopenclclang10:cppforopenclc
 group.clang.compilerType=clang
 compiler.cppforopenclclangdefault.exe=/usr/bin/clang
 compiler.cppforopenclclangdefault.name=clang default
-compiler.cppforopenclclangdefault.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
+compiler.cppforopenclclangdefault.options=-cl-std=clc++ -x cl
 compiler.cppforopenclclang10.exe=/usr/bin/clang-10
 compiler.cppforopenclclang10.name=clang 10
 compiler.cppforopenclclang10.options=-cl-std=clc++ -x cl -Xclang -finclude-default-header
@@ -29,16 +29,16 @@ group.spirv.compilers=spirvcppclang13spir:spirvcppclang13spir64:spirvcppclangdef
 group.spirv.compilerType=spirv
 compiler.spirvcppclangdefaultspir.exe=/usr/bin/clang
 compiler.spirvcppclangdefaultspir.name=clang default (SPIR-V asm, spir triple)
-compiler.spirvcppclangdefaultspir.options=-cl-std=clc++ -x cl -finclude-default-header -triple spir-unknown-unknown
+compiler.spirvcppclangdefaultspir.options=-cl-std=clc++ -x cl -finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
 compiler.spirvcppclangdefaultspir64.exe=/usr/bin/clang
 compiler.spirvcppclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
-compiler.spirvcppclangdefaultspir64.options=-cl-std=clc++ -x cl -finclude-default-header -triple spir64-unknown-unknown
+compiler.spirvcppclangdefaultspir64.options=-cl-std=clc++ -x cl -finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
 compiler.spirvcppclang13spir.exe=/usr/bin/clang-13
 compiler.spirvcppclang13spir.name=clang 13 (SPIR-V asm, spir triple)
-compiler.spirvcppclang13spir.options=-cl-std=clc++ -finclude-default-header -triple spir-unknown-unknown
+compiler.spirvcppclang13spir.options=-cl-std=clc++ -finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
 compiler.spirvcppclang13spir64.exe=/usr/bin/clang-13
 compiler.spirvcppclang13spir64.name=clang 13 (SPIR-V asm, spir64 triple)
-compiler.spirvcppclang13spir64.options=-cl-std=clc++ -finclude-default-header -triple spir64-unknown-unknown
+compiler.spirvcppclang13spir64.options=-cl-std=clc++ -finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -9,9 +9,9 @@ translatorPath=/opt/compiler-explorer/llvm-spirv-trunk/bin/llvm-spirv
 disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
 # Clang for Arm
-# Provides 32- and 64-bit menu items for clang-9, clang-10, clang-11, clang-12 and trunk
+# Provides 32- and 64-bit menu items for clang-9, clang-10, clang-11, clang-12, clang-13 and trunk
 group.armoclcclang32.groupName=Arm 32-bit clang
-group.armoclcclang32.compilers=armv7-oclcclang900:armv7-oclcclang901:armv7-oclcclang1000:armv7-oclcclang1001:armv7-oclcclang1100:armv7-oclcclang1101:armv7-oclcclang1200:armv7-oclcclang-trunk:armv7-oclcclang-trunk-assertions
+group.armoclcclang32.compilers=armv7-oclcclang900:armv7-oclcclang901:armv7-oclcclang1000:armv7-oclcclang1001:armv7-oclcclang1100:armv7-oclcclang1101:armv7-oclcclang1200:armv7-oclcclang1300:armv7-oclcclang-trunk:armv7-oclcclang-trunk-assertions
 group.armoclcclang32.isSemVer=true
 group.armoclcclang32.compilerType=clang
 group.armoclcclang32.supportsExecute=false
@@ -20,7 +20,7 @@ group.armoclcclang32.instructionSet=arm32
 group.armoclcclang32.baseOptions=-Dkernel= -D__kernel=
 
 group.armoclcclang64.groupName=Arm 64-bit clang
-group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk:armv8-oclcclang-trunk-assertions
+group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang1300:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk:armv8-oclcclang-trunk-assertions
 group.armoclcclang64.isSemVer=true
 group.armoclcclang64.compilerType=clang
 group.armoclcclang64.supportsExecute=false
@@ -28,6 +28,22 @@ group.armoclcclang64.instructionSet=aarch64
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
 group.armoclcclang64.baseOptions=-Dkernel= -D__kernel=
 
+#Specify each Clang versions
+
+#version 13
+compiler.armv7-oclcclang1300.name=armv7-a clang 13.0.0
+compiler.armv7-oclcclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.armv7-oclcclang1300.semver=13.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-oclcclang1300.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+
+compiler.armv8-oclcclang1300.name=armv8-a clang 13.0.0
+compiler.armv8-oclcclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.armv8-oclcclang1300.semver=13.0.0
+# Arm v8-a
+compiler.armv8-oclcclang1300.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
+#version 12
 compiler.armv7-oclcclang1200.name=armv7-a clang 12.0.0
 compiler.armv7-oclcclang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
 compiler.armv7-oclcclang1200.semver=12.0.0
@@ -40,6 +56,7 @@ compiler.armv8-oclcclang1200.semver=12.0.0
 # Arm v8-a
 compiler.armv8-oclcclang1200.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 11.0.1
 compiler.armv7-oclcclang1101.name=armv7-a clang 11.0.1
 compiler.armv7-oclcclang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
 compiler.armv7-oclcclang1101.semver=11.0.1
@@ -52,6 +69,7 @@ compiler.armv8-oclcclang1101.semver=11.0.1
 # Arm v8-a
 compiler.armv8-oclcclang1101.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 11
 compiler.armv7-oclcclang1100.name=armv7-a clang 11.0.0
 compiler.armv7-oclcclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.armv7-oclcclang1100.semver=11.0.0
@@ -64,6 +82,7 @@ compiler.armv8-oclcclang1100.semver=11.0.0
 # Arm v8-a
 compiler.armv8-oclcclang1100.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 10.0.1
 compiler.armv7-oclcclang1001.name=armv7-a clang 10.0.1
 compiler.armv7-oclcclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.armv7-oclcclang1001.semver=10.0.1
@@ -76,6 +95,7 @@ compiler.armv8-oclcclang1001.semver=10.0.1
 # Arm v8-a
 compiler.armv8-oclcclang1001.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 10
 compiler.armv7-oclcclang1000.name=armv7-a clang 10.0.0
 compiler.armv7-oclcclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.armv7-oclcclang1000.semver=10.0.0
@@ -88,6 +108,7 @@ compiler.armv8-oclcclang1000.semver=10.0.0
 # Arm v8-a
 compiler.armv8-oclcclang1000.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 9.0.1
 compiler.armv7-oclcclang901.name=armv7-a clang 9.0.1
 compiler.armv7-oclcclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
 compiler.armv7-oclcclang901.semver=9.0.1
@@ -100,6 +121,7 @@ compiler.armv8-oclcclang901.semver=9.0.1
 # Arm v8-a
 compiler.armv8-oclcclang901.options=-Xclang -finclude-default-header -target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
+#version 9
 compiler.armv7-oclcclang900.name=armv7-a clang 9.0.0
 compiler.armv7-oclcclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.armv7-oclcclang900.semver=9.0.0
@@ -160,7 +182,7 @@ group.armoclcclang32spir.compilerType=spirv
 group.armoclcclang32spir.supportsExecute=false
 group.armoclcclang32spir.instructionSet=arm32
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armoclcclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir-unknown-unknown
+group.armoclcclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
 group.armoclcclang64spir.groupName=Arm 64-bit clang (SPIR-V asm)
 group.armoclcclang64spir.compilers=armv8-oclcclang-trunk-spir64:armv8-oclcclang-trunk-assertions-spir64
@@ -169,7 +191,7 @@ group.armoclcclang64spir.compilerType=spirv
 group.armoclcclang64spir.supportsExecute=false
 group.armoclcclang64spir.instructionSet=aarch64
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armoclcclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -triple spir64-unknown-unknown
+group.armoclcclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-oclcclang-trunk-spir.name=armv7-a clang (trunk, SPIR-V asm)

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -37,16 +37,16 @@ group.spirv.compilers=spirvclang13spir:spirvclang13spir64:spirvclangdefaultspir:
 group.spirv.compilerType=spirv
 compiler.spirvclang13spir.exe=/usr/bin/clang-13
 compiler.spirvclang13spir.name=clang 13 (SPIR-V asm, spir triple)
-compiler.spirvclang13spir.options=-finclude-default-header -triple spir-unknown-unknown
+compiler.spirvclang13spir.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
 compiler.spirvclang13spir64.exe=/usr/bin/clang-13
 compiler.spirvclang13spir64.name=clang 13 (SPIR-V asm, spir64 triple)
-compiler.spirvclang13spir64.options=-finclude-default-header -triple spir64-unknown-unknown
+compiler.spirvclang13spir64.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
 compiler.spirvclangdefaultspir.exe=/usr/bin/clang
 compiler.spirvclangdefaultspir.name=clang default (SPIR-V asm, spir triple)
-compiler.spirvclangdefaultspir.options=-finclude-default-header -triple spir-unknown-unknown
+compiler.spirvclangdefaultspir.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
 compiler.spirvclangdefaultspir64.exe=/usr/bin/clang
 compiler.spirvclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
-compiler.spirvclangdefaultspir64.options=-finclude-default-header -triple spir64-unknown-unknown
+compiler.spirvclangdefaultspir64.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown


### PR DESCRIPTION
Added clang-13 to OpenCL C and C++ for OpenCL.

Improved compilation speed by using '-fdeclare-opencl-builtins'
on the newer clang versions where applicable.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
