### PR TITLE
[PoC] Automatically enable text search for language dropdown

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -372,7 +372,7 @@ pre.content.wrap * {
 
 .change-language {
     line-height: 14px;
-    min-width: 150px !important;
+    min-width: 200px !important;
 }
 
 .change-language .ts-input {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -130,11 +130,13 @@ function Editor(hub, state, container) {
         valueField: 'id',
         labelField: 'name',
         searchField: ['name'],
+        placeholder: '🔍 Select a language...',
         options: _.map(usableLanguages, _.identity),
         items: [this.currentLanguage.id],
         dropdownParent: 'body',
-        plugins: ['input_autogrow'],
+        plugins: ['dropdown_input'],
         onChange: _.bind(this.onLanguageChange, this),
+        closeAfterSelect: true,
     });
 
 


### PR DESCRIPTION
As requested in #2410 the language dropdown now properly indicates that it is text-searchable.

This is a proof of concept with the same selector used for the compilers dropdown. It is an essential part of the CE UI which is why I'd like more opinions on it before moving forward with this change.

![Peek 2021-12-07 13-26](https://user-images.githubusercontent.com/42585241/145028793-da2479b6-da09-4d72-976c-cd62a020874e.gif)