### PR TITLE
Handle filecontent and filename errors

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -995,8 +995,9 @@ export class BaseCompiler {
         const buildResults = await this.loadPackageWithExecutable(key, dirPath);
         if (buildResults) return buildResults;
 
+        let compilationResult;
         try {
-            const compilationResult = await this.buildExecutableInFolder(key, dirPath);
+            compilationResult = await this.buildExecutableInFolder(key, dirPath);
             if (compilationResult.code !== 0) {
                 return compilationResult;
             }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -915,6 +915,8 @@ export class BaseCompiler {
         const filesToWrite = [];
 
         for (let file of files) {
+            if (!file.filename) throw new Error('One of more files do not have a filename');
+
             const fullpath = this.getExtraFilepath(dirPath, file.filename);
             filesToWrite.push(fs.outputFile(fullpath, file.contents));
         }
@@ -923,6 +925,8 @@ export class BaseCompiler {
     }
 
     async writeAllFiles(dirPath, source, files, filters) {
+        if (!source) throw new Error(`File ${this.compileFilename} has no content or file is missing`);
+
         const inputFilename = path.join(dirPath, this.compileFilename);
         await fs.writeFile(inputFilename, source);
 
@@ -938,6 +942,8 @@ export class BaseCompiler {
     }
 
     async writeAllFilesCMake(dirPath, source, files, filters) {
+        if (!source) throw new Error('File CMakeLists.txt has no content or file is missing');
+
         const inputFilename = path.join(dirPath, 'CMakeLists.txt');
         await fs.writeFile(inputFilename, source);
 
@@ -989,9 +995,13 @@ export class BaseCompiler {
         const buildResults = await this.loadPackageWithExecutable(key, dirPath);
         if (buildResults) return buildResults;
 
-        const compilationResult = await this.buildExecutableInFolder(key, dirPath);
-        if (compilationResult.code !== 0) {
-            return compilationResult;
+        try {
+            const compilationResult = await this.buildExecutableInFolder(key, dirPath);
+            if (compilationResult.code !== 0) {
+                return compilationResult;
+            }
+        } catch (e) {
+            return this.handleUserError(e, dirPath);
         }
 
         await this.storePackageWithExecutable(key, dirPath, compilationResult);
@@ -1313,6 +1323,17 @@ export class BaseCompiler {
         return result;
     }
 
+    handleUserError(error, dirPath) {
+        return {
+            dirPath,
+            okToCache: false,
+            code: -1,
+            asm: [{text: `<${error.message}>`}],
+            stdout: [],
+            stderr: [{text: `<${error.message}>` }],
+        };
+    }
+
     async doBuildstepAndAddToResult(result, name, command, args, execParams) {
         const stepResult = await this.doBuildstep(command, args, execParams);
         stepResult.step = name;
@@ -1383,7 +1404,12 @@ export class BaseCompiler {
 
         let fullResult = await this.loadPackageWithExecutable(cacheKey, dirPath);
         if (!fullResult) {
-            const writeSummary = await this.writeAllFilesCMake(dirPath, cacheKey.source, files, cacheKey.filters);
+            let writeSummary;
+            try {
+                writeSummary = await this.writeAllFilesCMake(dirPath, cacheKey.source, files, cacheKey.filters);
+            } catch (e) {
+                return this.handleUserError(e, dirPath);
+            }
 
             const execParams = this.getDefaultExecOptions();
             execParams.appHome = dirPath;
@@ -1559,7 +1585,12 @@ export class BaseCompiler {
 
             const dirPath = await this.newTempDir();
 
-            const writeSummary = await this.writeAllFiles(dirPath, source, files, filters);
+            let writeSummary;
+            try {
+                writeSummary = await this.writeAllFiles(dirPath, source, files, filters);
+            } catch (e) {
+                return this.handleUserError(e, dirPath);
+            }
             const inputFilename = writeSummary.inputFilename;
 
             const [result, optOutput] = await this.doCompilation(


### PR DESCRIPTION
This handles the errors serverside.

Want to iteratively work on this, so we can have better user errors sooner rather than later.
