### PR TITLE
Describe which opcode and arch that was not found

### DIFF
--- a/lib/handlers/assembly-documentation/router.js
+++ b/lib/handlers/assembly-documentation/router.js
@@ -46,9 +46,10 @@ export const setup = (router) => router.get('/asm/:arch/:opcode', (req, res) => 
     if (MAX_STATIC_AGE > 0) {
         res.setHeader('Cache-Control', `public, max-age=${MAX_STATIC_AGE}`);
     }
-    const handler = ASSEMBLY_DOCUMENTATION_HANDLERS[req.params.arch];
+    const architecture = req.params.arch;
+    const handler = ASSEMBLY_DOCUMENTATION_HANDLERS[architecture];
     if (handler !== undefined) {
         return handler.handle(req, res);
     }
-    res.status(404).send({ error: 'Unknown architecture '});
+    res.status(404).json({ error: `No documentation for '${architecture}'` }).send();
 });

--- a/lib/handlers/base-assembly-documentation-handler.js
+++ b/lib/handlers/base-assembly-documentation-handler.js
@@ -57,7 +57,7 @@ export class BaseAssemblyDocumentationHandler {
         const instruction = (request.params.opcode || '__UNKNOWN_OPCODE').toUpperCase();
         const information = this.getInstructionInformation(instruction);
         if (information === null) {
-            return response.status(404).send({ error: 'Unknown opcode' });
+            return response.status(404).send({ error: `Unknown opcode '${instruction}'` });
         }
         // Accept either JSON or Plaintext Content-Type
         const requestedContentType = request.accepts(['text', 'json']);

--- a/test/handlers/api-tests.js
+++ b/test/handlers/api-tests.js
@@ -166,18 +166,6 @@ describe('API handling', () => {
                 throw err;
             });
     });
-    it('should respond to ASM doc requests', () => {
-        return chai.request(app)
-            .get('/api/asm/MOV')
-            .set('Accept', 'application/json')
-            .then(res => {
-                res.should.have.status(200);
-                res.should.be.json;
-            })
-            .catch(err => {
-                throw err;
-            });
-    });
     it('should respond to JSON compilers requests with c++ filter', () => {
         return chai.request(app)
             .get('/api/compilers/c++')

--- a/test/handlers/assembly-documentation/amd64-tests.js
+++ b/test/handlers/assembly-documentation/amd64-tests.js
@@ -40,7 +40,7 @@ describe('amd64 assembly documentation', () => {
            .then(res => {
                res.should.have.status(404);
                res.should.be.json;
-               res.body.should.deep.equal({ error: 'Unknown opcode' });
+               res.body.should.deep.equal({ error: 'Unknown opcode \'MOV_OH_WAIT\'' });
            }).catch(e => { throw e; });
    });
 
@@ -64,16 +64,6 @@ describe('amd64 assembly documentation', () => {
               res.body.url.should.contain('www.felixcloutier.com');
           }).catch(e => { throw e; });
    });
-
-    it('should respond to json for unknown opcodes', () => {
-        return chai.request(app)
-            .get('/asm/NOANOPCODE')
-            .set('Accept', 'application/json')
-            .then(res => {
-                res.should.have.status(404);
-                res.should.be.json;
-            }).catch(e => { throw e; });
-    });
 
     it('should return 406 on bad accept type', () => {
         return chai.request(app).get('/asm/mov')

--- a/test/handlers/assembly-documentation/arm32-tests.js
+++ b/test/handlers/assembly-documentation/arm32-tests.js
@@ -40,7 +40,7 @@ describe('arm32 assembly documentation', () => {
             .then(res => {
                 res.should.have.status(404);
                 res.should.be.json;
-                res.body.should.deep.equal({ error: 'Unknown opcode' });
+                res.body.should.deep.equal({ error: 'Unknown opcode \'MOV_OH_WAIT\'' });
             }).catch(e => { throw e; });
     });
 
@@ -62,16 +62,6 @@ describe('arm32 assembly documentation', () => {
                 res.body.html.should.contain('writes an immediate value');
                 res.body.tooltip.should.contain('writes an immediate value');
                 res.body.url.should.contain('https://developer.arm.com/documentation/');
-            }).catch(e => { throw e; });
-    });
-
-    it('should respond to json for unknown opcodes', () => {
-        return chai.request(app)
-            .get('/asm/NOANOPCODE')
-            .set('Accept', 'application/json')
-            .then(res => {
-                res.should.have.status(404);
-                res.should.be.json;
             }).catch(e => { throw e; });
     });
 
@@ -109,7 +99,7 @@ describe('arm32 assembly documentation', () => {
             .then(res => {
                 res.should.have.status(404);
                 res.should.be.json;
-                res.body.should.deep.equal({ error: 'Unknown opcode' });
+                res.body.should.deep.equal({ error: 'Unknown opcode \'JNE\'' });
             }).catch(e => { throw e; });
     });
 });


### PR DESCRIPTION
Fixes #3167

This is a tiny adjustment to the assembly documentation API to include which architecture/opcode that was not found.

```diff
// GET /api/asm/amd64/not_an_op
- { "error": "Unknown opcode" }
+ { "error": "Unknown opcode 'not_an_op'" }
```

```diff
// GET /api/asm/notarch/mov
- { "error": "Unknown architecture " }
+ { "error": "No documentation for 'notarch'" }
```