### PR TITLE
Fix source/assembly mapping when GNAT expanded code pane opened

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -789,10 +789,6 @@ export class BaseCompiler {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
     }
 
-    getGnatDebugOutputFilename(inputFilename) {
-        return inputFilename + '.dg';
-    }
-
     getOutputFilename(dirPath, outputFilebase, key) {
         let filename;
         if (key && key.backendOptions && key.backendOptions.customOutputFilename) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -812,25 +812,40 @@ export class BaseCompiler {
         return this.getOutputFilename(dirPath, outputFilebase, key);
     }
 
-    async processGnatDebugOutput(inputFilename, output) {
-        const gnatDebugPath = this.getGnatDebugOutputFilename(inputFilename);
+    async processGnatDebugOutput(inputFilename, result) {
+        const content = [];
+        const keep_stdout = [];
+
+        // Everything before this stays in stdout.
+        // Everything after is considered expanded code and is moved to the
+        // corresponding pane.
+        const startOfExpandedCode = /^Source recreated/;
+        let isInExpandedCode = false;
+
+        for (const obj of Object.values(result.stdout)) {
+            if (!isInExpandedCode && startOfExpandedCode.test(obj.text)) {
+                isInExpandedCode = true;
+            }
+
+            if (isInExpandedCode)
+                content.push(obj);
+            else
+                keep_stdout.push(obj);
+        }
 
         // Do not check compiler result before looking for expanded code. The
-        // compiler may exit with an error after the emission. This file is also
+        // compiler may exit with an error after the emission. This dump is also
         // very usefull to debug error message.
-        if (await fs.exists(gnatDebugPath)) {
-            const content = await fs.readFile(gnatDebugPath, 'utf-8');
-            return content.split('\n').map((line) => ({
-                text: line,
-            }));
-        } else {
-            // check for possible cause for missing file
-            if (output.code !== 0) {
+
+        if (content.length === 0)
+            if (result.code !== 0) {
                 return [{text: 'GNAT exited with an error and did not create the expanded code'}];
             } else {
                 return [{text: 'GNAT exited successfully but the expanded code is missing, something is wrong'}];
             }
-        }
+
+        result.stdout = keep_stdout;
+        return content;
     }
 
     /**

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -51,7 +51,8 @@ export class AdaCompiler extends BaseCompiler {
         const opts = super.optionsForBackend (backendOptions, outputFilename);
 
         if (backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugView)
-            opts.push('-gnatDGL');
+            // This is using stdout
+            opts.push('-gnatGL');
 
         return opts;
     }


### PR DESCRIPTION
Using -gnatDGL to get the expanded code also asks GNAT to emit debug
informations pointing to the .dg file containing the expanded code, breaking CE
that is using these info to map assembly and source lines. Using -gnatGL instead
avoids the breaking of asm/source mapping but emits the expanded code in stdout
instead of a plain file.

This change replaces -gnatDGL by -gnatGL and extracts the expanded code from
stdout.

fixes #3171

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>