### PR TITLE
Fix missing gimple and original tree dump in GCC dump

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -835,7 +835,7 @@ export class BaseCompiler {
 
     /**
      * @returns {{filename_suffix: string, name: string, command_prefix: string}}
-     * `filename_suffix`: dump file name suffix if GCC default dump names is used
+     * `filename_suffix`: dump file name suffix if GCC default dump name is used
      *
      * `name`: the name to be displayed in the UI
      *
@@ -1735,24 +1735,55 @@ export class BaseCompiler {
             currentPassOutput: '<No pass selected>',
             syntaxHighlight: false,
         };
+        const treeDumpsNotInPasses = [];
+
         const selectedPasses = [];
 
-        if (opts.treeDump) selectedPasses.push('tree');
+        if (opts.treeDump) {
+            selectedPasses.push('tree');
+
+            // Fake 2 lines as coming from -fdump-passes
+            // This allows the insertion of 'gimple' and 'original'
+            // tree dumps that are not really part of a tree pass.
+            treeDumpsNotInPasses.push (
+                [ { text: 'tree-original:  ON'},
+                  {
+                      filename_suffix: 't.original',
+                      name: 'original (tree)',
+                      command_prefix: '-fdump-tree-original',
+                  },
+                ],
+                [ { text: 'tree-gimple:  ON'},
+                  {
+                      filename_suffix: 't.gimple',
+                      name: 'gimple (tree)',
+                      command_prefix: '-fdump-tree-gimple',
+                  },
+                ]);
+        }
+
         if (opts.ipaDump) selectedPasses.push('ipa');
         if (opts.rtlDump) selectedPasses.push('rtl');
 
+        // Defaults to a custom file derived from output file name. Works when
+        // using the -fdump-tree-foo=FILE variant (!removeEmptyPasses).
+        // Will be overriden later if not.
         let dumpFileName = this.getGccDumpFileName(outputFilename);
         let passFound = false;
 
         const filtered_stderr = [];
         const toRemoveFromStderr = /^\s*((ipa|tree|rtl)-)|(\*)([\w-]+).*(ON|OFF)$/;
-        for (const obj of Object.values(result.stderr)) {
-            const selectizeObject = this.fromInternalGccDumpName(obj.text, selectedPasses);
-            if (selectizeObject){
+
+        const dumpPassesLines = treeDumpsNotInPasses.concat(
+            Object.values(result.stderr).map(
+                x => [x, this.fromInternalGccDumpName(x.text, selectedPasses)]));
+
+        for (const [obj, selectizeObject] of dumpPassesLines) {
+            if (selectizeObject) {
                 if (opts.pass && opts.pass.name === selectizeObject.name)
                     passFound = true;
 
-                if (removeEmptyPasses){
+                if (removeEmptyPasses) {
                     const f = fs.readdirSync(rootDir).filter(fn => fn.endsWith(selectizeObject.filename_suffix));
 
                     // pass is enabled, but the dump hasn't produced anything:
@@ -1760,14 +1791,14 @@ export class BaseCompiler {
                     if (f.length === 0)
                         continue;
 
-                    if (opts.pass && opts.pass.name === selectizeObject.name)
+                    if (passFound)
                         dumpFileName = path.join(rootDir, f[0]);
                 }
 
                 output.all.push(selectizeObject);
             }
 
-            if (!toRemoveFromStderr.test(obj.text)){
+            if (!toRemoveFromStderr.test(obj.text)) {
                 filtered_stderr.push(obj);
             }
         }


### PR DESCRIPTION
Both gimple and original dumps are missing because CE currently only checks for
dumps coming from a pass advertised in -fdump-passes.
Fix this by faking 2 lines as coming from -fdump-passes.

fixes #3180

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>