### PR TITLE
Ada: new pane for GNAT Debug Tree

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -809,39 +809,74 @@ export class BaseCompiler {
     }
 
     async processGnatDebugOutput(inputFilename, result) {
-        const content = [];
+        const contentDebugExpanded = [];
+        const contentDebugTree = [];
         const keep_stdout = [];
 
-        // Everything before this stays in stdout.
-        // Everything after is considered expanded code and is moved to the
-        // corresponding pane.
-        const startOfExpandedCode = /^Source recreated/;
+        // stdout layout:
+        //
+        // ----- start
+        // everything here stays
+        // ... in stdout
+        // ... until :
+        // Source recreated from tree... <-\
+        // everything here is              |
+        // ... sent in expanded            | this is optionnal
+        // ... pane... until :           <-/
+        // Tree created for ...          <-\
+        // everything after is             | this is optionnal
+        // ... sent in Tree pane         <-/
+        // ----- EOF
+        const startOfExpandedCode = /^Source recreated from tree/;
+        const startOfTree = /^Tree created for/;
+
         let isInExpandedCode = false;
+        let isInTree = false;
 
         for (const obj of Object.values(result.stdout)) {
             if (!isInExpandedCode && startOfExpandedCode.test(obj.text)) {
                 isInExpandedCode = true;
+                isInTree = false;
             }
 
-            if (isInExpandedCode)
-                content.push(obj);
-            else
+            if (!isInTree && startOfTree.test(obj.text)) {
+                isInExpandedCode = false;
+                isInTree = true;
+            }
+
+            if (isInExpandedCode) {
+                contentDebugExpanded.push(obj);
+            } else if (isInTree){
+                contentDebugTree.push(obj);
+            } else {
                 keep_stdout.push(obj);
+            }
         }
 
         // Do not check compiler result before looking for expanded code. The
         // compiler may exit with an error after the emission. This dump is also
         // very usefull to debug error message.
 
-        if (content.length === 0)
+        if (contentDebugExpanded.length === 0)
             if (result.code !== 0) {
-                return [{text: 'GNAT exited with an error and did not create the expanded code'}];
+                contentDebugExpanded.push({text: 'GNAT exited with an error and did not create the expanded code'});
             } else {
-                return [{text: 'GNAT exited successfully but the expanded code is missing, something is wrong'}];
+                contentDebugExpanded.push(
+                    {text: 'GNAT exited successfully but the expanded code is missing, something is wrong'});
             }
 
-        result.stdout = keep_stdout;
-        return content;
+        if (contentDebugTree.length === 0)
+            if (result.code !== 0) {
+                contentDebugTree.push({text: 'GNAT exited with an error and did not create the Tree'});
+            } else {
+                contentDebugTree.push({text: 'GNAT exited successfully but the Tree is missing, something is wrong'});
+            }
+
+        return {
+            stdout: keep_stdout,
+            tree: contentDebugTree,
+            expandedcode: contentDebugExpanded,
+        };
     }
 
     /**
@@ -1216,7 +1251,8 @@ export class BaseCompiler {
         execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         const makeAst = backendOptions.produceAst && this.compiler.supportsAstView;
-        const makeGnatDebug = backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugView;
+        const makeGnatDebug = backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugViews;
+        const makeGnatDebugTree = backendOptions.produceGnatDebugTree && this.compiler.supportsGnatDebugViews;
         const makeIr = backendOptions.produceIr && this.compiler.supportsIrView;
         const makeRustMir = backendOptions.produceRustMir && this.compiler.supportsRustMirView;
         const makeRustMacroExp = backendOptions.produceRustMacroExp && this.compiler.supportsRustMacroExpView;
@@ -1247,9 +1283,10 @@ export class BaseCompiler {
 
         // GNAT, GCC and rustc can produce their extra output files along
         // with the main compilation command.
-        const gnatDebugResult = (makeGnatDebug ?
-                                 await this.processGnatDebugOutput(inputFilenameSafe, asmResult)
-                                 : '');
+        const gnatDebugResults = ((makeGnatDebug || makeGnatDebugTree)?
+                                  await this.processGnatDebugOutput(inputFilenameSafe, asmResult)
+                                  : '');
+
         const gccDumpResult = (makeGccDump ?
                                await this.processGccDumpOutput(backendOptions.produceGccDump,
                                                                asmResult, this.compiler.removeEmptyGccDump,
@@ -1267,9 +1304,17 @@ export class BaseCompiler {
             asmResult.gccDumpOutput = gccDumpResult;
         }
 
-        if (this.compiler.supportsGnatDebugView && gnatDebugResult) {
-            asmResult.hasGnatDebugOutput = true;
-            asmResult.gnatDebugOutput = gnatDebugResult;
+        if (this.compiler.supportsGnatDebugViews && gnatDebugResults) {
+            asmResult.stdout = gnatDebugResults.stdout;
+
+            if (makeGnatDebug && gnatDebugResults.expandedcode.length > 0) {
+                asmResult.hasGnatDebugOutput = true;
+                asmResult.gnatDebugOutput = gnatDebugResults.expandedcode;
+            }
+            if (makeGnatDebugTree && gnatDebugResults.tree.length > 0) {
+                asmResult.hasGnatDebugTreeOutput = true;
+                asmResult.gnatDebugTreeOutput = gnatDebugResults.tree;
+            }
         }
 
         asmResult.tools = toolsResult;

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -35,7 +35,9 @@ export class AdaCompiler extends BaseCompiler {
         this.compiler.supportsGccDump = true;
         this.compiler.removeEmptyGccDump = true;
         this.compiler.supportsIntel = true;
-        this.compiler.supportsGnatDebugView = true;
+
+        // used for all GNAT related panes (Expanded code, Tree)
+        this.compiler.supportsGnatDebugViews = true;
     }
 
     getExecutableFilename(dirPath) {
@@ -50,9 +52,13 @@ export class AdaCompiler extends BaseCompiler {
         // super is needed as it handles the GCC Dump files.
         const opts = super.optionsForBackend (backendOptions, outputFilename);
 
-        if (backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugView)
+        if (backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugViews)
             // This is using stdout
             opts.push('-gnatGL');
+
+        if (backendOptions.produceGnatDebugTree && this.compiler.supportsGnatDebugViews)
+            // This is also using stdout
+            opts.push('-gnatdt');
 
         return opts;
     }

--- a/static/components.js
+++ b/static/components.js
@@ -310,6 +310,28 @@ module.exports = {
             },
         };
     },
+
+    getGnatDebugTreeView: function () {
+        return {
+            type: 'component',
+            componentName: 'gnatdebugtree',
+            componentState: {},
+        };
+    },
+    getGnatDebugTreeViewWith: function (id, source, gnatDebugTreeOutput, compilerName, editorid) {
+        return {
+            type: 'component',
+            componentName: 'gnatdebugtree',
+            componentState: {
+                id: id,
+                source: source,
+                gnatDebugTreeOutput: gnatDebugTreeOutput,
+                compilerName: compilerName,
+                editorid: editorid,
+            },
+        };
+    },
+
     getGnatDebugView: function () {
         return {
             type: 'component',

--- a/static/hub.js
+++ b/static/hub.js
@@ -42,6 +42,7 @@ var irView = require('./panes/ir-view');
 var deviceView = require('./panes/device-view');
 var rustMirView = require('./panes/rustmir-view');
 var gnatDebugView = require('./panes/gnatdebug-view');
+var gnatDebugTreeView = require('./panes/gnatdebugtree-view');
 var rustMacroExpView = require('./panes/rustmacroexp-view');
 var rustHirView = require('./panes/rusthir-view');
 var gccDumpView = require('./panes/gccdump-view');
@@ -145,6 +146,10 @@ function Hub(layout, subLangId, defaultLangId) {
     layout.registerComponent(Components.getRustMirView().componentName,
         function (container, state) {
             return self.rustMirViewFactory(container, state);
+        });
+    layout.registerComponent(Components.getGnatDebugTreeView().componentName,
+        function (container, state) {
+            return self.gnatDebugTreeViewFactory(container, state);
         });
     layout.registerComponent(Components.getGnatDebugView().componentName,
         function (container, state) {
@@ -326,6 +331,10 @@ Hub.prototype.irViewFactory = function (container, state) {
 
 Hub.prototype.deviceViewFactory = function (container, state) {
     return new deviceView.DeviceAsm(this, container, state);
+};
+
+Hub.prototype.gnatDebugTreeViewFactory = function (container, state) {
+    return new gnatDebugTreeView.GnatDebugTree(this, container, state);
 };
 
 Hub.prototype.gnatDebugViewFactory = function (container, state) {

--- a/static/panes/diff.js
+++ b/static/panes/diff.js
@@ -41,7 +41,8 @@ var
     DiffType_CompilerStdErr = 2,
     DiffType_ExecStdOut = 3,
     DiffType_ExecStdErr = 4,
-    DiffType_GNAT_ExpandedCode = 5;
+    DiffType_GNAT_ExpandedCode = 5,
+    DiffType_GNAT_Tree = 6;
 
 function State(id, model, difftype) {
     this.id = id;
@@ -85,6 +86,11 @@ State.prototype.refresh = function () {
                 if (this.result.hasGnatDebugOutput)
                     output = this.result.gnatDebugOutput || [];
                 break;
+            case DiffType_GNAT_Tree:
+                if (this.result.hasGnatDebugTreeOutput)
+                    output = this.result.gnatDebugTreeOutput || [];
+                break;
+
         }
     }
     this.model.setValue(_.pluck(output, 'text').join('\n'));
@@ -136,6 +142,7 @@ function Diff(hub, container, state) {
                 {id: DiffType_ExecStdOut, name: 'Execution stdout'},
                 {id: DiffType_ExecStdErr, name: 'Execution stderr'},
                 {id: DiffType_GNAT_ExpandedCode, name: 'GNAT Expanded Code'},
+                {id: DiffType_GNAT_Tree, name: 'GNAT Tree Code'},
             ],
             items: [],
             render: {

--- a/static/panes/gnatdebugtree-view.interfaces.ts
+++ b/static/panes/gnatdebugtree-view.interfaces.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+export interface GnatDebugTreeState {
+    gnatDebugTreeOutput: any;
+}

--- a/static/panes/gnatdebugtree-view.ts
+++ b/static/panes/gnatdebugtree-view.ts
@@ -27,27 +27,27 @@ import * as monaco from 'monaco-editor';
 import { Container } from 'golden-layout';
 
 import { Pane } from './pane';
-import { GnatDebugState } from './gnatdebug-view.interfaces';
+import { GnatDebugTreeState } from './gnatdebugtree-view.interfaces';
 import { BasePaneState } from './pane.interfaces';
 
 import { ga } from '../analytics';
 import { extendConfig } from '../monaco-config';
 
-export class GnatDebug extends Pane<monaco.editor.IStandaloneCodeEditor, GnatDebugState> {
-    constructor(hub: any, container: Container, state: GnatDebugState & BasePaneState) {
+export class GnatDebugTree extends Pane<monaco.editor.IStandaloneCodeEditor, GnatDebugTreeState> {
+    constructor(hub: any, container: Container, state: GnatDebugTreeState & BasePaneState) {
         super(hub, container, state);
-        if (state && state.gnatDebugOutput) {
-            this.showGnatDebugResults(state.gnatDebugOutput);
+        if (state && state.gnatDebugTreeOutput) {
+            this.showGnatDebugTreeResults(state.gnatDebugTreeOutput);
         }
     }
 
     override getInitialHTML(): string {
-        return $('#gnatdebug').html();
+        return $('#gnatdebugtree').html();
     }
 
     override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
         return monaco.editor.create(editorRoot, extendConfig({
-            language: 'ada',
+            language: 'plainText',
             readOnly: true,
             glyphMargin: true,
             lineNumbersMinChars: 3,
@@ -58,12 +58,12 @@ export class GnatDebug extends Pane<monaco.editor.IStandaloneCodeEditor, GnatDeb
         ga.proxy('send', {
             hitType: 'event',
             eventCategory: 'OpenViewPane',
-            eventAction: 'GnatDebug',
+            eventAction: 'GnatDebugTree',
         });
     }
 
     override getPaneName(): string {
-        return `GNAT Debug Viewer ${this.compilerInfo.compilerName}` +
+        return `GNAT Debug Tree Viewer ${this.compilerInfo.compilerName}` +
             `(Editor #${this.compilerInfo.editorId}, ` +
             `Compiler #${this.compilerInfo.compilerId})`;
     }
@@ -71,16 +71,16 @@ export class GnatDebug extends Pane<monaco.editor.IStandaloneCodeEditor, GnatDeb
     override registerCallbacks(): void {
         const throttleFunction = _.throttle((event) => this.onDidChangeCursorSelection(event), 500);
         this.editor.onDidChangeCursorSelection((event) => throttleFunction(event));
-        this.eventHub.emit('gnatDebugViewOpened', this.compilerInfo.compilerId);
+        this.eventHub.emit('gnatDebugTreeViewOpened', this.compilerInfo.compilerId);
         this.eventHub.emit('requestSettings');
     }
 
     override onCompileResult(compilerId: number, compiler: any, result: any): void {
         if (this.compilerInfo.compilerId !== compilerId) return;
-        if (result.hasGnatDebugOutput) {
-            this.showGnatDebugResults(result.gnatDebugOutput);
+        if (result.hasGnatDebugTreeOutput) {
+            this.showGnatDebugTreeResults(result.gnatDebugTreeOutput);
         } else if (compiler.supportsGnatDebugViews) {
-            this.showGnatDebugResults([{text: '<No output>'}]);
+            this.showGnatDebugTreeResults([{text: '<No output>'}]);
         }
     }
 
@@ -90,16 +90,16 @@ export class GnatDebug extends Pane<monaco.editor.IStandaloneCodeEditor, GnatDeb
             this.compilerInfo.editorId = editorId;
             this.setTitle();
             if (compiler && !compiler.supportsGnatDebugViews) {
-                this.showGnatDebugResults([{text: '<GNAT Debug output is not supported for this compiler>'}]);
+                this.showGnatDebugTreeResults([{text: '<GNAT Debug Tree output is not supported for this compiler>'}]);
             }
         }
     }
 
-    showGnatDebugResults(result: any[]): void {
+    showGnatDebugTreeResults(result: any[]): void {
         if (!this.editor) return;
         this.editor.getModel().setValue(result.length
             ? _.pluck(result, 'text').join('\n')
-            : '<No GNAT Debug generated>');
+            : '<No GNAT Debug Tree generated>');
 
         if (!this.isAwaitingInitialResults) {
             if (this.selection) {
@@ -113,7 +113,7 @@ export class GnatDebug extends Pane<monaco.editor.IStandaloneCodeEditor, GnatDeb
 
     override close(): void {
         this.eventHub.unsubscribe();
-        this.eventHub.emit('gnatDebugViewClosed', this.compilerInfo.compilerId);
+        this.eventHub.emit('gnatDebugTreeViewClosed', this.compilerInfo.compilerId);
         this.editor.dispose();
     }
 }

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -114,6 +114,9 @@
           button.dropdown-item.btn.btn-sm.btn-light.view-gccdump(title="Show Tree/RTL dump (GCC only)")
             span.dropdown-icon.fas.fa-tree
             | GCC Tree/RTL output
+          button.dropdown-item.btn.btn-sm.btn-light.view-gnatdebugtree(title="Show GNAT Debug Tree")
+              span.dropdown-icon.fas.fa-tree
+              | GNAT Debug Tree
           button.dropdown-item.btn.btn-sm.btn-light.view-gnatdebug(title="Show GNAT Debug Expanded Code")
             span.dropdown-icon.fas.fa-tree
             | GNAT Debug Expanded Code
@@ -292,6 +295,11 @@
       include font-size.pug
       .btn-group.btn-group-sm(role="group")
         select.change-device(placeholder="Select a device...")
+    .monaco-placeholder
+
+  #gnatdebugtree
+    .top-bar.btn-toolbar.bg-light(role="toolbar")
+      include font-size
     .monaco-placeholder
 
   #gnatdebug


### PR DESCRIPTION
Support for the GNAT Tree emitted by `-gnatdt` on stdout.
The pane is also available in the diff tool.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>