### PR TITLE
Add GCC compiler for MRISC32

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,3 +105,4 @@ From oldest to newest contributor, we would like to thank:
 - [Quinton Miller](https://github.com/HertzDevil)
 - [Kevin Adler](https://github.com/kadler)
 - [Björn Gustavsson](https://github.com/bjorng)
+- [Marcus Geelnard](https://github.com/mbitsnbites)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -653,7 +653,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray
+group.cross.compilers=&ppc:&mips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -970,6 +970,17 @@ compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknow
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
 compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+
+###############################
+# GCC for MRISC32
+group.mrisc32.compilers=mrisc32-gcc-trunk
+group.mrisc32.groupName=MRISC32 GCC
+group.mrisc32.isSemVer=true
+
+compiler.mrisc32-gcc-trunk.exe=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-g++
+compiler.mrisc32-gcc-trunk.name=MRISC32 gcc (trunk)
+compiler.mrisc32-gcc-trunk.semver=(trunk)
+compiler.mrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-objdump
 
 ###############################
 # GCC for RISC-V

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -563,7 +563,7 @@ compiler.cicx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray
+group.ccross.compilers=&cppc:&cmips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
@@ -864,6 +864,18 @@ compiler.cmips564.semver=5.4
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
+
+###############################
+# GCC for MRISC32
+group.cmrisc32.compilers=cmrisc32-gcc-trunk
+group.cmrisc32.groupName=MRISC32 GCC
+group.cmrisc32.isSemVer=true
+group.cmrisc32.supportsBinary=true
+
+compiler.cmrisc32-gcc-trunk.exe=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-gcc
+compiler.cmrisc32-gcc-trunk.name=MRISC32 gcc (trunk)
+compiler.cmrisc32-gcc-trunk.semver=(trunk)
+compiler.cmrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-objdump
 
 ###############################
 # GCC for RISC-V


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

*This PR depends on https://github.com/compiler-explorer/infra/pull/650*

## About MRISC32

MRISC32 is an open Vector/RISC ISA (inspired by architectures such as Cray and MIPS). More information here:

* https://mrisc32.bitsnbites.eu
* https://github.com/mrisc32
* https://www.bitsnbites.eu/category/hardware-development/mrisc32

## About this patch

This adds C and C++ cross compilation targets for MRISC32, based on the MRISC32 GNU toolchain.

I have "kind of" tested the "amazon" setup locally:

* I ran `make ce && ./bin/ce_install install compilers` in infra (which downloaded the MRISC32 toolchain to my /opt/compiler-explorer folder).
* Then I added the relevant stuff to custom `c++.local.properties` and  `c.local.properties` files, ran `make dev` in a local clone of compiler-explorer, and verified that I could run the compiler.

Please let me know if there is anything else that I should do to ensure that things will work as expected in the live version.