### PR TITLE
add intel oneapi 2022, 2021.4 releases

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -540,7 +540,7 @@ compiler.wasm32clang.options=-target wasm32
 
 ################################
 # icc for x86
-group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120:icc202130
+group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120:icc202130:icc202140:icc202150
 group.icc.intelAsm=-masm=intel
 group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
@@ -584,15 +584,28 @@ compiler.icc202120.ldPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler
 compiler.icc202120.libPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icc202120.semver=2021.2.0
 compiler.icc202120.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 compiler.icc202130.exe=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/bin/intel64/icc
 compiler.icc202130.ldPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin
 compiler.icc202130.libPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icc202130.semver=2021.3.0
 compiler.icc202130.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
+compiler.icc202140.exe=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/bin/intel64/icc
+compiler.icc202140.ldPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icc202140.libPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc202140.semver=2021.4.0
+compiler.icc202140.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
+compiler.icc202150.exe=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/bin/intel64/icc
+compiler.icc202150.ldPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icc202150.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc202150.semver=2021.5.0
+compiler.icc202150.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -616,6 +629,18 @@ compiler.icx202130.ldPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compile
 compiler.icx202130.libPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icx202130.semver=2021.3.0
 compiler.icx202130.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.icx202140.exe=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/bin/icpx
+compiler.icx202140.ldPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icx202140.libPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icx202140.semver=2021.4.0
+compiler.icx202140.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.icx202200.exe=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/bin/icpx
+compiler.icx202200.ldPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icx202200.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icx202200.semver=2022.0.0
+compiler.icx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ################################
 # zapcc

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -499,6 +499,12 @@ compiler.cicc202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compile
 compiler.cicc202112.semver=2021.1.2
 compiler.cicc202112.options=-gcc-name=/opt/compiler-explorer/gcc-10.1.0/bin/gcc
 
+compiler.cicc202120.exe=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/bin/intel64/icc
+compiler.cicc202120.ldPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc202120.libPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc202120.semver=2021.2.0
+compiler.cicc202120.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 compiler.cicc202130.exe=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/bin/intel64/icc
 compiler.cicc202130.ldPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin
 compiler.cicc202130.libPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/ia32_lin

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -467,7 +467,7 @@ compiler.ppci055.semver=0.5.5
 compiler.ppci055.exe=/opt/compiler-explorer/ppci-0.5.5/ppci/cli/cc.py
 
 # icc for x86
-group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112
+group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112:cicc202120:cicc202130:cicc202140:cicc202150
 group.cicc.intelAsm=-masm=intel
 group.cicc.options=-x c -gcc-name=/opt/compiler-explorer/gcc-4.7.1/bin/gcc
 group.cicc.groupName=ICC x86-64
@@ -499,8 +499,26 @@ compiler.cicc202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compile
 compiler.cicc202112.semver=2021.1.2
 compiler.cicc202112.options=-gcc-name=/opt/compiler-explorer/gcc-10.1.0/bin/gcc
 
+compiler.cicc202130.exe=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/bin/intel64/icc
+compiler.cicc202130.ldPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc202130.libPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc202130.semver=2021.3.0
+compiler.cicc202130.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
+compiler.cicc202140.exe=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/bin/intel64/icc
+compiler.cicc202140.ldPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc202140.libPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc202140.semver=2021.4.0
+compiler.cicc202140.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
+compiler.cicc202150.exe=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/bin/intel64/icc
+compiler.cicc202150.ldPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc202150.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc202150.semver=2021.5.0
+compiler.cicc202150.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 # icx for x86
-group.cicx.compilers=cicx202112
+group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200
 group.cicx.intelAsm=-masm=intel
 group.cicx.options=
 group.cicx.groupName=ICX x86-64
@@ -512,6 +530,30 @@ compiler.cicx202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler
 compiler.cicx202112.libPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.cicx202112.semver=2021.1.2
 compiler.cicx202112.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.cicx202120.exe=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/bin/icx
+compiler.cicx202120.ldPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicx202120.libPath=/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.2.0.118/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202120.semver=2021.2.0
+compiler.cicx202120.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.cicx202130.exe=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/bin/icx
+compiler.cicx202130.ldPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicx202130.libPath=/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.3.0.3168/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202130.semver=2021.3.0
+compiler.cicx202130.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.cicx202140.exe=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/bin/icx
+compiler.cicx202140.ldPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicx202140.libPath=/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.4.0.3201/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202140.semver=2021.4.0
+compiler.cicx202140.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.cicx202200.exe=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/bin/icx
+compiler.cicx202200.ldPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicx202200.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202200.semver=2022.0.0
+compiler.cicx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -57,7 +57,7 @@ compiler.gfortransnapshot.semver=(trunk)
 
 ###############################
 # Intel Parallel Studio XE for x86
-group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130
+group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150
 group.ifort.intelAsm=-masm=intel
 group.ifort.groupName=IFORT x86-64
 group.ifort.isSemVer=true
@@ -90,9 +90,21 @@ compiler.ifort202130.libPath=/opt/compiler-explorer/intel-fortran-2021.3.0.3168/
 compiler.ifort202130.semver=2021.3.0
 compiler.ifort202130.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
+compiler.ifort202140.exe=/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/bin/intel64/ifort
+compiler.ifort202140.ldPath=/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifort202140.libPath=/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifort202140.semver=2021.4.0
+compiler.ifort202140.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
+compiler.ifort202150.exe=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/bin/intel64/ifort
+compiler.ifort202150.ldPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifort202150.libPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifort202150.semver=2021.5.0
+compiler.ifort202150.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 ###############################
 # Intel oneAPI for x86
-group.ifx.compilers=ifx202112:ifx202120:ifx202130
+group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200
 group.ifx.intelAsm=-masm=intel
 group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
@@ -113,6 +125,16 @@ compiler.ifx202130.exe=/opt/compiler-explorer/intel-fortran-2021.3.0.3168/compil
 compiler.ifx202130.ldPath=/opt/compiler-explorer/intel-fortran-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin
 compiler.ifx202130.libPath=/opt/compiler-explorer/intel-fortran-2021.3.0.3168/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.3.0.3168/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifx202130.semver=2021.3.0
+
+compiler.ifx202140.exe=/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/bin/ifx
+compiler.ifx202140.ldPath=/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifx202140.libPath=/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2021.4.0.3224/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202140.semver=2021.4.0
+
+compiler.ifx202200.exe=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/bin/ifx
+compiler.ifx202200.ldPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifx202200.libPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202200.semver=2022.0.0
 
 ###############################
 # GCC Cross-Compilers


### PR DESCRIPTION
In addition to 2022 & 2021.4 releases, I added some missing C compilers for earlier versions

Note that the version number in the package, icc version, and icx version are no longer in sync.

| package         | icc         | icx          |
| --------------- |--------- |---------- |
| 2022.0.1.71     |2021.5.0 |2022.0.0 |
| 2021.4.0.3201 |2021.4.0 |2021.4.0 |

Depends on https://github.com/compiler-explorer/infra/pull/652