### PR TITLE
MRISC32 GCC should have instruction set "mrisc32"

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -871,6 +871,7 @@ group.cmrisc32.compilers=cmrisc32-gcc-trunk
 group.cmrisc32.groupName=MRISC32 GCC
 group.cmrisc32.isSemVer=true
 group.cmrisc32.supportsBinary=true
+group.cmrisc32.supportsExecute=false
 
 compiler.cmrisc32-gcc-trunk.exe=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-gcc
 compiler.cmrisc32-gcc-trunk.name=MRISC32 gcc (trunk)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -876,6 +876,7 @@ compiler.cmrisc32-gcc-trunk.exe=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu
 compiler.cmrisc32-gcc-trunk.name=MRISC32 gcc (trunk)
 compiler.cmrisc32-gcc-trunk.semver=(trunk)
 compiler.cmrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-objdump
+compiler.cmrisc32-gcc-trunk.instructionSet=mrisc32
 
 ###############################
 # GCC for RISC-V


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
This PR adds one line to the compiler configuration file, specifying that the MRISC32 GCC compiler outputs the "mrisc32" instruction set. 
