### PR TITLE
Enable gemmlowp C++ header-only lib on CE site

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -107,3 +107,4 @@ From oldest to newest contributor, we would like to thank:
 - [Björn Gustavsson](https://github.com/bjorng)
 - [Gregory Anders](https://github.com/gpanders)
 - [Marcus Geelnard](https://github.com/mbitsnbites)
+- [Haneef Mubarak](https://github.com/haneefmubarak)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1188,7 +1188,7 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:glm:gnufs:googletest:gsl:hedley:hfsm:highway:hotels-template-library:immer:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
+libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:googletest:gsl:hedley:hfsm:highway:hotels-template-library:immer:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -1645,6 +1645,12 @@ libs.fmt.versions.700.version=7.0.0
 libs.fmt.versions.700.path=/opt/compiler-explorer/libs/fmt/7.0.0/include
 libs.fmt.versions.713.version=7.1.3
 libs.fmt.versions.713.path=/opt/compiler-explorer/libs/fmt/7.1.3/include
+
+libs.gemmlowp.name=gemmlowp
+libs.gemmlowp.url=https://github.com/google/gemmlowp
+libs.gemmlowp.versions=trunk
+libs.gemmlowp.versions.trunk.version=trunk
+libs.gemmlowp.versions.trunk.path=/opt/compiler-explorer/libs/gemmlowp/trunk
 
 libs.glm.name=GLM
 libs.glm.description=OpenGL Mathematics


### PR DESCRIPTION
See also compiler-explorer/infra#657:

 > Adds support for a useful C++ header-only library from Google that provides a low/fixed-precision general matrix multiplication routine alongside miscellaneous transcendental functions.