### PR TITLE
Support for compiling to binary object

### DIFF
--- a/lib/asm-parser-vc.js
+++ b/lib/asm-parser-vc.js
@@ -85,7 +85,7 @@ export class VcAsmParser extends AsmParser {
     }
 
     processAsm(asm, filters) {
-        if (filters.binary) {
+        if (filters.binary || filters.binaryobject) {
             return this.asmBinaryParser.processAsm(asm, filters);
         }
 

--- a/lib/asm-parser-vc6.js
+++ b/lib/asm-parser-vc6.js
@@ -85,7 +85,7 @@ export class Vc6AsmParser extends AsmParser {
     }
 
     processAsm(asm, filters) {
-        if (filters.binary) {
+        if (filters.binary || filters.binaryobject) {
             return this.asmBinaryParser.processAsm(asm, filters);
         }
 

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -67,6 +67,7 @@ export class AsmParser extends AsmRegex {
         }
 
         this.asmOpcodeRe = /^\s*(?<address>[\da-f]+):\s*(?<opcodes>([\da-f]{2} ?)+)\s*(?<disasm>.*)/;
+        this.relocationRe = /^\s*(?<address>[\da-f]+):\s*(?<relocname>(R_[\dA-Z_]))\s*(?<relocdata>.*)/;
         this.lineRe = /^(\/[^:]+):(?<line>\d+).*/;
         this.labelRe = /^([\da-f]+)\s+<([^>]+)>:$/;
         this.destRe = /\s([\da-f]+)\s+<([^+>]+)(\+0x[\da-f]+)?>$/;
@@ -258,7 +259,7 @@ export class AsmParser extends AsmRegex {
     }
 
     processAsm(asmResult, filters) {
-        if (filters.binary) return this.processBinaryAsm(asmResult, filters);
+        if (filters.binary || filters.binaryobject) return this.processBinaryAsm(asmResult, filters);
 
         const startTime = process.hrtime.bigint();
 
@@ -633,6 +634,19 @@ export class AsmParser extends AsmRegex {
                     text: disassembly,
                     source: source,
                     labels: labelsInLine,
+                });
+            }
+
+            match = line.match(this.relocationRe);
+            if (match) {
+                const address = parseInt(match.groups.address, 16);
+                const relocname = match.groups.relocname;
+                const relocdata = match.groups.relocdata;
+                asm.push({
+                    text: `      ${relocname} ${relocdata}`,
+                    address: address,
+                    labels: labelsInLine,
+                    source: null,
                 });
             }
         }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -304,7 +304,7 @@ export class BaseCompiler {
         return output;
     }
 
-    async objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+    async objdump(outputFilename, result, maxSize, intelAsm, demangle, staticReloc, dynamicReloc) {
         outputFilename = this.getObjdumpOutputFilename(outputFilename);
 
         if (!await utils.fileExists(outputFilename)) {
@@ -314,6 +314,8 @@ export class BaseCompiler {
 
         const objdumper = new this.objdumperClass();
         const args = ['-d', outputFilename, '-l', ...objdumper.widthOptions];
+        if (staticReloc) args.push('-r');
+        if (dynamicReloc) args.push('-R');
         if (demangle) args.push('-C');
         if (intelAsm) args.push(...objdumper.intelAsmOptions);
         const execOptions = {maxOutput: maxSize, customCwd: result.dirPath || path.dirname(outputFilename)};
@@ -444,10 +446,12 @@ export class BaseCompiler {
 
     optionsForFilter(filters, outputFilename) {
         let options = ['-g', '-o', this.filename(outputFilename)];
-        if (this.compiler.intelAsm && filters.intel && !filters.binary) {
+        if (this.compiler.intelAsm && filters.intel && !filters.binary && !filters.binaryobject) {
             options = options.concat(this.compiler.intelAsm.split(' '));
         }
-        if (!filters.binary) options = options.concat('-S');
+        if (!filters.binary && !filters.binaryobject) options = options.concat('-S');
+        else if (filters.binaryobject) options = options.concat('-c');
+
         return options;
     }
 
@@ -667,7 +671,7 @@ export class BaseCompiler {
         let libPaths = [];
         let staticLibLinks = [];
 
-        if (filters.binary) {
+        if (filters.binary || filters.binaryobject) {
             libLinks = this.getSharedLibraryLinks(libraries);
             libPaths = this.getSharedLibraryPathsAsArguments(libraries);
             staticLibLinks = this.getStaticLibraryLinks(libraries);
@@ -1235,7 +1239,7 @@ export class BaseCompiler {
 
     async doCompilation(inputFilename, dirPath, key, options, filters, backendOptions, libraries, tools) {
         let buildEnvironment = Promise.resolve();
-        if (filters.binary) {
+        if (filters.binary || filters.binaryobject) {
             buildEnvironment = this.setupBuildEnvironment(key, dirPath);
         }
 
@@ -1904,8 +1908,8 @@ but nothing was dumped. Possible causes are:
         const postProcess = _.compact(this.compiler.postProcess);
         const maxSize = this.env.ceProps('max-asm-size', 64 * 1024 * 1024);
         const optPromise = result.hasOptOutput ? this.processOptOutput(result.optPath) : '';
-        const asmPromise = (filters.binary && this.supportsObjdump())
-            ? this.objdump(outputFilename, result, maxSize, filters.intel, filters.demangle)
+        const asmPromise = ((filters.binary || filters.binaryobject) && this.supportsObjdump())
+            ? this.objdump(outputFilename, result, maxSize, filters.intel, filters.demangle, filters.binaryobject, false)
             : (async () => {
                 if (result.asmSize === undefined) {
                     result.asm = '<No output file>';

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -30,7 +30,7 @@ export class PaholeTool extends BaseTool {
     static get key() { return 'pahole-tool'; }
 
     async runTool(compilationInfo, inputFilepath, args) {
-        if (!compilationInfo.filters.binary) {
+        if (!compilationInfo.filters.binary || !compilationInfo.filters.binaryobject) {
             return this.createErrorResponse('Pahole requires a binary output');
         }
 

--- a/lib/tooling/readelf-tool.js
+++ b/lib/tooling/readelf-tool.js
@@ -30,7 +30,7 @@ export class ReadElfTool extends BaseTool {
     static get key() { return 'readelf-tool'; }
 
     async runTool(compilationInfo, inputFilename, args) {
-        if(!compilationInfo.filters.binary)
+        if(!compilationInfo.filters.binary && !compilationInfo.filters.binaryobject)
         {
             return this.createErrorResponse('readelf requires an executable');
         }

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -966,7 +966,7 @@ Compiler.prototype.setAssembly = function (result, filteredCount) {
     this.updateDecorations();
 
     var codeLenses = [];
-    if (this.getEffectiveFilters().binary) {
+    if (this.getEffectiveFilters().binary || this.getEffectiveFilters().binaryobject) {
         this.setBinaryMargin();
         _.each(this.assembly, _.bind(function (obj, line) {
             if (obj.opcodes) {

--- a/views/options-output.pug
+++ b/views/options-output.pug
@@ -13,6 +13,7 @@ mixin outputoption(name, longdescription, shortdescription, defaultchecked)
         span=shortdescription
       input.d-none(type="checkbox" checked=defaultchecked)
 
++outputoption('binaryobject', 'Compile to binary object and disassemble the output', 'Compile to binary object', false)
 +outputoption('binary', 'Compile to binary and disassemble the output', 'Compile to binary', false)
 +outputoption('execute', 'Execute code and show its output', 'Execute the code', false)
 +outputoption('intel', 'Output disassembly in Intel syntax', 'Intel asm syntax', true)


### PR DESCRIPTION
Support for compiling until assembler, before invoking the linker (eg. gcc -c).
Basic support for displaying relocation informations.

Still WIP.

refs #3222

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>