### PR TITLE
Fix parsing assembler from binary whent templates are used

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -68,7 +68,10 @@ export class AsmParser extends AsmRegex {
 
         this.asmOpcodeRe = /^\s*(?<address>[\da-f]+):\s*(?<opcodes>([\da-f]{2} ?)+)\s*(?<disasm>.*)/;
         this.lineRe = /^(\/[^:]+):(?<line>\d+).*/;
-        this.labelRe = /^([\da-f]+)\s+<([^>]+)>:$/;
+
+        // labelRe is made very greedy as it's also used with demangled objdump
+        // output (eg. it can have c++ template with <>).
+        this.labelRe = /^([\da-f]+)\s+<(.+)>:$/;
         this.destRe = /\s([\da-f]+)\s+<([^+>]+)(\+0x[\da-f]+)?>$/;
         this.commentRe = /[#;]/;
         this.instOpcodeRe = /(\.inst\.?\w?)\s*(.*)/;


### PR DESCRIPTION
When compiling to binary and with the demangling enabled, the assembler parser
was not correctly matching the "labels". The labelRe regex is tailored from
matching against the real symbol names, before any demangling. In the
binary+demangle context, we rely on objdump doing both at once, feeding our
parser with demangled names.

Make the labelRe match anything of the form:
```
00000000123af    <every thing here is the label>:
```

fixes #3235

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>