### PR TITLE
Fix bug: /compile endpoint API errors should be 400s

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -361,7 +361,7 @@ export class CompileHandler {
 
     handleApiError(error, res, next) {
         if (error.message) {
-            return res.status(404).send({
+            return res.status(400).send({
                 error: true,
                 message: error.message,
             });


### PR DESCRIPTION
closes #2560