### PR TITLE
NFC: Move BaseFormatter into /lib/formatters

### DIFF
--- a/lib/formatters/base.js
+++ b/lib/formatters/base.js
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import * as exec from './exec';
+import * as exec from '../exec';
 
 export class BaseFormatter {
     constructor(formatterInfo) {

--- a/lib/formatters/clang-format.js
+++ b/lib/formatters/clang-format.js
@@ -22,8 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BaseFormatter } from '../base-formatter';
 import * as exec from '../exec';
+
+import { BaseFormatter } from './base';
 
 export class ClangFormatFormatter extends BaseFormatter {
     static get key() {

--- a/lib/formatters/gofmt.js
+++ b/lib/formatters/gofmt.js
@@ -22,8 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BaseFormatter } from '../base-formatter';
 import * as exec from '../exec';
+
+import { BaseFormatter } from './base';
 
 export class GoFmtFormatter extends BaseFormatter {
     static get key() { return 'gofmt'; }

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -26,7 +26,7 @@ import { makeKeyedTypeGetter } from '../keyed-type';
 
 import * as all from './_all';
 
-export { BaseFormatter } from '../base-formatter';
+export { BaseFormatter } from './base';
 export * from './_all';
 
 export const getFormatterTypeByKey = makeKeyedTypeGetter('formatter', all);

--- a/lib/formatters/rustfmt.js
+++ b/lib/formatters/rustfmt.js
@@ -22,8 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BaseFormatter } from '../base-formatter';
 import * as exec from '../exec';
+
+import { BaseFormatter } from './base';
 
 export class RustFmtFormatter extends BaseFormatter {
     static get key() { return 'rustfmt'; }

--- a/test/base-formatter-tests.js
+++ b/test/base-formatter-tests.js
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BaseFormatter } from '../lib/base-formatter';
+import { BaseFormatter } from '../lib/formatters/base';
 
 describe('Basic formatter functionality', () => {
     it('should be one-true-style if the styles are empty', () => {


### PR DESCRIPTION
As mentioned in https://github.com/compiler-explorer/compiler-explorer/pull/3247#issuecomment-1007636098, the BaseFormatter class now lives inside the /lib/formatters directory.