### PR TITLE
Fix strings tool calling wrt binary/executable targets

### DIFF
--- a/lib/tooling/strings-tool.js
+++ b/lib/tooling/strings-tool.js
@@ -22,16 +22,22 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import { fileExists } from '../utils';
+
 import { BaseTool } from './base-tool';
 
 export class StringsTool extends BaseTool {
     static get key() { return 'strings-tool'; }
 
-    runTool(compilationInfo, inputFilename, args) {
+    async runTool(compilationInfo, inputFilename, args) {
         if(!compilationInfo.filters.binary)
         {
             return this.createErrorResponse('Strings requires a binary output');
         }
-        return super.runTool(compilationInfo, compilationInfo.executableFilename, args);
+        if (await fileExists(compilationInfo.executableFilename)) {
+            return super.runTool(compilationInfo, compilationInfo.executableFilename, args);
+        } else {
+            return super.runTool(compilationInfo, compilationInfo.outputFilename, args);
+        }
     }
 }


### PR DESCRIPTION
If only binary output is selected without the execution, strings would complain
about missing file.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>