### PR TITLE
Add comments for GNAT handling of command line options and enable strings

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -36,7 +36,7 @@ libs=
 
 #################################
 # Tools
-tools=readelf:ldd
+tools=readelf:ldd:strings
 
 tools.readelf.name=readelf (trunk)
 tools.readelf.exe=/opt/compiler-explorer/gcc-snapshot/bin/readelf
@@ -49,5 +49,12 @@ tools.ldd.name=ldd
 tools.ldd.exe=/usr/bin/ldd
 tools.ldd.type=postcompilation
 tools.ldd.class=readelf-tool
-tools.ldd.exclude=djggp
+tools.ldd.exclude=
 tools.ldd.stdinHint=disabled
+
+tools.strings.exe=/opt/compiler-explorer/gcc-snapshot/bin/strings
+tools.strings.name=strings
+tools.strings.type=postcompilation
+tools.strings.class=strings-tool
+tools.strings.exclude=
+tools.strings.stdinHint=disabled

--- a/etc/config/ada.defaults.properties
+++ b/etc/config/ada.defaults.properties
@@ -4,8 +4,8 @@ defaultCompiler=gnat
 demangler=c++filt
 objdumper=objdump
 versionFlag=--version
-supportsBinary=false
-supportsExecute=false
+supportsBinary=true
+supportsExecute=true
 compilerType=ada
 intelAsm=-masm=intel
 

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -41,10 +41,14 @@ export class AdaCompiler extends BaseCompiler {
     }
 
     getExecutableFilename(dirPath) {
+        // The name here must match the value used in the pragma Source_File
+        // in the user provided source.
         return path.join(dirPath, 'example');
     }
 
     getOutputFilename(dirPath) {
+        // The basename here must match the value used in the pragma Source_File
+        // in the user provided source.
         return path.join(dirPath, 'example.o');
     }
 
@@ -66,7 +70,13 @@ export class AdaCompiler extends BaseCompiler {
     optionsForFilter(filters, outputFilename) {
         let options = [];
 
+        // Always add -cargs to the options. If not needed here, put it last.
+        // It's used in runCompiler to insert the input filename at the correct
+        // location in the command line.
+        // input filename is inserted before -cargs.
+
         if (!filters.binary) {
+            // produce assembly output in outputFilename
             options.push(
                 'compile',
                 '-g', // enable debugging
@@ -84,12 +94,14 @@ export class AdaCompiler extends BaseCompiler {
                 options = options.concat(this.compiler.intelAsm.split(' '));
             }
         } else {
+            // produce an executable in the file specified in getExecutableFilename.
+            // The output file is automatically decided by GNAT based on the Source_File_Name being used.
+            // As we are for forcing 'example.adb', the output here will be 'example'.
             options.push(
                 'make',
                 '-eS',
                 '-g',
-                'example',
-                '-cargs',
+                '-cargs', // Compiler Switches for gcc.
             );
         }
 


### PR DESCRIPTION
Add some comments around the command line options handling of GNAT.

Add strings tool for Ada.

Also enable binary and execution in the default config.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>