### PR TITLE
Install Rust 1.58.0

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,12 +1,14 @@
 compilers=&rust:&rustgcc:&mrustc:&rustccggcc
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-11.1.0/bin/gcc
-defaultCompiler=r1570
+defaultCompiler=r1580
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
-group.rust.compilers=r1570:r1560:r1550:r1540:r1530:r1520:r1510:r1500:r1490:r1480:r1470:r1460:r1452:r1450:r1440:r1430:r1420:r1410:r1400:r1390:r1380:r1370:r1360:r1350:r1340:r1330:r1320:r1310:r1300:r1290:r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190:r180:r170:r160:r150:r140:r130:r120:r110:r100:nightly:beta
+group.rust.compilers=r1580:r1570:r1560:r1550:r1540:r1530:r1520:r1510:r1500:r1490:r1480:r1470:r1460:r1452:r1450:r1440:r1430:r1420:r1410:r1400:r1390:r1380:r1370:r1360:r1350:r1340:r1330:r1320:r1310:r1300:r1290:r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190:r180:r170:r160:r150:r140:r130:r120:r110:r100:nightly:beta
 group.rust.compilerType=rust
 group.rust.isSemVer=true
 group.rust.baseName=rustc
+compiler.r1580.exe=/opt/compiler-explorer/rust-1.58.0/bin/rustc
+compiler.r1580.semver=1.58.0
 compiler.r1570.exe=/opt/compiler-explorer/rust-1.57.0/bin/rustc
 compiler.r1570.semver=1.57.0
 compiler.r1560.exe=/opt/compiler-explorer/rust-1.56.0/bin/rustc


### PR DESCRIPTION
Installer for blog.rust-lang.org/2022/01/13/Rust-1.58.0.html

Infra: https://github.com/compiler-explorer/infra/pull/660