### PR TITLE
Fix changelog not showing

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -186,7 +186,7 @@ function setupButtons(options) {
     });
 
     $('#changes').on('click', function () {
-        alertSystem.alert('Changelog', $(require('./changelog.html')));
+        alertSystem.alert('Changelog', $(require('./changelog.html').default));
     });
 
     $('#ces').on('click', function () {


### PR DESCRIPTION
Fixes #3260 

I'm not too sure what change broke the changelog, but after a quick inspection it seems that we tried to pass the entire ESModule into JQuery which failed.

Only passing the actual content (default export) seems to work just fine.