### PR TITLE
Improve numeric tool tip to display character value

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2312,16 +2312,10 @@ function getNumericToolTip(value) {
         result += ' = 0x' + numericValue.toString(16).toUpperCase();
     }
 
-    // ASCII character.
-    if (numericValue.greaterOrEquals(0) && numericValue.lesserOrEquals(0x7F)) {
+    // Printable ASCII character.
+    if (numericValue.greaterOrEquals(0x20) && numericValue.lesserOrEquals(0x7E)) {
         var char = String.fromCharCode(numericValue.valueOf());
-        if (('A' <= char && char <= 'Z')
-            || ('a' <= char && char <= 'z')
-            || ('0' <= char && char <= '9')
-            || "!\"#$%&'()*+,-./:;<=>?@[] ^_`{|}~ ".includes(char)) {
-            // Printable ASCII character.
-            result += ' = \'' + char + '\'';
-        }
+        result += ' = \'' + char + '\'';
     }
 
     return result;


### PR DESCRIPTION
I'm currently looking at a lot of assembly for parsing things, so I often have constants that represent ASCII characters. To save me the mental ASCII table lookup, I've extended the tooltip to show the ASCII character value, if applicable:

![Example tooltip](https://user-images.githubusercontent.com/9192733/150588827-97af9ddf-dd4e-4135-a758-de98539dc897.png)

To simplify the code, I've changed the formatting order: it used to show the value as-is and then in decimal/hexadecimal (the other format). Now it always prints it in decimal, followed by hexadecimal, followed by ASCII.