### PR TITLE
Some more Ctrl-S behaviours

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -862,7 +862,7 @@ html[data-theme=dark] {
     cursor: pointer;
 }
 
-.currentCursorPosition {
+.currentCursorPosition, .ctrlSNothing {
     font-size: small;
     border: none;
     user-select: text;

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -500,7 +500,6 @@ Editor.prototype.handleCtrlS = function (event) {
             }, this));
         }
     } else {
-        console.log(typeof(this.settings.enableCtrlS));
         if (this.settings.enableCtrlS === 'true') {
             loadSave.setMinimalOptions(this.getSource(), this.currentLanguage);
             if (!loadSave.onSaveToFile(this.id)) {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -469,23 +469,7 @@ Editor.prototype.initButtons = function (state) {
     this.initLoadSaver();
     $(this.domRoot).on('keydown', _.bind(function (event) {
         if ((event.ctrlKey || event.metaKey) && String.fromCharCode(event.which).toLowerCase() === 's') {
-            event.preventDefault();
-            if (this.settings.enableCtrlStree && this.hub.hasTree()) {
-                var trees = this.hub.trees;
-                // todo: change when multiple trees are used
-                if (trees && trees.length > 0) {
-                    trees[0].multifileService.includeByEditorId(this.id).then(_.bind(function () {
-                        trees[0].refresh();
-                    }, this));
-                }
-            } else if (this.settings.enableCtrlS) {
-                loadSave.setMinimalOptions(this.getSource(), this.currentLanguage);
-                if (!loadSave.onSaveToFile(this.id)) {
-                    this.showLoadSaver();
-                }
-            } else {
-                this.eventHub.emit('displaySharingPopover');
-            }
+            this.handleCtrlS(event);
         }
     }, this));
 
@@ -503,6 +487,54 @@ Editor.prototype.initButtons = function (state) {
 
     this.currentCursorPosition = this.domRoot.find('.currentCursorPosition');
     this.currentCursorPosition.hide();
+};
+
+Editor.prototype.handleCtrlS = function (event) {
+    event.preventDefault();
+    if (this.settings.enableCtrlStree && this.hub.hasTree()) {
+        var trees = this.hub.trees;
+        // todo: change when multiple trees are used
+        if (trees && trees.length > 0) {
+            trees[0].multifileService.includeByEditorId(this.id).then(_.bind(function () {
+                trees[0].refresh();
+            }, this));
+        }
+    } else {
+        console.log(typeof(this.settings.enableCtrlS));
+        if (this.settings.enableCtrlS === "true") {
+            loadSave.setMinimalOptions(this.getSource(), this.currentLanguage);
+            if (!loadSave.onSaveToFile(this.id)) {
+                this.showLoadSaver();
+            }
+        } else if (this.settings.enableCtrlS === "false") {
+            this.eventHub.emit('displaySharingPopover');
+        } else if (this.settings.enableCtrlS === "2") {
+            this.runFormatDocumentAction();
+        } else if (this.settings.enableCtrlS === "3") {
+            this.handleCtrlSDoNothing();
+        }
+    }
+};
+
+Editor.prototype.handleCtrlSDoNothing = function () {
+    if (this.nothingCtrlSTimes === undefined) {
+        this.nothingCtrlSTimes = 0;
+        this.nothingCtrlSSince = Date.now();
+    } else {
+        if (Date.now() - this.nothingCtrlSSince > 5000) {
+            this.nothingCtrlSTimes = undefined;
+        } else if (this.nothingCtrlSTimes === 4) {
+            var element = this.domRoot.find('.ctrlSNothing');
+            element.show(100);
+            setTimeout(function () {
+                element.hide();
+            }, 2000);
+            this.nothingCtrlSTimes = undefined;
+        } else {
+            this.nothingCtrlSTimes++;
+        }
+    }
+
 };
 
 Editor.prototype.updateButtons = function () {
@@ -787,12 +819,16 @@ Editor.prototype.initEditorActions = function () {
     });
 
     this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.F9, _.bind(function () {
-        this.editor.getAction('editor.action.formatDocument').run();
+        this.runFormatDocumentAction();
     }, this));
 
     this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, _.bind(function () {
         this.editor.getAction('editor.action.duplicateSelection').run();
     }, this));
+};
+
+Editor.prototype.runFormatDocumentAction = function () {
+    this.editor.getAction('editor.action.formatDocument').run();
 };
 
 Editor.prototype.searchOnCppreference = function (ed) {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -501,16 +501,16 @@ Editor.prototype.handleCtrlS = function (event) {
         }
     } else {
         console.log(typeof(this.settings.enableCtrlS));
-        if (this.settings.enableCtrlS === "true") {
+        if (this.settings.enableCtrlS === 'true') {
             loadSave.setMinimalOptions(this.getSource(), this.currentLanguage);
             if (!loadSave.onSaveToFile(this.id)) {
                 this.showLoadSaver();
             }
-        } else if (this.settings.enableCtrlS === "false") {
+        } else if (this.settings.enableCtrlS === 'false') {
             this.eventHub.emit('displaySharingPopover');
-        } else if (this.settings.enableCtrlS === "2") {
+        } else if (this.settings.enableCtrlS === '2') {
             this.runFormatDocumentAction();
-        } else if (this.settings.enableCtrlS === "3") {
+        } else if (this.settings.enableCtrlS === '3') {
             this.handleCtrlSDoNothing();
         }
     }

--- a/static/settings.interfaces.ts
+++ b/static/settings.interfaces.ts
@@ -52,7 +52,7 @@ export interface SiteSettings {
     delayAfterChange: number;
     enableCodeLens: boolean;
     enableCommunityAds: boolean
-    enableCtrlS: boolean;
+    enableCtrlS: boolean | number;
     enableCtrlStree: boolean;
     editorsFFont: string
     editorsFLigatures: boolean;

--- a/static/settings.js
+++ b/static/settings.js
@@ -255,7 +255,13 @@ function setupSettings(root, settings, onChange, subLangId) {
     add(root.find('.useSpaces'), 'useSpaces', true, Checkbox);
     add(root.find('.tabWidth'), 'tabWidth', 4, Numeric, {min: 1, max: 80});
     // note: this is the ctrl+s "Save option"
-    add(root.find('.enableCtrlS'), 'enableCtrlS', true, Checkbox);
+    var actions = [
+        {label: true, desc: "Save To Local File"},
+        {label: false, desc: "Create Short Link"},
+        {label: 2, desc: "Reformat code"},
+        {label: 3, desc: "Do nothing"},
+    ];
+    add(root.find('.enableCtrlS'), 'enableCtrlS', true, Select, actions);
     add(root.find('.enableCtrlStree'), 'enableCtrlStree', true, Checkbox);
     add(root.find('.editorsFFont'), 'editorsFFont', 'Consolas, "Liberation Mono", Courier, monospace', Textbox);
     add(root.find('.editorsFLigatures'), 'editorsFLigatures', false, Checkbox);

--- a/static/settings.js
+++ b/static/settings.js
@@ -256,10 +256,10 @@ function setupSettings(root, settings, onChange, subLangId) {
     add(root.find('.tabWidth'), 'tabWidth', 4, Numeric, {min: 1, max: 80});
     // note: this is the ctrl+s "Save option"
     var actions = [
-        {label: true, desc: "Save To Local File"},
-        {label: false, desc: "Create Short Link"},
-        {label: 2, desc: "Reformat code"},
-        {label: 3, desc: "Do nothing"},
+        {label: true, desc: 'Save To Local File'},
+        {label: false, desc: 'Create Short Link'},
+        {label: 2, desc: 'Reformat code'},
+        {label: 3, desc: 'Do nothing'},
     ];
     add(root.find('.enableCtrlS'), 'enableCtrlS', true, Select, actions);
     add(root.find('.enableCtrlStree'), 'enableCtrlStree', true, Checkbox);

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -131,14 +131,13 @@
                 label
                   input.useVim(type="checkbox")
                   | Vim editor mode
-              .checkbox.the-save-option-to-auto-share
+              .the-save-option-to-auto-share
                 label
-                  input.enableCtrlS(type="checkbox")
-                  | Make
                   kbd Ctrl
                   | +
                   kbd S
-                  | &nbsp;save to local file instead of creating a share link
+                  | &nbsp;behaviour
+                select.enableCtrlS
               .checkbox.the-save-option-to-tree-save
                 label
                   input.enableCtrlStree(type="checkbox")

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -38,6 +38,8 @@
             span.hideable Quick-bench
       .btn-group.btn-group-sm.mx-auto
         button.btn.btn-sm.btn-outline-info.currentCursorPosition(disabled=true)
+        button.btn.btn-sm.btn-outline-info.ctrlSNothing(disabled=true style="display: none")
+          span.fas.fa-smile
       .btn-group.btn-group-sm.ml-auto(role="group" aria-label="Editor language")
         select.change-language(title="Change this editor's (and associated panels) language" placeholder="Language" disabled=embedded && readOnly)
     div#v-status


### PR DESCRIPTION
As suggested by the linked issue, it adds both "Reformat Code" and "Do nothing" options.
The weird labeling allows to keep backwards compatibility for the setting, so that it will get the correct old behaviour

Closes #3266