### PR TITLE
Add 2 MIPS GCC based toolchains

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -644,7 +644,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray
+group.cross.compilers=&ppc:&mips:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -941,7 +941,7 @@ compiler.avrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdum
 
 ###############################
 # GCC for MIPS
-group.mips.compilers=mips5:mips5el:mips564:mips564el
+group.mips.compilers=mips5:mips5el:mips564:mips564el:mips930
 group.mips.groupName=MIPS GCC
 group.mips.isSemVer=true
 
@@ -961,6 +961,20 @@ compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknow
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
 compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.mips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-g++
+compiler.mips930.name=MIPS gcc 9.3.0 (codescape)
+compiler.mips930.semver=9.3.0
+compiler.mips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
+
+###############################
+# GCC for nanoMIPS
+group.nanomips.compilers=nanomips630
+group.nanomips.groupName=nanoMIPS GCC
+group.nanomips.isSemVer=true
+compiler.nanomips630.exe=/opt/compiler-explorer/nanomips/nanomips-linux-musl/2021.11-02/bin/nanomips-linux-musl-g++
+compiler.nanomips630.name=nanoMIPS gcc 6.3.0 (mtk)
+compiler.nanomips630.semver=6.3.0
+compiler.nanomips630.objdumper=/opt/compiler-explorer/nanomips/nanomips-linux-musl/2021.11-02/bin/nanomips-linux-musl/2021.11-02/bin/nanomips-linux-musl-objdump
 
 ###############################
 # GCC for MRISC32

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -563,7 +563,7 @@ compiler.cicx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray
+group.ccross.compilers=&cppc:&cmips:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
@@ -864,6 +864,18 @@ compiler.cmips564.semver=5.4
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
+compiler.cmips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
+compiler.cmips930.name=MIPS gcc 9.3.0
+compiler.cmips930.semver=9.3.0
+
+###############################
+# GCC for nanoMIPS
+group.cnanomips.compilers=cnanomips630
+group.cnanomips.groupName=nanoMIPS GCC
+group.cnanomips.isSemVer=true
+compiler.cnanomips630.exe=/opt/compiler-explorer/nanomips/nanomips-linux-musl/2021.11-02/bin/nanomips-linux-musl-gcc
+compiler.cnanomips630.name=nanoMIPS gcc 6.3.0
+compiler.cnanomips630.semver=6.3.0
 
 ###############################
 # GCC for MRISC32


### PR DESCRIPTION
MIPS GCC 9.3.0 from Codescape :
 - https://codescape.mips.com/components/toolchain/2020.06-01/downloads.html

nanoMIPS GCC 6.3.0 from MediaTek:
 - https://github.com/MediaTek-Labs/nanomips-gnu-toolchain/releases/tag/nanoMIPS-2021.11-02

refs #3282

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>