### PR TITLE
Add ISPC 1.17.0

### DIFF
--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -1,9 +1,11 @@
 compilers=&ispc
-defaultCompiler=ispc1161
+defaultCompiler=ispc1170
 
-group.ispc.compilers=ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk
+group.ispc.compilers=ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk
 group.ispc.isSemVer=true
 group.ispc.baseName=ispc
+compiler.ispc1170.exe=/opt/compiler-explorer/ispc-1.17.0/bin/ispc
+compiler.ispc1170.semver=1.17.0
 compiler.ispc1161.exe=/opt/compiler-explorer/ispc-1.16.1/bin/ispc
 compiler.ispc1161.semver=1.16.1
 compiler.ispc1160.exe=/opt/compiler-explorer/ispc-1.16.0/bin/ispc


### PR DESCRIPTION
This should be merged after https://github.com/compiler-explorer/infra/pull/663, so ISPC 1.17.0 is available in the infra.

Fixes #3279 
