### PR TITLE
Add ldpaths for Clang 13 libc++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -295,6 +295,7 @@ compiler.clang1201.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.1.0
 compiler.clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.clang1300.semver=13.0.0
 compiler.clang1300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
+compiler.clang1300.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
 group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_patmat:clang_embed:clang_reflection
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel


### PR DESCRIPTION
Unfortunately Clang 13 suffers the same as the Trunk versions. They have put the libc++ in a separate folder.
Assuming this will be the norm, maybe we should include it in the x86 group instead.