### PR TITLE
Add GNAT cross compiler from Alire project

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,17 +1,17 @@
 # Default settings for Ada
-compilers=&gnat
+compilers=&gnat:&gnatriscv64:&gnatarm
 defaultCompiler=gnat112
 demangler=/opt/compiler-explorer/gcc-11.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.2.0/bin/objdump
 versionFlag=--version
 supportsBinary=true
 supportsExecute=true
-intelAsm=-masm=intel
 compilerType=ada
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
 group.gnat.compilers=gnat82:gnat102:gnat111:gnat112:gnatsnapshot
+group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=GNAT x86-64
 group.gnat.isSemVer=true
 group.gnat.baseName=x86-64 gnat
@@ -29,6 +29,43 @@ compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnatsnapshot.name=x86-64 gnat (trunk)
 compiler.gnatsnapshot.semver=(trunk)
 
+################################
+# GNAT for riscv64
+group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103
+group.gnatriscv64.groupName=GNAT riscv64
+group.gnatriscv64.instructionSet=riscv
+group.gnatriscv64.baseName=riscv64 gnat
+group.gnatriscv64.isSemVer=true
+group.gnatriscv64.adarts=foo
+
+compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnat
+compiler.gnatriscv64103.semver=10.3.0
+compiler.gnatriscv64103.supportsBinary=false
+compiler.gnatriscv64103.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/riscv64-elf/lib/gnat/zfp-rv64imac
+
+compiler.gnatriscv64112.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/bin/riscv64-elf-gnat
+compiler.gnatriscv64112.semver=11.2.0
+compiler.gnatriscv64112.supportsBinary=false
+compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
+
+################################
+# GNAT for arm
+group.gnatarm.compilers=gnatarm112:gnatarm103
+group.gnatarm.groupName=GNAT arm
+group.gnatarm.instructionSet=arm32
+group.gnatarm.baseName=arm gnat
+group.gnatarm.isSemVer=true
+
+compiler.gnatarm103.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-gnat
+compiler.gnatarm103.semver=10.3.0
+compiler.gnatarm103.supportsBinary=false
+compiler.gnatarm103.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/arm-eabi/lib/gnat/zfp-cortex-m4f/
+
+compiler.gnatarm112.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/bin/arm-eabi-gnat
+compiler.gnatarm112.semver=11.2.0
+compiler.gnatarm112.supportsBinary=false
+compiler.gnatarm112.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/arm-eabi/lib/gnat/zfp-cortex-m4f/
+
 #################################
 #################################
 # Installed libs (See c++.amazon.properties for a scheme of libs group)
@@ -42,7 +79,7 @@ tools.readelf.name=readelf (trunk)
 tools.readelf.exe=/opt/compiler-explorer/gcc-snapshot/bin/readelf
 tools.readelf.type=postcompilation
 tools.readelf.class=readelf-tool
-tools.readelf.exclude=djggp
+tools.readelf.exclude=
 tools.readelf.stdinHint=disabled
 
 tools.ldd.name=ldd

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -212,6 +212,7 @@ export class CompilerFinder {
             intelAsm: props('intelAsm', ''),
             instructionSet: props('instructionSet', ''),
             needsMulti: !!props('needsMulti', true),
+            adarts: props('adarts', ''),
             supportsDemangle: !!demangler,
             supportsBinary,
             interpreted,

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -123,6 +123,14 @@ export class AdaCompiler extends BaseCompiler {
         for (let i = 0; i < options.length; i++) {
             if (options[i] === '-cargs') {
                 options.splice(i, 0, inputFileName);
+
+                // If the compiler contains a RTS, add the extra --RTS=.
+                // FIXME: should probably check the user did not use one.
+                if (this.compiler.adarts) {
+                    options.splice(i, 0,
+                        `--RTS=${this.compiler.adarts}`,
+                    );
+                }
                 break;
             }
         }


### PR DESCRIPTION
Add new adarts compiler properties used to set the RTS (if needed) to be used by
GNAT. This is needed as the cross compilers come with several RTS and you must
provide one.

Use Alire (https://alire.ada.dev/) cross compilers for ARM32 and RISC-V 64.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>