### PR TITLE
✨ Dang compiler addition!

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -296,7 +296,7 @@ compiler.clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.clang1300.semver=13.0.0
 compiler.clang1300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_patmat:clang_embed:clang_reflection
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -342,6 +342,11 @@ compiler.clang_embed.exe=/opt/compiler-explorer/clang-embed-trunk/bin/clang++
 compiler.clang_embed.semver=(std::embed)
 compiler.clang_embed.options=-std=c++2a -stdlib=libc++
 compiler.clang_embed.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_embed.hidden=true
+compiler.clang_dang.exe=/opt/compiler-explorer/clang-dang-main/bin/clang++
+compiler.clang_dang.semver=(thephd.dev)
+compiler.clang_dang.options=-std=c++2a -stdlib=libc++
+compiler.clang_dang.notification=<code>#embed</code>, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 compiler.clang_reflection.exe=/opt/compiler-explorer/clang-reflection-trunk/bin/clang++
 compiler.clang_reflection.semver=(reflection)
 compiler.clang_reflection.options=-std=c++20 -freflection-ts -stdlib=libc++


### PR DESCRIPTION
This adds the Derpstorm Clang ("Dang") compiler. It's meant to be the central place for all the proposal and other implementations I'll be cranking out over the months/years. It also hides the (old, unmaintained, barely compiling) `std::embed` of old. Hopefully, this will be the last time I have to bother you fantastic and lovely folks with something like this... 😅

In conjunction with:
- https://github.com/compiler-explorer/clang-builder/pull/30
- https://github.com/compiler-explorer/infra/pull/666