### PR TITLE
✨ Add clang_dang as a C compiler!

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -126,7 +126,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang_trunk:cclang_assertions_trunk
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang_trunk:cclang_assertions_trunk:cclang_dang
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -236,6 +236,11 @@ compiler.cclang_assertions_trunk.demangler=/opt/compiler-explorer/gcc-snapshot/b
 compiler.cclang_assertions_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_assertions_trunk.semver=(assertions trunk)
 compiler.cclang_assertions_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang_dang.exe=/opt/compiler-explorer/clang-dang-main/bin/clang
+compiler.cclang_dang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cclang_dang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.cclang_dang.semver=(thephd.dev)
+compiler.cclang_dang.options=-std=c2x
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -240,7 +240,7 @@ compiler.cclang_dang.exe=/opt/compiler-explorer/clang-dang-main/bin/clang
 compiler.cclang_dang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_dang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_dang.semver=(thephd.dev)
-compiler.cclang_dang.options=-std=c2x
+compiler.cclang_dang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0 -std=c2x
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk


### PR DESCRIPTION
`clang_dang` has mostly C features right now, so we add it to the list of C compilers! I think this is the only file we have to edit, but do let me know if I messed this up at all!