### PR TITLE
Add setting for automatically formatting on compilation

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -678,6 +678,9 @@ Editor.prototype.tryPanesLinkLine = function (thisLineNumber, column, reveal) {
 
 Editor.prototype.requestCompilation = function () {
     this.eventHub.emit('requestCompilation', this.id);
+    if (this.settings.formatOnCompile) {
+        this.editor.getAction('editor.action.formatDocument').run();
+    }
 
     _.each(this.hub.trees, _.bind(function (tree) {
         if (tree.multifileService.isEditorPartOfProject(this.id)) {

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -63,6 +63,7 @@ export interface SiteSettings {
     editorsFFont: string
     editorsFLigatures: boolean;
     formatBase: FormatBase;
+    formatOnCompile: boolean;
     hoverShowAsmDoc: boolean;
     hoverShowSource: boolean;
     keepSourcesOnLangChange: boolean;
@@ -249,6 +250,7 @@ export class Settings {
             ['.enableCommunityAds', 'enableCommunityAds', true],
             ['.enableCtrlS', 'enableCtrlS', true],
             ['.enableCtrlStree', 'enableCtrlStree', true],
+            ['.formatOnCompile', 'formatOnCompile', false],
             ['.hoverShowAsmDoc', 'hoverShowAsmDoc', true],
             ['.hoverShowSource', 'hoverShowSource', true],
             ['.keepSourcesOnLangChange', 'keepSourcesOnLangChange', false],

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -222,6 +222,10 @@
                   label
                     input.compileOnChange(type="checkbox")
                     | Compile automatically when source changes
+                .checkbox
+                  label
+                    input.enableFormatCompile(type="checkbox")
+                    | Enable formatting on compilation (for supported languages)
                 div
                   label Delay before compiling:&nbsp;
                     span.delay-current-value &nbsp;


### PR DESCRIPTION
Fixes #1801

Adds a new checkbox setting for automatically formatting the code upon compilation request. I added a note in the setting text indicating that it only runs for languages that have a formatter set up.