### PR TITLE
Fix libs widget selection properly updating

### DIFF
--- a/static/libs-widget.ts
+++ b/static/libs-widget.ts
@@ -514,7 +514,12 @@ export class LibsWidget {
     };
 
     selectLibAndVersion(libId: string, versionId: string) {
-        this.markLibrary(libId, versionId, true);
+        const actualId = this.getVersionOrAlias(libId, versionId);
+        const libInfo = this.getLibInfoById(libId);
+        for (let v in libInfo?.versions) {
+            const version = libInfo.versions[v];
+            version.used = v == actualId;
+        }
     };
 
     get(): {name: string, ver: any}[] {

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -28,7 +28,6 @@ export interface LibraryVersion {
     libId: string;
     used: boolean;
     version?: string;
-    versionId: string;
 }
 
 export interface Library {


### PR DESCRIPTION
The .used flag was not being cleared on version change for the other
versions of the same library

It's totally my bad. I broke it two months ago in #3077 
The functionality was there https://github.com/compiler-explorer/compiler-explorer/pull/3077/files#diff-449c94e1ad968cdcf587dae5e5dfc15bf5ded7dbbf1ef689c5677e7f503cd2a1L495 but I somehow missed that on the port,
and as found by @partouf while reproducing this, it was not easy to spot

Closes #3311 
