### PR TITLE
Ada: Fix intel filter active even for cross compilers

### DIFF
--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -34,7 +34,6 @@ export class AdaCompiler extends BaseCompiler {
         super(info, env);
         this.compiler.supportsGccDump = true;
         this.compiler.removeEmptyGccDump = true;
-        this.compiler.supportsIntel = true;
 
         // used for all GNAT related panes (Expanded code, Tree)
         this.compiler.supportsGnatDebugViews = true;


### PR DESCRIPTION
The property was incorrectly hardcoded in the AdaCompiler class.
As GNAT does not have an argument-parser, we can't rely on autodetecting the
-masm support. The easiest way is to simply define the intelAsm property for
GNAT compilers known to support it.

Fixes #3310

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>