### PR TITLE
Improve -E support

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1595,6 +1595,16 @@ export class BaseCompiler {
         if (filters.binary && !this.compiler.supportsBinary) {
             delete filters.binary;
         }
+
+        // For C/C++ turn off filters when compiling with -E
+        // This is done for all compilers. Not every compiler handles -E the same but they all use
+        // it for preprocessor output.
+        if ((this.compiler.lang === 'c++' || this.compiler.lang === 'c') && options.includes('-E')) {
+            for (let key in filters) {
+                filters[key] = false;
+            }
+        }
+
         const executeParameters = {
             args: executionParameters.args || [],
             stdin: executionParameters.stdin || '',


### PR DESCRIPTION
This is an attempt/suggestion for resolving issue #1380 by turning off filters in the backend if -E is provided for C/C++ code.

Sir Walrus pointed out on the CE discord that though the handling of -E differs between compilers they all use -E for dumping preprocessor output so no special case handling is needed as far as turning off filters goes.