### PR TITLE
Improve .NET toolchain (faster compilation)

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -2,16 +2,14 @@ compilers=&csharp
 supportsBinary=false
 needsMulti=false
 compilerType=csharp
-defaultCompiler=dotnet601csharp
+defaultCompiler=dotnetMainCs
 
-group.csharp.compilers=dotnet601csharp
+group.csharp.compilers=dotnetMainCs
 
-compiler.dotnet601csharp.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
-compiler.dotnet601csharp.name=.NET 6.0.101
-compiler.dotnet601csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
-compiler.dotnet601csharp.runtimeId=linux-x64
-compiler.dotnet601csharp.targetFramework=net6.0
-compiler.dotnet601csharp.buildConfig=Release
-compiler.dotnet601csharp.additionalSources=
-compiler.dotnet601csharp.langVersion=latest
-compiler.dotnet601csharp.nugetPackages=/opt/compiler-explorer/dotnet_nuget-v6.0.0/packages
+compiler.dotnetMainCs.name=.NET R2R (Main)
+compiler.dotnetMainCs.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
+compiler.dotnetMainCs.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
+compiler.dotnetMainCs.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/csapp
+
+
+

--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -7,9 +7,9 @@ defaultCompiler=dotnetMainCs
 group.csharp.compilers=dotnetMainCs
 
 compiler.dotnetMainCs.name=.NET R2R (Main)
-compiler.dotnetMainCs.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
-compiler.dotnetMainCs.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
-compiler.dotnetMainCs.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/csapp
+compiler.dotnetMainCs.coreRoot=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
+compiler.dotnetMainCs.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
+compiler.dotnetMainCs.testAppSrc=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/csapp
 
 
 

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -1,14 +1,10 @@
-compilers=dotnet6csharp
+compilers=dotnetMainCs
 supportsBinary=false
 needsMulti=false
 compilerType=csharp
-defaultCompiler=dotnet6csharp
+defaultCompiler=dotnetMainCs
 
-compiler.dotnet6csharp.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
-compiler.dotnet6csharp.name=.NET 6.0.101
-compiler.dotnet6csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
-compiler.dotnet6csharp.runtimeId=linux-x64
-compiler.dotnet6csharp.targetFramework=net6.0
-compiler.dotnet6csharp.buildConfig=Release
-compiler.dotnet6csharp.additionalSources=
-compiler.dotnet6csharp.langVersion=latest
+compiler.dotnetMainCs.name=.NET R2R (Main)
+compiler.dotnetMainCs.coreRoot=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
+compiler.dotnetMainCs.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
+compiler.dotnetMainCs.testAppSrc=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/csapp

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -7,6 +7,6 @@ defaultCompiler=dotnetMainFs
 group.fsharp.compilers=dotnetMainFs
 
 compiler.dotnetMainFs.name=.NET R2R (Main)
-compiler.dotnetMainFs.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
-compiler.dotnetMainFs.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
-compiler.dotnetMainFs.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/fsapp
+compiler.dotnetMainFs.coreRoot=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
+compiler.dotnetMainFs.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
+compiler.dotnetMainFs.testAppSrc=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/fsapp

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -2,16 +2,11 @@ compilers=&fsharp
 supportsBinary=false
 needsMulti=false
 compilerType=fsharp
-defaultCompiler=dotnet601fsharp
+defaultCompiler=dotnetMainFs
 
-group.fsharp.compilers=dotnet601fsharp
+group.fsharp.compilers=dotnetMainFs
 
-compiler.dotnet601fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
-compiler.dotnet601fsharp.name=.NET 6.0.101
-compiler.dotnet601fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
-compiler.dotnet601fsharp.runtimeId=linux-x64
-compiler.dotnet601fsharp.targetFramework=net6.0
-compiler.dotnet601fsharp.buildConfig=Release
-compiler.dotnet601fsharp.additionalSources=
-compiler.dotnet601fsharp.langVersion=latest
-compiler.dotnet601fsharp.nugetPackages=/opt/compiler-explorer/dotnet_nuget-v6.0.0/packages
+compiler.dotnetMainFs.name=.NET R2R (Main)
+compiler.dotnetMainFs.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
+compiler.dotnetMainFs.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
+compiler.dotnetMainFs.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/fsapp

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -1,14 +1,10 @@
-compilers=dotnet6fsharp
+compilers=dotnetMainFs
 supportsBinary=false
 needsMulti=false
 compilerType=fsharp
-defaultCompiler=dotnet6fsharp
+defaultCompiler=dotnetMainFs
 
-compiler.dotnet6fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
-compiler.dotnet6fsharp.name=.NET 6.0.101
-compiler.dotnet6fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
-compiler.dotnet6fsharp.runtimeId=linux-x64
-compiler.dotnet6fsharp.targetFramework=net6.0
-compiler.dotnet6fsharp.buildConfig=Release
-compiler.dotnet6fsharp.additionalSources=
-compiler.dotnet6fsharp.langVersion=latest
+compiler.dotnetMainFs.name=.NET R2R (Main)
+compiler.dotnetMainFs.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
+compiler.dotnetMainFs.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
+compiler.dotnetMainFs.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/fsapp

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -5,6 +5,6 @@ compilerType=fsharp
 defaultCompiler=dotnetMainFs
 
 compiler.dotnetMainFs.name=.NET R2R (Main)
-compiler.dotnetMainFs.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
-compiler.dotnetMainFs.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
-compiler.dotnetMainFs.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/fsapp
+compiler.dotnetMainFs.coreRoot=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
+compiler.dotnetMainFs.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
+compiler.dotnetMainFs.testAppSrc=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/fsapp

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -7,6 +7,6 @@ defaultCompiler=dotnetMainVb
 group.vb.compilers=dotnetMainVb
 
 compiler.dotnetMainVb.name=.NET R2R (Main)
-compiler.dotnetMainVb.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
-compiler.dotnetMainVb.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
-compiler.dotnetMainVb.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/vbapp
+compiler.dotnetMainVb.coreRoot=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
+compiler.dotnetMainVb.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
+compiler.dotnetMainVb.testAppSrc=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/vbapp

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -2,16 +2,11 @@ compilers=&vb
 supportsBinary=false
 needsMulti=false
 compilerType=vb
-defaultCompiler=dotnet601vb
+defaultCompiler=dotnetMainVb
 
-group.vb.compilers=dotnet601vb
+group.vb.compilers=dotnetMainVb
 
-compiler.dotnet601vb.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
-compiler.dotnet601vb.name=.NET 6.0.101
-compiler.dotnet601vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
-compiler.dotnet601vb.runtimeId=linux-x64
-compiler.dotnet601vb.targetFramework=net6.0
-compiler.dotnet601vb.buildConfig=Release
-compiler.dotnet601vb.additionalSources=
-compiler.dotnet601vb.langVersion=latest
-compiler.dotnet601vb.nugetPackages=/opt/compiler-explorer/dotnet_nuget-v6.0.0/packages
+compiler.dotnetMainVb.name=.NET R2R (Main)
+compiler.dotnetMainVb.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
+compiler.dotnetMainVb.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
+compiler.dotnetMainVb.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/vbapp

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -1,14 +1,11 @@
-compilers=dotnet6vb
+compilers=dotnetMainVb
 supportsBinary=false
 needsMulti=false
 compilerType=vb
-defaultCompiler=dotnet6vb
+defaultCompiler=dotnetMainVb
 
-compiler.dotnet6vb.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
-compiler.dotnet6vb.name=.NET 6.0.101
-compiler.dotnet6vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
-compiler.dotnet6vb.runtimeId=linux-x64
-compiler.dotnet6vb.targetFramework=net6.0
-compiler.dotnet6vb.buildConfig=Release
-compiler.dotnet6vb.additionalSources=
-compiler.dotnet6vb.langVersion=latest
+compiler.dotnetMainVb.name=.NET R2R (Main)
+compiler.dotnetMainVb.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
+compiler.dotnetMainVb.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
+compiler.dotnetMainVb.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/vbapp
+

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -5,7 +5,7 @@ compilerType=vb
 defaultCompiler=dotnetMainVb
 
 compiler.dotnetMainVb.name=.NET R2R (Main)
-compiler.dotnetMainVb.coreRoot=/home/egorbo/prj/godbolt-net/Core_Root
-compiler.dotnetMainVb.exe=/home/egorbo/prj/godbolt-net/Core_Root/.dotnet/dotnet
-compiler.dotnetMainVb.testAppSrc=/home/egorbo/prj/godbolt-net/Core_Root/vbapp
+compiler.dotnetMainVb.coreRoot=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked
+compiler.dotnetMainVb.exe=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/.dotnet/dotnet
+compiler.dotnetMainVb.testAppSrc=/opt/compiler-explorer/dotnet-v6.0.1/bin/coreclr/Linux.x64.Checked/vbapp
 


### PR DESCRIPTION
Needs: https://github.com/compiler-explorer/misc-builder/pull/27

Significantly improves compilation speed for .NET languages (C#/F#/VB)
Basically, it switches to `dotnet build` over a pre-generated template project

There is still a room for improvements.

PS: I am not sure about the paths in configs, I was using local paths