### PR TITLE
Move each settings category to its own tab

### DIFF
--- a/views/popups.pug
+++ b/views/popups.pug
@@ -94,12 +94,13 @@
             | These settings control how Compiler Explorer acts for you. They are not
             | preserved as part of shared URLs, and are persisted locally using browser
             | local storage.
-        .card.mt-2
-          .card-header
-            .card-title
-              h4 Site behaviour
-          .card-body
-            .form-group(role="group")
+            ul.nav.nav-tabs.card-header-tabs(role="tablist")
+              li.nav-item(role="presentation"): a.nav-link.active(href="#site-behaviour" role="tab" data-toggle="tab") Site behaviour
+              li.nav-item(role="presentation"): a.nav-link(href="#keybindings" role="tab" data-toggle="tab") Keybindings
+              li.nav-item(role="presentation"): a.nav-link(href="#editor" role="tab" data-toggle="tab") Editor
+              li.nav-item(role="presentation"): a.nav-link(href="#compilation" role="tab" data-toggle="tab") Compilation
+          .card-body.tab-content
+            #site-behaviour.tab-pane.active.form-group(role="group")
               label
                 | Default language
                 small(style="margin-left: 3px")
@@ -121,12 +122,7 @@
                 label
                   input.enableCommunityAds(type="checkbox")
                   | Show community events
-        .card.mt-1
-          .card-header
-            .card-title
-              h4 Keybindings
-          .card-body
-            .form-group(role="group")
+            #keybindings.tab-pane.form-group(role="group")
               .checkbox
                 label
                   input.useVim(type="checkbox")
@@ -154,12 +150,7 @@
                   | +
                   kbd S
                   | &nbsp; is set to create a short link.
-        .card.mt-1
-          .card-header
-            .card-title
-              h4 Editor
-          .card-body
-            .form-group(role="group")
+            #editor.tab-pane.form-group(role="group")
               div
                 label
                   | Desired Font Family in editors
@@ -218,12 +209,7 @@
                 label
                   input.enableCodeLens(type="checkbox")
                   | Enable CodeLens features (requires refresh to take effect)
-        .card.mt-1
-          .card-header
-            .card-title
-              h4 Compilation
-          .card-body
-            .form-group(role="group")
+            #compilation.tab-pane.form-group(role="group")
               div
                 .checkbox
                   label

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -95,12 +95,29 @@
             | preserved as part of shared URLs, and are persisted locally using browser
             | local storage.
             ul.nav.nav-tabs.card-header-tabs(role="tablist")
-              li.nav-item(role="presentation"): a.nav-link.active(href="#site-behaviour" role="tab" data-toggle="tab") Site behaviour
+              li.nav-item(role="presentation"): a.nav-link.active(href="#colouring" role="tab" data-toggle="tab") Colouring
+              li.nav-item(role="presentation"): a.nav-link(href="#site-behaviour" role="tab" data-toggle="tab") Site behaviour
               li.nav-item(role="presentation"): a.nav-link(href="#keybindings" role="tab" data-toggle="tab") Keybindings
               li.nav-item(role="presentation"): a.nav-link(href="#editor" role="tab" data-toggle="tab") Editor
               li.nav-item(role="presentation"): a.nav-link(href="#compilation" role="tab" data-toggle="tab") Compilation
           .card-body.tab-content
-            #site-behaviour.tab-pane.active.form-group(role="group")
+            #colouring.tab-pane.active.form-group(role="group")
+              div
+                label
+                  | Site theme
+                select.theme
+              .checkbox
+                label
+                  input.colourise(type="checkbox")
+                  | Colourise lines to show how the source maps to the output
+              .checkbox
+                label
+                  input.alwaysEnableAllSchemes(type="checkbox")
+                  | Make all colour schemes available regardless of theme
+              label
+                | Line highlighting colour scheme&nbsp;
+                select.colourScheme
+            #site-behaviour.tab-pane.form-group(role="group")
               label
                 | Default language
                 small(style="margin-left: 3px")
@@ -110,10 +127,6 @@
                 label
                   input.allowStoreCodeDebug(type="checkbox")
                   | Allow my source code to be temporarily stored for diagnostic purposes in the event of an error
-              div
-                label
-                  | Theme
-                select.theme
               .checkbox
                 label
                   input.newEditorLastLang(type="checkbox")
@@ -226,17 +239,6 @@
                     b 0.25s
                     input.delay(type="range")
                     b 3s
-              .checkbox
-                label
-                  input.colourise(type="checkbox")
-                  | Colourise lines to show how the source maps to the output
-              .checkbox
-                label
-                  input.alwaysEnableAllSchemes(type="checkbox")
-                  | Make all colour schemes available regardless of theme
-              label
-                | Colour scheme&nbsp;
-                select.colourScheme
       .modal-footer
         button.btn.btn-outline-primary(type="button" data-dismiss="modal") Close
 


### PR DESCRIPTION
Looks like this
![imagen](https://user-images.githubusercontent.com/5364255/152669003-7d24caff-d75f-49d7-abae-0c42aea3eebf.png)

Which I think makes the popup more user firendly