### PR TITLE
Remove leftover in config file

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -37,7 +37,6 @@ group.gnatriscv64.groupName=GNAT riscv64
 group.gnatriscv64.instructionSet=riscv
 group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.isSemVer=true
-group.gnatriscv64.adarts=foo
 
 compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnat
 compiler.gnatriscv64103.semver=10.3.0


### PR DESCRIPTION
Remove incorrect (but harmless as unused) adarts property from Ada config file. This should not have been merged.
