### PR TITLE
Implement asm-parser for dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 # Compiler Explorer
 
-**Compiler Explorer** is an interactive compiler exploration website. Edit code in C, C++, Rust, Go, D, Haskell, Swift, Pascal, [ispc](https://ispc.github.io/), Python, Java
- or in any of the other [31 supported languages](https://godbolt.org/api/languages), and see how that code looks after being compiled in real time.
+**Compiler Explorer** is an interactive compiler exploration website. Edit code in C, C++, C#, F#, Rust, Go, D, Haskell, Swift, Pascal, [ispc](https://ispc.github.io/), Python, Java
+ or in any of the other [35 supported languages](https://godbolt.org/api/languages), and see how that code looks after being compiled in real time.
  Multiple compilers are supported for each language, many different tools and visualisations are available, and the UI layout
  is configurable (thanks to [GoldenLayout](https://www.golden-layout.com/)).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Compiler Explorer
 
 **Compiler Explorer** is an interactive compiler exploration website. Edit code in C, C++, C#, F#, Rust, Go, D, Haskell, Swift, Pascal, [ispc](https://ispc.github.io/), Python, Java
- or in any of the other [35 supported languages](https://godbolt.org/api/languages), and see how that code looks after being compiled in real time.
+ or in any of the other [30+ supported languages](https://godbolt.org/api/languages), and see how that code looks after being compiled in real time.
  Multiple compilers are supported for each language, many different tools and visualisations are available, and the UI layout
  is configurable (thanks to [GoldenLayout](https://www.golden-layout.com/)).
 

--- a/lib/asm-parser-dotnet.ts
+++ b/lib/asm-parser-dotnet.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as utils from './utils';
+
+type InlineLabel = { name: string, range: { startCol: number, endCol: number } };
+type Source = { file: string, line: number };
+
+export class DotNetAsmParser {
+    scanLabelsAndMethods(asmLines: string[], removeUnused: boolean) {
+        const labelDef: Record<number, { name: string, remove: boolean }> = {};
+        const methodDef: Record<number, string> = {};
+        const labelUsage: Record<number, InlineLabel> = {};
+        const methodUsage: Record<number, InlineLabel> = {};
+        const allAvailable: string[] = [];
+        const usedLabels: string[] = [];
+
+        const methodRefRe = /^\w+\s+\[(.*)]/g;
+        const tailCallRe = /^tail\.jmp\s+\[.*?](.*)/g;
+        const labelRefRe = /^\w+\s+.*?(G_M\w+)/g;
+
+        for (const line in asmLines) {
+            const trimmedLine = asmLines[line].trim();
+            if (!trimmedLine || trimmedLine.startsWith(';')) continue;
+            if (trimmedLine.endsWith(':')) {
+                if (trimmedLine.includes('(')) {
+                    methodDef[line] = trimmedLine.substring(0, trimmedLine.length - 1);
+                    allAvailable.push(methodDef[line]);
+                }
+                else {
+                    labelDef[line] = {
+                        name: trimmedLine.substring(0, trimmedLine.length - 1),
+                        remove: false,
+                    };
+                    allAvailable.push(labelDef[line].name);
+                }
+                continue;
+            }
+
+            const labelResult = trimmedLine.matchAll(labelRefRe).next();
+            if (!labelResult.done) {
+                const name = labelResult.value[1];
+                const index = asmLines[line].indexOf(name) + 1;
+                labelUsage[line] = {
+                    name: labelResult.value[1],
+                    range: { startCol: index, endCol: index + name.length },
+                };
+                usedLabels.push(labelResult.value[1]);
+            }
+
+            let methodResult = trimmedLine.matchAll(methodRefRe).next();
+            if (methodResult.done) methodResult = trimmedLine.matchAll(tailCallRe).next();
+            if (!methodResult.done) {
+                const name = methodResult.value[1];
+                const index = asmLines[line].indexOf(name) + 1;
+                methodUsage[line] = {
+                    name: methodResult.value[1],
+                    range: { startCol: index, endCol: index + name.length },
+                };
+            }
+        }
+
+        if (removeUnused) {
+            for (const line in labelDef) {
+                if (!usedLabels.includes(labelDef[line].name)) {
+                    labelDef[line].remove = true;
+                }
+            }
+        }
+
+        return {
+            labelDef,
+            labelUsage,
+            methodDef,
+            methodUsage,
+            allAvailable,
+        };
+    }
+
+    cleanAsm(asmLines: string[]) {
+        const cleanedAsm = [];
+
+        for (const line of asmLines) {
+            if (line.startsWith('; Assembly listing for method')) {
+                // ; Assembly listing for method ConsoleApplication.Program:Main(System.String[])
+                //                               ^ This character is the 31st character in this string.
+                // `substring` removes the first 30 characters from it and uses the rest as a label.
+                cleanedAsm.push(line.substring(30) + ':');
+                continue;
+            }
+
+            if (line.startsWith('Emitting R2R PE file')) continue;
+            if (line.startsWith(';') && !line.startsWith('; Emitting')) continue;
+
+            cleanedAsm.push(line);
+        }
+
+        return cleanedAsm;
+    }
+
+    process(asmResult: string, filters) {
+        const startTime = process.hrtime.bigint();
+
+        const asm: {
+            text: string,
+            source: Source | null,
+            labels: InlineLabel[],
+        }[] = [];
+        let labelDefinitions: Record<string, number> = {};
+
+        let asmLines: string[] = this.cleanAsm(utils.splitLines(asmResult));
+        const startingLineCount = asmLines.length;
+
+        if (filters.commentOnly) {
+            const commentRe = /^\s*(;.*)$/g;
+            asmLines = asmLines.flatMap(l => commentRe.test(l) ? [] : [l]);
+        }
+
+        const result = this.scanLabelsAndMethods(asmLines, filters.labels);
+
+        for (const i in result.labelDef) {
+            const label = result.labelDef[i];
+            labelDefinitions[label.name] = parseInt(i);
+        }
+
+        for (const i in result.methodDef) {
+            const method = result.methodDef[i];
+            labelDefinitions[method] = parseInt(i);
+        }
+
+        for (const line in asmLines) {
+            if (result.labelDef[line] && result.labelDef[line].remove) continue;
+
+            const labels: InlineLabel[] = [];
+            const label = result.labelUsage[line] || result.methodUsage[line];
+            if (label) {
+                if (result.allAvailable.includes(label.name)) {
+                    labels.push(label);
+                }
+            }
+
+            asm.push({
+                text: asmLines[line],
+                source: null,
+                labels,
+            });
+        }
+
+        function sortLabel(labels: Record<string, number>) {
+            return Object.fromEntries(Object.entries(labels).sort((a, b) => a[1] < b[1] ? -1 : 1));
+        }
+
+        let lineOffset = 1;
+        labelDefinitions = sortLabel(labelDefinitions);
+
+        for (const label in labelDefinitions) {
+            if (result.labelDef[labelDefinitions[label]]
+                && result.labelDef[labelDefinitions[label]].remove) {
+                lineOffset--;
+                delete labelDefinitions[label];
+                continue;
+            }
+
+            labelDefinitions[label] += lineOffset;
+        }
+
+        const endTime = process.hrtime.bigint();
+        return {
+            asm: asm,
+            labelDefinitions: labelDefinitions,
+            parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
+            filteredCount: startingLineCount - asm.length,
+        };
+    }
+}

--- a/lib/asm-parser-dotnet.ts
+++ b/lib/asm-parser-dotnet.ts
@@ -102,7 +102,9 @@ export class DotNetAsmParser {
         const cleanedAsm = [];
 
         for (const line of asmLines) {
+            if (!line) continue;
             if (line.startsWith('; Assembly listing for method')) {
+                if (cleanedAsm.length > 0) cleanedAsm.push('');
                 // ; Assembly listing for method ConsoleApplication.Program:Main(System.String[])
                 //                               ^ This character is the 31st character in this string.
                 // `substring` removes the first 30 characters from it and uses the rest as a label.

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -93,7 +93,6 @@ class DotNetCompiler extends BaseCompiler {
             <PropertyGroup>
                 <TargetFramework>${this.targetFramework}</TargetFramework>
                 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-                <Nullable>enable</Nullable>
                 <AssemblyName>CompilerExplorer</AssemblyName>
                 <LangVersion>${this.langVersion}</LangVersion>
                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -167,7 +167,7 @@ class DotNetCompiler extends BaseCompiler {
         const crossgen2Options = [
             crossgen2Path, '-r', path.join(publishPath, '*'), dllPath, '-o', 'CompilerExplorer.r2r.dll',
             '--codegenopt', 'NgenDisasm=*', '--codegenopt', 'JitDiffableDasm=1', '--parallelism', '1',
-            '--inputbubble', '--compilebubblegenerics', '--resilient',
+            '--inputbubble', '--compilebubblegenerics',
         ].concat(options);
 
         const result = await this.exec(compiler, crossgen2Options, execOptions);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -167,6 +167,7 @@ class DotNetCompiler extends BaseCompiler {
         const crossgen2Options = [
             crossgen2Path, '-r', path.join(publishPath, '*'), dllPath, '-o', 'CompilerExplorer.r2r.dll',
             '--codegenopt', 'NgenDisasm=*', '--codegenopt', 'JitDiffableDasm=1', '--parallelism', '1',
+            '--inputbubble', '--compilebubblegenerics', '--resilient',
         ].concat(options);
 
         const result = await this.exec(compiler, crossgen2Options, execOptions);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -168,7 +168,7 @@ class DotNetCompiler extends BaseCompiler {
                 // ; Assembly listing for method ConsoleApplication.Program:Main(System.String[])
                 //                               ^ This character is the 31st character in this string.
                 // `substring` removes the first 30 characters from it and uses the rest as a label.
-                cleanedAsm = cleanedAsm.concat(line.text.substring(30) + ':\n');
+                cleanedAsm = cleanedAsm.concat('Method ' + line.text.substring(30) + ':\n');
                 continue;
             }
 

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -27,6 +27,7 @@ import path from 'path';
 import fs from 'fs-extra';
 
 /// <reference types="../base-compiler" />
+import { DotNetAsmParser } from '../asm-parser-dotnet';
 import { BaseCompiler } from '../base-compiler';
 
 class DotNetCompiler extends BaseCompiler {
@@ -37,6 +38,7 @@ class DotNetCompiler extends BaseCompiler {
     private clrBuildDir: string;
     private additionalSources: string;
     private langVersion: string;
+    protected asm: DotNetAsmParser;
 
     constructor(compilerInfo, env) {
         super(compilerInfo, env);
@@ -48,6 +50,7 @@ class DotNetCompiler extends BaseCompiler {
         this.clrBuildDir = this.compilerProps(`compiler.${this.compiler.id}.clrDir`);
         this.additionalSources = this.compilerProps(`compiler.${this.compiler.id}.additionalSources`);
         this.langVersion = this.compilerProps(`compiler.${this.compiler.id}.langVersion`);
+        this.asm = new DotNetAsmParser();
     }
 
     get compilerOptions() {
@@ -160,32 +163,6 @@ class DotNetCompiler extends BaseCompiler {
         return this.compilerOptions;
     }
 
-    cleanAsm(stdout) {
-        let cleanedAsm = '';
-
-        for (const line of stdout) {
-            if (line.text.startsWith('; Assembly listing for method')) {
-                // ; Assembly listing for method ConsoleApplication.Program:Main(System.String[])
-                //                               ^ This character is the 31st character in this string.
-                // `substring` removes the first 30 characters from it and uses the rest as a label.
-                cleanedAsm = cleanedAsm.concat('Method ' + line.text.substring(30) + ':\n');
-                continue;
-            }
-
-            if (line.text.startsWith('Emitting R2R PE file')) {
-                continue;
-            }
-
-            if (line.text.startsWith(';') && !line.text.startsWith('; Emitting')) {
-                continue;
-            }
-
-            cleanedAsm = cleanedAsm.concat(line.text + '\n');
-        }
-
-        return cleanedAsm;
-    }
-
     async runCrossgen2(compiler, execOptions, crossgen2Path, publishPath, dllPath, options, outputPath) {
         const crossgen2Options = [
             crossgen2Path, '-r', path.join(publishPath, '*'), dllPath, '-o', 'CompilerExplorer.r2r.dll',
@@ -199,7 +176,7 @@ class DotNetCompiler extends BaseCompiler {
 
         await fs.writeFile(
             outputPath,
-            this.cleanAsm(result.stdout),
+            result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`),
         );
 
         return result;


### PR DESCRIPTION
- Implement asm-parser for dotnet.
- Update the README.md to reflect language changes.
- Fix codegen perf issue while compiling code against intrinsics.
- Fix issue where there's an empty line after method signature.

Before/After unused labels filter:

![image](https://user-images.githubusercontent.com/14960345/152989420-c7978258-81b8-403f-8401-f9c68b6b7d65.png)

![image](https://user-images.githubusercontent.com/14960345/152989263-05c8f264-4638-4da6-9df6-e5c8749364c3.png)

Fixes #3325