### PR TITLE
[draft] Dark+ theme

### DIFF
--- a/static/colour.ts
+++ b/static/colour.ts
@@ -24,7 +24,7 @@
 
 import * as monaco from 'monaco-editor';
 
-export type AppTheme = 'default' | 'dark' | 'all';
+export type AppTheme = 'default' | 'dark' | 'darkplus' | 'all';
 
 interface ColourScheme {
     name: string;
@@ -39,8 +39,8 @@ export const schemes: ColourScheme[] = [
     {name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default']},
     {name: 'earth', desc: 'Earth tones (colourblind safe)', count: 9, themes: ['default']},
     {name: 'green-blue', desc: 'Greens and blues (colourblind safe)', count: 4, themes: ['default']},
-    {name: 'gray-shade', desc: 'Gray shades', count: 4, themes: ['dark']},
-    {name: 'rainbow-dark', desc: 'Dark Rainbow', count: 12, themes: ['dark']},
+    {name: 'gray-shade', desc: 'Gray shades', count: 4, themes: ['dark', 'darkplus']},
+    {name: 'rainbow-dark', desc: 'Dark Rainbow', count: 12, themes: ['dark', 'darkplus']},
 ];
 
 export function applyColours(

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -25,7 +25,7 @@
 import { editor } from 'monaco-editor';
 import { SiteSettings } from './settings';
 
-export type Themes = 'default' | 'dark';
+export type Themes = 'default' | 'dark' | 'darkplus';
 
 export interface Theme {
     path: string;
@@ -50,6 +50,13 @@ export const themes: Record<Themes, Theme> = {
         mainColor: '#333333',
         monaco: 'ce-dark',
     },
+    darkplus: {
+        path: 'dark',
+        id: 'darkplus',
+        name: 'Dark+',
+        mainColor: '#333333',
+        monaco: 'ce-dark-plus',
+    },
 };
 
 editor.defineTheme('ce', {
@@ -66,6 +73,22 @@ editor.defineTheme('ce-dark', {
     inherit: true,
     rules: [
         {token: 'identifier.definition.cppx-blue', foreground: '7c9c7c', fontStyle: 'bold'},
+    ],
+    colors: {},
+});
+
+editor.defineTheme('ce-dark-plus', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+        {token: 'identifier.definition.cppx-blue', foreground: '7c9c7c', fontStyle: 'bold'},
+        {token: 'keyword.if.cpp', foreground: 'c586c0' },
+        {token: 'keyword.else.cpp', foreground: 'c586c0' },
+        {token: 'keyword.while.cpp', foreground: 'c586c0' },
+        {token: 'keyword.for.cpp', foreground: 'c586c0' },
+        {token: 'keyword.return.cpp', foreground: 'c586c0' },
+        {token: 'keyword.break.cpp', foreground: 'c586c0' },
+        {token: 'keyword.directive.include.cpp', foreground: 'c586c0'},
     ],
     colors: {},
 });


### PR DESCRIPTION
Adds a (continously evolving?) theme that tries to get closer to Visual Studio Code's Dark+ theme.

Of course we can't do everything that Dark+ does, and depending on how the tokenizer was written for the language, it might be difficult or laborious or easy.

In the case of C++ (and C), we mostly use the original tokenizer that's available in the editor, which doesn't separate flow-control keywords from other keywords, so we have to give a different color to every single control keyword.

* [x] Basic theme
* [ ] Might be good to create some example code that contains all possibilities so we can compare.
* [ ] More things
* [ ] More languages

Notes on how to find out what's what:
* Press F1 in the source editor and find "Developer: inspect tokens" and then select a word to see how the token is categorized
