### PR TITLE
Fix objdumper property for several cross compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -367,6 +367,7 @@ group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
 group.armclang32.instructionSet=arm32
 group.armclang32.baseName=armv7-a clang
+group.armclang32.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 
 compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv7-clang1101.semver=11.0.1
@@ -435,12 +436,12 @@ compiler.armv8-clang900.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/c
 compiler.armv8-clang900.alias=armv8-clang-9
 compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-clang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-clang-trunk.semver=(trunk)
 compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-full-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-full-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-full-clang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-clang-trunk.semver=(trunk, all architectural features)
 # Arm v8-a with all supported architectural features
 compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -348,7 +348,7 @@ compiler.armv8-cclang900.alias=armv8-cclang-9
 compiler.armv7-cclang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv7-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv7-cclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv7-cclang-trunk.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armv7-cclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
 compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
@@ -356,7 +356,7 @@ compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/o
 compiler.armv8-cclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-cclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-cclang-trunk.semver=(trunk)
 # Arm v8-a
 compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
@@ -364,7 +364,7 @@ compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/o
 compiler.armv8-full-cclang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-full-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
 compiler.armv8-full-cclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
@@ -463,7 +463,6 @@ group.wasmcclang.groupName=Clang WebAssembly
 group.wasmcclang.supportsBinary=false
 compiler.wasm32cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.wasm32cclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.wasm32cclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.wasm32cclang.name=WebAssembly clang (trunk)
 compiler.wasm32cclang.options=-target wasm32
 
@@ -599,12 +598,10 @@ compiler.cppc64g9.name=power64 AT13.0 (gcc9)
 compiler.cppc64g9.semver=(snapshot)
 compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cppc64clang.name=powerpc64 clang (trunk)
 compiler.cppc64clang.options=-target powerpc64
 compiler.cppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.cppc64leclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cppc64leclang.name=power64le clang (trunk)
 compiler.cppc64leclang.options=-target powerpc64le
 compiler.cppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc


### PR DESCRIPTION
objdumper was wrongly set to use native objdump for some targets:
- when binary is enabled, use a correct objdump (usually using one from the
equivalent cross-gcc toolchain)
- when binary is disabled, remove the property

refs #3327

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>