### PR TITLE
win32 binary library filter fix

### DIFF
--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -27,6 +27,7 @@ import path from 'path';
 import temp from 'temp';
 import _ from 'underscore';
 
+import { AsmParser } from '../asm-parser';
 import { BaseCompiler } from '../base-compiler';
 import { MapFileReaderVS } from '../map-file-vs';
 import { PELabelReconstructor } from '../pe32-support';
@@ -34,6 +35,12 @@ import * as utils from '../utils';
 
 export class Win32Compiler extends BaseCompiler {
     static get key() { return 'win32'; }
+
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+
+        this.binaryAsmParser = new AsmParser(this.compilerProps);
+    }
 
     newTempDir() {
         return new Promise((resolve, reject) => {
@@ -140,6 +147,15 @@ export class Win32Compiler extends BaseCompiler {
                 '/Fa' + this.filename(outputFilename),
                 '/Fo' + this.filename(outputFilename + '.obj'),
             ];
+        }
+    }
+
+    processAsm(result, filters/*, options*/) {
+        if (filters.binary) {
+            filters.dontMaskFilenames = true;
+            return this.binaryAsmParser.process(result.asm, filters);
+        } else {
+            return this.asm.process(result.asm, filters);
         }
     }
 

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -221,6 +221,7 @@ export class PELabelReconstructor {
      */
     insertLabels() {
         let currentSegment = false;
+        let segmentChanged = false;
 
         let lineIdx = 0;
         while (lineIdx < this.asmLines.length) {
@@ -234,6 +235,7 @@ export class PELabelReconstructor {
                 const segmentInfo = this.mapFileReader.getSegmentInfoByStartingAddress(false, address);
                 if (segmentInfo) {
                     currentSegment = segmentInfo;
+                    segmentChanged = true;
                 }
 
                 let namedAddr = false;
@@ -267,7 +269,14 @@ export class PELabelReconstructor {
 
                 const lineInfo = this.mapFileReader.getLineInfoByAddress(false, address);
                 if (lineInfo && currentSegment.unitName) {
-                    this.asmLines.splice(lineIdx, 0, '/app/' + currentSegment.unitName + ':' + lineInfo.lineNumber);
+                    this.asmLines.splice(lineIdx, 0,
+                        '/app/' + currentSegment.unitName +
+                        ':' + lineInfo.lineNumber);
+                    lineIdx++;
+                } else if (segmentChanged) {
+                    this.asmLines.splice(lineIdx, 0,
+                        '/app/' + currentSegment.unitName +
+                        ':0');
                     lineIdx++;
                 }
             }


### PR DESCRIPTION
Library filter removed all assembly except for the labels in binary mode.

In case of win32 binary mode, use the binary parser and associate obj filenames even if theres no lineno info.
This way the library filter keeps working without having to disable the option. (because in normal mode library filter should work)
