### PR TITLE
Change codeLens font on setting change

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2283,6 +2283,7 @@ Compiler.prototype.onSettingsChange = function (newSettings) {
             enabled: this.settings.showMinimap && !options.embedded,
         },
         fontFamily: this.settings.editorsFFont,
+        codeLensFontFamily: this.settings.editorsFFont,
         fontLigatures: this.settings.editorsFLigatures,
     });
 };

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -173,6 +173,7 @@ Tool.prototype.onSettingsChange = function (newSettings) {
             enabled: newSettings.showMinimap,
         },
         fontFamily: newSettings.editorsFFont,
+        codeLensFontFamily: newSettings.editorsFFont,
         fontLigatures: newSettings.editorsFLigatures,
     });
 };


### PR DESCRIPTION
https://github.com/compiler-explorer/compiler-explorer/pull/3332/files#diff-cdc081b094f9b17444477d134e0c5b05df6db1e5f3536dfb057ca32cdd645750L82 removed the now unecessary workaround to change the codelens font family, but while [the API docs say that it defaults to the editor font](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IEditorOptions.html#codeLensFontFamily), that does not seem to be the case once the settings are updated, so we need to explicitly set them.