### PR TITLE
Fixes check for empty request body

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -433,7 +433,7 @@ export class CompileHandler {
         let files;
         if (req.body.files) files = req.body.files;
 
-        if (source === undefined) {
+        if (source === undefined || Object.keys(req.body).length === 0) {
             logger.warn('No body found in request', req);
             return next(new Error('Bad request'));
         }

--- a/test/handlers/compile-tests.js
+++ b/test/handlers/compile-tests.js
@@ -340,6 +340,23 @@ describe('Compiler tests', () => {
                     .send(source || ''));
         }
 
+        it("error on empty request body", () => {
+            return compileHandler.setCompilers([{
+                compilerType: 'fake-for-test',
+                exe: 'fake',
+                fakeResult: {}
+            }])
+                .then(() => chai.request(app)
+                    .post('/fake-for-test/compile')
+                    .set('Accept', 'application/json'))
+                .then(res => {
+                    res.should.have.status(500);
+                })
+                .catch(err => {
+                    throw err;
+                });
+        });
+
         it('handles filters set directly', () => {
             return makeFakeQuery('source', {filters: 'a,b,c'})
                 .then(res => {


### PR DESCRIPTION
Check `req.body` being empty in addition to `source` being `undefined`.

One thing of note that I wasn't entirely sure about was that the error given when an empty body is passed, is seen as an internal server error, unlike other user errors like passing in a body with no content like `{}` - but I didn't want to change that behavior without asking about it. This also results in the output error being html even when posting with accept: application/json. I'd be happy to change that, just wanted to make sure of anything first.

![image](https://user-images.githubusercontent.com/10470872/153130669-4d0dcc9b-c859-495d-8411-0929c7732dcd.png)
![image](https://user-images.githubusercontent.com/10470872/153130791-5f63944f-6e50-4f4b-894d-5ad045055f81.png)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
