### PR TITLE
Add cross GCC 11.2.0 for several targets + some tweaks

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -35,7 +35,6 @@ compiler.gnatsnapshot.semver=(trunk)
 group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103
 group.gnatriscv64.groupName=GNAT riscv64
 group.gnatriscv64.instructionSet=riscv
-group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.isSemVer=true
 group.gnatriscv64.supportsBinary=false
 group.gnatriscv64.supportsExecute=false
@@ -55,21 +54,19 @@ compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-l
 group.gnats390x.compilers=gnats390x1120
 group.gnats390x.groupName=GNAT s390x
 group.gnats390x.instructionSet=s390x
-group.gnats390x.baseName=s390x gnat
+group.gnats390x.baseName=s390x GNAT
 group.gnats390x.isSemVer=true
 group.gnats390x.supportsBinary=false
 group.gnats390x.supportsExecute=false
 
 compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnat
 compiler.gnats390x1120.semver=11.2.0
-compiler.gnats390x1120.name=s390x GNAT 11.2.0
 
 ################################
 # GNAT for ppc
 group.gnatppc.compilers=gnatppc1120:gnatppc641120:gnatppc64le1120
 group.gnatppc.groupName=GNAT POWER
 group.gnatppc.instructionSet=ppc
-group.gnatppc.baseName=ppc gnat
 group.gnatppc.isSemVer=true
 group.gnatppc.supportsBinary=false
 group.gnatppc.supportsExecute=false

--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,5 +1,5 @@
 # Default settings for Ada
-compilers=&gnat:&gnatriscv64:&gnatarm
+compilers=&gnat:&gnatriscv64:&gnatarm:&gnats390x:&gnatmips:&gnatppc
 defaultCompiler=gnat112
 demangler=/opt/compiler-explorer/gcc-11.2.0/bin/c++filt
 versionFlag=--version
@@ -37,16 +37,71 @@ group.gnatriscv64.groupName=GNAT riscv64
 group.gnatriscv64.instructionSet=riscv
 group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.isSemVer=true
+group.gnatriscv64.supportsBinary=false
+group.gnatriscv64.supportsExecute=false
 
 compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnat
+compiler.gnatriscv64103.name=riscv64 gnat 10.3.0-2 (Alire)
 compiler.gnatriscv64103.semver=10.3.0
-compiler.gnatriscv64103.supportsBinary=false
 compiler.gnatriscv64103.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/riscv64-elf/lib/gnat/zfp-rv64imac
 
 compiler.gnatriscv64112.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/bin/riscv64-elf-gnat
+compiler.gnatriscv64103.name=riscv64 gnat 11.2.0-3 (Alire)
 compiler.gnatriscv64112.semver=11.2.0
-compiler.gnatriscv64112.supportsBinary=false
 compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
+
+################################
+# GNAT for s390x
+group.gnats390x.compilers=gnats390x1120
+group.gnats390x.groupName=GNAT s390x
+group.gnats390x.instructionSet=s390x
+group.gnats390x.baseName=s390x gnat
+group.gnats390x.isSemVer=true
+group.gnats390x.supportsBinary=false
+group.gnats390x.supportsExecute=false
+
+compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnat
+compiler.gnats390x1120.semver=11.2.0
+compiler.gnats390x1120.name=s390x GNAT 11.2.0
+
+################################
+# GNAT for ppc
+group.gnatppc.compilers=gnatppc1120:gnatppc641120:gnatppc64le1120
+group.gnatppc.groupName=GNAT POWER
+group.gnatppc.instructionSet=ppc
+group.gnatppc.baseName=ppc gnat
+group.gnatppc.isSemVer=true
+group.gnatppc.supportsBinary=false
+group.gnatppc.supportsExecute=false
+
+compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnat
+compiler.gnatppc1120.semver=11.2.0
+compiler.gnatppc1120.name=powerpc GNAT 11.2.0
+
+compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnat
+compiler.gnatppc641120.semver=11.2.0
+compiler.gnatppc641120.name=powerpc64 GNAT 11.2.0
+
+compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnat
+compiler.gnatppc64le1120.semver=11.2.0
+compiler.gnatppc64le1120.name=powerpc64le GNAT 11.2.0
+
+################################
+# GNAT for MIPS
+group.gnatmips.compilers=gnatmips1120:gnatmips641120
+group.gnatmips.groupName=GNAT MIPS
+group.gnatmips.instructionSet=mips
+group.gnatmips.isSemVer=true
+group.gnatmips.supportsBinary=false
+group.gnatmips.supportsExecute=false
+
+compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnat 
+compiler.gnatmips1120.semver=11.2.0
+compiler.gnatmips1120.name=MIPS GNAT 11.2.0
+
+compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnat
+compiler.gnatmips641120.semver=11.2.0
+compiler.gnatmips1120.name=MIPS64 GNAT 11.2.0
 
 ################################
 # GNAT for arm
@@ -55,15 +110,17 @@ group.gnatarm.groupName=GNAT arm
 group.gnatarm.instructionSet=arm32
 group.gnatarm.baseName=arm gnat
 group.gnatarm.isSemVer=true
+group.gnatarm.supportsBinary=false
+group.gnatarm.supportsExecute=false
 
 compiler.gnatarm103.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-gnat
+compiler.gnatarm103.name=arm gnat 10.3.0-2 (Alire)
 compiler.gnatarm103.semver=10.3.0
-compiler.gnatarm103.supportsBinary=false
 compiler.gnatarm103.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/arm-eabi/lib/gnat/zfp-cortex-m4f/
 
 compiler.gnatarm112.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/bin/arm-eabi-gnat
+compiler.gnatarm112.name=arm gnat 11.2.0-3 (Alire)
 compiler.gnatarm112.semver=11.2.0
-compiler.gnatarm112.supportsBinary=false
 compiler.gnatarm112.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/arm-eabi/lib/gnat/zfp-cortex-m4f/
 
 #################################

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -659,55 +659,86 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray
+group.cross.compilers=&ppc:&mips:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
 
 ###############################
+# Cross for s390x
+group.s390x.compilers=&gccs390x
+
+# GCC for s390x
+group.gccs390x.supportsBinary=true
+group.gccs390x.supportsExecute=false
+
+group.gccs390x.groupName=s390x G++
+group.gccs390x.compilers=cgccs390x1120
+group.gccs390x.isSemVer=true
+group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+compiler.gccs390x1120.exe=/opt/compiler-explorer/arm/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.gccs390x1120.name=s390x gcc 11.2.0
+compiler.gccs390x1120.semver=11.2.0
+
+###############################
 # GCC for PPC
-group.ppc.compilers=ppcg48:ppc64leg630:ppc64leg8:ppc64g8:ppc64leg9:ppc64g9:ppc64clang:ppc64leclang
+group.ppc.compilers=ppcg1120:ppcg48:ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64g8:ppc64g9:ppc64g1120:ppc64clang:ppc64leclang
 group.ppc.groupName=POWER Compilers
 group.ppc.isSemVer=true
+group.ppc.supportsBinary=true
+group.ppc.supportsExecute=false
 
-compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
-compiler.ppcg48.name=PowerPC gcc 4.8.5
-compiler.ppcg48.semver=4.8.5
-compiler.ppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg630.name=power64le gcc 6.3.0
 compiler.ppc64leg630.semver=6.3.0
-compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
-compiler.ppc64leg8.name=power64le AT12.0
-compiler.ppc64leg8.semver=(snapshot)
+compiler.ppc64leg8.name=power64le AT12.0 (gcc8)
 compiler.ppc64leg8.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
-compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
-compiler.ppc64g8.name=power64 AT12.0
-compiler.ppc64g8.semver=(snapshot)
-compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64leg8.semver=(snapshot)
 compiler.ppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
-compiler.ppc64leg9.name=power64le AT13.0
-compiler.ppc64leg9.semver=(snapshot)
 compiler.ppc64leg9.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg9.name=power64le AT13.0 (gcc9)
+compiler.ppc64leg9.semver=(snapshot)
+compiler.ppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg1120.name=power64le gcc 11.2.0
+compiler.ppc64leg1120.semver=11.2.0
+compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g8.name=power64 AT12.0 (gcc8)
+compiler.ppc64g8.semver=(snapshot)
 compiler.ppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
-compiler.ppc64g9.name=power64 AT13.0
-compiler.ppc64g9.semver=(snapshot)
 compiler.ppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g9.name=power64 AT13.0 (gcc9)
+compiler.ppc64g9.semver=(snapshot)
+compiler.ppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1120.name=power64 gcc 11.2.0
+compiler.ppc64g1120.semver=11.2.0
 compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64clang.name=powerpc64 clang (trunk)
 compiler.ppc64clang.options=-target powerpc64
 compiler.ppc64clang.supportsBinary=false
 compiler.ppc64clang.semver=(snapshot)
 compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.ppc64leclang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.ppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leclang.name=power64le clang (trunk)
 compiler.ppc64leclang.options=-target powerpc64le
 compiler.ppc64leclang.supportsBinary=false
 compiler.ppc64leclang.semver=(snapshot)
+compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg48.name=power gcc 4.8.5
+compiler.ppcg48.semver=4.8.5
+compiler.ppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1120.name=power gcc 11.2.0
+compiler.ppcg1120.semver=11.2.0
 
 ###############################
 # GCC for ARM
@@ -956,22 +987,32 @@ compiler.avrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdum
 
 ###############################
 # GCC for MIPS
-group.mips.compilers=mips5:mips5el:mips564:mips564el:mips930
+group.mips.compilers=mips5:mips1120:mips5el:mips564:mips112064:mips564el:mips930
 group.mips.groupName=MIPS GCC
 group.mips.isSemVer=true
+group.mips.supportsBinary=true
+group.mips.supportsExecute=false
 
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mips5.name=MIPS gcc 5.4
 compiler.mips5.semver=5.4
 compiler.mips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
-compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
-compiler.mips5el.name=MIPS gcc 5.4 (el)
-compiler.mips5el.semver=5.4
-compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
+compiler.mips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mips1120.name=MIPS gcc 11.2.0
+compiler.mips1120.semver=11.2.0
+compiler.mips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips564.name=MIPS64 gcc 5.4
 compiler.mips564.semver=5.4
 compiler.mips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips112064.name=MIPS64 gcc 11.2.0
+compiler.mips112064.semver=11.2.0
+compiler.mips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
+compiler.mips5el.name=MIPS gcc 5.4 (el)
+compiler.mips5el.semver=5.4
+compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -677,7 +677,7 @@ group.gccs390x.compilers=cgccs390x1120
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
-compiler.gccs390x1120.exe=/opt/compiler-explorer/arm/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.gccs390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
 compiler.gccs390x1120.name=s390x gcc 11.2.0
 compiler.gccs390x1120.semver=11.2.0
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -574,42 +574,83 @@ compiler.cicx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray
+group.ccross.compilers=&cppc:&cmips:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
 
 ###############################
+# Cross for s390x
+group.cs390x.compilers=&cgccs390x
+
+# GCC for s390x
+group.cgccs390x.supportsBinary=true
+group.cgccs390x.supportsExecute=false
+
+group.cgccs390x.groupName=s390x GCC
+group.cgccs390x.compilers=cgccs390x112
+group.cgccs390x.isSemVer=true
+group.cgccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+compiler.cgccs390x112.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cgccs390x112.name=s390x GCC 11.2.0
+compiler.cgccs390x112.semver=11.2.0
+
+###############################
 # GCC for PPC
-group.cppc.compilers=cppcg48:cppc64leg630:cppc64leg8:cppc64g8:cppc64leg9:cppc64g9:cppc64clang:cppc64leclang
+group.cppc.compilers=cppcg1120:cppcg48:cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64g8:cppc64g9:cppc64g1120:cppc64clang:cppc64leclang
 group.cppc.groupName=POWER Compilers
+group.cppc.supportsBinary=true
+group.cppc.supportsExecute=false
 group.cppc.isSemVer=true
+
+compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg630.name=power64le gcc 6.3.0
+compiler.cppc64leg630.semver=6.3.0
 compiler.cppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg8.name=power64le AT12.0 (gcc8)
+compiler.cppc64leg8.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg8.semver=(snapshot)
-compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
-compiler.cppc64g8.name=power64 AT12.0 (gcc8)
-compiler.cppc64g8.semver=(snapshot)
 compiler.cppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg9.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg9.name=power64le AT13.0 (gcc9)
 compiler.cppc64leg9.semver=(snapshot)
+compiler.cppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1120.name=power64le gcc 11.2.0
+compiler.cppc64leg1120.semver=11.2.0
+compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g8.name=power64 AT12.0 (gcc8)
+compiler.cppc64g8.semver=(snapshot)
 compiler.cppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g9.name=power64 AT13.0 (gcc9)
 compiler.cppc64g9.semver=(snapshot)
+compiler.cppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1120.name=power64 gcc 11.2.0
+compiler.cppc64g1120.semver=11.2.0
 compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.cppc64clang.name=powerpc64 clang (trunk)
+compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64clang.name=power64 clang (trunk)
 compiler.cppc64clang.options=-target powerpc64
 compiler.cppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leclang.name=power64le clang (trunk)
 compiler.cppc64leclang.options=-target powerpc64le
 compiler.cppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc
-compiler.cppcg48.name=PowerPC gcc 4.8.5
+compiler.cppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg48.name=power gcc 4.8.5
 compiler.cppcg48.semver=4.8.5
-compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
-compiler.cppc64leg630.name=PowerPC64 gcc 6.3.0
-compiler.cppc64leg630.semver=6.3.0
+compiler.cppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1120.name=power gcc 11.2.0
+compiler.cppcg1120.semver=11.2.0
+
 
 ###############################
 # GCC for ARM
@@ -858,24 +899,40 @@ compiler.cavrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdu
 
 ###############################
 # GCC for MIPS
-group.cmips.compilers=cmips5:cmips5el:cmips564:cmips564el
+group.cmips.compilers=cmips5:cmips930:cmips1120:cmips5el:cmips564:cmips112064:cmips564el
 group.cmips.groupName=MIPS GCC
 group.cmips.isSemVer=true
+group.cmips.supportsBinary=true
+group.cmips.supportsExecute=false
+
 compiler.cmips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmips5.name=MIPS gcc 5.4
 compiler.cmips5.semver=5.4
-compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
-compiler.cmips5el.name=MIPS gcc 5.4 (el)
-compiler.cmips5el.semver=5.4
+compiler.cmips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmips1120.name=MIPS gcc 11.2.0
+compiler.cmips1120.semver=11.2.0
+compiler.cmips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.cmips564.name=MIPS64 gcc 5.4
 compiler.cmips564.semver=5.4
+compiler.cmips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips112064.name=MIPS64 gcc 11.2.0
+compiler.cmips112064.semver=11.2.0
+compiler.cmips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
+compiler.cmips5el.name=MIPS gcc 5.4 (el)
+compiler.cmips5el.semver=5.4
+compiler.cmips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
+compiler.cmips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
 compiler.cmips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
-compiler.cmips930.name=MIPS gcc 9.3.0
+compiler.cmips930.name=MIPS gcc 9.3.0 (codescape)
 compiler.cmips930.semver=9.3.0
+compiler.cmips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
 
 ###############################
 # GCC for nanoMIPS


### PR DESCRIPTION
Add cross GCC 11.2.0 for : s390x-linux, mips-linux, mips64-linux, ppc, ppc64 and
ppc64le for C, C++ and Ada.

Toggle supportsBinary for these targets for c/c++.

Small cleanup in Ada configuration for cross:
- credit Alire for riscv/arm
- disable binary/exec in group instead of compilers

refs #3282, #2470

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>