### PR TITLE
Codefix for when multifile isn't used

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -1073,7 +1073,7 @@ export class BaseCompiler {
         const inputFilename = path.join(dirPath, this.compileFilename);
         await fs.writeFile(inputFilename, source);
 
-        if (files) {
+        if (files && files.length > 0) {
             filters.dontMaskFilenames = true;
 
             await this.writeMultipleFiles(files, dirPath);
@@ -1090,7 +1090,7 @@ export class BaseCompiler {
         const inputFilename = path.join(dirPath, 'CMakeLists.txt');
         await fs.writeFile(inputFilename, source);
 
-        if (files) {
+        if (files && files.length > 0) {
             filters.dontMaskFilenames = true;
 
             await this.writeMultipleFiles(files, dirPath);

--- a/lib/compilers/pascal-win.js
+++ b/lib/compilers/pascal-win.js
@@ -126,7 +126,7 @@ export class PascalWinCompiler extends BaseCompiler {
 
         await fs.writeFile(inputFilename, source);
 
-        if (files) {
+        if (files && files.length > 0) {
             filters.dontMaskFilenames = true;
 
             await this.writeMultipleFiles(files, dirPath);

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -153,7 +153,7 @@ export class FPCCompiler extends BaseCompiler {
             await fs.writeFile(inputFilename, source);
         }
 
-        if (files) {
+        if (files && files.length > 0) {
             filters.dontMaskFilenames = true;
 
             await this.writeMultipleFiles(files, dirPath);


### PR DESCRIPTION
When no files are supplied, no need to do anything special for them either

Shouldn't really change anything on live, but it caused some weird behaviour in https://github.com/compiler-explorer/compiler-explorer/pull/3278.
