### PR TITLE
Add dartformat to the list of formatters

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -37,7 +37,7 @@ make=/usr/bin/make
 ld=/usr/bin/ld
 readelf=/usr/bin/readelf
 
-formatters=clangformat:rustfmt:gofmt
+formatters=clangformat:rustfmt:gofmt:dartformat
 formatter.clangformat.name=clang-format
 formatter.clangformat.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit:Microsoft:GNU


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
I forgot to add `dartformat` to the list of formatters in `compiler-explorer.amazon.properties` in #3362, which is why it's not working on the live site.