### PR TITLE
Minor cleanup/tidy of MIPS/POWER compilers

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,5 +1,5 @@
 # Default settings for Ada
-compilers=&gnat:&gnatriscv64:&gnatarm:&gnats390x:&gnatmips:&gnatppc
+compilers=&gnat:&gnatriscv64:&gnatarm:&gnats390x:&gnatmipss:&gnatppcs
 defaultCompiler=gnat112
 demangler=/opt/compiler-explorer/gcc-11.2.0/bin/c++filt
 versionFlag=--version
@@ -54,7 +54,7 @@ compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-l
 group.gnats390x.compilers=gnats390x1120
 group.gnats390x.groupName=GNAT s390x
 group.gnats390x.instructionSet=s390x
-group.gnats390x.baseName=s390x GNAT
+group.gnats390x.baseName=s390x gnat
 group.gnats390x.isSemVer=true
 group.gnats390x.supportsBinary=false
 group.gnats390x.supportsExecute=false
@@ -64,48 +64,58 @@ compiler.gnats390x1120.semver=11.2.0
 
 ################################
 # GNAT for ppc
-group.gnatppc.compilers=gnatppc1120:gnatppc641120:gnatppc64le1120
-group.gnatppc.groupName=GNAT POWER
-group.gnatppc.instructionSet=ppc
-group.gnatppc.isSemVer=true
-group.gnatppc.supportsBinary=false
-group.gnatppc.supportsExecute=false
+group.gnatppcs.compilers=&gnatppc:&gnatppc64:&gnatppc64le
+group.gnatppcs.groupName=GNAT power
+group.gnatppcs.instructionSet=ppc
+group.gnatppcs.isSemVer=true
+group.gnatppcs.supportsBinary=false
+group.gnatppcs.supportsExecute=false
 
+## POWER
+group.gnatppc.compilers=gnatppc1120
+group.gnatppc.baseName=powerpc gnat
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnat
 compiler.gnatppc1120.semver=11.2.0
-compiler.gnatppc1120.name=powerpc GNAT 11.2.0
 
+## POWER64
+group.gnatppc64.compilers=gnatppc641120
+group.gnatppc64.baseName=powerpc64 gnat
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnat
 compiler.gnatppc641120.semver=11.2.0
-compiler.gnatppc641120.name=powerpc64 GNAT 11.2.0
 
+## POWER64LE
+group.gnatppc64le.compilers=gnatppc64le1120
+group.gnatppc64le.baseName=powerpc64le gnat
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnat
 compiler.gnatppc64le1120.semver=11.2.0
-compiler.gnatppc64le1120.name=powerpc64le GNAT 11.2.0
 
 ################################
 # GNAT for MIPS
-group.gnatmips.compilers=gnatmips1120:gnatmips641120
-group.gnatmips.groupName=GNAT MIPS
-group.gnatmips.instructionSet=mips
-group.gnatmips.isSemVer=true
-group.gnatmips.supportsBinary=false
-group.gnatmips.supportsExecute=false
+group.gnatmipss.compilers=&gnatmips:&gnatmips64
+group.gnatmipss.groupName=GNAT MIPS
+group.gnatmipss.instructionSet=mips
+group.gnatmipss.isSemVer=true
+group.gnatmipss.supportsBinary=false
+group.gnatmipss.supportsExecute=false
 
+## MIPS
+group.gnatmips.compilers=gnatmips1120
+group.gnatmips.baseName=mips gnat
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnat 
 compiler.gnatmips1120.semver=11.2.0
-compiler.gnatmips1120.name=MIPS GNAT 11.2.0
+
+## MIPS64
+group.gnatmips64.compilers=gnatmips641120
+group.gnatmips64.baseName=mips64 gnat
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnat
 compiler.gnatmips641120.semver=11.2.0
-compiler.gnatmips1120.name=MIPS64 GNAT 11.2.0
 
 ################################
 # GNAT for arm
 group.gnatarm.compilers=gnatarm112:gnatarm103
 group.gnatarm.groupName=GNAT arm
 group.gnatarm.instructionSet=arm32
-group.gnatarm.baseName=arm gnat
 group.gnatarm.isSemVer=true
 group.gnatarm.supportsBinary=false
 group.gnatarm.supportsExecute=false

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -659,7 +659,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x
+group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -682,13 +682,47 @@ compiler.gccs390x1120.name=s390x gcc 11.2.0
 compiler.gccs390x1120.semver=11.2.0
 
 ###############################
-# GCC for PPC
-group.ppc.compilers=ppcg1120:ppcg48:ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64g8:ppc64g9:ppc64g1120:ppc64clang:ppc64leclang
-group.ppc.groupName=POWER Compilers
-group.ppc.isSemVer=true
-group.ppc.supportsBinary=true
-group.ppc.supportsExecute=false
+# Cross compilers for PPC
+group.ppcs.compilers=&ppc:&ppc64:&ppc64le
+group.ppcs.groupName=POWER Compilers
+group.ppcs.isSemVer=true
+group.ppcs.supportsBinary=true
+group.ppcs.supportsExecute=false
 
+## POWER
+group.ppc.compilers=ppcg1120:ppcg48
+group.ppc.baseName=power gcc
+
+compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg48.semver=4.8.5
+compiler.ppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1120.semver=11.2.0
+
+## POWER64
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64clang
+compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g8.name=power64 AT12.0 (gcc8)
+compiler.ppc64g8.semver=(snapshot)
+compiler.ppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g9.name=power64 AT13.0 (gcc9)
+compiler.ppc64g9.semver=(snapshot)
+compiler.ppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1120.semver=power64 gcc 11.2.0
+compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.ppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64clang.name=powerpc64 clang (trunk)
+compiler.ppc64clang.options=-target powerpc64
+compiler.ppc64clang.supportsBinary=false
+compiler.ppc64clang.semver=(snapshot)
+
+## POWER64LE
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leclang
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg630.name=power64le gcc 6.3.0
@@ -705,25 +739,6 @@ compiler.ppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc6
 compiler.ppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg1120.name=power64le gcc 11.2.0
 compiler.ppc64leg1120.semver=11.2.0
-compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
-compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.ppc64g8.name=power64 AT12.0 (gcc8)
-compiler.ppc64g8.semver=(snapshot)
-compiler.ppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
-compiler.ppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.ppc64g9.name=power64 AT13.0 (gcc9)
-compiler.ppc64g9.semver=(snapshot)
-compiler.ppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
-compiler.ppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.ppc64g1120.name=power64 gcc 11.2.0
-compiler.ppc64g1120.semver=11.2.0
-compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
-compiler.ppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
-compiler.ppc64clang.name=powerpc64 clang (trunk)
-compiler.ppc64clang.options=-target powerpc64
-compiler.ppc64clang.supportsBinary=false
-compiler.ppc64clang.semver=(snapshot)
 compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -731,14 +746,6 @@ compiler.ppc64leclang.name=power64le clang (trunk)
 compiler.ppc64leclang.options=-target powerpc64le
 compiler.ppc64leclang.supportsBinary=false
 compiler.ppc64leclang.semver=(snapshot)
-compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
-compiler.ppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
-compiler.ppcg48.name=power gcc 4.8.5
-compiler.ppcg48.semver=4.8.5
-compiler.ppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
-compiler.ppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
-compiler.ppcg1120.name=power gcc 11.2.0
-compiler.ppcg1120.semver=11.2.0
 
 ###############################
 # GCC for ARM
@@ -987,40 +994,51 @@ compiler.avrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdum
 
 ###############################
 # GCC for MIPS
-group.mips.compilers=mips5:mips1120:mips5el:mips564:mips112064:mips564el:mips930
-group.mips.groupName=MIPS GCC
-group.mips.isSemVer=true
-group.mips.supportsBinary=true
-group.mips.supportsExecute=false
+group.mipss.compilers=&mips:&mipsel:&mips64:&mips64el
 
+group.mipss.groupName=MIPS GCC
+group.mipss.isSemVer=true
+group.mipss.supportsBinary=true
+group.mipss.supportsExecute=false
+
+## MIPS
+group.mips.compilers=mips5:mips930:mips1120
+group.mips.baseName=mips gcc
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
-compiler.mips5.name=MIPS gcc 5.4
 compiler.mips5.semver=5.4
 compiler.mips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-g++
+compiler.mips930.name=mips gcc 9.3.0 (codescape)
+compiler.mips930.semver=9.3.0
+compiler.mips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
 compiler.mips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
-compiler.mips1120.name=MIPS gcc 11.2.0
 compiler.mips1120.semver=11.2.0
 compiler.mips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+## MIPS 64
+group.mips64.compilers=mips564:mips112064
+group.mips64.baseName=mips64 gcc
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
-compiler.mips564.name=MIPS64 gcc 5.4
 compiler.mips564.semver=5.4
 compiler.mips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.mips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
-compiler.mips112064.name=MIPS64 gcc 11.2.0
 compiler.mips112064.semver=11.2.0
 compiler.mips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+## MIPS EL
+group.mipsel.compilers=mips5el
+group.mipsel.baseName=mips (el) gcc
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
-compiler.mips5el.name=MIPS gcc 5.4 (el)
 compiler.mips5el.semver=5.4
 compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
+
+## MIPS 64 EL
+group.mips64el.compilers=mips564el
+group.mips64el.baseName=mips64 (el) gcc
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
 compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
-compiler.mips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-g++
-compiler.mips930.name=MIPS gcc 9.3.0 (codescape)
-compiler.mips930.semver=9.3.0
-compiler.mips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
 
 ###############################
 # GCC for nanoMIPS

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -574,7 +574,7 @@ compiler.cicx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x
+group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
@@ -597,13 +597,44 @@ compiler.cgccs390x112.name=s390x GCC 11.2.0
 compiler.cgccs390x112.semver=11.2.0
 
 ###############################
-# GCC for PPC
-group.cppc.compilers=cppcg1120:cppcg48:cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64g8:cppc64g9:cppc64g1120:cppc64clang:cppc64leclang
-group.cppc.groupName=POWER Compilers
-group.cppc.supportsBinary=true
-group.cppc.supportsExecute=false
-group.cppc.isSemVer=true
+# Cross compilers for PPC
+group.cppcs.compilers=&cppc:&cppc64:&cppc64le
+group.cppcs.groupName=POWER Compilers
+group.cppcs.isSemVer=true
+group.cppcs.supportsBinary=true
+group.cppcs.supportsExecute=false
 
+group.cppc.compilers=cppcg1120:cppcg48
+group.cppc.baseName=power gcc
+
+compiler.cppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg48.semver=4.8.5
+compiler.cppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1120.semver=11.2.0
+
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64clang
+compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g8.name=power64 AT12.0 (gcc8)
+compiler.cppc64g8.semver=(snapshot)
+compiler.cppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g9.name=power64 AT13.0 (gcc9)
+compiler.cppc64g9.semver=(snapshot)
+compiler.cppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1120.semver=power64 gcc 11.2.0
+compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64clang.name=powerpc64 clang (trunk)
+compiler.cppc64clang.options=-target powerpc64
+compiler.cppc64clang.supportsBinary=false
+compiler.cppc64clang.semver=(snapshot)
+
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leclang
 compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg630.name=power64le gcc 6.3.0
@@ -620,37 +651,13 @@ compiler.cppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc
 compiler.cppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg1120.name=power64le gcc 11.2.0
 compiler.cppc64leg1120.semver=11.2.0
-compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
-compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.cppc64g8.name=power64 AT12.0 (gcc8)
-compiler.cppc64g8.semver=(snapshot)
-compiler.cppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
-compiler.cppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.cppc64g9.name=power64 AT13.0 (gcc9)
-compiler.cppc64g9.semver=(snapshot)
-compiler.cppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
-compiler.cppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.cppc64g1120.name=power64 gcc 11.2.0
-compiler.cppc64g1120.semver=11.2.0
-compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.cppc64clang.name=power64 clang (trunk)
-compiler.cppc64clang.options=-target powerpc64
 compiler.cppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leclang.name=power64le clang (trunk)
 compiler.cppc64leclang.options=-target powerpc64le
-compiler.cppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc
-compiler.cppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
-compiler.cppcg48.name=power gcc 4.8.5
-compiler.cppcg48.semver=4.8.5
-compiler.cppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
-compiler.cppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
-compiler.cppcg1120.name=power gcc 11.2.0
-compiler.cppcg1120.semver=11.2.0
-
+compiler.cppc64leclang.supportsBinary=false
+compiler.cppc64leclang.semver=(snapshot)
 
 ###############################
 # GCC for ARM
@@ -899,40 +906,52 @@ compiler.cavrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdu
 
 ###############################
 # GCC for MIPS
-group.cmips.compilers=cmips5:cmips930:cmips1120:cmips5el:cmips564:cmips112064:cmips564el
-group.cmips.groupName=MIPS GCC
-group.cmips.isSemVer=true
-group.cmips.supportsBinary=true
-group.cmips.supportsExecute=false
+group.cmipss.compilers=&cmips:&cmipsel:&cmips64:&cmips64el
 
+group.cmipss.groupName=MIPS GCC
+group.cmipss.isSemVer=true
+group.cmipss.supportsBinary=true
+group.cmipss.supportsExecute=false
+
+## MIPS
+group.cmips.compilers=cmips5:cmips930:cmips1120
+group.cmips.baseName=mips gcc
 compiler.cmips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
-compiler.cmips5.name=MIPS gcc 5.4
 compiler.cmips5.semver=5.4
 compiler.cmips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
+compiler.cmips930.name=mips gcc 9.3.0 (codescape)
+compiler.cmips930.semver=9.3.0
+compiler.cmips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
 compiler.cmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
-compiler.cmips1120.name=MIPS gcc 11.2.0
 compiler.cmips1120.semver=11.2.0
 compiler.cmips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+## MIPS64
+group.cmips64.compilers=cmips564:cmips112064
+group.cmips64.baseName=mips64 gcc
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
-compiler.cmips564.name=MIPS64 gcc 5.4
 compiler.cmips564.semver=5.4
 compiler.cmips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.cmips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
-compiler.cmips112064.name=MIPS64 gcc 11.2.0
 compiler.cmips112064.semver=11.2.0
 compiler.cmips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+## MIPS EL
+group.cmipsel.compilers=cmips5el
+group.cmipsel.baseName=mips (el) gcc
 compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
-compiler.cmips5el.name=MIPS gcc 5.4 (el)
 compiler.cmips5el.semver=5.4
 compiler.cmips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
+
+## MIPS64 EL
+group.cmips64el.compilers=cmips564el
+group.cmips64el.baseName=mips64 (el) gcc
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
 compiler.cmips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
-compiler.cmips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
-compiler.cmips930.name=MIPS gcc 9.3.0 (codescape)
-compiler.cmips930.semver=9.3.0
-compiler.cmips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
+
 
 ###############################
 # GCC for nanoMIPS


### PR DESCRIPTION
Try to have a more homogeneous naming for some compilers and use
groups for different archs (e.g. MIPS/MIPS64).

fixes #3370

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>