### PR TITLE
Changed Python default example to classical square

### DIFF
--- a/examples/python/default.py
+++ b/examples/python/default.py
@@ -1,2 +1,2 @@
-def main():
-    pass
+def square(num):
+    return num * num


### PR DESCRIPTION
Just realized that it does not have the classic square function like the rest of the languages