### PR TITLE
Fixes OpenCLs defaultCompilers to (prob.) intended ones

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,4 @@
 make prereqs
 npx lint-staged
 npm run test
+python3 ./etc/scripts/orphancompiler.py

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&armcpp4oclclang32:&armcpp4oclclang64:&armcpp4oclclang32spir:&armcpp4oclclang64spir
-defaultCompiler=armcpp4oclclang64
+defaultCompiler=armv8-cpp4oclclang-trunk
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 needsMulti=false

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&armoclcclang32:&armoclcclang64:&armoclcclang32spir:&armoclcclang64spir
-defaultCompiler=armoclcclang64
+defaultCompiler=armv8-oclcclang-trunk
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 needsMulti=false


### PR DESCRIPTION
They were set to a group id, and https://github.com/compiler-explorer/compiler-explorer/blob/7e2eb51f8d0e5381d750cc158c1252c9cd8254fd/static/compiler-service.js#L67 triggers if no _compiler_ is found with such id, so the first compiler in the array was being used.

Also adds a check to the config script to ensure this does not happen again, and adds the script to the pre-commit (`time python3
etc/scripts/orphancompiler.py` is 50ms in my machine)