### PR TITLE
Makes notification messages more readable

### DIFF
--- a/static/alert.ts
+++ b/static/alert.ts
@@ -101,29 +101,33 @@ export class Alert {
         const container = $('#notifications');
         if (!container) return;
         const newElement = $(`
-            <div class="alert notification ${alertClass}" tabindex="-1" role="dialog">
-                <button type="button" class="close" style="float: left; margin-right: 5px;" data-dismiss="alert">
-                    &times;
-                </button>
-                <span id="msg">${this.prefixMessage}${body}</span>
+            <div class="toast" tabindex="-1" role="alert" aria-live="assertive" aria-atomic="true">
+                <div class="toast-header ${alertClass}">
+                    <strong class="mr-auto">${this.prefixMessage}</strong>
+                    <button type="button" class="ml-2 mb-1 close" style="float: left; margin-right: 5px;" data-dismiss="toast" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="toast-body ${alertClass}">
+                    <span id="msg">${body}</span>
+               </div>
             </div>
         `);
+        container.append(newElement);
+        newElement.toast({
+            autohide: false,
+            delay: dismissTime,
+        });
         if (group !== '') {
             if (collapseSimilar) {
                 // Only collapsing if a group has been specified
-                container.find(`[data-group="${group}"]`).remove();
+                const old = container.find(`[data-group="${group}"]`);
+                old.toast('hide');
+                old.remove();
             }
             newElement.attr('data-group', group);
         }
-        if (autoDismiss) {
-            setTimeout(() => {
-                newElement.fadeOut('slow', () => {
-                    newElement.remove();
-                });
-            }, dismissTime);
-        }
-        // Append the newly created element to the container
-        container.append(newElement);
+        newElement.toast('show');
     }
 
     /**

--- a/static/alert.ts
+++ b/static/alert.ts
@@ -104,7 +104,7 @@ export class Alert {
             <div class="toast" tabindex="-1" role="alert" aria-live="assertive" aria-atomic="true">
                 <div class="toast-header ${alertClass}">
                     <strong class="mr-auto">${this.prefixMessage}</strong>
-                    <button type="button" class="ml-2 mb-1 close" style="float: left; margin-right: 5px;" data-dismiss="toast" aria-label="Close">
+                    <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>

--- a/static/alert.ts
+++ b/static/alert.ts
@@ -115,7 +115,7 @@ export class Alert {
         `);
         container.append(newElement);
         newElement.toast({
-            autohide: false,
+            autohide: autoDismiss,
             delay: dismissTime,
         });
         if (group !== '') {

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -339,6 +339,11 @@ pre.content.wrap * {
     max-width: 100% !important;
 }
 
+.toast-header .close {
+    float: left;
+    margin-right: 5px;
+}
+
 .font-size-list {
     min-width: 43px !important;
     max-height: 70% !important;

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -326,16 +326,17 @@ pre.content.wrap * {
 }
 
 #notifications {
-    max-width: 33%;
+    padding: 5px;
+    border-radius: 0.5rem;
+    background-color: rgba(49, 54, 60, 0.85);
     position: fixed;
     bottom: 3px;
     right: 5px;
+    max-width: 40%;
 }
 
-.notification {
-    padding: 5px;
-    border-radius: 5px;
-    color: black;
+.toast {
+    max-width: 100% !important;
 }
 
 .font-size-list {

--- a/static/load-save.ts
+++ b/static/load-save.ts
@@ -44,7 +44,7 @@ export class LoadSave {
 
     constructor() {
         this.alertSystem = new Alert();
-        this.alertSystem.prefixMessage = 'Load-Saver: ';
+        this.alertSystem.prefixMessage = 'Load-Saver';
         this.base = window.httpRoot;
         this.fetchBuiltins().then(() => {}).catch(() => {});
     }

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2014,7 +2014,10 @@ Compiler.prototype.checkForUnwiseArguments = function (optionsArray) {
     }
 
     if (unwiseOptions.length > 0) {
-        this.alertSystem.notify(msg, {group: 'unwiseOption', collapseSimilar: true});
+        this.alertSystem.notify(msg, {
+            group: 'unwiseOption',
+            collapseSimilar: true,
+        });
     }
 };
 
@@ -2025,7 +2028,7 @@ Compiler.prototype.updateCompilerInfo = function () {
             this.alertSystem.notify(this.compiler.notification, {
                 group: 'compilerwarning',
                 alertClass: 'notification-info',
-                dismissTime: 5000,
+                dismissTime: 7000,
             });
         }
         this.prependOptions.data('content', this.compiler.options);
@@ -2564,7 +2567,7 @@ Compiler.prototype.onAsmToolTip = function (ed) {
             this.alertSystem.notify('This token was not found in the documentation. Sorry!', {
                 group: 'notokenindocs',
                 alertClass: 'notification-error',
-                dismissTime: 3000,
+                dismissTime: 5000,
             });
         }
     }, this), _.bind(function (rejection) {
@@ -2572,7 +2575,7 @@ Compiler.prototype.onAsmToolTip = function (ed) {
             .notify('There was an error fetching the documentation for this opcode (' + rejection + ').', {
                 group: 'notokenindocs',
                 alertClass: 'notification-error',
-                dismissTime: 3000,
+                dismissTime: 5000,
             });
     }, this));
 };

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -117,7 +117,7 @@ function Compiler(hub, container, state) {
     this.prevDecorations = [];
     this.labelDefinitions = {};
     this.alertSystem = new Alert();
-    this.alertSystem.prefixMessage = 'Compiler #' + this.id + ': ';
+    this.alertSystem.prefixMessage = 'Compiler #' + this.id;
 
     this.awaitingInitialResults = false;
     this.selection = state.selection;

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -72,7 +72,7 @@ function Editor(hub, state, container) {
 
     this.editorSourceByLang = {};
     this.alertSystem = new Alert();
-    this.alertSystem.prefixMessage = 'Editor #' + this.id + ': ';
+    this.alertSystem.prefixMessage = 'Editor #' + this.id;
 
     this.filename = state.filename || false;
 

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -86,7 +86,7 @@ function Executor(hub, container, state) {
     this.nextCMakeRequest = null;
 
     this.alertSystem = new Alert();
-    this.alertSystem.prefixMessage = 'Executor #' + this.id + ': ';
+    this.alertSystem.prefixMessage = 'Executor #' + this.id;
 
     this.normalAnsiToHtml = makeAnsiToHtml();
     this.errorAnsiToHtml = makeAnsiToHtml('red');

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -86,7 +86,7 @@ export class Tree {
         this.httpRoot = window.httpRoot;
 
         this.alertSystem = new Alert();
-        this.alertSystem.prefixMessage = 'Tree #' + this.id + ': ';
+        this.alertSystem.prefixMessage = 'Tree #' + this.id;
 
         this.root = this.domRoot.find('.tree');
         this.rowTemplate = $('#tree-editor-tpl');

--- a/static/themes/dark-theme.scss
+++ b/static/themes/dark-theme.scss
@@ -201,12 +201,13 @@ a.navbar-brand img.logo.normal {
 }
 
 .notification-info {
-    background-color: #f2f2f2 !important;
+    background-color: #676767 !important;
+    color: #000;
 }
 
 .notification-error {
     background-color: #aa3333 !important;
-    color: #000;
+    color: #fff;
 }
 
 .notification-on {

--- a/static/themes/dark-theme.scss
+++ b/static/themes/dark-theme.scss
@@ -202,7 +202,7 @@ a.navbar-brand img.logo.normal {
 
 .notification-info {
     background-color: #676767 !important;
-    color: #000;
+    color: #f2f2f2;
 }
 
 .notification-error {

--- a/static/themes/default-theme.scss
+++ b/static/themes/default-theme.scss
@@ -157,7 +157,7 @@ a.navbar-brand img.logo.normal {
 
 .notification-on {
     background-color: green;
-    color: black;
+    color: #fff;
 }
 
 .notification-off {

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -257,7 +257,7 @@
         span.fas.fa-thumbs-up
         | &nbsp;Consent
 
-#notifications
+#notifications(aria-live="polite" aria-atomic="true")
 
 #sharelinkdialog.modal.fade.gl_keep(tabindex="-1" role="dialog")
   .modal-dialog.modal-lg


### PR DESCRIPTION
Saw on Discord an example of dark theme error notification and realized that it could look better.

| light | dark |
|------|------|
|![imagen](https://user-images.githubusercontent.com/5364255/154989836-305c2cf8-e910-465e-b3e3-e95075b8da50.png)| ![imagen](https://user-images.githubusercontent.com/5364255/154989775-a21bc1f6-431b-472b-8e8f-33c2f0dd4424.png)|