### PR TITLE
Rename the PPC/MIPS groups accordingly to their architectures

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -65,25 +65,27 @@ compiler.gnats390x1120.semver=11.2.0
 ################################
 # GNAT for ppc
 group.gnatppcs.compilers=&gnatppc:&gnatppc64:&gnatppc64le
-group.gnatppcs.groupName=GNAT power
 group.gnatppcs.instructionSet=ppc
 group.gnatppcs.isSemVer=true
 group.gnatppcs.supportsBinary=false
 group.gnatppcs.supportsExecute=false
 
 ## POWER
+group.gnatppc.groupName=GNAT power
 group.gnatppc.compilers=gnatppc1120
 group.gnatppc.baseName=powerpc gnat
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnat
 compiler.gnatppc1120.semver=11.2.0
 
 ## POWER64
+group.gnatppc64.groupName=GNAT power64
 group.gnatppc64.compilers=gnatppc641120
 group.gnatppc64.baseName=powerpc64 gnat
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnat
 compiler.gnatppc641120.semver=11.2.0
 
 ## POWER64LE
+group.gnatppc64le.groupName=GNAT power64le
 group.gnatppc64le.compilers=gnatppc64le1120
 group.gnatppc64le.baseName=powerpc64le gnat
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnat
@@ -92,19 +94,20 @@ compiler.gnatppc64le1120.semver=11.2.0
 ################################
 # GNAT for MIPS
 group.gnatmipss.compilers=&gnatmips:&gnatmips64
-group.gnatmipss.groupName=GNAT MIPS
 group.gnatmipss.instructionSet=mips
 group.gnatmipss.isSemVer=true
 group.gnatmipss.supportsBinary=false
 group.gnatmipss.supportsExecute=false
 
 ## MIPS
+group.gnatmips.groupName=GNAT mips
 group.gnatmips.compilers=gnatmips1120
 group.gnatmips.baseName=mips gnat
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnat 
 compiler.gnatmips1120.semver=11.2.0
 
 ## MIPS64
+group.gnatmips64.groupName=GNAT mips64
 group.gnatmips64.compilers=gnatmips641120
 group.gnatmips64.baseName=mips64 gnat
 

--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -9,7 +9,7 @@ compilerType=ada
 # GCC (as in GNU Compiler Collection) for x86
 group.gnat.compilers=gnat82:gnat102:gnat111:gnat112:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
-group.gnat.groupName=GNAT x86-64
+group.gnat.groupName=x86-64
 group.gnat.isSemVer=true
 group.gnat.baseName=x86-64 gnat
 group.gnat.supportsBinary=true
@@ -33,7 +33,7 @@ compiler.gnatsnapshot.semver=(trunk)
 ################################
 # GNAT for riscv64
 group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103
-group.gnatriscv64.groupName=GNAT riscv64
+group.gnatriscv64.groupName=riscv64
 group.gnatriscv64.instructionSet=riscv
 group.gnatriscv64.isSemVer=true
 group.gnatriscv64.supportsBinary=false
@@ -52,7 +52,7 @@ compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-l
 ################################
 # GNAT for s390x
 group.gnats390x.compilers=gnats390x1120
-group.gnats390x.groupName=GNAT s390x
+group.gnats390x.groupName=s390x
 group.gnats390x.instructionSet=s390x
 group.gnats390x.baseName=s390x gnat
 group.gnats390x.isSemVer=true
@@ -71,21 +71,21 @@ group.gnatppcs.supportsBinary=false
 group.gnatppcs.supportsExecute=false
 
 ## POWER
-group.gnatppc.groupName=GNAT power
+group.gnatppc.groupName=power
 group.gnatppc.compilers=gnatppc1120
 group.gnatppc.baseName=powerpc gnat
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnat
 compiler.gnatppc1120.semver=11.2.0
 
 ## POWER64
-group.gnatppc64.groupName=GNAT power64
+group.gnatppc64.groupName=power64
 group.gnatppc64.compilers=gnatppc641120
 group.gnatppc64.baseName=powerpc64 gnat
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnat
 compiler.gnatppc641120.semver=11.2.0
 
 ## POWER64LE
-group.gnatppc64le.groupName=GNAT power64le
+group.gnatppc64le.groupName=power64le
 group.gnatppc64le.compilers=gnatppc64le1120
 group.gnatppc64le.baseName=powerpc64le gnat
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnat
@@ -100,14 +100,14 @@ group.gnatmipss.supportsBinary=false
 group.gnatmipss.supportsExecute=false
 
 ## MIPS
-group.gnatmips.groupName=GNAT mips
+group.gnatmips.groupName=mips
 group.gnatmips.compilers=gnatmips1120
 group.gnatmips.baseName=mips gnat
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnat 
 compiler.gnatmips1120.semver=11.2.0
 
 ## MIPS64
-group.gnatmips64.groupName=GNAT mips64
+group.gnatmips64.groupName=mips64
 group.gnatmips64.compilers=gnatmips641120
 group.gnatmips64.baseName=mips64 gnat
 
@@ -117,7 +117,7 @@ compiler.gnatmips641120.semver=11.2.0
 ################################
 # GNAT for arm
 group.gnatarm.compilers=gnatarm112:gnatarm103
-group.gnatarm.groupName=GNAT arm
+group.gnatarm.groupName=arm
 group.gnatarm.instructionSet=arm32
 group.gnatarm.isSemVer=true
 group.gnatarm.supportsBinary=false

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -684,13 +684,13 @@ compiler.gccs390x1120.semver=11.2.0
 ###############################
 # Cross compilers for PPC
 group.ppcs.compilers=&ppc:&ppc64:&ppc64le
-group.ppcs.groupName=POWER Compilers
 group.ppcs.isSemVer=true
 group.ppcs.supportsBinary=true
 group.ppcs.supportsExecute=false
 
 ## POWER
 group.ppc.compilers=ppcg1120:ppcg48
+group.ppc.groupName=POWER
 group.ppc.baseName=power gcc
 
 compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
@@ -701,6 +701,7 @@ compiler.ppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-un
 compiler.ppcg1120.semver=11.2.0
 
 ## POWER64
+group.ppc64.groupName=POWER64
 group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64clang
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -722,6 +723,7 @@ compiler.ppc64clang.supportsBinary=false
 compiler.ppc64clang.semver=(snapshot)
 
 ## POWER64LE
+group.ppc64le.groupName=POWER64LE
 group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leclang
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -996,12 +998,12 @@ compiler.avrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdum
 # GCC for MIPS
 group.mipss.compilers=&mips:&mipsel:&mips64:&mips64el
 
-group.mipss.groupName=MIPS GCC
 group.mipss.isSemVer=true
 group.mipss.supportsBinary=true
 group.mipss.supportsExecute=false
 
 ## MIPS
+group.mips.groupName=MIPS GCC
 group.mips.compilers=mips5:mips930:mips1120
 group.mips.baseName=mips gcc
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
@@ -1016,6 +1018,7 @@ compiler.mips1120.semver=11.2.0
 compiler.mips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
 ## MIPS 64
+group.mips64.groupName=MIPS64 GCC
 group.mips64.compilers=mips564:mips112064
 group.mips64.baseName=mips64 gcc
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
@@ -1026,17 +1029,18 @@ compiler.mips112064.semver=11.2.0
 compiler.mips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
 ## MIPS EL
+group.mipsel.groupName=MIPSEL GCC
 group.mipsel.compilers=mips5el
-group.mipsel.baseName=mips (el) gcc
+group.mipsel.baseName=mipsel gcc
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
 compiler.mips5el.semver=5.4
 compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 
 ## MIPS 64 EL
+group.mips64el.groupName=MIPS64EL GCC
 group.mips64el.compilers=mips564el
 group.mips64el.baseName=mips64 (el) gcc
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
-compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
 compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -599,12 +599,12 @@ compiler.cgccs390x112.semver=11.2.0
 ###############################
 # Cross compilers for PPC
 group.cppcs.compilers=&cppc:&cppc64:&cppc64le
-group.cppcs.groupName=POWER Compilers
 group.cppcs.isSemVer=true
 group.cppcs.supportsBinary=true
 group.cppcs.supportsExecute=false
 
 group.cppc.compilers=cppcg1120:cppcg48
+group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
 compiler.cppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc
@@ -615,6 +615,7 @@ compiler.cppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-u
 compiler.cppcg1120.semver=11.2.0
 
 group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64clang
+group.cppc64.groupName=POWER64
 compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g8.name=power64 AT12.0 (gcc8)
@@ -635,6 +636,7 @@ compiler.cppc64clang.supportsBinary=false
 compiler.cppc64clang.semver=(snapshot)
 
 group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leclang
+group.cppc64le.groupName=POWER64LE
 compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg630.name=power64le gcc 6.3.0
@@ -908,13 +910,13 @@ compiler.cavrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdu
 # GCC for MIPS
 group.cmipss.compilers=&cmips:&cmipsel:&cmips64:&cmips64el
 
-group.cmipss.groupName=MIPS GCC
 group.cmipss.isSemVer=true
 group.cmipss.supportsBinary=true
 group.cmipss.supportsExecute=false
 
 ## MIPS
 group.cmips.compilers=cmips5:cmips930:cmips1120
+group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
 compiler.cmips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmips5.semver=5.4
@@ -928,6 +930,7 @@ compiler.cmips1120.semver=11.2.0
 compiler.cmips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
 ## MIPS64
+group.cmips64.groupName=MIPS64 GCC
 group.cmips64.compilers=cmips564:cmips112064
 group.cmips64.baseName=mips64 gcc
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -938,6 +941,7 @@ compiler.cmips112064.semver=11.2.0
 compiler.cmips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
 ## MIPS EL
+group.cmipsel.groupName=MIPSEL GCC
 group.cmipsel.compilers=cmips5el
 group.cmipsel.baseName=mips (el) gcc
 compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
@@ -945,13 +949,13 @@ compiler.cmips5el.semver=5.4
 compiler.cmips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 
 ## MIPS64 EL
+group.cmips64el.groupName=MIPS64EL GCC
 group.cmips64el.compilers=cmips564el
 group.cmips64el.baseName=mips64 (el) gcc
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
 compiler.cmips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
-
 
 ###############################
 # GCC for nanoMIPS


### PR DESCRIPTION
Previous change split archs in different groups (e.g.
MIPS+MIPS64+MIPSEL+MIPS64EL) within a parent group (MIPSS) without giving them a
groupName property. All these groups inherit the groupName from their
parent group (e.g. MIPSS.MIPS64.groupName => "MIPS"), making the name
incorrectly duplicated.

Keep the group spliting but treat all these architectures as separate ones by
giveng each group a corresponding groupName.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>