### PR TITLE
Position of cursor position

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -892,6 +892,8 @@ html[data-theme=dark] {
     right: 14px; // width of monaco scrollbar
     font-size: small;
     color: #17a2b8;
+    border-radius: 0.5rem;
+    background-color: rgba(49, 54, 60, 0.85);
     z-index: 1;
     padding: 5px;
 }

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -884,4 +884,17 @@ html[data-theme=dark] {
     font-size: small;
     border: none;
     user-select: text;
+    position: relative;
+}
+
+.currentCursorPosition .invisiblePlaceholder {
+    opacity: 0;
+    cursor: default;
+}
+
+.currentCursorPosition .currentCursorPositionContent {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -884,17 +884,10 @@ html[data-theme=dark] {
     font-size: small;
     border: none;
     user-select: text;
-    position: relative;
 }
 
 .currentCursorPosition .invisiblePlaceholder {
-    opacity: 0;
+    height: 0px;
+    overflow: hidden;
     cursor: default;
-}
-
-.currentCursorPosition .currentCursorPositionContent {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
 }

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -880,14 +880,18 @@ html[data-theme=dark] {
     cursor: pointer;
 }
 
-.currentCursorPosition, .ctrlSNothing {
+.ctrlSNothing {
     font-size: small;
     border: none;
     user-select: text;
 }
 
-.currentCursorPosition .invisiblePlaceholder {
-    height: 0px;
-    overflow: hidden;
-    cursor: default;
+.currentCursorPosition {
+    position: absolute;
+    bottom: 0;
+    right: 14px; // width of monaco scrollbar
+    font-size: small;
+    color: #17a2b8;
+    z-index: 1;
+    padding: 5px;
 }

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -346,17 +346,17 @@ Editor.prototype.onDidChangeCursorSelection = function (e) {
 
 Editor.prototype.onDidChangeCursorPosition = function (e) {
     if (e.position) {
-        this.currentCursorPosition.text('(' + e.position.lineNumber + ', ' + e.position.column + ')');
+        this.currentCursorPositionContent.text('(' + e.position.lineNumber + ', ' + e.position.column + ')');
     }
 };
 
 Editor.prototype.onDidFocusEditorText = function () {
-    this.currentCursorPosition.show();
+    var position = this.editor.getPosition();
+    this.currentCursorPositionContent.text('(' + position.lineNumber + ', ' + position.column + ')');
 };
 
 Editor.prototype.onDidBlurEditorText = function () {
-    this.currentCursorPosition.text('');
-    this.currentCursorPosition.hide();
+    this.currentCursorPositionContent.text('');
 };
 
 Editor.prototype.onEscapeKey = function () {
@@ -485,8 +485,7 @@ Editor.prototype.initButtons = function (state) {
         }, this));
     }
 
-    this.currentCursorPosition = this.domRoot.find('.currentCursorPosition');
-    this.currentCursorPosition.hide();
+    this.currentCursorPositionContent = this.domRoot.find('.currentCursorPositionContent');
 };
 
 Editor.prototype.handleCtrlS = function (event) {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -352,7 +352,9 @@ Editor.prototype.onDidChangeCursorPosition = function (e) {
 
 Editor.prototype.onDidFocusEditorText = function () {
     var position = this.editor.getPosition();
-    this.currentCursorPosition.text('(' + position.lineNumber + ', ' + position.column + ')');
+    if (position) {
+        this.currentCursorPosition.text('(' + position.lineNumber + ', ' + position.column + ')');
+    }
     this.currentCursorPosition.show();
 };
 

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -346,17 +346,19 @@ Editor.prototype.onDidChangeCursorSelection = function (e) {
 
 Editor.prototype.onDidChangeCursorPosition = function (e) {
     if (e.position) {
-        this.currentCursorPositionContent.text('(' + e.position.lineNumber + ', ' + e.position.column + ')');
+        this.currentCursorPosition.text('(' + e.position.lineNumber + ', ' + e.position.column + ')');
     }
 };
 
 Editor.prototype.onDidFocusEditorText = function () {
     var position = this.editor.getPosition();
-    this.currentCursorPositionContent.text('(' + position.lineNumber + ', ' + position.column + ')');
+    this.currentCursorPosition.text('(' + position.lineNumber + ', ' + position.column + ')');
+    this.currentCursorPosition.show();
 };
 
 Editor.prototype.onDidBlurEditorText = function () {
-    this.currentCursorPositionContent.text('');
+    this.currentCursorPosition.text('');
+    this.currentCursorPosition.hide();
 };
 
 Editor.prototype.onEscapeKey = function () {
@@ -485,7 +487,8 @@ Editor.prototype.initButtons = function (state) {
         }, this));
     }
 
-    this.currentCursorPositionContent = this.domRoot.find('.currentCursorPositionContent');
+    this.currentCursorPosition = this.domRoot.find('.currentCursorPosition');
+    this.currentCursorPosition.hide();
 };
 
 Editor.prototype.handleCtrlS = function (event) {

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -37,13 +37,11 @@
               include resources/quickbench.svg
             span.hideable Quick-bench
       .btn-group.btn-group-sm.mx-auto
-        button.btn.btn-sm.btn-outline-info.currentCursorPosition(disabled=true)
-          div.invisiblePlaceholder (9999, 999)
-          div.currentCursorPositionContent
         button.btn.btn-sm.btn-outline-info.ctrlSNothing(disabled=true style="display: none")
           span.fas.fa-smile
       .btn-group.btn-group-sm.ml-auto(role="group" aria-label="Editor language")
         select.change-language(title="Change this editor's (and associated panels) language" placeholder="Language" disabled=embedded && readOnly)
+    div.currentCursorPosition
     div#v-status
     .monaco-placeholder
 

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -38,6 +38,8 @@
             span.hideable Quick-bench
       .btn-group.btn-group-sm.mx-auto
         button.btn.btn-sm.btn-outline-info.currentCursorPosition(disabled=true)
+          div.invisiblePlaceholder (9999, 999)
+          div.currentCursorPositionContent
         button.btn.btn-sm.btn-outline-info.ctrlSNothing(disabled=true style="display: none")
           span.fas.fa-smile
       .btn-group.btn-group-sm.ml-auto(role="group" aria-label="Editor language")


### PR DESCRIPTION
This PR is an attempted improvement for how the cursor position is displayed in the CE editor. It moves the cursor position display to the bottom-right corner of the editor:
![image](https://user-images.githubusercontent.com/51220084/155250354-80884d74-0372-4ae3-9a0d-981cfe0e6ce1.png)

Currently, the hiding/showing of the value can cause some funny behavior on small editors:
![ce-cursor-position-bug-3](https://user-images.githubusercontent.com/51220084/155250160-18007c3b-3da0-44f2-970a-52b19b38fd21.gif)

One consideration: It's tricky to get the background of this display synced with the theme and aligned with various components of the editor. A better solution would probably require diving into monaco widgets, I think this should work reasonably well most of the time though.
![image](https://user-images.githubusercontent.com/51220084/155250270-8ce233d4-c1c5-4a2f-93e3-df7dcc75ffb0.png)
![image](https://user-images.githubusercontent.com/51220084/155250616-1c0f37ec-0869-456b-aa58-01fb438a609f.png)

