### PR TITLE
Preprocessor output filtering enhancement

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -769,7 +769,8 @@ export class BaseCompiler {
                 }
             } else {
                 let path = match[1];
-                if (path.trim() === '' || path === '<source>' || path.endsWith('.c') || path.endsWith('.cpp')) {
+                if (path.trim() === '' || path === '<source>' || path === '<stdin>'
+                || path.endsWith('.c') || path.endsWith('.cpp')) {
                     isInSourceRegion = true;
                 } else {
                     isInSourceRegion = false;

--- a/test/pp-output-cases/filter-tests.js
+++ b/test/pp-output-cases/filter-tests.js
@@ -49,6 +49,10 @@ foo
 # 2 "<source>" 2
 bar
 # 66 "/usr/include/assert.h" 3 4
+baz
+# 2 "<stdin>"
+biz
+# 66 "/usr/include/assert.h" 3 4
 
 
 # 3 "/app/example.cpp"
@@ -72,6 +76,7 @@ int main() {
                 ;
 }`,
         output: `bar
+biz
 int main() {
 
 #pragma foo bar


### PR DESCRIPTION
I noticed a little bug with preprocessor filtering when url #includes are used. It seems the expansion of the url include renames the source file to `<stdin>` so I've updated the filter to consider this a source marking.

https://godbolt.org/z/oq6b6r8ba, screenshot of the output:
![image](https://user-images.githubusercontent.com/51220084/155420073-6516073f-f423-4a61-a8d0-c3b3d990d474.png)
