### PR TITLE
Remove some deprecated functions

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -462,7 +462,7 @@ function start() {
         }],
     };
 
-    $(window).bind('hashchange', function () {
+    $(window).on('hashchange', function () {
         // punt on hash events and just reload the page if there's a hash
         if (window.location.hash.substr(1)) window.location.reload();
     });
@@ -507,7 +507,7 @@ function start() {
     }
 
     $(window)
-        .resize(sizeRoot)
+        .on('resize', sizeRoot)
         .on('beforeunload', function () {
             // Only preserve state in localStorage in non-embedded mode.
             var shouldSave = !window.hasUIBeenReset && !hasUIBeenReset;
@@ -533,7 +533,7 @@ function start() {
                 addDropdown.dropdown('toggle');
             });
 
-        thing.click(function () {
+        thing.on('click', function () {
             if (hub.hasTree()) {
                 hub.addInEditorStackIfPossible(func());
             } else {
@@ -555,7 +555,7 @@ function start() {
 
     if (hashPart) {
         var element = $(hashPart);
-        if (element) element.click();
+        if (element) element.trigger('click');
     }
     initPolicies(options);
 

--- a/static/noscript.js
+++ b/static/noscript.js
@@ -63,6 +63,6 @@ function initMenus() {
     new Toggles($('.filters'));
 }
 
-$(document).ready(function () {
+$(document).on('ready', function () {
     initMenus();
 });

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1079,7 +1079,7 @@ Compiler.prototype.handleCompileRequestAndResult = function (request, result, ca
     });
 
     // Delete trailing empty lines
-    if ($.isArray(result.asm)) {
+    if (Array.isArray(result.asm)) {
         var indexToDiscard = _.findLastIndex(result.asm, function (line) {
             return !_.isEmpty(line.text);
         });
@@ -1828,7 +1828,7 @@ Compiler.prototype.handlePopularArgumentsResult = function (result) {
                 '<span class=\'argdescription\'>' + arg.description + '</span>' +
                 '</div>');
 
-            argumentButton.click(_.bind(function () {
+            argumentButton.on('click', _.bind(function () {
                 var button = argumentButton;
                 var curOptions = this.optionsField.val();
                 if (curOptions.length > 0) {


### PR DESCRIPTION
Found them with WebStorm's code inspection.

We are using `String.substr` in a lot of places and that might be harder to replace, but this is a good first step
