### PR TITLE
Enqueue running formatters, at least in most cases.

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -80,7 +80,7 @@ export class BaseCompiler {
         this.llvmIr = new LlvmIrParser(this.compilerProps);
         this.llvmAst = new LlvmAstParser(this.compilerProps);
 
-        this.formatHandler = new FormattingHandler(this.env.ceProps);
+        this.formatHandler = new FormattingHandler(this.env.ceProps, async job => await this.env.enqueue(job));
 
         this.toolchainPath = getToolchainPath(this.compiler.exe, this.compiler.options);
 

--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -29,7 +29,8 @@ import { getFormatterTypeByKey } from '../formatters';
 import { logger } from '../logger';
 
 export class FormattingHandler {
-    constructor(ceProps) {
+    constructor(ceProps, maybeEnqueue) {
+        this.enqueue = maybeEnqueue || (async job => await job());
         this.formatters = {};
         this.ceProps = ceProps;
         const formatters = _.compact(ceProps('formatters', '').split(':'));
@@ -49,7 +50,7 @@ export class FormattingHandler {
         const versionRe = this.ceProps(`formatter.${formatter}.versionRe`, '.*');
         const hasExplicitVersion = this.ceProps(`formatter.${formatter}.explicitVersion`, '') !== '';
         try {
-            const result = await exec.execute(exe, [versionArg], {});
+            const result = await this.enqueue(async () => exec.execute(exe, [versionArg], {}));
             const match = result.stdout.match(versionRe);
             const formatterClass = getFormatterTypeByKey(type);
             const styleList = this.ceProps(`formatter.${formatter}.styles`);


### PR DESCRIPTION
Partial mitigation of #3407; but really we need a more
general solution and hopefully one that can support caching,
as we run many of the same formatters over and over again during
startup.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
