### PR TITLE
Construct one FormattingHandler for all compilers

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -80,8 +80,6 @@ export class BaseCompiler {
         this.llvmIr = new LlvmIrParser(this.compilerProps);
         this.llvmAst = new LlvmAstParser(this.compilerProps);
 
-        this.formatHandler = new FormattingHandler(this.env.ceProps);
-
         this.toolchainPath = getToolchainPath(this.compiler.exe, this.compiler.options);
 
         this.possibleArguments = new CompilerArguments(this.compiler.id);
@@ -784,7 +782,7 @@ export class BaseCompiler {
     async applyClangFormat(output) {
         // Currently hard-coding llvm style
         try {
-            let [stdout, stderr] = await this.formatHandler.internalFormat('clangformat', 'LLVM', output);
+            let [stdout, stderr] = await this.env.formatHandler.internalFormat('clangformat', 'LLVM', output);
             if (stderr) {
                 stdout += '\n/* clang-format stderr:\n' + stderr.trim() + '\n*/';
             }

--- a/lib/compilation-env.js
+++ b/lib/compilation-env.js
@@ -29,6 +29,7 @@ import _ from 'underscore';
 
 import { BaseCache } from './cache/base';
 import { createCacheFromConfig } from './cache/from-config';
+import { FormattingHandler } from './handlers/formatting';
 import { logger } from './logger';
 
 export class CompilationEnvironment {
@@ -70,6 +71,9 @@ export class CompilationEnvironment {
             if (!environmentVariable) return;
             this.baseEnv[environmentVariable] = process.env[environmentVariable];
         });
+        // I'm not sure that this is the best design; but each compiler having its own means each constructs its own
+        // handler, and passing it in from the outside is a pain as each compiler's constructor needs it.
+        this.formatHandler = new FormattingHandler(this.ceProps);
     }
 
     getEnv(needsMulti) {


### PR DESCRIPTION
Not my greatest design moment, but putting it in the CompilationEnvironment
is a compromise between creating the handler in the compilation create()
and passing it into all the compilers' constructors.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
