### PR TITLE
Support MSVC's backtick strings

### DIFF
--- a/static/modes/asm-mode.ts
+++ b/static/modes/asm-mode.ts
@@ -85,6 +85,8 @@ function definition() {
                 // strings
                 [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-terminated string
                 [/"/, {token: 'string.quote', bracket: '@open', next: '@string'}],
+                // `msvc does this, sometimes'
+                [/`/, {token: 'string.backtick', bracket: '@open', next: '@msvcstring'}],
                 [/'/, {token: 'string.singlequote', bracket: '@open', next: '@sstring'}],
 
                 // characters
@@ -111,6 +113,14 @@ function definition() {
                 [/@escapes/, 'string.escape'],
                 [/\\./, 'string.escape.invalid'],
                 [/"/, {token: 'string.quote', bracket: '@close', next: '@pop'}],
+            ],
+
+            msvcstring: [
+                [/[^\\']+/, 'string'],
+                [/@escapes/, 'string.escape'],
+                [/''/, 'string.escape'], // ` isn't escaped but ' is escaped as ''
+                [/\\./, 'string.escape.invalid'],
+                [/'/, {token: 'string.backtick', bracket: '@close', next: '@pop'}],
             ],
 
             sstring: [

--- a/static/modes/asm-mode.ts
+++ b/static/modes/asm-mode.ts
@@ -55,6 +55,8 @@ function definition() {
                 [/[.a-zA-Z_][.a-zA-Z_0-9]*/, {token: 'keyword', next: '@rest'}],
                 // braces and parentheses at the start of the line (e.g. nvcc output)
                 [/[(){}]/, {token: 'operator', next: '@rest'}],
+                // msvc can have strings at the start of a line in a inSegDirList
+                [/`/, {token: 'string.backtick', bracket: '@open', next: '@segDirMsvcstring'}],
 
                 // whitespace
                 {include: '@whitespace'},
@@ -115,12 +117,21 @@ function definition() {
                 [/"/, {token: 'string.quote', bracket: '@close', next: '@pop'}],
             ],
 
-            msvcstring: [
+            msvcstringCommon: [
                 [/[^\\']+/, 'string'],
                 [/@escapes/, 'string.escape'],
                 [/''/, 'string.escape'], // ` isn't escaped but ' is escaped as ''
                 [/\\./, 'string.escape.invalid'],
+            ],
+
+            msvcstring: [
+                {include: '@msvcstringCommon'},
                 [/'/, {token: 'string.backtick', bracket: '@close', next: '@pop'}],
+            ],
+
+            segDirMsvcstring: [
+                {include: '@msvcstringCommon'},
+                [/'/, {token: 'string.backtick', bracket: '@close', switchTo: '@rest'}],
             ],
 
             sstring: [


### PR DESCRIPTION
Followup to #3403/ #3405, there's another string case to handle with a leading backtick as a quote:
![image](https://user-images.githubusercontent.com/51220084/156510911-d6828617-be93-404f-8522-9d56314dac36.png)

(https://godbolt.org/z/EW63q8eqE)