### PR TITLE
Improve clang asan output

### DIFF
--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import path from 'path';
+import fs from 'fs';
 
 import { BaseCompiler } from '../base-compiler';
 import { AmdgpuAsmParser } from '../parsers/asm-parser-amdgpu';
@@ -38,6 +39,20 @@ export class ClangCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
         this.compiler.supportsDeviceAsmView = true;
+        const asanSymbolizerPath = path.dirname(this.compiler.exe) + '/llvm-symbolizer';
+        if (fs.existsSync(asanSymbolizerPath)) {
+            this.asanSymbolizerPath = asanSymbolizerPath;
+        }
+    }
+
+    runExecutable(executable, executeParameters, homeDir) {
+        if(this.asanSymbolizerPath) {
+            executeParameters.env = {
+                ASAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
+                ...executeParameters.env,
+            };
+        }
+        return super.runExecutable(executable, executeParameters, homeDir);
     }
 
     runCompiler(compiler, options, inputFilename, execOptions) {


### PR DESCRIPTION
This PR adds the path to llvm-symbolizer to the environment used for executing binaries compiled with clang, implements #3023.