### PR TITLE
Add keyword-spacing eslint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -83,6 +83,9 @@ rules:
     - anonymous: always
       asyncArrow: always
       named: never
+  keyword-spacing:
+    - error
+    - after: true
   yoda:
     - error
     - never

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -22,8 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
 import { BaseCompiler } from '../base-compiler';
 import { AmdgpuAsmParser } from '../parsers/asm-parser-amdgpu';
@@ -46,7 +46,7 @@ export class ClangCompiler extends BaseCompiler {
     }
 
     runExecutable(executable, executeParameters, homeDir) {
-        if(this.asanSymbolizerPath) {
+        if (this.asanSymbolizerPath) {
             executeParameters.env = {
                 ASAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
                 ...executeParameters.env,

--- a/lib/compilers/spirv.js
+++ b/lib/compilers/spirv.js
@@ -152,7 +152,7 @@ export class SPIRVCompiler extends BaseCompiler {
         newOptions.concat('-S');
 
         let index = newOptions.indexOf(outputFile);
-        if(index !== -1){
+        if (index !== -1){
             newOptions[index] = inputFilename.replace(path.extname(inputFilename), '.ll');
         }
 

--- a/lib/llvm-ast.js
+++ b/lib/llvm-ast.js
@@ -75,7 +75,7 @@ export class LlvmAstParser {
         var lfrom = {line:null, loc:null}, lto = {line:null, loc:null};
         for (var line of astDump) {
             const span = this.parseSpan(line.text, lfrom.line);
-            switch(span.type) {
+            switch (span.type) {
                 case this.locTypes.NONE:
                     break;
                 case this.locTypes.POINT:

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -134,7 +134,7 @@ export class ClientOptionsHandler {
                     const Tool = getToolTypeByKey(className);
 
                     const toolPath = this.compilerProps(lang, toolBaseName + '.exe');
-                    if(fs.existsSync(toolPath)) {
+                    if (fs.existsSync(toolPath)) {
                         tools[lang][tool] = new Tool({
                             id: tool,
                             name: this.compilerProps(lang, toolBaseName + '.name'),

--- a/lib/parsers/asm-parser-ewavr.js
+++ b/lib/parsers/asm-parser-ewavr.js
@@ -286,11 +286,11 @@ export class AsmEWAVRParser extends AsmParser {
                 for (const line of label.lines) {
                     // Match variable inits to the source line of declaration.
                     // No source line for global section initilization
-                    if(match && line.source != null) {
+                    if (match && line.source != null) {
                         line.source.line = ddefLabels[match[2]];
                     }
                     // Filter section inits as directives
-                    if(segInitMatch && filters.directives) {
+                    if (segInitMatch && filters.directives) {
                         continue;
                     }
                     pushLine(line);

--- a/lib/tooling/readelf-tool.js
+++ b/lib/tooling/readelf-tool.js
@@ -30,7 +30,7 @@ export class ReadElfTool extends BaseTool {
     static get key() { return 'readelf-tool'; }
 
     async runTool(compilationInfo, inputFilename, args) {
-        if(!compilationInfo.filters.binary)
+        if (!compilationInfo.filters.binary)
         {
             return this.createErrorResponse('readelf requires an executable');
         }

--- a/lib/tooling/strings-tool.js
+++ b/lib/tooling/strings-tool.js
@@ -30,7 +30,7 @@ export class StringsTool extends BaseTool {
     static get key() { return 'strings-tool'; }
 
     async runTool(compilationInfo, inputFilename, args) {
-        if(!compilationInfo.filters.binary)
+        if (!compilationInfo.filters.binary)
         {
             return this.createErrorResponse('Strings requires a binary output');
         }

--- a/test/pp-output-test.js
+++ b/test/pp-output-test.js
@@ -52,7 +52,7 @@ describe('Preprocessor Output Handling', () => {
             },
         };
         const compiler = new BaseCompiler(compilerInfo, env);
-        for(const testCase of filterTests.cases) {
+        for (const testCase of filterTests.cases) {
             const output = compiler.filterPP(testCase.input)[1];
             output.trim().should.eql(testCase.output.trim());
         }


### PR DESCRIPTION
This patch adds a linter rule to spot uses of `if(...)` vs `if (...)` (and same for `for`, `switch`, `while`, etc.)

I keep doing the first out of habit 😅

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
