### PR TITLE
Move Ids out of hub.js

### DIFF
--- a/static/hub.js
+++ b/static/hub.js
@@ -50,35 +50,14 @@ var gccDumpView = require('./panes/gccdump-view');
 var cfgView = require('./panes/cfg-view');
 var conformanceView = require('./panes/conformance-view');
 var CompilerService = require('compiler-service').CompilerService;
-
-function Ids() {
-    this.used = {};
-}
-
-Ids.prototype.add = function (id) {
-    this.used[id] = true;
-};
-
-Ids.prototype.remove = function (id) {
-    delete this.used[id];
-};
-
-Ids.prototype.next = function () {
-    for (var i = 1; i < 100000; ++i) {
-        if (!this.used[i]) {
-            this.used[i] = true;
-            return i;
-        }
-    }
-    throw 'Ran out of ids!?';
-};
+var IdentifierSet = require('./identifier-set').IdentifierSet;
 
 function Hub(layout, subLangId, defaultLangId) {
     this.layout = layout;
-    this.editorIds = new Ids();
-    this.compilerIds = new Ids();
-    this.executorIds = new Ids();
-    this.treeIds = new Ids();
+    this.editorIds = new IdentifierSet();
+    this.compilerIds = new IdentifierSet();
+    this.executorIds = new IdentifierSet();
+    this.treeIds = new IdentifierSet();
     this.trees = [];
     this.editors = [];
     this.compilerService = new CompilerService(layout.eventHub);

--- a/static/identifier-set.ts
+++ b/static/identifier-set.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+export class IdentifierSet {
+    private readonly items: Map<number, boolean> = new Map();
+
+    public add(id: number): void {
+        this.items.set(id, true);
+    }
+
+    public remove(id: number): void {
+        this.items.delete(id);
+    }
+
+    public next(): number {
+        for (let i = 1; i < Number.MAX_SAFE_INTEGER; i++) {
+            if (!this.items.has(i)) {
+                this.add(i);
+                return i;
+            }
+        }
+        throw 'Ran out of ids!?';
+    }
+}

--- a/tsconfig.frontend.json
+++ b/tsconfig.frontend.json
@@ -8,6 +8,7 @@
     "inlineSources": true,
     "strict": true,
     "strictPropertyInitialization": false,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "lib": ["dom", "es5"]
   }
 }


### PR DESCRIPTION
In preparation for refactoring Hub to TypeScript, I've moved Ids out of the hub.js file and renamed it to IdentifierSet which is a bit more descriptive.