### PR TITLE
Improve cppinsights button for large sources

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -608,8 +608,14 @@ Editor.prototype.updateOpenInCppInsights = function () {
             }
         }, this));
 
-        var link = 'https://cppinsights.io/lnk?code='
-            + this.b64UTFEncode(this.getSource()) + '&std=' + cppStd + '&rev=1.0';
+        var maxURL = 8177; // apache's default maximum url length
+        var maxCode = maxURL - ('/lnk?code=&std=' + cppStd + '&rev=1.0').length;
+        var codeData = this.b64UTFEncode(this.getSource());
+        if (codeData.length > maxCode) {
+            codeData = this.b64UTFEncode('/** Source too long to fit in a URL */\n');
+        }
+
+        var link = 'https://cppinsights.io/lnk?code=' + codeData + '&std=' + cppStd + '&rev=1.0';
 
         this.cppInsightsButton.attr('href', link);
     }


### PR DESCRIPTION
For really large sources the generated cppinsights URL can be too long for the server and result in an HTTP 414 error page. Not a big deal, this should be exceedingly rare anyway, but I've tried to improve the behavior here. The idea is for a large source that would break the URL the button can at least be a shortcut and the user can quickly copy-paste.