### PR TITLE
Moved inputFilename forward in compiler arguments

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -689,8 +689,8 @@ export class BaseCompiler {
         }
 
         userOptions = this.filterUserOptions(userOptions) || [];
-        return options.concat(libIncludes, libOptions, libPaths, libLinks, userOptions,
-            [this.filename(inputFilename)], staticLibLinks);
+        return options.concat([this.filename(inputFilename)], libIncludes, libOptions, 
+          libPaths, libLinks, userOptions, staticLibLinks);
     }
 
     filterUserOptions(userOptions) {


### PR DESCRIPTION
When compiling to binary the order of source files and linked libraries
can matter for some compilers (and linkers). Putting the input file
first avoids linking issues in these cases.

- [x] ran `make test`
- [x] tested with local instanced and `g++-8.x, g++-9.x, clang-9, clang-12`
