### PR TITLE
Update disabled compiler options input background on dark mode

### DIFF
--- a/static/themes/dark-theme.scss
+++ b/static/themes/dark-theme.scss
@@ -247,6 +247,10 @@ input {
     border: 0 !important;
 }
 
+.form-control:disabled {
+    background-color: darken(#474747, 10%);
+}
+
 input:focus {
     color: #eee !important;
     background-color: #474747;


### PR DESCRIPTION
Small tweak for dark mode for the compiler options input field when flags view is open:

Old:
![image](https://user-images.githubusercontent.com/51220084/161124254-af0db469-8c43-4bff-885c-b1f7201e3756.png)

New:
![image](https://user-images.githubusercontent.com/51220084/161124463-ce3be8b9-f150-4604-95cd-856fd10201c4.png)

