### PR TITLE
Add HDF5 and HighFive libraries to amazon config

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1852,6 +1852,13 @@ libs.hfsm.versions.08.path=/opt/compiler-explorer/libs/hfsm/0.8
 libs.hfsm.versions.010.version=0.10
 libs.hfsm.versions.010.path=/opt/compiler-explorer/libs/hfsm/0.10
 
+libs.highfive.name=HighFive
+libs.highfive.description=A header-only C++ wrapper for HDF5. Note: Please also load the HDF5 library.
+libs.highfive.url=https://github.com/BlueBrain/HighFive
+libs.highfive.versions=trunk
+libs.highfive.versions.trunk.version=trunk
+libs.highfive.versions.trunk.path=/opt/compiler-explorer/libs/HighFive/trunk/include
+
 libs.highway.name=Highway
 libs.highway.versions=trunk:0_12_2
 libs.highway.url=https://github.com/google/highway
@@ -1860,13 +1867,6 @@ libs.highway.versions.trunk.version=trunk
 libs.highway.versions.trunk.path=/opt/compiler-explorer/libs/highway/trunk
 libs.highway.versions.0_12_2.version=0.12.2
 libs.highway.versions.0_12_2.path=/opt/compiler-explorer/libs/highway/0.12.2
-
-libs.highfive.name=HighFive
-libs.highfive.description=A header-only C++ wrapper for HDF5. Note: Please also load the HDF5 library.
-libs.highfive.url=https://github.com/BlueBrain/HighFive
-libs.highfive.versions=trunk
-libs.highfive.versions.trunk.version=trunk
-libs.highfive.versions.trunk.path=/opt/compiler-explorer/libs/HighFive/trunk/include
 
 libs.hotels-template-library.name=Hotels Template Library
 libs.hotels-template-library.description=Hotels Template Library contains an open-source collection of C++ template libraries that are developed to make C++ development easier, safer and more efficient.

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1281,7 +1281,7 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:googletest:gsl:hedley:hfsm:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
+libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -1821,6 +1821,19 @@ libs.gsl.versions.301.path=/opt/compiler-explorer/libs/GSL/v3.0.1/include
 libs.gsl.versions.lite.version=lite
 libs.gsl.versions.lite.path=/opt/compiler-explorer/libs/gsl-lite/include
 
+libs.hdf5.name=HDF5
+libs.hdf5.description=Hierarchical Data Format (HDF) v5 library
+libs.hdf5.url=https://github.com/HDFGroup/hdf5
+libs.hdf5.versions=1121:1131
+libs.hdf5.versions.1121.version=1.12.1
+libs.hdf5.versions.1121.path=/opt/compiler-explorer/libs/hdf5/hdf5-1_12_1/include
+libs.hdf5.versions.1121.libpath=/opt/compiler-explorer/libs/hdf5/hdf5-1_12_1/lib
+libs.hdf5.versions.1121.liblink=hdf5
+libs.hdf5.versions.1131.version=1.13.1
+libs.hdf5.versions.1131.path=/opt/compiler-explorer/libs/hdf5/hdf5-1_13_1/include
+libs.hdf5.versions.1131.libpath=/opt/compiler-explorer/libs/hdf5/hdf5-1_13_1/lib
+libs.hdf5.versions.1131.liblink=hdf5
+
 libs.hedley.name=hedley
 libs.hedley.description=A C/C++ header to help move ifdefs out of your code
 libs.hedley.versions=v12
@@ -1847,6 +1860,13 @@ libs.highway.versions.trunk.version=trunk
 libs.highway.versions.trunk.path=/opt/compiler-explorer/libs/highway/trunk
 libs.highway.versions.0_12_2.version=0.12.2
 libs.highway.versions.0_12_2.path=/opt/compiler-explorer/libs/highway/0.12.2
+
+libs.highfive.name=HighFive
+libs.highfive.description=A header-only C++ wrapper for HDF5. Note: Please also load the HDF5 library.
+libs.highfive.url=https://github.com/BlueBrain/HighFive
+libs.highfive.versions=trunk
+libs.highfive.versions.trunk.version=trunk
+libs.highfive.versions.trunk.path=/opt/compiler-explorer/libs/HighFive/trunk/include
 
 libs.hotels-template-library.name=Hotels Template Library
 libs.hotels-template-library.description=Hotels Template Library contains an open-source collection of C++ template libraries that are developed to make C++ development easier, safer and more efficient.


### PR DESCRIPTION
This updates the configuration to add both HDF5 (1.12.1, 1.13.1) and
HighFive to the libraries available in CE. Since HDF5 is a shared object
library, these changes should go along with changes in infra.

See also PR here: https://github.com/compiler-explorer/infra/pull/695

The main question that is still open is how the paths should be exactly set. For the local setup I have verified that in principle all components play long well. But adjusting the paths for the `/opt/compiler-explorer` tree on the AWS instances I am flying blind.

More specifically:
- How do we deal with multiple libhdf5.so (coming from multiple library versions?)
- The headers had to be installed with a `post_stage` script (in the infra config), but I am not entirely sure where they actually end up?
