### PR TITLE
Bug fix for 'Option -flto is being used without Compile to Binary'

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2008,7 +2008,7 @@ Compiler.prototype.checkForUnwiseArguments = function (optionsArray) {
     var are = unwiseOptions.length === 1 ? ' is ' : ' are ';
     var msg = options + names + are + 'not recommended, as behaviour might change based on server hardware.';
 
-    if (_.contains(optionsArray, '-flto')) {
+    if (_.contains(optionsArray, '-flto') && !this.filters.state.binary) {
         this.alertSystem.notify('Option -flto is being used without Compile to Binary.', {
             group: 'unwiseOption',
             collapseSimilar: true,


### PR DESCRIPTION
The 'Option -flto is being used without Compile to Binary.' unwise argument notification shows up even when compiling to binary currently. PR adds check for whether we're compiling to binary.