### PR TITLE
Update toast .close coloring

### DIFF
--- a/static/themes/dark-theme.scss
+++ b/static/themes/dark-theme.scss
@@ -208,6 +208,9 @@ a.navbar-brand img.logo.normal {
 .notification-error {
     background-color: #aa3333 !important;
     color: #fff;
+    .close {
+        color: #fff;
+    }
 }
 
 .notification-on {
@@ -218,6 +221,9 @@ a.navbar-brand img.logo.normal {
 .notification-off {
     background-color: #222 !important;
     color: #fff;
+    .close {
+        color: #fff;
+    }
 }
 
 pre {
@@ -476,10 +482,6 @@ a {
 }
 
 .fa, .fas {
-    color: white;
-}
-
-.close:hover {
     color: white;
 }
 

--- a/static/themes/default-theme.scss
+++ b/static/themes/default-theme.scss
@@ -153,11 +153,17 @@ a.navbar-brand img.logo.normal {
 .notification-error {
     background-color: indianred;
     color: white;
+    .close {
+        color: white;
+    }
 }
 
 .notification-on {
     background-color: green;
     color: #fff;
+    .close {
+        color: white;
+    }
 }
 
 .notification-off {


### PR DESCRIPTION
https://github.com/compiler-explorer/compiler-explorer/blob/4db110ec51ff84c81f1e05cd18608768beaada6c/static/themes/dark-theme.scss#L486-L488

This rule causes the 'x' to disappear when hovering over it for plain white toast notifications. As far as I can tell `.close` is only used for toast close buttons so I think it's safe to remove.

I've also updated the close button's color to match the toast's text color (looks a little better to my eye).

![image](https://user-images.githubusercontent.com/51220084/161303344-d8e8daaa-6fa5-420a-a8a2-7a9e39bca80d.png)
![image](https://user-images.githubusercontent.com/51220084/161303416-fb46a9b2-2aff-4a64-a5ec-f20fe95dd320.png)
