### PR TITLE
Reorder user args first

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -664,12 +664,12 @@ export class BaseCompiler {
 
     orderArguments(options, inputFilename, libIncludes, libOptions, libPaths, libLinks, userOptions, staticLibLinks) {
         return options.concat(
+            userOptions,
             [this.filename(inputFilename)],
             libIncludes,
             libOptions,
             libPaths,
             libLinks,
-            userOptions,
             staticLibLinks,
         );
     }


### PR DESCRIPTION
Rationale is "user args", filename, then autogenerated.
Closes #3492. Hopefully doesn't introduce another issue.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
