### PR TITLE
Fix for msvc library issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -524,7 +524,7 @@ async function main() {
     const noscriptHandler = new NoScriptHandler(router, handlerConfig);
     const routeApi = new RouteAPI(router, handlerConfig, noscriptHandler.renderNoScriptLayout);
 
-    function onCompilerChange(compilers) {
+    async function onCompilerChange(compilers) {
         if (JSON.stringify(prevCompilers) === JSON.stringify(compilers)) {
             return;
         }
@@ -534,13 +534,13 @@ async function main() {
             logger.error('#### No compilers found: no compilation will be done!');
         }
         prevCompilers = compilers;
-        clientOptionsHandler.setCompilers(compilers);
+        await clientOptionsHandler.setCompilers(compilers);
         routeApi.apiHandler.setCompilers(compilers);
         routeApi.apiHandler.setLanguages(languages);
         routeApi.apiHandler.setOptions(clientOptionsHandler);
     }
 
-    onCompilerChange(initialCompilers);
+    await onCompilerChange(initialCompilers);
 
     const rescanCompilerSecs = ceProps('rescanCompilerSecs', 0);
     if (rescanCompilerSecs && !opts.prediscovered) {

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -291,6 +291,13 @@ export class ClientOptionsHandler {
         const libs = {};
         for (const lib of libsArr) {
             libs[lib.id] = lib;
+
+            const versions = lib.versions;
+            lib.versions = {};
+
+            for (const version of versions) {
+                lib.versions[version.id] = version;
+            }
         }
         return libs;
     }

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -22,6 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import https from 'https';
+
 import fs from 'fs-extra';
 import semverParser from 'semver';
 import _ from 'underscore';
@@ -67,6 +69,8 @@ export class ClientOptionsHandler {
         const libs = this.parseLibraries(this.compilerProps(languages, 'libs'));
         const tools = this.parseTools(this.compilerProps(languages, 'tools'));
 
+        this.remoteLibs = {};
+
         const cookiePolicyEnabled = !!ceProps('cookiePolicyEnabled');
         const privacyPolicyEnabled = !!ceProps('privacyPolicyEnabled');
         const cookieDomainRe = ceProps('cookieDomainRe', '');
@@ -82,6 +86,7 @@ export class ClientOptionsHandler {
             defaultSource: ceProps('defaultSource', ''),
             compilers: [],
             libs: libs,
+            remoteLibs: {},
             tools: tools,
             defaultLibs: this.compilerProps(languages, 'defaultLibs', ''),
             defaultCompiler: this.compilerProps(languages, 'defaultCompiler', ''),
@@ -277,7 +282,48 @@ export class ClientOptionsHandler {
         return '9999999.99999.999';
     }
 
-    setCompilers(compilers) {
+    getRemoteId(remoteUrl, language) {
+        const url = new URL(remoteUrl);
+        return url.host.replace(/\./g, '_') + '_' + language;
+    }
+    
+    libArrayToObject(libsArr) {
+        const libs = {};
+        for (const lib of libsArr) {
+            libs[lib.id] = lib;
+        }
+        return libs;
+    }
+
+    async getRemoteLibraries(language, remoteUrl) {
+        const remoteId = this.getRemoteId(remoteUrl, language);
+        if (!this.remoteLibs[remoteId]) {
+            return new Promise((resolve) => {
+                const url = remoteUrl + '/api/libraries/' + language;
+                logger.info(`Fetching remote libraries from ${url}`);
+                let fullData = '';
+                https.get(url, (res) => {
+                    res.on('data', (data) => {
+                        fullData += data;
+                    });
+                    res.on('end', () => {
+                        const libsArr = JSON.parse(fullData);
+
+                        this.remoteLibs[remoteId] = this.libArrayToObject(libsArr);
+
+                        resolve(this.remoteLibs[remoteId]);
+                    });
+                });
+            });
+        }
+        return this.remoteLibs[remoteId];
+    }
+
+    async fetchRemoteLibrariesIfNeeded(language, remote) {
+        await this.getRemoteLibraries(language, remote.target);
+    }
+
+    async setCompilers(compilers) {
         const forbiddenKeys = new Set(['exe', 'versionFlag', 'versionRe', 'compilerType', 'demangler', 'objdumper',
             'postProcess', 'demanglerType', 'isSemVer']);
         const copiedCompilers = JSON.parse(JSON.stringify(compilers));
@@ -301,6 +347,10 @@ export class ClientOptionsHandler {
                 semverGroups[compiler.group].splice(index, 0, compiler);
             }
 
+            if (compiler.remote) {
+                await this.fetchRemoteLibrariesIfNeeded(compiler.lang, compiler.remote);
+            }
+
             for (const propKey of Object.keys(compiler)){
                 if (forbiddenKeys.has(propKey)) {
                     delete copiedCompilers[compilersKey][propKey];
@@ -315,6 +365,7 @@ export class ClientOptionsHandler {
         }
 
         this.options.compilers = copiedCompilers;
+        this.options.remoteLibs = this.remoteLibs;
         this._updateOptionsHash();
     }
 

--- a/static/lib-utils.ts
+++ b/static/lib-utils.ts
@@ -23,25 +23,18 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import { options } from './options';
-import { LanguageLibs, Library, Libs, LibsPerRemote } from './options.interfaces';
+import { LanguageLibs, Library, Libs } from './options.interfaces';
 
 const LIB_MATCH_RE = /([\w-]*)\.([\w-]*)/i;
 
-const remoteLibs: LibsPerRemote = {};
-
-function getRemoteId(remoteUrl: string, language: string): string {
+function getRemoteId(language: string, remoteUrl: string): string {
     const url: URL = new URL(remoteUrl);
     return url.host.replace(/\./g, '_') + '_' + language;
 }
 
-function getRemoteLibraries(language: string, remoteUrl: string): Libs {
-    const remoteId = getRemoteId(remoteUrl, language);
-    if (!remoteLibs[remoteId]) {
-        $.get(remoteUrl + '/api/libraries/' + language, (data) => {
-            remoteLibs[remoteId] = data;
-        });
-    }
-    return remoteLibs[remoteId];
+function getRemoteLibraries(language: string, remoteUrl: string): LanguageLibs {
+    const remoteId = getRemoteId(language, remoteUrl);
+    return options.remoteLibs[remoteId];
 }
 
 function copyAndFilterLibraries(allLibraries: LanguageLibs, filter: string[]) {
@@ -73,16 +66,16 @@ function copyAndFilterLibraries(allLibraries: LanguageLibs, filter: string[]) {
 }
 
 export function getSupportedLibraries(supportedLibrariesArr: string[], langId: string,
-    remoteUrl: string): LanguageLibs {
-    if (!remoteUrl) {
+    remote): LanguageLibs {
+    if (!remote) {
         const allLibs = options.libs[langId];
         if (supportedLibrariesArr && supportedLibrariesArr.length > 0) {
             return copyAndFilterLibraries(allLibs, supportedLibrariesArr);
         }
         return allLibs;
     } else {
-        const allRemotes = getRemoteLibraries(langId, remoteUrl);
-        const allLibs = allRemotes[langId];
+        const allRemotes = getRemoteLibraries(langId, remote.target);
+        const allLibs = allRemotes;
         if (supportedLibrariesArr && supportedLibrariesArr.length > 0) {
             return copyAndFilterLibraries(allLibs, supportedLibrariesArr);
         }

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -45,10 +45,11 @@ export type LanguageLibs = Record<string, Library>;
 
 export type Libs = Record<string, LanguageLibs>;
 
-export type LibsPerRemote = Record<string, Libs>;
+export type LibsPerRemote = Record<string, LanguageLibs>;
 
 export interface Options {
     libs: Libs;
+    remoteLibs: LibsPerRemote;
     languages: Record<string, Language>;
     defaultLibs: Record<string, string | null>;
     defaultFontScale: number;

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -45,6 +45,8 @@ export type LanguageLibs = Record<string, Library>;
 
 export type Libs = Record<string, LanguageLibs>;
 
+export type LibsPerRemote = Record<string, Libs>;
+
 export interface Options {
     libs: Libs;
     languages: Record<string, Language>;

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1634,7 +1634,9 @@ Compiler.prototype.initLibraries = function (state) {
         this.libsButton,
         state,
         _.bind(this.onLibsChanged, this),
-        LibUtils.getSupportedLibraries(this.compiler ? this.compiler.libsArr: [], this.currentLangId)
+        LibUtils.getSupportedLibraries(this.compiler ? this.compiler.libsArr: [],
+            this.currentLangId,
+            this.compiler ? this.compiler.remote : '')
     );
 };
 
@@ -1642,7 +1644,9 @@ Compiler.prototype.updateLibraries = function () {
     if (this.libsWidget) {
         var filteredLibraries = {};
         if (this.compiler) {
-            filteredLibraries = LibUtils.getSupportedLibraries(this.compiler.libsArr, this.currentLangId);
+            filteredLibraries = LibUtils.getSupportedLibraries(this.compiler.libsArr,
+                this.currentLangId,
+                this.compiler ? this.compiler.remote : '');
         }
 
         this.libsWidget.setNewLangId(this.currentLangId,

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1636,7 +1636,7 @@ Compiler.prototype.initLibraries = function (state) {
         _.bind(this.onLibsChanged, this),
         LibUtils.getSupportedLibraries(this.compiler ? this.compiler.libsArr: [],
             this.currentLangId,
-            this.compiler ? this.compiler.remote : '')
+            this.compiler ? this.compiler.remote : null)
     );
 };
 
@@ -1646,7 +1646,7 @@ Compiler.prototype.updateLibraries = function () {
         if (this.compiler) {
             filteredLibraries = LibUtils.getSupportedLibraries(this.compiler.libsArr,
                 this.currentLangId,
-                this.compiler ? this.compiler.remote : '');
+                this.compiler ? this.compiler.remote : null);
         }
 
         this.libsWidget.setNewLangId(this.currentLangId,

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -422,8 +422,9 @@ Conformance.prototype.getOverlappingLibraries = function (compilerIds) {
     var first = true;
     _.forEach(compilers, function (compiler) {
         if (compiler) {
-            var filteredLibraries = LibUtils.getSupportedLibraries(compiler.libsArr, langId);
-
+            var filteredLibraries = LibUtils.getSupportedLibraries(compiler.libsArr, langId,
+                compiler.remote);
+            
             if (first) {
                 libraries = _.extend({}, filteredLibraries);
                 first = false;

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -690,7 +690,8 @@ Executor.prototype.initLibraries = function (state) {
         this.libsButton,
         state,
         _.bind(this.onLibsChanged, this),
-        LibUtils.getSupportedLibraries(this.compiler ? this.compiler.libsArr : [], this.currentLangId)
+        LibUtils.getSupportedLibraries(this.compiler ? this.compiler.libsArr : [], this.currentLangId,
+            this.compiler ? this.compiler.remote : null)
     );
 };
 
@@ -1054,7 +1055,8 @@ Executor.prototype.updateLibraries = function () {
     if (this.libsWidget) {
         var filteredLibraries = {};
         if (this.compiler) {
-            filteredLibraries = LibUtils.getSupportedLibraries(this.compiler.libsArr, this.currentLangId);
+            filteredLibraries = LibUtils.getSupportedLibraries(this.compiler.libsArr, this.currentLangId,
+                this.compiler ? this.compiler.remote : null);
         }
 
         this.libsWidget.setNewLangId(this.currentLangId,


### PR DESCRIPTION
Problem:
In 2021 I tried to fix the problem of producing extremely large client-options.js files, because all the supported libraries got listed per library. We decided that there should be only 1 list of libraries and then have exceptions per compiler.
(https://github.com/compiler-explorer/compiler-explorer/commit/e24f724e47bcdc1e4acc7c62036a32282dc4e8af)

This saved a lot of megabytes, but obviously I somehow forgot about the fact that the Microsoft compilers would mess up this logic. Unfortunately this didn't show up asap, because the version of CE that Microsoft had was ancient and somehow it worked better. Until Microsoft updated to latest and didn't mention the libraries anymore per compiler, and we're now faced with a mismatch of the libraries that we have and disregarding the libraries that the Microsoft remote has.

Solution:
I think I figured out a solution where all we need to do is update our frontend, that way we don't mess up too much and we don't have to rely on other things.

So; if a compiler is a remote (this is information available in our client-options) - we instead query the libraries API of the remote. We use those libraries as the basic set of supported libraries for that compiler.

Fixes #3412

TODO
- [x] Test locally
- [x] There's more things that call these library functions, those should be updated as well
- [ ] Test on staging
