### PR TITLE
updated OSACA version

### DIFF
--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -21,7 +21,7 @@ group.osaca.supportsBinary=false
 group.osaca.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 group.osaca.compilerType=osaca
 
-compiler.osacatrunk.name=OSACA (0.4.7)
-compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+compiler.osacatrunk.name=OSACA (0.4.8)
+compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 # Intel syntax currently unsupported (WIP)
 # compiler.osacatrunk.intelAsm=--intel-syntax

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2485,8 +2485,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1401,8 +1401,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/clean.amazon.properties
+++ b/etc/config/clean.amazon.properties
@@ -49,8 +49,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=_32
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=_32

--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -40,8 +40,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_blue.amazon.properties
+++ b/etc/config/cppx_blue.amazon.properties
@@ -23,8 +23,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_gold.amazon.properties
+++ b/etc/config/cppx_gold.amazon.properties
@@ -22,8 +22,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -251,8 +251,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=dmd

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -202,8 +202,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -465,8 +465,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=gl:6g141
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=gl:6g141

--- a/etc/config/haskell.amazon.properties
+++ b/etc/config/haskell.amazon.properties
@@ -50,8 +50,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -49,8 +49,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -166,8 +166,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=opt
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=opt

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -41,8 +41,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -173,8 +173,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -60,8 +60,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -55,8 +55,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.4.7)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.7/bin/osaca
+tools.osacatrunk.name=OSACA (0.4.8)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.8/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/examples/analysis/default.asm
+++ b/examples/analysis/default.asm
@@ -1,6 +1,6 @@
 code_snippet:
-    vpslldq xmm1, xmm0, 3
-    vaddps xmm0, xmm0, xmm1
-    vmulps xmm1, xmm0, xmm0
-    dec rcx
+    vpslldq $3, %xmm0, %xmm1
+    vaddps %xmm1, %xmm0, %xmm0
+    vmulps %xmm0, %xmm0, %xmm1
+    dec %rcx
     jne code_snippet

--- a/examples/analysis/default.asm
+++ b/examples/analysis/default.asm
@@ -1,6 +1,6 @@
 code_snippet:
-    vpslldq $3, %xmm0, %xmm1
-    vaddps %xmm1, %xmm0, %xmm0
-    vmulps %xmm0, %xmm0, %xmm1
-    dec %rcx
+    vpslldq xmm1, xmm0, 3
+    vaddps xmm0, xmm0, xmm1
+    vmulps xmm1, xmm0, xmm0
+    dec rcx
     jne code_snippet


### PR DESCRIPTION
Updated OSACA to version 0.4.8.
This gets rid of a few bugs, enhances OSACA's database by some instruction forms and adds support for the HiSilicon TaiShan v110 micro-architecture (`--arch tsv110`).

See also the corresponding [PR 703 in `compiler-explorer/infra`](https://github.com/compiler-explorer/infra/pull/703)
