### PR TITLE
Change syntax of Analysis default from Intel to AT&T

### DIFF
--- a/examples/analysis/default.asm
+++ b/examples/analysis/default.asm
@@ -1,6 +1,6 @@
 code_snippet:
-    vpslldq xmm1, xmm0, 3
-    vaddps xmm0, xmm0, xmm1
-    vmulps xmm1, xmm0, xmm0
-    dec rcx
+    vpslldq $3, %xmm0, %xmm1
+    vaddps %xmm1, %xmm0, %xmm0
+    vmulps %xmm0, %xmm0, %xmm1
+    dec %rcx
     jne code_snippet


### PR DESCRIPTION
The default code in the *Analysis* source editor always has been:
```asm
code_snippet:
    vpslldq xmm1, xmm0, 3
    vaddps xmm0, xmm0, xmm1
    vmulps xmm1, xmm0, xmm0
    dec rcx
    jne code_snippet
```

Unfortunately, this is Intel syntax and OSACA only supports AT&T syntax so far.
This leads to an initial wrong assumption by OSACA (guessing it is aarch64) and consequently an useless output:
```
Open Source Architecture Code Analyzer (OSACA) - 0.4.7
Analyzed file:      /app/example.asm
Architecture:       A64FX
Timestamp:          2022-04-08 11:50:18

-------------------------- WARNING: No micro-architecture was specified -------------------------
         A default uarch for this particular ISA was used. Specify the uarch with --arch.
         See --help for more information.
-------------------------------------------------------------------------------------------------

 P - Throughput of LOAD operation can be hidden behind a past or future STORE instruction
 * - Instruction micro-ops not bound to a port
 X - No throughput/latency information for this instruction in data file

Combined Analysis Report
------------------------
                                     Port pressure in cycles                                     
     |  0   - 0DV  |  1   |  2   |  3   |  4   |  5   -  5D  |  6   -  6D  |  7   ||  CP  | LCD  |
--------------------------------------------------------------------------------------------------
   1 |             |      |      |      |      |             |             |      ||  0.0 |      |   code_snippet:
   2 |             |      |      |      |      |             |             |      ||      |      | X vpslldq xmm1, xmm0, 3
   3 |             |      |      |      |      |             |             |      ||      |      | X vaddps xmm0, xmm0, xmm1
   4 |             |      |      |      |      |             |             |      ||      |      | X vmulps xmm1, xmm0, xmm0
   5 |             |      |      |      |      |             |             |      ||      |      | X dec rcx
   6 |             |      |      |      |      |             |             |      ||      |      | X jne code_snippet

------------------ WARNING: The performance data for 5 instructions is missing.------------------
[...]
```

However, if we change the code example to AT&T syntax, OSACA can recognize the assembly and provide correct output for the default x86 micro-architecture:
```
Open Source Architecture Code Analyzer (OSACA) - 0.4.7
Analyzed file:      /app/example.asm
Architecture:       SKX
Timestamp:          2022-04-08 13:12:42

-------------------------- WARNING: No micro-architecture was specified -------------------------
         A default uarch for this particular ISA was used. Specify the uarch with --arch.
         See --help for more information.
-------------------------------------------------------------------------------------------------

 P - Throughput of LOAD operation can be hidden behind a past or future STORE instruction
 * - Instruction micro-ops not bound to a port
 X - No throughput/latency information for this instruction in data file

Combined Analysis Report
------------------------
                                     Port pressure in cycles                                     
     |  0   - 0DV  |  1   |  2   -  2D  |  3   -  3D  |  4   |  5   |  6   |  7   ||  CP  | LCD  |
--------------------------------------------------------------------------------------------------
   1 |             |      |             |             |      |      |      |      ||      |      |   code_snippet:
   2 |             |      |             |             |      | 1.00 |      |      ||  1.0 |  1.0 |   vpslldq $3, %xmm0, %xmm1
   3 | 0.50        | 0.50 |             |             |      |      |      |      ||  4.0 |  4.0 |   vaddps %xmm1, %xmm0, %xmm0
   4 | 0.50        | 0.50 |             |             |      |      |      |      ||  4.0 |      |   vmulps %xmm0, %xmm0, %xmm1
   5 | 0.00        | 0.00 |             |             |      | 0.00 | 1.00 |      ||      |      |   dec %rcx
   6 |             |      |             |             |      |      |      |      ||      |      | * jne code_snippet

       1.00          1.00                                      1.00   1.00              9    5.0  

Loop-Carried Dependencies Analysis Report
-----------------------------------------
   2 |  5.0 | vpslldq $3, %xmm0, %xmm1            | [2, 3]
   3 |  4.0 | vaddps %xmm1, %xmm0, %xmm0          | [3]
   5 |  1.0 | dec %rcx                            | [5]
```
The only other analysis tool currently in CE, llvm-mca, works with both syntaxes and prints out the same output (despite of the syntax, of course), so there would be no downside in changing the code snippet.
