### PR TITLE
Adds missing types to PaneRenaming

### DIFF
--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -210,12 +210,12 @@ export abstract class Pane<S> {
     }
 
     /** Get name for the pane */
-    protected getPaneName() {
+    getPaneName() {
         return this.paneName ?? this.getDefaultPaneName() + ' ' + this.getPaneTag();
     }
 
     /** Update the pane's title, called when the pane name or compiler info changes */
-    protected updateTitle() {
+    public updateTitle() {
         this.container.setTitle(_.escape(this.getPaneName()));
     }
 

--- a/static/widgets/pane-renaming.ts
+++ b/static/widgets/pane-renaming.ts
@@ -66,10 +66,11 @@ export class PaneRenaming extends EventEmitter.EventEmitter {
         btn.on('click', () => {
             const modalTextPlaceholder = this.pane.paneName || this.pane.getPaneName();
             this.alertSystem.enterSomething('Rename pane', 'Please enter new pane name', modalTextPlaceholder, {
-                yes: (value?: string) => {
+                // TS does not know we have a text input, so it thinks it might be also a number
+                yes: (value?: string | string[] | number) => {
                     // Update title and emit event to save it into the state
                     if (value) {
-                        this.pane.paneName = value;
+                        this.pane.paneName = value.toString();
                         this.pane.updateTitle();
                         this.emit('renamePane');
                     }

--- a/static/widgets/pane-renaming.ts
+++ b/static/widgets/pane-renaming.ts
@@ -22,15 +22,16 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import _ from 'underscore';
 import { Tab } from 'golden-layout';
 import { EventEmitter } from 'events';
 import { Alert } from '../alert';
+import { MonacoPane } from '../panes/pane';
+import { PaneState } from '../panes/pane.interfaces';
 
 export class PaneRenaming extends EventEmitter.EventEmitter {
-    private pane: any;
-    private alertSystem: any;
-    private state: any;
+    private pane: MonacoPane<any, any> & {alertSystem?: Alert};
+    private alertSystem: Alert;
+    private state: PaneState & {paneName: string};
 
     constructor(pane: any, state: any) {
         super();

--- a/static/widgets/pane-renaming.ts
+++ b/static/widgets/pane-renaming.ts
@@ -66,11 +66,13 @@ export class PaneRenaming extends EventEmitter.EventEmitter {
         btn.on('click', () => {
             const modalTextPlaceholder = this.pane.paneName || this.pane.getPaneName();
             this.alertSystem.enterSomething('Rename pane', 'Please enter new pane name', modalTextPlaceholder, {
-                yes: (value: string) => {
+                yes: (value?: string) => {
                     // Update title and emit event to save it into the state
-                    this.pane.paneName = value;
-                    this.pane.updateTitle();
-                    this.emit('renamePane');
+                    if (value) {
+                        this.pane.paneName = value;
+                        this.pane.updateTitle();
+                        this.emit('renamePane');
+                    }
                 },
                 no: () => {
                     this.alertSystem.resolve(false);


### PR DESCRIPTION
PaneRenaming still used some `any` here and there.
We should probably look around the code once the TS conversion is done to catch all cases like this one.

As a draft mostly because I don't like my solution as there probably is a better and more permanent one