### PR TITLE
Fixes bad usage of alert system entersomething

### DIFF
--- a/static/widgets/pane-renaming.ts
+++ b/static/widgets/pane-renaming.ts
@@ -71,9 +71,6 @@ export class PaneRenaming extends EventEmitter.EventEmitter {
                     this.pane.updateTitle();
                     this.emit('renamePane');
                 },
-                no: () => {
-                    this.alertSystem.resolve(false);
-                },
                 yesClass: 'btn btn-primary',
                 yesHtml: 'Rename',
                 noClass: 'btn-outline-info',


### PR DESCRIPTION
Saw on Sentry that this was happening and decided to take a look. No idea where the "reject" comes from, but it's now gone. The default `no` callback is ok in this case

Fixes COMPILER-EXPLORER-8VJ
