### PR TITLE
Catches the rison deserialization exception to allow page loads

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -275,7 +275,11 @@ function findConfig(defaultConfig, options) {
             if (options.config) {
                 config = options.config;
             } else {
-                config = url.deserialiseState(window.location.hash.substr(1));
+                try {
+                    config = url.deserialiseState(window.location.hash.substring(1));
+                } catch (e) {
+                    // Ignore so we at least load the site, but it would be good to notify the user
+                }
             }
 
             if (config) {


### PR DESCRIPTION
Saw COMPILER-EXPLORER-7PV on Sentry. The linked full url seems to be missing things so probably the error is not on our side of cases like this, but I guess that at least letting the user load the page would be good.

Would a notification here of some sort make sense? Yes, right?