### PR TITLE
Add Swift 5.6.

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,9 +1,9 @@
 compilers=&swift
-demangler=/opt/compiler-explorer/swift-5.5/usr/bin/swift-demangle
-defaultCompiler=swift55
+demangler=/opt/compiler-explorer/swift-5.6/usr/bin/swift-demangle
+defaultCompiler=swift56
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
-group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swiftnightly
+group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swiftnightly
 group.swift.isSemVer=true
 group.swift.baseName=x86-64 swiftc
 compiler.swift311.exe=/opt/compiler-explorer/swift-3.1.1/usr/bin/swiftc
@@ -40,6 +40,8 @@ compiler.swift54.exe=/opt/compiler-explorer/swift-5.4/usr/bin/swiftc
 compiler.swift54.semver=5.4
 compiler.swift55.exe=/opt/compiler-explorer/swift-5.5/usr/bin/swiftc
 compiler.swift55.semver=5.5
+compiler.swift56.exe=/opt/compiler-explorer/swift-5.6/usr/bin/swiftc
+compiler.swift56.semver=5.6
 compiler.swiftnightly.exe=/opt/compiler-explorer/swift-nightly/usr/bin/swiftc
 compiler.swiftnightly.semver=nightly
 


### PR DESCRIPTION
Adds Swift 5.6 as a compiler option. The associated infra PR is compiler-explorer/infra#706.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
