### PR TITLE
Fix ppc64 GCC 11.2 names for C and C++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -725,6 +725,7 @@ compiler.ppc64g9.semver=(snapshot)
 compiler.ppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g1120.semver=power64 gcc 11.2.0
+compiler.ppc64g1120.name=power64 gcc 11.2.0
 compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -634,6 +634,7 @@ compiler.cppc64g9.semver=(snapshot)
 compiler.cppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1120.semver=power64 gcc 11.2.0
+compiler.cppc64g1120.name=power64 gcc 11.2.0
 compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump


### PR DESCRIPTION
Both compilers were missing a name and were defaulting the their id.