### PR TITLE
Enable Prettier for TypeScript frontend

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           npm run lint
           npm run ci-test
+          npm run format-check
           python3 ./etc/scripts/util/orphancompiler.py
       - name: Code coverage
         run: npm run codecov

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 trailingComma: es5
-printWidth: 80
+printWidth: 120
 singleQuote: true
 arrowParens: avoid
 tabWidth: 4

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,9 +1,9 @@
-trailingComma: all
+trailingComma: es5
 printWidth: 80
 singleQuote: true
 arrowParens: avoid
 tabWidth: 4
-bracketSpacing: true
+bracketSpacing: false
 overrides:
   - files: '*.{yml,json}'
     options:

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -3,12 +3,8 @@ printWidth: 80
 singleQuote: true
 arrowParens: avoid
 tabWidth: 4
-bracketSpacing: false
-requirePragma: true
+bracketSpacing: true
 overrides:
   - files: '*.{yml,json}'
     options:
       tabWidth: 2
-  - files: 'static/**/*'
-    options:
-      trailingComma: es5

--- a/package.json
+++ b/package.json
@@ -165,8 +165,9 @@
     "sentry": "npx -p @sentry/cli sentry-cli",
     "update-browserslist": "npx browserslist@latest -- --update-db",
     "prepare": "husky install",
-    "format": "prettier --ignore-unknown .",
-    "format-fix": "prettier --write --ignore-unknown .",
+    "format": "prettier --ignore-unknown ./static/*.ts",
+    "format-fix": "prettier --write --ignore-unknown ./static/*.ts",
+    "format-check": "prettier --ignore-unknown --check ./static/*.ts",
     "ts-compile": "tsc",
     "webpack": "webpack --node-env=production"
   },

--- a/static/alert.interfaces.ts
+++ b/static/alert.interfaces.ts
@@ -42,33 +42,38 @@ export interface AlertAskOptions {
 export type AlertEnterTextOptions = {
     /** The enter-text action returns a value which is captured here */
     yes?: (answer?: string | number | string[]) => void;
-} & Partial<Pick<AlertAskOptions, 'no' | 'yesHtml' | 'yesClass' | 'noHtml' | 'noClass' | 'onClose'>>;
+} & Partial<
+    Pick<
+        AlertAskOptions,
+        'no' | 'yesHtml' | 'yesClass' | 'noHtml' | 'noClass' | 'onClose'
+    >
+>;
 
 export interface AlertNotifyOptions {
     /**
      * Which group this notification is from. Sets data-group attribute value
      * Default: ""
      */
-    group?: string
+    group?: string;
     /** If set to true, other notifications within the same group will be removed before sending this one. (Note that
      * this only has any effect if options.group is set).
      * Default: true
      */
-    collapseSimilar?: boolean
+    collapseSimilar?: boolean;
     /**
      * Space separated list of HTML classes to give to the notification's div element.
      * Default: ""
      */
-    alertClass?: string
+    alertClass?: string;
     /**
      * If set to true, the notification will fade out and be removed automatically.
      * Default: true
      */
-    autoDismiss?: boolean
+    autoDismiss?: boolean;
     /**
      * If allow by autoDismiss, controls how long the notification will be visible (in milliseconds) before
      * automatically removed
      * Default: 5000
      */
-    dismissTime?: number
+    dismissTime?: number;
 }

--- a/static/alert.interfaces.ts
+++ b/static/alert.interfaces.ts
@@ -42,12 +42,7 @@ export interface AlertAskOptions {
 export type AlertEnterTextOptions = {
     /** The enter-text action returns a value which is captured here */
     yes?: (answer?: string | number | string[]) => void;
-} & Partial<
-    Pick<
-        AlertAskOptions,
-        'no' | 'yesHtml' | 'yesClass' | 'noHtml' | 'noClass' | 'onClose'
-    >
->;
+} & Partial<Pick<AlertAskOptions, 'no' | 'yesHtml' | 'yesClass' | 'noHtml' | 'noClass' | 'onClose'>>;
 
 export interface AlertNotifyOptions {
     /**

--- a/static/alert.ts
+++ b/static/alert.ts
@@ -24,7 +24,11 @@
 
 import $ from 'jquery';
 
-import { AlertAskOptions, AlertEnterTextOptions, AlertNotifyOptions } from './alert.interfaces';
+import {
+    AlertAskOptions,
+    AlertEnterTextOptions,
+    AlertNotifyOptions,
+} from './alert.interfaces';
 import { toggleEventListener } from './utils';
 import Sentry from '@sentry/browser';
 
@@ -66,18 +70,20 @@ export class Alert {
         this.yesHandler = askOptions.yes ?? (() => undefined);
         this.noHandler = askOptions.no ?? (() => undefined);
         modal.find('.modal-title').html(title);
-        modal.find('.modal-body')
-            .css('min-height', 'inherit')
-            .html(question);
-        if (askOptions.yesHtml) modal.find('.modal-footer .yes').html(askOptions.yesHtml);
+        modal.find('.modal-body').css('min-height', 'inherit').html(question);
+        if (askOptions.yesHtml)
+            modal.find('.modal-footer .yes').html(askOptions.yesHtml);
         if (askOptions.yesClass) {
-            modal.find('.modal-footer .yes')
+            modal
+                .find('.modal-footer .yes')
                 .removeClass('btn-link')
                 .addClass(askOptions.yesClass);
         }
-        if (askOptions.noHtml) modal.find('.modal-footer .no').html(askOptions.noHtml);
+        if (askOptions.noHtml)
+            modal.find('.modal-footer .no').html(askOptions.noHtml);
         if (askOptions.noClass) {
-            modal.find('.modal-footer .no')
+            modal
+                .find('.modal-footer .no')
                 .removeClass('btn-link')
                 .addClass(askOptions.noClass);
         }
@@ -92,13 +98,16 @@ export class Alert {
     /**
      * Notifies the user of something by a popup which can be stacked, auto-dismissed, etc... based on options
      */
-    notify(body: string, {
-        group = '',
-        collapseSimilar = true,
-        alertClass = '',
-        autoDismiss = true,
-        dismissTime = 5000,
-    }: AlertNotifyOptions) {
+    notify(
+        body: string,
+        {
+            group = '',
+            collapseSimilar = true,
+            alertClass = '',
+            autoDismiss = true,
+            dismissTime = 5000,
+        }: AlertNotifyOptions,
+    ) {
         const container = $('#notifications');
         if (container.length === 0) {
             Sentry.captureMessage('#notifications not found');
@@ -137,7 +146,12 @@ export class Alert {
     /**
      * Asks the user a two choice question, where the title, content and buttons are customizable
      */
-    enterSomething(title: string, question: string, defaultValue: string, askOptions: AlertEnterTextOptions) {
+    enterSomething(
+        title: string,
+        question: string,
+        defaultValue: string,
+        askOptions: AlertEnterTextOptions,
+    ) {
         const modal = $('#enter-something');
         this.yesHandler = askOptions.yes ?? (() => undefined);
         this.noHandler = askOptions.no ?? (() => undefined);
@@ -157,7 +171,7 @@ export class Alert {
 
         const answerEdit = modal.find('.modal-body .question-answer');
         answerEdit.val(defaultValue);
-        answerEdit.on('keyup', (e) => {
+        answerEdit.on('keyup', e => {
             if (e.keyCode === 13 || e.which === 13) {
                 yesButton.trigger('click');
             }

--- a/static/alert.ts
+++ b/static/alert.ts
@@ -24,11 +24,7 @@
 
 import $ from 'jquery';
 
-import {
-    AlertAskOptions,
-    AlertEnterTextOptions,
-    AlertNotifyOptions,
-} from './alert.interfaces';
+import {AlertAskOptions, AlertEnterTextOptions, AlertNotifyOptions} from './alert.interfaces';
 import {toggleEventListener} from './utils';
 import Sentry from '@sentry/browser';
 
@@ -71,21 +67,13 @@ export class Alert {
         this.noHandler = askOptions.no ?? (() => undefined);
         modal.find('.modal-title').html(title);
         modal.find('.modal-body').css('min-height', 'inherit').html(question);
-        if (askOptions.yesHtml)
-            modal.find('.modal-footer .yes').html(askOptions.yesHtml);
+        if (askOptions.yesHtml) modal.find('.modal-footer .yes').html(askOptions.yesHtml);
         if (askOptions.yesClass) {
-            modal
-                .find('.modal-footer .yes')
-                .removeClass('btn-link')
-                .addClass(askOptions.yesClass);
+            modal.find('.modal-footer .yes').removeClass('btn-link').addClass(askOptions.yesClass);
         }
-        if (askOptions.noHtml)
-            modal.find('.modal-footer .no').html(askOptions.noHtml);
+        if (askOptions.noHtml) modal.find('.modal-footer .no').html(askOptions.noHtml);
         if (askOptions.noClass) {
-            modal
-                .find('.modal-footer .no')
-                .removeClass('btn-link')
-                .addClass(askOptions.noClass);
+            modal.find('.modal-footer .no').removeClass('btn-link').addClass(askOptions.noClass);
         }
         if (askOptions.onClose) {
             modal.off('hidden.bs.modal');
@@ -146,12 +134,7 @@ export class Alert {
     /**
      * Asks the user a two choice question, where the title, content and buttons are customizable
      */
-    enterSomething(
-        title: string,
-        question: string,
-        defaultValue: string,
-        askOptions: AlertEnterTextOptions
-    ) {
+    enterSomething(title: string, question: string, defaultValue: string, askOptions: AlertEnterTextOptions) {
         const modal = $('#enter-something');
         this.yesHandler = askOptions.yes ?? (() => undefined);
         this.noHandler = askOptions.no ?? (() => undefined);

--- a/static/alert.ts
+++ b/static/alert.ts
@@ -29,7 +29,7 @@ import {
     AlertEnterTextOptions,
     AlertNotifyOptions,
 } from './alert.interfaces';
-import { toggleEventListener } from './utils';
+import {toggleEventListener} from './utils';
 import Sentry from '@sentry/browser';
 
 export class Alert {
@@ -106,7 +106,7 @@ export class Alert {
             alertClass = '',
             autoDismiss = true,
             dismissTime = 5000,
-        }: AlertNotifyOptions,
+        }: AlertNotifyOptions
     ) {
         const container = $('#notifications');
         if (container.length === 0) {
@@ -150,7 +150,7 @@ export class Alert {
         title: string,
         question: string,
         defaultValue: string,
-        askOptions: AlertEnterTextOptions,
+        askOptions: AlertEnterTextOptions
     ) {
         const modal = $('#enter-something');
         this.yesHandler = askOptions.yes ?? (() => undefined);

--- a/static/analytics.ts
+++ b/static/analytics.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { options } from './options';
+import {options} from './options';
 import * as Sentry from '@sentry/browser';
 
 if (options.statusTrackingEnabled && options.sentryDsn) {
@@ -71,7 +71,7 @@ class GAProxy {
                     document,
                     'script',
                     '//www.google-analytics.com/analytics.js',
-                    'ga',
+                    'ga'
                 );
                 window.ga('set', 'anonymizeIp', true);
                 window.ga('create', options.googleAnalyticsAccount, {
@@ -104,4 +104,4 @@ class GAProxy {
 }
 
 const ga = new GAProxy();
-export { ga };
+export {ga};

--- a/static/analytics.ts
+++ b/static/analytics.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {options} from './options';
+import { options } from './options';
 import * as Sentry from '@sentry/browser';
 
 if (options.statusTrackingEnabled && options.sentryDsn) {
@@ -36,20 +36,25 @@ if (options.statusTrackingEnabled && options.sentryDsn) {
 class GAProxy {
     private hasBeenEnabled = false;
     private isEnabled = false;
-    private _proxy: (...args) => void = () => {
-    };
+    private _proxy: (...args) => void = () => {};
 
     initialise() {
-        if (!this.isEnabled && options.statusTrackingEnabled && options.googleAnalyticsEnabled) {
+        if (
+            !this.isEnabled &&
+            options.statusTrackingEnabled &&
+            options.googleAnalyticsEnabled
+        ) {
             // Check if this is a re-enable, as the script is already there in this case
             if (!this.hasBeenEnabled) {
                 (function (i, s, o, g, r, a, m) {
                     i.GoogleAnalyticsObject = r;
-                    i[r] = i[r] || function () {
-                        // We could push the unexpanded args, but better might have some unintended side-effects
-                        // eslint-disable-next-line prefer-rest-params
-                        (i[r].q = i[r].q || []).push(arguments);
-                    };
+                    i[r] =
+                        i[r] ||
+                        function () {
+                            // We could push the unexpanded args, but better might have some unintended side-effects
+                            // eslint-disable-next-line prefer-rest-params
+                            (i[r].q = i[r].q || []).push(arguments);
+                        };
                     i[r].l = Date.now();
                     // @ts-ignore
                     a = s.createElement(o);
@@ -61,7 +66,13 @@ class GAProxy {
                     a.src = g;
                     // @ts-ignore
                     m.parentNode.insertBefore(a, m);
-                })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+                })(
+                    window,
+                    document,
+                    'script',
+                    '//www.google-analytics.com/analytics.js',
+                    'ga',
+                );
                 window.ga('set', 'anonymizeIp', true);
                 window.ga('create', options.googleAnalyticsAccount, {
                     cookieDomain: 'auto',
@@ -74,8 +85,7 @@ class GAProxy {
             this.hasBeenEnabled = true;
         } else {
             this.isEnabled = false;
-            this._proxy = () => {
-            };
+            this._proxy = () => {};
         }
     }
 
@@ -84,8 +94,7 @@ class GAProxy {
             if (!this.isEnabled) this.initialise();
         } else {
             this.isEnabled = false;
-            this._proxy = () => {
-            };
+            this._proxy = () => {};
         }
     }
 
@@ -95,6 +104,4 @@ class GAProxy {
 }
 
 const ga = new GAProxy();
-export {
-    ga,
-};
+export { ga };

--- a/static/analytics.ts
+++ b/static/analytics.ts
@@ -39,11 +39,7 @@ class GAProxy {
     private _proxy: (...args) => void = () => {};
 
     initialise() {
-        if (
-            !this.isEnabled &&
-            options.statusTrackingEnabled &&
-            options.googleAnalyticsEnabled
-        ) {
+        if (!this.isEnabled && options.statusTrackingEnabled && options.googleAnalyticsEnabled) {
             // Check if this is a re-enable, as the script is already there in this case
             if (!this.hasBeenEnabled) {
                 (function (i, s, o, g, r, a, m) {
@@ -66,13 +62,7 @@ class GAProxy {
                     a.src = g;
                     // @ts-ignore
                     m.parentNode.insertBefore(a, m);
-                })(
-                    window,
-                    document,
-                    'script',
-                    '//www.google-analytics.com/analytics.js',
-                    'ga'
-                );
+                })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
                 window.ga('set', 'anonymizeIp', true);
                 window.ga('create', options.googleAnalyticsAccount, {
                     cookieDomain: 'auto',

--- a/static/ansi-to-html.ts
+++ b/static/ansi-to-html.ts
@@ -28,7 +28,7 @@
 // Converted to typescript by MarkusJx
 
 import _ from 'underscore';
-import { AnsiToHtmlOptions, ColorCodes } from './ansi-to-html.interfaces';
+import {AnsiToHtmlOptions, ColorCodes} from './ansi-to-html.interfaces';
 
 const defaults: AnsiToHtmlOptions = {
     fg: '#FFF',
@@ -59,15 +59,15 @@ function getDefaultColors(): ColorCodes {
         15: '#FFF',
     };
 
-    range(0, 5).forEach((red) => {
-        range(0, 5).forEach((green) => {
-            range(0, 5).forEach((blue) => {
+    range(0, 5).forEach(red => {
+        range(0, 5).forEach(green => {
+            range(0, 5).forEach(blue => {
                 setStyleColor(red, green, blue, colors);
             });
         });
     });
 
-    range(0, 23).forEach((gray) => {
+    range(0, 23).forEach(gray => {
         const c = gray + 232;
         const l = toHexString(gray * 10 + 8);
 
@@ -77,7 +77,12 @@ function getDefaultColors(): ColorCodes {
     return colors;
 }
 
-function setStyleColor(red: number, green: number, blue: number, colors: ColorCodes): void {
+function setStyleColor(
+    red: number,
+    green: number,
+    blue: number,
+    colors: ColorCodes
+): void {
     const c = 16 + red * 36 + green * 6 + blue;
     const r = red > 0 ? red * 40 + 55 : 0;
     const g = green > 0 ? green * 40 + 55 : 0;
@@ -118,7 +123,12 @@ function toColorHexString(ref: number[]): string {
     return '#' + results.join('');
 }
 
-function generateOutput(stack: string[], token: string, data: string | number, options: AnsiToHtmlOptions): string {
+function generateOutput(
+    stack: string[],
+    token: string,
+    data: string | number,
+    options: AnsiToHtmlOptions
+): string {
     if (token === 'text') {
         // Note: Param 'data' must be a string at this point
         return pushText(data as string, options);
@@ -131,7 +141,11 @@ function generateOutput(stack: string[], token: string, data: string | number, o
     return '';
 }
 
-function handleXterm256(stack: string[], data: string, options: AnsiToHtmlOptions): string {
+function handleXterm256(
+    stack: string[],
+    data: string,
+    options: AnsiToHtmlOptions
+): string {
     data = data.substring(2).slice(0, -1);
     const operation = +data.substr(0, 2);
     const color = +data.substr(5);
@@ -144,7 +158,11 @@ function handleXterm256(stack: string[], data: string, options: AnsiToHtmlOption
     }
 }
 
-function handleDisplay(stack: string[], _code: string | number, options: AnsiToHtmlOptions): string {
+function handleDisplay(
+    stack: string[],
+    _code: string | number,
+    options: AnsiToHtmlOptions
+): string {
     const code: number = parseInt(_code as string, 10);
     const codeMap: Record<number, () => string> = {
         '-1': () => '<br />',
@@ -190,7 +208,10 @@ function resetStyles(stack: string[]): string {
     const stackClone = stack.slice(0);
     stack.length = 0;
 
-    return stackClone.reverse().map((tag) => `</${tag}>`).join('');
+    return stackClone
+        .reverse()
+        .map(tag => `</${tag}>`)
+        .join('');
 }
 
 /**
@@ -241,9 +262,17 @@ function categoryForCode(_code: string | number): string {
         return 'hide';
     } else if (code === 9) {
         return 'strike';
-    } else if (29 < code && code < 38 || code === 39 || 89 < code && code < 98) {
+    } else if (
+        (29 < code && code < 38) ||
+        code === 39 ||
+        (89 < code && code < 98)
+    ) {
         return 'foreground-color';
-    } else if (39 < code && code < 48 || code === 49 || 99 < code && code < 108) {
+    } else if (
+        (39 < code && code < 48) ||
+        code === 49 ||
+        (99 < code && code < 108)
+    ) {
         return 'background-color';
     }
     return '';
@@ -251,7 +280,10 @@ function categoryForCode(_code: string | number): string {
 
 function pushText(text: string, options: AnsiToHtmlOptions): string {
     if (options.escapeXML) {
-        return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
     }
 
     return text;
@@ -299,7 +331,11 @@ interface Token {
     sub: (m: string, ...args: any[]) => string;
 }
 
-function tokenize(text: string, options: AnsiToHtmlOptions, callback: TokenizeCallback) {
+function tokenize(
+    text: string,
+    options: AnsiToHtmlOptions,
+    callback: TokenizeCallback
+) {
     let ansiMatch = false;
     const ansiHandler = 3;
 
@@ -344,28 +380,36 @@ function tokenize(text: string, options: AnsiToHtmlOptions, callback: TokenizeCa
     }
 
     /* eslint no-control-regex:0 */
-    const tokens: Token[] = [{
-        pattern: /^\x08+/,
-        sub: remove,
-    }, {
-        pattern: /^\x1b\[[012]?K/,
-        sub: remove,
-    }, {
-        pattern: /^\x1b\[[34]8;5;(\d+)m/,
-        sub: removeXterm256,
-    }, {
-        pattern: /^\n/,
-        sub: newline,
-    }, {
-        pattern: /^\x1b\[((?:\d{1,3};)*\d{1,3}|)m/,
-        sub: ansiMess,
-    }, {
-        pattern: /^\x1b\[?[\d;]{0,3}/,
-        sub: remove,
-    }, {
-        pattern: /^([^\x1b\x08\n]+)/,
-        sub: realText,
-    }];
+    const tokens: Token[] = [
+        {
+            pattern: /^\x08+/,
+            sub: remove,
+        },
+        {
+            pattern: /^\x1b\[[012]?K/,
+            sub: remove,
+        },
+        {
+            pattern: /^\x1b\[[34]8;5;(\d+)m/,
+            sub: removeXterm256,
+        },
+        {
+            pattern: /^\n/,
+            sub: newline,
+        },
+        {
+            pattern: /^\x1b\[((?:\d{1,3};)*\d{1,3}|)m/,
+            sub: ansiMess,
+        },
+        {
+            pattern: /^\x1b\[?[\d;]{0,3}/,
+            sub: remove,
+        },
+        {
+            pattern: /^([^\x1b\x08\n]+)/,
+            sub: realText,
+        },
+    ];
 
     function process(handler: Token, i: number): void {
         if (i > ansiHandler && ansiMatch) {
@@ -421,7 +465,8 @@ interface StickyStackElement {
 function updateStickyStack(
     stickyStack: StickyStackElement[],
     token: string,
-    data: string | number): StickyStackElement[] {
+    data: string | number
+): StickyStackElement[] {
     if (token !== 'text') {
         stickyStack = stickyStack.filter(notCategory(categoryForCode(data)));
         stickyStack.push({
@@ -456,7 +501,12 @@ export class Filter {
         const buf: string[] = [];
 
         this.stickyStack.forEach((element: StickyStackElement) => {
-            const output: string = generateOutput(stack, element.token, element.data, options);
+            const output: string = generateOutput(
+                stack,
+                element.token,
+                element.data,
+                options
+            );
 
             if (output) {
                 buf.push(output);
@@ -471,7 +521,11 @@ export class Filter {
             }
 
             if (options.stream) {
-                this.stickyStack = updateStickyStack(this.stickyStack, token, data);
+                this.stickyStack = updateStickyStack(
+                    this.stickyStack,
+                    token,
+                    data
+                );
             }
         });
 

--- a/static/ansi-to-html.ts
+++ b/static/ansi-to-html.ts
@@ -77,12 +77,7 @@ function getDefaultColors(): ColorCodes {
     return colors;
 }
 
-function setStyleColor(
-    red: number,
-    green: number,
-    blue: number,
-    colors: ColorCodes
-): void {
+function setStyleColor(red: number, green: number, blue: number, colors: ColorCodes): void {
     const c = 16 + red * 36 + green * 6 + blue;
     const r = red > 0 ? red * 40 + 55 : 0;
     const g = green > 0 ? green * 40 + 55 : 0;
@@ -123,12 +118,7 @@ function toColorHexString(ref: number[]): string {
     return '#' + results.join('');
 }
 
-function generateOutput(
-    stack: string[],
-    token: string,
-    data: string | number,
-    options: AnsiToHtmlOptions
-): string {
+function generateOutput(stack: string[], token: string, data: string | number, options: AnsiToHtmlOptions): string {
     if (token === 'text') {
         // Note: Param 'data' must be a string at this point
         return pushText(data as string, options);
@@ -141,11 +131,7 @@ function generateOutput(
     return '';
 }
 
-function handleXterm256(
-    stack: string[],
-    data: string,
-    options: AnsiToHtmlOptions
-): string {
+function handleXterm256(stack: string[], data: string, options: AnsiToHtmlOptions): string {
     data = data.substring(2).slice(0, -1);
     const operation = +data.substr(0, 2);
     const color = +data.substr(5);
@@ -158,11 +144,7 @@ function handleXterm256(
     }
 }
 
-function handleDisplay(
-    stack: string[],
-    _code: string | number,
-    options: AnsiToHtmlOptions
-): string {
+function handleDisplay(stack: string[], _code: string | number, options: AnsiToHtmlOptions): string {
     const code: number = parseInt(_code as string, 10);
     const codeMap: Record<number, () => string> = {
         '-1': () => '<br />',
@@ -262,17 +244,9 @@ function categoryForCode(_code: string | number): string {
         return 'hide';
     } else if (code === 9) {
         return 'strike';
-    } else if (
-        (29 < code && code < 38) ||
-        code === 39 ||
-        (89 < code && code < 98)
-    ) {
+    } else if ((29 < code && code < 38) || code === 39 || (89 < code && code < 98)) {
         return 'foreground-color';
-    } else if (
-        (39 < code && code < 48) ||
-        code === 49 ||
-        (99 < code && code < 108)
-    ) {
+    } else if ((39 < code && code < 48) || code === 49 || (99 < code && code < 108)) {
         return 'background-color';
     }
     return '';
@@ -280,10 +254,7 @@ function categoryForCode(_code: string | number): string {
 
 function pushText(text: string, options: AnsiToHtmlOptions): string {
     if (options.escapeXML) {
-        return text
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
+        return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 
     return text;
@@ -331,11 +302,7 @@ interface Token {
     sub: (m: string, ...args: any[]) => string;
 }
 
-function tokenize(
-    text: string,
-    options: AnsiToHtmlOptions,
-    callback: TokenizeCallback
-) {
+function tokenize(text: string, options: AnsiToHtmlOptions, callback: TokenizeCallback) {
     let ansiMatch = false;
     const ansiHandler = 3;
 
@@ -501,12 +468,7 @@ export class Filter {
         const buf: string[] = [];
 
         this.stickyStack.forEach((element: StickyStackElement) => {
-            const output: string = generateOutput(
-                stack,
-                element.token,
-                element.data,
-                options
-            );
+            const output: string = generateOutput(stack, element.token, element.data, options);
 
             if (output) {
                 buf.push(output);
@@ -521,11 +483,7 @@ export class Filter {
             }
 
             if (options.stream) {
-                this.stickyStack = updateStickyStack(
-                    this.stickyStack,
-                    token,
-                    data
-                );
+                this.stickyStack = updateStickyStack(this.stickyStack, token, data);
             }
         });
 

--- a/static/codelens-handler.ts
+++ b/static/codelens-handler.ts
@@ -37,10 +37,14 @@ const providersPerLanguage: Record<string, monaco.IDisposable> = {};
 export function registerLensesForCompiler(
     compilerId: number,
     editorModel: monaco.editor.ITextModel,
-    lenses: monaco.languages.CodeLens[]): void {
-    const item = _.find(registeredCodelenses, (item: RegisteredCodeLens): boolean => {
-        return item.compilerId === compilerId;
-    });
+    lenses: monaco.languages.CodeLens[]
+): void {
+    const item = _.find(
+        registeredCodelenses,
+        (item: RegisteredCodeLens): boolean => {
+            return item.compilerId === compilerId;
+        }
+    );
 
     if (item) {
         item.lenses = lenses;
@@ -53,10 +57,15 @@ export function registerLensesForCompiler(
     }
 }
 
-function provide(model: monaco.editor.ITextModel): monaco.languages.CodeLensList {
-    const item = _.find(registeredCodelenses, (item: RegisteredCodeLens): boolean => {
-        return item.editorModel === model;
-    });
+function provide(
+    model: monaco.editor.ITextModel
+): monaco.languages.CodeLensList {
+    const item = _.find(
+        registeredCodelenses,
+        (item: RegisteredCodeLens): boolean => {
+            return item.editorModel === model;
+        }
+    );
 
     if (item) {
         return {
@@ -72,9 +81,12 @@ function provide(model: monaco.editor.ITextModel): monaco.languages.CodeLensList
 }
 
 export function unregister(compilerId: number): void {
-    const item = _.find(registeredCodelenses, (item: RegisteredCodeLens): boolean => {
-        return item.compilerId === compilerId;
-    });
+    const item = _.find(
+        registeredCodelenses,
+        (item: RegisteredCodeLens): boolean => {
+            return item.compilerId === compilerId;
+        }
+    );
 
     if (item) {
         registeredCodelenses = _.without(registeredCodelenses, item);
@@ -83,8 +95,9 @@ export function unregister(compilerId: number): void {
 
 export function registerProviderForLanguage(language: string): void {
     if (!(language in providersPerLanguage)) {
-        providersPerLanguage[language] = monaco.languages.registerCodeLensProvider(language, {
-            provideCodeLenses: provide,
-        });
+        providersPerLanguage[language] =
+            monaco.languages.registerCodeLensProvider(language, {
+                provideCodeLenses: provide,
+            });
     }
 }

--- a/static/codelens-handler.ts
+++ b/static/codelens-handler.ts
@@ -39,12 +39,9 @@ export function registerLensesForCompiler(
     editorModel: monaco.editor.ITextModel,
     lenses: monaco.languages.CodeLens[]
 ): void {
-    const item = _.find(
-        registeredCodelenses,
-        (item: RegisteredCodeLens): boolean => {
-            return item.compilerId === compilerId;
-        }
-    );
+    const item = _.find(registeredCodelenses, (item: RegisteredCodeLens): boolean => {
+        return item.compilerId === compilerId;
+    });
 
     if (item) {
         item.lenses = lenses;
@@ -57,15 +54,10 @@ export function registerLensesForCompiler(
     }
 }
 
-function provide(
-    model: monaco.editor.ITextModel
-): monaco.languages.CodeLensList {
-    const item = _.find(
-        registeredCodelenses,
-        (item: RegisteredCodeLens): boolean => {
-            return item.editorModel === model;
-        }
-    );
+function provide(model: monaco.editor.ITextModel): monaco.languages.CodeLensList {
+    const item = _.find(registeredCodelenses, (item: RegisteredCodeLens): boolean => {
+        return item.editorModel === model;
+    });
 
     if (item) {
         return {
@@ -81,12 +73,9 @@ function provide(
 }
 
 export function unregister(compilerId: number): void {
-    const item = _.find(
-        registeredCodelenses,
-        (item: RegisteredCodeLens): boolean => {
-            return item.compilerId === compilerId;
-        }
-    );
+    const item = _.find(registeredCodelenses, (item: RegisteredCodeLens): boolean => {
+        return item.compilerId === compilerId;
+    });
 
     if (item) {
         registeredCodelenses = _.without(registeredCodelenses, item);
@@ -95,9 +84,8 @@ export function unregister(compilerId: number): void {
 
 export function registerProviderForLanguage(language: string): void {
     if (!(language in providersPerLanguage)) {
-        providersPerLanguage[language] =
-            monaco.languages.registerCodeLensProvider(language, {
-                provideCodeLenses: provide,
-            });
+        providersPerLanguage[language] = monaco.languages.registerCodeLensProvider(language, {
+            provideCodeLenses: provide,
+        });
     }
 }

--- a/static/colour.ts
+++ b/static/colour.ts
@@ -70,23 +70,17 @@ export function applyColours(
     schemeName: string,
     previousDecorations: string[]
 ): string[] {
-    const scheme =
-        schemes.find(scheme => scheme.name === schemeName) ?? schemes[0];
-    const newDecorations: monaco.editor.IModelDeltaDecoration[] =
-        Object.entries(colours).map(([line, index]) => {
-            const realLineNumber = parseInt(line) + 1;
-            return {
-                range: new monaco.Range(realLineNumber, 1, realLineNumber, 1),
-                options: {
-                    isWholeLine: true,
-                    className:
-                        'line-linkage ' +
-                        scheme.name +
-                        '-' +
-                        (index % scheme.count),
-                },
-            };
-        });
+    const scheme = schemes.find(scheme => scheme.name === schemeName) ?? schemes[0];
+    const newDecorations: monaco.editor.IModelDeltaDecoration[] = Object.entries(colours).map(([line, index]) => {
+        const realLineNumber = parseInt(line) + 1;
+        return {
+            range: new monaco.Range(realLineNumber, 1, realLineNumber, 1),
+            options: {
+                isWholeLine: true,
+                className: 'line-linkage ' + scheme.name + '-' + (index % scheme.count),
+            },
+        };
+    });
 
     return editor.deltaDecorations(previousDecorations, newDecorations);
 }

--- a/static/colour.ts
+++ b/static/colour.ts
@@ -36,29 +36,54 @@ export interface ColourSchemeInfo {
 
 // If you want to use a scheme in every theme, set `theme: ['all']`
 export const schemes: ColourSchemeInfo[] = [
-    {name: 'rainbow', desc: 'Rainbow 1', count: 12, themes: ['default']},
-    {name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default']},
-    {name: 'earth', desc: 'Earth tones (colourblind safe)', count: 9, themes: ['default']},
-    {name: 'green-blue', desc: 'Greens and blues (colourblind safe)', count: 4, themes: ['default']},
-    {name: 'gray-shade', desc: 'Gray shades', count: 4, themes: ['dark', 'darkplus']},
-    {name: 'rainbow-dark', desc: 'Dark Rainbow', count: 12, themes: ['dark', 'darkplus']},
+    { name: 'rainbow', desc: 'Rainbow 1', count: 12, themes: ['default'] },
+    { name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default'] },
+    {
+        name: 'earth',
+        desc: 'Earth tones (colourblind safe)',
+        count: 9,
+        themes: ['default'],
+    },
+    {
+        name: 'green-blue',
+        desc: 'Greens and blues (colourblind safe)',
+        count: 4,
+        themes: ['default'],
+    },
+    {
+        name: 'gray-shade',
+        desc: 'Gray shades',
+        count: 4,
+        themes: ['dark', 'darkplus'],
+    },
+    {
+        name: 'rainbow-dark',
+        desc: 'Dark Rainbow',
+        count: 12,
+        themes: ['dark', 'darkplus'],
+    },
 ];
 
 export function applyColours(
     editor: monaco.editor.ICodeEditor,
     colours: Record<number, number>,
     schemeName: string,
-    previousDecorations: string[]
+    previousDecorations: string[],
 ): string[] {
-    const scheme = schemes.find((scheme) => scheme.name === schemeName) ?? schemes[0];
-    const newDecorations: monaco.editor.IModelDeltaDecoration[] = Object.entries(colours)
-        .map(([line, index]) => {
+    const scheme =
+        schemes.find(scheme => scheme.name === schemeName) ?? schemes[0];
+    const newDecorations: monaco.editor.IModelDeltaDecoration[] =
+        Object.entries(colours).map(([line, index]) => {
             const realLineNumber = parseInt(line) + 1;
             return {
                 range: new monaco.Range(realLineNumber, 1, realLineNumber, 1),
                 options: {
                     isWholeLine: true,
-                    className: 'line-linkage ' + scheme.name + '-' + (index % scheme.count),
+                    className:
+                        'line-linkage ' +
+                        scheme.name +
+                        '-' +
+                        (index % scheme.count),
                 },
             };
         });

--- a/static/colour.ts
+++ b/static/colour.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import * as monaco from 'monaco-editor';
-import { Themes } from './themes';
+import {Themes} from './themes';
 
 export type AppTheme = Themes | 'all';
 
@@ -36,8 +36,8 @@ export interface ColourSchemeInfo {
 
 // If you want to use a scheme in every theme, set `theme: ['all']`
 export const schemes: ColourSchemeInfo[] = [
-    { name: 'rainbow', desc: 'Rainbow 1', count: 12, themes: ['default'] },
-    { name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default'] },
+    {name: 'rainbow', desc: 'Rainbow 1', count: 12, themes: ['default']},
+    {name: 'rainbow2', desc: 'Rainbow 2', count: 12, themes: ['default']},
     {
         name: 'earth',
         desc: 'Earth tones (colourblind safe)',
@@ -68,7 +68,7 @@ export function applyColours(
     editor: monaco.editor.ICodeEditor,
     colours: Record<number, number>,
     schemeName: string,
-    previousDecorations: string[],
+    previousDecorations: string[]
 ): string[] {
     const scheme =
         schemes.find(scheme => scheme.name === schemeName) ?? schemes[0];

--- a/static/compiler-picker.ts
+++ b/static/compiler-picker.ts
@@ -64,11 +64,7 @@ export class CompilerPicker {
         this.domNode = compilerPicker;
         this.compilerService = hub.compilerService;
         this.onCompilerChange = onCompilerChange;
-        this.eventHub.on(
-            'compilerFavoriteChange',
-            this.onCompilerFavoriteChange,
-            this
-        );
+        this.eventHub.on('compilerFavoriteChange', this.onCompilerFavoriteChange, this);
         this.tomSelect = null;
         if (compilerIsVisible) {
             this.compilerIsVisible = compilerIsVisible;
@@ -125,13 +121,8 @@ export class CompilerPicker {
             duplicates: true,
             render: {
                 option: (data, escape) => {
-                    const isFavoriteGroup =
-                        data.$groups.indexOf(
-                            CompilerPicker.favoriteGroupName
-                        ) !== -1;
-                    const extraClasses = isFavoriteGroup
-                        ? 'fas fa-star fav'
-                        : 'far fa-star';
+                    const isFavoriteGroup = data.$groups.indexOf(CompilerPicker.favoriteGroupName) !== -1;
+                    const extraClasses = isFavoriteGroup ? 'fas fa-star fav' : 'far fa-star';
                     return (
                         '<div class="d-flex"><div>' +
                         escape(data.name) +
@@ -156,19 +147,14 @@ export class CompilerPicker {
                 const clickedGroup = optionElement.parentElement.dataset.group;
                 const value = optionElement.dataset.value;
                 const data = this.tomSelect.options[value];
-                const isAddingNewFavorite =
-                    data.$groups.indexOf(CompilerPicker.favoriteGroupName) ===
-                    -1;
+                const isAddingNewFavorite = data.$groups.indexOf(CompilerPicker.favoriteGroupName) === -1;
                 const elemTop = optionElement.offsetTop;
 
                 if (isAddingNewFavorite) {
                     data.$groups.push(CompilerPicker.favoriteGroupName);
                     this.addToFavorites(data.id);
                 } else {
-                    data.$groups.splice(
-                        data.group.indexOf(CompilerPicker.favoriteGroupName),
-                        1
-                    );
+                    data.$groups.splice(data.group.indexOf(CompilerPicker.favoriteGroupName), 1);
                     this.removeFromFavorites(data.id);
                 }
 
@@ -180,14 +166,10 @@ export class CompilerPicker {
                     // or removed a bunch of controls way up in the list. Find the new element top and adjust the scroll
                     // so the element that was just clicked is back under the mouse.
                     optionElement = this.tomSelect.getOption(value);
-                    const previousSmooth =
-                        this.tomSelect.dropdown_content.style.scrollBehavior;
-                    this.tomSelect.dropdown_content.style.scrollBehavior =
-                        'auto';
-                    this.tomSelect.dropdown_content.scrollTop +=
-                        optionElement.offsetTop - elemTop;
-                    this.tomSelect.dropdown_content.style.scrollBehavior =
-                        previousSmooth;
+                    const previousSmooth = this.tomSelect.dropdown_content.style.scrollBehavior;
+                    this.tomSelect.dropdown_content.style.scrollBehavior = 'auto';
+                    this.tomSelect.dropdown_content.scrollTop += optionElement.offsetTop - elemTop;
+                    this.tomSelect.dropdown_content.style.scrollBehavior = previousSmooth;
                 }
             }
         });
@@ -195,20 +177,11 @@ export class CompilerPicker {
 
     getOptions(langId: string, compilerId: string) {
         const favorites = this.getFavorites();
-        return (
-            Object.values(
-                this.compilerService.getCompilersForLang(langId)
-            ) as any[]
-        )
-            .filter(
-                e =>
-                    (this.compilerIsVisible(e) && !e.hidden) ||
-                    e.id === compilerId
-            )
+        return (Object.values(this.compilerService.getCompilersForLang(langId)) as any[])
+            .filter(e => (this.compilerIsVisible(e) && !e.hidden) || e.id === compilerId)
             .map(e => {
                 e.$groups = [e.group];
-                if (favorites[e.id])
-                    e.$groups.unshift(CompilerPicker.favoriteGroupName);
+                if (favorites[e.id]) e.$groups.unshift(CompilerPicker.favoriteGroupName);
                 return e;
             });
     }

--- a/static/compiler-picker.ts
+++ b/static/compiler-picker.ts
@@ -24,13 +24,13 @@
 
 import TomSelect from 'tom-select';
 
-import { ga } from './analytics';
+import {ga} from './analytics';
 import * as local from './local';
-import { EventHub } from './event-hub';
-import { Hub } from './hub';
+import {EventHub} from './event-hub';
+import {Hub} from './hub';
 
 type Favourites = {
-    [compilerId: string]: boolean
+    [compilerId: string]: boolean;
 };
 
 export class CompilerPicker {
@@ -64,7 +64,11 @@ export class CompilerPicker {
         this.domNode = compilerPicker;
         this.compilerService = hub.compilerService;
         this.onCompilerChange = onCompilerChange;
-        this.eventHub.on('compilerFavoriteChange', this.onCompilerFavoriteChange, this);
+        this.eventHub.on(
+            'compilerFavoriteChange',
+            this.onCompilerFavoriteChange,
+            this
+        );
         this.tomSelect = null;
         if (compilerIsVisible) {
             this.compilerIsVisible = compilerIsVisible;
@@ -80,8 +84,7 @@ export class CompilerPicker {
         // bypasses this function and does compilerEntry.picker.tomSelect.close(); manually. This function is the
         // only time this.tomSelect can be null, might be nice if we can get rid of that.
         this.eventHub.unsubscribe();
-        if (this.tomSelect)
-            this.tomSelect.destroy();
+        if (this.tomSelect) this.tomSelect.destroy();
         this.tomSelect = null;
     }
 
@@ -104,7 +107,7 @@ export class CompilerPicker {
             closeAfterSelect: true,
             plugins: ['dropdown_input'],
             maxOptions: 1000,
-            onChange: (val) => {
+            onChange: val => {
                 // TODO(jeremy-rifkin) I don't think this can be undefined.
                 // Typing here needs improvement later anyway.
                 /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */
@@ -122,13 +125,24 @@ export class CompilerPicker {
             duplicates: true,
             render: {
                 option: (data, escape) => {
-                    const isFavoriteGroup = data.$groups.indexOf(CompilerPicker.favoriteGroupName) !== -1;
-                    const extraClasses = isFavoriteGroup ? 'fas fa-star fav' : 'far fa-star';
-                    return '<div class="d-flex"><div>' + escape(data.name) + '</div>' +
-                        '<div title="Click to mark or unmark as a favorite" class="ml-auto toggle-fav">' +
-                        '<i class="' + extraClasses + '"></i>' +
+                    const isFavoriteGroup =
+                        data.$groups.indexOf(
+                            CompilerPicker.favoriteGroupName
+                        ) !== -1;
+                    const extraClasses = isFavoriteGroup
+                        ? 'fas fa-star fav'
+                        : 'far fa-star';
+                    return (
+                        '<div class="d-flex"><div>' +
+                        escape(data.name) +
                         '</div>' +
-                        '</div>';
+                        '<div title="Click to mark or unmark as a favorite" class="ml-auto toggle-fav">' +
+                        '<i class="' +
+                        extraClasses +
+                        '"></i>' +
+                        '</div>' +
+                        '</div>'
+                    );
                 },
             },
         });
@@ -142,14 +156,19 @@ export class CompilerPicker {
                 const clickedGroup = optionElement.parentElement.dataset.group;
                 const value = optionElement.dataset.value;
                 const data = this.tomSelect.options[value];
-                const isAddingNewFavorite = data.$groups.indexOf(CompilerPicker.favoriteGroupName) === -1;
+                const isAddingNewFavorite =
+                    data.$groups.indexOf(CompilerPicker.favoriteGroupName) ===
+                    -1;
                 const elemTop = optionElement.offsetTop;
 
                 if (isAddingNewFavorite) {
                     data.$groups.push(CompilerPicker.favoriteGroupName);
                     this.addToFavorites(data.id);
                 } else {
-                    data.$groups.splice(data.group.indexOf(CompilerPicker.favoriteGroupName), 1);
+                    data.$groups.splice(
+                        data.group.indexOf(CompilerPicker.favoriteGroupName),
+                        1
+                    );
                     this.removeFromFavorites(data.id);
                 }
 
@@ -161,10 +180,14 @@ export class CompilerPicker {
                     // or removed a bunch of controls way up in the list. Find the new element top and adjust the scroll
                     // so the element that was just clicked is back under the mouse.
                     optionElement = this.tomSelect.getOption(value);
-                    const previousSmooth = this.tomSelect.dropdown_content.style.scrollBehavior;
-                    this.tomSelect.dropdown_content.style.scrollBehavior = 'auto';
-                    this.tomSelect.dropdown_content.scrollTop += (optionElement.offsetTop - elemTop);
-                    this.tomSelect.dropdown_content.style.scrollBehavior = previousSmooth;
+                    const previousSmooth =
+                        this.tomSelect.dropdown_content.style.scrollBehavior;
+                    this.tomSelect.dropdown_content.style.scrollBehavior =
+                        'auto';
+                    this.tomSelect.dropdown_content.scrollTop +=
+                        optionElement.offsetTop - elemTop;
+                    this.tomSelect.dropdown_content.style.scrollBehavior =
+                        previousSmooth;
                 }
             }
         });
@@ -172,8 +195,16 @@ export class CompilerPicker {
 
     getOptions(langId: string, compilerId: string) {
         const favorites = this.getFavorites();
-        return (Object.values(this.compilerService.getCompilersForLang(langId)) as any[])
-            .filter(e => (this.compilerIsVisible(e) && !e.hidden) || e.id === compilerId)
+        return (
+            Object.values(
+                this.compilerService.getCompilersForLang(langId)
+            ) as any[]
+        )
+            .filter(
+                e =>
+                    (this.compilerIsVisible(e) && !e.hidden) ||
+                    e.id === compilerId
+            )
             .map(e => {
                 e.$groups = [e.group];
                 if (favorites[e.id])
@@ -184,7 +215,10 @@ export class CompilerPicker {
 
     getGroups(langId: string) {
         const optgroups = this.compilerService.getGroupsInUse(langId);
-        optgroups.unshift({value: CompilerPicker.favoriteGroupName, label: 'Favorites'});
+        optgroups.unshift({
+            value: CompilerPicker.favoriteGroupName,
+            label: 'Favorites',
+        });
         return optgroups;
     }
 

--- a/static/event-hub.ts
+++ b/static/event-hub.ts
@@ -25,13 +25,13 @@
 import GoldenLayout from 'golden-layout';
 import Sentry from '@sentry/browser';
 
-import { Hub } from './hub';
+import {Hub} from './hub';
 
 export type EventHubCallback<T extends unknown[]> = (...args: T) => void;
 
 export interface DependencyProxies<
     T1 extends unknown[],
-    T2 extends unknown[] = T1,
+    T2 extends unknown[] = T1
 > {
     dependencyProxy: EventHubCallback<T1>;
     dependentProxy: EventHubCallback<T2>;
@@ -76,10 +76,10 @@ export class EventHub {
     public on<T extends unknown[], C = any>(
         event: string,
         callback: EventHubCallback<T>,
-        context?: C,
+        context?: C
     ): void {
         this.layoutEventHub.on(event, callback, context);
-        this.subscriptions.push({ evt: event, fn: callback, ctx: context });
+        this.subscriptions.push({evt: event, fn: callback, ctx: context});
     }
 
     /** Remove all listeners from the layout event hub. */
@@ -89,11 +89,11 @@ export class EventHub {
                 this.layoutEventHub.off(
                     subscription.evt,
                     subscription.fn,
-                    subscription.ctx,
+                    subscription.ctx
                 );
             } catch (e) {
                 Sentry.captureMessage(
-                    `Can not unsubscribe from ${subscription.evt.toString()}`,
+                    `Can not unsubscribe from ${subscription.evt.toString()}`
                 );
                 Sentry.captureException(e);
             }
@@ -103,10 +103,10 @@ export class EventHub {
 
     public mediateDependentCalls<
         T1 extends unknown[],
-        T2 extends unknown[] = T1,
+        T2 extends unknown[] = T1
     >(
         dependent: EventHubCallback<any>,
-        dependency: EventHubCallback<any>,
+        dependency: EventHubCallback<any>
     ): DependencyProxies<T1, T2> {
         let hasDependencyExecuted = false;
         let lastDependentArguments: unknown[] | null = null;
@@ -125,6 +125,6 @@ export class EventHub {
                 lastDependentArguments = args;
             }
         };
-        return { dependencyProxy, dependentProxy };
+        return {dependencyProxy, dependentProxy};
     }
 }

--- a/static/event-hub.ts
+++ b/static/event-hub.ts
@@ -29,10 +29,7 @@ import {Hub} from './hub';
 
 export type EventHubCallback<T extends unknown[]> = (...args: T) => void;
 
-export interface DependencyProxies<
-    T1 extends unknown[],
-    T2 extends unknown[] = T1
-> {
+export interface DependencyProxies<T1 extends unknown[], T2 extends unknown[] = T1> {
     dependencyProxy: EventHubCallback<T1>;
     dependentProxy: EventHubCallback<T2>;
 }
@@ -73,11 +70,7 @@ export class EventHub {
     }
 
     /** Attach a listener to the layout event hub. */
-    public on<T extends unknown[], C = any>(
-        event: string,
-        callback: EventHubCallback<T>,
-        context?: C
-    ): void {
+    public on<T extends unknown[], C = any>(event: string, callback: EventHubCallback<T>, context?: C): void {
         this.layoutEventHub.on(event, callback, context);
         this.subscriptions.push({evt: event, fn: callback, ctx: context});
     }
@@ -86,25 +79,16 @@ export class EventHub {
     public unsubscribe(): void {
         for (const subscription of this.subscriptions) {
             try {
-                this.layoutEventHub.off(
-                    subscription.evt,
-                    subscription.fn,
-                    subscription.ctx
-                );
+                this.layoutEventHub.off(subscription.evt, subscription.fn, subscription.ctx);
             } catch (e) {
-                Sentry.captureMessage(
-                    `Can not unsubscribe from ${subscription.evt.toString()}`
-                );
+                Sentry.captureMessage(`Can not unsubscribe from ${subscription.evt.toString()}`);
                 Sentry.captureException(e);
             }
         }
         this.subscriptions = [];
     }
 
-    public mediateDependentCalls<
-        T1 extends unknown[],
-        T2 extends unknown[] = T1
-    >(
+    public mediateDependentCalls<T1 extends unknown[], T2 extends unknown[] = T1>(
         dependent: EventHubCallback<any>,
         dependency: EventHubCallback<any>
     ): DependencyProxies<T1, T2> {

--- a/static/event-hub.ts
+++ b/static/event-hub.ts
@@ -29,7 +29,10 @@ import { Hub } from './hub';
 
 export type EventHubCallback<T extends unknown[]> = (...args: T) => void;
 
-export interface DependencyProxies<T1 extends unknown[], T2 extends unknown[] = T1> {
+export interface DependencyProxies<
+    T1 extends unknown[],
+    T2 extends unknown[] = T1,
+> {
     dependencyProxy: EventHubCallback<T1>;
     dependentProxy: EventHubCallback<T2>;
 }
@@ -70,7 +73,11 @@ export class EventHub {
     }
 
     /** Attach a listener to the layout event hub. */
-    public on<T extends unknown[], C = any>(event: string, callback: EventHubCallback<T>, context?: C): void {
+    public on<T extends unknown[], C = any>(
+        event: string,
+        callback: EventHubCallback<T>,
+        context?: C,
+    ): void {
         this.layoutEventHub.on(event, callback, context);
         this.subscriptions.push({ evt: event, fn: callback, ctx: context });
     }
@@ -79,19 +86,28 @@ export class EventHub {
     public unsubscribe(): void {
         for (const subscription of this.subscriptions) {
             try {
-                this.layoutEventHub.off(subscription.evt, subscription.fn, subscription.ctx);
+                this.layoutEventHub.off(
+                    subscription.evt,
+                    subscription.fn,
+                    subscription.ctx,
+                );
             } catch (e) {
-                Sentry.captureMessage(`Can not unsubscribe from ${subscription.evt.toString()}`);
+                Sentry.captureMessage(
+                    `Can not unsubscribe from ${subscription.evt.toString()}`,
+                );
                 Sentry.captureException(e);
             }
         }
         this.subscriptions = [];
     }
 
-    public mediateDependentCalls<T1 extends unknown[], T2 extends unknown[]= T1>(
+    public mediateDependentCalls<
+        T1 extends unknown[],
+        T2 extends unknown[] = T1,
+    >(
         dependent: EventHubCallback<any>,
-        dependency: EventHubCallback<any>
-    ): DependencyProxies<T1, T2>  {
+        dependency: EventHubCallback<any>,
+    ): DependencyProxies<T1, T2> {
         let hasDependencyExecuted = false;
         let lastDependentArguments: unknown[] | null = null;
         const dependencyProxy = function (this: unknown, ...args: unknown[]) {

--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -33,13 +33,10 @@ import {getFormattedCode} from './api/api';
 // Proxy function to emit the error to the alert system
 const onFormatError = (cause: string, source: string) => {
     const alertSystem = new Alert();
-    alertSystem.notify(
-        `We encountered an error formatting your code: ${cause}`,
-        {
-            group: 'formatting',
-            alertClass: 'notification-error',
-        }
-    );
+    alertSystem.notify(`We encountered an error formatting your code: ${cause}`, {
+        group: 'formatting',
+        alertClass: 'notification-error',
+    });
     return source;
 };
 

--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -33,10 +33,13 @@ import { getFormattedCode } from './api/api';
 // Proxy function to emit the error to the alert system
 const onFormatError = (cause: string, source: string) => {
     const alertSystem = new Alert();
-    alertSystem.notify(`We encountered an error formatting your code: ${cause}`, {
-        group: 'formatting',
-        alertClass: 'notification-error',
-    });
+    alertSystem.notify(
+        `We encountered an error formatting your code: ${cause}`,
+        {
+            group: 'formatting',
+            alertClass: 'notification-error',
+        },
+    );
     return source;
 };
 
@@ -64,12 +67,12 @@ const doFormatRequest = async (options: FormattingRequest) => {
 const getDocumentFormatter = (
     language: string,
     formatter: string,
-    isOneTrueStyle: boolean
+    isOneTrueStyle: boolean,
 ): monaco.languages.DocumentFormattingEditProvider => ({
     async provideDocumentFormattingEdits(
         model: monaco.editor.ITextModel,
         options: monaco.languages.FormattingOptions,
-        token: monaco.CancellationToken
+        token: monaco.CancellationToken,
     ): Promise<monaco.languages.TextEdit[]> {
         const settings = Settings.getStoredSettings();
         // If there is only one style, return __DefaultStyle.
@@ -84,10 +87,12 @@ const getDocumentFormatter = (
             source,
             base,
         }).catch(err => onFormatError(err, source));
-        return [{
-            range: model.getFullModelRange(),
-            text: formattedSource,
-        }];
+        return [
+            {
+                range: model.getFullModelRange(),
+                text: formattedSource,
+            },
+        ];
     },
 });
 

--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -24,11 +24,11 @@
 
 import * as monaco from 'monaco-editor';
 
-import { Alert } from './alert';
-import { Settings } from './settings';
-import { SiteSettings } from './settings';
-import { FormattingRequest } from './api/formatting.interfaces';
-import { getFormattedCode } from './api/api';
+import {Alert} from './alert';
+import {Settings} from './settings';
+import {SiteSettings} from './settings';
+import {FormattingRequest} from './api/formatting.interfaces';
+import {getFormattedCode} from './api/api';
 
 // Proxy function to emit the error to the alert system
 const onFormatError = (cause: string, source: string) => {
@@ -38,7 +38,7 @@ const onFormatError = (cause: string, source: string) => {
         {
             group: 'formatting',
             alertClass: 'notification-error',
-        },
+        }
     );
     return source;
 };
@@ -67,12 +67,12 @@ const doFormatRequest = async (options: FormattingRequest) => {
 const getDocumentFormatter = (
     language: string,
     formatter: string,
-    isOneTrueStyle: boolean,
+    isOneTrueStyle: boolean
 ): monaco.languages.DocumentFormattingEditProvider => ({
     async provideDocumentFormattingEdits(
         model: monaco.editor.ITextModel,
         options: monaco.languages.FormattingOptions,
-        token: monaco.CancellationToken,
+        token: monaco.CancellationToken
     ): Promise<monaco.languages.TextEdit[]> {
         const settings = Settings.getStoredSettings();
         // If there is only one style, return __DefaultStyle.

--- a/static/global.ts
+++ b/static/global.ts
@@ -22,8 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { IFrontendTesting } from './tests/frontend-testing.interfaces';
-import { Options } from './options.interfaces';
+import {IFrontendTesting} from './tests/frontend-testing.interfaces';
+import {Options} from './options.interfaces';
 
 type CompilerExplorerOptions = Record<string, unknown> & Options;
 

--- a/static/global.ts
+++ b/static/global.ts
@@ -25,7 +25,7 @@
 import { IFrontendTesting } from './tests/frontend-testing.interfaces';
 import { Options } from './options.interfaces';
 
-type CompilerExplorerOptions = Record<string, unknown> & Options
+type CompilerExplorerOptions = Record<string, unknown> & Options;
 
 declare global {
     export interface Window {

--- a/static/history.ts
+++ b/static/history.ts
@@ -24,12 +24,12 @@
 
 import * as local from './local';
 import _ from 'underscore';
-import { Sharing } from './sharing';
+import {Sharing} from './sharing';
 
 const maxHistoryEntries = 30;
-type Source = { dt: number; source: string };
-export type HistoryEntry = { dt: number; sources: EditorSource[]; config: any };
-export type EditorSource = { lang: string; source: string };
+type Source = {dt: number; source: string};
+export type HistoryEntry = {dt: number; sources: EditorSource[]; config: any};
+export type EditorSource = {lang: string; source: string};
 
 function extractEditorSources(content: any[]): EditorSource[] {
     const sources: EditorSource[] = [];
@@ -54,21 +54,21 @@ function list(): HistoryEntry[] {
 }
 
 function getArrayWithJustTheCode(
-    editorSources: Record<string, any>[],
+    editorSources: Record<string, any>[]
 ): string[] {
     return editorSources.map(s => s.source);
 }
 
 function getSimilarSourcesIndex(
     completeHistory: HistoryEntry[],
-    sourcesToCompareTo: any[],
+    sourcesToCompareTo: any[]
 ): number {
     let duplicateIdx = -1;
 
     for (let i = 0; i < completeHistory.length; i++) {
         const diff = _.difference(
             sourcesToCompareTo,
-            getArrayWithJustTheCode(completeHistory[i].sources),
+            getArrayWithJustTheCode(completeHistory[i].sources)
         );
         if (diff.length === 0) {
             duplicateIdx = i;
@@ -86,7 +86,7 @@ function push(stringifiedConfig: string) {
         const completeHistory = list();
         const duplicateIdx = getSimilarSourcesIndex(
             completeHistory,
-            getArrayWithJustTheCode(sources),
+            getArrayWithJustTheCode(sources)
         );
 
         if (duplicateIdx === -1) {
@@ -112,7 +112,7 @@ export function trackHistory(layout: any) {
     const debouncedPush = _.debounce(push, 500);
     layout.on('stateChanged', () => {
         const stringifiedConfig = JSON.stringify(
-            Sharing.filterComponentState(layout.toConfig()),
+            Sharing.filterComponentState(layout.toConfig())
         );
         if (stringifiedConfig !== lastState) {
             lastState = stringifiedConfig;

--- a/static/history.ts
+++ b/static/history.ts
@@ -26,11 +26,10 @@ import * as local from './local';
 import _ from 'underscore';
 import { Sharing } from './sharing';
 
-
 const maxHistoryEntries = 30;
-type Source = {dt: number, source: string};
-export type HistoryEntry = {dt: number, sources: EditorSource[], config: any};
-export type EditorSource = {lang: string, source: string};
+type Source = { dt: number; source: string };
+export type HistoryEntry = { dt: number; sources: EditorSource[]; config: any };
+export type EditorSource = { lang: string; source: string };
 
 function extractEditorSources(content: any[]): EditorSource[] {
     const sources: EditorSource[] = [];
@@ -54,15 +53,23 @@ function list(): HistoryEntry[] {
     return JSON.parse(local.get('history', '[]'));
 }
 
-function getArrayWithJustTheCode(editorSources: Record<string, any>[]): string[] {
+function getArrayWithJustTheCode(
+    editorSources: Record<string, any>[],
+): string[] {
     return editorSources.map(s => s.source);
 }
 
-function getSimilarSourcesIndex(completeHistory: HistoryEntry[], sourcesToCompareTo: any[]): number {
+function getSimilarSourcesIndex(
+    completeHistory: HistoryEntry[],
+    sourcesToCompareTo: any[],
+): number {
     let duplicateIdx = -1;
 
     for (let i = 0; i < completeHistory.length; i++) {
-        const diff = _.difference(sourcesToCompareTo, getArrayWithJustTheCode(completeHistory[i].sources));
+        const diff = _.difference(
+            sourcesToCompareTo,
+            getArrayWithJustTheCode(completeHistory[i].sources),
+        );
         if (diff.length === 0) {
             duplicateIdx = i;
             break;
@@ -77,7 +84,10 @@ function push(stringifiedConfig: string) {
     const sources = extractEditorSources(config.content);
     if (sources.length > 0) {
         const completeHistory = list();
-        const duplicateIdx = getSimilarSourcesIndex(completeHistory, getArrayWithJustTheCode(sources));
+        const duplicateIdx = getSimilarSourcesIndex(
+            completeHistory,
+            getArrayWithJustTheCode(sources),
+        );
 
         if (duplicateIdx === -1) {
             while (completeHistory.length >= maxHistoryEntries) {
@@ -101,7 +111,9 @@ export function trackHistory(layout: any) {
     let lastState: string | null = null;
     const debouncedPush = _.debounce(push, 500);
     layout.on('stateChanged', () => {
-        const stringifiedConfig = JSON.stringify(Sharing.filterComponentState(layout.toConfig()));
+        const stringifiedConfig = JSON.stringify(
+            Sharing.filterComponentState(layout.toConfig()),
+        );
         if (stringifiedConfig !== lastState) {
             lastState = stringifiedConfig;
             debouncedPush(stringifiedConfig);

--- a/static/history.ts
+++ b/static/history.ts
@@ -53,23 +53,15 @@ function list(): HistoryEntry[] {
     return JSON.parse(local.get('history', '[]'));
 }
 
-function getArrayWithJustTheCode(
-    editorSources: Record<string, any>[]
-): string[] {
+function getArrayWithJustTheCode(editorSources: Record<string, any>[]): string[] {
     return editorSources.map(s => s.source);
 }
 
-function getSimilarSourcesIndex(
-    completeHistory: HistoryEntry[],
-    sourcesToCompareTo: any[]
-): number {
+function getSimilarSourcesIndex(completeHistory: HistoryEntry[], sourcesToCompareTo: any[]): number {
     let duplicateIdx = -1;
 
     for (let i = 0; i < completeHistory.length; i++) {
-        const diff = _.difference(
-            sourcesToCompareTo,
-            getArrayWithJustTheCode(completeHistory[i].sources)
-        );
+        const diff = _.difference(sourcesToCompareTo, getArrayWithJustTheCode(completeHistory[i].sources));
         if (diff.length === 0) {
             duplicateIdx = i;
             break;
@@ -84,10 +76,7 @@ function push(stringifiedConfig: string) {
     const sources = extractEditorSources(config.content);
     if (sources.length > 0) {
         const completeHistory = list();
-        const duplicateIdx = getSimilarSourcesIndex(
-            completeHistory,
-            getArrayWithJustTheCode(sources)
-        );
+        const duplicateIdx = getSimilarSourcesIndex(completeHistory, getArrayWithJustTheCode(sources));
 
         if (duplicateIdx === -1) {
             while (completeHistory.length >= maxHistoryEntries) {
@@ -111,9 +100,7 @@ export function trackHistory(layout: any) {
     let lastState: string | null = null;
     const debouncedPush = _.debounce(push, 500);
     layout.on('stateChanged', () => {
-        const stringifiedConfig = JSON.stringify(
-            Sharing.filterComponentState(layout.toConfig())
-        );
+        const stringifiedConfig = JSON.stringify(Sharing.filterComponentState(layout.toConfig()));
         if (stringifiedConfig !== lastState) {
             lastState = stringifiedConfig;
             debouncedPush(stringifiedConfig);

--- a/static/hub.ts
+++ b/static/hub.ts
@@ -22,35 +22,35 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import GoldenLayout, { ContentItem } from 'golden-layout';
+import GoldenLayout, {ContentItem} from 'golden-layout';
 
-import { CompilerService } from './compiler-service';
-import { IdentifierSet } from './identifier-set';
-import { EventHub } from './event-hub';
+import {CompilerService} from './compiler-service';
+import {IdentifierSet} from './identifier-set';
+import {EventHub} from './event-hub';
 import * as Components from './components';
 
-import { Tree } from './panes/tree';
-import { Editor } from './panes/editor';
-import { Compiler } from './panes/compiler';
-import { Executor } from './panes/executor';
-import { Output } from './panes/output';
-import { Tool } from './panes/tool';
-import { Diff, getComponent as getDiffComponent } from './panes/diff';
-import { ToolInputView } from './panes/tool-input-view';
-import { Opt as OptView } from './panes/opt-view';
-import { Flags as FlagsView } from './panes/flags-view';
-import { PP as PreProcessorView } from './panes/pp-view';
-import { Ast as AstView } from './panes/ast-view';
-import { Ir as IrView } from './panes/ir-view';
-import { DeviceAsm as DeviceView } from './panes/device-view';
-import { GnatDebug as GnatDebugView } from './panes/gnatdebug-view';
-import { RustMir as RustMirView } from './panes/rustmir-view';
-import { RustHir as RustHirView } from './panes/rusthir-view';
-import { GccDump as GCCDumpView } from './panes/gccdump-view';
-import { Cfg as CfgView } from './panes/cfg-view';
-import { Conformance as ConformanceView } from './panes/conformance-view';
-import { GnatDebugTree as GnatDebugTreeView } from './panes/gnatdebugtree-view';
-import { RustMacroExp as RustMacroExpView } from './panes/rustmacroexp-view';
+import {Tree} from './panes/tree';
+import {Editor} from './panes/editor';
+import {Compiler} from './panes/compiler';
+import {Executor} from './panes/executor';
+import {Output} from './panes/output';
+import {Tool} from './panes/tool';
+import {Diff, getComponent as getDiffComponent} from './panes/diff';
+import {ToolInputView} from './panes/tool-input-view';
+import {Opt as OptView} from './panes/opt-view';
+import {Flags as FlagsView} from './panes/flags-view';
+import {PP as PreProcessorView} from './panes/pp-view';
+import {Ast as AstView} from './panes/ast-view';
+import {Ir as IrView} from './panes/ir-view';
+import {DeviceAsm as DeviceView} from './panes/device-view';
+import {GnatDebug as GnatDebugView} from './panes/gnatdebug-view';
+import {RustMir as RustMirView} from './panes/rustmir-view';
+import {RustHir as RustHirView} from './panes/rusthir-view';
+import {GccDump as GCCDumpView} from './panes/gccdump-view';
+import {Cfg as CfgView} from './panes/cfg-view';
+import {Conformance as ConformanceView} from './panes/conformance-view';
+import {GnatDebugTree as GnatDebugTreeView} from './panes/gnatdebugtree-view';
+import {RustMacroExp as RustMacroExpView} from './panes/rustmacroexp-view';
 import Sentry from '@sentry/browser';
 
 export class Hub {
@@ -71,77 +71,185 @@ export class Hub {
     public subdomainLangId: string | undefined;
     public defaultLangId: string;
 
-    public constructor(public readonly layout: GoldenLayout, subLangId: string, defaultLangId: string) {
+    public constructor(
+        public readonly layout: GoldenLayout,
+        subLangId: string,
+        defaultLangId: string
+    ) {
         this.lastOpenedLangId = null;
         this.subdomainLangId = subLangId || undefined;
         this.defaultLangId = defaultLangId;
         this.compilerService = new CompilerService(this.layout.eventHub);
 
-        layout.registerComponent(Components.getEditor().componentName, (c, s) => this.codeEditorFactory(c, s));
-        layout.registerComponent(Components.getCompiler().componentName, (c, s) => this.compilerFactory(c, s));
-        layout.registerComponent(Components.getTree().componentName, (c, s) => this.treeFactory(c, s));
-        layout.registerComponent(Components.getExecutor().componentName, (c, s) => this.executorFactory(c, s));
-        layout.registerComponent(Components.getOutput().componentName, (c, s) => this.outputFactory(c, s));
-        layout.registerComponent(Components.getToolViewWith().componentName, (c, s) => this.toolFactory(c, s));
+        layout.registerComponent(Components.getEditor().componentName, (c, s) =>
+            this.codeEditorFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getCompiler().componentName,
+            (c, s) => this.compilerFactory(c, s)
+        );
+        layout.registerComponent(Components.getTree().componentName, (c, s) =>
+            this.treeFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getExecutor().componentName,
+            (c, s) => this.executorFactory(c, s)
+        );
+        layout.registerComponent(Components.getOutput().componentName, (c, s) =>
+            this.outputFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getToolViewWith().componentName,
+            (c, s) => this.toolFactory(c, s)
+        );
         // eslint-disable-next-line max-len
-        layout.registerComponent(Components.getToolInputView().componentName, (c, s) => this.toolInputViewFactory(c, s));
-        layout.registerComponent(getDiffComponent().componentName, (c, s) => this.diffFactory(c, s));
-        layout.registerComponent(Components.getOptView().componentName, (c, s) => this.optViewFactory(c, s));
-        layout.registerComponent(Components.getFlagsView().componentName, (c, s) => this.flagsViewFactory(c, s));
-        layout.registerComponent(Components.getPpView().componentName, (c, s) => this.ppViewFactory(c, s));
-        layout.registerComponent(Components.getAstView().componentName, (c, s) => this.astViewFactory(c, s));
-        layout.registerComponent(Components.getIrView().componentName, (c, s) => this.irViewFactory(c, s));
-        layout.registerComponent(Components.getDeviceView().componentName, (c, s) => this.deviceViewFactory(c, s));
-        layout.registerComponent(Components.getRustMirView().componentName, (c, s) => this.rustMirViewFactory(c, s));
+        layout.registerComponent(
+            Components.getToolInputView().componentName,
+            (c, s) => this.toolInputViewFactory(c, s)
+        );
+        layout.registerComponent(getDiffComponent().componentName, (c, s) =>
+            this.diffFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getOptView().componentName,
+            (c, s) => this.optViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getFlagsView().componentName,
+            (c, s) => this.flagsViewFactory(c, s)
+        );
+        layout.registerComponent(Components.getPpView().componentName, (c, s) =>
+            this.ppViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getAstView().componentName,
+            (c, s) => this.astViewFactory(c, s)
+        );
+        layout.registerComponent(Components.getIrView().componentName, (c, s) =>
+            this.irViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getDeviceView().componentName,
+            (c, s) => this.deviceViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getRustMirView().componentName,
+            (c, s) => this.rustMirViewFactory(c, s)
+        );
         // eslint-disable-next-line max-len
-        layout.registerComponent(Components.getGnatDebugTreeView().componentName, (c, s) => this.gnatDebugTreeViewFactory(c, s));
+        layout.registerComponent(
+            Components.getGnatDebugTreeView().componentName,
+            (c, s) => this.gnatDebugTreeViewFactory(c, s)
+        );
         // eslint-disable-next-line max-len
-        layout.registerComponent(Components.getGnatDebugView().componentName, (c, s) => this.gnatDebugViewFactory(c, s));
+        layout.registerComponent(
+            Components.getGnatDebugView().componentName,
+            (c, s) => this.gnatDebugViewFactory(c, s)
+        );
         // eslint-disable-next-line max-len
-        layout.registerComponent(Components.getRustMacroExpView().componentName, (c, s) => this.rustMacroExpViewFactory(c, s));
-        layout.registerComponent(Components.getRustHirView().componentName, (c, s) => this.rustHirViewFactory(c, s));
-        layout.registerComponent(Components.getGccDumpView().componentName, (c, s) => this.gccDumpViewFactory(c, s));
-        layout.registerComponent(Components.getCfgView().componentName, (c, s) => this.cfgViewFactory(c, s));
+        layout.registerComponent(
+            Components.getRustMacroExpView().componentName,
+            (c, s) => this.rustMacroExpViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getRustHirView().componentName,
+            (c, s) => this.rustHirViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getGccDumpView().componentName,
+            (c, s) => this.gccDumpViewFactory(c, s)
+        );
+        layout.registerComponent(
+            Components.getCfgView().componentName,
+            (c, s) => this.cfgViewFactory(c, s)
+        );
         // eslint-disable-next-line max-len
-        layout.registerComponent(Components.getConformanceView().componentName, (c, s) => this.conformanceViewFactory(c, s));
+        layout.registerComponent(
+            Components.getConformanceView().componentName,
+            (c, s) => this.conformanceViewFactory(c, s)
+        );
 
-        layout.eventHub.on('editorOpen', function (this: Hub, id: number) {
-            this.editorIds.add(id);
-        }, this);
-        layout.eventHub.on('editorClose', function (this: Hub, id: number) {
-            this.editorIds.remove(id);
-        }, this);
-        layout.eventHub.on('compilerOpen', function (this: Hub, id: number) {
-            this.compilerIds.add(id);
-        }, this);
-        layout.eventHub.on('compilerClose', function (this: Hub, id: number) {
-            this.compilerIds.remove(id);
-        }, this);
-        layout.eventHub.on('treeOpen', function (this: Hub, id: number) {
-            this.treeIds.add(id);
-        }, this);
-        layout.eventHub.on('treeClose', function (this: Hub, id: number) {
-            this.treeIds.remove(id);
-        }, this);
-        layout.eventHub.on('executorOpen', function (this: Hub, id: number) {
-            this.executorIds.add(id);
-        }, this);
-        layout.eventHub.on('executorClose', function (this: Hub, id: number) {
-            this.executorIds.remove(id);
-        }, this);
-        layout.eventHub.on('languageChange', function (this: Hub, editorId: number, langId: string) {
-            this.lastOpenedLangId = langId;
-        }, this);
+        layout.eventHub.on(
+            'editorOpen',
+            function (this: Hub, id: number) {
+                this.editorIds.add(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'editorClose',
+            function (this: Hub, id: number) {
+                this.editorIds.remove(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'compilerOpen',
+            function (this: Hub, id: number) {
+                this.compilerIds.add(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'compilerClose',
+            function (this: Hub, id: number) {
+                this.compilerIds.remove(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'treeOpen',
+            function (this: Hub, id: number) {
+                this.treeIds.add(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'treeClose',
+            function (this: Hub, id: number) {
+                this.treeIds.remove(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'executorOpen',
+            function (this: Hub, id: number) {
+                this.executorIds.add(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'executorClose',
+            function (this: Hub, id: number) {
+                this.executorIds.remove(id);
+            },
+            this
+        );
+        layout.eventHub.on(
+            'languageChange',
+            function (this: Hub, editorId: number, langId: string) {
+                this.lastOpenedLangId = langId;
+            },
+            this
+        );
 
         layout.init();
         this.undefer();
         layout.eventHub.emit('initialised');
     }
 
-    public nextTreeId(): number { return this.treeIds.next(); }
-    public nextEditorId(): number { return this.editorIds.next(); }
-    public nextCompilerId(): number { return this.compilerIds.next(); }
-    public nextExecutorId(): number { return this.executorIds.next(); }
+    public nextTreeId(): number {
+        return this.treeIds.next();
+    }
+    public nextEditorId(): number {
+        return this.editorIds.next();
+    }
+    public nextCompilerId(): number {
+        return this.compilerIds.next();
+    }
+    public nextExecutorId(): number {
+        return this.executorIds.next();
+    }
 
     public createEventHub(): EventHub {
         return new EventHub(this, this.layout.eventHub);
@@ -189,7 +297,9 @@ export class Hub {
     }
 
     public getTreesWithEditorId(editorId: number) {
-        return this.trees.filter((tree) => tree.multifileService.isEditorPartOfProject(editorId));
+        return this.trees.filter(tree =>
+            tree.multifileService.isEditorPartOfProject(editorId)
+        );
     }
 
     public getTrees(): Tree[] {
@@ -206,27 +316,42 @@ export class Hub {
 
     // Layout getters
 
-    public findParentRowOrColumn(elem: GoldenLayout.ContentItem): GoldenLayout.ContentItem {
+    public findParentRowOrColumn(
+        elem: GoldenLayout.ContentItem
+    ): GoldenLayout.ContentItem {
         let currentElem: GoldenLayout.ContentItem | null = elem;
         while (currentElem) {
             if (currentElem.isRow || currentElem.isColumn) return currentElem;
             currentElem = currentElem.parent as GoldenLayout.ContentItem | null;
         }
-        Sentry.captureMessage('findParentRowOrColumn: Unable to find parent row or column');
+        Sentry.captureMessage(
+            'findParentRowOrColumn: Unable to find parent row or column'
+        );
         return null as any;
     }
 
-    public findParentRowOrColumnOrStack(elem: GoldenLayout.ContentItem): GoldenLayout.ContentItem {
+    public findParentRowOrColumnOrStack(
+        elem: GoldenLayout.ContentItem
+    ): GoldenLayout.ContentItem {
         let currentElem: GoldenLayout.ContentItem | null = elem;
         while (currentElem) {
-            if (currentElem.isRow || currentElem.isColumn || currentElem.isStack) return currentElem;
+            if (
+                currentElem.isRow ||
+                currentElem.isColumn ||
+                currentElem.isStack
+            )
+                return currentElem;
             currentElem = currentElem.parent as GoldenLayout.ContentItem | null;
         }
-        Sentry.captureMessage('#findParentRowOrColumnOrStack: Unable to find parent row, column, or stack');
+        Sentry.captureMessage(
+            '#findParentRowOrColumnOrStack: Unable to find parent row, column, or stack'
+        );
         return null as any;
     }
 
-    public findEditorInChildren(elem: GoldenLayout.ContentItem): GoldenLayout.ContentItem | boolean {
+    public findEditorInChildren(
+        elem: GoldenLayout.ContentItem
+    ): GoldenLayout.ContentItem | boolean {
         const count = elem.contentItems.length;
         let index = 0;
         while (index < count) {
@@ -263,15 +388,20 @@ export class Hub {
     }
 
     public addAtRoot(elem: GoldenLayout.ContentItem): void {
-        const rootFirstItem = this.layout.root.contentItems[0] as typeof this.layout.root.contentItems[0] | undefined;
+        const rootFirstItem = this.layout.root.contentItems[0] as
+            | typeof this.layout.root.contentItems[0]
+            | undefined;
         if (rootFirstItem) {
             if (rootFirstItem.isRow || rootFirstItem.isColumn) {
                 rootFirstItem.addChild(elem);
             } else {
                 // @ts-expect-error -- GoldenLayout's types are messed up here?
-                const newRow: ContentItem = this.layout.createContentItem({
-                    type: 'row',
-                }, this.layout.root);
+                const newRow: ContentItem = this.layout.createContentItem(
+                    {
+                        type: 'row',
+                    },
+                    this.layout.root
+                );
                 this.layout.root.replaceChild(rootFirstItem, newRow);
                 newRow.addChild(rootFirstItem);
                 newRow.addChild(elem);
@@ -285,14 +415,19 @@ export class Hub {
     }
 
     public activateTabForContainer(container?: GoldenLayout.Container) {
-        if (container && container.tab as typeof container.tab | null) {
-            container.tab.header.parent.setActiveContentItem(container.tab.contentItem);
+        if (container && (container.tab as typeof container.tab | null)) {
+            container.tab.header.parent.setActiveContentItem(
+                container.tab.contentItem
+            );
         }
     }
 
     // Component Factories
 
-    private codeEditorFactory(container: GoldenLayout.Container, state: any): void {
+    private codeEditorFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): void {
         // Ensure editors are closable: some older versions had 'isClosable' false.
         // NB there doesn't seem to be a better way to do this than reach into the config and rely on the fact nothing
         // has used it yet.
@@ -307,83 +442,143 @@ export class Hub {
         return tree;
     }
 
-    public compilerFactory(container: GoldenLayout.Container, state: any): any /* typeof Compiler */ {
+    public compilerFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof Compiler */ {
         return new Compiler(this, container, state);
     }
 
-    public executorFactory(container: GoldenLayout.Container, state: any): any /* typeof Executor */ {
+    public executorFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof Executor */ {
         return new Executor(this, container, state);
     }
 
-    public outputFactory(container: GoldenLayout.Container, state: any): any /* typeof Output */ {
+    public outputFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof Output */ {
         return new Output(this, container, state);
     }
 
-    public toolFactory(container: GoldenLayout.Container, state: any): any /* typeof Tool */ {
+    public toolFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof Tool */ {
         return new Tool(this, container, state);
     }
 
-    public diffFactory(container: GoldenLayout.Container, state: any): any /* typeof Diff */ {
+    public diffFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof Diff */ {
         return new Diff(this, container, state);
     }
 
-    public toolInputViewFactory(container: GoldenLayout.Container, state: any): any /* typeof ToolInputView */ {
+    public toolInputViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof ToolInputView */ {
         return new ToolInputView(this, container, state);
     }
 
-    public optViewFactory(container: GoldenLayout.Container, state: any): OptView {
+    public optViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): OptView {
         return new OptView(this, container, state);
     }
 
-    public flagsViewFactory(container: GoldenLayout.Container, state: any): any /* typeof FlagsView */ {
+    public flagsViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof FlagsView */ {
         return new FlagsView(this, container, state);
     }
 
-    public ppViewFactory(container: GoldenLayout.Container, state: any): PreProcessorView {
+    public ppViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): PreProcessorView {
         return new PreProcessorView(this, container, state);
     }
 
-    public astViewFactory(container: GoldenLayout.Container, state: any): AstView {
+    public astViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): AstView {
         return new AstView(this, container, state);
     }
 
-    public irViewFactory(container: GoldenLayout.Container, state: any): IrView {
+    public irViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): IrView {
         return new IrView(this, container, state);
     }
 
-    public deviceViewFactory(container: GoldenLayout.Container, state: any): any /* typeof DeviceView */ {
+    public deviceViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof DeviceView */ {
         return new DeviceView(this, container, state);
     }
 
-    public gnatDebugTreeViewFactory(container: GoldenLayout.Container, state: any): GnatDebugTreeView {
+    public gnatDebugTreeViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): GnatDebugTreeView {
         return new GnatDebugTreeView(this, container, state);
     }
 
-    public gnatDebugViewFactory(container: GoldenLayout.Container, state: any): GnatDebugView {
+    public gnatDebugViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): GnatDebugView {
         return new GnatDebugView(this, container, state);
     }
 
-    public rustMirViewFactory(container: GoldenLayout.Container, state: any): RustMirView {
+    public rustMirViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): RustMirView {
         return new RustMirView(this, container, state);
     }
 
-    public rustMacroExpViewFactory(container: GoldenLayout.Container, state: any): RustMacroExpView {
+    public rustMacroExpViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): RustMacroExpView {
         return new RustMacroExpView(this, container, state);
     }
 
-    public rustHirViewFactory(container: GoldenLayout.Container, state: any): RustHirView {
+    public rustHirViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): RustHirView {
         return new RustHirView(this, container, state);
     }
 
-    public gccDumpViewFactory(container: GoldenLayout.Container, state: any): any /* typeof GccDumpView */ {
+    public gccDumpViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof GccDumpView */ {
         return new GCCDumpView(this, container, state);
     }
 
-    public cfgViewFactory(container: GoldenLayout.Container, state: any): any /* typeof CfgView */ {
+    public cfgViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof CfgView */ {
         return new CfgView(this, container, state);
     }
 
-    public conformanceViewFactory(container: GoldenLayout.Container, state: any): any /* typeof ConformanceView */ {
+    public conformanceViewFactory(
+        container: GoldenLayout.Container,
+        state: any
+    ): any /* typeof ConformanceView */ {
         return new ConformanceView(this, container, state);
     }
 }

--- a/static/hub.ts
+++ b/static/hub.ts
@@ -71,102 +71,48 @@ export class Hub {
     public subdomainLangId: string | undefined;
     public defaultLangId: string;
 
-    public constructor(
-        public readonly layout: GoldenLayout,
-        subLangId: string,
-        defaultLangId: string
-    ) {
+    public constructor(public readonly layout: GoldenLayout, subLangId: string, defaultLangId: string) {
         this.lastOpenedLangId = null;
         this.subdomainLangId = subLangId || undefined;
         this.defaultLangId = defaultLangId;
         this.compilerService = new CompilerService(this.layout.eventHub);
 
-        layout.registerComponent(Components.getEditor().componentName, (c, s) =>
-            this.codeEditorFactory(c, s)
+        layout.registerComponent(Components.getEditor().componentName, (c, s) => this.codeEditorFactory(c, s));
+        layout.registerComponent(Components.getCompiler().componentName, (c, s) => this.compilerFactory(c, s));
+        layout.registerComponent(Components.getTree().componentName, (c, s) => this.treeFactory(c, s));
+        layout.registerComponent(Components.getExecutor().componentName, (c, s) => this.executorFactory(c, s));
+        layout.registerComponent(Components.getOutput().componentName, (c, s) => this.outputFactory(c, s));
+        layout.registerComponent(Components.getToolViewWith().componentName, (c, s) => this.toolFactory(c, s));
+        // eslint-disable-next-line max-len
+        layout.registerComponent(Components.getToolInputView().componentName, (c, s) =>
+            this.toolInputViewFactory(c, s)
         );
-        layout.registerComponent(
-            Components.getCompiler().componentName,
-            (c, s) => this.compilerFactory(c, s)
-        );
-        layout.registerComponent(Components.getTree().componentName, (c, s) =>
-            this.treeFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getExecutor().componentName,
-            (c, s) => this.executorFactory(c, s)
-        );
-        layout.registerComponent(Components.getOutput().componentName, (c, s) =>
-            this.outputFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getToolViewWith().componentName,
-            (c, s) => this.toolFactory(c, s)
+        layout.registerComponent(getDiffComponent().componentName, (c, s) => this.diffFactory(c, s));
+        layout.registerComponent(Components.getOptView().componentName, (c, s) => this.optViewFactory(c, s));
+        layout.registerComponent(Components.getFlagsView().componentName, (c, s) => this.flagsViewFactory(c, s));
+        layout.registerComponent(Components.getPpView().componentName, (c, s) => this.ppViewFactory(c, s));
+        layout.registerComponent(Components.getAstView().componentName, (c, s) => this.astViewFactory(c, s));
+        layout.registerComponent(Components.getIrView().componentName, (c, s) => this.irViewFactory(c, s));
+        layout.registerComponent(Components.getDeviceView().componentName, (c, s) => this.deviceViewFactory(c, s));
+        layout.registerComponent(Components.getRustMirView().componentName, (c, s) => this.rustMirViewFactory(c, s));
+        // eslint-disable-next-line max-len
+        layout.registerComponent(Components.getGnatDebugTreeView().componentName, (c, s) =>
+            this.gnatDebugTreeViewFactory(c, s)
         );
         // eslint-disable-next-line max-len
-        layout.registerComponent(
-            Components.getToolInputView().componentName,
-            (c, s) => this.toolInputViewFactory(c, s)
-        );
-        layout.registerComponent(getDiffComponent().componentName, (c, s) =>
-            this.diffFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getOptView().componentName,
-            (c, s) => this.optViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getFlagsView().componentName,
-            (c, s) => this.flagsViewFactory(c, s)
-        );
-        layout.registerComponent(Components.getPpView().componentName, (c, s) =>
-            this.ppViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getAstView().componentName,
-            (c, s) => this.astViewFactory(c, s)
-        );
-        layout.registerComponent(Components.getIrView().componentName, (c, s) =>
-            this.irViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getDeviceView().componentName,
-            (c, s) => this.deviceViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getRustMirView().componentName,
-            (c, s) => this.rustMirViewFactory(c, s)
+        layout.registerComponent(Components.getGnatDebugView().componentName, (c, s) =>
+            this.gnatDebugViewFactory(c, s)
         );
         // eslint-disable-next-line max-len
-        layout.registerComponent(
-            Components.getGnatDebugTreeView().componentName,
-            (c, s) => this.gnatDebugTreeViewFactory(c, s)
+        layout.registerComponent(Components.getRustMacroExpView().componentName, (c, s) =>
+            this.rustMacroExpViewFactory(c, s)
         );
+        layout.registerComponent(Components.getRustHirView().componentName, (c, s) => this.rustHirViewFactory(c, s));
+        layout.registerComponent(Components.getGccDumpView().componentName, (c, s) => this.gccDumpViewFactory(c, s));
+        layout.registerComponent(Components.getCfgView().componentName, (c, s) => this.cfgViewFactory(c, s));
         // eslint-disable-next-line max-len
-        layout.registerComponent(
-            Components.getGnatDebugView().componentName,
-            (c, s) => this.gnatDebugViewFactory(c, s)
-        );
-        // eslint-disable-next-line max-len
-        layout.registerComponent(
-            Components.getRustMacroExpView().componentName,
-            (c, s) => this.rustMacroExpViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getRustHirView().componentName,
-            (c, s) => this.rustHirViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getGccDumpView().componentName,
-            (c, s) => this.gccDumpViewFactory(c, s)
-        );
-        layout.registerComponent(
-            Components.getCfgView().componentName,
-            (c, s) => this.cfgViewFactory(c, s)
-        );
-        // eslint-disable-next-line max-len
-        layout.registerComponent(
-            Components.getConformanceView().componentName,
-            (c, s) => this.conformanceViewFactory(c, s)
+        layout.registerComponent(Components.getConformanceView().componentName, (c, s) =>
+            this.conformanceViewFactory(c, s)
         );
 
         layout.eventHub.on(
@@ -297,9 +243,7 @@ export class Hub {
     }
 
     public getTreesWithEditorId(editorId: number) {
-        return this.trees.filter(tree =>
-            tree.multifileService.isEditorPartOfProject(editorId)
-        );
+        return this.trees.filter(tree => tree.multifileService.isEditorPartOfProject(editorId));
     }
 
     public getTrees(): Tree[] {
@@ -316,42 +260,27 @@ export class Hub {
 
     // Layout getters
 
-    public findParentRowOrColumn(
-        elem: GoldenLayout.ContentItem
-    ): GoldenLayout.ContentItem {
+    public findParentRowOrColumn(elem: GoldenLayout.ContentItem): GoldenLayout.ContentItem {
         let currentElem: GoldenLayout.ContentItem | null = elem;
         while (currentElem) {
             if (currentElem.isRow || currentElem.isColumn) return currentElem;
             currentElem = currentElem.parent as GoldenLayout.ContentItem | null;
         }
-        Sentry.captureMessage(
-            'findParentRowOrColumn: Unable to find parent row or column'
-        );
+        Sentry.captureMessage('findParentRowOrColumn: Unable to find parent row or column');
         return null as any;
     }
 
-    public findParentRowOrColumnOrStack(
-        elem: GoldenLayout.ContentItem
-    ): GoldenLayout.ContentItem {
+    public findParentRowOrColumnOrStack(elem: GoldenLayout.ContentItem): GoldenLayout.ContentItem {
         let currentElem: GoldenLayout.ContentItem | null = elem;
         while (currentElem) {
-            if (
-                currentElem.isRow ||
-                currentElem.isColumn ||
-                currentElem.isStack
-            )
-                return currentElem;
+            if (currentElem.isRow || currentElem.isColumn || currentElem.isStack) return currentElem;
             currentElem = currentElem.parent as GoldenLayout.ContentItem | null;
         }
-        Sentry.captureMessage(
-            '#findParentRowOrColumnOrStack: Unable to find parent row, column, or stack'
-        );
+        Sentry.captureMessage('#findParentRowOrColumnOrStack: Unable to find parent row, column, or stack');
         return null as any;
     }
 
-    public findEditorInChildren(
-        elem: GoldenLayout.ContentItem
-    ): GoldenLayout.ContentItem | boolean {
+    public findEditorInChildren(elem: GoldenLayout.ContentItem): GoldenLayout.ContentItem | boolean {
         const count = elem.contentItems.length;
         let index = 0;
         while (index < count) {
@@ -388,9 +317,7 @@ export class Hub {
     }
 
     public addAtRoot(elem: GoldenLayout.ContentItem): void {
-        const rootFirstItem = this.layout.root.contentItems[0] as
-            | typeof this.layout.root.contentItems[0]
-            | undefined;
+        const rootFirstItem = this.layout.root.contentItems[0] as typeof this.layout.root.contentItems[0] | undefined;
         if (rootFirstItem) {
             if (rootFirstItem.isRow || rootFirstItem.isColumn) {
                 rootFirstItem.addChild(elem);
@@ -416,18 +343,13 @@ export class Hub {
 
     public activateTabForContainer(container?: GoldenLayout.Container) {
         if (container && (container.tab as typeof container.tab | null)) {
-            container.tab.header.parent.setActiveContentItem(
-                container.tab.contentItem
-            );
+            container.tab.header.parent.setActiveContentItem(container.tab.contentItem);
         }
     }
 
     // Component Factories
 
-    private codeEditorFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): void {
+    private codeEditorFactory(container: GoldenLayout.Container, state: any): void {
         // Ensure editors are closable: some older versions had 'isClosable' false.
         // NB there doesn't seem to be a better way to do this than reach into the config and rely on the fact nothing
         // has used it yet.
@@ -442,143 +364,83 @@ export class Hub {
         return tree;
     }
 
-    public compilerFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof Compiler */ {
+    public compilerFactory(container: GoldenLayout.Container, state: any): any /* typeof Compiler */ {
         return new Compiler(this, container, state);
     }
 
-    public executorFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof Executor */ {
+    public executorFactory(container: GoldenLayout.Container, state: any): any /* typeof Executor */ {
         return new Executor(this, container, state);
     }
 
-    public outputFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof Output */ {
+    public outputFactory(container: GoldenLayout.Container, state: any): any /* typeof Output */ {
         return new Output(this, container, state);
     }
 
-    public toolFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof Tool */ {
+    public toolFactory(container: GoldenLayout.Container, state: any): any /* typeof Tool */ {
         return new Tool(this, container, state);
     }
 
-    public diffFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof Diff */ {
+    public diffFactory(container: GoldenLayout.Container, state: any): any /* typeof Diff */ {
         return new Diff(this, container, state);
     }
 
-    public toolInputViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof ToolInputView */ {
+    public toolInputViewFactory(container: GoldenLayout.Container, state: any): any /* typeof ToolInputView */ {
         return new ToolInputView(this, container, state);
     }
 
-    public optViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): OptView {
+    public optViewFactory(container: GoldenLayout.Container, state: any): OptView {
         return new OptView(this, container, state);
     }
 
-    public flagsViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof FlagsView */ {
+    public flagsViewFactory(container: GoldenLayout.Container, state: any): any /* typeof FlagsView */ {
         return new FlagsView(this, container, state);
     }
 
-    public ppViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): PreProcessorView {
+    public ppViewFactory(container: GoldenLayout.Container, state: any): PreProcessorView {
         return new PreProcessorView(this, container, state);
     }
 
-    public astViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): AstView {
+    public astViewFactory(container: GoldenLayout.Container, state: any): AstView {
         return new AstView(this, container, state);
     }
 
-    public irViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): IrView {
+    public irViewFactory(container: GoldenLayout.Container, state: any): IrView {
         return new IrView(this, container, state);
     }
 
-    public deviceViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof DeviceView */ {
+    public deviceViewFactory(container: GoldenLayout.Container, state: any): any /* typeof DeviceView */ {
         return new DeviceView(this, container, state);
     }
 
-    public gnatDebugTreeViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): GnatDebugTreeView {
+    public gnatDebugTreeViewFactory(container: GoldenLayout.Container, state: any): GnatDebugTreeView {
         return new GnatDebugTreeView(this, container, state);
     }
 
-    public gnatDebugViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): GnatDebugView {
+    public gnatDebugViewFactory(container: GoldenLayout.Container, state: any): GnatDebugView {
         return new GnatDebugView(this, container, state);
     }
 
-    public rustMirViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): RustMirView {
+    public rustMirViewFactory(container: GoldenLayout.Container, state: any): RustMirView {
         return new RustMirView(this, container, state);
     }
 
-    public rustMacroExpViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): RustMacroExpView {
+    public rustMacroExpViewFactory(container: GoldenLayout.Container, state: any): RustMacroExpView {
         return new RustMacroExpView(this, container, state);
     }
 
-    public rustHirViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): RustHirView {
+    public rustHirViewFactory(container: GoldenLayout.Container, state: any): RustHirView {
         return new RustHirView(this, container, state);
     }
 
-    public gccDumpViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof GccDumpView */ {
+    public gccDumpViewFactory(container: GoldenLayout.Container, state: any): any /* typeof GccDumpView */ {
         return new GCCDumpView(this, container, state);
     }
 
-    public cfgViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof CfgView */ {
+    public cfgViewFactory(container: GoldenLayout.Container, state: any): any /* typeof CfgView */ {
         return new CfgView(this, container, state);
     }
 
-    public conformanceViewFactory(
-        container: GoldenLayout.Container,
-        state: any
-    ): any /* typeof ConformanceView */ {
+    public conformanceViewFactory(container: GoldenLayout.Container, state: any): any /* typeof ConformanceView */ {
         return new ConformanceView(this, container, state);
     }
 }

--- a/static/lib-utils.ts
+++ b/static/lib-utils.ts
@@ -22,8 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { options } from './options';
-import { LanguageLibs, Library, Libs } from './options.interfaces';
+import {options} from './options';
+import {LanguageLibs, Library, Libs} from './options.interfaces';
 
 const LIB_MATCH_RE = /([\w-]*)\.([\w-]*)/i;
 
@@ -51,7 +51,7 @@ function copyAndFilterLibraries(allLibraries: LanguageLibs, filter: string[]) {
     const copiedLibraries: Record<string, Library> = {};
     for (const libid in allLibraries) {
         if (!filterLibIds.has(libid)) continue;
-        const lib = { ...allLibraries[libid] };
+        const lib = {...allLibraries[libid]};
         for (const versionid in lib.versions) {
             for (const filter of filterLibAndVersion) {
                 if (!(!filter.version || filter.version === versionid)) {
@@ -65,8 +65,11 @@ function copyAndFilterLibraries(allLibraries: LanguageLibs, filter: string[]) {
     return copiedLibraries;
 }
 
-export function getSupportedLibraries(supportedLibrariesArr: string[] | undefined, langId: string,
-    remote): LanguageLibs {
+export function getSupportedLibraries(
+    supportedLibrariesArr: string[] | undefined,
+    langId: string,
+    remote
+): LanguageLibs {
     if (!remote) {
         const allLibs = options.libs[langId];
         if (supportedLibrariesArr && supportedLibrariesArr.length > 0) {

--- a/static/line-colouring.ts
+++ b/static/line-colouring.ts
@@ -52,9 +52,11 @@ export class LineColouring {
 
     public addFromAssembly(compilerId, asm) {
         let asmLineIdx = 0;
-        for (const asmLine of asm ) {
+        for (const asmLine of asm) {
             if (asmLine.source && asmLine.source.line > 0) {
-                const editorId = this.multifileService.getEditorIdByFilename(asmLine.source.file);
+                const editorId = this.multifileService.getEditorIdByFilename(
+                    asmLine.source.file,
+                );
                 if (editorId != null && editorId > 0) {
                     if (!this.colouredSourceLinesByEditor[editorId]) {
                         this.colouredSourceLinesByEditor[editorId] = [];
@@ -84,14 +86,17 @@ export class LineColouring {
         const lines: number[] = [];
 
         for (const info of this.colouredSourceLinesByEditor[editorId]) {
-            if (!lines.includes(info.sourceLine))
-                lines.push(info.sourceLine);
+            if (!lines.includes(info.sourceLine)) lines.push(info.sourceLine);
         }
 
         return lines;
     }
 
-    private setColourBySourceline(editorId: number, line: number, colourIdx: number) {
+    private setColourBySourceline(
+        editorId: number,
+        line: number,
+        colourIdx: number,
+    ) {
         for (const info of this.colouredSourceLinesByEditor[editorId]) {
             if (info.sourceLine === line) {
                 info.colourIdx = colourIdx;
@@ -120,7 +125,9 @@ export class LineColouring {
             for (const editorId of _.keys(this.colouredSourceLinesByEditor)) {
                 for (const info of this.colouredSourceLinesByEditor[editorId]) {
                     if (info.compilerId === compilerId && info.colourIdx >= 0) {
-                        this.linesAndColourByCompiler[compilerId][info.compilerLine] = info.colourIdx;
+                        this.linesAndColourByCompiler[compilerId][
+                            info.compilerLine
+                        ] = info.colourIdx;
                     }
                 }
             }
@@ -129,7 +136,8 @@ export class LineColouring {
         for (const editorId of editorIds) {
             for (const info of this.colouredSourceLinesByEditor[editorId]) {
                 if (info.colourIdx >= 0) {
-                    this.linesAndColourByEditor[editorId][info.sourceLine] = info.colourIdx;
+                    this.linesAndColourByEditor[editorId][info.sourceLine] =
+                        info.colourIdx;
                 }
             }
         }

--- a/static/line-colouring.ts
+++ b/static/line-colouring.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import _ from 'underscore';
-import { MultifileService } from './multifile-service';
+import {MultifileService} from './multifile-service';
 
 interface ColouredSourcelineInfo {
     sourceLine: number;
@@ -55,7 +55,7 @@ export class LineColouring {
         for (const asmLine of asm) {
             if (asmLine.source && asmLine.source.line > 0) {
                 const editorId = this.multifileService.getEditorIdByFilename(
-                    asmLine.source.file,
+                    asmLine.source.file
                 );
                 if (editorId != null && editorId > 0) {
                     if (!this.colouredSourceLinesByEditor[editorId]) {
@@ -95,7 +95,7 @@ export class LineColouring {
     private setColourBySourceline(
         editorId: number,
         line: number,
-        colourIdx: number,
+        colourIdx: number
     ) {
         for (const info of this.colouredSourceLinesByEditor[editorId]) {
             if (info.sourceLine === line) {

--- a/static/line-colouring.ts
+++ b/static/line-colouring.ts
@@ -54,9 +54,7 @@ export class LineColouring {
         let asmLineIdx = 0;
         for (const asmLine of asm) {
             if (asmLine.source && asmLine.source.line > 0) {
-                const editorId = this.multifileService.getEditorIdByFilename(
-                    asmLine.source.file
-                );
+                const editorId = this.multifileService.getEditorIdByFilename(asmLine.source.file);
                 if (editorId != null && editorId > 0) {
                     if (!this.colouredSourceLinesByEditor[editorId]) {
                         this.colouredSourceLinesByEditor[editorId] = [];
@@ -92,11 +90,7 @@ export class LineColouring {
         return lines;
     }
 
-    private setColourBySourceline(
-        editorId: number,
-        line: number,
-        colourIdx: number
-    ) {
+    private setColourBySourceline(editorId: number, line: number, colourIdx: number) {
         for (const info of this.colouredSourceLinesByEditor[editorId]) {
             if (info.sourceLine === line) {
                 info.colourIdx = colourIdx;
@@ -125,9 +119,7 @@ export class LineColouring {
             for (const editorId of _.keys(this.colouredSourceLinesByEditor)) {
                 for (const info of this.colouredSourceLinesByEditor[editorId]) {
                     if (info.compilerId === compilerId && info.colourIdx >= 0) {
-                        this.linesAndColourByCompiler[compilerId][
-                            info.compilerLine
-                        ] = info.colourIdx;
+                        this.linesAndColourByCompiler[compilerId][info.compilerLine] = info.colourIdx;
                     }
                 }
             }
@@ -136,8 +128,7 @@ export class LineColouring {
         for (const editorId of editorIds) {
             for (const info of this.colouredSourceLinesByEditor[editorId]) {
                 if (info.colourIdx >= 0) {
-                    this.linesAndColourByEditor[editorId][info.sourceLine] =
-                        info.colourIdx;
+                    this.linesAndColourByEditor[editorId][info.sourceLine] = info.colourIdx;
                 }
             }
         }

--- a/static/local.ts
+++ b/static/local.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { options } from './options';
+import {options} from './options';
 
 const prefix = options.localStoragePrefix ?? '';
 

--- a/static/monaco-config.ts
+++ b/static/monaco-config.ts
@@ -40,15 +40,12 @@ const DEFAULT_MONACO_CONFIG = {
     emptySelectionClipboard: true,
 };
 
-type EditorKinds =
-    | monaco.editor.IStandaloneDiffEditor
-    | monaco.editor.IStandaloneCodeEditor;
+type EditorKinds = monaco.editor.IStandaloneDiffEditor | monaco.editor.IStandaloneCodeEditor;
 
 /** Pick consturction options based on editor kind */
-type EditorConstructionType<E extends EditorKinds> =
-    E extends monaco.editor.IStandaloneDiffEditor
-        ? monaco.editor.IDiffEditorConstructionOptions
-        : monaco.editor.IStandaloneEditorConstructionOptions;
+type EditorConstructionType<E extends EditorKinds> = E extends monaco.editor.IStandaloneDiffEditor
+    ? monaco.editor.IDiffEditorConstructionOptions
+    : monaco.editor.IStandaloneEditorConstructionOptions;
 
 /**
  * Extend the default monaco editor construction options.
@@ -63,13 +60,7 @@ type EditorConstructionType<E extends EditorKinds> =
 export function extendConfig<
     E extends EditorKinds = monaco.editor.IStandaloneCodeEditor,
     T = EditorConstructionType<E>
->(
-    overrides: T,
-    settings?: Pick<
-        SiteSettings,
-        'editorsFFont' | 'autoIndent' | 'useVim' | 'editorsFLigatures'
-    >
-): T {
+>(overrides: T, settings?: Pick<SiteSettings, 'editorsFFont' | 'autoIndent' | 'useVim' | 'editorsFLigatures'>): T {
     if (settings !== undefined) {
         return _.extend(
             {},

--- a/static/monaco-config.ts
+++ b/static/monaco-config.ts
@@ -62,17 +62,26 @@ type EditorConstructionType<E extends EditorKinds> =
  */
 export function extendConfig<
     E extends EditorKinds = monaco.editor.IStandaloneCodeEditor,
-    T = EditorConstructionType<E>>(
+    T = EditorConstructionType<E>,
+>(
     overrides: T,
-    settings?: Pick<SiteSettings, 'editorsFFont' | 'autoIndent' | 'useVim' | 'editorsFLigatures'>
+    settings?: Pick<
+        SiteSettings,
+        'editorsFFont' | 'autoIndent' | 'useVim' | 'editorsFLigatures'
+    >,
 ): T {
     if (settings !== undefined) {
-        return _.extend({}, DEFAULT_MONACO_CONFIG, {
-            fontFamily: settings.editorsFFont,
-            autoIndent: settings.autoIndent ? 'advanced' : 'none',
-            vimInUse: settings.useVim,
-            fontLigatures: settings.editorsFLigatures,
-        }, overrides);
+        return _.extend(
+            {},
+            DEFAULT_MONACO_CONFIG,
+            {
+                fontFamily: settings.editorsFFont,
+                autoIndent: settings.autoIndent ? 'advanced' : 'none',
+                vimInUse: settings.useVim,
+                fontLigatures: settings.editorsFLigatures,
+            },
+            overrides,
+        );
     }
     return _.extend({}, DEFAULT_MONACO_CONFIG, overrides);
 }

--- a/static/monaco-config.ts
+++ b/static/monaco-config.ts
@@ -25,7 +25,7 @@
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 
-import { SiteSettings } from './settings';
+import {SiteSettings} from './settings';
 
 const DEFAULT_MONACO_CONFIG = {
     fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
@@ -62,13 +62,13 @@ type EditorConstructionType<E extends EditorKinds> =
  */
 export function extendConfig<
     E extends EditorKinds = monaco.editor.IStandaloneCodeEditor,
-    T = EditorConstructionType<E>,
+    T = EditorConstructionType<E>
 >(
     overrides: T,
     settings?: Pick<
         SiteSettings,
         'editorsFFont' | 'autoIndent' | 'useVim' | 'editorsFLigatures'
-    >,
+    >
 ): T {
     if (settings !== undefined) {
         return _.extend(
@@ -80,7 +80,7 @@ export function extendConfig<
                 vimInUse: settings.useVim,
                 fontLigatures: settings.editorsFLigatures,
             },
-            overrides,
+            overrides
         );
     }
     return _.extend({}, DEFAULT_MONACO_CONFIG, overrides);

--- a/static/motd.interfaces.ts
+++ b/static/motd.interfaces.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { editor } from 'monaco-editor/';
+import {editor} from 'monaco-editor/';
 
 interface Decoration {
     decoration: editor.IModelDecorationOptions;

--- a/static/motd.ts
+++ b/static/motd.ts
@@ -23,9 +23,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import $ from 'jquery';
-import { ga } from './analytics';
+import {ga} from './analytics';
 
-import { Motd } from './motd.interfaces';
+import {Motd} from './motd.interfaces';
 
 function ensureShownMessage(message: string, motdNode: JQuery) {
     motdNode.find('.content').html(message);
@@ -43,7 +43,7 @@ function handleMotd(
     motdNode: JQuery,
     subLang: string,
     adsEnabled: boolean,
-    onHide: () => void,
+    onHide: () => void
 ) {
     if (motd.update) {
         ensureShownMessage(motd.update, motdNode);
@@ -92,7 +92,7 @@ export function initialise(
     defaultLanguage: string,
     adsEnabled: boolean,
     onMotd: (res?: Motd) => void,
-    onHide: () => void,
+    onHide: () => void
 ) {
     if (!url) return;
     $.getJSON(url)

--- a/static/motd.ts
+++ b/static/motd.ts
@@ -23,33 +23,45 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import $ from 'jquery';
-import {ga} from './analytics';
+import { ga } from './analytics';
 
-import {Motd} from './motd.interfaces';
-
+import { Motd } from './motd.interfaces';
 
 function ensureShownMessage(message: string, motdNode: JQuery) {
     motdNode.find('.content').html(message);
     motdNode.removeClass('d-none');
-    motdNode.find('.close')
+    motdNode
+        .find('.close')
         .on('click', () => {
             motdNode.addClass('d-none');
         })
         .prop('title', 'Hide message');
 }
 
-function handleMotd(motd: Motd, motdNode: JQuery, subLang: string, adsEnabled: boolean, onHide: () => void) {
+function handleMotd(
+    motd: Motd,
+    motdNode: JQuery,
+    subLang: string,
+    adsEnabled: boolean,
+    onHide: () => void,
+) {
     if (motd.update) {
         ensureShownMessage(motd.update, motdNode);
     } else if (motd.motd) {
         ensureShownMessage(motd.motd, motdNode);
     } else if (adsEnabled) {
-        const applicableAds = motd.ads?.filter((ad) => {
-            return !subLang || !ad.filter || ad.filter.length === 0 || ad.filter.indexOf(subLang) >= 0;
+        const applicableAds = motd.ads?.filter(ad => {
+            return (
+                !subLang ||
+                !ad.filter ||
+                ad.filter.length === 0 ||
+                ad.filter.indexOf(subLang) >= 0
+            );
         });
 
         if (applicableAds != null && applicableAds.length > 0) {
-            const randomAd = applicableAds[Math.floor(Math.random() * applicableAds.length)];
+            const randomAd =
+                applicableAds[Math.floor(Math.random() * applicableAds.length)];
             motdNode.find('.content').html(randomAd.html);
             motdNode.find('.close').on('click', () => {
                 ga.proxy('send', {
@@ -80,8 +92,8 @@ export function initialise(
     defaultLanguage: string,
     adsEnabled: boolean,
     onMotd: (res?: Motd) => void,
-    onHide: () => void)
-{
+    onHide: () => void,
+) {
     if (!url) return;
     $.getJSON(url)
         .then((res: Motd) => {

--- a/static/motd.ts
+++ b/static/motd.ts
@@ -38,30 +38,18 @@ function ensureShownMessage(message: string, motdNode: JQuery) {
         .prop('title', 'Hide message');
 }
 
-function handleMotd(
-    motd: Motd,
-    motdNode: JQuery,
-    subLang: string,
-    adsEnabled: boolean,
-    onHide: () => void
-) {
+function handleMotd(motd: Motd, motdNode: JQuery, subLang: string, adsEnabled: boolean, onHide: () => void) {
     if (motd.update) {
         ensureShownMessage(motd.update, motdNode);
     } else if (motd.motd) {
         ensureShownMessage(motd.motd, motdNode);
     } else if (adsEnabled) {
         const applicableAds = motd.ads?.filter(ad => {
-            return (
-                !subLang ||
-                !ad.filter ||
-                ad.filter.length === 0 ||
-                ad.filter.indexOf(subLang) >= 0
-            );
+            return !subLang || !ad.filter || ad.filter.length === 0 || ad.filter.indexOf(subLang) >= 0;
         });
 
         if (applicableAds != null && applicableAds.length > 0) {
-            const randomAd =
-                applicableAds[Math.floor(Math.random() * applicableAds.length)];
+            const randomAd = applicableAds[Math.floor(Math.random() * applicableAds.length)];
             motdNode.find('.content').html(randomAd.html);
             motdNode.find('.close').on('click', () => {
                 ga.proxy('send', {

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -74,14 +74,7 @@ export class MultifileService {
         this.files = state.files;
         this.newFileId = state.newFileId || 1;
 
-        this.validExtraFilenameExtensions = [
-            '.txt',
-            '.md',
-            '.rst',
-            '.sh',
-            '.cmake',
-            '.in',
-        ];
+        this.validExtraFilenameExtensions = ['.txt', '.md', '.rst', '.sh', '.cmake', '.in'];
         this.defaultLangIdUnknownExt = 'c++';
         this.cmakeLangId = 'cmake';
         this.cmakeMainSourceFilename = 'CMakeLists.txt';
@@ -285,9 +278,7 @@ export class MultifileService {
     }
 
     private filterOutNonsense() {
-        this.files = _.filter(this.files, (file: MultifileFile) =>
-            MultifileService.isValidFile(file)
-        );
+        this.files = _.filter(this.files, (file: MultifileFile) => MultifileService.isValidFile(file));
     }
 
     public getFiles(): Array<FiledataPair> {
@@ -320,12 +311,7 @@ export class MultifileService {
                     return false;
                 }
             } else {
-                if (
-                    file.filename ===
-                    MultifileService.getDefaultMainSourceFilename(
-                        this.compilerLanguageId
-                    )
-                ) {
+                if (file.filename === MultifileService.getDefaultMainSourceFilename(this.compilerLanguageId)) {
                     this.setAsMainSource(file.fileId);
                 } else {
                     return false;
@@ -395,9 +381,7 @@ export class MultifileService {
     public removeFileByFileId(fileId: number): MultifileFile | undefined {
         const file = this.getFileByFileId(fileId);
         if (file) {
-            this.files = this.files.filter(
-                (obj: MultifileFile) => obj.fileId !== fileId
-            );
+            this.files = this.files.filter((obj: MultifileFile) => obj.fileId !== fileId);
         }
         return file;
     }
@@ -479,8 +463,7 @@ export class MultifileService {
                 if (langId === this.cmakeLangId) {
                     suggestedFilename = this.getDefaultMainCMakeFilename();
                 } else {
-                    suggestedFilename =
-                        MultifileService.getDefaultMainSourceFilename(langId);
+                    suggestedFilename = MultifileService.getDefaultMainSourceFilename(langId);
                 }
             }
         }
@@ -506,45 +489,34 @@ export class MultifileService {
         const suggestedFilename = this.getSuggestedFilename(file, editor);
 
         return new Promise(resolve => {
-            this.alertSystem.enterSomething(
-                'Rename file',
-                'Please enter new filename',
-                suggestedFilename,
-                {
-                    yes: (value: string) => {
-                        if (value !== '' && value[0] !== '/') {
-                            if (!this.fileExists(value, file)) {
-                                file.filename = value;
+            this.alertSystem.enterSomething('Rename file', 'Please enter new filename', suggestedFilename, {
+                yes: (value: string) => {
+                    if (value !== '' && value[0] !== '/') {
+                        if (!this.fileExists(value, file)) {
+                            file.filename = value;
 
-                                if (editor) {
-                                    editor.setFilename(file.filename);
-                                }
-
-                                resolve(true);
-                            } else {
-                                this.alertSystem.alert(
-                                    'Rename file',
-                                    'Filename already exists'
-                                );
-                                resolve(false);
+                            if (editor) {
+                                editor.setFilename(file.filename);
                             }
+
+                            resolve(true);
                         } else {
-                            this.alertSystem.alert(
-                                'Rename file',
-                                'Filename cannot be empty or start with a "/"'
-                            );
+                            this.alertSystem.alert('Rename file', 'Filename already exists');
                             resolve(false);
                         }
-                    },
-                    no: () => {
+                    } else {
+                        this.alertSystem.alert('Rename file', 'Filename cannot be empty or start with a "/"');
                         resolve(false);
-                    },
-                    yesClass: 'btn btn-primary',
-                    yesHtml: 'Rename',
-                    noClass: 'btn-outline-info',
-                    noHtml: 'Cancel',
-                }
-            );
+                    }
+                },
+                no: () => {
+                    resolve(false);
+                },
+                yesClass: 'btn btn-primary',
+                yesHtml: 'Rename',
+                noClass: 'btn-outline-info',
+                noHtml: 'Cancel',
+            });
         });
     }
 

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -25,7 +25,7 @@
 import _ from 'underscore';
 import path from 'path';
 import JSZip from 'jszip';
-import { Hub } from './hub';
+import {Hub} from './hub';
 const options = require('./options').options;
 const languages = options.languages;
 
@@ -187,13 +187,13 @@ export class MultifileService {
             }
         });
 
-        zip.generateAsync({ type: 'blob' }).then(
+        zip.generateAsync({type: 'blob'}).then(
             blob => {
                 callback(blob);
             },
             err => {
                 throw err;
-            },
+            }
         );
     }
 
@@ -286,7 +286,7 @@ export class MultifileService {
 
     private filterOutNonsense() {
         this.files = _.filter(this.files, (file: MultifileFile) =>
-            MultifileService.isValidFile(file),
+            MultifileService.isValidFile(file)
         );
     }
 
@@ -323,7 +323,7 @@ export class MultifileService {
                 if (
                     file.filename ===
                     MultifileService.getDefaultMainSourceFilename(
-                        this.compilerLanguageId,
+                        this.compilerLanguageId
                     )
                 ) {
                     this.setAsMainSource(file.fileId);
@@ -396,7 +396,7 @@ export class MultifileService {
         const file = this.getFileByFileId(fileId);
         if (file) {
             this.files = this.files.filter(
-                (obj: MultifileFile) => obj.fileId !== fileId,
+                (obj: MultifileFile) => obj.fileId !== fileId
             );
         }
         return file;
@@ -524,14 +524,14 @@ export class MultifileService {
                             } else {
                                 this.alertSystem.alert(
                                     'Rename file',
-                                    'Filename already exists',
+                                    'Filename already exists'
                                 );
                                 resolve(false);
                             }
                         } else {
                             this.alertSystem.alert(
                                 'Rename file',
-                                'Filename cannot be empty or start with a "/"',
+                                'Filename cannot be empty or start with a "/"'
                             );
                             resolve(false);
                         }
@@ -543,7 +543,7 @@ export class MultifileService {
                     yesHtml: 'Rename',
                     noClass: 'btn-outline-info',
                     noHtml: 'Cancel',
-                },
+                }
             );
         });
     }

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -74,7 +74,14 @@ export class MultifileService {
         this.files = state.files;
         this.newFileId = state.newFileId || 1;
 
-        this.validExtraFilenameExtensions = ['.txt', '.md', '.rst', '.sh', '.cmake', '.in'];
+        this.validExtraFilenameExtensions = [
+            '.txt',
+            '.md',
+            '.rst',
+            '.sh',
+            '.cmake',
+            '.in',
+        ];
         this.defaultLangIdUnknownExt = 'c++';
         this.cmakeLangId = 'cmake';
         this.cmakeMainSourceFilename = 'CMakeLists.txt';
@@ -82,7 +89,7 @@ export class MultifileService {
     }
 
     private static isHiddenFile(filename: string): boolean {
-        return (filename.length > 0 && filename[0] === '.');
+        return filename.length > 0 && filename[0] === '.';
     }
 
     private isValidFilename(filename: string): boolean {
@@ -93,7 +100,7 @@ export class MultifileService {
             return true;
         }
 
-        return _.any(languages, (lang) => {
+        return _.any(languages, lang => {
             return lang.extensions.includes(filenameExt);
         });
     }
@@ -110,7 +117,7 @@ export class MultifileService {
     private getLanguageIdFromFilename(filename: string): string {
         const filenameExt = path.extname(filename);
 
-        const possibleLang = _.filter(languages, (lang) => {
+        const possibleLang = _.filter(languages, lang => {
             return lang.extensions.includes(filenameExt);
         });
 
@@ -146,7 +153,7 @@ export class MultifileService {
                 }
 
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                let content = await (zip.file(zipEntry.name)!.async('string'));
+                let content = await zip.file(zipEntry.name)!.async('string');
                 if (content.length > this.maxFilesize) {
                     return;
                 }
@@ -180,11 +187,14 @@ export class MultifileService {
             }
         });
 
-        zip.generateAsync({type:'blob'}).then((blob) => {
-            callback(blob);
-        }, (err) => {
-            throw err;
-        });
+        zip.generateAsync({ type: 'blob' }).then(
+            blob => {
+                callback(blob);
+            },
+            err => {
+                throw err;
+            },
+        );
     }
 
     public getState(): MultifileServiceState {
@@ -201,8 +211,11 @@ export class MultifileService {
     }
 
     public isCompatibleWithCMake(): boolean {
-        return this.compilerLanguageId === 'c++' || this.compilerLanguageId === 'c' ||
-            this.compilerLanguageId === 'fortran';
+        return (
+            this.compilerLanguageId === 'c++' ||
+            this.compilerLanguageId === 'c' ||
+            this.compilerLanguageId === 'fortran'
+        );
     }
 
     public setLanguageId(id: string) {
@@ -240,7 +253,7 @@ export class MultifileService {
 
     public isEditorPartOfProject(editorId: number) {
         const found = _.find(this.files, (file: MultifileFile) => {
-            return (file.isIncluded) && file.isOpen && (editorId === file.editorId);
+            return file.isIncluded && file.isOpen && editorId === file.editorId;
         });
 
         return !!found;
@@ -268,11 +281,13 @@ export class MultifileService {
     }
 
     private static isValidFile(file: MultifileFile): boolean {
-        return (file.editorId > 0) || !!file.filename;
+        return file.editorId > 0 || !!file.filename;
     }
 
     private filterOutNonsense() {
-        this.files = _.filter(this.files, (file: MultifileFile) => MultifileService.isValidFile(file));
+        this.files = _.filter(this.files, (file: MultifileFile) =>
+            MultifileService.isValidFile(file),
+        );
     }
 
     public getFiles(): Array<FiledataPair> {
@@ -305,7 +320,12 @@ export class MultifileService {
                     return false;
                 }
             } else {
-                if (file.filename === MultifileService.getDefaultMainSourceFilename(this.compilerLanguageId)) {
+                if (
+                    file.filename ===
+                    MultifileService.getDefaultMainSourceFilename(
+                        this.compilerLanguageId,
+                    )
+                ) {
                     this.setAsMainSource(file.fileId);
                 } else {
                     return false;
@@ -336,10 +356,10 @@ export class MultifileService {
 
     public getEditorIdByFilename(filename: string): number | null {
         const file = _.find(this.files, (file: MultifileFile) => {
-            return file.isIncluded && (file.filename === filename);
+            return file.isIncluded && file.filename === filename;
         });
 
-        return (file && file.editorId > 0) ? file.editorId : null;
+        return file && file.editorId > 0 ? file.editorId : null;
     }
 
     public getMainSourceEditorId(): number | null {
@@ -349,7 +369,7 @@ export class MultifileService {
 
         this.checkFileEditor(file);
 
-        return (file && file.editorId > 0) ? file.editorId : null;
+        return file && file.editorId > 0 ? file.editorId : null;
     }
 
     private addFile(file: MultifileFile) {
@@ -375,7 +395,9 @@ export class MultifileService {
     public removeFileByFileId(fileId: number): MultifileFile | undefined {
         const file = this.getFileByFileId(fileId);
         if (file) {
-            this.files = this.files.filter((obj: MultifileFile) => obj.fileId !== fileId);
+            this.files = this.files.filter(
+                (obj: MultifileFile) => obj.fileId !== fileId,
+            );
         }
         return file;
     }
@@ -457,7 +479,8 @@ export class MultifileService {
                 if (langId === this.cmakeLangId) {
                     suggestedFilename = this.getDefaultMainCMakeFilename();
                 } else {
-                    suggestedFilename = MultifileService.getDefaultMainSourceFilename(langId);
+                    suggestedFilename =
+                        MultifileService.getDefaultMainSourceFilename(langId);
                 }
             }
         }
@@ -467,7 +490,7 @@ export class MultifileService {
 
     private fileExists(filename: string, excludeFile: MultifileFile): boolean {
         return !!_.find(this.files, (file: MultifileFile) => {
-            return (file !== excludeFile) && (file.filename === filename);
+            return file !== excludeFile && file.filename === filename;
         });
     }
 
@@ -482,35 +505,46 @@ export class MultifileService {
 
         const suggestedFilename = this.getSuggestedFilename(file, editor);
 
-        return new Promise((resolve) => {
-            this.alertSystem.enterSomething('Rename file', 'Please enter new filename', suggestedFilename, {
-                yes: (value: string) => {
-                    if (value !== '' && value[0] !== '/') {
-                        if (!this.fileExists(value, file)) {
-                            file.filename = value;
+        return new Promise(resolve => {
+            this.alertSystem.enterSomething(
+                'Rename file',
+                'Please enter new filename',
+                suggestedFilename,
+                {
+                    yes: (value: string) => {
+                        if (value !== '' && value[0] !== '/') {
+                            if (!this.fileExists(value, file)) {
+                                file.filename = value;
 
-                            if (editor) {
-                                editor.setFilename(file.filename);
+                                if (editor) {
+                                    editor.setFilename(file.filename);
+                                }
+
+                                resolve(true);
+                            } else {
+                                this.alertSystem.alert(
+                                    'Rename file',
+                                    'Filename already exists',
+                                );
+                                resolve(false);
                             }
-
-                            resolve(true);
                         } else {
-                            this.alertSystem.alert('Rename file', 'Filename already exists');
+                            this.alertSystem.alert(
+                                'Rename file',
+                                'Filename cannot be empty or start with a "/"',
+                            );
                             resolve(false);
                         }
-                    } else {
-                        this.alertSystem.alert('Rename file', 'Filename cannot be empty or start with a "/"');
+                    },
+                    no: () => {
                         resolve(false);
-                    }
+                    },
+                    yesClass: 'btn btn-primary',
+                    yesHtml: 'Rename',
+                    noClass: 'btn-outline-info',
+                    noHtml: 'Cancel',
                 },
-                no: () => {
-                    resolve(false);
-                },
-                yesClass: 'btn btn-primary',
-                yesHtml: 'Rename',
-                noClass: 'btn-outline-info',
-                noHtml: 'Cancel',
-            });
+            );
         });
     }
 

--- a/static/noscript.ts
+++ b/static/noscript.ts
@@ -42,10 +42,7 @@ $(document).on('ready', () => {
         button.attr('type', 'button');
         button.attr('title', option.attr('title') ?? '');
         button.data('bind', option.attr('name') ?? '');
-        button.attr(
-            'aria-pressed',
-            option.attr('checked') === 'checked' ? 'true' : 'false'
-        );
+        button.attr('aria-pressed', option.attr('checked') === 'checked' ? 'true' : 'false');
         button.append(span);
 
         container.prepend(button);
@@ -54,12 +51,8 @@ $(document).on('ready', () => {
         parent.addClass('dropdown-menu');
     });
 
-    $('.noscriptdropdown')
-        .removeClass('noscriptdropdown')
-        .addClass('dropdown-menu');
-    $('.nodropdown-toggle')
-        .removeClass('nodropdown-toggle')
-        .addClass('dropdown-toggle');
+    $('.noscriptdropdown').removeClass('noscriptdropdown').addClass('dropdown-menu');
+    $('.nodropdown-toggle').removeClass('nodropdown-toggle').addClass('dropdown-toggle');
 
     new Toggles($('.output'), {});
     new Toggles($('.filters'), {});

--- a/static/noscript.ts
+++ b/static/noscript.ts
@@ -42,7 +42,10 @@ $(document).on('ready', () => {
         button.attr('type', 'button');
         button.attr('title', option.attr('title') ?? '');
         button.data('bind', option.attr('name') ?? '');
-        button.attr('aria-pressed', option.attr('checked') === 'checked' ? 'true' : 'false');
+        button.attr(
+            'aria-pressed',
+            option.attr('checked') === 'checked' ? 'true' : 'false',
+        );
         button.append(span);
 
         container.prepend(button);
@@ -51,8 +54,12 @@ $(document).on('ready', () => {
         parent.addClass('dropdown-menu');
     });
 
-    $('.noscriptdropdown').removeClass('noscriptdropdown').addClass('dropdown-menu');
-    $('.nodropdown-toggle').removeClass('nodropdown-toggle').addClass('dropdown-toggle');
+    $('.noscriptdropdown')
+        .removeClass('noscriptdropdown')
+        .addClass('dropdown-menu');
+    $('.nodropdown-toggle')
+        .removeClass('nodropdown-toggle')
+        .addClass('dropdown-toggle');
 
     new Toggles($('.output'), {});
     new Toggles($('.filters'), {});

--- a/static/noscript.ts
+++ b/static/noscript.ts
@@ -26,7 +26,7 @@ import $ from 'jquery';
 import 'bootstrap';
 import 'popper.js';
 
-import { Toggles } from './widgets/toggles';
+import {Toggles} from './widgets/toggles';
 import './noscript.scss';
 
 $(document).on('ready', () => {
@@ -44,7 +44,7 @@ $(document).on('ready', () => {
         button.data('bind', option.attr('name') ?? '');
         button.attr(
             'aria-pressed',
-            option.attr('checked') === 'checked' ? 'true' : 'false',
+            option.attr('checked') === 'checked' ? 'true' : 'false'
         );
         button.append(span);
 

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { Language } from '../types/languages.interfaces';
+import {Language} from '../types/languages.interfaces';
 
 export interface LibraryVersion {
     alias: string[];

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -55,5 +55,5 @@ export interface Options {
     defaultFontScale: number;
     sentryDsn?: string;
     release?: string;
-    sentryEnvironment?: string
+    sentryEnvironment?: string;
 }

--- a/static/options.ts
+++ b/static/options.ts
@@ -32,9 +32,7 @@ window.httpRoot = configElement.getAttribute('httpRoot') as string;
 window.staticRoot = configElement.getAttribute('staticRoot') as string;
 
 const extraOptions: object = JSON.parse(
-    decodeURIComponent(
-        configElement.getAttribute('extraOptions') ?? '"%7B%7D"',
-    ),
+    decodeURIComponent(configElement.getAttribute('extraOptions') ?? '"%7B%7D"')
 ); // Encoded {}
 for (const key in extraOptions) {
     window.compilerExplorerOptions[key] = extraOptions[key];

--- a/static/options.ts
+++ b/static/options.ts
@@ -31,7 +31,11 @@ if (!configElement) {
 window.httpRoot = configElement.getAttribute('httpRoot') as string;
 window.staticRoot = configElement.getAttribute('staticRoot') as string;
 
-const extraOptions: object = JSON.parse(decodeURIComponent(configElement.getAttribute('extraOptions') ?? '"%7B%7D"')); // Encoded {}
+const extraOptions: object = JSON.parse(
+    decodeURIComponent(
+        configElement.getAttribute('extraOptions') ?? '"%7B%7D"',
+    ),
+); // Encoded {}
 for (const key in extraOptions) {
     window.compilerExplorerOptions[key] = extraOptions[key];
 }

--- a/static/options.ts
+++ b/static/options.ts
@@ -31,9 +31,7 @@ if (!configElement) {
 window.httpRoot = configElement.getAttribute('httpRoot') as string;
 window.staticRoot = configElement.getAttribute('staticRoot') as string;
 
-const extraOptions: object = JSON.parse(
-    decodeURIComponent(configElement.getAttribute('extraOptions') ?? '"%7B%7D"')
-); // Encoded {}
+const extraOptions: object = JSON.parse(decodeURIComponent(configElement.getAttribute('extraOptions') ?? '"%7B%7D"')); // Encoded {}
 for (const key in extraOptions) {
     window.compilerExplorerOptions[key] = extraOptions[key];
 }

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -22,11 +22,11 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { options } from './options';
+import {options} from './options';
 import * as colour from './colour';
 import * as local from './local';
-import { themes, Themes } from './themes';
-import { AppTheme, ColourSchemeInfo } from './colour';
+import {themes, Themes} from './themes';
+import {AppTheme, ColourSchemeInfo} from './colour';
 
 type ColourScheme =
     | 'rainbow'
@@ -110,7 +110,7 @@ class Select extends BaseSetting {
     constructor(
         elem: JQuery,
         name: string,
-        populate: { label: string; desc: string }[],
+        populate: {label: string; desc: string}[]
     ) {
         super(elem, name);
 
@@ -178,7 +178,7 @@ class Numeric extends BaseSetting {
     constructor(
         elem: JQuery,
         name: string,
-        params: Record<'min' | 'max', number>,
+        params: Record<'min' | 'max', number>
     ) {
         super(elem, name);
 
@@ -208,7 +208,7 @@ export class Settings {
         private root: JQuery,
         private settings: SiteSettings,
         private onChange: (SiteSettings) => void,
-        private subLangId: string | null,
+        private subLangId: string | null
     ) {
         this.settings = settings;
         this.settingsObjs = [];
@@ -283,7 +283,7 @@ export class Settings {
         for (const [selector, name, defaultValue] of checkboxes) {
             this.add(
                 new Checkbox(this.root.find(selector), name),
-                defaultValue,
+                defaultValue
             );
         }
     }
@@ -292,30 +292,30 @@ export class Settings {
         const addSelector = (
             selector: string,
             name: keyof SiteSettings,
-            populate: { label: string; desc: string }[],
-            defaultValue: string,
+            populate: {label: string; desc: string}[],
+            defaultValue: string
         ) => {
             this.add(
                 new Select(this.root.find(selector), name, populate),
-                defaultValue,
+                defaultValue
             );
         };
 
         const colourSchemesData = colour.schemes.map(scheme => {
-            return { label: scheme.name, desc: scheme.desc };
+            return {label: scheme.name, desc: scheme.desc};
         });
         addSelector(
             '.colourScheme',
             'colourScheme',
             colourSchemesData,
-            colour.schemes[0].name,
+            colour.schemes[0].name
         );
 
         // keys(themes) is Themes[] but TS does not realize without help
         const themesData = (Object.keys(themes) as Themes[]).map(
             (theme: Themes) => {
-                return { label: themes[theme].id, desc: themes[theme].name };
-            },
+                return {label: themes[theme].id, desc: themes[theme].name};
+            }
         );
         let defaultThemeId = themes.default.id;
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
@@ -329,13 +329,13 @@ export class Settings {
             this.settings.defaultLanguage || Object.keys(langs)[0] || 'c++';
 
         const defaultLanguageData = Object.keys(langs).map(lang => {
-            return { label: langs[lang].id, desc: langs[lang].name };
+            return {label: langs[lang].id, desc: langs[lang].name};
         });
         addSelector(
             '.defaultLanguage',
             'defaultLanguage',
             defaultLanguageData,
-            defLang,
+            defLang
         );
 
         if (this.subLangId) {
@@ -355,15 +355,15 @@ export class Settings {
             'GNU',
         ];
         const formatsData = formats.map(format => {
-            return { label: format, desc: format };
+            return {label: format, desc: format};
         });
         addSelector('.formatBase', 'formatBase', formatsData, formats[0]);
 
         const enableCtrlSData = [
-            { label: 'true', desc: 'Save To Local File' },
-            { label: 'false', desc: 'Create Short Link' },
-            { label: '2', desc: 'Reformat code' },
-            { label: '3', desc: 'Do nothing' },
+            {label: 'true', desc: 'Save To Local File'},
+            {label: 'false', desc: 'Create Short Link'},
+            {label: '2', desc: 'Reformat code'},
+            {label: '3', desc: 'Do nothing'},
         ];
         addSelector('.enableCtrlS', 'enableCtrlS', enableCtrlSData, 'true');
     }
@@ -386,9 +386,9 @@ export class Settings {
             new Slider(
                 this.root.find('.delay'),
                 'delayAfterChange',
-                delayAfterChangeSettings,
+                delayAfterChangeSettings
             ),
-            750,
+            750
         );
     }
 
@@ -398,14 +398,14 @@ export class Settings {
                 min: 1,
                 max: 80,
             }),
-            4,
+            4
         );
     }
 
     private addTextBoxes() {
         this.add(
             new Textbox(this.root.find('.editorsFFont'), 'editorsFFont'),
-            'Consolas, "Liberation Mono", Courier, monospace',
+            'Consolas, "Liberation Mono", Courier, monospace'
         );
     }
 
@@ -422,12 +422,12 @@ export class Settings {
             $.data(
                 themeSelect,
                 'theme-' + currentTheme,
-                colourSchemeSelect.val() as ColourScheme,
+                colourSchemeSelect.val() as ColourScheme
             );
         });
 
         const enableAllSchemesCheckbox = this.root.find(
-            '.alwaysEnableAllSchemes',
+            '.alwaysEnableAllSchemes'
         );
         enableAllSchemesCheckbox.on('change', this.onThemeChange.bind(this));
 
@@ -438,7 +438,7 @@ export class Settings {
         for (const scheme of colour.schemes) {
             if (this.isSchemeUsable(scheme, newTheme)) {
                 colourSchemeSelect.append(
-                    $(`<option value="${scheme.name}">${scheme.desc}</option>`),
+                    $(`<option value="${scheme.name}">${scheme.desc}</option>`)
                 );
             }
         }
@@ -446,7 +446,7 @@ export class Settings {
 
     private isSchemeUsable(
         scheme: ColourSchemeInfo,
-        newTheme?: AppTheme,
+        newTheme?: AppTheme
     ): boolean {
         return (
             this.settings.alwaysEnableAllSchemes ||
@@ -475,7 +475,7 @@ export class Settings {
         this.fillThemeSelector(colourSchemeSelect, newTheme);
         const newThemeStoredScheme = $.data(
             themeSelect,
-            'theme-' + newTheme,
+            'theme-' + newTheme
         ) as colour.AppTheme | undefined;
 
         // If nothing else, set the new scheme to the first of the available ones

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -57,11 +57,11 @@ export interface SiteSettings {
     defaultLanguage?: string;
     delayAfterChange: number;
     enableCodeLens: boolean;
-    enableCommunityAds: boolean
+    enableCommunityAds: boolean;
     enableCtrlS: string;
     enableSharingPopover: boolean;
     enableCtrlStree: boolean;
-    editorsFFont: string
+    editorsFFont: string;
     editorsFLigatures: boolean;
     formatBase: FormatBase;
     formatOnCompile: boolean;
@@ -107,7 +107,11 @@ class Checkbox extends BaseSetting {
 }
 
 class Select extends BaseSetting {
-    constructor(elem: JQuery, name: string, populate: {label: string, desc: string}[]) {
+    constructor(
+        elem: JQuery,
+        name: string,
+        populate: { label: string; desc: string }[],
+    ) {
         super(elem, name);
 
         elem.empty();
@@ -144,8 +148,7 @@ class Slider extends BaseSetting {
         this.max = sliderSettings.max || 100;
         this.min = sliderSettings.min || 1;
 
-        elem
-            .prop('max', this.max)
+        elem.prop('max', this.max)
             .prop('min', this.min)
             .prop('step', sliderSettings.step || 1);
 
@@ -172,14 +175,17 @@ class Numeric extends BaseSetting {
     private readonly min: number;
     private readonly max: number;
 
-    constructor(elem: JQuery, name: string, params: Record<'min' | 'max', number>) {
+    constructor(
+        elem: JQuery,
+        name: string,
+        params: Record<'min' | 'max', number>,
+    ) {
         super(elem, name);
 
         this.min = params.min;
         this.max = params.max;
 
-        elem.attr('min', this.min)
-            .attr('max', this.max);
+        elem.attr('min', this.min).attr('max', this.max);
     }
 
     override getUi(): number {
@@ -198,11 +204,12 @@ class Numeric extends BaseSetting {
 export class Settings {
     private readonly settingsObjs: BaseSetting[];
 
-    constructor(private root: JQuery,
-                private settings: SiteSettings,
-                private onChange: (SiteSettings) => void,
-                private subLangId: string | null) {
-
+    constructor(
+        private root: JQuery,
+        private settings: SiteSettings,
+        private onChange: (SiteSettings) => void,
+        private subLangId: string | null,
+    ) {
         this.settings = settings;
         this.settingsObjs = [];
 
@@ -248,7 +255,7 @@ export class Settings {
 
     private addCheckboxes() {
         // Known checkbox options in order [selector, key, defaultValue]
-        const checkboxes: [string, keyof SiteSettings, boolean][]= [
+        const checkboxes: [string, keyof SiteSettings, boolean][] = [
             ['.allowStoreCodeDebug', 'allowStoreCodeDebug', true],
             ['.alwaysEnableAllSchemes', 'alwaysEnableAllSchemes', false],
             ['.autoCloseBrackets', 'autoCloseBrackets', true],
@@ -274,7 +281,10 @@ export class Settings {
         ];
 
         for (const [selector, name, defaultValue] of checkboxes) {
-            this.add(new Checkbox(this.root.find(selector), name), defaultValue);
+            this.add(
+                new Checkbox(this.root.find(selector), name),
+                defaultValue,
+            );
         }
     }
 
@@ -282,21 +292,31 @@ export class Settings {
         const addSelector = (
             selector: string,
             name: keyof SiteSettings,
-            populate: {label: string, desc: string}[],
-            defaultValue: string
+            populate: { label: string; desc: string }[],
+            defaultValue: string,
         ) => {
-            this.add(new Select(this.root.find(selector), name, populate), defaultValue);
+            this.add(
+                new Select(this.root.find(selector), name, populate),
+                defaultValue,
+            );
         };
 
         const colourSchemesData = colour.schemes.map(scheme => {
-            return {label: scheme.name, desc: scheme.desc};
+            return { label: scheme.name, desc: scheme.desc };
         });
-        addSelector('.colourScheme', 'colourScheme', colourSchemesData, colour.schemes[0].name);
+        addSelector(
+            '.colourScheme',
+            'colourScheme',
+            colourSchemesData,
+            colour.schemes[0].name,
+        );
 
         // keys(themes) is Themes[] but TS does not realize without help
-        const themesData = (Object.keys(themes) as Themes[]).map((theme: Themes) => {
-            return {label: themes[theme].id, desc: themes[theme].name};
-        });
+        const themesData = (Object.keys(themes) as Themes[]).map(
+            (theme: Themes) => {
+                return { label: themes[theme].id, desc: themes[theme].name };
+            },
+        );
         let defaultThemeId = themes.default.id;
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
             defaultThemeId = themes.dark.id;
@@ -305,12 +325,18 @@ export class Settings {
 
         const langs = options.languages;
         const defaultLanguageSelector = this.root.find('.defaultLanguage');
-        const defLang = this.settings.defaultLanguage || Object.keys(langs)[0] || 'c++';
+        const defLang =
+            this.settings.defaultLanguage || Object.keys(langs)[0] || 'c++';
 
         const defaultLanguageData = Object.keys(langs).map(lang => {
-            return {label: langs[lang].id, desc: langs[lang].name};
+            return { label: langs[lang].id, desc: langs[lang].name };
         });
-        addSelector('.defaultLanguage', 'defaultLanguage', defaultLanguageData, defLang);
+        addSelector(
+            '.defaultLanguage',
+            'defaultLanguage',
+            defaultLanguageData,
+            defLang,
+        );
 
         if (this.subLangId) {
             defaultLanguageSelector
@@ -319,17 +345,25 @@ export class Settings {
                 .css('cursor', 'not-allowed');
         }
 
-        const formats: FormatBase[] = ['Google', 'LLVM', 'Mozilla', 'Chromium', 'WebKit', 'Microsoft', 'GNU'];
+        const formats: FormatBase[] = [
+            'Google',
+            'LLVM',
+            'Mozilla',
+            'Chromium',
+            'WebKit',
+            'Microsoft',
+            'GNU',
+        ];
         const formatsData = formats.map(format => {
-            return {label: format, desc: format};
+            return { label: format, desc: format };
         });
         addSelector('.formatBase', 'formatBase', formatsData, formats[0]);
 
         const enableCtrlSData = [
-            {label: 'true', desc: 'Save To Local File'},
-            {label: 'false', desc: 'Create Short Link'},
-            {label: '2', desc: 'Reformat code'},
-            {label: '3', desc: 'Do nothing'},
+            { label: 'true', desc: 'Save To Local File' },
+            { label: 'false', desc: 'Create Short Link' },
+            { label: '2', desc: 'Reformat code' },
+            { label: '3', desc: 'Do nothing' },
         ];
         addSelector('.enableCtrlS', 'enableCtrlS', enableCtrlSData, 'true');
     }
@@ -348,17 +382,30 @@ export class Settings {
             display: this.root.find('.delay-current-value'),
             formatter: x => (x / 1000.0).toFixed(2) + 's',
         };
-        this.add(new Slider(this.root.find('.delay'), 'delayAfterChange', delayAfterChangeSettings), 750);
+        this.add(
+            new Slider(
+                this.root.find('.delay'),
+                'delayAfterChange',
+                delayAfterChangeSettings,
+            ),
+            750,
+        );
     }
 
     private addNumerics() {
-        this.add(new Numeric(this.root.find('.tabWidth'), 'tabWidth', {min: 1, max: 80}), 4);
+        this.add(
+            new Numeric(this.root.find('.tabWidth'), 'tabWidth', {
+                min: 1,
+                max: 80,
+            }),
+            4,
+        );
     }
 
     private addTextBoxes() {
         this.add(
             new Textbox(this.root.find('.editorsFFont'), 'editorsFFont'),
-            'Consolas, "Liberation Mono", Courier, monospace'
+            'Consolas, "Liberation Mono", Courier, monospace',
         );
     }
 
@@ -370,12 +417,18 @@ export class Settings {
         });
 
         const colourSchemeSelect = this.root.find('.colourScheme');
-        colourSchemeSelect.on('change', (e) => {
+        colourSchemeSelect.on('change', e => {
             const currentTheme = this.settings.theme;
-            $.data(themeSelect, 'theme-' + currentTheme, colourSchemeSelect.val() as ColourScheme);
+            $.data(
+                themeSelect,
+                'theme-' + currentTheme,
+                colourSchemeSelect.val() as ColourScheme,
+            );
         });
 
-        const enableAllSchemesCheckbox = this.root.find('.alwaysEnableAllSchemes');
+        const enableAllSchemesCheckbox = this.root.find(
+            '.alwaysEnableAllSchemes',
+        );
         enableAllSchemesCheckbox.on('change', this.onThemeChange.bind(this));
 
         $.data(themeSelect, 'last-theme', themeSelect.val() as string);
@@ -384,14 +437,23 @@ export class Settings {
     private fillThemeSelector(colourSchemeSelect: JQuery, newTheme?: AppTheme) {
         for (const scheme of colour.schemes) {
             if (this.isSchemeUsable(scheme, newTheme)) {
-                colourSchemeSelect.append($(`<option value="${scheme.name}">${scheme.desc}</option>`));
+                colourSchemeSelect.append(
+                    $(`<option value="${scheme.name}">${scheme.desc}</option>`),
+                );
             }
         }
     }
 
-    private isSchemeUsable(scheme: ColourSchemeInfo, newTheme?: AppTheme): boolean {
-        return this.settings.alwaysEnableAllSchemes || scheme.themes.length === 0
-            || (newTheme && scheme.themes.includes(newTheme)) || scheme.themes.includes('all');
+    private isSchemeUsable(
+        scheme: ColourSchemeInfo,
+        newTheme?: AppTheme,
+    ): boolean {
+        return (
+            this.settings.alwaysEnableAllSchemes ||
+            scheme.themes.length === 0 ||
+            (newTheme && scheme.themes.includes(newTheme)) ||
+            scheme.themes.includes('all')
+        );
     }
 
     private selectorHasOption(selector: JQuery, option: string): boolean {
@@ -411,12 +473,18 @@ export class Settings {
 
         colourSchemeSelect.empty();
         this.fillThemeSelector(colourSchemeSelect, newTheme);
-        const newThemeStoredScheme = $.data(themeSelect, 'theme-' + newTheme) as colour.AppTheme | undefined;
+        const newThemeStoredScheme = $.data(
+            themeSelect,
+            'theme-' + newTheme,
+        ) as colour.AppTheme | undefined;
 
         // If nothing else, set the new scheme to the first of the available ones
         let newScheme = colourSchemeSelect.first().val() as string;
         // If we have one old one stored, check if it's still valid and set it if so
-        if (newThemeStoredScheme && this.selectorHasOption(colourSchemeSelect, newThemeStoredScheme)) {
+        if (
+            newThemeStoredScheme &&
+            this.selectorHasOption(colourSchemeSelect, newThemeStoredScheme)
+        ) {
             newScheme = newThemeStoredScheme;
         } else if (this.selectorHasOption(colourSchemeSelect, oldScheme)) {
             newScheme = oldScheme;

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -28,22 +28,9 @@ import * as local from './local';
 import {themes, Themes} from './themes';
 import {AppTheme, ColourSchemeInfo} from './colour';
 
-type ColourScheme =
-    | 'rainbow'
-    | 'rainbow2'
-    | 'earth'
-    | 'green-blue'
-    | 'gray-shade'
-    | 'rainbow-dark';
+type ColourScheme = 'rainbow' | 'rainbow2' | 'earth' | 'green-blue' | 'gray-shade' | 'rainbow-dark';
 
-export type FormatBase =
-    | 'Google'
-    | 'LLVM'
-    | 'Mozilla'
-    | 'Chromium'
-    | 'WebKit'
-    | 'Microsoft'
-    | 'GNU';
+export type FormatBase = 'Google' | 'LLVM' | 'Mozilla' | 'Chromium' | 'WebKit' | 'Microsoft' | 'GNU';
 
 export interface SiteSettings {
     autoCloseBrackets: boolean;
@@ -107,11 +94,7 @@ class Checkbox extends BaseSetting {
 }
 
 class Select extends BaseSetting {
-    constructor(
-        elem: JQuery,
-        name: string,
-        populate: {label: string; desc: string}[]
-    ) {
+    constructor(elem: JQuery, name: string, populate: {label: string; desc: string}[]) {
         super(elem, name);
 
         elem.empty();
@@ -175,11 +158,7 @@ class Numeric extends BaseSetting {
     private readonly min: number;
     private readonly max: number;
 
-    constructor(
-        elem: JQuery,
-        name: string,
-        params: Record<'min' | 'max', number>
-    ) {
+    constructor(elem: JQuery, name: string, params: Record<'min' | 'max', number>) {
         super(elem, name);
 
         this.min = params.min;
@@ -281,10 +260,7 @@ export class Settings {
         ];
 
         for (const [selector, name, defaultValue] of checkboxes) {
-            this.add(
-                new Checkbox(this.root.find(selector), name),
-                defaultValue
-            );
+            this.add(new Checkbox(this.root.find(selector), name), defaultValue);
         }
     }
 
@@ -295,28 +271,18 @@ export class Settings {
             populate: {label: string; desc: string}[],
             defaultValue: string
         ) => {
-            this.add(
-                new Select(this.root.find(selector), name, populate),
-                defaultValue
-            );
+            this.add(new Select(this.root.find(selector), name, populate), defaultValue);
         };
 
         const colourSchemesData = colour.schemes.map(scheme => {
             return {label: scheme.name, desc: scheme.desc};
         });
-        addSelector(
-            '.colourScheme',
-            'colourScheme',
-            colourSchemesData,
-            colour.schemes[0].name
-        );
+        addSelector('.colourScheme', 'colourScheme', colourSchemesData, colour.schemes[0].name);
 
         // keys(themes) is Themes[] but TS does not realize without help
-        const themesData = (Object.keys(themes) as Themes[]).map(
-            (theme: Themes) => {
-                return {label: themes[theme].id, desc: themes[theme].name};
-            }
-        );
+        const themesData = (Object.keys(themes) as Themes[]).map((theme: Themes) => {
+            return {label: themes[theme].id, desc: themes[theme].name};
+        });
         let defaultThemeId = themes.default.id;
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
             defaultThemeId = themes.dark.id;
@@ -325,18 +291,12 @@ export class Settings {
 
         const langs = options.languages;
         const defaultLanguageSelector = this.root.find('.defaultLanguage');
-        const defLang =
-            this.settings.defaultLanguage || Object.keys(langs)[0] || 'c++';
+        const defLang = this.settings.defaultLanguage || Object.keys(langs)[0] || 'c++';
 
         const defaultLanguageData = Object.keys(langs).map(lang => {
             return {label: langs[lang].id, desc: langs[lang].name};
         });
-        addSelector(
-            '.defaultLanguage',
-            'defaultLanguage',
-            defaultLanguageData,
-            defLang
-        );
+        addSelector('.defaultLanguage', 'defaultLanguage', defaultLanguageData, defLang);
 
         if (this.subLangId) {
             defaultLanguageSelector
@@ -345,15 +305,7 @@ export class Settings {
                 .css('cursor', 'not-allowed');
         }
 
-        const formats: FormatBase[] = [
-            'Google',
-            'LLVM',
-            'Mozilla',
-            'Chromium',
-            'WebKit',
-            'Microsoft',
-            'GNU',
-        ];
+        const formats: FormatBase[] = ['Google', 'LLVM', 'Mozilla', 'Chromium', 'WebKit', 'Microsoft', 'GNU'];
         const formatsData = formats.map(format => {
             return {label: format, desc: format};
         });
@@ -382,14 +334,7 @@ export class Settings {
             display: this.root.find('.delay-current-value'),
             formatter: x => (x / 1000.0).toFixed(2) + 's',
         };
-        this.add(
-            new Slider(
-                this.root.find('.delay'),
-                'delayAfterChange',
-                delayAfterChangeSettings
-            ),
-            750
-        );
+        this.add(new Slider(this.root.find('.delay'), 'delayAfterChange', delayAfterChangeSettings), 750);
     }
 
     private addNumerics() {
@@ -419,16 +364,10 @@ export class Settings {
         const colourSchemeSelect = this.root.find('.colourScheme');
         colourSchemeSelect.on('change', e => {
             const currentTheme = this.settings.theme;
-            $.data(
-                themeSelect,
-                'theme-' + currentTheme,
-                colourSchemeSelect.val() as ColourScheme
-            );
+            $.data(themeSelect, 'theme-' + currentTheme, colourSchemeSelect.val() as ColourScheme);
         });
 
-        const enableAllSchemesCheckbox = this.root.find(
-            '.alwaysEnableAllSchemes'
-        );
+        const enableAllSchemesCheckbox = this.root.find('.alwaysEnableAllSchemes');
         enableAllSchemesCheckbox.on('change', this.onThemeChange.bind(this));
 
         $.data(themeSelect, 'last-theme', themeSelect.val() as string);
@@ -437,17 +376,12 @@ export class Settings {
     private fillThemeSelector(colourSchemeSelect: JQuery, newTheme?: AppTheme) {
         for (const scheme of colour.schemes) {
             if (this.isSchemeUsable(scheme, newTheme)) {
-                colourSchemeSelect.append(
-                    $(`<option value="${scheme.name}">${scheme.desc}</option>`)
-                );
+                colourSchemeSelect.append($(`<option value="${scheme.name}">${scheme.desc}</option>`));
             }
         }
     }
 
-    private isSchemeUsable(
-        scheme: ColourSchemeInfo,
-        newTheme?: AppTheme
-    ): boolean {
+    private isSchemeUsable(scheme: ColourSchemeInfo, newTheme?: AppTheme): boolean {
         return (
             this.settings.alwaysEnableAllSchemes ||
             scheme.themes.length === 0 ||
@@ -473,18 +407,12 @@ export class Settings {
 
         colourSchemeSelect.empty();
         this.fillThemeSelector(colourSchemeSelect, newTheme);
-        const newThemeStoredScheme = $.data(
-            themeSelect,
-            'theme-' + newTheme
-        ) as colour.AppTheme | undefined;
+        const newThemeStoredScheme = $.data(themeSelect, 'theme-' + newTheme) as colour.AppTheme | undefined;
 
         // If nothing else, set the new scheme to the first of the available ones
         let newScheme = colourSchemeSelect.first().val() as string;
         // If we have one old one stored, check if it's still valid and set it if so
-        if (
-            newThemeStoredScheme &&
-            this.selectorHasOption(colourSchemeSelect, newThemeStoredScheme)
-        ) {
+        if (newThemeStoredScheme && this.selectorHasOption(colourSchemeSelect, newThemeStoredScheme)) {
             newScheme = newThemeStoredScheme;
         } else if (this.selectorHasOption(colourSchemeSelect, oldScheme)) {
             newScheme = oldScheme;

--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -116,24 +116,15 @@ export class Sharing {
         const config = Sharing.filterComponentState(this.layout.toConfig());
         this.ensureUrlIsNotOutdated(config);
         if (options.embedded) {
-            const strippedToLast = window.location.pathname.substr(
-                0,
-                window.location.pathname.lastIndexOf('/') + 1
-            );
-            $('a.link').prop(
-                'href',
-                strippedToLast + '#' + url.serialiseState(config)
-            );
+            const strippedToLast = window.location.pathname.substr(0, window.location.pathname.lastIndexOf('/') + 1);
+            $('a.link').prop('href', strippedToLast + '#' + url.serialiseState(config));
         }
     }
 
     private ensureUrlIsNotOutdated(config: any): void {
         const stringifiedConfig = JSON.stringify(config);
         if (stringifiedConfig !== this.lastState) {
-            if (
-                this.lastState != null &&
-                window.location.pathname !== window.httpRoot
-            ) {
+            if (this.lastState != null && window.location.pathname !== window.httpRoot) {
                 window.history.replaceState(null, '', window.httpRoot);
             }
             this.lastState = stringifiedConfig;
@@ -153,9 +144,7 @@ export class Sharing {
         }
     }
 
-    private onOpenModalPane(
-        event: TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
-    ): void {
+    private onOpenModalPane(event: TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>): void {
         // @ts-ignore The property is added by bootstrap
         const button = $(event.relatedTarget);
         const currentBind = Sharing.bindToLinkType(button.data('bind'));
@@ -167,41 +156,29 @@ export class Sharing {
         const updatePermaLink = () => {
             socialSharingElements.empty();
             const config = this.layout.toConfig();
-            Sharing.getLinks(
-                config,
-                currentBind,
-                (
-                    error: any,
-                    newUrl: string,
-                    extra: string,
-                    updateState: boolean
-                ) => {
-                    permalink.off('click');
-                    if (error || !newUrl) {
-                        permalink.prop('disabled', true);
-                        permalink.val(error || 'Error providing URL');
-                        Sentry.captureException(error);
-                    } else {
-                        if (updateState) {
-                            Sharing.storeCurrentConfig(config, extra);
-                        }
-                        permalink.val(newUrl);
-                        permalink.on('click', () => {
-                            permalink.trigger('focus').trigger('select');
-                        });
-                        if (options.sharingEnabled) {
-                            Sharing.updateShares(socialSharingElements, newUrl);
-                            // Disable the links for every share item which does not support embed html as links
-                            if (currentBind === LinkType.Embed) {
-                                socialSharingElements
-                                    .children('.share-no-embeddable')
-                                    .hide()
-                                    .on('click', false);
-                            }
+            Sharing.getLinks(config, currentBind, (error: any, newUrl: string, extra: string, updateState: boolean) => {
+                permalink.off('click');
+                if (error || !newUrl) {
+                    permalink.prop('disabled', true);
+                    permalink.val(error || 'Error providing URL');
+                    Sentry.captureException(error);
+                } else {
+                    if (updateState) {
+                        Sharing.storeCurrentConfig(config, extra);
+                    }
+                    permalink.val(newUrl);
+                    permalink.on('click', () => {
+                        permalink.trigger('focus').trigger('select');
+                    });
+                    if (options.sharingEnabled) {
+                        Sharing.updateShares(socialSharingElements, newUrl);
+                        // Disable the links for every share item which does not support embed html as links
+                        if (currentBind === LinkType.Embed) {
+                            socialSharingElements.children('.share-no-embeddable').hide().on('click', false);
                         }
                     }
                 }
-            );
+            });
         };
 
         const clippyElement = modal.find('button.clippy').get(0);
@@ -248,21 +225,12 @@ export class Sharing {
         const shareFullCopyToClipBtn = this.shareFull.find('.clip-icon');
         const shareEmbedCopyToClipBtn = this.shareEmbed.find('.clip-icon');
 
-        shareShortCopyToClipBtn.on('click', e =>
-            this.onClipButtonPressed(e, LinkType.Short)
-        );
-        shareFullCopyToClipBtn.on('click', e =>
-            this.onClipButtonPressed(e, LinkType.Full)
-        );
-        shareEmbedCopyToClipBtn.on('click', e =>
-            this.onClipButtonPressed(e, LinkType.Embed)
-        );
+        shareShortCopyToClipBtn.on('click', e => this.onClipButtonPressed(e, LinkType.Short));
+        shareFullCopyToClipBtn.on('click', e => this.onClipButtonPressed(e, LinkType.Full));
+        shareEmbedCopyToClipBtn.on('click', e => this.onClipButtonPressed(e, LinkType.Embed));
 
         if (options.sharingEnabled) {
-            Sharing.updateShares(
-                $('#socialshare'),
-                window.location.protocol + '//' + window.location.hostname
-            );
+            Sharing.updateShares($('#socialshare'), window.location.protocol + '//' + window.location.hostname);
         }
     }
 
@@ -279,29 +247,17 @@ export class Sharing {
 
     private copyLinkTypeToClipboard(type: LinkType): void {
         const config = this.layout.toConfig();
-        Sharing.getLinks(
-            config,
-            type,
-            (
-                error: any,
-                newUrl: string,
-                extra: string,
-                updateState: boolean
-            ) => {
-                if (error || !newUrl) {
-                    this.displayTooltip(
-                        this.share,
-                        'Oops, something went wrong'
-                    );
-                    Sentry.captureException(error);
-                } else {
-                    if (updateState) {
-                        Sharing.storeCurrentConfig(config, extra);
-                    }
-                    this.doLinkCopyToClipboard(type, newUrl);
+        Sharing.getLinks(config, type, (error: any, newUrl: string, extra: string, updateState: boolean) => {
+            if (error || !newUrl) {
+                this.displayTooltip(this.share, 'Oops, something went wrong');
+                Sentry.captureException(error);
+            } else {
+                if (updateState) {
+                    Sharing.storeCurrentConfig(config, extra);
                 }
+                this.doLinkCopyToClipboard(type, newUrl);
             }
-        );
+        });
     }
 
     private displayTooltip(where: JQuery, message: string): void {
@@ -334,20 +290,14 @@ export class Sharing {
         if (Sharing.isNavigatorClipboardAvailable()) {
             navigator.clipboard
                 .writeText(link)
-                .then(() =>
-                    this.displayTooltip(this.share, 'Link copied to clipboard')
-                )
+                .then(() => this.displayTooltip(this.share, 'Link copied to clipboard'))
                 .catch(() => this.openShareModalForType(type));
         } else {
             this.openShareModalForType(type);
         }
     }
 
-    public static getLinks(
-        config: any,
-        currentBind: LinkType,
-        done: CallableFunction
-    ): void {
+    public static getLinks(config: any, currentBind: LinkType, done: CallableFunction): void {
         const root = window.httpRoot;
         ga.proxy('send', {
             hitType: 'event',
@@ -359,25 +309,14 @@ export class Sharing {
                 Sharing.getShortLink(config, root, done);
                 return;
             case LinkType.Full:
-                done(
-                    null,
-                    window.location.origin +
-                        root +
-                        '#' +
-                        url.serialiseState(config),
-                    false
-                );
+                done(null, window.location.origin + root + '#' + url.serialiseState(config), false);
                 return;
             case LinkType.Embed: {
                 const options = {};
                 $('#sharelinkdialog input:checked').each((i, element) => {
                     options[$(element).prop('class')] = true;
                 });
-                done(
-                    null,
-                    Sharing.getEmbeddedHtml(config, root, false, options),
-                    false
-                );
+                done(null, Sharing.getEmbeddedHtml(config, root, false, options), false);
                 return;
             }
             default:
@@ -386,11 +325,7 @@ export class Sharing {
         }
     }
 
-    private static getShortLink(
-        config: any,
-        root: string,
-        done: CallableFunction
-    ): void {
+    private static getShortLink(config: any, root: string, done: CallableFunction): void {
         const useExternalShortener = options.urlShortenService !== 'default';
         const data = JSON.stringify({
             config: useExternalShortener ? url.serialiseState(config) : config,
@@ -413,27 +348,12 @@ export class Sharing {
         });
     }
 
-    private static getEmbeddedHtml(
-        config,
-        root,
-        isReadOnly,
-        extraOptions
-    ): string {
-        const embedUrl = Sharing.getEmbeddedUrl(
-            config,
-            root,
-            isReadOnly,
-            extraOptions
-        );
+    private static getEmbeddedHtml(config, root, isReadOnly, extraOptions): string {
+        const embedUrl = Sharing.getEmbeddedUrl(config, root, isReadOnly, extraOptions);
         return `<iframe width="800px" height="200px" src="${embedUrl}"></iframe>`;
     }
 
-    private static getEmbeddedUrl(
-        config: any,
-        root: string,
-        readOnly: boolean,
-        extraOptions: object
-    ): string {
+    private static getEmbeddedUrl(config: any, root: string, readOnly: boolean, extraOptions: object): string {
         const location = window.location.origin + root;
         const parameters = _.reduce(
             extraOptions,
@@ -462,10 +382,7 @@ export class Sharing {
         return (navigator.clipboard as Clipboard | undefined) !== undefined;
     }
 
-    public static filterComponentState(
-        config: any,
-        keysToRemove: [string] = ['selection']
-    ): any {
+    public static filterComponentState(config: any, keysToRemove: [string] = ['selection']): any {
         function filterComponentStateImpl(component: any) {
             if (component.content) {
                 for (let i = 0; i < component.content.length; i++) {
@@ -491,10 +408,7 @@ export class Sharing {
             const newElement = baseTemplate.children('a.share-item').clone();
             if (service.logoClass) {
                 newElement.prepend(
-                    $('<span>')
-                        .addClass('dropdown-icon mr-1')
-                        .addClass(service.logoClass)
-                        .prop('title', serviceName)
+                    $('<span>').addClass('dropdown-icon mr-1').addClass(service.logoClass).prop('title', serviceName)
                 );
             }
             if (service.text) {

--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -39,7 +39,7 @@ const cloneDeep = require('lodash.clonedeep');
 enum LinkType {
     Short,
     Full,
-    Embed
+    Embed,
 }
 
 const shareServices = {
@@ -48,10 +48,12 @@ const shareServices = {
         logoClass: 'fab fa-twitter',
         cssClass: 'share-twitter',
         getLink: (title, url) => {
-            return 'https://twitter.com/intent/tweet' +
+            return (
+                'https://twitter.com/intent/tweet' +
                 `?text=${encodeURIComponent(title)}` +
                 `&url=${encodeURIComponent(url)}` +
-                '&via=CompileExplore';
+                '&via=CompileExplore'
+            );
         },
         text: 'Tweet',
     },
@@ -60,9 +62,11 @@ const shareServices = {
         logoClass: 'fab fa-reddit',
         cssClass: 'share-reddit',
         getLink: (title, url) => {
-            return 'http://www.reddit.com/submit' +
+            return (
+                'http://www.reddit.com/submit' +
                 `?url=${encodeURIComponent(url)}` +
-                `&title=${encodeURIComponent(title)}`;
+                `&title=${encodeURIComponent(title)}`
+            );
         },
         text: 'Share on Reddit',
     },
@@ -103,7 +107,8 @@ export class Sharing {
         });
         this.layout.on('stateChanged', this.onStateChanged.bind(this));
 
-        $('#sharelinkdialog').on('show.bs.modal', this.onOpenModalPane.bind(this))
+        $('#sharelinkdialog')
+            .on('show.bs.modal', this.onOpenModalPane.bind(this))
             .on('hidden.bs.modal', this.onCloseModalPane.bind(this));
     }
 
@@ -111,15 +116,24 @@ export class Sharing {
         const config = Sharing.filterComponentState(this.layout.toConfig());
         this.ensureUrlIsNotOutdated(config);
         if (options.embedded) {
-            const strippedToLast = window.location.pathname.substr(0, window.location.pathname.lastIndexOf('/') + 1);
-            $('a.link').prop('href', strippedToLast + '#' + url.serialiseState(config));
+            const strippedToLast = window.location.pathname.substr(
+                0,
+                window.location.pathname.lastIndexOf('/') + 1,
+            );
+            $('a.link').prop(
+                'href',
+                strippedToLast + '#' + url.serialiseState(config),
+            );
         }
     }
 
     private ensureUrlIsNotOutdated(config: any): void {
         const stringifiedConfig = JSON.stringify(config);
         if (stringifiedConfig !== this.lastState) {
-            if (this.lastState != null && window.location.pathname !== window.httpRoot) {
+            if (
+                this.lastState != null &&
+                window.location.pathname !== window.httpRoot
+            ) {
                 window.history.replaceState(null, '', window.httpRoot);
             }
             this.lastState = stringifiedConfig;
@@ -128,14 +142,20 @@ export class Sharing {
 
     private static bindToLinkType(bind: string): LinkType {
         switch (bind) {
-            case 'Full': return LinkType.Full;
-            case 'Short': return LinkType.Short;
-            case 'Embed': return LinkType.Embed;
-            default: return LinkType.Full;
+            case 'Full':
+                return LinkType.Full;
+            case 'Short':
+                return LinkType.Short;
+            case 'Embed':
+                return LinkType.Embed;
+            default:
+                return LinkType.Full;
         }
     }
 
-    private onOpenModalPane(event: TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>): void {
+    private onOpenModalPane(
+        event: TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>,
+    ): void {
         // @ts-ignore The property is added by bootstrap
         const button = $(event.relatedTarget);
         const currentBind = Sharing.bindToLinkType(button.data('bind'));
@@ -147,48 +167,59 @@ export class Sharing {
         const updatePermaLink = () => {
             socialSharingElements.empty();
             const config = this.layout.toConfig();
-            Sharing.getLinks(config, currentBind, (error: any, newUrl: string, extra: string, updateState: boolean) => {
-                permalink.off('click');
-                if (error || !newUrl) {
-                    permalink.prop('disabled', true);
-                    permalink.val(error || 'Error providing URL');
-                    Sentry.captureException(error);
-                } else {
-                    if (updateState) {
-                        Sharing.storeCurrentConfig(config, extra);
-                    }
-                    permalink.val(newUrl);
-                    permalink.on('click', () => {
-                        permalink.trigger('focus').trigger('select');
-                    });
-                    if (options.sharingEnabled) {
-                        Sharing.updateShares(socialSharingElements, newUrl);
-                        // Disable the links for every share item which does not support embed html as links
-                        if (currentBind === LinkType.Embed) {
-                            socialSharingElements.children('.share-no-embeddable')
-                                .hide()
-                                .on('click', false);
+            Sharing.getLinks(
+                config,
+                currentBind,
+                (
+                    error: any,
+                    newUrl: string,
+                    extra: string,
+                    updateState: boolean,
+                ) => {
+                    permalink.off('click');
+                    if (error || !newUrl) {
+                        permalink.prop('disabled', true);
+                        permalink.val(error || 'Error providing URL');
+                        Sentry.captureException(error);
+                    } else {
+                        if (updateState) {
+                            Sharing.storeCurrentConfig(config, extra);
+                        }
+                        permalink.val(newUrl);
+                        permalink.on('click', () => {
+                            permalink.trigger('focus').trigger('select');
+                        });
+                        if (options.sharingEnabled) {
+                            Sharing.updateShares(socialSharingElements, newUrl);
+                            // Disable the links for every share item which does not support embed html as links
+                            if (currentBind === LinkType.Embed) {
+                                socialSharingElements
+                                    .children('.share-no-embeddable')
+                                    .hide()
+                                    .on('click', false);
+                            }
                         }
                     }
-                }
-            });
+                },
+            );
         };
 
         const clippyElement = modal.find('button.clippy').get(0);
         if (clippyElement != null) {
             this.clippyButton = new ClipboardJS(clippyElement);
-            this.clippyButton.on('success', (e) => {
+            this.clippyButton.on('success', e => {
                 this.displayTooltip(permalink, 'Link copied to clipboard');
                 e.clearSelection();
             });
-            this.clippyButton.on('error', (e) => {
+            this.clippyButton.on('error', e => {
                 this.displayTooltip(permalink, 'Error copying to clipboard');
             });
         }
 
         if (currentBind === LinkType.Embed) {
             embedsettings.show();
-            embedsettings.find('input')
+            embedsettings
+                .find('input')
                 // Off any prev click handlers to avoid multiple events triggering after opening the modal more than once
                 .off('click')
                 .on('click', () => updatePermaLink());
@@ -217,12 +248,21 @@ export class Sharing {
         const shareFullCopyToClipBtn = this.shareFull.find('.clip-icon');
         const shareEmbedCopyToClipBtn = this.shareEmbed.find('.clip-icon');
 
-        shareShortCopyToClipBtn.on('click', (e) => this.onClipButtonPressed(e, LinkType.Short));
-        shareFullCopyToClipBtn.on('click', (e) => this.onClipButtonPressed(e, LinkType.Full));
-        shareEmbedCopyToClipBtn.on('click', (e) => this.onClipButtonPressed(e, LinkType.Embed));
+        shareShortCopyToClipBtn.on('click', e =>
+            this.onClipButtonPressed(e, LinkType.Short),
+        );
+        shareFullCopyToClipBtn.on('click', e =>
+            this.onClipButtonPressed(e, LinkType.Full),
+        );
+        shareEmbedCopyToClipBtn.on('click', e =>
+            this.onClipButtonPressed(e, LinkType.Embed),
+        );
 
         if (options.sharingEnabled) {
-            Sharing.updateShares($('#socialshare'), window.location.protocol + '//' + window.location.hostname);
+            Sharing.updateShares(
+                $('#socialshare'),
+                window.location.protocol + '//' + window.location.hostname,
+            );
         }
     }
 
@@ -239,17 +279,29 @@ export class Sharing {
 
     private copyLinkTypeToClipboard(type: LinkType): void {
         const config = this.layout.toConfig();
-        Sharing.getLinks(config, type, (error: any, newUrl: string, extra: string, updateState: boolean) => {
-            if (error || !newUrl) {
-                this.displayTooltip(this.share, 'Oops, something went wrong');
-                Sentry.captureException(error);
-            } else {
-                if (updateState) {
-                    Sharing.storeCurrentConfig(config, extra);
+        Sharing.getLinks(
+            config,
+            type,
+            (
+                error: any,
+                newUrl: string,
+                extra: string,
+                updateState: boolean,
+            ) => {
+                if (error || !newUrl) {
+                    this.displayTooltip(
+                        this.share,
+                        'Oops, something went wrong',
+                    );
+                    Sentry.captureException(error);
+                } else {
+                    if (updateState) {
+                        Sharing.storeCurrentConfig(config, extra);
+                    }
+                    this.doLinkCopyToClipboard(type, newUrl);
                 }
-                this.doLinkCopyToClipboard(type, newUrl);
-            }
-        });
+            },
+        );
     }
 
     private displayTooltip(where: JQuery, message: string): void {
@@ -280,15 +332,22 @@ export class Sharing {
 
     private doLinkCopyToClipboard(type: LinkType, link: string): void {
         if (Sharing.isNavigatorClipboardAvailable()) {
-            navigator.clipboard.writeText(link)
-                .then(() => this.displayTooltip(this.share, 'Link copied to clipboard'))
+            navigator.clipboard
+                .writeText(link)
+                .then(() =>
+                    this.displayTooltip(this.share, 'Link copied to clipboard'),
+                )
                 .catch(() => this.openShareModalForType(type));
         } else {
             this.openShareModalForType(type);
         }
     }
 
-    public static getLinks(config: any, currentBind: LinkType, done: CallableFunction): void {
+    public static getLinks(
+        config: any,
+        currentBind: LinkType,
+        done: CallableFunction,
+    ): void {
         const root = window.httpRoot;
         ga.proxy('send', {
             hitType: 'event',
@@ -300,14 +359,25 @@ export class Sharing {
                 Sharing.getShortLink(config, root, done);
                 return;
             case LinkType.Full:
-                done(null, window.location.origin + root + '#' + url.serialiseState(config), false);
+                done(
+                    null,
+                    window.location.origin +
+                        root +
+                        '#' +
+                        url.serialiseState(config),
+                    false,
+                );
                 return;
             case LinkType.Embed: {
                 const options = {};
                 $('#sharelinkdialog input:checked').each((i, element) => {
                     options[$(element).prop('class')] = true;
                 });
-                done(null, Sharing.getEmbeddedHtml(config, root, false, options), false);
+                done(
+                    null,
+                    Sharing.getEmbeddedHtml(config, root, false, options),
+                    false,
+                );
                 return;
             }
             default:
@@ -316,7 +386,11 @@ export class Sharing {
         }
     }
 
-    private static getShortLink(config: any, root: string, done: CallableFunction): void {
+    private static getShortLink(
+        config: any,
+        root: string,
+        done: CallableFunction,
+    ): void {
         const useExternalShortener = options.urlShortenService !== 'default';
         const data = JSON.stringify({
             config: useExternalShortener ? url.serialiseState(config) : config,
@@ -324,14 +398,14 @@ export class Sharing {
         $.ajax({
             type: 'POST',
             url: window.location.origin + root + 'api/shortener',
-            dataType: 'json',  // Expected
-            contentType: 'application/json',  // Sent
+            dataType: 'json', // Expected
+            contentType: 'application/json', // Sent
             data: data,
             success: (result: any) => {
                 const pushState = useExternalShortener ? null : result.url;
                 done(null, result.url, pushState, true);
             },
-            error: (err) => {
+            error: err => {
                 // Notify the user that we ran into trouble?
                 done(err.statusText, null, false);
             },
@@ -339,22 +413,41 @@ export class Sharing {
         });
     }
 
-    private static getEmbeddedHtml(config, root, isReadOnly, extraOptions): string {
-        const embedUrl = Sharing.getEmbeddedUrl(config, root, isReadOnly, extraOptions);
+    private static getEmbeddedHtml(
+        config,
+        root,
+        isReadOnly,
+        extraOptions,
+    ): string {
+        const embedUrl = Sharing.getEmbeddedUrl(
+            config,
+            root,
+            isReadOnly,
+            extraOptions,
+        );
         return `<iframe width="800px" height="200px" src="${embedUrl}"></iframe>`;
     }
 
-    private static getEmbeddedUrl(config: any, root: string, readOnly: boolean, extraOptions: object): string {
+    private static getEmbeddedUrl(
+        config: any,
+        root: string,
+        readOnly: boolean,
+        extraOptions: object,
+    ): string {
         const location = window.location.origin + root;
-        const parameters = _.reduce(extraOptions, (total, value, key): string => {
-            if (total === '') {
-                total = '?';
-            } else {
-                total += '&';
-            }
+        const parameters = _.reduce(
+            extraOptions,
+            (total, value, key): string => {
+                if (total === '') {
+                    total = '?';
+                } else {
+                    total += '&';
+                }
 
-            return total + key + '=' + value;
-        }, '');
+                return total + key + '=' + value;
+            },
+            '',
+        );
 
         const path = (readOnly ? 'embed-ro' : 'e') + parameters + '#';
 
@@ -369,7 +462,10 @@ export class Sharing {
         return (navigator.clipboard as Clipboard | undefined) !== undefined;
     }
 
-    public static filterComponentState(config: any, keysToRemove: [string] = ['selection']): any {
+    public static filterComponentState(
+        config: any,
+        keysToRemove: [string] = ['selection'],
+    ): any {
         function filterComponentStateImpl(component: any) {
             if (component.content) {
                 for (let i = 0; i < component.content.length; i++) {
@@ -379,8 +475,8 @@ export class Sharing {
 
             if (component.componentState) {
                 Object.keys(component.componentState)
-                    .filter((e) => keysToRemove.includes(e))
-                    .forEach((key) => delete component.componentState[key]);
+                    .filter(e => keysToRemove.includes(e))
+                    .forEach(key => delete component.componentState[key]);
             }
         }
 
@@ -394,15 +490,15 @@ export class Sharing {
         _.each(shareServices, (service, serviceName) => {
             const newElement = baseTemplate.children('a.share-item').clone();
             if (service.logoClass) {
-                newElement.prepend($('<span>')
-                    .addClass('dropdown-icon mr-1')
-                    .addClass(service.logoClass)
-                    .prop('title', serviceName)
+                newElement.prepend(
+                    $('<span>')
+                        .addClass('dropdown-icon mr-1')
+                        .addClass(service.logoClass)
+                        .prop('title', serviceName),
                 );
             }
             if (service.text) {
-                newElement.children('span.share-item-text')
-                    .text(service.text);
+                newElement.children('span.share-item-text').text(service.text);
             }
             newElement
                 .prop('href', service.getLink('Compiler Explorer', url))

--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -118,11 +118,11 @@ export class Sharing {
         if (options.embedded) {
             const strippedToLast = window.location.pathname.substr(
                 0,
-                window.location.pathname.lastIndexOf('/') + 1,
+                window.location.pathname.lastIndexOf('/') + 1
             );
             $('a.link').prop(
                 'href',
-                strippedToLast + '#' + url.serialiseState(config),
+                strippedToLast + '#' + url.serialiseState(config)
             );
         }
     }
@@ -154,7 +154,7 @@ export class Sharing {
     }
 
     private onOpenModalPane(
-        event: TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>,
+        event: TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
     ): void {
         // @ts-ignore The property is added by bootstrap
         const button = $(event.relatedTarget);
@@ -174,7 +174,7 @@ export class Sharing {
                     error: any,
                     newUrl: string,
                     extra: string,
-                    updateState: boolean,
+                    updateState: boolean
                 ) => {
                     permalink.off('click');
                     if (error || !newUrl) {
@@ -200,7 +200,7 @@ export class Sharing {
                             }
                         }
                     }
-                },
+                }
             );
         };
 
@@ -249,19 +249,19 @@ export class Sharing {
         const shareEmbedCopyToClipBtn = this.shareEmbed.find('.clip-icon');
 
         shareShortCopyToClipBtn.on('click', e =>
-            this.onClipButtonPressed(e, LinkType.Short),
+            this.onClipButtonPressed(e, LinkType.Short)
         );
         shareFullCopyToClipBtn.on('click', e =>
-            this.onClipButtonPressed(e, LinkType.Full),
+            this.onClipButtonPressed(e, LinkType.Full)
         );
         shareEmbedCopyToClipBtn.on('click', e =>
-            this.onClipButtonPressed(e, LinkType.Embed),
+            this.onClipButtonPressed(e, LinkType.Embed)
         );
 
         if (options.sharingEnabled) {
             Sharing.updateShares(
                 $('#socialshare'),
-                window.location.protocol + '//' + window.location.hostname,
+                window.location.protocol + '//' + window.location.hostname
             );
         }
     }
@@ -286,12 +286,12 @@ export class Sharing {
                 error: any,
                 newUrl: string,
                 extra: string,
-                updateState: boolean,
+                updateState: boolean
             ) => {
                 if (error || !newUrl) {
                     this.displayTooltip(
                         this.share,
-                        'Oops, something went wrong',
+                        'Oops, something went wrong'
                     );
                     Sentry.captureException(error);
                 } else {
@@ -300,7 +300,7 @@ export class Sharing {
                     }
                     this.doLinkCopyToClipboard(type, newUrl);
                 }
-            },
+            }
         );
     }
 
@@ -335,7 +335,7 @@ export class Sharing {
             navigator.clipboard
                 .writeText(link)
                 .then(() =>
-                    this.displayTooltip(this.share, 'Link copied to clipboard'),
+                    this.displayTooltip(this.share, 'Link copied to clipboard')
                 )
                 .catch(() => this.openShareModalForType(type));
         } else {
@@ -346,7 +346,7 @@ export class Sharing {
     public static getLinks(
         config: any,
         currentBind: LinkType,
-        done: CallableFunction,
+        done: CallableFunction
     ): void {
         const root = window.httpRoot;
         ga.proxy('send', {
@@ -365,7 +365,7 @@ export class Sharing {
                         root +
                         '#' +
                         url.serialiseState(config),
-                    false,
+                    false
                 );
                 return;
             case LinkType.Embed: {
@@ -376,7 +376,7 @@ export class Sharing {
                 done(
                     null,
                     Sharing.getEmbeddedHtml(config, root, false, options),
-                    false,
+                    false
                 );
                 return;
             }
@@ -389,7 +389,7 @@ export class Sharing {
     private static getShortLink(
         config: any,
         root: string,
-        done: CallableFunction,
+        done: CallableFunction
     ): void {
         const useExternalShortener = options.urlShortenService !== 'default';
         const data = JSON.stringify({
@@ -417,13 +417,13 @@ export class Sharing {
         config,
         root,
         isReadOnly,
-        extraOptions,
+        extraOptions
     ): string {
         const embedUrl = Sharing.getEmbeddedUrl(
             config,
             root,
             isReadOnly,
-            extraOptions,
+            extraOptions
         );
         return `<iframe width="800px" height="200px" src="${embedUrl}"></iframe>`;
     }
@@ -432,7 +432,7 @@ export class Sharing {
         config: any,
         root: string,
         readOnly: boolean,
-        extraOptions: object,
+        extraOptions: object
     ): string {
         const location = window.location.origin + root;
         const parameters = _.reduce(
@@ -446,7 +446,7 @@ export class Sharing {
 
                 return total + key + '=' + value;
             },
-            '',
+            ''
         );
 
         const path = (readOnly ? 'embed-ro' : 'e') + parameters + '#';
@@ -464,7 +464,7 @@ export class Sharing {
 
     public static filterComponentState(
         config: any,
-        keysToRemove: [string] = ['selection'],
+        keysToRemove: [string] = ['selection']
     ): any {
         function filterComponentStateImpl(component: any) {
             if (component.content) {
@@ -494,7 +494,7 @@ export class Sharing {
                     $('<span>')
                         .addClass('dropdown-icon mr-1')
                         .addClass(service.logoClass)
-                        .prop('title', serviceName),
+                        .prop('title', serviceName)
                 );
             }
             if (service.text) {

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -140,10 +140,7 @@ export class Themer {
     }
 
     private onSettingsChange(newSettings: SiteSettings) {
-        const newTheme =
-            newSettings.theme in themes
-                ? themes[newSettings.theme]
-                : themes.default;
+        const newTheme = newSettings.theme in themes ? themes[newSettings.theme] : themes.default;
         if (!newTheme.monaco) newTheme.monaco = 'vs';
         this.setTheme(newTheme);
     }

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -22,8 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { editor } from 'monaco-editor';
-import { SiteSettings } from './settings';
+import {editor} from 'monaco-editor';
+import {SiteSettings} from './settings';
 
 export type Themes = 'default' | 'dark' | 'darkplus';
 
@@ -63,7 +63,11 @@ editor.defineTheme('ce', {
     base: 'vs',
     inherit: true,
     rules: [
-        {token: 'identifier.definition.cppx-blue', foreground: '008a00', fontStyle: 'bold'},
+        {
+            token: 'identifier.definition.cppx-blue',
+            foreground: '008a00',
+            fontStyle: 'bold',
+        },
     ],
     colors: {},
 });
@@ -72,7 +76,11 @@ editor.defineTheme('ce-dark', {
     base: 'vs-dark',
     inherit: true,
     rules: [
-        {token: 'identifier.definition.cppx-blue', foreground: '7c9c7c', fontStyle: 'bold'},
+        {
+            token: 'identifier.definition.cppx-blue',
+            foreground: '7c9c7c',
+            fontStyle: 'bold',
+        },
     ],
     colors: {},
 });
@@ -81,7 +89,11 @@ editor.defineTheme('ce-dark-plus', {
     base: 'vs-dark',
     inherit: true,
     rules: [
-        {token: 'identifier.definition.cppx-blue', foreground: '7c9c7c', fontStyle: 'bold'},
+        {
+            token: 'identifier.definition.cppx-blue',
+            foreground: '7c9c7c',
+            fontStyle: 'bold',
+        },
         {token: 'keyword.if.cpp', foreground: 'c586c0'},
         {token: 'keyword.else.cpp', foreground: 'c586c0'},
         {token: 'keyword.while.cpp', foreground: 'c586c0'},
@@ -109,9 +121,13 @@ export class Themer {
 
         this.eventHub.on('settingsChange', this.onSettingsChange, this);
 
-        this.eventHub.on('requestTheme', () => {
-            this.eventHub.emit('themeChange', this.currentTheme);
-        }, this);
+        this.eventHub.on(
+            'requestTheme',
+            () => {
+                this.eventHub.emit('themeChange', this.currentTheme);
+            },
+            this
+        );
     }
 
     public setTheme(theme: Theme) {
@@ -124,9 +140,11 @@ export class Themer {
     }
 
     private onSettingsChange(newSettings: SiteSettings) {
-        const newTheme = newSettings.theme in themes ? themes[newSettings.theme] : themes.default;
-        if (!newTheme.monaco)
-            newTheme.monaco = 'vs';
+        const newTheme =
+            newSettings.theme in themes
+                ? themes[newSettings.theme]
+                : themes.default;
+        if (!newTheme.monaco) newTheme.monaco = 'vs';
         this.setTheme(newTheme);
     }
 }

--- a/static/url.ts
+++ b/static/url.ts
@@ -47,9 +47,7 @@ export function convertOldState(state: any): any {
     const filters = _.clone(state.filterAsm);
     delete filters.colouriseAsm;
     content.push(Components.getEditorWith(1, source, options));
-    content.push(
-        Components.getCompilerWith(1, filters, sc.options, sc.compiler)
-    );
+    content.push(Components.getCompilerWith(1, filters, sc.options, sc.compiler));
     return {version: 4, content: [{type: 'row', content: content}]};
 }
 

--- a/static/url.ts
+++ b/static/url.ts
@@ -29,7 +29,6 @@ const lzstring = require('lz-string');
 const rison = require('rison');
 const Components = require('./components');
 
-
 export function convertOldState(state: any): any {
     const sc = state.compilers[0];
     if (!sc) throw new Error('Unable to determine compiler from old state');
@@ -41,14 +40,18 @@ export function convertOldState(state: any): any {
     } else {
         source = sc.source;
     }
-    const options = {compileOnChange: true, colouriseAsm: state.filterAsm.colouriseAsm};
+    const options = {
+        compileOnChange: true,
+        colouriseAsm: state.filterAsm.colouriseAsm,
+    };
     const filters = _.clone(state.filterAsm);
     delete filters.colouriseAsm;
     content.push(Components.getEditorWith(1, source, options));
-    content.push(Components.getCompilerWith(1, filters, sc.options, sc.compiler));
-    return {version: 4, content: [{type: 'row', content: content}]};
+    content.push(
+        Components.getCompilerWith(1, filters, sc.options, sc.compiler),
+    );
+    return { version: 4, content: [{ type: 'row', content: content }] };
 }
-
 
 export function loadState(state: any): any {
     if (!state || state.version === undefined) return false;
@@ -63,7 +66,7 @@ export function loadState(state: any): any {
         /* falls through */
         case 3:
             state = convertOldState(state);
-            break;  // no fall through
+            break; // no fall through
         case 4:
             state = GoldenLayout.unminifyConfig(state);
             break;
@@ -105,11 +108,11 @@ export function deserialiseState(stateText: string): any {
 }
 
 export function serialiseState(stateText: any): string {
-    const ctx = GoldenLayout.minifyConfig({content: stateText.content});
+    const ctx = GoldenLayout.minifyConfig({ content: stateText.content });
     ctx.version = 4;
     const uncompressed = risonify(ctx);
-    const compressed = risonify({z: lzstring.compressToBase64(uncompressed)});
-    const MinimalSavings = 0.20;  // at least this ratio smaller
+    const compressed = risonify({ z: lzstring.compressToBase64(uncompressed) });
+    const MinimalSavings = 0.2; // at least this ratio smaller
     if (compressed.length < uncompressed.length * (1.0 - MinimalSavings)) {
         return compressed;
     } else {

--- a/static/url.ts
+++ b/static/url.ts
@@ -48,9 +48,9 @@ export function convertOldState(state: any): any {
     delete filters.colouriseAsm;
     content.push(Components.getEditorWith(1, source, options));
     content.push(
-        Components.getCompilerWith(1, filters, sc.options, sc.compiler),
+        Components.getCompilerWith(1, filters, sc.options, sc.compiler)
     );
-    return { version: 4, content: [{ type: 'row', content: content }] };
+    return {version: 4, content: [{type: 'row', content: content}]};
 }
 
 export function loadState(state: any): any {
@@ -108,10 +108,10 @@ export function deserialiseState(stateText: string): any {
 }
 
 export function serialiseState(stateText: any): string {
-    const ctx = GoldenLayout.minifyConfig({ content: stateText.content });
+    const ctx = GoldenLayout.minifyConfig({content: stateText.content});
     ctx.version = 4;
     const uncompressed = risonify(ctx);
-    const compressed = risonify({ z: lzstring.compressToBase64(uncompressed) });
+    const compressed = risonify({z: lzstring.compressToBase64(uncompressed)});
     const MinimalSavings = 0.2; // at least this ratio smaller
     if (compressed.length < uncompressed.length * (1.0 - MinimalSavings)) {
         return compressed;

--- a/static/utils.ts
+++ b/static/utils.ts
@@ -22,7 +22,11 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-export function updateAndCalcTopBarHeight(domRoot: JQuery, topBar: JQuery, hideable: JQuery): number {
+export function updateAndCalcTopBarHeight(
+    domRoot: JQuery,
+    topBar: JQuery,
+    hideable: JQuery,
+): number {
     let topBarHeight = 0;
     if (!topBar.hasClass('d-none')) {
         hideable.show();
@@ -45,7 +49,11 @@ export function updateAndCalcTopBarHeight(domRoot: JQuery, topBar: JQuery, hidea
  * @param  {(event:JQuery.Event)=>void} callback
  * @returns void
  */
-export function toggleEventListener(element: JQuery, eventName: string, callback: (event: JQuery.Event) => void): void {
+export function toggleEventListener(
+    element: JQuery,
+    eventName: string,
+    callback: (event: JQuery.Event) => void,
+): void {
     element.on(eventName, (event: JQuery.Event) => {
         callback(event);
         element.off(eventName);

--- a/static/utils.ts
+++ b/static/utils.ts
@@ -25,7 +25,7 @@
 export function updateAndCalcTopBarHeight(
     domRoot: JQuery,
     topBar: JQuery,
-    hideable: JQuery,
+    hideable: JQuery
 ): number {
     let topBarHeight = 0;
     if (!topBar.hasClass('d-none')) {
@@ -52,7 +52,7 @@ export function updateAndCalcTopBarHeight(
 export function toggleEventListener(
     element: JQuery,
     eventName: string,
-    callback: (event: JQuery.Event) => void,
+    callback: (event: JQuery.Event) => void
 ): void {
     element.on(eventName, (event: JQuery.Event) => {
         callback(event);

--- a/static/utils.ts
+++ b/static/utils.ts
@@ -22,11 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-export function updateAndCalcTopBarHeight(
-    domRoot: JQuery,
-    topBar: JQuery,
-    hideable: JQuery
-): number {
+export function updateAndCalcTopBarHeight(domRoot: JQuery, topBar: JQuery, hideable: JQuery): number {
     let topBarHeight = 0;
     if (!topBar.hasClass('d-none')) {
         hideable.show();
@@ -49,11 +45,7 @@ export function updateAndCalcTopBarHeight(
  * @param  {(event:JQuery.Event)=>void} callback
  * @returns void
  */
-export function toggleEventListener(
-    element: JQuery,
-    eventName: string,
-    callback: (event: JQuery.Event) => void
-): void {
+export function toggleEventListener(element: JQuery, eventName: string, callback: (event: JQuery.Event) => void): void {
     element.on(eventName, (event: JQuery.Event) => {
         callback(event);
         element.off(eventName);


### PR DESCRIPTION
Until now, the prettier formatting has been effectively disabled because we required a pragma comment to enable formatting. This PR enables prettier for the entire TypeScript part of the frontend.