### PR TITLE
Use pattern for asm-docs generated files in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,5 @@
 docs/*  linguist-documentation
 *.s linguist-generated
 *.asm linguist-generated
-lib/asm-docs/generated/asm-docs-amd64.js linguist-generated
-lib/asm-docs/generated/asm-docs-arm32.js linguist-generated
-lib/asm-docs/generated/asm-docs-java.js linguist-generated
+lib/asm-docs/generated/asm-docs-*.js linguist-generated
 test/*-cases/* linguist-generated


### PR DESCRIPTION
Tiny fix, GH was crawing our avr and 6502 generated code.