### PR TITLE
Map solidity EVM assembly to lines of code

### DIFF
--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -22,18 +22,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import * as fs from 'fs';
 import path from 'path';
 
-import _ from 'underscore';
+import {BaseCompiler} from '../base-compiler';
 
-import { BaseCompiler } from '../base-compiler';
-
-import { ClangParser } from './argument-parsers';
-
-import * as fs from "fs";
+import {ClangParser} from './argument-parsers';
 
 export class SolidityCompiler extends BaseCompiler {
-    static get key() { return 'solidity'; }
+    static get key() {
+        return 'solidity';
+    }
 
     getSharedLibraryPathsAsArguments() {
         return [];
@@ -45,8 +44,11 @@ export class SolidityCompiler extends BaseCompiler {
 
     optionsForFilter(filters, outputFilename, userOptions) {
         return [
-            '--combined-json', 'asm,ast,generated-sources,generated-sources-runtime', // We use it instead of `--asm-json` to have compacted json
-            '-o', 'contracts',
+            // We use --combined-json instead of `--asm-json` to have compacted json
+            '--combined-json',
+            'asm,ast,generated-sources,generated-sources-runtime',
+            '-o',
+            'contracts',
         ];
     }
 
@@ -61,14 +63,14 @@ export class SolidityCompiler extends BaseCompiler {
     processAsm(result) {
         // Handle "error" documents.
         if (!result.asm.includes('\n') && result.asm[0] === '<') {
-            return { asm: [{ text: result.asm }] };
+            return {asm: [{text: result.asm}]};
         }
 
         const inputFile = fs.readFileSync(result.inputFilename);
         let currentLine = 1;
         const charToLine = inputFile.map(c => {
             const line = currentLine;
-            if (c == "\n".charCodeAt(0)) {
+            if (c === '\n'.codePointAt(0)) {
                 ++currentLine;
             }
             return line;
@@ -77,65 +79,66 @@ export class SolidityCompiler extends BaseCompiler {
         const asm = JSON.parse(result.asm);
         return {
             asm: Object.entries(asm.contracts)
-                .sort(([_name1, data1], [_name2, data2]) =>
-                    data1.asm['.code'][0].begin - data2.asm['.code'][0].begin,
-                ).map(([name, data]) => {
+                .sort(([_name1, data1], [_name2, data2]) => data1.asm['.code'][0].begin - data2.asm['.code'][0].begin)
+                .map(([name, data]) => {
                     const [sourceName, contractName] = name.split(':');
 
                     const contractFunctions = asm.sources[sourceName].AST.nodes
                         .find(node => {
-                            return node.nodeType == "ContractDefinition" &&
-                                node.name == contractName;
-                        }).nodes
-                        .filter(node => {
-                            return node.nodeType == "FunctionDefinition"
+                            return node.nodeType === 'ContractDefinition' && node.name === contractName;
+                        })
+                        .nodes.filter(node => {
+                            return node.nodeType === 'FunctionDefinition';
                         })
                         .map(node => {
-                            const [begin, length] = node.src.split(":").map(x => parseInt(x));
+                            const [begin, length] = node.src.split(':').map(x => parseInt(x));
 
                             // encode the args into the name so we can
                             // differentiate between overloads
-                            let name = node.kind == "constructor" ? "constructor" : node.name;
+                            let name = node.kind === 'constructor' ? 'constructor' : node.name;
 
                             if (node.parameters.parameters.length > 0) {
-                                name += '_' + node.parameters.parameters.map(paramNode => {
-                                    return paramNode.typeName.name;
-                                }).join('_');
+                                name +=
+                                    '_' +
+                                    node.parameters.parameters
+                                        .map(paramNode => {
+                                            return paramNode.typeName.name;
+                                        })
+                                        .join('_');
                             }
 
                             return {
                                 name: name,
                                 begin: begin,
                                 end: begin + length,
-                                tagCount: 0
-                            }
+                                tagCount: 0,
+                            };
                         });
 
-                    const processGeneratedSources = (generatedSourcesData) => {
+                    const processGeneratedSources = generatedSourcesData => {
                         let generatedSources = {};
-                        generatedSourcesData.forEach(generatedSource => {
+                        for (const generatedSource of generatedSourcesData) {
                             generatedSources[generatedSource.id] = generatedSource.ast.statements.map(statement => {
-                                const [begin, length] = statement.src.split(":").map(x => parseInt(x));
+                                const [begin, length] = statement.src.split(':').map(x => parseInt(x));
                                 return {
                                     name: statement.name,
                                     begin: begin,
                                     end: begin + length,
-                                    tagCount: 0
+                                    tagCount: 0,
                                 };
                             });
-                        });
+                        }
                         return generatedSources;
                     };
-                    const generatedSources = processGeneratedSources(data["generated-sources"]);
-                    const generatedSourcesRuntime = processGeneratedSources(data["generated-sources-runtime"]);
+                    const generatedSources = processGeneratedSources(data['generated-sources']);
+                    const generatedSourcesRuntime = processGeneratedSources(data['generated-sources-runtime']);
 
                     const processOpcodes = (opcodes, indent, generatedSources) => {
                         let tagNames = {};
                         const processPossibleTagOpcode = (opcode, funcList) => {
-                            if (opcode.name == "tag") {
+                            if (opcode.name === 'tag') {
                                 const func = funcList.find(func => {
-                                    return opcode.begin >= func.begin &&
-                                        opcode.end <= func.end;
+                                    return opcode.begin >= func.begin && opcode.end <= func.end;
                                 });
 
                                 if (func !== undefined) {
@@ -149,46 +152,48 @@ export class SolidityCompiler extends BaseCompiler {
                             }
                         };
 
-                        opcodes.forEach((opcode) => {
-                            if (opcode.source == 0) {
+                        for (const opcode of opcodes) {
+                            if (opcode.source === 0) {
                                 opcode.line = charToLine[opcode.begin];
 
                                 processPossibleTagOpcode(opcode, contractFunctions);
-                            }
-                            else {
+                            } else {
                                 processPossibleTagOpcode(opcode, generatedSources[opcode.source]);
                             }
-                        });
+                        }
 
                         return opcodes.map(opcode => {
-                            let value = opcode.value;
-                            if (opcode.name == "PUSH [tag]") {
+                            const name = `${opcode.name.startsWith('tag') ? indent : `${indent}\t`}${opcode.name}`;
+
+                            let value = opcode.value || '';
+                            if (opcode.name === 'PUSH [tag]') {
                                 if (tagNames[value] !== undefined) {
                                     value = tagNames[value];
                                 }
                             }
+
                             return {
-                                text: `${opcode.name.startsWith('tag') ? `${indent}` : `${indent}\t`}${opcode.name}${value !== undefined ? ` ${value}` : ''}`,
-                                source: { line: opcode.line, file: null }
+                                text: `${name} ${value}`,
+                                source: {line: opcode.line, file: null},
                             };
                         });
-                    }
+                    };
 
                     return [
-                        { text: `// ${contractName}` },
+                        {text: `// ${contractName}`},
                         // .code section is the code only run when deploying - the constructor
-                        { text: '.code' },
+                        {text: '.code'},
                         processOpcodes(data.asm['.code'], '', generatedSources),
-                        { text: '' },
+                        {text: ''},
                         // .data section is deployed bytecode - everything else
-                        { text: '.data' },
-                        Object.entries(data.asm['.data']).map(([id, { '.code': code }]) => [
-                            { text: `\t${id}:` },
+                        {text: '.data'},
+                        Object.entries(data.asm['.data']).map(([id, {'.code': code}]) => [
+                            {text: `\t${id}:`},
                             processOpcodes(code, '\t', generatedSourcesRuntime),
                         ]),
                     ];
                 })
-                .flat(Infinity)
+                .flat(Infinity),
         };
     }
 }

--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -45,7 +45,7 @@ export class SolidityCompiler extends BaseCompiler {
 
     optionsForFilter(filters, outputFilename, userOptions) {
         return [
-            '--combined-json', 'asm,srcmap,srcmap-runtime,bin,bin-runtime,generated-sources-runtime', // We use it instead of `--asm-json` to have compacted json
+            '--combined-json', 'asm,ast,generated-sources-runtime', // We use it instead of `--asm-json` to have compacted json
             '-o', 'contracts',
         ];
     }
@@ -105,35 +105,35 @@ export class SolidityCompiler extends BaseCompiler {
         return {
             asm: contracts.map(([name, data]) => {
                 let generatedSources = {};
+                let tagName = {};
                 // TODO check no overlapping regions, shouldn't be, but even so...
                 data["generated-sources-runtime"].forEach(generatedSource => {
                     generatedSources[generatedSource.id] = generatedSource.ast.statements.map(statement => {
                         const srcSplit = statement.src.split(":").map(x => parseInt(x));
-                        return { begin: srcSplit[0], end: srcSplit[0] + srcSplit[1], name: statement.name };
+                        return { begin: srcSplit[0], end: srcSplit[0] + srcSplit[1], name: statement.name, tagCount: 0 };
                     });
                 });
 
                 let lineToAsm = {};
+                let tagNames = {};
                 Object.entries(data.asm['.data']).forEach(([id, { '.code': code }]) => {
                     code.forEach((asmInstruction) => {
                         if (asmInstruction.source == 0) {
-                            const firstLine = charToLine[asmInstruction.begin];
-                            const lastLine = charToLine[asmInstruction.end];
-                            for (let i = firstLine; i <= lastLine; ++i) {
-                                if (lineToAsm[i] == undefined) {
-                                    lineToAsm[i] = [];
-                                }
-                                lineToAsm[i].push(asmInstruction);
-                                asmInstruction.line = i;
-                            }
-                            asmInstruction.line = firstLine;
+                            asmInstruction.line = charToLine[asmInstruction.begin];
                         }
                         else {
-                            for (let i = 0; i < generatedSources[asmInstruction.source].length; ++i) {
-                                if (asmInstruction.begin >= generatedSources[asmInstruction.source][i].begin &&
-                                    asmInstruction.end <= generatedSources[asmInstruction.source][i].end) {
-                                    asmInstruction.generatedFunc = generatedSources[asmInstruction.source][i].name;
-                                    break;
+                            if (asmInstruction.name == "tag") {
+                                const generatedFunc = generatedSources[asmInstruction.source].find(func => {
+                                    return asmInstruction.begin >= func.begin &&
+                                        asmInstruction.end <= func.end;
+                                });
+                                if (generatedFunc !== undefined) {
+                                    const tagName = `${generatedFunc.name}_${generatedFunc.tagCount}`;
+
+                                    ++generatedFunc.tagCount;
+
+                                    tagNames[asmInstruction.value] = tagName;
+                                    asmInstruction.value = tagName;
                                 }
                             }
                         }
@@ -142,8 +142,14 @@ export class SolidityCompiler extends BaseCompiler {
 
                 const processOpcodes = (opcodes, indent) => opcodes
                     .map(opcode => {
+                        let value = opcode.value;
+                        if (opcode.name == "PUSH [tag]") {
+                            if (tagNames[value] !== undefined) {
+                                value = tagNames[value];
+                            }
+                        }
                         return {
-                            text: `${opcode.name.startsWith('tag') ? indent : `\t${indent}`}${opcode.name}${opcode.value !== undefined ? ` ${opcode.value}` : ''} ${opcode.line !== undefined ? opcode.line : ""}:${opcode.source}:${opcode.begin}:${opcode.end}${opcode.generatedFunc !== undefined ? ` ${opcode.generatedFunc}` : ''} `,
+                            text: `${opcode.name.startsWith('tag') ? indent : `\t${indent}`}${opcode.name}${value !== undefined ? ` ${value}` : ''}`,
                             source: { line: opcode.line, file: null }
                         };
                     });

--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -30,6 +30,8 @@ import { BaseCompiler } from '../base-compiler';
 
 import { ClangParser } from './argument-parsers';
 
+import * as fs from "fs";
+
 export class SolidityCompiler extends BaseCompiler {
     static get key() { return 'solidity'; }
 
@@ -43,7 +45,7 @@ export class SolidityCompiler extends BaseCompiler {
 
     optionsForFilter(filters, outputFilename, userOptions) {
         return [
-            '--combined-json', 'asm', // We use it instead of `--asm-json` to have compacted json
+            '--combined-json', 'asm,srcmap,srcmap-runtime,bin,bin-runtime,generated-sources-runtime', // We use it instead of `--asm-json` to have compacted json
             '-o', 'contracts',
         ];
     }
@@ -56,13 +58,112 @@ export class SolidityCompiler extends BaseCompiler {
         return path.join(dirPath, 'contracts/combined.json');
     }
 
+    parseSourceMap(sourceMapStr) {
+        let prev = [0, 0, 0, 0, 0];
+        return sourceMapStr.split(";").map((item) => {
+            let ret = prev.map(x => x);
+
+            item.split(":").forEach((value, index) => {
+                if (value != "") {
+                    ret[index] = value;
+                }
+            });
+
+            prev = ret;
+            return { start: ret[0], length: ret[1], sourceIndex: ret[2], jump: ret[3], modifierDepth: ret[4] };
+        });
+    }
+
     processAsm(result) {
+        fs.writeFileSync("/home/jbr/out.json", JSON.stringify(result, null, 4));
         // Handle "error" documents.
         if (!result.asm.includes('\n') && result.asm[0] === '<') {
-            return {asm: [{text: result.asm}]};
+            return { asm: [{ text: result.asm }] };
         }
 
+        const inputFile = fs.readFileSync(result.inputFilename);
+        const inputFileStr = inputFile.toString();
+        let currentLine = 1;
+        const charToLine = inputFile.map(c => {
+            const line = currentLine;
+            if (c == "\n".charCodeAt(0)) {
+                ++currentLine;
+            }
+            return line;
+        });
+
+        const asm = JSON.parse(result.asm);
+
+        // TODO what happens if we have multiple contracts, can they share generated sources? probably not
+        // TODO should lineToAsm be rebuilt per contract??
+
+        let contracts = Object.entries(asm.contracts)
+            .sort(([_name1, data1], [_name2, data2]) =>
+                data1.asm['.code'][0].begin - data2.asm['.code'][0].begin,
+            );
+
+        contracts.forEach(([name, data]) => {
+
+        });
+
         return {
+            asm: contracts.map(([name, data]) => {
+                let generatedSources = {};
+                // TODO check no overlapping regions, shouldn't be, but even so...
+                data["generated-sources-runtime"].forEach(generatedSource => {
+                    generatedSources[generatedSource.id] = generatedSource.ast.statements.map(statement => {
+                        const srcSplit = statement.src.split(":").map(x => parseInt(x));
+                        return { begin: srcSplit[0], end: srcSplit[0] + srcSplit[1], name: statement.name };
+                    });
+                });
+
+                let lineToAsm = {};
+                Object.entries(data.asm['.data']).forEach(([id, { '.code': code }]) => {
+                    code.forEach((asmInstruction) => {
+                        if (asmInstruction.source == 0) {
+                            const firstLine = charToLine[asmInstruction.begin];
+                            const lastLine = charToLine[asmInstruction.end];
+                            for (let i = firstLine; i <= lastLine; ++i) {
+                                if (lineToAsm[i] == undefined) {
+                                    lineToAsm[i] = [];
+                                }
+                                lineToAsm[i].push(asmInstruction);
+                                asmInstruction.line = i;
+                            }
+                        }
+                        else {
+                            for (let i = 0; i < generatedSources[asmInstruction.source].length; ++i) {
+                                if (asmInstruction.begin >= generatedSources[asmInstruction.source][i].begin &&
+                                    asmInstruction.end <= generatedSources[asmInstruction.source][i].end) {
+                                    asmInstruction.generatedFunc = generatedSources[asmInstruction.source][i].name;
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                });
+
+                const processOpcodes = (opcodes, indent) => opcodes
+                    .map(opcode => {
+                        return {
+                            text: `${opcode.name.startsWith('tag') ? indent : `\t${indent}`}${opcode.name}${opcode.value !== undefined ? ` ${opcode.value}` : ''} ${opcode.line !== undefined ? opcode.line : ""}:${opcode.source}:${opcode.begin}:${opcode.end}${opcode.generatedFunc !== undefined ? ` ${opcode.generatedFunc}` : ''} `,
+                            source: { line: opcode.line, file: null }
+                        };
+                    });
+
+                return [
+                    { text: `// ${_.last(name.split(':'))}` },
+                    Object.entries(data.asm['.data']).map(([id, { '.code': code }]) => [
+                        processOpcodes(code, ''),
+                    ]),
+                    { text: '\n' },
+                ];
+            })
+                .flat(Infinity)
+                .slice(0, -1),
+        };
+
+        /*return {
             asm: Object.entries(JSON.parse(result.asm).contracts)
                 .sort(([_name1, data1], [_name2, data2]) =>
                     data1.asm['.code'][0].begin - data2.asm['.code'][0].begin,
@@ -81,7 +182,7 @@ export class SolidityCompiler extends BaseCompiler {
                         '.code',
                         processOpcodes(data.asm['.code']),
                         '.data',
-                        Object.entries(data.asm['.data']).map(([id, {'.code': code}]) => [
+                        Object.entries(data.asm['.data']).map(([id, { '.code': code }]) => [
                             `\t${id}:`,
                             '\t\t.code',
                             processOpcodes(code, '\t\t'),
@@ -91,7 +192,7 @@ export class SolidityCompiler extends BaseCompiler {
                 })
                 .flat(Infinity)
                 .slice(0, -1)
-                .map(line => ({text: line})),
-        };
+                .map(line => ({ text: line })),
+        };*/
     }
 }

--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -104,38 +104,77 @@ export class SolidityCompiler extends BaseCompiler {
 
         return {
             asm: contracts.map(([name, data]) => {
+                const [sourceName, contractName] = name.split(':');
+
+                const contractFunctions = asm.sources[sourceName].AST.nodes
+                    .find(node => {
+                        return node.nodeType == "ContractDefinition" &&
+                            node.name == contractName;
+                    }).nodes
+                    .filter(node => {
+                        return node.nodeType == "FunctionDefinition"
+                    })
+                    .map(node => {
+                        const [begin, length] = node.src.split(":").map(x => parseInt(x));
+
+                        // encode the args into the name so we can
+                        // differentiate between overloads
+                        let name = node.name;
+                        if (node.parameters.parameters.length > 0) {
+                            name += '_' + node.parameters.parameters.map(paramNode => {
+                                return paramNode.typeName.name;
+                            }).join('_');
+                        }
+
+                        return {
+                            name: name,
+                            begin: begin,
+                            end: begin + length,
+                            tagCount: 0
+                        }
+                    });
+
                 let generatedSources = {};
-                let tagName = {};
-                // TODO check no overlapping regions, shouldn't be, but even so...
                 data["generated-sources-runtime"].forEach(generatedSource => {
                     generatedSources[generatedSource.id] = generatedSource.ast.statements.map(statement => {
-                        const srcSplit = statement.src.split(":").map(x => parseInt(x));
-                        return { begin: srcSplit[0], end: srcSplit[0] + srcSplit[1], name: statement.name, tagCount: 0 };
+                        const [begin, length] = statement.src.split(":").map(x => parseInt(x));
+                        return {
+                            name: statement.name,
+                            begin: begin,
+                            end: begin + length,
+                            tagCount: 0
+                        };
                     });
                 });
 
-                let lineToAsm = {};
                 let tagNames = {};
                 Object.entries(data.asm['.data']).forEach(([id, { '.code': code }]) => {
+                    const processPossibleTagInstruction = function (asmInstruction, funcList) {
+                        if (asmInstruction.name == "tag") {
+                            const func = funcList.find(func => {
+                                return asmInstruction.begin >= func.begin &&
+                                    asmInstruction.end <= func.end;
+                            });
+
+                            if (func !== undefined) {
+                                const tagName = `${func.name}_${func.tagCount}`;
+
+                                ++func.tagCount;
+
+                                tagNames[asmInstruction.value] = tagName;
+                                asmInstruction.value = tagName;
+                            }
+                        }
+                    };
+
                     code.forEach((asmInstruction) => {
                         if (asmInstruction.source == 0) {
                             asmInstruction.line = charToLine[asmInstruction.begin];
+
+                            processPossibleTagInstruction(asmInstruction, contractFunctions);
                         }
                         else {
-                            if (asmInstruction.name == "tag") {
-                                const generatedFunc = generatedSources[asmInstruction.source].find(func => {
-                                    return asmInstruction.begin >= func.begin &&
-                                        asmInstruction.end <= func.end;
-                                });
-                                if (generatedFunc !== undefined) {
-                                    const tagName = `${generatedFunc.name}_${generatedFunc.tagCount}`;
-
-                                    ++generatedFunc.tagCount;
-
-                                    tagNames[asmInstruction.value] = tagName;
-                                    asmInstruction.value = tagName;
-                                }
-                            }
+                            processPossibleTagInstruction(asmInstruction, generatedSources[asmInstruction.source]);
                         }
                     });
                 });
@@ -155,7 +194,7 @@ export class SolidityCompiler extends BaseCompiler {
                     });
 
                 return [
-                    { text: `// ${_.last(name.split(':'))}` },
+                    { text: `// ${contractName}` },
                     Object.entries(data.asm['.data']).map(([id, { '.code': code }]) => [
                         processOpcodes(code, ''),
                     ]),
@@ -179,7 +218,7 @@ export class SolidityCompiler extends BaseCompiler {
                         .map(opcode =>
                             (indent || '') + (opcode.startsWith('tag') ? opcode : `\t${opcode}`),
                         );
-
+    
                     return [
                         `// ${_.last(name.split(':'))}`,
                         '.code',

--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -102,10 +102,6 @@ export class SolidityCompiler extends BaseCompiler {
                 data1.asm['.code'][0].begin - data2.asm['.code'][0].begin,
             );
 
-        contracts.forEach(([name, data]) => {
-
-        });
-
         return {
             asm: contracts.map(([name, data]) => {
                 let generatedSources = {};
@@ -130,6 +126,7 @@ export class SolidityCompiler extends BaseCompiler {
                                 lineToAsm[i].push(asmInstruction);
                                 asmInstruction.line = i;
                             }
+                            asmInstruction.line = firstLine;
                         }
                         else {
                             for (let i = 0; i < generatedSources[asmInstruction.source].length; ++i) {

--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -66,6 +66,9 @@ export class SolidityCompiler extends BaseCompiler {
             return {asm: [{text: result.asm}]};
         }
 
+        // solc gives us a character range for each asm instruction,
+        // so open the input file and figure out what line each
+        // character is on
         const inputFile = fs.readFileSync(result.inputFilename);
         let currentLine = 1;
         const charToLine = inputFile.map(c => {
@@ -81,8 +84,14 @@ export class SolidityCompiler extends BaseCompiler {
             asm: Object.entries(asm.contracts)
                 .sort(([_name1, data1], [_name2, data2]) => data1.asm['.code'][0].begin - data2.asm['.code'][0].begin)
                 .map(([name, data]) => {
+                    // name is in the format of file:contract
+                    // e.g. MyFile.sol:MyContract
                     const [sourceName, contractName] = name.split(':');
 
+                    // to make the asm more readable, we rename the
+                    // tags (jumpdests) to show what function they're
+                    // part of. here we parse the AST so we know what
+                    // range of characters belongs to each function.
                     const contractFunctions = asm.sources[sourceName].AST.nodes
                         .find(node => {
                             return node.nodeType === 'ContractDefinition' && node.name === contractName;
@@ -93,10 +102,10 @@ export class SolidityCompiler extends BaseCompiler {
                         .map(node => {
                             const [begin, length] = node.src.split(':').map(x => parseInt(x));
 
-                            // encode the args into the name so we can
-                            // differentiate between overloads
                             let name = node.kind === 'constructor' ? 'constructor' : node.name;
 
+                            // encode the args into the name so we can
+                            // differentiate between overloads
                             if (node.parameters.parameters.length > 0) {
                                 name +=
                                     '_' +
@@ -115,6 +124,9 @@ export class SolidityCompiler extends BaseCompiler {
                             };
                         });
 
+                    // solc generates some code, for things like detecting
+                    // and reverting if a multiplication results in
+                    // integer overflow, etc.
                     const processGeneratedSources = generatedSourcesData => {
                         let generatedSources = {};
                         for (const generatedSource of generatedSourcesData) {
@@ -130,10 +142,17 @@ export class SolidityCompiler extends BaseCompiler {
                         }
                         return generatedSources;
                     };
+
+                    // there are two sets of generated sources, one for the code which deploys
+                    // the contract (i.e. the constructor) 'generated-sources', and the code
+                    // which is deployed and stored on-chain 'generated-sources-runtime'
                     const generatedSources = processGeneratedSources(data['generated-sources']);
                     const generatedSourcesRuntime = processGeneratedSources(data['generated-sources-runtime']);
 
                     const processOpcodes = (opcodes, indent, generatedSources) => {
+                        // first iterate the opcodes to find all the tags,
+                        // and assign human-readable names to as many of
+                        // them as we can
                         let tagNames = {};
                         const processPossibleTagOpcode = (opcode, funcList) => {
                             if (opcode.name === 'tag') {
@@ -142,6 +161,8 @@ export class SolidityCompiler extends BaseCompiler {
                                 });
 
                                 if (func !== undefined) {
+                                    // a function can have multiple tags, so append
+                                    // a number to each
                                     const tagName = `${func.name}_${func.tagCount}`;
 
                                     ++func.tagCount;
@@ -153,6 +174,9 @@ export class SolidityCompiler extends BaseCompiler {
                         };
 
                         for (const opcode of opcodes) {
+                            // source 0 is the .sol file the user is
+                            // editing, everything else is generated
+                            // sources
                             if (opcode.source === 0) {
                                 opcode.line = charToLine[opcode.begin];
 

--- a/lib/compilers/solidity.js
+++ b/lib/compilers/solidity.js
@@ -45,7 +45,7 @@ export class SolidityCompiler extends BaseCompiler {
 
     optionsForFilter(filters, outputFilename, userOptions) {
         return [
-            '--combined-json', 'asm,ast,generated-sources-runtime', // We use it instead of `--asm-json` to have compacted json
+            '--combined-json', 'asm,ast,generated-sources,generated-sources-runtime', // We use it instead of `--asm-json` to have compacted json
             '-o', 'contracts',
         ];
     }
@@ -58,31 +58,13 @@ export class SolidityCompiler extends BaseCompiler {
         return path.join(dirPath, 'contracts/combined.json');
     }
 
-    parseSourceMap(sourceMapStr) {
-        let prev = [0, 0, 0, 0, 0];
-        return sourceMapStr.split(";").map((item) => {
-            let ret = prev.map(x => x);
-
-            item.split(":").forEach((value, index) => {
-                if (value != "") {
-                    ret[index] = value;
-                }
-            });
-
-            prev = ret;
-            return { start: ret[0], length: ret[1], sourceIndex: ret[2], jump: ret[3], modifierDepth: ret[4] };
-        });
-    }
-
     processAsm(result) {
-        fs.writeFileSync("/home/jbr/out.json", JSON.stringify(result, null, 4));
         // Handle "error" documents.
         if (!result.asm.includes('\n') && result.asm[0] === '<') {
             return { asm: [{ text: result.asm }] };
         }
 
         const inputFile = fs.readFileSync(result.inputFilename);
-        const inputFileStr = inputFile.toString();
         let currentLine = 1;
         const charToLine = inputFile.map(c => {
             const line = currentLine;
@@ -93,148 +75,120 @@ export class SolidityCompiler extends BaseCompiler {
         });
 
         const asm = JSON.parse(result.asm);
-
-        // TODO what happens if we have multiple contracts, can they share generated sources? probably not
-        // TODO should lineToAsm be rebuilt per contract??
-
-        let contracts = Object.entries(asm.contracts)
-            .sort(([_name1, data1], [_name2, data2]) =>
-                data1.asm['.code'][0].begin - data2.asm['.code'][0].begin,
-            );
-
         return {
-            asm: contracts.map(([name, data]) => {
-                const [sourceName, contractName] = name.split(':');
-
-                const contractFunctions = asm.sources[sourceName].AST.nodes
-                    .find(node => {
-                        return node.nodeType == "ContractDefinition" &&
-                            node.name == contractName;
-                    }).nodes
-                    .filter(node => {
-                        return node.nodeType == "FunctionDefinition"
-                    })
-                    .map(node => {
-                        const [begin, length] = node.src.split(":").map(x => parseInt(x));
-
-                        // encode the args into the name so we can
-                        // differentiate between overloads
-                        let name = node.name;
-                        if (node.parameters.parameters.length > 0) {
-                            name += '_' + node.parameters.parameters.map(paramNode => {
-                                return paramNode.typeName.name;
-                            }).join('_');
-                        }
-
-                        return {
-                            name: name,
-                            begin: begin,
-                            end: begin + length,
-                            tagCount: 0
-                        }
-                    });
-
-                let generatedSources = {};
-                data["generated-sources-runtime"].forEach(generatedSource => {
-                    generatedSources[generatedSource.id] = generatedSource.ast.statements.map(statement => {
-                        const [begin, length] = statement.src.split(":").map(x => parseInt(x));
-                        return {
-                            name: statement.name,
-                            begin: begin,
-                            end: begin + length,
-                            tagCount: 0
-                        };
-                    });
-                });
-
-                let tagNames = {};
-                Object.entries(data.asm['.data']).forEach(([id, { '.code': code }]) => {
-                    const processPossibleTagInstruction = function (asmInstruction, funcList) {
-                        if (asmInstruction.name == "tag") {
-                            const func = funcList.find(func => {
-                                return asmInstruction.begin >= func.begin &&
-                                    asmInstruction.end <= func.end;
-                            });
-
-                            if (func !== undefined) {
-                                const tagName = `${func.name}_${func.tagCount}`;
-
-                                ++func.tagCount;
-
-                                tagNames[asmInstruction.value] = tagName;
-                                asmInstruction.value = tagName;
-                            }
-                        }
-                    };
-
-                    code.forEach((asmInstruction) => {
-                        if (asmInstruction.source == 0) {
-                            asmInstruction.line = charToLine[asmInstruction.begin];
-
-                            processPossibleTagInstruction(asmInstruction, contractFunctions);
-                        }
-                        else {
-                            processPossibleTagInstruction(asmInstruction, generatedSources[asmInstruction.source]);
-                        }
-                    });
-                });
-
-                const processOpcodes = (opcodes, indent) => opcodes
-                    .map(opcode => {
-                        let value = opcode.value;
-                        if (opcode.name == "PUSH [tag]") {
-                            if (tagNames[value] !== undefined) {
-                                value = tagNames[value];
-                            }
-                        }
-                        return {
-                            text: `${opcode.name.startsWith('tag') ? indent : `\t${indent}`}${opcode.name}${value !== undefined ? ` ${value}` : ''}`,
-                            source: { line: opcode.line, file: null }
-                        };
-                    });
-
-                return [
-                    { text: `// ${contractName}` },
-                    Object.entries(data.asm['.data']).map(([id, { '.code': code }]) => [
-                        processOpcodes(code, ''),
-                    ]),
-                    { text: '\n' },
-                ];
-            })
-                .flat(Infinity)
-                .slice(0, -1),
-        };
-
-        /*return {
-            asm: Object.entries(JSON.parse(result.asm).contracts)
+            asm: Object.entries(asm.contracts)
                 .sort(([_name1, data1], [_name2, data2]) =>
                     data1.asm['.code'][0].begin - data2.asm['.code'][0].begin,
-                )
-                .map(([name, data]) => {
-                    const processOpcodes = (opcodes, indent) => opcodes
-                        .map(opcode =>
-                            `${opcode.name}${opcode.value !== undefined ? ` ${opcode.value}` : ''}`,
-                        )
-                        .map(opcode =>
-                            (indent || '') + (opcode.startsWith('tag') ? opcode : `\t${opcode}`),
-                        );
-    
+                ).map(([name, data]) => {
+                    const [sourceName, contractName] = name.split(':');
+
+                    const contractFunctions = asm.sources[sourceName].AST.nodes
+                        .find(node => {
+                            return node.nodeType == "ContractDefinition" &&
+                                node.name == contractName;
+                        }).nodes
+                        .filter(node => {
+                            return node.nodeType == "FunctionDefinition"
+                        })
+                        .map(node => {
+                            const [begin, length] = node.src.split(":").map(x => parseInt(x));
+
+                            // encode the args into the name so we can
+                            // differentiate between overloads
+                            let name = node.kind == "constructor" ? "constructor" : node.name;
+
+                            if (node.parameters.parameters.length > 0) {
+                                name += '_' + node.parameters.parameters.map(paramNode => {
+                                    return paramNode.typeName.name;
+                                }).join('_');
+                            }
+
+                            return {
+                                name: name,
+                                begin: begin,
+                                end: begin + length,
+                                tagCount: 0
+                            }
+                        });
+
+                    const processGeneratedSources = (generatedSourcesData) => {
+                        let generatedSources = {};
+                        generatedSourcesData.forEach(generatedSource => {
+                            generatedSources[generatedSource.id] = generatedSource.ast.statements.map(statement => {
+                                const [begin, length] = statement.src.split(":").map(x => parseInt(x));
+                                return {
+                                    name: statement.name,
+                                    begin: begin,
+                                    end: begin + length,
+                                    tagCount: 0
+                                };
+                            });
+                        });
+                        return generatedSources;
+                    };
+                    const generatedSources = processGeneratedSources(data["generated-sources"]);
+                    const generatedSourcesRuntime = processGeneratedSources(data["generated-sources-runtime"]);
+
+                    const processOpcodes = (opcodes, indent, generatedSources) => {
+                        let tagNames = {};
+                        const processPossibleTagOpcode = (opcode, funcList) => {
+                            if (opcode.name == "tag") {
+                                const func = funcList.find(func => {
+                                    return opcode.begin >= func.begin &&
+                                        opcode.end <= func.end;
+                                });
+
+                                if (func !== undefined) {
+                                    const tagName = `${func.name}_${func.tagCount}`;
+
+                                    ++func.tagCount;
+
+                                    tagNames[opcode.value] = tagName;
+                                    opcode.value = tagName;
+                                }
+                            }
+                        };
+
+                        opcodes.forEach((opcode) => {
+                            if (opcode.source == 0) {
+                                opcode.line = charToLine[opcode.begin];
+
+                                processPossibleTagOpcode(opcode, contractFunctions);
+                            }
+                            else {
+                                processPossibleTagOpcode(opcode, generatedSources[opcode.source]);
+                            }
+                        });
+
+                        return opcodes.map(opcode => {
+                            let value = opcode.value;
+                            if (opcode.name == "PUSH [tag]") {
+                                if (tagNames[value] !== undefined) {
+                                    value = tagNames[value];
+                                }
+                            }
+                            return {
+                                text: `${opcode.name.startsWith('tag') ? `${indent}` : `${indent}\t`}${opcode.name}${value !== undefined ? ` ${value}` : ''}`,
+                                source: { line: opcode.line, file: null }
+                            };
+                        });
+                    }
+
                     return [
-                        `// ${_.last(name.split(':'))}`,
-                        '.code',
-                        processOpcodes(data.asm['.code']),
-                        '.data',
+                        { text: `// ${contractName}` },
+                        // .code section is the code only run when deploying - the constructor
+                        { text: '.code' },
+                        processOpcodes(data.asm['.code'], '', generatedSources),
+                        { text: '' },
+                        // .data section is deployed bytecode - everything else
+                        { text: '.data' },
                         Object.entries(data.asm['.data']).map(([id, { '.code': code }]) => [
-                            `\t${id}:`,
-                            '\t\t.code',
-                            processOpcodes(code, '\t\t'),
+                            { text: `\t${id}:` },
+                            processOpcodes(code, '\t', generatedSourcesRuntime),
                         ]),
-                        '\n',
                     ];
                 })
                 .flat(Infinity)
-                .slice(0, -1)
-                .map(line => ({ text: line })),
-        };*/
+        };
     }
 }


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

As per the request here https://github.com/compiler-explorer/compiler-explorer/issues/3520

![image](https://user-images.githubusercontent.com/95024805/164947084-d8b12628-03a0-4113-8e0c-1899144f0aea.png)

This PR is a small tweak to the Solidity support which aims to map asm instructions to lines of code. Solc attributes each instruction a range of characters from the source, sometimes this range can be quite large - e.g. a whole function, or even a whole contract. In these cases I just use the first line, which seems to work ok as if an instruction is attributed to an entire function then attributing it to the function sig instead has a similar effect.

I also found the tags (jumpdests) kind of hard to follow so this PR also replaces as many of those tags as possible with human readable function names.

Suggestions etc are most welcome, JS isn't really my thing!
