### PR TITLE
Defer running buildenv stuff

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -102,9 +102,7 @@ export class BaseCompiler {
         this.buildenvsetup = null;
         if (this.compiler.buildenvsetup && this.compiler.buildenvsetup.id) {
             const buildenvsetupclass = getBuildEnvTypeByKey(this.compiler.buildenvsetup.id);
-            this.buildenvsetup = new buildenvsetupclass(this.compiler, this.env, async (compiler, args, options) => {
-                return this.execCompilerCached(compiler, args, options);
-            });
+            this.buildenvsetup = new buildenvsetupclass(this.compiler, this.env);
         }
 
         if (!this.compiler.instructionSet) {
@@ -2139,6 +2137,12 @@ but nothing was dumped. Possible causes are:
 
     async initialise(mtime, clientOptions, isPrediscovered = false) {
         this.mtime = mtime;
+
+        if (this.buildenvsetup) {
+            await this.buildenvsetup.initialise(async (compiler, args, options) => {
+                return this.execCompilerCached(compiler, args, options);
+            });
+        }
 
         if (this.getRemote()) return this;
 

--- a/lib/buildenvsetup/base.js
+++ b/lib/buildenvsetup/base.js
@@ -31,35 +31,33 @@ import { logger } from '../logger';
 import * as utils from '../utils';
 
 export class BuildEnvSetupBase {
-    constructor(compilerInfo, env, execCompilerCachedFunc) {
+    constructor(compilerInfo, env) {
         this.compiler = compilerInfo;
         this.env = env;
-        this.execCompilerCached = execCompilerCachedFunc;
 
         this.compilerOptionsArr = utils.splitArguments(this.compiler.options);
         this.compilerArch = this.getCompilerArch();
         this.compilerTypeOrGCC = compilerInfo.compilerType ? compilerInfo.compilerType : 'gcc';
-        this.compilerSupportsX86 = true;
-
-        if (this.compilerArch) {
-            this.compilerSupportsX86 = false;
-        } else if (execCompilerCachedFunc) {
-            this.hasSupportForArch('x86')
-                .then(res => this.compilerSupportsX86 = res)
-                .catch(error => {
-                    // Log & keep going, we assume x86 is supported
-                    logger.error('Could not check for x86 arch support', error);
-                });
-        }
+        this.compilerSupportsX86 = !this.compilerArch;
     }
 
-    async hasSupportForArch(arch) {
+    async initialise(execCompilerCachedFunc) {
+        if (this.compilerArch) return;
+        await this.hasSupportForArch(execCompilerCachedFunc, 'x86')
+            .then(res => (this.compilerSupportsX86 = res))
+            .catch(error => {
+                // Log & keep going, we assume x86 is supported
+                logger.error('Could not check for x86 arch support', error);
+            });
+    }
+
+    async hasSupportForArch(execCompilerCached, arch) {
         let result = null;
         let searchFor = arch;
         if (this.compiler.exe.includes('icpx')) {
             return arch === 'x86' || arch === 'x86_64';
         } else if (this.compiler.group === 'icc') {
-            result = await this.execCompilerCached(this.compiler.exe, ['--help']);
+            result = await execCompilerCached(this.compiler.exe, ['--help']);
             if (arch === 'x86') {
                 searchFor = '-m32';
             } else if (arch === 'x86_64') {
@@ -69,13 +67,13 @@ export class BuildEnvSetupBase {
             if (this.compiler.exe.includes('/icpx')) {
                 result = (arch === 'x86') || (arch === 'x86_64');
             } else {
-                result = await this.execCompilerCached(this.compiler.exe, ['--target-help']);
+                result = await execCompilerCached(this.compiler.exe, ['--target-help']);
             }
         } else if (this.compilerTypeOrGCC === 'clang') {
             const binpath = path.dirname(this.compiler.exe);
             const llc = path.join(binpath, 'llc');
             if (fs.existsSync(llc)) {
-                result = await this.execCompilerCached(llc, ['--version']);
+                result = await execCompilerCached(llc, ['--version']);
             }
         }
 


### PR DESCRIPTION
* compiler cache is keyed off of compiler's `mtime`
* `mtime` isn't set until `initialise()`
* buildenv was running stuff ahead of that, and so was being cached with a `null` `mtime`
* introduces a new `initialise()` call for `buildenv`
* now `throw` on trying to use compiler cache before mtime is set
