### PR TITLE
Fix jquery import regression in noscript.ts

### DIFF
--- a/static/noscript.ts
+++ b/static/noscript.ts
@@ -22,6 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+// This jQuery import needs to be here, because noscript.ts is a different entrypoint than the rest of the code.
+// See webpack.config.esm.js -> entry for more details.
+import $ from 'jquery';
 import 'bootstrap';
 import 'popper.js';
 


### PR DESCRIPTION
Tiny regression from #3576 

Noscript.ts is compiled as its own target, therefore it also needs the jQuery import