### PR TITLE
Add npm script for noEmit compiling frontend and backend to catch ts errors

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -22,6 +22,7 @@ jobs:
           npm run lint
           npm run ci-test
           npm run format-check
+          npm run ts-check
           python3 ./etc/scripts/util/orphancompiler.py
       - name: Code coverage
         run: npm run codecov

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -21,3 +21,5 @@ jobs:
         run: |
           npm run lint
           npm run ci-test
+          npm run format-check
+          npm run ts-check

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "format-fix-files": "prettier --write --ignore-unknown",
     "format-check": "prettier --ignore-unknown --check ./static/**/*.ts",
     "ts-compile": "tsc",
+    "ts-check": "tsc -p ./tsconfig.backend.json --noEmit --module esnext && tsc -p ./tsconfig.frontend.json --noEmit",
     "webpack": "webpack --node-env=production"
   },
   "lint-staged": {

--- a/tsconfig.frontend.json
+++ b/tsconfig.frontend.json
@@ -8,5 +8,6 @@
     "inlineSources": true,
     "strictPropertyInitialization": false,
     "lib": ["dom", "es5"]
-  }
+  },
+  "exclude": ["app.js", "lib", "examples"]
 }


### PR DESCRIPTION
Ensures that there are no typescript errors when the regular test CI run is being performed.

This means we won't accidentally merge in frontend code that doesn't compile because the external contributors don't run the build-dist CI (which does the check when compiling)