### PR TITLE
Quickbench now supports https

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -691,7 +691,7 @@ Editor.prototype.updateOpenInQuickBench = function () {
             }
         }, this));
 
-        var link = 'http://quick-bench.com/#' + btoa(this.asciiEncodeJsonText(JSON.stringify(quickBenchState)));
+        var link = 'https://quick-bench.com/#' + btoa(this.asciiEncodeJsonText(JSON.stringify(quickBenchState)));
         this.quickBenchButton.attr('href', link);
     }
 };


### PR DESCRIPTION
It used not to, so we linked to the unsecured version. https://quick-bench.com/ now works so we can update acordingly