### PR TITLE
Add Benchmark 1.6.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1297,7 +1297,7 @@ libs.abseil.versions.trunk.version=trunk
 libs.abseil.versions.trunk.path=/opt/compiler-explorer/libs/abseil
 
 libs.benchmark.name=Google Benchmark
-libs.benchmark.versions=trunk:120:130:140:141:150
+libs.benchmark.versions=trunk:120:130:140:141:150:161
 libs.benchmark.url=https://github.com/google/benchmark
 libs.benchmark.staticliblink=benchmark
 libs.benchmark.versions.trunk.version=trunk
@@ -1312,6 +1312,8 @@ libs.benchmark.versions.141.version=1.4.1
 libs.benchmark.versions.141.path=/opt/compiler-explorer/libs/google-benchmark/v1.4.1/include
 libs.benchmark.versions.150.version=1.5.0
 libs.benchmark.versions.150.path=/opt/compiler-explorer/libs/google-benchmark/v1.5.0/include
+libs.benchmark.versions.161.version=1.6.1
+libs.benchmark.versions.161.path=/opt/compiler-explorer/libs/google-benchmark/v1.6.1/include
 
 libs.benri.name=benri
 libs.benri.description=Compile time checking of physical quantities.


### PR DESCRIPTION
While not a fix, it could help in #3092 by adding an alternative version (IF it builds)