### PR TITLE
Use a deterministic toJSON for hashing.

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,6 +28,7 @@ import {fileURLToPath} from 'url';
 
 import fs from 'fs-extra';
 import {ComponentConfig, ItemConfigType} from 'golden-layout';
+import stringifyDeterministic from 'json-stringify-deterministic';
 import semverParser from 'semver';
 import {parse as quoteParse} from 'shell-quote';
 import _ from 'underscore';
@@ -200,9 +201,9 @@ export function anonymizeIp(ip: string): string {
  * @param {*} object
  * @returns {string}
  */
-function objectToHashableString(object: any): string {
+export function objectToHashableString(object: any): string {
     // See https://stackoverflow.com/questions/899574/which-is-best-to-use-typeof-or-instanceof/6625960#6625960
-    return typeof object === 'string' ? object : JSON.stringify(object);
+    return typeof object === 'string' ? object : stringifyDeterministic(object);
 }
 
 const DefaultHash = 'Compiler Explorer Default Version 1';

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "husky-init": "^7.0.0",
         "jquery": "^3.6.0",
         "js-cookie": "^3.0.1",
+        "json-stringify-deterministic": "^1.0.6",
         "jszip": "^3.7.1",
         "lodash": "^4.17.21",
         "lodash.clonedeep": "^4.5.0",
@@ -8210,6 +8211,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "node_modules/json-stringify-deterministic": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.6.tgz",
+      "integrity": "sha512-/LbStPoVnzj/FBFxxdJH0bXesMIVTwZzO3K/5Jr74/exrBOV2/Hw96dJMryhfwnE6Jp5tnByh+RvRl+omSzLVg==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -21391,6 +21400,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "json-stringify-deterministic": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.6.tgz",
+      "integrity": "sha512-/LbStPoVnzj/FBFxxdJH0bXesMIVTwZzO3K/5Jr74/exrBOV2/Hw96dJMryhfwnE6Jp5tnByh+RvRl+omSzLVg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "husky-init": "^7.0.0",
     "jquery": "^3.6.0",
     "js-cookie": "^3.0.1",
+    "json-stringify-deterministic": "^1.0.6",
     "jszip": "^3.7.1",
     "lodash": "^4.17.21",
     "lodash.clonedeep": "^4.5.0",

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -23,12 +23,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import path from 'path';
-import { fileURLToPath } from 'url';
+import {fileURLToPath} from 'url';
 
-import { logger } from '../lib/logger';
+import {logger} from '../lib/logger';
 import * as utils from '../lib/utils';
 
-import { fs } from './utils';
+import {fs} from './utils';
 
 describe('Splits lines', () => {
     it('handles empty input', () => {
@@ -44,12 +44,10 @@ describe('Splits lines', () => {
         utils.splitLines('A line\nAnother line\n').should.deep.equals(['A line', 'Another line']);
     });
     it('handles multiple lines ending on a non-newline', () => {
-        utils.splitLines('A line\nAnother line\nLast line').should.deep.equals(
-            ['A line', 'Another line', 'Last line']);
+        utils.splitLines('A line\nAnother line\nLast line').should.deep.equals(['A line', 'Another line', 'Last line']);
     });
     it('handles empty lines', () => {
-        utils.splitLines('A line\n\nA line after an empty').should.deep.equals(
-            ['A line', '', 'A line after an empty']);
+        utils.splitLines('A line\n\nA line after an empty').should.deep.equals(['A line', '', 'A line after an empty']);
     });
     it('handles a single empty line', () => {
         utils.splitLines('\n').should.deep.equals(['']);
@@ -84,10 +82,7 @@ describe('Expands tabs', () => {
 
 describe('Parses compiler output', () => {
     it('handles simple cases', () => {
-        utils.parseOutput('Line one\nLine two', 'bob.cpp').should.deep.equals([
-            {text: 'Line one'},
-            {text: 'Line two'},
-        ]);
+        utils.parseOutput('Line one\nLine two', 'bob.cpp').should.deep.equals([{text: 'Line one'}, {text: 'Line two'}]);
         utils.parseOutput('Line one\nbob.cpp:1 Line two', 'bob.cpp').should.deep.equals([
             {text: 'Line one'},
             {
@@ -120,15 +115,16 @@ describe('Parses compiler output', () => {
         ]);
     });
     it('treats <stdin> as if it were the compiler source', () => {
-        utils.parseOutput('<stdin>:120:25: error: variable or field \'transform_data\' declared void', 'bob.cpp')
+        utils
+            .parseOutput("<stdin>:120:25: error: variable or field 'transform_data' declared void", 'bob.cpp')
             .should.deep.equals([
                 {
                     tag: {
                         column: 25,
                         line: 120,
-                        text: 'error: variable or field \'transform_data\' declared void',
+                        text: "error: variable or field 'transform_data' declared void",
                     },
-                    text: '<source>:120:25: error: variable or field \'transform_data\' declared void',
+                    text: "<source>:120:25: error: variable or field 'transform_data' declared void",
                 },
             ]);
     });
@@ -149,41 +145,48 @@ describe('Pascal compiler output', () => {
     });
 
     it('recognize fpc exiting error', () => {
-        utils.parseOutput('output.pas(17) Fatal: There were 1 errors compiling module, stopping', 'output.pas').should.deep.equals([
-            {
-                tag: {
-                    column: 0,
-                    line: 17,
-                    text: 'Fatal: There were 1 errors compiling module, stopping',
+        utils
+            .parseOutput('output.pas(17) Fatal: There were 1 errors compiling module, stopping', 'output.pas')
+            .should.deep.equals([
+                {
+                    tag: {
+                        column: 0,
+                        line: 17,
+                        text: 'Fatal: There were 1 errors compiling module, stopping',
+                    },
+                    text: '<source>(17) Fatal: There were 1 errors compiling module, stopping',
                 },
-                text: '<source>(17) Fatal: There were 1 errors compiling module, stopping',
-            },
-        ]);
+            ]);
     });
 
     it('removes the temp path', () => {
-        utils.parseOutput('Compiling /tmp/path/prog.dpr\noutput.pas(17) Fatal: There were 1 errors compiling module, stopping', 'output.pas', '/tmp/path/').should.deep.equals([
-            {
-                text: 'Compiling prog.dpr',
-            },
-            {
-                tag: {
-                    column: 0,
-                    line: 17,
-                    text: 'Fatal: There were 1 errors compiling module, stopping',
+        utils
+            .parseOutput(
+                'Compiling /tmp/path/prog.dpr\noutput.pas(17) Fatal: There were 1 errors compiling module, stopping',
+                'output.pas',
+                '/tmp/path/',
+            )
+            .should.deep.equals([
+                {
+                    text: 'Compiling prog.dpr',
                 },
-                text: '<source>(17) Fatal: There were 1 errors compiling module, stopping',
-            },
-        ]);
+                {
+                    tag: {
+                        column: 0,
+                        line: 17,
+                        text: 'Fatal: There were 1 errors compiling module, stopping',
+                    },
+                    text: '<source>(17) Fatal: There were 1 errors compiling module, stopping',
+                },
+            ]);
     });
 });
 
 describe('Rust compiler output', () => {
     it('handles simple cases', () => {
-        utils.parseRustOutput('Line one\nLine two', 'bob.rs').should.deep.equals([
-            {text: 'Line one'},
-            {text: 'Line two'},
-        ]);
+        utils
+            .parseRustOutput('Line one\nLine two', 'bob.rs')
+            .should.deep.equals([{text: 'Line one'}, {text: 'Line two'}]);
         utils.parseRustOutput('Unrelated\nLine one\n --> bob.rs:1\nUnrelated', 'bob.rs').should.deep.equals([
             {text: 'Unrelated'},
             {
@@ -222,58 +225,66 @@ describe('Rust compiler output', () => {
     });
 
     it('treats <stdin> as if it were the compiler source', () => {
-        utils.parseRustOutput('error: <stdin> is sad\n --> <stdin>:120:25', 'bob.rs')
-            .should.deep.equals([
-                {
-                    tag: {column: 25, line: 120, text: 'error: <source> is sad'},
-                    text: 'error: <source> is sad',
-                },
-                {
-                    tag: {column: 25, line: 120, text: ''},
-                    text: ' --> <source>:120:25',
-                },
-            ]);
+        utils.parseRustOutput('error: <stdin> is sad\n --> <stdin>:120:25', 'bob.rs').should.deep.equals([
+            {
+                tag: {column: 25, line: 120, text: 'error: <source> is sad'},
+                text: 'error: <source> is sad',
+            },
+            {
+                tag: {column: 25, line: 120, text: ''},
+                text: ' --> <source>:120:25',
+            },
+        ]);
     });
 });
 
 describe('Tool output', () => {
     it('removes the relative path', () => {
-        utils.parseOutput('./example.cpp:1:1: Fatal: There were 1 errors compiling module, stopping', './example.cpp').should.deep.equals([
-            {
-                tag: {
-                    column: 1,
-                    line: 1,
-                    text: 'Fatal: There were 1 errors compiling module, stopping',
+        utils
+            .parseOutput('./example.cpp:1:1: Fatal: There were 1 errors compiling module, stopping', './example.cpp')
+            .should.deep.equals([
+                {
+                    tag: {
+                        column: 1,
+                        line: 1,
+                        text: 'Fatal: There were 1 errors compiling module, stopping',
+                    },
+                    text: '<source>:1:1: Fatal: There were 1 errors compiling module, stopping',
                 },
-                text: '<source>:1:1: Fatal: There were 1 errors compiling module, stopping',
-            },
-        ]);
+            ]);
     });
 
     it('removes fortran relative path', () => {
-        utils.parseOutput('./example.f90:5:22: error: No explicit type declared for \'y\'', './example.f90').should.deep.equals([
-            {
-                tag: {
-                    column: 22,
-                    line: 5,
-                    text: 'error: No explicit type declared for \'y\'',
+        utils
+            .parseOutput("./example.f90:5:22: error: No explicit type declared for 'y'", './example.f90')
+            .should.deep.equals([
+                {
+                    tag: {
+                        column: 22,
+                        line: 5,
+                        text: "error: No explicit type declared for 'y'",
+                    },
+                    text: "<source>:5:22: error: No explicit type declared for 'y'",
                 },
-                text: '<source>:5:22: error: No explicit type declared for \'y\'',
-            },
-        ]);
+            ]);
     });
 
     it('removes the jailed path', () => {
-        utils.parseOutput('/home/ubuntu/example.cpp:1:1: Fatal: There were 1 errors compiling module, stopping', './example.cpp').should.deep.equals([
-            {
-                tag: {
-                    column: 1,
-                    line: 1,
-                    text: 'Fatal: There were 1 errors compiling module, stopping',
+        utils
+            .parseOutput(
+                '/home/ubuntu/example.cpp:1:1: Fatal: There were 1 errors compiling module, stopping',
+                './example.cpp',
+            )
+            .should.deep.equals([
+                {
+                    tag: {
+                        column: 1,
+                        line: 1,
+                        text: 'Fatal: There were 1 errors compiling module, stopping',
+                    },
+                    text: '<source>:1:1: Fatal: There were 1 errors compiling module, stopping',
                 },
-                text: '<source>:1:1: Fatal: There were 1 errors compiling module, stopping',
-            },
-        ]);
+            ]);
     });
 });
 
@@ -330,17 +341,25 @@ describe('Logger functionality', () => {
 describe('Hash interface', () => {
     it('correctly hashes strings', () => {
         const version = 'Compiler Explorer Tests Version 0';
-        utils.getHash('cream cheese', version).should.equal('cfff2d1f7a213e314a67cce8399160ae884f794a3ee9d4a01cd37a8c22c67d94');
-        utils.getHash('large eggs', version).should.equal('9144dec50b8df5bc5cc24ba008823cafd6616faf2f268af84daf49ac1d24feb0');
-        utils.getHash('sugar', version).should.equal('afa3c89d0f6a61de6805314c9bd7c52d020425a3a3c7bbdfa7c0daec594e5ef1');
+        utils
+            .getHash('cream cheese', version)
+            .should.equal('cfff2d1f7a213e314a67cce8399160ae884f794a3ee9d4a01cd37a8c22c67d94');
+        utils
+            .getHash('large eggs', version)
+            .should.equal('9144dec50b8df5bc5cc24ba008823cafd6616faf2f268af84daf49ac1d24feb0');
+        utils
+            .getHash('sugar', version)
+            .should.equal('afa3c89d0f6a61de6805314c9bd7c52d020425a3a3c7bbdfa7c0daec594e5ef1');
     });
     it('correctly hashes objects', () => {
-        utils.getHash({
-            toppings: [
-                {name: 'raspberries', optional: false},
-                {name: 'ground cinnamon', optional: true},
-            ],
-        }).should.equal('e205d63abd5db363086621fdc62c4c23a51b733bac5855985a8b56642d570491');
+        utils
+            .getHash({
+                toppings: [
+                    {name: 'raspberries', optional: false},
+                    {name: 'ground cinnamon', optional: true},
+                ],
+            })
+            .should.equal('e205d63abd5db363086621fdc62c4c23a51b733bac5855985a8b56642d570491');
     });
 });
 
@@ -393,31 +412,29 @@ describe('squashes horizontal whitespace', () => {
 describe('replaces all substrings', () => {
     it('works with no substitutions', () => {
         const string = 'This is a line with no replacements';
-        utils.replaceAll(string, 'not present', 'won\'t be substituted').should.equal(string);
+        utils.replaceAll(string, 'not present', "won't be substituted").should.equal(string);
     });
     it('handles odd cases', () => {
         utils.replaceAll('', '', '').should.equal('');
         utils.replaceAll('Hello', '', '').should.equal('Hello');
     });
     it('works with single replacement', () => {
-        utils.replaceAll('This is a line with a mistook in it', 'mistook', 'mistake')
+        utils
+            .replaceAll('This is a line with a mistook in it', 'mistook', 'mistake')
             .should.equal('This is a line with a mistake in it');
-        utils.replaceAll('This is a line with a mistook', 'mistook', 'mistake')
+        utils
+            .replaceAll('This is a line with a mistook', 'mistook', 'mistake')
             .should.equal('This is a line with a mistake');
-        utils.replaceAll('Mistooks were made', 'Mistooks', 'Mistakes')
-            .should.equal('Mistakes were made');
+        utils.replaceAll('Mistooks were made', 'Mistooks', 'Mistakes').should.equal('Mistakes were made');
     });
 
     it('works with multiple replacements', () => {
-        utils.replaceAll('A mistook is a mistook', 'mistook', 'mistake')
-            .should.equal('A mistake is a mistake');
-        utils.replaceAll('aaaaaaaaaaaaaaaaaaaaaaaaaaa', 'a', 'b')
-            .should.equal('bbbbbbbbbbbbbbbbbbbbbbbbbbb');
+        utils.replaceAll('A mistook is a mistook', 'mistook', 'mistake').should.equal('A mistake is a mistake');
+        utils.replaceAll('aaaaaaaaaaaaaaaaaaaaaaaaaaa', 'a', 'b').should.equal('bbbbbbbbbbbbbbbbbbbbbbbbbbb');
     });
 
     it('works with overlapping replacements', () => {
-        utils.replaceAll('aaaaaaaa', 'a', 'ba')
-            .should.equal('babababababababa');
+        utils.replaceAll('aaaaaaaa', 'a', 'ba').should.equal('babababababababa');
     });
 });
 
@@ -462,7 +479,7 @@ describe('fileExists', () => {
     it('Returns true for files that exists', async () => {
         (await utils.fileExists(fileURLToPath(import.meta.url))).should.be.true;
     });
-    it('Returns false for files that don\'t exist', async () => {
+    it("Returns false for files that don't exist", async () => {
         (await utils.fileExists('./ABC-FileThatDoesNotExist.extension')).should.be.false;
     });
     it('Returns false for directories that exist', async () => {
@@ -496,5 +513,16 @@ describe('safe semver', () => {
         utils.asSafeVer('123 TEXT').should.equal('123.0.0');
         utils.asSafeVer('123.456 TEXT').should.equal('123.456.0');
         utils.asSafeVer('123.456.789 TEXT').should.equal('123.456.789');
+    });
+});
+
+describe('object hashing', () => {
+    it('should work for strings and empty objects', () => {
+        utils.objectToHashableString('i am a string').should.equal('i am a string');
+        utils.objectToHashableString({}).should.equal('{}');
+    });
+    it('should consistently output objects', () => {
+        utils.objectToHashableString({a: 1, b: 2}).should.equal('{"a":1,"b":2}');
+        utils.objectToHashableString({b: 2, a: 1}).should.equal('{"a":1,"b":2}');
     });
 });


### PR DESCRIPTION
* Some circumstantial evidence that our cache misses might be
  due to non-determinism in JSON.stringify()
* This change uses a deterministic JSONifier, but it will cause
  all hashes to change, which is probably fine as it'll just mean
  one more round of "no really we should hit caches"

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
