### PR TITLE
Make Ctrl-A in output pane only select its contents

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -159,6 +159,10 @@ pre.content {
     overflow: auto;
 }
 
+pre.content.output-content {
+    padding-left: 1rem;
+}
+
 pre.content p {
     margin: 0;
 }

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -161,6 +161,7 @@ pre.content {
 
 pre.content.output-content {
     padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 pre.content p {

--- a/static/panes/cfg-view.ts
+++ b/static/panes/cfg-view.ts
@@ -303,8 +303,10 @@ export class Cfg extends Pane<CfgState> {
 
     override resize() {
         const height = (this.domRoot.height() as number) - (this.topBar.outerHeight(true) ?? 0);
-        this.cfgVisualiser.setSize('100%', height.toString());
-        this.cfgVisualiser.redraw();
+        if ((this.cfgVisualiser as any).canvas !== undefined) {
+            this.cfgVisualiser.setSize('100%', height.toString());
+            this.cfgVisualiser.redraw();
+        }
     }
 
     override getDefaultPaneName() {

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -123,11 +123,11 @@ export class Output extends Pane<OutputState> {
         this.eventHub.on('compiling', this.onCompiling, this);
         this.selectAllButton.on('click', this.onSelectAllButton.bind(this));
 
-        this.clickCallback = (e) => {
+        this.clickCallback = e => {
             this.onClickCallback(e);
         };
 
-        this.keydownCallback = (e) => {
+        this.keydownCallback = e => {
             this.onKeydownCallback(e);
         };
 

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -91,6 +91,21 @@ export class Output extends Pane<OutputState> {
     override registerCallbacks() {
         this.options.on('change', this.onOptionsChange.bind(this));
         this.eventHub.on('compiling', this.onCompiling, this);
+        let s = false;
+        $(document).on('click', e => {
+            s = this.contentRoot[0].contains(e.target);
+        });
+        $(document).on('keydown', e => {
+            if (s && e.ctrlKey && e.key === 'a') {
+                e.preventDefault();
+                const range = document.createRange();
+                range.selectNode(this.contentRoot[0]);
+                const selection = window.getSelection();
+                if (selection !== null) {
+                    selection.addRange(range);
+                }
+            }
+        });
     }
 
     onOptionsChange() {

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -48,6 +48,7 @@ export class Output extends Pane<OutputState> {
     optionsToolbar: JQuery<HTMLElement>;
     fontScale: FontScale;
     wrapButton: JQuery<HTMLElement>;
+    selectAllButton: JQuery;
     normalAnsiToHtml: AnsiToHtml.Filter;
     errorAnsiToHtml: AnsiToHtml.Filter;
     wrapTitle: string;
@@ -76,15 +77,20 @@ export class Output extends Pane<OutputState> {
         this.isOutputCurrentSelection = this.contentRoot[0].contains(e.target);
     }
 
+    private selectAll() {
+        const range = document.createRange();
+        range.selectNode(this.contentRoot[0]);
+        const selection = window.getSelection();
+        if (selection !== null) {
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    }
+
     private onKeydownCallback(e: JQuery.KeyDownEvent) {
         if (this.isOutputCurrentSelection && e.ctrlKey && e.key === 'a') {
             e.preventDefault();
-            const range = document.createRange();
-            range.selectNode(this.contentRoot[0]);
-            const selection = window.getSelection();
-            if (selection !== null) {
-                selection.addRange(range);
-            }
+            this.selectAll();
         }
     }
 
@@ -102,6 +108,7 @@ export class Output extends Pane<OutputState> {
 
     override registerButtons(state: OutputState & PaneState) {
         this.wrapButton = this.domRoot.find('.wrap-lines');
+        this.selectAllButton = this.domRoot.find('.select-all');
         this.wrapTitle = this.wrapButton.prop('title');
         // TODO: Would be nice to be able to get rid of this cast
         this.options = new Toggles(this.domRoot.find('.options'), state as unknown as Record<string, boolean>);
@@ -110,6 +117,7 @@ export class Output extends Pane<OutputState> {
     override registerCallbacks() {
         this.options.on('change', this.onOptionsChange.bind(this));
         this.eventHub.on('compiling', this.onCompiling, this);
+        this.selectAllButton.on('click', this.onSelectAllButton.bind(this));
         $(document).on('click', this.onClickCallback.bind(this));
         $(document).on('keydown', this.onKeydownCallback.bind(this));
     }
@@ -296,5 +304,9 @@ export class Output extends Pane<OutputState> {
 
     setCompileStatus(isCompiling) {
         this.contentRoot.toggleClass('compiling', isCompiling);
+    }
+
+    private onSelectAllButton(unused: JQuery.ClickEvent) {
+        this.selectAll();
     }
 }

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -228,7 +228,10 @@
           button.btn.btn-sm.btn-light.wrap-lines(type="button" title="Wrap lines" data-bind="wrap" aria-pressed="false" aria-label="Wrap lines")
             span Wrap lines
           input.d-none(type="checkbox" checked=false)
-    pre.content
+      .btn-group.btn-group-sm(role="group")
+        button.btn.btn-sm.btn-light.select-all(type="button" title="Select all lines")
+          span Select all
+    pre.content.output-content
 
   #tool-input
     .top-bar.btn-toolbar.bg-light(role="toolbar")


### PR DESCRIPTION
This seems to be the only way to restrict what gets selected.
The first listener is to check if the later Ctrl-A happens inside the output pane.
The only issue now is the fact that this is a global callback, and closing the pane might break it, but nothing seems to output in the console so... 🤞 