### PR TITLE
Add autodetect for staticlib `stdc++_libbacktrace`

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1287,7 +1287,7 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
+libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -1802,6 +1802,11 @@ libs.gnufs.name=Filesystem (GNU)
 libs.gnufs.versions=autodetect
 libs.gnufs.versions.autodetect.version=autodetect
 libs.gnufs.versions.autodetect.staticliblink=stdc++fs
+
+libs.gnulibbacktrace.name=backtrace support (GNU)
+libs.gnulibbacktrace.versions=autodetect
+libs.gnulibbacktrace.versions.autodetect.version=autodetect
+libs.gnulibbacktrace.versions.autodetect.staticliblink=stdc++_libbacktrace
 
 libs.googletest.name=Google Test
 libs.googletest.versions=trunk:110


### PR DESCRIPTION
`<stacktrace>` support for GCC 12 requires linking to `libstdc++_libbacktrace.a`, similar to `stdc++fs` in GCC 8.

Ref: https://github.com/gcc-mirror/gcc/commit/3acb929cc0beb79e6f4005eb22ee88b45e1cbc1d