### PR TITLE
Automatically detect Java entry points

### DIFF
--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -144,7 +144,7 @@ export class JavaCompiler extends BaseCompiler {
                         return null;
                     }
 
-                    if (objResult.stdout.match(this.mainRegex) != null) {
+                    if (this.mainRegex.test(objResult.stdout)) {
                         return classFile;
                     }
                     return null;

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -26,11 +26,11 @@ import path from 'path';
 
 import fs from 'fs-extra';
 
-import { BaseCompiler } from '../base-compiler';
-import { logger } from '../logger';
+import {BaseCompiler} from '../base-compiler';
+import {logger} from '../logger';
 import * as utils from '../utils';
 
-import { JavaParser } from './argument-parsers';
+import {JavaParser} from './argument-parsers';
 
 export class JavaCompiler extends BaseCompiler {
     static get key() {
@@ -54,33 +54,40 @@ export class JavaCompiler extends BaseCompiler {
         const dirPath = path.dirname(outputFilename);
         const files = await fs.readdir(dirPath);
         logger.verbose('Class files: ', files);
-        const results = await Promise.all(files.filter(f => f.endsWith('.class')).map(async classFile => {
-            const args = [
-                // Prints out disassembled code, i.e., the instructions that comprise the Java bytecodes,
-                // for each of the methods in the class.
-                '-c',
-                // Prints out line and local variable tables.
-                '-l',
-                // Private things
-                '-p',
-                // Final constants
-                '-constants',
-                // Verbose - ideally we'd enable this and then we get constant pools too. Needs work to parse.
-                //'-v',
-                classFile,
-            ];
-            const objResult = await this.exec(this.compiler.objdumper, args, {maxOutput: maxSize, customCwd: dirPath});
-            const oneResult = {
-                asm: objResult.stdout,
-            };
+        const results = await Promise.all(
+            files
+                .filter(f => f.endsWith('.class'))
+                .map(async classFile => {
+                    const args = [
+                        // Prints out disassembled code, i.e., the instructions that comprise the Java bytecodes,
+                        // for each of the methods in the class.
+                        '-c',
+                        // Prints out line and local variable tables.
+                        '-l',
+                        // Private things
+                        '-p',
+                        // Final constants
+                        '-constants',
+                        // Verbose - ideally we'd enable this and then we get constant pools too. Needs work to parse.
+                        //'-v',
+                        classFile,
+                    ];
+                    const objResult = await this.exec(this.compiler.objdumper, args, {
+                        maxOutput: maxSize,
+                        customCwd: dirPath,
+                    });
+                    const oneResult = {
+                        asm: objResult.stdout,
+                    };
 
-            if (objResult.code !== 0) {
-                oneResult.asm = '<No output: javap returned ' + objResult.code + '>';
-            } else {
-                oneResult.objdumpTime = objResult.execTime;
-            }
-            return oneResult;
-        }));
+                    if (objResult.code !== 0) {
+                        oneResult.asm = '<No output: javap returned ' + objResult.code + '>';
+                    } else {
+                        oneResult.objdumpTime = objResult.execTime;
+                    }
+                    return oneResult;
+                }),
+        );
 
         const merged = {asm: []};
         for (const result of results) {
@@ -98,11 +105,7 @@ export class JavaCompiler extends BaseCompiler {
         // Forcibly enable javap
         filters.binary = true;
 
-        return [
-            '-Xlint:all',
-            '-encoding',
-            'utf8',
-        ];
+        return ['-Xlint:all', '-encoding', 'utf8'];
     }
 
     async handleInterpreting(key, executeParameters) {
@@ -113,7 +116,7 @@ export class JavaCompiler extends BaseCompiler {
             '-XX:-UseDynamicNumberOfCompilerThreads',
             '-XX:-UseDynamicNumberOfGCThreads',
             '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
-            this.getMainClassName(),
+            await this.getMainClassName(compileResult.dirPath),
             '-cp',
             compileResult.dirPath,
             ...executeParameters.args,
@@ -124,8 +127,36 @@ export class JavaCompiler extends BaseCompiler {
         return result;
     }
 
-    getMainClassName() {
-        // TODO(supergrecko): The main class name is currently hardcoded
+    async getMainClassName(dirPath) {
+        const maxSize = this.env.ceProps('max-asm-size', 64 * 1024 * 1024);
+        const files = await fs.readdir(dirPath);
+        const results = await Promise.all(
+            files
+                .filter(f => f.endsWith('.class'))
+                .map(async classFile => {
+                    const options = {
+                        maxOutput: maxSize,
+                        customCwd: dirPath,
+                    };
+                    const objResult = await this.exec(this.compiler.objdumper, [classFile], options);
+                    if (objResult.code !== 0) {
+                        return null;
+                    }
+
+                    if (objResult.stdout.includes('void main(java.lang.String[])')) {
+                        return classFile;
+                    }
+                    return null;
+                }),
+        );
+
+        const candidates = results.filter(file => file !== null);
+        if (candidates.length > 0) {
+            // In case of multiple candidates, we'll just take the first one.
+            const fileName = candidates[0];
+            return fileName.substring(0, fileName.lastIndexOf('.'));
+        }
+        // We were unable to find a main method, let's error out assuming "Main"
         return 'Main';
     }
 
@@ -167,7 +198,8 @@ export class JavaCompiler extends BaseCompiler {
             '-s',
             // --source-path path or -sourcepath path
             // Specifies where to find input source files.
-            '--source-path', '-sourcepath',
+            '--source-path',
+            '-sourcepath',
         ]);
 
         return this.filterUserOptionsWithArg(userOptions, oneArgForbiddenList);
@@ -238,7 +270,7 @@ export class JavaCompiler extends BaseCompiler {
             for (const codeLineCandidate of utils.splitLines(codeAndLineNumberTable)) {
                 // Match
                 //       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
-                // Or match the "default: <code>" block inside a lookupswitch instruction   
+                // Or match the "default: <code>" block inside a lookupswitch instruction
                 const match = codeLineCandidate.match(/\s+(\d+|default): (.*)/);
                 if (match) {
                     const instrOffset = Number.parseInt(match[1]);
@@ -281,8 +313,10 @@ export class JavaCompiler extends BaseCompiler {
                     // Some instructions don't receive an explicit line number.
                     // They are all assigned to the previous explicit line number,
                     // because the line consists of multiple instructions.
-                    while (currentInstr < method.instructions.length
-                    && method.instructions[currentInstr].instrOffset !== instrOffset) {
+                    while (
+                        currentInstr < method.instructions.length &&
+                        method.instructions[currentInstr].instrOffset !== instrOffset
+                    ) {
                         if (currentSourceLine !== -1) {
                             // instructions without explicit line number get assigned the last explicit/same line number
                             method.instructions[currentInstr].sourceLine = currentSourceLine;
@@ -320,7 +354,7 @@ export class JavaCompiler extends BaseCompiler {
         }
         return {
             // Used for sorting
-            firstSourceLine: methods.reduce((p, m) => p === -1 ? m.startLine : Math.min(p, m.startLine), -1),
+            firstSourceLine: methods.reduce((p, m) => (p === -1 ? m.startLine : Math.min(p, m.startLine)), -1),
             methods: methods,
             textsBeforeMethod,
         };

--- a/lib/compilers/java.js
+++ b/lib/compilers/java.js
@@ -44,6 +44,7 @@ export class JavaCompiler extends BaseCompiler {
         }
         super(compilerInfo, env);
         this.javaRuntime = this.compilerProps(`compiler.${this.compiler.id}.runtime`);
+        this.mainRegex = /public static ?(.*?) void main\(java\.lang\.String\[]\)/;
     }
 
     getSharedLibraryPathsAsArguments() {
@@ -143,7 +144,7 @@ export class JavaCompiler extends BaseCompiler {
                         return null;
                     }
 
-                    if (objResult.stdout.includes('void main(java.lang.String[])')) {
+                    if (objResult.stdout.match(this.mainRegex) != null) {
                         return classFile;
                     }
                     return null;


### PR DESCRIPTION
Hello!

This patch implements a todo left behind with the Java implementation, as we can now detect the main methods for Java executions. This was a bit of a pain point for [Headline/discord-compiler](https://github.com/Headline/discord-compiler), as many folks struggled to find appropriate class names, so I figured I'd contribute this patch.

Most of this patch was derived from the previous `objdump()` implementation, but essentially we're just calling `javap` for lists of methods in each class file and hand picking ones that contain a main method. If this is a bit of a dirty implementation, I'd love hear feedback about how I can improve it (as well as adding tests).

It seems the linter went ahead and made other file changes, changes I didn't recognize until after it was committed. I presume this was a part of the pre-commit step and are desired? Just checking

Thanks!