### PR TITLE
Fix #3275 : move from compiler-opt-info to compiler-opt-info2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,3 +117,4 @@ From oldest to newest contributor, we would like to thank:
 - [m8mble](https://github.com/m8mble)
 - [Anders-T](https://github.com/anders-torbjornsen)
 - [Adam Sandberg Eriksson](https://github.com/adamse)
+- [Ofek Shilon](https://github.com/ofekshilon)

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -24,7 +24,6 @@
 
 import path from 'path';
 
-import * as compilerOptInfo from 'compiler-opt-info2';
 import fs from 'fs-extra';
 import temp from 'temp';
 import _ from 'underscore';
@@ -41,6 +40,7 @@ import {InstructionSets} from './instructionsets';
 import {languages} from './languages';
 import {LlvmAstParser} from './llvm-ast';
 import {LlvmIrParser} from './llvm-ir';
+import * as compilerOptInfo from './llvm-opt-transformer';
 import {logger} from './logger';
 import {getObjdumperTypeByKey} from './objdumper';
 import {Packager} from './packager';

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import * as compilerOptInfo from 'compiler-opt-info';
+import * as compilerOptInfo from 'compiler-opt-info2';
 import fs from 'fs-extra';
 import temp from 'temp';
 import _ from 'underscore';

--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -1,0 +1,82 @@
+import {Transform, TransformCallback} from 'stream';
+
+import * as R from 'ramda';
+import * as YAML from 'yamljs';
+
+type Path = string;
+type OptType = 'Missed' | 'Passed' | 'Analysis';
+
+interface OptInfo {
+    optType: OptType;
+    displayString: string;
+}
+
+interface LLVMOptInfo extends OptInfo {
+    Pass: string;
+    Name: string;
+    DebugLoc: DebugLoc;
+    Function: string;
+    Args: Array<object>;
+}
+
+interface DebugLoc {
+    File: Path;
+    Line: number;
+    Column: number;
+}
+
+function DisplayOptInfo(optInfo: LLVMOptInfo) {
+    return optInfo.Args.reduce((acc, x) => {
+        return (
+            acc + R.pipe(R.partial(R.pickBy, [(v: any, k: string) => k !== 'DebugLoc']), R.toPairs, R.head, R.last)(x)
+        );
+    }, '');
+}
+
+const optTypeMatcher = /---\s(.*)\r?\n/;
+const docStart = '---';
+const docEnd = '\n...';
+const IsDocumentStart = (x: string) => x.substring(0, 3) === docStart;
+const FindDocumentEnd = (x: string) => {
+    const index = x.indexOf(docEnd);
+    return {found: index > -1, endpos: index + docEnd.length};
+};
+
+export class LLVMOptTransformer extends Transform {
+    _buffer: string;
+    constructor(options: object) {
+        super(R.merge(options || {}, {objectMode: true}));
+        this._buffer = '';
+    }
+    override _flush(done: TransformCallback) {
+        this.processBuffer();
+        done();
+    }
+    override _transform(chunk: any, encoding: string, done: TransformCallback) {
+        this._buffer += chunk.toString();
+        //buffer until we have a start and and end
+        //if at any time i care about improving performance stash the offset
+        this.processBuffer();
+        done();
+    }
+    processBuffer() {
+        while (IsDocumentStart(this._buffer)) {
+            const {found, endpos} = FindDocumentEnd(this._buffer);
+            if (found) {
+                const [head, tail] = R.splitAt(endpos, this._buffer);
+                const optTypeMatch = head.match(optTypeMatcher);
+                const opt = YAML.parse(head);
+                if (!optTypeMatch) {
+                    console.warn('missing optimization type');
+                } else {
+                    opt.optType = optTypeMatch[1].replace('!', '');
+                }
+                opt.displayString = DisplayOptInfo(opt);
+                this.push(opt as LLVMOptInfo);
+                this._buffer = tail.replace(/^\n/, '');
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -1,3 +1,24 @@
+// MIT License
+//
+// Copyright (c) 2017 Jared Wyles, fixes by Aviv Polak and Ofek Shilon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 import {Transform, TransformCallback} from 'stream';
 
 import * as R from 'ramda';

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "bootstrap": "^4.6.1",
         "chart.js": "^3.6.2",
         "clipboard": "^2.0.8",
-        "compiler-opt-info": "0.0.4",
+        "compiler-opt-info2": "0.0.3",
         "compression": "^1.7.1",
         "copy-webpack-plugin": "^9.1.0",
         "cross-env": "^7.0.3",
@@ -3879,14 +3879,21 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "node_modules/compiler-opt-info": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/compiler-opt-info/-/compiler-opt-info-0.0.4.tgz",
-      "integrity": "sha1-YgqkuBFqA6Q5PMties8Qe9sz4pQ=",
+    "node_modules/compiler-opt-info2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/compiler-opt-info2/-/compiler-opt-info2-0.0.3.tgz",
+      "integrity": "sha512-pdTIJ5GISwzcCXF+DWqi2g4I64uaGProNVvtCdu/BsYDcsbV/BHEmksiv4loCOQ/ybkUju9TzIiGRW0kI/OPcw==",
       "dependencies": {
+        "@types/node": "7.0.7",
         "ramda": "^0.23.0",
-        "yamljs": "^0.2.9"
+        "yamljs": "^0.2.9",
+        "yarn": "^1.22.18"
       }
+    },
+    "node_modules/compiler-opt-info2/node_modules/@types/node": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.7.tgz",
+      "integrity": "sha1-kmN8bEhEv8mgpoYyPjjz6TGRGMI="
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
@@ -15271,6 +15278,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/yarn": {
+      "version": "1.22.18",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
+      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -18200,13 +18220,22 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "compiler-opt-info": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/compiler-opt-info/-/compiler-opt-info-0.0.4.tgz",
-      "integrity": "sha1-YgqkuBFqA6Q5PMties8Qe9sz4pQ=",
+    "compiler-opt-info2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/compiler-opt-info2/-/compiler-opt-info2-0.0.3.tgz",
+      "integrity": "sha512-pdTIJ5GISwzcCXF+DWqi2g4I64uaGProNVvtCdu/BsYDcsbV/BHEmksiv4loCOQ/ybkUju9TzIiGRW0kI/OPcw==",
       "requires": {
+        "@types/node": "7.0.7",
         "ramda": "^0.23.0",
-        "yamljs": "^0.2.9"
+        "yamljs": "^0.2.9",
+        "yarn": "^1.22.18"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.7.tgz",
+          "integrity": "sha1-kmN8bEhEv8mgpoYyPjjz6TGRGMI="
+        }
       }
     },
     "component-emitter": {
@@ -26690,6 +26719,11 @@
           "dev": true
         }
       }
+    },
+    "yarn": {
+      "version": "1.22.18",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
+      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "bootstrap": "^4.6.1",
         "chart.js": "^3.6.2",
         "clipboard": "^2.0.8",
-        "compiler-opt-info2": "0.0.3",
         "compression": "^1.7.1",
         "copy-webpack-plugin": "^9.1.0",
         "cross-env": "^7.0.3",
@@ -51,6 +50,7 @@
         "profanities": "^2.14.0",
         "prom-client": "^14.0.1",
         "pug": "^3.0.2",
+        "ramda": "^0.23.0",
         "request": "^2.88.2",
         "response-time": "^2.3.2",
         "sanitize-filename": "^1.6.3",
@@ -74,7 +74,8 @@
         "winston-loki": "^6.0.3",
         "winston-papertrail": "^1.0.5",
         "winston-transport": "^4.4.1",
-        "yaml": "^1.10.2"
+        "yaml": "^1.10.2",
+        "yamljs": "^0.2.9"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.16.5",
@@ -3878,22 +3879,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
-    },
-    "node_modules/compiler-opt-info2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/compiler-opt-info2/-/compiler-opt-info2-0.0.3.tgz",
-      "integrity": "sha512-pdTIJ5GISwzcCXF+DWqi2g4I64uaGProNVvtCdu/BsYDcsbV/BHEmksiv4loCOQ/ybkUju9TzIiGRW0kI/OPcw==",
-      "dependencies": {
-        "@types/node": "7.0.7",
-        "ramda": "^0.23.0",
-        "yamljs": "^0.2.9",
-        "yarn": "^1.22.18"
-      }
-    },
-    "node_modules/compiler-opt-info2/node_modules/@types/node": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.7.tgz",
-      "integrity": "sha1-kmN8bEhEv8mgpoYyPjjz6TGRGMI="
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
@@ -15278,19 +15263,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yarn": {
-      "version": "1.22.18",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
-      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==",
-      "hasInstallScript": true,
-      "bin": {
-        "yarn": "bin/yarn.js",
-        "yarnpkg": "bin/yarn.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -18219,24 +18191,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
-    },
-    "compiler-opt-info2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/compiler-opt-info2/-/compiler-opt-info2-0.0.3.tgz",
-      "integrity": "sha512-pdTIJ5GISwzcCXF+DWqi2g4I64uaGProNVvtCdu/BsYDcsbV/BHEmksiv4loCOQ/ybkUju9TzIiGRW0kI/OPcw==",
-      "requires": {
-        "@types/node": "7.0.7",
-        "ramda": "^0.23.0",
-        "yamljs": "^0.2.9",
-        "yarn": "^1.22.18"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "7.0.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.7.tgz",
-          "integrity": "sha1-kmN8bEhEv8mgpoYyPjjz6TGRGMI="
-        }
-      }
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -26719,11 +26673,6 @@
           "dev": true
         }
       }
-    },
-    "yarn": {
-      "version": "1.22.18",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
-      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "bootstrap": "^4.6.1",
     "chart.js": "^3.6.2",
     "clipboard": "^2.0.8",
-    "compiler-opt-info2": "0.0.3",
     "compression": "^1.7.1",
     "copy-webpack-plugin": "^9.1.0",
     "cross-env": "^7.0.3",
@@ -62,6 +61,7 @@
     "profanities": "^2.14.0",
     "prom-client": "^14.0.1",
     "pug": "^3.0.2",
+    "ramda": "^0.23.0",
     "request": "^2.88.2",
     "response-time": "^2.3.2",
     "sanitize-filename": "^1.6.3",
@@ -85,7 +85,8 @@
     "winston-loki": "^6.0.3",
     "winston-papertrail": "^1.0.5",
     "winston-transport": "^4.4.1",
-    "yaml": "^1.10.2"
+    "yaml": "^1.10.2",
+    "yamljs": "^0.2.9"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.16.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bootstrap": "^4.6.1",
     "chart.js": "^3.6.2",
     "clipboard": "^2.0.8",
-    "compiler-opt-info": "0.0.4",
+    "compiler-opt-info2": "0.0.3",
     "compression": "^1.7.1",
     "copy-webpack-plugin": "^9.1.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
`make check` passes.   

Following [this concern](https://twitter.com/OfekShilon/status/1496593807500062721) I checked the differences between the original compiler-opt-info github version and the npm version, and they seem non-functional. So my fork includes a fix based on the github version.

Not sure whether `yarn` is essential in the generated packages-lock, and don't think it matters.

Closes #3275 
