### PR TITLE
Fix resize bug

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -604,12 +604,14 @@ Compiler.prototype.undefer = function () {
 };
 
 Compiler.prototype.resize = function () {
-    var topBarHeight = utils.updateAndCalcTopBarHeight(this.domRoot, this.topBar, this.hideable);
-    var bottomBarHeight = this.bottomBar.outerHeight(true);
-    this.outputEditor.layout({
-        width: this.domRoot.width(),
-        height: this.domRoot.height() - topBarHeight - bottomBarHeight,
-    });
+    _.defer(function (self) {
+        var topBarHeight = utils.updateAndCalcTopBarHeight(self.domRoot, self.topBar, self.hideable);
+        var bottomBarHeight = self.bottomBar.outerHeight(true);
+        self.outputEditor.layout({
+            width: self.domRoot.width(),
+            height: self.domRoot.height() - topBarHeight - bottomBarHeight,
+        });
+    }, this);
 };
 
 // Returns a label name if it can be found in the given position, otherwise

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -158,21 +158,23 @@ Executor.prototype.undefer = function () {
 };
 
 Executor.prototype.resize = function () {
-    var topBarHeight = utils.updateAndCalcTopBarHeight(this.domRoot, $(this.topBar[0]), this.hideable);
+    _.defer(function (self) {
+        var topBarHeight = utils.updateAndCalcTopBarHeight(self.domRoot, $(self.topBar[0]), self.hideable);
 
-    // We have some more elements that modify the topBarHeight
-    if (!this.panelCompilation.hasClass('d-none')) {
-        topBarHeight += this.panelCompilation.outerHeight(true);
-    }
-    if (!this.panelArgs.hasClass('d-none')) {
-        topBarHeight += this.panelArgs.outerHeight(true);
-    }
-    if (!this.panelStdin.hasClass('d-none')) {
-        topBarHeight += this.panelStdin.outerHeight(true);
-    }
+        // We have some more elements that modify the topBarHeight
+        if (!self.panelCompilation.hasClass('d-none')) {
+            topBarHeight += self.panelCompilation.outerHeight(true);
+        }
+        if (!self.panelArgs.hasClass('d-none')) {
+            topBarHeight += self.panelArgs.outerHeight(true);
+        }
+        if (!self.panelStdin.hasClass('d-none')) {
+            topBarHeight += self.panelStdin.outerHeight(true);
+        }
 
-    var bottomBarHeight = this.bottomBar.outerHeight(true);
-    this.outputContentRoot.outerHeight(this.domRoot.height() - topBarHeight - bottomBarHeight);
+        var bottomBarHeight = self.bottomBar.outerHeight(true);
+        self.outputContentRoot.outerHeight(self.domRoot.height() - topBarHeight - bottomBarHeight);
+    }, this);
 };
 
 function errorResult(message) {

--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -292,10 +292,12 @@ export abstract class MonacoPane<E extends monaco.editor.IEditor, S> extends Pan
     }
 
     resize() {
-        const topBarHeight = utils.updateAndCalcTopBarHeight(this.domRoot, this.topBar, this.hideable);
-        this.editor.layout({
-            width: this.domRoot.width() as number,
-            height: (this.domRoot.height() as number) - topBarHeight,
+        _.defer(() => {
+            const topBarHeight = utils.updateAndCalcTopBarHeight(this.domRoot, this.topBar, this.hideable);
+            this.editor.layout({
+                width: this.domRoot.width() as number,
+                height: (this.domRoot.height() as number) - topBarHeight,
+            });
         });
     }
 


### PR DESCRIPTION
This fixes #3616.

Printbugging triage:
```js
1651639870337 resize <-- w: 1277 h: 638 top: 70 bottom: 32 // resize information before drag
1651639879099 resize <-- w: 1277 h: 638 top: 0 bottom: 0   // drag
1651639881524 resize <-- w: 1277 h: 638 top: 0 bottom: 0   // drop
1651639883889 resize <-- w: 1277 h: 637 top: 70 bottom: 32 // first resize after drop (e.g. by resizing the window)
```

I guess somehow there's no `outerHeight` for these when golden layout is dragging them around, not sure why. What I've done to fix is `_.defer` in the resize function. The compiler and executor panes are directly affected and then I've made the change in pane.ts too for any other and all future panels.