### PR TITLE
Add 405 handlers for API endpoints

### DIFF
--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -34,6 +34,11 @@ import * as utils from '../utils';
 import {withAssemblyDocumentationProviders} from './assembly-documentation';
 import {FormattingHandler} from './formatting';
 
+function methodNotAllowed(req, res) {
+    res.send('Method Not Allowed');
+    return res.status(405).end();
+}
+
 export class ApiHandler {
     constructor(compileHandler, ceProps, storageHandler, urlShortenService) {
         this.compilers = [];
@@ -52,53 +57,79 @@ export class ApiHandler {
             });
             next();
         });
-        this.handle.get('/compilers', this.handleCompilers.bind(this));
-        this.handle.get('/compilers/:language', this.handleCompilers.bind(this));
-        this.handle.get('/languages', this.handleLanguages.bind(this));
-        this.handle.get('/libraries/:language', this.handleLangLibraries.bind(this));
-        this.handle.get('/libraries', this.handleAllLibraries.bind(this));
+        this.handle.route('/compilers').get(this.handleCompilers.bind(this)).all(methodNotAllowed);
+
+        this.handle.route('/compilers/:language').get(this.handleCompilers.bind(this)).all(methodNotAllowed);
+
+        this.handle.route('/languages').get(this.handleLanguages.bind(this)).all(methodNotAllowed);
+
+        this.handle.route('/libraries/:language').get(this.handleLangLibraries.bind(this)).all(methodNotAllowed);
+
+        this.handle.route('/libraries').get(this.handleAllLibraries.bind(this)).all(methodNotAllowed);
 
         // Binding for assembly documentation
         withAssemblyDocumentationProviders(this.handle);
         // Legacy binding for old clients.
-        this.handle.get('/asm/:opcode', (req, res) => res.redirect(`amd64/${req.params.opcode}`));
+        this.handle
+            .route('/asm/:opcode')
+            .get((req, res) => res.redirect(`amd64/${req.params.opcode}`))
+            .all(methodNotAllowed);
 
         const maxUploadSize = ceProps('maxUploadSize', '1mb');
         const textParser = bodyParser.text({limit: ceProps('bodyParserLimit', maxUploadSize), type: () => true});
 
-        this.handle.post('/compiler/:compiler/compile', textParser, compileHandler.handle.bind(compileHandler));
-        this.handle.post('/compiler/:compiler/cmake', compileHandler.handleCmake.bind(compileHandler));
-        this.handle.post('/popularArguments/:compiler', compileHandler.handlePopularArguments.bind(compileHandler));
-        this.handle.post(
-            '/optimizationArguments/:compiler',
-            compileHandler.handleOptimizationArguments.bind(compileHandler),
-        );
+        this.handle
+            .route('/compiler/:compiler/compile')
+            .post(textParser, compileHandler.handle.bind(compileHandler))
+            .all(methodNotAllowed);
+        this.handle
+            .route('/compiler/:compiler/cmake')
+            .post(compileHandler.handleCmake.bind(compileHandler))
+            .all(methodNotAllowed);
 
-        this.handle.get('/popularArguments/:compiler', compileHandler.handlePopularArguments.bind(compileHandler));
-        this.handle.get(
-            '/optimizationArguments/:compiler',
-            compileHandler.handleOptimizationArguments.bind(compileHandler),
-        );
+        this.handle
+            .route('/popularArguments/:compiler')
+            .post(compileHandler.handlePopularArguments.bind(compileHandler))
+            .all(methodNotAllowed);
+        this.handle
+            .route('/optimizationArguments/:compiler')
+            .post(compileHandler.handleOptimizationArguments.bind(compileHandler))
+            .all(methodNotAllowed);
+
+        this.handle
+            .route('/popularArguments/:compiler')
+            .get(compileHandler.handlePopularArguments.bind(compileHandler))
+            .all(methodNotAllowed);
+        this.handle
+            .route('/optimizationArguments/:compiler')
+            .get(compileHandler.handleOptimizationArguments.bind(compileHandler))
+            .all(methodNotAllowed);
 
         const formatHandler = new FormattingHandler(ceProps);
-        this.handle.post('/format/:tool', (req, res) => formatHandler.handle(req, res));
-        this.handle.get('/formats', (req, res) => {
-            const all = Object.values(formatHandler.formatters).map(formatter => formatter.formatterInfo);
-            res.send(all);
-        });
+        this.handle
+            .route('/format/:tool')
+            .post((req, res) => formatHandler.handle(req, res))
+            .all(methodNotAllowed);
+        this.handle
+            .route('/formats')
+            .get((req, res) => {
+                const all = Object.values(formatHandler.formatters).map(formatter => formatter.formatterInfo);
+                res.send(all);
+            })
+            .all(methodNotAllowed);
 
-        this.handle.get('/shortlinkinfo/:id', this.shortlinkInfoHandler.bind(this));
+        this.handle.route('/shortlinkinfo/:id').get(this.shortlinkInfoHandler.bind(this)).all(methodNotAllowed);
 
         const shortenerType = getShortenerTypeByKey(urlShortenService);
         this.shortener = new shortenerType(storageHandler);
-        this.handle.post('/shortener', this.shortener.handle.bind(this.shortener));
+        this.handle.route('/shortener').post(this.shortener.handle.bind(this.shortener)).all(methodNotAllowed);
 
         this.release = {
             gitReleaseName: '',
             releaseBuildNumber: '',
         };
-        this.handle.get('/version', this.handleReleaseName.bind(this));
-        this.handle.get('/releaseBuild', this.handleReleaseBuild.bind(this));
+        this.handle.route('/version').get(this.handleReleaseName.bind(this)).all(methodNotAllowed);
+        this.handle.route('/releaseBuild').get(this.handleReleaseBuild.bind(this)).all(methodNotAllowed);
     }
 
     shortlinkInfoHandler(req, res, next) {


### PR DESCRIPTION
This makes it so any other method other than the defined returns 405