### PR TITLE
Add ISPC v1.18.0

### DIFF
--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -1,9 +1,11 @@
 compilers=&ispc
-defaultCompiler=ispc1170
+defaultCompiler=ispc1180
 
-group.ispc.compilers=ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk
+group.ispc.compilers=ispc1180:ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk
 group.ispc.isSemVer=true
 group.ispc.baseName=ispc
+compiler.ispc1180.exe=/opt/compiler-explorer/ispc-1.18.0/bin/ispc
+compiler.ispc1180.semver=1.18.0
 compiler.ispc1170.exe=/opt/compiler-explorer/ispc-1.17.0/bin/ispc
 compiler.ispc1170.semver=1.17.0
 compiler.ispc1161.exe=/opt/compiler-explorer/ispc-1.16.1/bin/ispc


### PR DESCRIPTION
Adding ISPC v1.18.0.

Corresponding infra commit PR, which needs to be merged before this PR: https://github.com/compiler-explorer/infra/pull/716  (so ISPC v1.18.0 is available in the infra).
