### PR TITLE
Add GCC 12.1.0

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,13 +1,13 @@
 # Default settings for Ada
 compilers=&gnat:&gnatriscv64:&gnatarm:&gnats390x:&gnatmipss:&gnatppcs
-defaultCompiler=gnat113
-demangler=/opt/compiler-explorer/gcc-11.3.0/bin/c++filt
+defaultCompiler=gnat121
+demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
 versionFlag=--version
 compilerType=ada
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=gnat82:gnat102:gnat111:gnat112:gnat113:gnatsnapshot
+group.gnat.compilers=gnat82:gnat102:gnat111:gnat112:gnat113:gnat121:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=x86-64
 group.gnat.isSemVer=true
@@ -26,6 +26,8 @@ compiler.gnat112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gnat
 compiler.gnat112.semver=11.2
 compiler.gnat113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gnat
 compiler.gnat113.semver=11.3
+compiler.gnat121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gnat
+compiler.gnat121.semver=12.1
 compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnat
 compiler.gnatsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&nasm:&gnuas:&llvmas:&ptxas:&gnuasarm:&gnuasarm64
 compilerType=assembly
-objdumper=/opt/compiler-explorer/gcc-11.2.0/bin/objdump
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 supportsBinary=true
 supportsExecute=true
 demangler=
@@ -22,7 +22,7 @@ compiler.nasm21402.semver=2.14.02
 compiler.nasm21402.exe=/opt/compiler-explorer/nasm-2.14.02/nasm
 
 
-group.gnuas.compilers=gnuas72:gnuas73:gnuas92:gnuas103:gnuas112:gnuassnapshot
+group.gnuas.compilers=gnuas72:gnuas73:gnuas92:gnuas103:gnuas112:gnuas121:gnuassnapshot
 group.gnuas.versionFlag=--version
 group.gnuas.options=-g
 group.gnuas.isSemVer=true
@@ -37,6 +37,8 @@ compiler.gnuas103.exe=/opt/compiler-explorer/gcc-10.3.0/bin/as
 compiler.gnuas103.semver=2.34
 compiler.gnuas112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/as
 compiler.gnuas112.semver=2.36.1
+compiler.gnuas121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/as
+compiler.gnuas121.semver=2.38
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx
-defaultCompiler=g113
-demangler=/opt/compiler-explorer/gcc-11.3.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
+defaultCompiler=g121
+demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g101:g102:g103:g111:g112:g113:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g101:g102:g103:g111:g112:g113:g121:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -123,6 +123,8 @@ compiler.g112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/g++
 compiler.g112.semver=11.2
 compiler.g113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/g++
 compiler.g113.semver=11.3
+compiler.g121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/g++
+compiler.g121.semver=12.1
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc
-defaultCompiler=cg113
-demangler=/opt/compiler-explorer/gcc-11.3.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
+defaultCompiler=cg121
+demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 needsMulti=false
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg101:cg102:cg103:cg111:cg112:cg113:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg101:cg102:cg103:cg111:cg112:cg113:cg121:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -101,6 +101,8 @@ compiler.cg112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gcc
 compiler.cg112.semver=11.2
 compiler.cg113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gcc
 compiler.cg113.semver=11.3
+compiler.cg121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gcc
+compiler.cg121.semver=12.1
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,9 +1,9 @@
 compilers=&gdc:&ldc:&dmd
 defaultCompiler=ldc1_27
-objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 demangler=/opt/compiler-explorer/ldc1.27.1/ldc2-1.27.1-linux-x86_64/bin/ddemangle
 
-group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc101:gdc102:gdc111:gdc113:gdctrunk
+group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc101:gdc102:gdc111:gdc113:gdc121:gdctrunk
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
 group.gdc.baseName=gdc
@@ -29,6 +29,8 @@ compiler.gdc111.exe=/opt/compiler-explorer/gcc-11.1.0/bin/gdc
 compiler.gdc111.semver=11.1
 compiler.gdc113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gdc
 compiler.gdc113.semver=11.3
+compiler.gdc121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gdc
+compiler.gdc121.semver=12.1
 compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gdctrunk.semver=(trunk)

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&gfortran_86:&ifort:&ifx:&cross:&clang_llvmflang
-defaultCompiler=gfortran113
-demangler=/opt/compiler-explorer/gcc-11.3.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
+defaultCompiler=gfortran121
+demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran111:gfortran112:gfortran113:gfortransnapshot
+group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran111:gfortran112:gfortran113:gfortran121:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -52,6 +52,8 @@ compiler.gfortran112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gfortran
 compiler.gfortran112.semver=11.2
 compiler.gfortran113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gfortran
 compiler.gfortran113.semver=11.3
+compiler.gfortran121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gfortran
+compiler.gfortran121.semver=12.1
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gfortransnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -1,9 +1,9 @@
 defaultCompiler=gl1180
-objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 
 compilers=&gccgo:&gl:&cross:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl
 
-group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo102:gccgo111:gccgo112:gccgo113
+group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo102:gccgo111:gccgo112:gccgo113:gccgo121
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -26,6 +26,8 @@ compiler.gccgo112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gccgo
 compiler.gccgo112.semver=11.2.0
 compiler.gccgo113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gccgo
 compiler.gccgo113.semver=11.3.0
+compiler.gccgo121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gccgo
+compiler.gccgo121.semver=12.1.0
 
 group.gl.compilers=6g141:gl172:gl185:gl187:gl192:gl194:gl1100:gl1101:gl1110:gl1120:gl1130:gl1140:386_gl114:gl1150:386_gl115:gl1160:386_gl116:gl1170:386_gl117:gl1180:386_gl118:gltip:386_gltip
 group.gl.versionFlag=version


### PR DESCRIPTION
GCC 12.1.0 has been released:
https://gcc.gnu.org/gcc-12/changes.html

fixes #3624

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>