### PR TITLE
Get GA script back to Google's default

### DIFF
--- a/static/analytics.ts
+++ b/static/analytics.ts
@@ -51,7 +51,8 @@ class GAProxy {
                             // eslint-disable-next-line prefer-rest-params
                             (i[r].q = i[r].q || []).push(arguments);
                         };
-                    i[r].l = Date.now();
+                    // @ts-ignore
+                    i[r].l = 1 * new Date();
                     // @ts-ignore
                     a = s.createElement(o);
                     // @ts-ignore
@@ -70,7 +71,10 @@ class GAProxy {
                 });
                 window.ga('send', 'pageview');
             }
-            this._proxy = (...args) => window.ga.apply(window.ga, args);
+            this._proxy = function () {
+                // eslint-disable-next-line prefer-rest-params
+                window.ga.apply(window.ga, arguments);
+            };
             this.isEnabled = true;
             this.hasBeenEnabled = true;
         } else {


### PR DESCRIPTION
@jeremy-rifkin found that have not been receiving many analytic events since January 1st. This PR undoes the only two iffy changes made to the file in that time period, to see if it fixes the situation