### PR TITLE
Add semver check for ast dump in iscp

### DIFF
--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -22,7 +22,11 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import Semver from 'semver';
+import * as _ from 'underscore';
+
 import {BaseCompiler} from '../base-compiler';
+import {asSafeVer} from '../utils';
 
 import {ISPCParser} from './argument-parsers';
 
@@ -35,6 +39,10 @@ export class ISPCCompiler extends BaseCompiler {
         super(info, env);
         this.compiler.supportsIrView = true;
         this.compiler.irArg = ['--emit-llvm-text'];
+    }
+
+    couldSupportASTDump(version) {
+        return Semver.gte(asSafeVer(this.compiler.semver), '1.18.0', true);
     }
 
     optionsForFilter(filters, outputFilename) {
@@ -52,6 +60,19 @@ export class ISPCCompiler extends BaseCompiler {
 
     getArgumentParser() {
         return ISPCParser;
+    }
+
+    async generateAST(inputFilename, options) {
+        // These options make Clang produce an AST dump
+        const newOptions = options.concat(['--ast-dump']);
+
+        const execOptions = this.getDefaultExecOptions();
+        // A higher max output is needed for when the user includes headers
+        execOptions.maxOutput = 1024 * 1024 * 1024;
+
+        return this.llvmAst.processAst(
+            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions),
+        );
     }
 
     isCfgCompiler(/*compilerVersion*/) {


### PR DESCRIPTION
> Note that AST format looks similar to clang, but it's not quite clang AST. So clang highlighting will not work out of the box, but we can tweak the format to match clang parse in the future.

It currently uses the llvmAst processor from base-compiler, which seems to work ok for simple test cases, but might break for the mentioned differences?

Closes #3648
