### PR TITLE
Development speedups

### DIFF
--- a/etc/config/compiler-explorer.defaults.properties
+++ b/etc/config/compiler-explorer.defaults.properties
@@ -18,6 +18,7 @@ urlShortenService=default
 storageSolution=local
 localStorageFolder=./lib/storage/data/
 showSponsors=false
+compilerCacheConfig=OnDisk(out/compiler-cache,1024)
 
 demanglerType=default
 objdumperType=default

--- a/webpack.config.esm.js
+++ b/webpack.config.esm.js
@@ -101,6 +101,12 @@ export default {
         filename: isDev ? '[name].js' : `[name]${webjackJsHack}[contenthash].js`,
         path: staticPath,
     },
+    cache: {
+        type: 'filesystem',
+        buildDependencies: {
+            config: [fileURLToPath(import.meta.url)],
+        },
+    },
     resolve: {
         alias: {
             'monaco-editor$': 'monaco-editor/esm/vs/editor/editor.api',


### PR DESCRIPTION
* Enable persistent disk cache for webpack (we'll have to keep an eye on this...)
* Configure a default persistent compiler discovery cache in the `out` dir.