### PR TITLE
Add widberg compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -309,7 +309,7 @@ compiler.clang1400.semver=14.0.0
 compiler.clang1400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.clang1400.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_widberg
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -363,6 +363,10 @@ compiler.clang_dang.exe=/opt/compiler-explorer/clang-dang-main/bin/clang++
 compiler.clang_dang.semver=(thephd.dev)
 compiler.clang_dang.options=-std=c++2a -stdlib=libc++
 compiler.clang_dang.notification=Embed, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
+compiler.clang_widberg.exe=/opt/compiler-explorer/clang-widberg-main/bin/clang++
+compiler.clang_widberg.semver=(widberg)
+compiler.clang_widberg.options=-std=c++2a -stdlib=libc++
+compiler.clang_widberg.notification=Experimental Reverse Engineering Compiler; see <a href="https://github.com/widberg/llvm-project-widberg-extensions" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_reflection.exe=/opt/compiler-explorer/clang-reflection-trunk/bin/clang++
 compiler.clang_reflection.semver=(reflection)
 compiler.clang_reflection.options=-std=c++20 -freflection-ts -stdlib=libc++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -130,7 +130,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang_trunk:cclang_assertions_trunk:cclang_dang
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_widberg
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -251,6 +251,10 @@ compiler.cclang_dang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_dang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_dang.semver=(thephd.dev)
 compiler.cclang_dang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0 -std=c2x
+compiler.cclang_widberg.exe=/opt/compiler-explorer/clang-widberg-main/bin/clang
+compiler.cclang_widberg.semver=(widberg)
+compiler.cclang_widberg.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
+compiler.cclang_widberg.notification=Experimental Reverse Engineering Compiler; see <a href="https://github.com/widberg/llvm-project-widberg-extensions" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk


### PR DESCRIPTION
This PR adds the [widberg clang compiler](https://github.com/widberg/llvm-project-widberg-extensions). This compiler is an experimental reverse engineering compiler being developed at the University of Massachusetts Lowell Computer Science Department. We believe that there will be great utility in being able to provide live links to code samples using the compiler in publications. The multi-repo organization of CE is somewhat unwieldy to an outsider like me, so I have undoubtably made a mistake in at least one of these PRs; thank you for any fixes you are able to provide.

Related PRs:
https://github.com/compiler-explorer/clang-builder/pull/35
https://github.com/compiler-explorer/infra/pull/721
https://github.com/compiler-explorer/compiler-workflows/pull/8