### PR TITLE
Clear linked line in the editor on mouse move

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -374,6 +374,7 @@ Editor.prototype.sendEditor = function () {
 
 Editor.prototype.onMouseMove = function (e) {
     if (e !== null && e.target !== null && this.settings.hoverShowSource && e.target.position !== null) {
+        this.clearLinkedLine();
         var pos = e.target.position;
         this.tryPanesLinkLine(pos.lineNumber, pos.column, false);
     }


### PR DESCRIPTION
This change brings the behavior of the linked line system in the editor more in-line with the handling in other panes and improves two little oddities in the editor:

Linked line decorations interfere with selection decorations which can make selections invisible:
![image](https://user-images.githubusercontent.com/51220084/168414509-85c93852-336e-48e8-9ebb-2e719c22f25a.png)

Currently if a line is linked between an editor and other panes, hovering over other lines in the editor updates linked lines in other panes but doesn't update the linked lines in the editor which is a little surprising behavior.

