### PR TITLE
Change Xtensa ISA to "xtensa"

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1122,6 +1122,7 @@ group.xtensaesp32.compilers=esp32g2019r2:esp32g2020r1:esp32g2020r2:esp32g2020r3:
 group.xtensaesp32.groupName=Xtensa ESP32 GCC
 group.xtensaesp32.supportsBinary=false
 group.xtensaesp32.instructionSet=xtensa
+group.xtensaesp32.supportsAsmDocs=false
 
 compiler.esp32g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-g++
 compiler.esp32g2019r2.name=Xtensa ESP32 gcc 8.2.0 (2019r2)
@@ -1142,6 +1143,7 @@ group.xtensaesp32s2.compilers=esp32s2g2019r2:esp32s2g2020r1:esp32s2g2020r2:esp32
 group.xtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.xtensaesp32s2.supportsBinary=false
 group.xtensaesp32s2.instructionSet=xtensa
+group.xtensaesp32s2.supportsAsmDocs=false
 
 compiler.esp32s2g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-g++
 compiler.esp32s2g2019r2.name=Xtensa ESP32-S2 gcc 8.2.0 (2019r2)
@@ -1162,6 +1164,7 @@ group.xtensaesp32s3.compilers=esp32s3g2020r3:esp32s3g2021r1:esp32s3g2021r2
 group.xtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.xtensaesp32s3.supportsBinary=false
 group.xtensaesp32s3.instructionSet=xtensa
+group.xtensaesp32s3.supportsAsmDocs=false
 
 compiler.esp32s3g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-g++
 compiler.esp32s3g2020r3.name=Xtensa ESP32-S3 gcc 8.4.0 (2020r3)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1121,6 +1121,7 @@ compiler.rv32-gcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv3
 group.xtensaesp32.compilers=esp32g2019r2:esp32g2020r1:esp32g2020r2:esp32g2020r3:esp32g2021r1:esp32g2021r2
 group.xtensaesp32.groupName=Xtensa ESP32 GCC
 group.xtensaesp32.supportsBinary=false
+group.xtensaesp32.instructionSet=xtensa
 
 compiler.esp32g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-g++
 compiler.esp32g2019r2.name=Xtensa ESP32 gcc 8.2.0 (2019r2)
@@ -1140,6 +1141,7 @@ compiler.esp32g2021r2.name=Xtensa ESP32 gcc 8.4.0 (2021r2)
 group.xtensaesp32s2.compilers=esp32s2g2019r2:esp32s2g2020r1:esp32s2g2020r2:esp32s2g2020r3:esp32s2g2021r1:esp32s2g2021r2
 group.xtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.xtensaesp32s2.supportsBinary=false
+group.xtensaesp32s2.instructionSet=xtensa
 
 compiler.esp32s2g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-g++
 compiler.esp32s2g2019r2.name=Xtensa ESP32-S2 gcc 8.2.0 (2019r2)
@@ -1159,6 +1161,7 @@ compiler.esp32s2g2021r2.name=Xtensa ESP32-S2 gcc 8.4.0 (2021r2)
 group.xtensaesp32s3.compilers=esp32s3g2020r3:esp32s3g2021r1:esp32s3g2021r2
 group.xtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.xtensaesp32s3.supportsBinary=false
+group.xtensaesp32s3.instructionSet=xtensa
 
 compiler.esp32s3g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-g++
 compiler.esp32s3g2020r3.name=Xtensa ESP32-S3 gcc 8.4.0 (2020r3)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1032,6 +1032,7 @@ compiler.rv32-cgcc1020.supportsBinary=true
 group.cxtensaesp32.compilers=cesp32g2019r2:cesp32g2020r1:cesp32g2020r2:cesp32g2020r3:cesp32g2021r1:cesp32g2021r2
 group.cxtensaesp32.groupName=Xtensa ESP32 GCC
 group.cxtensaesp32.supportsBinary=false
+group.cxtensaesp32.instructionSet=xtensa
 
 compiler.cesp32g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-gcc
 compiler.cesp32g2019r2.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-objdump
@@ -1057,6 +1058,7 @@ compiler.cesp32g2021r2.name=Xtensa ESP32 gcc 8.4.0 (2021r2)
 group.cxtensaesp32s2.compilers=cesp32s2g2019r2:cesp32s2g2020r1:cesp32s2g2020r2:cesp32s2g2020r3:cesp32s2g2021r1:cesp32s2g2021r2
 group.cxtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.cxtensaesp32s2.supportsBinary=false
+group.cxtensaesp32s2.instructionSet=xtensa
 
 compiler.cesp32s2g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-gcc
 compiler.cesp32s2g2019r2.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-objdump
@@ -1082,6 +1084,7 @@ compiler.cesp32s2g2021r2.name=Xtensa ESP32-S2 gcc 8.4.0 (2021r2)
 group.cxtensaesp32s3.compilers=cesp32s3g2020r3:cesp32s3g2021r1:cesp32s3g2021r2
 group.cxtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.cxtensaesp32s3.supportsBinary=false
+group.cxtensaesp32s3.instructionSet=xtensa
 
 compiler.cesp32s3g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-gcc
 compiler.cesp32s3g2020r3.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1033,6 +1033,7 @@ group.cxtensaesp32.compilers=cesp32g2019r2:cesp32g2020r1:cesp32g2020r2:cesp32g20
 group.cxtensaesp32.groupName=Xtensa ESP32 GCC
 group.cxtensaesp32.supportsBinary=false
 group.cxtensaesp32.instructionSet=xtensa
+group.cxtensaesp32.supportsAsmDocs=false
 
 compiler.cesp32g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-gcc
 compiler.cesp32g2019r2.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32-elf-objdump
@@ -1059,6 +1060,7 @@ group.cxtensaesp32s2.compilers=cesp32s2g2019r2:cesp32s2g2020r1:cesp32s2g2020r2:c
 group.cxtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.cxtensaesp32s2.supportsBinary=false
 group.cxtensaesp32s2.instructionSet=xtensa
+group.cxtensaesp32s2.supportsAsmDocs=false
 
 compiler.cesp32s2g2019r2.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-gcc
 compiler.cesp32s2g2019r2.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc8_2_0-esp-2019r2/bin/xtensa-esp32s2-elf-objdump
@@ -1085,6 +1087,7 @@ group.cxtensaesp32s3.compilers=cesp32s3g2020r3:cesp32s3g2021r1:cesp32s3g2021r2
 group.cxtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.cxtensaesp32s3.supportsBinary=false
 group.cxtensaesp32s3.instructionSet=xtensa
+group.cxtensaesp32s3.supportsAsmDocs=false
 
 compiler.cesp32s3g2020r3.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-gcc
 compiler.cesp32s3g2020r3.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc8_4_0-esp-2020r3/bin/xtensa-esp32s3-elf-objdump


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
This PR sets the instructionSet configuration key for all Xtensa compilers to "xtensa", which prevents Compiler Explorer from defaulting to x86 assembly documentation.
Fixes #3451.