### PR TITLE
Have a way to disable asm docs if needed

### DIFF
--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -225,7 +225,7 @@ export class CompilerFinder {
             objdumper: props('objdumper', ''),
             objdumperType: props('objdumperType', ''),
             intelAsm: props('intelAsm', ''),
-            hasAsmDocs: props('hasAsmDocs', true),
+            supportsAsmDocs: props('supportsAsmDocs', true),
             instructionSet: props('instructionSet', ''),
             needsMulti: !!props('needsMulti', true),
             adarts: props('adarts', ''),

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -225,6 +225,7 @@ export class CompilerFinder {
             objdumper: props('objdumper', ''),
             objdumperType: props('objdumperType', ''),
             intelAsm: props('intelAsm', ''),
+            hasAsmDocs: props('hasAsmDocs', true),
             instructionSet: props('instructionSet', ''),
             needsMulti: !!props('needsMulti', true),
             adarts: props('adarts', ''),

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -750,7 +750,7 @@ Compiler.prototype.initEditorActions = function () {
             }
 
             if (this.isAsmKeywordCtxKey) {
-                if (!this.compiler.hasAsmDocs) {
+                if (!this.compiler.supportsAsmDocs) {
                     // No need to show the "Show asm documentation" if it's just going to fail.
                     // This is useful for things like xtensa which define an instructionSet but have no docs associated
                     this.isAsmKeywordCtxKey.set(false);
@@ -2863,7 +2863,7 @@ Compiler.prototype.onMouseMove = function (e) {
             this.updateDecorations();
         }
         var hoverShowAsmDoc = this.settings.hoverShowAsmDoc === true;
-        if (hoverShowAsmDoc && this.compiler.hasAsmDocs && this.isWordAsmKeyword(currentWord)) {
+        if (hoverShowAsmDoc && this.compiler.supportsAsmDocs && this.isWordAsmKeyword(currentWord)) {
             getAsmInfo(currentWord.word, this.compiler.instructionSet).then(
                 _.bind(function (response) {
                     if (!response) return;

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -750,16 +750,22 @@ Compiler.prototype.initEditorActions = function () {
             }
 
             if (this.isAsmKeywordCtxKey) {
-                var currentWord = this.outputEditor.getModel().getWordAtPosition(e.target.position);
-                if (currentWord) {
-                    currentWord.range = new monaco.Range(
-                        e.target.position.lineNumber,
-                        Math.max(currentWord.startColumn, 1),
-                        e.target.position.lineNumber,
-                        currentWord.endColumn
-                    );
-                    if (currentWord.word) {
-                        this.isAsmKeywordCtxKey.set(this.isWordAsmKeyword(currentWord));
+                if (!this.compiler.hasAsmDocs) {
+                    // No need to show the "Show asm documentation" if it's just going to fail.
+                    // This is useful for things like xtensa which define an instructionSet but have no docs associated
+                    this.isAsmKeywordCtxKey.set(false);
+                } else {
+                    var currentWord = this.outputEditor.getModel().getWordAtPosition(e.target.position);
+                    if (currentWord) {
+                        currentWord.range = new monaco.Range(
+                            e.target.position.lineNumber,
+                            Math.max(currentWord.startColumn, 1),
+                            e.target.position.lineNumber,
+                            currentWord.endColumn
+                        );
+                        if (currentWord.word) {
+                            this.isAsmKeywordCtxKey.set(this.isWordAsmKeyword(currentWord));
+                        }
                     }
                 }
             }
@@ -2857,7 +2863,7 @@ Compiler.prototype.onMouseMove = function (e) {
             this.updateDecorations();
         }
         var hoverShowAsmDoc = this.settings.hoverShowAsmDoc === true;
-        if (hoverShowAsmDoc && this.isWordAsmKeyword(currentWord)) {
+        if (hoverShowAsmDoc && this.compiler.hasAsmDocs && this.isWordAsmKeyword(currentWord)) {
             getAsmInfo(currentWord.word, this.compiler.instructionSet).then(
                 _.bind(function (response) {
                     if (!response) return;


### PR DESCRIPTION
#3665 will add `instructionSet` to xtensa compilers, but it does not have asm docs associated, so the "Show asm documentation" context menu item will still show just to error out if pressed. This PR adds a way to let the page know not to even try.

Note that an even better way would be to automatically detect cases like this, but for now this is good enough