### PR TITLE
Add new versions of GCC for rv32 and rv64

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1090,7 +1090,7 @@ compiler.mrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc3
 
 ###############################
 # GCC for RISC-V
-group.rvgcc.compilers=rv64-gcc1020:rv64-gcc820:rv32-gcc1020:rv32-gcc820
+group.rvgcc.compilers=rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
 group.rvgcc.groupName=RISC-V GCC
 group.rvgcc.supportsExecute=false
 group.rvgcc.isSemVer=true
@@ -1101,20 +1101,60 @@ compiler.rv64-gcc820.alias=riscv820
 compiler.rv64-gcc820.semver=8.2.0
 compiler.rv64-gcc820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.rv64-gcc850.exe=/opt/compiler-explorer/riscv64/gcc-8.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc850.name=RISC-V rv64gc gcc 8.5.0
+compiler.rv64-gcc850.semver=8.5.0
+compiler.rv64-gcc850.objdumper=/opt/compiler-explorer/riscv64/gcc-8.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.rv64-gcc940.exe=/opt/compiler-explorer/riscv64/gcc-9.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc940.name=RISC-V rv64gc gcc 9.4.0
+compiler.rv64-gcc940.semver=9.4.0
+compiler.rv64-gcc940.objdumper=/opt/compiler-explorer/riscv64/gcc-9.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
 compiler.rv64-gcc1020.exe=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcc1020.name=RISC-V rv64gc gcc 10.2.0
 compiler.rv64-gcc1020.semver=10.2.0
 compiler.rv64-gcc1020.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.rv64-gcc1030.exe=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1030.name=RISC-V rv64gc gcc 10.3.0
+compiler.rv64-gcc1030.semver=10.3.0
+compiler.rv64-gcc1030.objdumper=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.rv64-gcc1120.exe=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1120.name=RISC-V rv64gc gcc 11.2.0
+compiler.rv64-gcc1120.semver=11.2.0
+compiler.rv64-gcc1120.objdumper=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
 compiler.rv32-gcc820.semver=8.2.0
 compiler.rv32-gcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
+compiler.rv32-gcc850.exe=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc850.name=RISC-V rv32gc gcc 8.5.0
+compiler.rv32-gcc850.semver=8.5.0
+compiler.rv32-gcc850.objdumper=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.rv32-gcc940.exe=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc940.name=RISC-V rv32gc gcc 9.4.0
+compiler.rv32-gcc940.semver=9.4.0
+compiler.rv32-gcc940.objdumper=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
 compiler.rv32-gcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc1020.name=RISC-V rv32gc gcc 10.2.0
 compiler.rv32-gcc1020.semver=10.2.0
 compiler.rv32-gcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+
+compiler.rv32-gcc1030.exe=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1030.name=RISC-V rv32gc gcc 10.3.0
+compiler.rv32-gcc1030.semver=10.3.0
+compiler.rv32-gcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.rv32-gcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1120.name=RISC-V rv32gc gcc 11.2.0
+compiler.rv32-gcc1120.semver=11.2.0
+compiler.rv32-gcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -998,7 +998,7 @@ compiler.cmrisc32-gcc-trunk.instructionSet=mrisc32
 
 ###############################
 # GCC for RISC-V
-group.rvcgcc.compilers=rv64-cgcc1020:rv64-cgcc820:rv32-cgcc1020:rv32-cgcc820
+group.rvcgcc.compilers=rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
 group.rvcgcc.groupName=RISC-V GCC
 group.rvcgcc.supportsExecute=false
 
@@ -1009,11 +1009,35 @@ compiler.rv64-cgcc820.semver=8.2.0
 compiler.rv64-cgcc820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc820.supportsBinary=true
 
+compiler.rv64-cgcc850.exe=/opt/compiler-explorer/riscv64/gcc-8.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc850.name=RISC-V rv64gc gcc 8.5.0
+compiler.rv64-cgcc850.semver=8.5.0
+compiler.rv64-cgcc850.objdumper=/opt/compiler-explorer/riscv64/gcc-8.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc850.supportsBinary=true
+
+compiler.rv64-cgcc940.exe=/opt/compiler-explorer/riscv64/gcc-9.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc940.name=RISC-V rv64gc gcc 9.4.0
+compiler.rv64-cgcc940.semver=9.4.0
+compiler.rv64-cgcc940.objdumper=/opt/compiler-explorer/riscv64/gcc-9.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc940.supportsBinary=true
+
 compiler.rv64-cgcc1020.exe=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcc1020.name=RISC-V rv64gc gcc 10.2.0
 compiler.rv64-cgcc1020.semver=10.2.0
 compiler.rv64-cgcc1020.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1020.supportsBinary=true
+
+compiler.rv64-cgcc1030.exe=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1030.name=RISC-V rv64gc gcc 10.3.0
+compiler.rv64-cgcc1030.semver=10.3.0
+compiler.rv64-cgcc1030.objdumper=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1030.supportsBinary=true
+
+compiler.rv64-cgcc1120.exe=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1120.name=RISC-V rv64gc gcc 11.2.0
+compiler.rv64-cgcc1120.semver=11.2.0
+compiler.rv64-cgcc1120.objdumper=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1120.supportsBinary=true
 
 compiler.rv32-cgcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc820.name=RISC-V rv32gc gcc 8.2.0
@@ -1021,11 +1045,35 @@ compiler.rv32-cgcc820.semver=8.2.0
 compiler.rv32-cgcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc820.supportsBinary=true
 
+compiler.rv32-cgcc850.exe=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc850.name=RISC-V rv32gc gcc 8.5.0
+compiler.rv32-cgcc850.semver=8.5.0
+compiler.rv32-cgcc850.objdumper=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc850.supportsBinary=true
+
+compiler.rv32-cgcc940.exe=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc940.name=RISC-V rv32gc gcc 9.4.0
+compiler.rv32-cgcc940.semver=9.4.0
+compiler.rv32-cgcc940.objdumper=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc940.supportsBinary=true
+
 compiler.rv32-cgcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc1020.name=RISC-V rv32gc gcc 10.2.0
 compiler.rv32-cgcc1020.semver=10.2.0
 compiler.rv32-cgcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc1020.supportsBinary=true
+
+compiler.rv32-cgcc1030.exe=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1030.name=RISC-V rv32gc gcc 10.3.0
+compiler.rv32-cgcc1030.semver=10.3.0
+compiler.rv32-cgcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1030.supportsBinary=true
+
+compiler.rv32-cgcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1120.name=RISC-V rv32gc gcc 11.2.0
+compiler.rv32-cgcc1120.semver=11.2.0
+compiler.rv32-cgcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1120.supportsBinary=true
 
 ################################
 # GCC for Xtensa ESP32


### PR DESCRIPTION
Following https://github.com/compiler-explorer/gcc-cross-builder/pull/19
and https://github.com/compiler-explorer/infra/pull/725,
update C++ and C config files.

GCC versions for riscv32 and riscv64: 8.5.0, 9.4.0, 10.3.0 and 11.2.0.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>