### PR TITLE
Improve highlighting in ptx-mode

### DIFF
--- a/static/modes/ptx-mode.ts
+++ b/static/modes/ptx-mode.ts
@@ -44,7 +44,14 @@ function definition() {
     ];
 
     // Add predicated instructions to the list of root tokens. Search for an opcode next, which is also a root token.
-    ptx.tokenizer.root.push([/@%p[0-9]+/, {token: 'operator', next: '@root'}]);
+    // Can be @p, @%p, or @!p. PTX docs use lowercase p, nvdisasm uses uppercase P.
+    ptx.tokenizer.root.push([/@[!%]?[pP][0-9]+/, {token: 'operator', next: '@root'}]);
+
+    // nvdisasm seems to use a single backtick as basically a comment...:
+    //    @!P0 BRA `(.L_x_0)
+    // Almost weirder than how MASM uses backticks
+    // Comes after an opcode so it goes in rest. Putting it at the very beginning so it fires before any string logic.
+    ptx.tokenizer.rest.unshift([/`.+/, {token: 'comment', next: '@root'}]);
 
     return ptx;
 }


### PR DESCRIPTION
Fixes a couple things I noticed while looking at ptx assembly

Before:
![image](https://user-images.githubusercontent.com/51220084/169229935-97cd6dd1-e5e1-4578-bb7f-2c5fa5befc18.png)

After:
![image](https://user-images.githubusercontent.com/51220084/169230058-c9bee799-055f-4ace-967b-11126ef5f8e5.png)

(I didn't have the addresses on locally while testing, this PR doesn't remove those 😄)