### PR TITLE
Add 2 more versions of GCC for rv32 and rv64

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1090,7 +1090,7 @@ compiler.mrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc3
 
 ###############################
 # GCC for RISC-V
-group.rvgcc.compilers=rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
+group.rvgcc.compilers=rv64-gcc1210:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcc1210:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
 group.rvgcc.groupName=RISC-V GCC
 group.rvgcc.supportsExecute=false
 group.rvgcc.isSemVer=true
@@ -1126,6 +1126,16 @@ compiler.rv64-gcc1120.name=RISC-V rv64gc gcc 11.2.0
 compiler.rv64-gcc1120.semver=11.2.0
 compiler.rv64-gcc1120.objdumper=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.rv64-gcc1130.exe=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1130.name=RISC-V rv64gc gcc 11.3.0
+compiler.rv64-gcc1130.semver=11.3.0
+compiler.rv64-gcc1130.objdumper=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.rv64-gcc1210.exe=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1210.name=RISC-V rv64gc gcc 12.1.0
+compiler.rv64-gcc1210.semver=12.1.0
+compiler.rv64-gcc1210.objdumper=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
 compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
 compiler.rv32-gcc820.semver=8.2.0
@@ -1155,6 +1165,16 @@ compiler.rv32-gcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unkn
 compiler.rv32-gcc1120.name=RISC-V rv32gc gcc 11.2.0
 compiler.rv32-gcc1120.semver=11.2.0
 compiler.rv32-gcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.rv32-gcc1130.exe=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1130.name=RISC-V rv32gc gcc 11.3.0
+compiler.rv32-gcc1130.semver=11.3.0
+compiler.rv32-gcc1130.objdumper=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.rv32-gcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1210.name=RISC-V rv32gc gcc 12.1.0
+compiler.rv32-gcc1210.semver=12.1.0
+compiler.rv32-gcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 ################################
 # GCC for Xtensa ESP32


### PR DESCRIPTION
Thanks to these PR:
https://github.com/compiler-explorer/gcc-cross-builder/pull/27
https://github.com/compiler-explorer/gcc-cross-builder/pull/26

we can add 11.3.0 and (fresh) 12.1.0.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>