### PR TITLE
style: prefer built-in `Array#find()` over lodash lib

### DIFF
--- a/lib/toolchain-utils.js
+++ b/lib/toolchain-utils.js
@@ -24,22 +24,17 @@
 
 import path from 'path';
 
-import _ from 'underscore';
-
 export function getToolchainPath(compilerExe, compilerOptions) {
     const options = compilerOptions ? compilerOptions.split(' ') : [];
-    const existingChain = _.find(options, elem => elem.includes('--gcc-toolchain='));
+    const existingChain = options.find(elem => elem.includes('--gcc-toolchain='));
+    if (existingChain) return existingChain.substr(16);
 
-    if (!existingChain) {
-        const gxxname = _.find(options, elem => elem.includes('--gxx-name='));
-        if (gxxname) {
-            return path.resolve(path.dirname(gxxname.substr(11)), '..');
-        } else if (typeof compilerExe === 'string' && compilerExe.includes('/g++')) {
-            return path.resolve(path.dirname(compilerExe), '..');
-        } else {
-            return false;
-        }
+    const gxxname = options.find(elem => elem.includes('--gxx-name='));
+    if (gxxname) {
+        return path.resolve(path.dirname(gxxname.substr(11)), '..');
+    } else if (typeof compilerExe === 'string' && compilerExe.includes('/g++')) {
+        return path.resolve(path.dirname(compilerExe), '..');
     } else {
-        return existingChain.substr(16);
+        return false;
     }
 }


### PR DESCRIPTION
prefer built-in `Array#find()` over lodash lib in
`lib/toolchain-utils.js` file
