### PR TITLE
Highlight linked code (decoration) in red

### DIFF
--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -240,6 +240,7 @@ pre.content.wrap * {
 
 .linked-code-decoration-column {
     font-weight: 600;
+    color: red;
 }
 
 .modal {

--- a/static/explorer.scss
+++ b/static/explorer.scss
@@ -240,7 +240,7 @@ pre.content.wrap * {
 
 .linked-code-decoration-column {
     font-weight: 600;
-    color: red;
+    color: red !important;
 }
 
 .modal {


### PR DESCRIPTION
Linked code decoration is hardly visible.

To make it more visible, despite being rendered bold it now also gets colored in red.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
