### PR TITLE
Fix GCC riscv32 path

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1141,40 +1141,40 @@ compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
 compiler.rv32-gcc820.semver=8.2.0
 compiler.rv32-gcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-gcc850.exe=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc850.exe=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc850.name=RISC-V rv32gc gcc 8.5.0
 compiler.rv32-gcc850.semver=8.5.0
-compiler.rv32-gcc850.objdumper=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc850.objdumper=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-gcc940.exe=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc940.exe=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc940.name=RISC-V rv32gc gcc 9.4.0
 compiler.rv32-gcc940.semver=9.4.0
-compiler.rv32-gcc940.objdumper=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc940.objdumper=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
 compiler.rv32-gcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc1020.name=RISC-V rv32gc gcc 10.2.0
 compiler.rv32-gcc1020.semver=10.2.0
 compiler.rv32-gcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-gcc1030.exe=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1030.exe=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc1030.name=RISC-V rv32gc gcc 10.3.0
 compiler.rv32-gcc1030.semver=10.3.0
-compiler.rv32-gcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-gcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc1120.name=RISC-V rv32gc gcc 11.2.0
 compiler.rv32-gcc1120.semver=11.2.0
-compiler.rv32-gcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-gcc1130.exe=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1130.exe=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc1130.name=RISC-V rv32gc gcc 11.3.0
 compiler.rv32-gcc1130.semver=11.3.0
-compiler.rv32-gcc1130.objdumper=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1130.objdumper=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-gcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc1210.name=RISC-V rv32gc gcc 12.1.0
 compiler.rv32-gcc1210.semver=12.1.0
-compiler.rv32-gcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -998,7 +998,7 @@ compiler.cmrisc32-gcc-trunk.instructionSet=mrisc32
 
 ###############################
 # GCC for RISC-V
-group.rvcgcc.compilers=rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
+group.rvcgcc.compilers=rv64-cgcc1210:rv64-cgcc1130:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcc1210:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
 group.rvcgcc.groupName=RISC-V GCC
 group.rvcgcc.supportsExecute=false
 
@@ -1039,22 +1039,34 @@ compiler.rv64-cgcc1120.semver=11.2.0
 compiler.rv64-cgcc1120.objdumper=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1120.supportsBinary=true
 
+compiler.rv64-cgcc1130.exe=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1130.name=RISC-V rv64gc gcc 11.3.0
+compiler.rv64-cgcc1130.semver=11.3.0
+compiler.rv64-cgcc1130.objdumper=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1130.supportsBinary=true
+
+compiler.rv64-cgcc1210.exe=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1210.name=RISC-V rv64gc gcc 12.1.0
+compiler.rv64-cgcc1210.semver=12.1.0
+compiler.rv64-cgcc1210.objdumper=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1210.supportsBinary=true
+
 compiler.rv32-cgcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc820.name=RISC-V rv32gc gcc 8.2.0
 compiler.rv32-cgcc820.semver=8.2.0
 compiler.rv32-cgcc820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc820.supportsBinary=true
 
-compiler.rv32-cgcc850.exe=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc850.exe=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc850.name=RISC-V rv32gc gcc 8.5.0
 compiler.rv32-cgcc850.semver=8.5.0
-compiler.rv32-cgcc850.objdumper=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc850.objdumper=/opt/compiler-explorer/riscv32/gcc-8.5.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc850.supportsBinary=true
 
-compiler.rv32-cgcc940.exe=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc940.exe=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc940.name=RISC-V rv32gc gcc 9.4.0
 compiler.rv32-cgcc940.semver=9.4.0
-compiler.rv32-cgcc940.objdumper=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc940.objdumper=/opt/compiler-explorer/riscv32/gcc-9.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc940.supportsBinary=true
 
 compiler.rv32-cgcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
@@ -1066,14 +1078,26 @@ compiler.rv32-cgcc1020.supportsBinary=true
 compiler.rv32-cgcc1030.exe=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv32-cgcc1030.name=RISC-V rv32gc gcc 10.3.0
 compiler.rv32-cgcc1030.semver=10.3.0
-compiler.rv32-cgcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc1030.supportsBinary=true
 
-compiler.rv32-cgcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1120.exe=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc1120.name=RISC-V rv32gc gcc 11.2.0
 compiler.rv32-cgcc1120.semver=11.2.0
-compiler.rv32-cgcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1120.objdumper=/opt/compiler-explorer/riscv32/gcc-11.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc1120.supportsBinary=true
+
+compiler.rv32-cgcc1130.exe=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
+compiler.rv32-cgcc1130.name=RISC-V rv32gc gcc 11.3.0
+compiler.rv32-cgcc1130.semver=11.3.0
+compiler.rv32-cgcc1130.objdumper=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cgcc1130.supportsBinary=true
+
+compiler.rv32-cgcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
+compiler.rv32-cgcc1210.name=RISC-V rv32gc gcc 12.1.0
+compiler.rv32-cgcc1210.semver=12.1.0
+compiler.rv32-cgcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cgcc1210.supportsBinary=true
 
 ################################
 # GCC for Xtensa ESP32


### PR DESCRIPTION
Incorrect copy/paste, GCC riscv32 are -elf, not -linux.

refs #3677
Signed-off-by: Marc Poulhiès <dkm@kataplop.net>