### PR TITLE
Add 3 new versions of GCC for ARM GNU Toolchain

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -781,7 +781,7 @@ group.gccarm.includeFlag=-I
 
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
-group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm1020:arm1021:arm1030:arm1100:arm1120:armgtrunk
+group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -840,6 +840,18 @@ compiler.arm1021.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10-2020-q4-maj
 compiler.arm1021.name=ARM gcc 10.2.1 (none)
 compiler.arm1021.semver=10.2.1
 compiler.arm1021.supportsBinary=false
+compiler.arm1031_07.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10.3-2021.07/bin/arm-none-eabi-g++
+compiler.arm1031_07.name=ARM gcc 10.3.1 (2021.07 none)
+compiler.arm1031_07.semver=10.3.1
+compiler.arm1031_07.supportsBinary=false
+compiler.arm1031_10.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-g++
+compiler.arm1031_10.name=ARM gcc 10.3.1 (2021.10 none)
+compiler.arm1031_10.semver=10.3.1
+compiler.arm1031_10.supportsBinary=false
+compiler.arm1121.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-11.2-2022.02/bin/arm-none-eabi-g++
+compiler.arm1121.name=ARM gcc 11.2.1 (none)
+compiler.arm1121.semver=11.2.1
+compiler.arm1121.supportsBinary=false
 compiler.arm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm930.name=ARM gcc 9.3 (linux)
 compiler.arm930.semver=9.3.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -688,7 +688,7 @@ group.cgccarm.includeFlag=-I
 
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
-group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1021:carm1100:carm1120:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1031_07:carm1031_10:carm1021:carm1100:carm1120:carm1121:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -744,6 +744,18 @@ compiler.carm1021.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10-2020-q4-ma
 compiler.carm1021.name=ARM gcc 10.2.1 (none)
 compiler.carm1021.semver=10.2.1
 compiler.carm1021.supportsBinary=false
+compiler.carm1031_07.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10.3-2021.07/bin/arm-none-eabi-gcc
+compiler.carm1031_07.name=ARM gcc 10.3.1 (2021.07 none)
+compiler.carm1031_07.semver=10.3.1
+compiler.carm1031_07.supportsBinary=false
+compiler.carm1031_10.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gcc
+compiler.carm1031_10.name=ARM gcc 10.3.1 (2021.10 none)
+compiler.carm1031_10.semver=10.3.1
+compiler.carm1031_10.supportsBinary=false 
+compiler.carm1121.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-11.2-2022.02/bin/arm-none-eabi-gcc
+compiler.carm1121.name=ARM gcc 11.2.1 (none)
+compiler.carm1121.semver=11.2.1
+compiler.carm1121.supportsBinary=false
 compiler.carm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carm930.name=ARM gcc 9.3 (linux)
 compiler.carm930.semver=9.3.0


### PR DESCRIPTION
ARM GNU Toolchain: 11.2-2022.02 for AArch32 bare-metal target (arm-none-eabi)
ARM GNU Toolchain: 10.3-2021.10 for AArch32 bare-metal target (arm-none-eabi)
ARM GNU Toolchain: 10.3-2021.07 for AArch32 bare-metal target (arm-none-eabi)

Signed-off-by: Ryan McClelland <rymcclel@gmail.com>