### PR TITLE
Add LDC 1.28.1 and 1.29.0, make 1.29.0 the new default

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gdc:&ldc:&dmd
-defaultCompiler=ldc1_27
+defaultCompiler=ldc1_29
 objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
-demangler=/opt/compiler-explorer/ldc1.27.1/ldc2-1.27.1-linux-x86_64/bin/ddemangle
+demangler=/opt/compiler-explorer/ldc1.29.0/ldc2-1.29.0-linux-x86_64/bin/ddemangle
 
 group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc101:gdc102:gdc111:gdc113:gdc121:gdctrunk
 group.gdc.includeFlag=-isystem
@@ -35,7 +35,7 @@ compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gdctrunk.semver=(trunk)
 
-group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldcbeta:ldclatestci
+group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldc1_28:ldc1_29:ldcbeta:ldclatestci
 group.ldc.compilerType=ldc
 group.ldc.isSemVer=true
 group.ldc.baseName=ldc
@@ -106,6 +106,12 @@ compiler.ldc1_26.options=-gcc=gcc
 compiler.ldc1_27.exe=/opt/compiler-explorer/ldc1.27.1/ldc2-1.27.1-linux-x86_64/bin/ldc2
 compiler.ldc1_27.semver=1.27.1
 compiler.ldc1_27.options=-gcc=gcc
+compiler.ldc1_28.exe=/opt/compiler-explorer/ldc1.28.1/ldc2-1.28.1-linux-x86_64/bin/ldc2
+compiler.ldc1_28.semver=1.28.1
+compiler.ldc1_28.options=-gcc=gcc
+compiler.ldc1_29.exe=/opt/compiler-explorer/ldc1.29.0/ldc2-1.29.0-linux-x86_64/bin/ldc2
+compiler.ldc1_29.semver=1.29.0
+compiler.ldc1_29.options=-gcc=gcc
 compiler.ldcbeta.exe=/opt/compiler-explorer/ldcbeta/bin/ldc2
 compiler.ldcbeta.semver=beta
 compiler.ldcbeta.options=-gcc=gcc


### PR DESCRIPTION
And congrats on the 10th aniversary!

Infra: https://github.com/compiler-explorer/infra/pull/733