### PR TITLE
Add NVRTC CUDA compiler

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&nvcc:&cuclang:&hipclang
+compilers=&nvcc:&cuclang:&hipclang:&nvrtc
 defaultCompiler=nvcc115
 supportsBinary=true
 supportsExecute=false
@@ -119,6 +119,54 @@ group.hipclang.options=-x hip --offload-arch=gfx908 --cuda-device-only -nocudain
 compiler.hiptrunk.semver=trunk
 compiler.hiptrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.hiptrunk.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
+
+group.nvrtc.compilers=nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11:nvrtc102:nvrtc101u2:nvrtc101u1:nvrtc101:nvrtc100:nvrtc92:nvrtc91
+group.nvrtc.compilerType=nvcc # nvrtc_cli is sufficiently compatible with nvcc
+group.nvrtc.isSemVer=true
+group.nvrtc.baseName=NVRTC
+group.nvrtc.includeFlag=-I
+group.nvrtc.objdumper=/opt/compiler-explorer/cuda/11.5.0/bin/nvdisasm
+group.nvrtc.rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
+group.nvrtc.options=
+group.nvrtc.demangler=/opt/compiler-explorer/cuda/11.3.1/bin/cu++filt
+compiler.nvrtc91.semver=9.1.85 sm_30
+compiler.nvrtc91.exe=/opt/compiler-explorer/cuda/9.1.85/bin/nvrtc_cli
+compiler.nvrtc92.semver=9.2.88 sm_30
+compiler.nvrtc92.exe=/opt/compiler-explorer/cuda/9.2.88/bin/nvrtc_cli
+compiler.nvrtc100.semver=10.0.130 sm_30
+compiler.nvrtc100.exe=/opt/compiler-explorer/cuda/10.0.130/bin/nvrtc_cli
+compiler.nvrtc101.semver=10.1.105 sm_30
+compiler.nvrtc101.exe=/opt/compiler-explorer/cuda/10.1.105/bin/nvrtc_cli
+compiler.nvrtc101u1.semver=10.1.168 sm_30
+compiler.nvrtc101u1.exe=/opt/compiler-explorer/cuda/10.1.168/bin/nvrtc_cli
+compiler.nvrtc101u2.semver=10.1.243 sm_30
+compiler.nvrtc101u2.exe=/opt/compiler-explorer/cuda/10.1.243/bin/nvrtc_cli
+compiler.nvrtc102.exe=/opt/compiler-explorer/cuda/10.2.89/bin/nvrtc_cli
+compiler.nvrtc102.semver=10.2.89 sm_30
+compiler.nvrtc11.exe=/opt/compiler-explorer/cuda/11.0.2/bin/nvrtc_cli
+compiler.nvrtc11.semver=11.0.2 sm_52
+compiler.nvrtc11u1.exe=/opt/compiler-explorer/cuda/11.0.3/bin/nvrtc_cli
+compiler.nvrtc11u1.semver=11.0.3 sm_52
+compiler.nvrtc111.exe=/opt/compiler-explorer/cuda/11.1.0/bin/nvrtc_cli
+compiler.nvrtc111.semver=11.1.0 sm_52
+compiler.nvrtc111u1.exe=/opt/compiler-explorer/cuda/11.1.1/bin/nvrtc_cli
+compiler.nvrtc111u1.semver=11.1.1 sm_52
+compiler.nvrtc112.exe=/opt/compiler-explorer/cuda/11.2.0/bin/nvrtc_cli
+compiler.nvrtc112.semver=11.2.0 sm_52
+compiler.nvrtc112u1.exe=/opt/compiler-explorer/cuda/11.2.1/bin/nvrtc_cli
+compiler.nvrtc112u1.semver=11.2.1 sm_52
+compiler.nvrtc112u2.exe=/opt/compiler-explorer/cuda/11.2.2/bin/nvrtc_cli
+compiler.nvrtc112u2.semver=11.2.2 sm_52
+compiler.nvrtc113.exe=/opt/compiler-explorer/cuda/11.3.0/bin/nvrtc_cli
+compiler.nvrtc113.semver=11.3.0 sm_52
+compiler.nvrtc113u1.exe=/opt/compiler-explorer/cuda/11.3.1/bin/nvrtc_cli
+compiler.nvrtc113u1.semver=11.3.1 sm_52
+compiler.nvrtc114.exe=/opt/compiler-explorer/cuda/11.4.0/bin/nvrtc_cli
+compiler.nvrtc114.semver=11.4.0 sm_52
+compiler.nvrtc114u1.exe=/opt/compiler-explorer/cuda/11.4.1/bin/nvrtc_cli
+compiler.nvrtc114u1.semver=11.4.1 sm_52
+compiler.nvrtc115.exe=/opt/compiler-explorer/cuda/11.5.0/bin/nvrtc_cli
+compiler.nvrtc115.semver=11.5.0 sm_52
 
 libs=cueigen:thrustcub:cucub:cudacxx:nvtx:nsimd:cuco
 


### PR DESCRIPTION
Adds support for the [NVIDIA CUDA C++ runtime compilation library (NVRTC)](https://docs.nvidia.com/cuda/nvrtc/index.html) as a CUDA compiler. Available versions are the same as those for NVCC.

Fixes https://github.com/compiler-explorer/compiler-explorer/issues/1870

Depends on https://github.com/compiler-explorer/infra/pull/734

cc @jrhemstad 