### PR TITLE
urls werent being expanded in tree/ide mode

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -973,10 +973,8 @@ Compiler.prototype.compileFromTree = function (options, bypassCache) {
         return;
     }
 
-    var mainsource = tree.multifileService.getMainSource();
-
     var request = {
-        source: mainsource,
+        source: tree.multifileService.getMainSource(),
         compiler: this.compiler ? this.compiler.id : '',
         options: options,
         lang: this.currentLangId,
@@ -984,6 +982,13 @@ Compiler.prototype.compileFromTree = function (options, bypassCache) {
     };
 
     const fetches = [];
+
+    fetches.push(
+        this.compilerService.expand(request.source).then(contents => {
+            request.source = contents;
+        })
+    );
+
     for (let file of request.files) {
         fetches.push(
             this.compilerService.expand(file.contents).then(contents => {

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -252,10 +252,8 @@ Executor.prototype.compileFromTree = function (options, bypassCache) {
         return;
     }
 
-    var mainsource = tree.multifileService.getMainSource();
-
     var request = {
-        source: mainsource,
+        source: tree.multifileService.getMainSource(),
         compiler: this.compiler ? this.compiler.id : '',
         options: options,
         lang: this.currentLangId,
@@ -263,6 +261,13 @@ Executor.prototype.compileFromTree = function (options, bypassCache) {
     };
 
     const fetches = [];
+
+    fetches.push(
+        this.compilerService.expand(request.source).then(contents => {
+            request.source = contents;
+        })
+    );
+
     for (let file of request.files) {
         fetches.push(
             this.compilerService.expand(file.contents).then(contents => {


### PR DESCRIPTION
The #include <url> sources weren't being expanded when compiling via Tree/IDE mode.

Because it's an async process, I've used Promise.all() to wait to resolve all the files first before starting the compilation.
