### PR TITLE
Ada: Fix inputFileName at incorrect loc for binary and execution

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -16,19 +16,19 @@ group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
 group.gnat.objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
 
-compiler.gnat82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gnat
+compiler.gnat82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gnatmake
 compiler.gnat82.semver=8.2
-compiler.gnat102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gnat
+compiler.gnat102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gnatmake
 compiler.gnat102.semver=10.2
-compiler.gnat111.exe=/opt/compiler-explorer/gcc-11.1.0/bin/gnat
+compiler.gnat111.exe=/opt/compiler-explorer/gcc-11.1.0/bin/gnatmake
 compiler.gnat111.semver=11.1
-compiler.gnat112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gnat
+compiler.gnat112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gnatmake
 compiler.gnat112.semver=11.2
-compiler.gnat113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gnat
+compiler.gnat113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gnatmake
 compiler.gnat113.semver=11.3
-compiler.gnat121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gnat
+compiler.gnat121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gnatmake
 compiler.gnat121.semver=12.1
-compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnat
+compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnatmake
 compiler.gnatsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnatsnapshot.name=x86-64 gnat (trunk)
@@ -43,12 +43,12 @@ group.gnatriscv64.isSemVer=true
 group.gnatriscv64.supportsBinary=false
 group.gnatriscv64.supportsExecute=false
 
-compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnat
+compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnatmake
 compiler.gnatriscv64103.name=riscv64 gnat 10.3.0-2 (Alire)
 compiler.gnatriscv64103.semver=10.3.0
 compiler.gnatriscv64103.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/riscv64-elf/lib/gnat/zfp-rv64imac
 
-compiler.gnatriscv64112.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/bin/riscv64-elf-gnat
+compiler.gnatriscv64112.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/bin/riscv64-elf-gnatmake
 compiler.gnatriscv64112.name=riscv64 gnat 11.2.0-3 (Alire)
 compiler.gnatriscv64112.semver=11.2.0
 compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
@@ -63,7 +63,7 @@ group.gnats390x.isSemVer=true
 group.gnats390x.supportsBinary=false
 group.gnats390x.supportsExecute=false
 
-compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnat
+compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
 compiler.gnats390x1120.semver=11.2.0
 
 ################################
@@ -78,21 +78,21 @@ group.gnatppcs.supportsExecute=false
 group.gnatppc.groupName=power
 group.gnatppc.compilers=gnatppc1120
 group.gnatppc.baseName=powerpc gnat
-compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnat
+compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
 compiler.gnatppc1120.semver=11.2.0
 
 ## POWER64
 group.gnatppc64.groupName=power64
 group.gnatppc64.compilers=gnatppc641120
 group.gnatppc64.baseName=powerpc64 gnat
-compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnat
+compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641120.semver=11.2.0
 
 ## POWER64LE
 group.gnatppc64le.groupName=power64le
 group.gnatppc64le.compilers=gnatppc64le1120
 group.gnatppc64le.baseName=powerpc64le gnat
-compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnat
+compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1120.semver=11.2.0
 
 ################################
@@ -115,7 +115,7 @@ group.gnatmips64.groupName=mips64
 group.gnatmips64.compilers=gnatmips641120
 group.gnatmips64.baseName=mips64 gnat
 
-compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnat
+compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641120.semver=11.2.0
 
 ################################
@@ -127,12 +127,12 @@ group.gnatarm.isSemVer=true
 group.gnatarm.supportsBinary=false
 group.gnatarm.supportsExecute=false
 
-compiler.gnatarm103.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-gnat
+compiler.gnatarm103.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-gnatmake
 compiler.gnatarm103.name=arm gnat 10.3.0-2 (Alire)
 compiler.gnatarm103.semver=10.3.0
 compiler.gnatarm103.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/arm-eabi/lib/gnat/zfp-cortex-m4f/
 
-compiler.gnatarm112.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/bin/arm-eabi-gnat
+compiler.gnatarm112.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/bin/arm-eabi-gnatmake
 compiler.gnatarm112.name=arm gnat 11.2.0-3 (Alire)
 compiler.gnatarm112.semver=11.2.0
 compiler.gnatarm112.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/arm-eabi/lib/gnat/zfp-cortex-m4f/

--- a/etc/config/ada.defaults.properties
+++ b/etc/config/ada.defaults.properties
@@ -11,7 +11,7 @@ group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
 group.gnat.objdumper=objdump
 
-compiler.gnatdefault.exe=/usr/bin/gnat
+compiler.gnatdefault.exe=/usr/bin/gnatmake
 compiler.gnatdefault.name=gnat default
 
 #################################

--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, Mitch Kennedy
+// Copyright (c) 2022, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -53,91 +54,103 @@ export class AdaCompiler extends BaseCompiler {
         return path.join(dirPath, 'example.o');
     }
 
-    optionsForBackend(backendOptions, outputFilename) {
-        // super is needed as it handles the GCC Dump files.
-        const opts = super.optionsForBackend(backendOptions, outputFilename);
+    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
+        backendOptions = backendOptions || {};
+
+        // super call is needed as it handles the GCC Dump files.
+        let backend_opts = super.optionsForBackend(backendOptions, outputFilename);
+
+        // gnatmake  opts  name  {[-cargs opts] [-bargs opts] [-largs opts] [-margs opts]}
+        //                 ^                 ^    ^             ^             ^
+        //                 |                 |    |             |             |
+        //                 `- inputFilename  |    |             |             `-- for gnatmake
+        //                                   |    |             `-- for linker
+        //                                   |    `-- for binder (unused here)
+        //                                   `-- for compiler (gcc)
+
+        let gnatmake_opts = [];
+        let compiler_opts = [];
+        let binder_opts = [];
+        let linker_opts = [''];
+
+        if (this.compiler.adarts) {
+            gnatmake_opts.push(`--RTS=${this.compiler.adarts}`);
+        }
 
         if (backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugViews)
             // This is using stdout
-            opts.push('-gnatGL');
+            gnatmake_opts.push('-gnatGL');
 
         if (backendOptions.produceGnatDebugTree && this.compiler.supportsGnatDebugViews)
             // This is also using stdout
-            opts.push('-gnatdt');
+            gnatmake_opts.push('-gnatdt');
 
-        return opts;
-    }
-
-    optionsForFilter(filters, outputFilename) {
-        let options = [];
-
-        // Always add -cargs to the options. If not needed here, put it last.
-        // It's used in runCompiler to insert the input filename at the correct
-        // location in the command line.
-        // input filename is inserted before -cargs.
+        gnatmake_opts.push(
+            '-g',
+            '-fdiagnostics-color=always',
+            '-eS', // output commands to stdout, they are not errors
+            inputFilename,
+        );
 
         if (!filters.binary) {
-            // produce assembly output in outputFilename
-            options.push(
-                'compile',
-                '-g', // enable debugging
+            gnatmake_opts.push(
                 '-S', // Generate ASM
-                '-fdiagnostics-color=always',
-                '-fverbose-asm', // Generate verbose ASM showing variables
                 '-c', // Compile only
-                '-eS', // commands are not errors
-                '-cargs', // Compiler Switches for gcc.
-                '-o',
-                outputFilename,
+                '-fverbose-asm', // Generate verbose ASM showing variables
             );
+
+            // produce assembly output in outputFilename
+            compiler_opts.push('-o', outputFilename);
 
             if (this.compiler.intelAsm && filters.intel) {
-                options = options.concat(this.compiler.intelAsm.split(' '));
+                gnatmake_opts.push(this.compiler.intelAsm.split(' '));
             }
         } else {
-            // produce an executable in the file specified in getExecutableFilename.
-            // The output file is automatically decided by GNAT based on the Source_File_Name being used.
-            // As we are for forcing 'example.adb', the output here will be 'example'.
-            options.push(
-                'make',
-                '-eS',
-                '-g',
-                '-cargs', // Compiler Switches for gcc.
-            );
+            gnatmake_opts.push('-o', outputFilename);
         }
 
-        return options;
+        // Spread the options coming from outside (user, backend or config options)
+        // in the correct list.
+
+        let part = 0; // 0: gnatmake, 1: compiler, 2: linker, 3: binder
+        for (const a of backend_opts.concat(utils.splitArguments(this.compiler.options), userOptions)) {
+            if (a === '-cargs') {
+                part = 1;
+                continue;
+            } else if (a === '-largs') {
+                part = 2;
+                continue;
+            } else if (a === '-bargs') {
+                part = 3;
+                continue;
+            } else if (a === '-margs') {
+                part = 0;
+                continue;
+            }
+
+            if (part === 0) {
+                gnatmake_opts.push(a);
+            } else if (part === 1) {
+                compiler_opts.push(a);
+            } else if (part === 2) {
+                linker_opts.push(a);
+            } else if (part === 3) {
+                binder_opts.push(a);
+            }
+        }
+
+        return gnatmake_opts.concat('-cargs', compiler_opts, '-largs', linker_opts, '-bargs', binder_opts);
     }
 
     async runCompiler(compiler, options, inputFilename, execOptions) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
         }
-        // Set the working directory to be the temp directory that has been created
-        execOptions.customCwd = path.dirname(inputFilename);
-
-        // As the file name is always appended to the end of the options array we need to
-        // find where the '-cargs' flag is in options. This is to allow us to set the
-        // output as 'output.s' and not end up with 'example.s'. If the output is left
-        // as 'example.s' CE can't find it and thus you get no output.
-        const inputFileName = options.pop();
-        for (let i = 0; i < options.length; i++) {
-            if (options[i] === '-cargs') {
-                options.splice(i, 0, inputFileName);
-
-                // If the compiler contains a RTS, add the extra --RTS=.
-                // FIXME: should probably check the user did not use one.
-                if (this.compiler.adarts) {
-                    options.splice(i, 0, `--RTS=${this.compiler.adarts}`);
-                }
-                break;
-            }
-        }
 
         const result = await this.exec(compiler, options, execOptions);
         result.inputFilename = inputFilename;
 
-        const baseFilename = path.basename(inputFileName);
+        const baseFilename = path.basename(inputFilename);
         result.stdout = utils.parseOutput(result.stdout, baseFilename, execOptions.customCwd);
         result.stderr = utils.parseOutput(result.stderr, baseFilename, execOptions.customCwd);
         return result;


### PR DESCRIPTION
When compiling to binary or running the executable, extra options are inserted,
breaking some weak asumption in Ada/GNAT on where in the list is the
inputFilename.

Override prepareArguments() for GNAT and (more) cleanly handle the
options (split between gnatmake, compiler, binder and linker).

Also use 'gnatmake' as main compiler executable instead of 'gnat'.

Fixes #3709

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>