### PR TITLE
Fix demangling in CUDA PTX output

### DIFF
--- a/lib/demangler/base.js
+++ b/lib/demangler/base.js
@@ -53,6 +53,14 @@ export class BaseDemangler extends AsmRegex {
         this.movUnderscoreDef = /mov.*\s(_[\w$.@]*)/i;
         this.leaUnderscoreDef = /lea.*\s(_[\w$.@]*)/i;
         this.quadUnderscoreDef = /\.quad\s*(_[\w$.@]*)/i;
+
+        // E.g., ".entry _Z6squarePii("
+        // E.g., ".func  (.param .b32 func_retval0) bar("
+        this.ptxFuncDef = /\.(entry|func)\s+(?:\([^)]*\)\s*)?([$.A-Z_a-z][\w$.]*)\(/;
+        // E.g., ".const .attribute(.managed) .align 4 .v4 .u32 myvar"
+        // E.g., ".global .texref mytex"
+        this.ptxVarDef =
+            /^\.(global|const)\s+(?:\.(tex|sampler|surf)ref\s+)?(?:\.attribute\([^)]*\)\s+)?(?:\.align\s+\d+\s+)?(?:\.v\d+\s+)?(?:\.[a-z]\d+\s+)?([$.A-Z_a-z][\w$.]*)/;
     }
 
     // Iterates over the labels, demangle the label names and updates the start and
@@ -98,6 +106,8 @@ export class BaseDemangler extends AsmRegex {
             this.movUnderscoreDef,
             this.leaUnderscoreDef,
             this.quadUnderscoreDef,
+            this.ptxFuncDef,
+            this.ptxVarDef,
         ];
         for (let j = 0; j < this.result.asm.length; ++j) {
             const line = this.result.asm[j].text;


### PR DESCRIPTION
Demangling of PTX was previously very incomplete and in fact appears to have worked only through luck by relying on `// .globl` being parsed using the `jumpDef` regex (which failed completely when comment filtering was enabled).

This commit adds explicit regexes to robustly detect PTX function and variable declarations, which enables full demangling.

Fixes https://github.com/compiler-explorer/compiler-explorer/issues/1294