### PR TITLE
Ada: fix compile to binary/execute within jail

### DIFF
--- a/lib/compilers/ada.js
+++ b/lib/compilers/ada.js
@@ -24,6 +24,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import path from 'path';
+import fs from 'fs-extra';
 
 import {BaseCompiler} from '../base-compiler';
 import * as utils from '../utils';
@@ -51,7 +52,7 @@ export class AdaCompiler extends BaseCompiler {
     getOutputFilename(dirPath) {
         // The basename here must match the value used in the pragma Source_File
         // in the user provided source.
-        return path.join(dirPath, 'example.o');
+        return path.join(dirPath, 'example.out');
     }
 
     prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
@@ -146,6 +147,14 @@ export class AdaCompiler extends BaseCompiler {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
         }
+
+        // create a subdir so that files automatically created by GNAT don't
+        // conflict with anything else in parent dir.
+        const temp_dir = path.join(path.dirname(inputFilename), 'tempsub');
+        await fs.mkdir(temp_dir);
+
+        // Set the working directory to be the temp directory that has been created
+        execOptions.customCwd = temp_dir;
 
         const result = await this.exec(compiler, options, execOptions);
         result.inputFilename = inputFilename;


### PR DESCRIPTION
Need to jump in the dedicated directory, but then GNAT may write some files that
may conflict with ours: create a dedicated temp subdir to run GNAT.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>