### PR TITLE
Fix unused label filter for CUDA PTX output

### DIFF
--- a/lib/parsers/asm-parser.js
+++ b/lib/parsers/asm-parser.js
@@ -116,6 +116,7 @@ export class AsmParser extends AsmRegex {
         const startBlock = /\.cfi_startproc/;
         const endBlock = /\.cfi_endproc/;
         let inFunction = false;
+        let inNvccCode = false;
 
         // Scan through looking for definite label usages (ones used by opcodes),
         // and ones that are weakly used: that is, their use is conditional on another label.
@@ -138,6 +139,8 @@ export class AsmParser extends AsmRegex {
                 inFunction = true;
             } else if (endBlock.test(line)) {
                 inFunction = false;
+            } else if (this.cudaBeginDef.test(line)) {
+                inNvccCode = true;
             }
 
             if (inCustomAssembly > 0) line = this.fixLabelIndentation(line);
@@ -163,14 +166,14 @@ export class AsmParser extends AsmRegex {
             match = line.match(labelFind);
             if (!match) continue;
 
-            if (!filterDirectives || this.hasOpcode(line, false) || definesFunction) {
+            if (!filterDirectives || this.hasOpcode(line, inNvccCode) || definesFunction) {
                 // Only count a label as used if it's used by an opcode, or else we're not filtering directives.
                 for (const label of match) labelsUsed[label] = true;
             } else {
                 // If we have a current label, then any subsequent opcode or data definition's labels are referred to
                 // weakly by that label.
                 const isDataDefinition = !!this.dataDefn.test(line);
-                const isOpcode = this.hasOpcode(line, false);
+                const isOpcode = this.hasOpcode(line, inNvccCode);
                 if (isDataDefinition || isOpcode) {
                     for (const currentLabel of currentLabelSet) {
                         if (inFunction && isDataDefinition) {

--- a/test/filters-cases/nvcc-example.asm.directives.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.approved.txt
@@ -156,7 +156,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -299,6 +307,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 42,
     "entry": 11
   }
 }

--- a/test/filters-cases/nvcc-example.asm.directives.comments.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.comments.approved.txt
@@ -106,7 +106,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -249,6 +257,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 32,
     "entry": 1
   }
 }

--- a/test/filters-cases/nvcc-example.asm.directives.labels.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.labels.approved.txt
@@ -156,7 +156,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -275,6 +283,11 @@
     },
     {
       "labels": [],
+      "source": null,
+      "text": "BB0_2:"
+    },
+    {
+      "labels": [],
       "source": {
         "column": 1,
         "file": "/tmp/moo.cu",
@@ -294,6 +307,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 42,
     "entry": 11
   }
 }

--- a/test/filters-cases/nvcc-example.asm.directives.labels.comments.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.labels.comments.approved.txt
@@ -106,7 +106,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -225,6 +233,11 @@
     },
     {
       "labels": [],
+      "source": null,
+      "text": "BB0_2:"
+    },
+    {
+      "labels": [],
       "source": {
         "column": 1,
         "file": "/tmp/moo.cu",
@@ -244,6 +257,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 32,
     "entry": 1
   }
 }

--- a/test/filters-cases/nvcc-example.asm.directives.labels.comments.library.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.labels.comments.library.approved.txt
@@ -106,7 +106,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -225,6 +233,11 @@
     },
     {
       "labels": [],
+      "source": null,
+      "text": "BB0_2:"
+    },
+    {
+      "labels": [],
       "source": {
         "column": 1,
         "file": "/tmp/moo.cu",
@@ -244,6 +257,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 32,
     "entry": 1
   }
 }

--- a/test/filters-cases/nvcc-example.asm.directives.labels.comments.library.dontMaskFilenames.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.labels.comments.library.dontMaskFilenames.approved.txt
@@ -111,7 +111,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -242,6 +250,11 @@
     },
     {
       "labels": [],
+      "source": null,
+      "text": "BB0_2:"
+    },
+    {
+      "labels": [],
       "source": {
         "column": 1,
         "file": "/tmp/moo.cu",
@@ -262,6 +275,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 32,
     "entry": 1
   }
 }

--- a/test/filters-cases/nvcc-example.asm.directives.library.approved.txt
+++ b/test/filters-cases/nvcc-example.asm.directives.library.approved.txt
@@ -156,7 +156,15 @@
       "text": "        setp.ge.s32     %p1, %r1, %r2;"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "BB0_2",
+          "range": {
+            "endCol": 30,
+            "startCol": 25
+          }
+        }
+      ],
       "source": {
         "column": 5,
         "file": "/tmp/moo.cu",
@@ -299,6 +307,7 @@
     }
   ],
   "labelDefinitions": {
+    "BB0_2": 42,
     "entry": 11
   }
 }


### PR DESCRIPTION
Previously this filter did not correctly identify used labels in CUDA PTX output, which caused it to remove important labels.

Closes https://github.com/compiler-explorer/compiler-explorer/issues/1128 and https://github.com/compiler-explorer/compiler-explorer/issues/2886.