### PR TITLE
Sprinkle some path.delimiter around

### DIFF
--- a/etc/scripts/util/orphancompiler.py
+++ b/etc/scripts/util/orphancompiler.py
@@ -39,7 +39,7 @@ LIB_VERSIONS_LIST_RE = re.compile(r'libs\.(.*?)\.versions=(.*)')
 LIB_VERSION_RE = re.compile(r'libs\.(.*?)\.versions\.(.*?)\.version')
 TOOLS_LIST_RE = re.compile(r'tools=(.+)')
 TOOL_EXE_RE = re.compile(r'tools\.(.*?)\.exe')
-EMPTY_LIST_RE = re.compile(r'.*(compilers|formatters|versions|tools|alias|exclude)=.*::.*')
+EMPTY_LIST_RE = re.compile(r'.*(compilers|formatters|versions|tools|alias|exclude|libPath)=.*::.*')
 DISABLED_RE = re.compile(r'^# Disabled:\s*(.*)')
 
 

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -280,11 +280,8 @@ export class CompilerFinder {
             return [];
         }
 
-        if (process.platform === 'win32') {
-            compilerInfo.libPath = compilerInfo.libPath.split(';').filter(p => p !== '');
-        } else {
-            compilerInfo.libPath = compilerInfo.libPath.split(':').filter(p => p !== '');
-        }
+        // This seems like no longer needed with orphancompiler.py checks
+        compilerInfo.libPath = compilerInfo.libPath.split(path.delimiter).filter(p => p !== '');
 
         logger.debug('Found compiler', compilerInfo);
         return compilerInfo;

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -25,6 +25,7 @@
 import https from 'https';
 
 import fs from 'fs-extra';
+import path from 'path';
 import semverParser from 'semver';
 import _ from 'underscore';
 
@@ -226,19 +227,15 @@ export class ClientOptionsHandler {
                             }
 
                             const includes = this.compilerProps(lang, libVersionName + '.path');
-                            if (includes && process.platform === 'win32') {
-                                versionObject.path = includes.split(';');
-                            } else if (includes) {
-                                versionObject.path = includes.split(':');
+                            if (includes) {
+                                versionObject.path = includes.split(path.delimiter);
                             } else {
                                 logger.warn(`Library ${lib} ${version} (${lang}) has no include paths`);
                             }
 
                             const libpath = this.compilerProps(lang, libVersionName + '.libpath');
-                            if (libpath && process.platform === 'win32') {
-                                versionObject.libpath = libpath.split(';');
-                            } else if (libpath) {
-                                versionObject.libpath = libpath.split(':');
+                            if (libpath) {
+                                versionObject.libpath = libpath.split(path.delimiter);
                             }
 
                             const options = this.compilerProps(lang, libVersionName + '.options');


### PR DESCRIPTION
In #3673, @dkm suggested to use `path.delimiter` to avoid os checks for directorly list separators. This PR uses the same solution in a few more places, and updates the `orphancompiler.py` checks to include libPath arrays not being empty
