### PR TITLE
Allow hashes in arguments

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -354,12 +354,10 @@ export function base32Encode(buffer: Buffer): string {
     return output;
 }
 
-export function splitArguments(options?: string): string[] {
-    return _.chain(
-        quoteParse(options || '')
-            // FIXME: x might not contain a .pattern!
-            .map((x: any) => (typeof x === 'string' ? x : (x.pattern as string))),
-    )
+export function splitArguments(options = ''): string[] {
+    // escape hashes first, otherwise they're interpreted as comments
+    const escapedOptions = options.replaceAll(/#/g, '\\#');
+    return _.chain(quoteParse(escapedOptions).map((x: any) => (typeof x === 'string' ? x : (x.pattern as string))))
         .compact()
         .value();
 }

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -515,3 +515,25 @@ describe('safe semver', () => {
         utils.asSafeVer('123.456.789 TEXT').should.equal('123.456.789');
     });
 });
+
+describe('argument splitting', () => {
+    it('should handle normal things', () => {
+        utils
+            .splitArguments('-hello --world etc --std=c++20')
+            .should.deep.equal(['-hello', '--world', 'etc', '--std=c++20']);
+    });
+
+    it('should handle hash chars', () => {
+        utils
+            .splitArguments('-Wno#warnings -Wno-#pragma-messages')
+            .should.deep.equal(['-Wno#warnings', '-Wno-#pragma-messages']);
+    });
+
+    it('should handle doublequoted args', () => {
+        utils.splitArguments('--hello "-world etc"').should.deep.equal(['--hello', '-world etc']);
+    });
+
+    it('should handle singlequoted args', () => {
+        utils.splitArguments("--hello '-world etc'").should.deep.equal(['--hello', '-world etc']);
+    });
+});


### PR DESCRIPTION
Fixes #3719

Took a look at the source of https://www.npmjs.com/package/shell-quote and found out you can escape things with a \\ by default.