### PR TITLE
Add GCC 9.5 for native C/C++/D/Go and Ada

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -7,7 +7,7 @@ compilerType=ada
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=gnat82:gnat102:gnat111:gnat112:gnat113:gnat121:gnatsnapshot
+group.gnat.compilers=gnat82:gnat95:gnat102:gnat111:gnat112:gnat113:gnat121:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=x86-64
 group.gnat.isSemVer=true
@@ -18,6 +18,8 @@ group.gnat.objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
 
 compiler.gnat82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gnatmake
 compiler.gnat82.semver=8.2
+compiler.gnat95.exe=/opt/compiler-explorer/gcc-9.5.0/bin/gnatmake
+compiler.gnat95.semver=9.5
 compiler.gnat102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gnatmake
 compiler.gnat102.semver=10.2
 compiler.gnat111.exe=/opt/compiler-explorer/gcc-11.1.0/bin/gnatmake

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -12,7 +12,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g101:g102:g103:g111:g112:g113:g121:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g111:g112:g113:g121:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -114,6 +114,8 @@ compiler.g93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/g++
 compiler.g93.semver=9.3
 compiler.g94.exe=/opt/compiler-explorer/gcc-9.4.0/bin/g++
 compiler.g94.semver=9.4
+compiler.g95.exe=/opt/compiler-explorer/gcc-9.5.0/bin/g++
+compiler.g95.semver=9.5
 compiler.g101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 compiler.g101.semver=10.1
 compiler.g102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/g++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -6,7 +6,7 @@ needsMulti=false
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg101:cg102:cg103:cg111:cg112:cg113:cg121:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg111:cg112:cg113:cg121:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -89,6 +89,8 @@ compiler.cg93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gcc
 compiler.cg93.semver=9.3
 compiler.cg94.exe=/opt/compiler-explorer/gcc-9.4.0/bin/gcc
 compiler.cg94.semver=9.4
+compiler.cg95.exe=/opt/compiler-explorer/gcc-9.5.0/bin/gcc
+compiler.cg95.semver=9.5
 compiler.cg101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gcc
 compiler.cg101.semver=10.1
 compiler.cg102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gcc

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -3,7 +3,7 @@ defaultCompiler=ldc1_29
 objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 demangler=/opt/compiler-explorer/ldc1.29.0/ldc2-1.29.0-linux-x86_64/bin/ddemangle
 
-group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc101:gdc102:gdc111:gdc113:gdc121:gdctrunk
+group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc111:gdc113:gdc121:gdctrunk
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
 group.gdc.baseName=gdc
@@ -21,6 +21,8 @@ compiler.gdc92.exe=/opt/compiler-explorer/gcc-9.2.0/bin/gdc
 compiler.gdc92.semver=9.2
 compiler.gdc93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gdc
 compiler.gdc93.semver=9.3
+compiler.gdc95.exe=/opt/compiler-explorer/gcc-9.5.0/bin/gdc
+compiler.gdc95.semver=9.5
 compiler.gdc101.exe=/opt/compiler-explorer/gcc-10.1.0/bin/gdc
 compiler.gdc101.semver=10.1
 compiler.gdc102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gdc

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -3,7 +3,7 @@ objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 
 compilers=&gccgo:&gl:&cross:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl
 
-group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo102:gccgo111:gccgo112:gccgo113:gccgo121
+group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo111:gccgo112:gccgo113:gccgo121
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -18,6 +18,8 @@ compiler.gccgo830.semver=8.3.0
 compiler.gccgo830.alias=gccgo810
 compiler.gccgo930.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gccgo
 compiler.gccgo930.semver=9.3.0
+compiler.gccgo950.exe=/opt/compiler-explorer/gcc-9.5.0/bin/gccgo
+compiler.gccgo950.semver=9.5.0
 compiler.gccgo102.exe=/opt/compiler-explorer/gcc-10.2.0/bin/gccgo
 compiler.gccgo102.semver=10.2.0
 compiler.gccgo111.exe=/opt/compiler-explorer/gcc-11.1.0/bin/gccgo


### PR DESCRIPTION
GCC 9.5.0 has been released last week.
https://gcc.gnu.org/gcc-9/changes.html

refs https://github.com/compiler-explorer/compiler-explorer/issues/3731

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>