### PR TITLE
Create minimal support implementation for MLIR

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,6 +64,9 @@ lang-haskell:
 lang-ispc:
   - lib/compilers/ispc.js
   - etc/config/ispc.*.properties
+lang-mlir:
+  - lib/compilers/mlir.ts
+  - etc/config/mlir.*.properties
 lang-java:
   - lib/compilers/java.js
   - etc/config/java.*.properties

--- a/etc/config/mlir.defaults.properties
+++ b/etc/config/mlir.defaults.properties
@@ -4,6 +4,7 @@ compilerType=mlir
 
 supportsBinary=false
 supportsExecute=false
+supportsAsmDocs=false
 
 group.mliropt.compilers=mliropt14
 group.mliropt.isSemVer=true

--- a/etc/config/mlir.defaults.properties
+++ b/etc/config/mlir.defaults.properties
@@ -1,0 +1,13 @@
+compilers=&mliropt
+defaultCompiler=mliropt14
+compilerType=mlir
+
+supportsBinary=false
+supportsExecute=false
+
+group.mliropt.compilers=mliropt14
+group.mliropt.isSemVer=true
+group.mliropt.baseName=MLIR opt
+
+compiler.mliropt14.exe=/usr/bin/mlir-opt-14
+compiler.mliropt14.semver=14.0.0

--- a/examples/mlir/default.mlir
+++ b/examples/mlir/default.mlir
@@ -1,5 +1,10 @@
-func @multiple_conversion_casts(%arg0: i32, %arg1: i32) -> (i32, i32) {
-  %inputs:2 = builtin.unrealized_conversion_cast %arg0, %arg1 : i32, i32 to i64, i64
-  %outputs:2 = builtin.unrealized_conversion_cast %inputs#0, %inputs#1 : i64, i64 to i32, i32
-  return %outputs#0, %outputs#1 : i32, i32
+func @affine_parallel_with_reductions_i64(%arg0: memref<3x3xi64>, %arg1: memref<3x3xi64>) -> (i64, i64) {
+  %0:2 = affine.parallel (%kx, %ky) = (0, 0) to (2, 2) reduce ("addi", "muli") -> (i64, i64) {
+            %1 = affine.load %arg0[%kx, %ky] : memref<3x3xi64>
+            %2 = affine.load %arg1[%kx, %ky] : memref<3x3xi64>
+            %3 = arith.muli %1, %2 : i64
+            %4 = arith.addi %1, %2 : i64
+            affine.yield %3, %4 : i64, i64
+          }
+  return %0#0, %0#1 : i64, i64
 }

--- a/examples/mlir/default.mlir
+++ b/examples/mlir/default.mlir
@@ -1,0 +1,5 @@
+func @multiple_conversion_casts(%arg0: i32, %arg1: i32) -> (i32, i32) {
+  %inputs:2 = builtin.unrealized_conversion_cast %arg0, %arg1 : i32, i32 to i64, i64
+  %outputs:2 = builtin.unrealized_conversion_cast %inputs#0, %inputs#1 : i64, i64 to i32, i32
+  return %outputs#0, %outputs#1 : i32, i32
+}

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1671,7 +1671,7 @@ export class BaseCompiler {
 
     doTempfolderCleanup(buildResult) {
         if (buildResult.dirPath && !this.delayCleanupTemp) {
-            fs.remove(buildResult.dirPath);
+            // fs.remove(buildResult.dirPath);
         }
         buildResult.dirPath = undefined;
     }

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1671,7 +1671,7 @@ export class BaseCompiler {
 
     doTempfolderCleanup(buildResult) {
         if (buildResult.dirPath && !this.delayCleanupTemp) {
-            // fs.remove(buildResult.dirPath);
+            fs.remove(buildResult.dirPath);
         }
         buildResult.dirPath = undefined;
     }

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -57,6 +57,7 @@ export {KotlinCompiler} from './kotlin';
 export {LDCCompiler} from './ldc';
 export {LLCCompiler} from './llc';
 export {LLVMmcaTool} from './llvm-mca';
+export {MLIRCompiler} from './mlir';
 export {NimCompiler} from './nim';
 export {NvccCompiler} from './nvcc';
 export {OCamlCompiler} from './ocaml';

--- a/lib/compilers/mlir.ts
+++ b/lib/compilers/mlir.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Compiler Explorer Authors
+// Copyright (c) 2022, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -22,30 +22,48 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import './ada-mode';
-import './asm6502-mode';
-import './asm-mode';
-import './asmruby-mode';
-import './clean-mode';
-import './cmake-mode';
-import './cpp-for-opencl-mode';
-import './cppcircle-mode';
-import './cppp-mode';
-import './cppx-blue-mode';
-import './cppx-gold-mode';
-import './crystal-mode';
-import './cuda-mode';
-import './d-mode';
-import './erlang-mode';
-import './fortran-mode';
-import './gccdump-rtl-gimple-mode';
-import './haskell-mode';
-import './ispc-mode';
-import './llvm-ir-mode';
-import './mlir-mode';
-import './nc-mode';
-import './nim-mode';
-import './ocaml-mode';
-import './openclc-mode';
-import './ptx-mode';
-import './zig-mode';
+import path from 'path';
+
+import {ParseFilters} from '../../types/features/filters.interfaces';
+import {BaseCompiler} from '../base-compiler';
+
+import {BaseParser} from './argument-parsers';
+
+export class MLIRCompiler extends BaseCompiler {
+    static get key() {
+        return 'mlir';
+    }
+
+    constructor(compilerInfo, env) {
+        if (!compilerInfo.disabledFilters) {
+            compilerInfo.disabledFilters = [
+                'binary',
+                'execute',
+                'demangle',
+                'intel',
+                'labels',
+                'libraryCode',
+                'directives',
+                'commentOnly',
+                'trim',
+            ];
+        }
+        super(compilerInfo, env);
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {
+        return path.join(dirPath, 'example.out.mlir');
+    }
+
+    override optionsForBackend(backendOptions, outputFilename): string[] {
+        return ['-o', outputFilename];
+    }
+
+    override getArgumentParser(): any {
+        return BaseParser;
+    }
+
+    override optionsForFilter(filters: ParseFilters, outputFilename, userOptions?): any[] {
+        return [];
+    }
+}

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -68,6 +68,13 @@ export const languages = {
         alias: [],
         logoUrl: 'llvm.png',
     },
+    mlir: {
+        name: 'MLIR',
+        monaco: 'mlir',
+        extensions: ['.mlir'],
+        alias: [],
+        logoUrl: 'mlir.svg',
+    },
     cppx: {
         name: 'Cppx',
         monaco: 'cppp',

--- a/static/modes/llvm-ir-mode.ts
+++ b/static/modes/llvm-ir-mode.ts
@@ -28,7 +28,7 @@ const monaco = require('monaco-editor');
 // This definition is based on the official LLVM vim syntax:
 // http://llvm.org/svn/llvm-project/llvm/trunk/utils/vim/syntax/llvm.vim
 // For VIM regex syntax, see: http://vimdoc.sourceforge.net/htmldoc/pattern.html
-function definition() {
+export function definition() {
     return {
         // llvmType
         types: [

--- a/static/modes/mlir-mode.ts
+++ b/static/modes/mlir-mode.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Compiler Explorer Authors
+// Copyright (c) 2022, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -22,30 +22,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import './ada-mode';
-import './asm6502-mode';
-import './asm-mode';
-import './asmruby-mode';
-import './clean-mode';
-import './cmake-mode';
-import './cpp-for-opencl-mode';
-import './cppcircle-mode';
-import './cppp-mode';
-import './cppx-blue-mode';
-import './cppx-gold-mode';
-import './crystal-mode';
-import './cuda-mode';
-import './d-mode';
-import './erlang-mode';
-import './fortran-mode';
-import './gccdump-rtl-gimple-mode';
-import './haskell-mode';
-import './ispc-mode';
-import './llvm-ir-mode';
-import './mlir-mode';
-import './nc-mode';
-import './nim-mode';
-import './ocaml-mode';
-import './openclc-mode';
-import './ptx-mode';
-import './zig-mode';
+import * as monaco from 'monaco-editor';
+
+import {definition} from './llvm-ir-mode';
+
+// TODO: write an actual MLIR monaco mode
+
+monaco.languages.register({id: 'mlir'});
+monaco.languages.setMonarchTokensProvider('mlir', definition() as any);
+
+export {};

--- a/views/resources/logos/mlir.svg
+++ b/views/resources/logos/mlir.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="MLIR" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 360 360" style="enable-background:new 0 0 360 360;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#1B466C;}
+	.st2{fill:#3775E0;}
+	.st3{fill:#5EA8DB;}
+</style>
+    <g id="Full_Color">
+	<g>
+		<path class="st1" d="M324,263.14l-144,83.14L36,263.14V96.86l144-83.14l144,83.14V263.14z"/>
+        <polygon class="st2" points="180,60.66 110.77,100.63 147.16,121.65 180,102.69 212.84,121.65 249.23,100.63 		"/>
+        <polygon class="st3" points="180,299.34 249.23,259.37 212.84,238.35 180,257.31 147.16,238.35 110.77,259.37 		"/>
+        <polygon class="st0" points="180,180.04 76.65,120.33 76.65,239.67 113.05,218.64 113.05,180.77 180,219.45 246.95,180.77
+			246.95,218.64 283.35,239.67 283.35,120.33 		"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Partially addresses #3730

This PR contains a minimal implementation for running MLIR transforms and passes in Compiler Explorer.

**It currently supports:**
- Running passes and transforms with the mlir-opt command line

**It needs the following:**
- An actual monaco-editor mode, right now it's just copied LLVM's mode because a lot of operators are similar
- A better default example, right now it's just one test I found in the MLIR repository (maybe @siboehm has some ideas?)
- Infra installers and builders
- Probably a fair few other things I'm unable to name right now