### PR TITLE
NFC: Rename TypeScript to TypeScript Native on website

### DIFF
--- a/etc/config/typescript.amazon.properties
+++ b/etc/config/typescript.amazon.properties
@@ -1,21 +1,19 @@
-# Default settings for TypeScript Compiler
-compilers=&tsc
+compilers=&tsnative
 compilerType=typescript
 versionFlag=--version
 
-group.tsc.compilers=tsc_0_0_20_gc:tsc_0_0_20_nogc
-group.tsc.sharedlibs=
-group.tsc.isSemVer=true
+group.tsnative.compilers=tsc_0_0_20_gc:tsc_0_0_20_nogc
+group.tsnative.sharedlibs=
+group.tsnative.isSemVer=true
 compiler.tsc_0_0_20_gc.exe=/opt/compiler-explorer/tsc-0.0-pre-alpha20/bin/tsc
 compiler.tsc_0_0_20_gc.sharedlibs=/opt/compiler-explorer/tsc-0.0-pre-alpha20/lib/libTypeScriptRuntime.so
-compiler.tsc_0_0_20_gc.name=TypeScript 0.0.pre20 JIT (GC)
+compiler.tsc_0_0_20_gc.name=TypeScript Native Compiler 0.0.pre20 JIT (GC)
 compiler.tsc_0_0_20_gc.semver=0.0.20
 compiler.tsc_0_0_20_nogc.exe=/opt/compiler-explorer/tsc-0.0-pre-alpha20/bin/tsc
-compiler.tsc_0_0_20_nogc.name=TypeScript 0.0.pre20 JIT (No GC)
+compiler.tsc_0_0_20_nogc.name=TypeScript Native Compiler 0.0.pre20 JIT (No GC)
 compiler.tsc_0_0_20_nogc.semver=0.0.20
 
 defaultCompiler=tsc_0_0_20_gc
 supportsBinary=false
 supportsExecute=true
 interpreted=true
-

--- a/etc/config/typescript.defaults.properties
+++ b/etc/config/typescript.defaults.properties
@@ -1,18 +1,17 @@
 # Default settings for TypeScript Compiler
-compilers=&tsc
+compilers=&tsnative
 compilerType=typescript
 versionFlag=--version
 
-group.tsc.compilers=tsc_jit_gc:tsc_jit_nogc
+group.tsnative.compilers=tsc_jit_gc:tsc_jit_nogc
 compiler.tsc_jit_gc.exe=/opt/compiler-explorer/tsc-0.0-pre-alpha20/bin/tsc
 compiler.tsc_jit_gc.sharedlibs=/opt/compiler-explorer/tsc-0.0-pre-alpha20/bin/lib/libTypeScriptRuntime.so
-compiler.tsc_jit_gc.name=TypeScript JIT (GC)
+compiler.tsc_jit_gc.name=TypeScript Native Compiler JIT (GC)
 compiler.tsc_jit_nogc.exe=/opt/compiler-explorer/tsc-0.0-pre-alpha20/bin/tsc
 compiler.tsc_jit_nogc.sharedlibs=
-compiler.tsc_jit_nogc.name=TypeScript JIT (No GC)
+compiler.tsc_jit_nogc.name=TypeScript Native Compiler JIT (No GC)
 
 defaultCompiler=tsc_jit_gc
 supportsBinary=false
 supportsExecute=true
 interpreted=true
-

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -79,7 +79,7 @@ export {SPIRVCompiler} from './spirv';
 export {SwiftCompiler} from './swift';
 export {TenDRACompiler} from './tendra';
 export {TinyCCompiler} from './tinyc';
-export {TypeScriptCompiler} from './typescript';
+export {TypeScriptNativeCompiler} from './typescript-native';
 export {VBCompiler} from './dotnet';
 export {Win32Compiler} from './win32';
 export {Win32VcCompiler} from './win32-vc';

--- a/lib/compilers/typescript-native.js
+++ b/lib/compilers/typescript-native.js
@@ -26,7 +26,7 @@ import {BaseCompiler} from '../base-compiler';
 
 import {TypeScriptNativeParser} from './argument-parsers';
 
-export class TypeScriptCompiler extends BaseCompiler {
+export class TypeScriptNativeCompiler extends BaseCompiler {
     static get key() {
         return 'typescript';
     }

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -336,7 +336,7 @@ export const languages = {
         logoUrl: 'dart.svg',
     },
     typescript: {
-        name: 'TypeScript',
+        name: 'TypeScript Native',
         monaco: 'typescript',
         extensions: ['.ts', '.d.ts'],
         alias: [],


### PR DESCRIPTION
Non-functional and non-shortlink-breaking change

Renames some of the TypeScript compiler textual names to TypeScript Native based on feedback on Discord