### PR TITLE
Don't objdump when only executing cmake result

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1852,12 +1852,14 @@ export class BaseCompiler {
                 okToCache: true,
             };
 
-            const [asmResult] = await this.checkOutputFileAndDoPostProcess(
-                fullResult.result,
-                outputFilename,
-                cacheKey.filters,
-            );
-            fullResult.result = asmResult;
+            if (!key.backendOptions.skipAsm) {
+                const [asmResult] = await this.checkOutputFileAndDoPostProcess(
+                    fullResult.result,
+                    outputFilename,
+                    cacheKey.filters,
+                );
+                fullResult.result = asmResult;
+            }
 
             if (this.lang.id === 'c++') {
                 fullResult.result.compilationOptions = makeExecParams.env.CXXFLAGS.split(' ');


### PR DESCRIPTION
While investigating something else, I discovered that CE was objdumping binaries in CMake mode even when the user only asks for execution.

We have separate code for normal compilations that already takes this into account here by taking a different path https://github.com/compiler-explorer/compiler-explorer/blob/main/lib/base-compiler.ts#L1988
