### PR TITLE
Add the gitlab bmulti library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1386,7 +1386,7 @@ compiler.zcxxtrunk.semver=trunk
 #################################
 #################################
 # Installed libs
-libs=abseil:benchmark:benri:blaze:boost:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
+libs=abseil:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -1478,6 +1478,12 @@ libs.boost.versions.178.version=1.78.0
 libs.boost.versions.178.path=/opt/compiler-explorer/libs/boost_1_78_0
 libs.boost.versions.179.version=1.79.0
 libs.boost.versions.179.path=/opt/compiler-explorer/libs/boost_1_79_0
+
+libs.bmulti.name=B-Multi
+libs.bmulti.url=https://gitlab.com/correaa/boost-multi
+libs.bmulti.versions=trunk
+libs.bmulti.description=Modern C++ multidimensional arrays
+libs.bmulti.versions.trunk=/opt/compiler-explorer/libs/boost-multi/include
 
 libs.brigand.name=Brigand
 libs.brigand.versions=trunk:130

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1483,7 +1483,8 @@ libs.bmulti.name=B-Multi
 libs.bmulti.url=https://gitlab.com/correaa/boost-multi
 libs.bmulti.versions=trunk
 libs.bmulti.description=Modern C++ multidimensional arrays
-libs.bmulti.versions.trunk=/opt/compiler-explorer/libs/boost-multi/include
+libs.bmulti.versions.trunk.version=trunk
+libs.bmulti.versions.trunk.path=/opt/compiler-explorer/libs/boost-multi/include
 
 libs.brigand.name=Brigand
 libs.brigand.versions=trunk:130


### PR DESCRIPTION
Proposing to add the B-Multi library to the live site. https://gitlab.com/correaa/boost-multi

Followed the steps as best as I could in https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingALibrary.md#adding-a-new-library-to-the-live-site

Feedback on improving the hooks and the organizations of files in the repository is welcome.
The goal is to include the library by doing `#include<multi/array.hpp>`.

This PR is related to infra's PR https://github.com/compiler-explorer/infra/pull/745