### PR TITLE
Enable MLIR for prod with 14.0.0 and 14.0.5

### DIFF
--- a/etc/config/mlir.amazon.properties
+++ b/etc/config/mlir.amazon.properties
@@ -1,0 +1,16 @@
+compilers=&mliropt
+defaultCompiler=mliropt1405
+compilerType=mlir
+
+supportsBinary=false
+supportsExecute=false
+supportsAsmDocs=false
+
+group.mliropt.compilers=mliropt1400:mliropt1405
+group.mliropt.isSemVer=true
+group.mliropt.baseName=MLIR opt
+
+compiler.mliropt1405.exe=/opt/compiler-explorer/mlir-14.0.5/bin/mlir-opt
+compiler.mliropt1405.semver=14.0.5
+compiler.mliropt1400.exe=/opt/compiler-explorer/mlir-14.0.0/bin/mlir-opt
+compiler.mliropt1400.semver=14.0.0

--- a/examples/mlir/default.mlir
+++ b/examples/mlir/default.mlir
@@ -1,3 +1,7 @@
+// Example code of an affine reduction.
+// MLIR example code may not always work out of the box because the textual MLIR format is not stable.
+// The example tries to be compatible with the latest MLIR version, which may not work on previous versions.
+
 func @affine_parallel_with_reductions_i64(%arg0: memref<3x3xi64>, %arg1: memref<3x3xi64>) -> (i64, i64) {
   %0:2 = affine.parallel (%kx, %ky) = (0, 0) to (2, 2) reduce ("addi", "muli") -> (i64, i64) {
             %1 = affine.load %arg0[%kx, %ky] : memref<3x3xi64>

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -74,6 +74,7 @@ export const languages = {
         extensions: ['.mlir'],
         alias: [],
         logoUrl: 'mlir.svg',
+        monacoDisassembly: 'mlir',
     },
     cppx: {
         name: 'Cppx',


### PR DESCRIPTION
Also adds a tiny disclaimer to the default example because MLIRs text format isn't stable

(also changes the monaco output mode to mlir)
![image](https://user-images.githubusercontent.com/42585241/173269696-00c3054a-440e-4621-8b69-a6e93c27cc15.png)
