### PR TITLE
Display tool tags in the editor

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1351,6 +1351,12 @@ Editor.prototype.getAllOutputAndErrors = function (result) {
             all = all.concat(step.stderr);
         });
     }
+    if (result.tools) {
+        _.each(result.tools, function (tool) {
+            all = all.concat(tool.stdout);
+            all = all.concat(tool.stderr);
+        });
+    }
     all = all.concat(result.stderr || []);
 
     return all;


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
All the code was there to have tools output displayed as squiggles in the editor, but they were not taken into account.
If that was an overlook, this PR will fix it. If this was on purpose because some tools display a source location without us wanting it to be treated as an error, it might make sense to add a flag in the tools' configuration.