### PR TITLE
Fix token span calculations

### DIFF
--- a/static/panes/ast-view.ts
+++ b/static/panes/ast-view.ts
@@ -284,7 +284,7 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
                         astLine.source.to.line === lineNumber &&
                         astLine.source.from.col &&
                         astLine.source.to.col &&
-                        astLine.source.from.col <= colEnd &&
+                        astLine.source.from.col < colEnd &&
                         colBegin <= astLine.source.to.col
                     ) {
                         singleNodeLines.push(line);


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
The Monaco tokenizer works with 0-based offsets, while both the decorations and the compiler error messages use 1-based offsets, making getTokenSpan return a shifted result. Most of that is compensated by the call sites of getTokenSpan, but there was a small bug for squiggles on single-character tokens and in the AST view for AST highlighting on mouse-over of contiguous tokens.