### PR TITLE
Add GCC morello release 1

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -836,6 +836,17 @@ compiler.carm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown
 compiler.carm64gtrunk.name=ARM64 gcc trunk
 compiler.carm64gtrunk.semver=trunk
 
+# GCC Morello
+group.cgcc64arm.groupName=Arm Morello GCC
+group.cgcc64arm.compilers=carm64gm101a1
+group.cgcc64arm.isSemVer=true
+group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp1-x86_64/aarch64-none-elf/bin/objdump
+group.cgcc64arm.instructionSet=aarch64
+
+compiler.carm64gm101a1.exe=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp1-x86_64/bin/aarch64-none-elf-gcc
+compiler.carm64gm101a1.name=ARM64 Morello gcc 10.1 Alpha 1
+compiler.carm64gm101a1.semver=10.1.0
+
 ###############################
 # GCC for Kalray
 group.ckalray.compilers=ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750


### PR DESCRIPTION
Hi.

This adds the first Arm Morello[1] GCC release to compiler explorer.

The corresponding Infra patch is at https://github.com/compiler-explorer/infra/pull/753 

This release of the toolchain is C only.

[1] https://www.arm.com/architecture/cpu/morello