### PR TITLE
Properly async await so exceptions are processed in getVersion as one…

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2366,7 +2366,7 @@ but nothing was dumped. Possible causes are:
         return GCCParser;
     }
 
-    getVersion() {
+    async getVersion() {
         logger.info(`Gathering ${this.compiler.id} version information on ${this.compiler.exe}...`);
         if (this.compiler.explicitVersion) {
             logger.debug(`${this.compiler.id} has forced version output: ${this.compiler.explicitVersion}`);
@@ -2378,7 +2378,7 @@ but nothing was dumped. Possible causes are:
         execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         try {
-            return this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions);
+            return await this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions);
         } catch (err) {
             logger.error(`Unable to get version for compiler '${this.compiler.exe}' - ${err}`);
             return null;

--- a/test/base-compiler-tests.js
+++ b/test/base-compiler-tests.js
@@ -113,10 +113,11 @@ describe('Basic compiler invariants', function () {
         testIncludeNotG('#include <../fish.config> // for std::is_same_v<...>');
         testIncludeNotG('#include <./>      // for std::ranges::range<...> and std::ranges::range_type_v<...>');
     });
-    it('should skip version check if forced to', () => {
+    it('should skip version check if forced to', async () => {
         const newConfig = {...info, explicitVersion: '123'};
         const forcedVersionCompiler = new BaseCompiler(newConfig, ce);
-        forcedVersionCompiler.getVersion().stdout.should.deep.equal(['123']);
+        const result = await forcedVersionCompiler.getVersion();
+        result.stdout.should.deep.equal(['123']);
     });
 });
 


### PR DESCRIPTION
… would expect

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
