### PR TITLE
Add cross GCC 12.1.0 for Ada, C++, C, D and Fortran

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,20 +1,21 @@
 # Default settings for Ada
-compilers=&gnat:&gnatriscv64:&gnatarm:&gnats390x:&gnatmipss:&gnatppcs
+compilers=&gnat:&gnatcross
 defaultCompiler=gnat121
 versionFlag=--version
 compilerType=ada
+
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
 group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat111:gnat112:gnat113:gnat121:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=x86-64
-group.gnat.isSemVer=true
 group.gnat.baseName=x86-64 gnat
 group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
 group.gnat.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 group.gnat.demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
+group.gnat.isSemVer=true
 
 compiler.gnat82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gnatmake
 compiler.gnat82.semver=8.2
@@ -39,13 +40,17 @@ compiler.gnatsnapshot.name=x86-64 gnat (trunk)
 compiler.gnatsnapshot.semver=(trunk)
 
 ################################
+# Cross GNAT
+group.gnatcross.compilers=&gnatriscv64:&gnatarm:&gnatarm64:&gnats390x:&gnatmipss:&gnatppcs
+group.gnatcross.supportsExecute=false
+group.gnatcross.supportsBinary=false
+group.gnatcross.isSemVer=true
+
+################################
 # GNAT for riscv64
 group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103
 group.gnatriscv64.groupName=riscv64
 group.gnatriscv64.instructionSet=riscv
-group.gnatriscv64.isSemVer=true
-group.gnatriscv64.supportsBinary=false
-group.gnatriscv64.supportsExecute=false
 
 compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnatmake
 compiler.gnatriscv64103.demangler=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-c++filt
@@ -61,83 +66,109 @@ compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-l
 
 ################################
 # GNAT for s390x
-group.gnats390x.compilers=gnats390x1120
+group.gnats390x.compilers=gnats390x1120:gnats390x1210
 group.gnats390x.groupName=s390x
 group.gnats390x.instructionSet=s390x
 group.gnats390x.baseName=s390x gnat
-group.gnats390x.isSemVer=true
-group.gnats390x.supportsBinary=false
-group.gnats390x.supportsExecute=false
 
 compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
 compiler.gnats390x1120.demangler=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 compiler.gnats390x1120.semver=11.2.0
+compiler.gnats390x1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1210.semver=12.1.0
 
 ################################
 # GNAT for ppc
 group.gnatppcs.compilers=&gnatppc:&gnatppc64:&gnatppc64le
 group.gnatppcs.instructionSet=ppc
-group.gnatppcs.isSemVer=true
-group.gnatppcs.supportsBinary=false
-group.gnatppcs.supportsExecute=false
 
 ## POWER
 group.gnatppc.groupName=power
-group.gnatppc.compilers=gnatppc1120
+group.gnatppc.compilers=gnatppc1120:gnatppc1210
 group.gnatppc.baseName=powerpc gnat
+
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
 compiler.gnatppc1120.demangler=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 compiler.gnatppc1120.semver=11.2.0
 
+compiler.gnatppc1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1210.demangler=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+compiler.gnatppc1210.semver=12.1.0
+
 ## POWER64
 group.gnatppc64.groupName=power64
-group.gnatppc64.compilers=gnatppc641120
+group.gnatppc64.compilers=gnatppc641120:gnatppc641210
 group.gnatppc64.baseName=powerpc64 gnat
+
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 compiler.gnatppc641120.semver=11.2.0
 
+compiler.gnatppc641210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641210.demangler=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.gnatppc641210.semver=12.1.0
+
 ## POWER64LE
 group.gnatppc64le.groupName=power64le
-group.gnatppc64le.compilers=gnatppc64le1120
+group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210
 group.gnatppc64le.baseName=powerpc64le gnat
+
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1120.demangler=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 compiler.gnatppc64le1120.semver=11.2.0
 
+compiler.gnatppc64le1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1210.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.gnatppc64le1210.semver=12.1.0
+
 ################################
-# GNAT for MIPS
+# GNAT for MIPSs
+## GNAT builds for mipsel and mips64el are broken on 12.1.0
 group.gnatmipss.compilers=&gnatmips:&gnatmips64
 group.gnatmipss.instructionSet=mips
-group.gnatmipss.isSemVer=true
-group.gnatmipss.supportsBinary=false
-group.gnatmipss.supportsExecute=false
 
 ## MIPS
 group.gnatmips.groupName=mips
-group.gnatmips.compilers=gnatmips1120
+group.gnatmips.compilers=gnatmips1120:gnatmips1210
 group.gnatmips.baseName=mips gnat
+
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1120.demangler=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 compiler.gnatmips1120.semver=11.2.0
 
+compiler.gnatmips1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1210.semver=12.1.0
+compiler.gnatmips1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
 ## MIPS64
 group.gnatmips64.groupName=mips64
-group.gnatmips64.compilers=gnatmips641120
+group.gnatmips64.compilers=gnatmips641120:gnatmips641210
 group.gnatmips64.baseName=mips64 gnat
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641120.demangler=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 compiler.gnatmips641120.semver=11.2.0
 
+compiler.gnatmips641210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641210.demangler=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+compiler.gnatmips641210.semver=12.1.0
+
+################################
+# GNAT for arm64
+group.gnatarm64.compilers=gnatarm641210
+group.gnatarm64.groupName=arm64
+group.gnatarm64.baseName=arm64 gnat
+group.gnatarm64.instructionSet=arm64
+
+compiler.gnatarm641210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
+compiler.gnatarm641210.semver=12.1.0
+compiler.gnatarm641210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+
 ################################
 # GNAT for arm
 group.gnatarm.compilers=gnatarm112:gnatarm103
 group.gnatarm.groupName=arm
 group.gnatarm.instructionSet=arm32
-group.gnatarm.isSemVer=true
-group.gnatarm.supportsBinary=false
-group.gnatarm.supportsExecute=false
 
 compiler.gnatarm103.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-gnatmake
 compiler.gnatarm103.demangler=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-c++filt

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -701,15 +701,19 @@ group.s390x.compilers=&gccs390x
 # GCC for s390x
 group.gccs390x.supportsBinary=true
 group.gccs390x.supportsExecute=false
-
-group.gccs390x.groupName=s390x G++
-group.gccs390x.compilers=gccs390x1120
+group.gccs390x.baseName=s390x gcc
+group.gccs390x.groupName=s390x gcc
+group.gccs390x.compilers=gccs390x1120:s390xg1210
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
 compiler.gccs390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
 compiler.gccs390x1120.name=s390x gcc 11.2.0
 compiler.gccs390x1120.semver=11.2.0
+
+compiler.s390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.s390xg1210.semver=12.1.0
+compiler.s390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
 ###############################
 # Cross compilers for PPC
@@ -719,32 +723,46 @@ group.ppcs.supportsBinary=true
 group.ppcs.supportsExecute=false
 
 ## POWER
-group.ppc.compilers=ppcg1120:ppcg48
+group.ppc.compilers=ppcg48:ppcg1120:ppcg1210
 group.ppc.groupName=POWER
 group.ppc.baseName=power gcc
 
 compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
 compiler.ppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppcg48.semver=4.8.5
+
 compiler.ppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
 compiler.ppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppcg1120.semver=11.2.0
 
+compiler.ppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1210.semver=12.1.0
+compiler.ppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+
 ## POWER64
 group.ppc64.groupName=POWER64
-group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64clang
+group.ppc64.baseName=power64 gcc
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang
+
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g8.name=power64 AT12.0 (gcc8)
 compiler.ppc64g8.semver=(snapshot)
+
 compiler.ppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g9.name=power64 AT13.0 (gcc9)
 compiler.ppc64g9.semver=(snapshot)
+
 compiler.ppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g1120.semver=power64 gcc 11.2.0
 compiler.ppc64g1120.name=power64 gcc 11.2.0
+
+compiler.ppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1210.semver=12.1.0
+compiler.ppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+
 compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -755,23 +773,34 @@ compiler.ppc64clang.semver=(snapshot)
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE
-group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leclang
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang
+group.ppc64le.baseName=power64le gcc
+
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg630.name=power64le gcc 6.3.0
 compiler.ppc64leg630.semver=6.3.0
+
 compiler.ppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg8.name=power64le AT12.0 (gcc8)
 compiler.ppc64leg8.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg8.semver=(snapshot)
+
 compiler.ppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg9.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg9.name=power64le AT13.0 (gcc9)
 compiler.ppc64leg9.semver=(snapshot)
+
 compiler.ppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg1120.name=power64le gcc 11.2.0
 compiler.ppc64leg1120.semver=11.2.0
+
+compiler.ppc64leg1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1210.semver=12.1.0
+compiler.ppc64leg1120.name=power64le gcc 12.1.0
+compiler.ppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+
 compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -879,6 +908,7 @@ compiler.arm1130.exe=/opt/compiler-explorer/arm/gcc-11.3.0/arm-unknown-linux-gnu
 compiler.arm1130.name=ARM gcc 11.3 (linux)
 compiler.arm1130.semver=11.3.0
 compiler.arm1210.exe=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.arm1210.objdumper=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.arm1210.name=ARM gcc 12.1 (linux)
 compiler.arm1210.semver=12.1.0
 compiler.armgtrunk.exe=/opt/compiler-explorer/arm/gcc-trunk/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
@@ -921,6 +951,7 @@ compiler.arm64g1120.semver=11.2
 compiler.arm64g1130.exe=/opt/compiler-explorer/arm64/gcc-11.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1130.semver=11.3
 compiler.arm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1210.semver=12.1
 compiler.arm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64gtrunk.semver=trunk
@@ -1019,7 +1050,7 @@ compiler.msp430g621.semver=6.2.1
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100
+group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -1028,24 +1059,34 @@ compiler.avrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-g++
 compiler.avrg454.alias=avrg453
 compiler.avrg454.semver=4.5.4
 compiler.avrg454.supportsBinary=false
+
 compiler.avrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-g++
 compiler.avrg464.semver=4.6.4
 compiler.avrg464.objdumper=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-objdump
+
 compiler.avrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
 compiler.avrg540.semver=5.4.0
 compiler.avrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+
 compiler.avrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-g++
 compiler.avrg920.semver=9.2.0
 compiler.avrg920.objdumper=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-objdump
+
 compiler.avrg930.exe=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-g++
 compiler.avrg930.semver=9.3.0
 compiler.avrg930.objdumper=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-objdump
+
 compiler.avrg1030.exe=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-g++
 compiler.avrg1030.semver=10.3.0
 compiler.avrg1030.objdumper=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-objdump
+
 compiler.avrg1100.exe=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-g++
 compiler.avrg1100.semver=11.1.0
 compiler.avrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdump
+
+compiler.avrg1210.exe=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-g++
+compiler.avrg1210.semver=12.1.0
+compiler.avrg1210.objdumper=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-objdump
 
 ###############################
 # GCC for MIPS
@@ -1057,45 +1098,68 @@ group.mipss.supportsExecute=false
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mips930:mips1120
+group.mips.compilers=mips5:mips930:mips1120:mipsg1210
 group.mips.baseName=mips gcc
+
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mips5.semver=5.4
 compiler.mips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
 compiler.mips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-g++
 compiler.mips930.name=mips gcc 9.3.0 (codescape)
 compiler.mips930.semver=9.3.0
 compiler.mips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
+
 compiler.mips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mips1120.semver=11.2.0
 compiler.mips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.mipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg1210.semver=12.1.0
+compiler.mipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips564:mips112064
+group.mips64.compilers=mips564:mips112064:mips64g1210
 group.mips64.baseName=mips64 gcc
+
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips564.semver=5.4
 compiler.mips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
 compiler.mips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips112064.semver=11.2.0
 compiler.mips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
+compiler.mips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g1210.semver=12.1.0
+compiler.mips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el
+group.mipsel.compilers=mips5el:mipselg1210
 group.mipsel.baseName=mipsel gcc
+
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
 compiler.mips5el.semver=5.4
 compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 
+compiler.mipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.mipselg1210.semver=12.1.0
+compiler.mipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips564el
+group.mips64el.compilers=mips564el:mips64elg1210
 group.mips64el.baseName=mips64 (el) gcc
+
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
 compiler.mips564el.semver=5.4
 compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+
+compiler.mips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.mips64elg1210.semver=12.1.0
+compiler.mips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 
 ###############################
 # GCC for nanoMIPS

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -609,17 +609,20 @@ group.ccross.groupName=Cross GCC
 group.cs390x.compilers=&cgccs390x
 
 # GCC for s390x
+group.cgccs390x.compilers=cgccs390x112:cs390xg1210
 group.cgccs390x.supportsBinary=true
 group.cgccs390x.supportsExecute=false
-
+group.cgccs390x.baseName=s390x gcc
 group.cgccs390x.groupName=s390x GCC
-group.cgccs390x.compilers=cgccs390x112
 group.cgccs390x.isSemVer=true
-group.cgccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
 compiler.cgccs390x112.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
-compiler.cgccs390x112.name=s390x GCC 11.2.0
 compiler.cgccs390x112.semver=11.2.0
+compiler.cgccs390x112.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+compiler.cs390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cs390xg1210.semver=12.1.0
+compiler.cs390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
 ###############################
 # Cross compilers for PPC
@@ -628,18 +631,23 @@ group.cppcs.isSemVer=true
 group.cppcs.supportsBinary=true
 group.cppcs.supportsExecute=false
 
-group.cppc.compilers=cppcg1120:cppcg48
+group.cppc.compilers=cppcg1210:cppcg1120:cppcg48
 group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
 compiler.cppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc
 compiler.cppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg48.semver=4.8.5
+
 compiler.cppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.cppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1120.semver=11.2.0
 
-group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64clang
+compiler.cppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1210.semver=12.1.0
+
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang
 group.cppc64.groupName=POWER64
 compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -653,6 +661,12 @@ compiler.cppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-u
 compiler.cppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1120.semver=power64 gcc 11.2.0
 compiler.cppc64g1120.name=power64 gcc 11.2.0
+
+compiler.cppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1210.semver=power64 gcc 12.1.0
+compiler.cppc64g1210.name=power64 gcc 12.1.0
+
 compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -661,24 +675,34 @@ compiler.cppc64clang.options=-target powerpc64
 compiler.cppc64clang.supportsBinary=false
 compiler.cppc64clang.semver=(snapshot)
 
-group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leclang
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leg1210:cppc64leclang
 group.cppc64le.groupName=POWER64LE
+
 compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg630.name=power64le gcc 6.3.0
 compiler.cppc64leg630.semver=6.3.0
+
 compiler.cppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg8.name=power64le AT12.0 (gcc8)
 compiler.cppc64leg8.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg8.semver=(snapshot)
+
 compiler.cppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg9.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg9.name=power64le AT13.0 (gcc9)
 compiler.cppc64leg9.semver=(snapshot)
+
 compiler.cppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg1120.name=power64le gcc 11.2.0
 compiler.cppc64leg1120.semver=11.2.0
+
+compiler.cppc64leg1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1210.name=power64le gcc 12.1.0
+compiler.cppc64leg1210.semver=12.1.0
+
 compiler.cppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -785,6 +809,7 @@ compiler.carm1130.exe=/opt/compiler-explorer/arm/gcc-11.3.0/arm-unknown-linux-gn
 compiler.carm1130.name=ARM gcc 11.3 (linux)
 compiler.carm1130.semver=11.3.0
 compiler.carm1210.exe=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carm1210.objdumper=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.carm1210.name=ARM gcc 12.1 (linux)
 compiler.carm1210.semver=12.1.0
 compiler.carmgtrunk.exe=/opt/compiler-explorer/arm/gcc-trunk/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
@@ -838,6 +863,7 @@ compiler.carm64g1130.exe=/opt/compiler-explorer/arm64/gcc-11.3.0/aarch64-unknown
 compiler.carm64g1130.name=ARM64 gcc 11.3
 compiler.carm64g1130.semver=11.3.0
 compiler.carm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1210.name=ARM64 gcc 12.1
 compiler.carm64g1210.semver=12.1.0
 compiler.carm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
@@ -929,43 +955,58 @@ compiler.carduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hard
 
 ################################
 # GCC for MSP
-group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621
+group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210
 group.cmsp.groupName=MSP GCC
 group.cmsp.baseName=MSP430 gcc
 group.cmsp.isSemVer=true
+
 compiler.cmsp430g453.exe=/opt/compiler-explorer/msp430/gcc-4.5.3/bin/msp430-gcc
 compiler.cmsp430g453.semver=4.5.3
+
 compiler.cmsp430g530.exe=/opt/compiler-explorer/msp430-gcc-5.3.0.219_linux32/bin/msp430-elf-gcc
 compiler.cmsp430g530.semver=5.3.0
+
 compiler.cmsp430g621.exe=/opt/compiler-explorer/msp430-gcc-6.2.1.16_linux64/bin/msp430-elf-gcc
 compiler.cmsp430g621.semver=6.2.1
 
+compiler.cmsp430g1210.exe=/opt/compiler-explorer/gcc-12.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.cmsp430g1210.semver=12.1.0
+
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
+
 compiler.cavrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-gcc
 compiler.cavrg454.semver=4.5.4
 compiler.cavrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-gcc
 compiler.cavrg464.semver=4.6.4
+
 compiler.cavrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
 compiler.cavrg540.semver=5.4.0
-compiler.cavrg540.supportsBinary=false
 compiler.cavrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+
 compiler.cavrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-gcc
 compiler.cavrg920.semver=9.2.0
 compiler.cavrg920.objdumper=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-objdump
+
 compiler.cavrg930.exe=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-gcc
 compiler.cavrg930.semver=9.3.0
 compiler.cavrg930.objdumper=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-objdump
+
 compiler.cavrg1030.exe=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-gcc
 compiler.cavrg1030.semver=10.3.0
 compiler.cavrg1030.objdumper=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-objdump
+
 compiler.cavrg1100.exe=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-gcc
 compiler.cavrg1100.semver=11.1.0
 compiler.cavrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdump
+
+compiler.cavrg1210.exe=/opt/compiler-explorer/avr/gcc-12.1.0/bin/avr-gcc
+compiler.cavrg1210.semver=12.1.0
+compiler.cavrg1210.objdumper=/opt/compiler-explorer/avr/gcc-12.1.0/bin/avr-objdump
 
 ###############################
 # GCC for MIPS
@@ -976,47 +1017,70 @@ group.cmipss.supportsBinary=true
 group.cmipss.supportsExecute=false
 
 ## MIPS
-group.cmips.compilers=cmips5:cmips930:cmips1120
+group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
+
 compiler.cmips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmips5.semver=5.4
 compiler.cmips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
 compiler.cmips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
 compiler.cmips930.name=mips gcc 9.3.0 (codescape)
 compiler.cmips930.semver=9.3.0
 compiler.cmips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
+
 compiler.cmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmips1120.semver=11.2.0
 compiler.cmips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.cmipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg1210.semver=12.1.0
+compiler.cmipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips564:cmips112064
+group.cmips64.compilers=cmips564:cmips112064:cmips64g1210
 group.cmips64.baseName=mips64 gcc
+
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.cmips564.semver=5.4
 compiler.cmips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
 compiler.cmips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.cmips112064.semver=11.2.0
 compiler.cmips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
+compiler.cmips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g1210.semver=12.1.0
+compiler.cmips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el
+group.cmipsel.compilers=cmips5el:cmipselg1210
 group.cmipsel.baseName=mips (el) gcc
+
 compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
 compiler.cmips5el.semver=5.4
 compiler.cmips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 
+compiler.cmipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.cmipselg1210.semver=12.1.0
+compiler.cmipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips564el
+group.cmips64el.compilers=cmips564el:cmips64elg1210
 group.cmips64el.baseName=mips64 (el) gcc
+
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
 compiler.cmips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+
+compiler.cmips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.cmips64elg1210.semver=12.1.0
+compiler.cmips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 
 ###############################
 # GCC for nanoMIPS

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,13 +1,15 @@
-compilers=&gdc:&ldc:&dmd
+compilers=&gdc:&ldc:&dmd:&gdccross
 defaultCompiler=ldc1_30
-objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
-demangler=/opt/compiler-explorer/ldc1.30.0/ldc2-1.30.0-linux-x86_64/bin/ddemangle
-llvmSymbolizer=/opt/compiler-explorer/clang-14.0.0/bin/llvm-symbolizer
 
 group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc111:gdc113:gdc121:gdctrunk
+group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
 group.gdc.baseName=gdc
+group.gdc.demangler=/opt/compiler-explorer/ldc1.30.0/ldc2-1.30.0-linux-x86_64/bin/ddemangle
+group.gdc.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+group.gdc.llvmSymbolizer=/opt/compiler-explorer/clang-14.0.0/bin/llvm-symbolizer
+
 compiler.gdc49.exe=/opt/compiler-explorer/gdc4.9.3/x86_64-pc-linux-gnu/bin/gdc
 compiler.gdc49.alias=/opt/x86_64-gdcproject-linux-gnu/bin/gdc
 compiler.gdc49.semver=4.9.3
@@ -38,10 +40,96 @@ compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gdctrunk.semver=(trunk)
 
+## CROSS GDC
+group.gdccross.compilers=&gdcs390x:&gdcppc:&gdcppc64:&gdcppc64le:&gdcmips64:&gdcmips:&gdcmipsel
+group.gdccross.supportsExecute=false
+group.gdccross.supportsBinary=true
+
+### GDC for s390x
+group.gdcs390x.compilers=gdcs390x1210
+group.gdcs390x.groupName=GDC s390x
+group.gdcs390x.includeFlag=-isystem
+group.gdcs390x.isSemVer=true
+group.gdcs390x.baseName=gdc s390x
+
+compiler.gdcs390x1210.exe=/mnt/fatraid/dkm/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
+compiler.gdcs390x1210.semver=12.1.0
+compiler.gdcs390x1210.objdumper=/mnt/fatraid/dkm/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+### GDC for powerpc
+group.gdcppc.compilers=gdcppc1210
+group.gdcppc.groupName=GDC powerpc
+group.gdcppc.includeFlag=-isystem
+group.gdcppc.isSemVer=true
+group.gdcppc.baseName=gdc powerpc
+
+compiler.gdcppc1210.exe=/mnt/fatraid/dkm/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
+compiler.gdcppc1210.semver=12.1.0
+compiler.gdcppc1210.objdumper=/mnt/fatraid/dkm/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+
+### GDC for powerpc64
+group.gdcppc64.compilers=gdcppc641210
+group.gdcppc64.groupName=GDC powerpc64
+group.gdcppc64.includeFlag=-isystem
+group.gdcppc64.isSemVer=true
+group.gdcppc64.baseName=gdc powerpc64
+
+compiler.gdcppc641210.exe=/mnt/fatraid/dkm/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
+compiler.gdcppc641210.semver=12.1.0
+compiler.gdcppc641210.objdumper=/mnt/fatraid/dkm/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+
+### GDC for powerpc64le
+group.gdcppc64le.compilers=gdcppc64le1210
+group.gdcppc64le.groupName=GDC powerpc64le
+group.gdcppc64le.includeFlag=-isystem
+group.gdcppc64le.isSemVer=true
+group.gdcppc64le.baseName=gdc powerpc64le
+
+compiler.gdcppc64le1210.exe=/mnt/fatraid/dkm/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
+compiler.gdcppc64le1210.semver=12.1.0
+compiler.gdcppc64le1210.objdumper=/mnt/fatraid/dkm/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+
+### GDC for mips64
+group.gdcmips64.compilers=gdcmips641210
+group.gdcmips64.groupName=GDC mips64
+group.gdcmips64.includeFlag=-isystem
+group.gdcmips64.isSemVer=true
+group.gdcmips64.baseName=gdc mips64
+
+compiler.gdcmips641210.exe=/mnt/fatraid/dkm/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
+compiler.gdcmips641210.semver=12.1.0
+compiler.gdcmips641210.objdumper=/mnt/fatraid/dkm/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+### GDC for mips
+group.gdcmips.compilers=gdcmips1210
+group.gdcmips.groupName=GDC mips
+group.gdcmips.includeFlag=-isystem
+group.gdcmips.isSemVer=true
+group.gdcmips.baseName=gdc mips
+
+compiler.gdcmips1210.exe=/mnt/fatraid/dkm/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
+compiler.gdcmips1210.semver=12.1.0
+compiler.gdcmips1210.objdumper=/mnt/fatraid/dkm/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+### GDC for mipsel
+group.gdcmipsel.compilers=gdcmipsel1210
+group.gdcmipsel.groupName=GDC mipsel
+group.gdcmipsel.includeFlag=-isystem
+group.gdcmipsel.isSemVer=true
+group.gdcmipsel.baseName=gdc mipsel
+
+compiler.gdcmipsel1210.exe=/mnt/fatraid/dkm/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
+compiler.gdcmipsel1210.semver=12.1.0
+compiler.gdcmipsel1210.objdumper=/mnt/fatraid/dkm/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+
 group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldc1_28:ldc1_29:ldc1_30:ldcbeta:ldclatestci
 group.ldc.compilerType=ldc
 group.ldc.isSemVer=true
 group.ldc.baseName=ldc
+group.ldc.demangler=/opt/compiler-explorer/ldc1.30.0/ldc2-1.30.0-linux-x86_64/bin/ddemangle
+group.ldc.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+group.ldc.llvmSymbolizer=/opt/compiler-explorer/clang-14.0.0/bin/llvm-symbolizer
+
 compiler.ldc017.exe=/opt/compiler-explorer/ldc0.17.2/ldc2-0.17.2-linux-x86_64/bin/ldc2
 compiler.ldc017.semver=0.17.2
 compiler.ldc100.exe=/opt/compiler-explorer/ldc1.0.0/ldc2-1.0.0-linux-x86_64/bin/ldc2

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -144,20 +144,38 @@ compiler.ifx202200.semver=2022.0.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppc
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmipss:&gccmips64:&gccs390x
+group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820
-group.gccarm.groupName=ARM (32bit) GCC
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1210
+group.gccarm.groupName=ARM (32bit) gfortran
+group.gccarm.baseName=ARM (32bit) gfortran
+
 compiler.farmg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
-compiler.farmg640.name=ARM gfortran 6.4
+compiler.farmg640.semver=6.4
+
 compiler.farmg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
-compiler.farmg730.name=ARM gfortran 7.3
+compiler.farmg730.semver=7.3
+
 compiler.farmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
-compiler.farmg820.name=ARM gfortran 8.2
+compiler.farmg820.semver=8.2
+
+compiler.farmg1210.exe=/opt/compiler-explorer/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1210.semver=12.1.0
+
+###############################
+## GCC for s390x
+group.gccs390x.compilers=fs390xg1210
+group.gccs390x.groupName=s390x gfortran
+group.gccs390x.baseName=s390x gfortran
+
+compiler.fs390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
+compiler.fs390xg1210.semver=12.1.0
+compiler.fs390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
 ###############################
 # LLVM Flang for X86
@@ -178,7 +196,7 @@ compiler.flangtrunknew.supportsBinary=false
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820
+group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1210
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 compiler.farm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g640.name=AARCH64 gfortran 6.4
@@ -187,23 +205,124 @@ compiler.farm64g730.name=AARCH64 gfortran 7.3
 compiler.farm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g820.name=AARCH64 gfortran 8.2
 
+compiler.farm64g1210.exe=/mnt/fatraid/dkm/compiler-explorer/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1210.name=AARCH64 gfortran 12.1.0
+compiler.farm64g1210.exe=/mnt/fatraid/dkm/compiler-explorer/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+
+###############################
+# GCC for PPCs
+group.ppcs.compilers=&ppc64:&ppc64le:&ppc
+group.ppcs.groupName=POWER Compilers
+
 ###############################
 # GCC for PPC
-group.ppc.compilers=fppc64leg8:fppc64g8:fppc64leg9:fppc64g9
-group.ppc.groupName=POWER Compilers
-group.ppc.isSemVer=true
-compiler.fppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
-compiler.fppc64leg8.name=power64le AT12.0
-compiler.fppc64leg8.semver=(snapshot)
+group.ppc.compilers=fppcg1210
+group.ppc.groupName=POWER gfortran
+group.ppc.baseName=POWER gfortran
+
+compiler.fppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
+compiler.fppcg1210.semver=12.1.0
+compiler.fppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+
+###############################
+# GCC for PPC64
+group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210
+group.ppc64.groupName=POWER64 gfortran
+group.ppc64.baseName=POWER64 gfortran
+
 compiler.fppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64g8.name=power64 AT12.0
 compiler.fppc64g8.semver=(snapshot)
-compiler.fppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
-compiler.fppc64leg9.name=power64le AT13.0
-compiler.fppc64leg9.semver=(snapshot)
+
 compiler.fppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64g9.name=power64 AT13.0
 compiler.fppc64g9.semver=(snapshot)
+
+compiler.fppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.fppc64g1210.semver=12.1.0
+compiler.fppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+
+###############################
+# GCC for PPC64LE
+group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210
+group.ppc64le.groupName=POWER64le gfortran
+group.ppc64le.baseName=POWER64le gfortran
+
+compiler.fppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg8.name=power64le AT12.0
+compiler.fppc64leg8.semver=(snapshot)
+
+compiler.fppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg9.name=power64le AT13.0
+compiler.fppc64leg9.semver=(snapshot)
+
+compiler.fppc64leg1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg1210.semver=12.1.0
+compiler.fppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+
+################################
+# GCC for RISC-V 32-bits
+group.gccrv32.compilers=frv32g1210
+group.gccrv32.groupName=RISC-V 32-bits gfortran
+group.gccrv32.baseName=RISC-V 32-bits gfortran
+
+compiler.frv32g1210.exe=/opt/compiler-explorer/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gfortran
+compiler.frv32g1210.semver=12.1.0
+compiler.frv32g1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+
+################################
+# GCC for RISC-V 64-bits
+group.gccrv64.compilers=frv64g1210
+group.gccrv64.groupName=RISC-V 64-bits gfortran
+group.gccrv64.baseName=RISC-V 64-bits gfortran
+
+compiler.frv64g1210.exe=/opt/compiler-explorer/gcc-12.1.0/riscv64-unknown-elf/bin/riscv64-unknown-elf-gfortran
+compiler.frv64g1210.semver=12.1.0
+compiler.frv64g1210.exe=/opt/compiler-explorer/gcc-12.1.0/riscv64-unknown-elf/bin/riscv64-unknown-elf-objdump
+
+################################
+# GCC for MIPSs
+group.gccmipss.compilers=&gccmips:&gccmips64:&gccmipsel:&gccmips64el
+
+################################
+# GCC for MIPS
+group.gccmips.compilers=fmipsg1210
+group.gccmips.groupName=MIPS gfortran
+group.gccmips.baseName=MIPS gfortran
+
+compiler.fmipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg1210.semver=12.1.0
+compiler.fmipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+################################
+# GCC for MIPS64
+group.gccmips64.compilers=fmips64g1210
+group.gccmips64.groupName=MIPS64 gfortran
+group.gccmips64.baseName=MIPS64 gfortran
+
+compiler.fmips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g1210.semver=12.1.0
+compiler.fmips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+################################
+# GCC for MIPSEL
+group.gccmipsel.compilers=fmipselg1210
+group.gccmipsel.groupName=MIPSel gfortran
+group.gccmipsel.baseName=MIPSel gfortran
+
+compiler.fmipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
+compiler.fmipselg1210.semver=12.1.0
+compiler.fmipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+
+################################
+# GCC for MIPS64el
+group.gccmips64el.compilers=fmips64elg1210
+group.gccmips64el.groupName=MIPS64el gfortran
+group.gccmips64el.baseName=MIPS64el gfortran
+
+compiler.fmips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
+compiler.fmips64elg1210.semver=12.1.0
+compiler.fmips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 
 #################################
 #################################


### PR DESCRIPTION
Add GCC 12.1.0 for cross targets:
 - mips + mips64 + mipsel + mips64el
 - powerpc + powerpc64 + powerpc64le
 - s390x
 - arm + arm64 (only add new languages)
 - riscv32 + riscv64 (only add new languages)
 - avr
 - msp430

When possible, the following languages have been enabled:
 - Ada (GNAT), except for targets supported by Alire
 - D (GDC)
 - Fortran (gfortran)
 - C++
 - C

refs #3729
refs #3761