### PR TITLE
Update `c++.amazon.properties` for `range-v3` release `0.12.0`

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2326,7 +2326,7 @@ libs.python.versions.381.version=3.8.1
 libs.python.versions.381.path=/opt/compiler-explorer/python-3.8.1/include/python3.8
 
 libs.rangesv3.name=range-v3
-libs.rangesv3.versions=trunk:030:035:036:091:0100:0110
+libs.rangesv3.versions=trunk:030:035:036:091:0100:0110:0120
 libs.rangesv3.url=https://github.com/ericniebler/range-v3
 libs.rangesv3.versions.trunk.version=trunk
 libs.rangesv3.versions.trunk.path=/opt/compiler-explorer/libs/rangesv3/trunk/include
@@ -2342,6 +2342,8 @@ libs.rangesv3.versions.0100.version=0.10.0
 libs.rangesv3.versions.0100.path=/opt/compiler-explorer/libs/rangesv3/0.10.0/include
 libs.rangesv3.versions.0110.version=0.11.0
 libs.rangesv3.versions.0110.path=/opt/compiler-explorer/libs/rangesv3/0.11.0/include
+libs.rangesv3.versions.0120.version=0.12.0
+libs.rangesv3.versions.0120.path=/opt/compiler-explorer/libs/rangesv3/0.12.0/include
 
 libs.raberu.name=Raberu
 libs.raberu.description=C++20 Named Parameters Library


### PR DESCRIPTION
This is the corresponding change for the `infra` PR (https://github.com/compiler-explorer/infra/pull/755) to add `range-v3` release `0.12.0`.