### PR TITLE
Move default demangler from global to specific group

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,7 +1,6 @@
 # Default settings for Ada
 compilers=&gnat:&gnatriscv64:&gnatarm:&gnats390x:&gnatmipss:&gnatppcs
 defaultCompiler=gnat121
-demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
 versionFlag=--version
 compilerType=ada
 
@@ -14,7 +13,8 @@ group.gnat.isSemVer=true
 group.gnat.baseName=x86-64 gnat
 group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
-group.gnat.objdumper=/opt/compiler-explorer/gcc-11.3.0/bin/objdump
+group.gnat.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+group.gnat.demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
 
 compiler.gnat82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gnatmake
 compiler.gnat82.semver=8.2
@@ -46,11 +46,13 @@ group.gnatriscv64.supportsBinary=false
 group.gnatriscv64.supportsExecute=false
 
 compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnatmake
+compiler.gnatriscv64103.demangler=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-c++filt
 compiler.gnatriscv64103.name=riscv64 gnat 10.3.0-2 (Alire)
 compiler.gnatriscv64103.semver=10.3.0
 compiler.gnatriscv64103.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/riscv64-elf/lib/gnat/zfp-rv64imac
 
 compiler.gnatriscv64112.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/bin/riscv64-elf-gnatmake
+compiler.gnatriscv64112.demangler=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/bin/riscv64-elf-c++filt
 compiler.gnatriscv64112.name=riscv64 gnat 11.2.0-3 (Alire)
 compiler.gnatriscv64112.semver=11.2.0
 compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
@@ -66,6 +68,7 @@ group.gnats390x.supportsBinary=false
 group.gnats390x.supportsExecute=false
 
 compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1120.demangler=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 compiler.gnats390x1120.semver=11.2.0
 
 ################################
@@ -81,6 +84,7 @@ group.gnatppc.groupName=power
 group.gnatppc.compilers=gnatppc1120
 group.gnatppc.baseName=powerpc gnat
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1120.demangler=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 compiler.gnatppc1120.semver=11.2.0
 
 ## POWER64
@@ -88,6 +92,7 @@ group.gnatppc64.groupName=power64
 group.gnatppc64.compilers=gnatppc641120
 group.gnatppc64.baseName=powerpc64 gnat
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 compiler.gnatppc641120.semver=11.2.0
 
 ## POWER64LE
@@ -95,6 +100,7 @@ group.gnatppc64le.groupName=power64le
 group.gnatppc64le.compilers=gnatppc64le1120
 group.gnatppc64le.baseName=powerpc64le gnat
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1120.demangler=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 compiler.gnatppc64le1120.semver=11.2.0
 
 ################################
@@ -109,7 +115,8 @@ group.gnatmipss.supportsExecute=false
 group.gnatmips.groupName=mips
 group.gnatmips.compilers=gnatmips1120
 group.gnatmips.baseName=mips gnat
-compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnat 
+compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1120.demangler=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 compiler.gnatmips1120.semver=11.2.0
 
 ## MIPS64
@@ -118,6 +125,7 @@ group.gnatmips64.compilers=gnatmips641120
 group.gnatmips64.baseName=mips64 gnat
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641120.demangler=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 compiler.gnatmips641120.semver=11.2.0
 
 ################################
@@ -130,11 +138,13 @@ group.gnatarm.supportsBinary=false
 group.gnatarm.supportsExecute=false
 
 compiler.gnatarm103.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-gnatmake
+compiler.gnatarm103.demangler=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/bin/arm-eabi-c++filt
 compiler.gnatarm103.name=arm gnat 10.3.0-2 (Alire)
 compiler.gnatarm103.semver=10.3.0
 compiler.gnatarm103.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-10.3.0-2/arm-eabi/lib/gnat/zfp-cortex-m4f/
 
 compiler.gnatarm112.exe=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/bin/arm-eabi-gnatmake
+compiler.gnatarm112.demangler=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/bin/arm-eabi-c++filt
 compiler.gnatarm112.name=arm gnat 11.2.0-3 (Alire)
 compiler.gnatarm112.semver=11.2.0
 compiler.gnatarm112.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/arm-eabi/lib/gnat/zfp-cortex-m4f/


### PR DESCRIPTION
Use matching arch for native demangler. Cross groups will be fixed in a future
change.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>