### PR TITLE
Linked code background color doesn't need to be !important

### DIFF
--- a/static/themes/dark-theme.scss
+++ b/static/themes/dark-theme.scss
@@ -127,7 +127,7 @@ a.navbar-brand img.logo.normal {
 }
 
 .linked-code-decoration-inline {
-    background: #121212 !important;
+    background: #121212;
 }
 
 .linked-code-decoration-margin {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
This `!important` is no longer necessary to display correctly (I think it was in earlier versions of Monaco) and it can override more important decorations. Also the default theme doesn't have it so it looks like an overlook.