### PR TITLE
Make tools output parsing overridable.

### DIFF
--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -36,6 +36,7 @@ export class BaseTool {
         this.env = env;
         this.tool.exclude = this.tool.exclude ? this.tool.exclude.split(':') : [];
         this.addOptionsToToolArgs = true;
+        this.parseOutput = utils.parseOutput;
     }
 
     getId() {
@@ -146,8 +147,8 @@ export class BaseTool {
             name: this.tool.name,
             code: result.code,
             languageId: this.tool.languageId,
-            stderr: utils.parseOutput(result.stderr, transformedFilepath, exeDir),
-            stdout: utils.parseOutput(result.stdout, transformedFilepath, exeDir),
+            stderr: this.parseOutput(result.stderr, transformedFilepath, exeDir),
+            stdout: this.parseOutput(result.stdout, transformedFilepath, exeDir),
         };
     }
 }

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -29,6 +29,7 @@ import _ from 'underscore';
 import {BaseCompiler} from '../lib/base-compiler';
 import {ClientOptionsHandler} from '../lib/options-handler';
 import * as properties from '../lib/properties';
+import {parseOutput} from '../lib/utils';
 
 import {should} from './utils';
 
@@ -510,6 +511,7 @@ describe('Options handler', () => {
             fake: {
                 faketool: {
                     addOptionsToToolArgs: true,
+                    parseOutput: parseOutput,
                     tool: {
                         args: undefined,
                         compilerLanguage: 'fake',
@@ -527,6 +529,7 @@ describe('Options handler', () => {
                 },
                 someothertool: {
                     addOptionsToToolArgs: true,
+                    parseOutput: parseOutput,
                     tool: {
                         args: undefined,
                         compilerLanguage: 'fake',


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
This change makes it possible to create a tool that would have a different output format (which I am doing).