### PR TITLE
Move severity parsing with the rest of the output parsing.

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1393,9 +1393,6 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                     }
                 }
 
-                var severity = 3; // error
-                if (obj.tag.text.match(/^warning/)) severity = 2;
-                if (obj.tag.text.match(/^note/)) severity = 1;
                 var colBegin = 0;
                 var colEnd = Infinity;
                 if (obj.tag.column) {
@@ -1405,7 +1402,7 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                     if (colEnd === obj.tag.column) colEnd = -1;
                 }
                 return {
-                    severity: severity,
+                    severity: obj.tag.severity,
                     message: obj.tag.text,
                     source: obj.source,
                     startLineNumber: obj.tag.line,

--- a/types/resultline/resultline.interfaces.ts
+++ b/types/resultline/resultline.interfaces.ts
@@ -3,6 +3,7 @@ export type ResultLineTag = {
     column?: number;
     file?: string;
     text: string;
+    severity: number;
 };
 
 export type ResultLine = {


### PR DESCRIPTION
Moving severity parsing logic next to the rest of the parsing allows customizing both severity and the tag message for some tools. It also seems a bit more homogeneous to me from an architectural point of view.