### PR TITLE
Add a way to trigger model markers on a range instead of a single token.

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1395,19 +1395,28 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
 
                 var colBegin = 0;
                 var colEnd = Infinity;
+                var lineBegin = obj.tag.line;
+                var lineEnd = obj.tag.line;
                 if (obj.tag.column) {
-                    var span = this.getTokenSpan(obj.tag.line, obj.tag.column);
-                    colBegin = obj.tag.column;
-                    colEnd = span.colEnd;
-                    if (colEnd === obj.tag.column) colEnd = -1;
+                    if (obj.tag.endcolumn) {
+                        colBegin = obj.tag.column;
+                        colEnd = obj.tag.endcolumn;
+                        lineBegin = obj.tag.line;
+                        lineEnd = obj.tag.endline;
+                    } else {
+                        var span = this.getTokenSpan(obj.tag.line, obj.tag.column);
+                        colBegin = obj.tag.column;
+                        colEnd = span.colEnd;
+                        if (colEnd === obj.tag.column) colEnd = -1;
+                    }
                 }
                 return {
                     severity: obj.tag.severity,
                     message: obj.tag.text,
                     source: obj.source,
-                    startLineNumber: obj.tag.line,
+                    startLineNumber: lineBegin,
                     startColumn: colBegin,
-                    endLineNumber: obj.tag.line,
+                    endLineNumber: lineEnd,
                     endColumn: colEnd,
                 };
             },

--- a/types/resultline/resultline.interfaces.ts
+++ b/types/resultline/resultline.interfaces.ts
@@ -4,6 +4,8 @@ export type ResultLineTag = {
     file?: string;
     text: string;
     severity: number;
+    endline?: number;
+    endcolumn?: number;
 };
 
 export type ResultLine = {


### PR DESCRIPTION
The tool I'm trying to integrate can have markers that span more than one token and even when marking a single token, it already calculated the right span, so an additional calculation is redundant.