### PR TITLE
Make it possible to display a URL in marker tooltips.

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1410,6 +1410,13 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                         if (colEnd === obj.tag.column) colEnd = -1;
                     }
                 }
+                let link;
+                if (obj.tag.link) {
+                    link = {
+                        value: obj.tag.link.text,
+                        target: obj.tag.link.url,
+                    };
+                }
                 return {
                     severity: obj.tag.severity,
                     message: obj.tag.text,
@@ -1418,6 +1425,7 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                     startColumn: colBegin,
                     endLineNumber: lineEnd,
                     endColumn: colEnd,
+                    code: link,
                 };
             },
             this

--- a/types/resultline/resultline.interfaces.ts
+++ b/types/resultline/resultline.interfaces.ts
@@ -1,3 +1,8 @@
+export type Link = {
+    text: string;
+    url: string;
+};
+
 export type ResultLineTag = {
     line?: number;
     column?: number;
@@ -6,6 +11,7 @@ export type ResultLineTag = {
     severity: number;
     endline?: number;
     endcolumn?: number;
+    link?: Link;
 };
 
 export type ResultLine = {


### PR DESCRIPTION
In Monaco, tooltips for markers can have one (1) link, as a treat.
This link has to be passed in the `code` field. This PR allows using this feature. The resulting tooltip with the link included looks as follow:
![image](https://user-images.githubusercontent.com/95592999/176930998-10bd2485-3f9a-4f99-a9ff-6cb4d085cd43.png)
