### PR TITLE
Implement copy compiler button in conformance view

### DIFF
--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -214,12 +214,24 @@ Conformance.prototype.addCompilerPicker = function (config) {
     newSelector
         .find('.close')
         .not('.extract-compiler')
+        .not('.copy-compiler')
         .on(
             'click',
             _.bind(function () {
                 this.removeCompilerPicker(newCompilerEntry);
             }, this)
         );
+
+    newSelector.find('.close.copy-compiler').on(
+        'click',
+        _.bind(function () {
+            var config = {
+                compilerId: newCompilerEntry.picker.lastCompilerId,
+                options: newCompilerEntry.optionsField.val() || '',
+            };
+            this.copyCompilerPicker(config);
+        }, this)
+    );
 
     newCompilerEntry.statusIcon = newSelector.find('.status-icon');
     newCompilerEntry.prependOptions = newSelector.find('.prepend-options');
@@ -292,6 +304,12 @@ Conformance.prototype.removeCompilerPicker = function (compilerEntry) {
 
     this.updateLibraries();
     this.handleToolbarUI();
+    this.saveState();
+};
+
+Conformance.prototype.copyCompilerPicker = function (config) {
+    this.addCompilerPicker(config);
+    this.compileChild(this.compilerPickers.at(-1));
     this.saveState();
 };
 

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -521,6 +521,7 @@
           button.btn.btn-sm.fas.fa-receipt.d-none.compiler-out.compiler-selector-icon(disabled=true style="cursor: help;" title="This compiler has generated some output. Open its associated pane to read it.")
           button.btn.btn-sm.fas.fa-times.close.compiler-selector-icon(aria-label="Close" title="Close")
           button.btn.btn-sm.fas.fa-share.close.extract-compiler.compiler-selector-icon(aria-label="Pop compiler" title="Show compiler")
+          button.btn.btn-sm.fas.fa-copy.close.copy-compiler.compiler-selector-icon(aria-label="Copy compiler" title="Copy compiler")
 
   #libs-dropdown
     .no-libs


### PR DESCRIPTION
This should be fine for #3447.

The UI now looks like this:
![actual](https://user-images.githubusercontent.com/51851906/177035060-84ab704f-26bb-4f76-a618-c1cc7e3eb120.png)

This is what it was proposed in the issue:
![expected](https://user-images.githubusercontent.com/51851906/177035017-fa591312-f602-4136-9cce-f4c5458ec332.png)

Let me know if you would rather have the button in the place described in the screenshot above.

