### PR TITLE
Drop StandardOutput=syslog from systemd docs

### DIFF
--- a/docs/SystemdSocketActivation.md
+++ b/docs/SystemdSocketActivation.md
@@ -24,7 +24,6 @@ WorkingDirectory={{path_to_installation_directory}}/compiler-explorer
 ExecStart=/usr/bin/node {{path_to_installation_directory}}/compiler-explorer/app.js
 TimeoutStartSec=60
 TimeoutStopSec=60
-StandardOutput=syslog
 User={{run_as_this_user}}
 Group={{run_as_this_group}}
 ```


### PR DESCRIPTION
StandardOutput=syslog is deprecated. Let's remove the setting altogether from the example so we rely on the default behavior instead which works exactly the same but doesn't trigger a warning from systemd.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
