### PR TITLE
Add the jakt programming language

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,6 +55,9 @@ lang-fortran:
   - lib/compilers/flang.ts
   - lib/compilers/fortran.js
   - etc/config/fortran.*.properties
+lang-jakt:
+  - lib/compilers/jakt.ts
+  - etc/config/jakt.*.properties
 lang-go:
   - lib/compilers/golang.js
   - etc/config/go.*.properties

--- a/etc/config/jakt.amazon.properties
+++ b/etc/config/jakt.amazon.properties
@@ -1,0 +1,18 @@
+# Default settings for Jakt
+
+compilers=rustbased:selfhosted
+defaultCompiler=selfhosted
+
+objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+supportsBinary=true
+supportsExecute=true
+versionFlag=--version
+compilerType=jakt
+
+compiler.rustbased.exe=/opt/compiler-explorer/jakt-trunk/jakt-rs
+compiler.rustbased.name=jakt (Written in Rust)
+compiler.rustbased.options=--runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
+
+compiler.selfhosted.exe=/opt/compiler-explorer/jakt-trunk/jakt-selfhost
+compiler.selfhosted.name=jakt (Selfhosted)
+compiler.selfhosted.options=-b --runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++

--- a/etc/config/jakt.amazon.properties
+++ b/etc/config/jakt.amazon.properties
@@ -1,7 +1,8 @@
-# Default settings for Jakt
-
 compilers=rustbased:selfhosted
 defaultCompiler=selfhosted
+
+externalparser=CEAsmParser
+externalparser.exe=/usr/local/bin/asm-parser
 
 objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 supportsBinary=true

--- a/etc/config/jakt.defaults.properties
+++ b/etc/config/jakt.defaults.properties
@@ -6,12 +6,9 @@ supportsExecute=true
 versionFlag=--version
 compilerType=jakt
 
-compilers=rustbased:selfhosted
+compilers=jakt
+defaultCompiler=jakt
 
-compiler.rustbased.exe=/opt/compiler-explorer/jakt-trunk/jakt-rs
-compiler.rustbased.name=jakt (Written in Rust)
-compiler.rustbased.options = --runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
-
-compiler.selfhosted.exe=/opt/compiler-explorer/jakt-trunk/jakt-selfhost
-compiler.selfhosted.name=jakt (Selfhosted)
-compiler.selfhosted.options=-b --runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.jakt.exe=/usr/bin/jakt
+compiler.jakt.name=jakt
+compiler.jakt.options=--prettify-cpp-source

--- a/etc/config/jakt.defaults.properties
+++ b/etc/config/jakt.defaults.properties
@@ -1,0 +1,17 @@
+# Default settings for Jakt
+
+objdumper=objdump
+supportsBinary=true
+supportsExecute=true
+versionFlag=--version
+compilerType=jakt
+
+compilers=rustbased:selfhosted
+
+compiler.rustbased.exe=/opt/compiler-explorer/jakt-trunk/jakt-rs
+compiler.rustbased.name=jakt (Written in Rust)
+compiler.rustbased.options = --runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
+
+compiler.selfhosted.exe=/opt/compiler-explorer/jakt-trunk/jakt-selfhost
+compiler.selfhosted.name=jakt (Selfhosted)
+compiler.selfhosted.options=-b --runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++

--- a/examples/jakt/default.jakt
+++ b/examples/jakt/default.jakt
@@ -1,0 +1,7 @@
+function hello() throws -> String  {
+    return "Well, hello friends."
+}
+
+function main() {
+    println("{}", hello())
+}

--- a/examples/jakt/default.jakt
+++ b/examples/jakt/default.jakt
@@ -1,7 +1,7 @@
-function hello() throws -> String  {
-    return "Well, hello friends."
+function square(num: i32) -> i32 {
+    return num * num
 }
 
 function main() {
-    println("{}", hello())
+    return square(num: 3)
 }

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -52,6 +52,7 @@ export {GCCRSCompiler} from './gccrs';
 export {GolangCompiler} from './golang';
 export {HaskellCompiler} from './haskell';
 export {ISPCCompiler} from './ispc';
+export {JaktCompiler} from './jakt';
 export {JavaCompiler} from './java';
 export {KotlinCompiler} from './kotlin';
 export {LDCCompiler} from './ldc';

--- a/lib/compilers/jakt.ts
+++ b/lib/compilers/jakt.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import {ExecutionOptions} from '../../types/compilation/compilation.interfaces';
+import {ParseFilters} from '../../types/features/filters.interfaces';
+import {BaseCompiler} from '../base-compiler';
+import * as exec from '../exec';
+
+export class JaktCompiler extends BaseCompiler {
+    static get key() {
+        return 'jakt';
+    }
+
+    constructor(info, env) {
+        super(info, env);
+
+        // TODO: The jakt compiler emits a file by the same name as the input,
+        // so this won't work if we have another input file that isn't called example.jakt
+        this.outputFilebase = 'example';
+    }
+
+    override optionsForFilter(filters: ParseFilters, outputFilename: any) {
+        return ['--binary-dir', path.dirname(outputFilename)];
+    }
+
+    override getObjdumpOutputFilename(defaultOutputFilename) {
+        const parsed_path = path.parse(defaultOutputFilename);
+
+        return path.join(parsed_path.dir, parsed_path.name);
+    }
+
+    override getExecutableFilename(dirPath, outputFilebase, key?) {
+        return path.join(dirPath, outputFilebase);
+    }
+
+    // We have no dynamic linking in Jakt
+    override getSharedLibraryPathsAsArguments(libraries, libDownloadPath) {
+        return [];
+    }
+
+    // We have no dynamic linking in Jakt
+    override getSharedLibraryLinks(libraries): string[] {
+        return [];
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {
+        return path.join(dirPath, `${outputFilebase}.cpp`);
+    }
+
+    override async exec(filepath: string, args: string[], execOptions: ExecutionOptions) {
+        return exec.execute(filepath, args, execOptions).then(result => {
+            if (result.code !== 0) {
+                // We still want to display the transpiled C++, even if it can't execute.
+                // So fake a successful execute here.
+                result.code = 0;
+            }
+            return result;
+        });
+    }
+}

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -33,6 +33,16 @@ type DefKeys = 'name' | 'monaco' | 'extensions' | 'alias' | 'previewFilter' | 'f
 type LanguageDefinition = Pick<Language, DefKeys>;
 
 const definitions: Record<LanguageKey, LanguageDefinition> = {
+    jakt: {
+        name: 'Jakt',
+        monaco: 'jakt',
+        extensions: ['.jakt'],
+        alias: [],
+        logoUrl: '',
+        logoUrlDark: null,
+        formatter: null,
+        previewFilter: null,
+    },
     'c++': {
         name: 'C++',
         monaco: 'cppp',

--- a/static/modes/_all.ts
+++ b/static/modes/_all.ts
@@ -41,6 +41,7 @@ import './fortran-mode';
 import './gccdump-rtl-gimple-mode';
 import './haskell-mode';
 import './ispc-mode';
+import './jakt-mode';
 import './llvm-ir-mode';
 import './mlir-mode';
 import './nc-mode';

--- a/static/modes/jakt-mode.ts
+++ b/static/modes/jakt-mode.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Marc Tiehuis
+// Copyright (c) 2022, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/static/modes/jakt-mode.ts
+++ b/static/modes/jakt-mode.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2018, Marc Tiehuis
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+'use strict';
+const monaco = require('monaco-editor');
+
+function definition() {
+    return {
+        defaultToken: 'invalid',
+
+        keywords: [
+            'struct',
+            'class',
+            'enum',
+            'namespace',
+            'if',
+            'else',
+            'match',
+            'while',
+            'for',
+            'loop',
+            'return',
+            'break',
+            'continue',
+            'throw',
+            'yield',
+            'function',
+            'extern',
+            'import',
+            'throws',
+            'defer',
+            'unsafe',
+            'cpp',
+            'try',
+            'catch',
+            'mut',
+            'let',
+            'anon',
+            'raw',
+            'private',
+            'public',
+            'true',
+            'false',
+            'weak',
+        ],
+        typeKeywords: [
+            'Optional',
+            'String',
+            'i8',
+            'i16',
+            'i32',
+            'i64',
+            'f32',
+            'f64',
+            'bool',
+            'c_int',
+            'c_char',
+            'usize',
+            'void',
+        ],
+        operators: [
+            '=>',
+            '..',
+            '?',
+            'and',
+            'not',
+            'or',
+            'as',
+            'in',
+            '+',
+            '-',
+            '/',
+            '*',
+            '=',
+            '^',
+            '&',
+            '!',
+            '>',
+            '<',
+            '%',
+            '<<',
+            '>>',
+            '+=',
+            '-=',
+            '/=',
+            '*=',
+            '==',
+            '^=',
+            '&=',
+            '?=',
+            '|=',
+            '!=',
+            '>=',
+            '<=',
+            '%=',
+            '<<=',
+            '>>=',
+        ],
+
+        symbols: /[=><!~?:&|+\-*/^%]+/,
+
+        escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+        tokenizer: {
+            root: [
+                // identifiers and keywords
+                [
+                    /[a-z_$][\w$]*/,
+                    {
+                        cases: {
+                            '@typeKeywords': 'keyword',
+                            '@keywords': 'keyword',
+                            '@default': 'identifier',
+                        },
+                    },
+                ],
+
+                [/[A-Z][\w$]*/, 'type.identifier'], // to show class names nicely
+
+                // whitespace
+                {include: '@whitespace'},
+
+                // delimiters and operators
+                [/[{}()[\]]/, '@brackets'],
+                [/[<>](?!@symbols)/, '@brackets'],
+                [
+                    /@symbols/,
+                    {
+                        cases: {
+                            '@operators': 'operator',
+                            '@default': '',
+                        },
+                    },
+                ],
+
+                // numbers
+                [/\d*\.\d+([eE][-+]?\d+)?[fFdD]?/, 'number.float'],
+                [/0[xX][0-9a-fA-F_]*[0-9a-fA-F][Ll]?/, 'number.hex'],
+                [/0o[0-7_]*[0-7][Ll]?/, 'number.octal'],
+                [/0[bB][0-1_]*[0-1][Ll]?/, 'number.binary'],
+                [/\d+/, 'number'],
+
+                // delimiter: after number because of .\d floats
+                [/[;,.]/, 'delimiter'],
+
+                // strings
+                [/"([^"\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+                [/c?\\\\.*$/, 'string'],
+                [/c?"/, 'string', '@string'],
+
+                // characters
+                [/'[^\\']'/, 'string'],
+                [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
+                [/'/, 'string.invalid'],
+            ],
+
+            whitespace: [
+                [/[ \r\n]+/, 'white'],
+                [/\/\*/, 'comment', '@comment'],
+                [/\/\+/, 'comment', '@comment'],
+                [/\/\/.*$/, 'comment'],
+                [/\t/, 'comment.invalid'],
+            ],
+
+            comment: [
+                [/[^/*]+/, 'comment'],
+                [/\/\*/, 'comment.invalid'],
+                [/[/*]/, 'comment'],
+            ],
+
+            string: [
+                [/[^\\"]+/, 'string'],
+                [/@escapes/, 'string.escape'],
+                [/\\./, 'string.escape.invalid'],
+                [/"/, 'string', '@pop'],
+            ],
+        },
+    };
+}
+
+monaco.languages.register({id: 'jakt'});
+monaco.languages.setMonarchTokensProvider('jakt', definition());
+
+export {};

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -24,6 +24,7 @@
 
 export type LanguageKey =
     | 'mlir'
+    | 'jakt'
     | 'c++'
     | 'llvm'
     | 'cppx'


### PR DESCRIPTION
See https://github.com/SerenityOS/jakt for the language repository.

Jakt is a new, currently experimental, compiled programming language
designed for the SerenityOS project, especially for OO-style GUI
development. But if the language turns out to be useful, it will
probably be expanded to work for all kinds of systems programming in
SerenityOS.

It's current design for the forseeable future includes a transpilation step
to C++, using parts of the SerenityOS standard library (called AK)
as a runtime to provide underlying implementations for standard types
such as String, HashMap, Array, etc.

As of this point, there are two compiler implementations. The original
implementation is Rust-based, and a selfhosted Jakt compiler is being
developed to replace the Rust-based compiler soon. Then support for the
Rust-based compiler will be dropped.

The Jakt language is still in active development, and many major
features are not yet designed or implemented. At its core is a
philosophy of accurately tracking errors, including allocation failures,
by using value-based exceptions that are part of the function's
signature.

Another strong tenant is first-class C++-interoperability, as most current
SerenityOS code is written in C++.

Due to the included runtime, directly looking at assembly output is
possible but not too insightful. The main point of interest is looking
at the generated C++ code.

See https://github.com/compiler-explorer/infra/pull/765 for the infra integration PR.