### PR TITLE
Make line highlight more visible in dark mode.

### DIFF
--- a/static/themes/dark-theme.scss
+++ b/static/themes/dark-theme.scss
@@ -127,7 +127,7 @@ a.navbar-brand img.logo.normal {
 }
 
 .linked-code-decoration-inline {
-    background: #121212;
+    background: #444444;
 }
 
 .linked-code-decoration-margin {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Proposal to change the line highlight for dark mode, from:
![ce-highlight-before](https://user-images.githubusercontent.com/95592999/177603092-94d9960d-e9b4-4c15-905d-de19fa33a11c.PNG)

to:
![ce-highlight-after](https://user-images.githubusercontent.com/95592999/177603096-d674db52-7918-4b8b-9300-c807594729d6.PNG)

The former is barely visible if the screen is not well calibrated, which happens a lot during conference presentations for example.