### PR TITLE
Get statistics on tools usage per language / compiler

### DIFF
--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -24,11 +24,14 @@
 
 import path from 'path';
 
+import PromClient from 'prom-client';
 import _ from 'underscore';
 
 import * as exec from '../exec';
 import {logger} from '../logger';
 import * as utils from '../utils';
+
+const countersPerTool = {};
 
 export class BaseTool {
     constructor(toolInfo, env) {
@@ -37,6 +40,15 @@ export class BaseTool {
         this.tool.exclude = this.tool.exclude ? this.tool.exclude.split(':') : [];
         this.addOptionsToToolArgs = true;
         this.parseOutput = utils.parseOutput;
+
+        const toolName = this.tool.name;
+        if (toolName && !(toolName in countersPerTool)) {
+            countersPerTool[toolName] = new PromClient.Counter({
+                name: `${toolName.replaceAll(/\W/g, '_').toLowerCase()}_compilation_total`,
+                help: `Number of compilations with ${toolName} active`,
+                labelNames: ['language', 'compiler'],
+            });
+        }
     }
 
     getId() {
@@ -121,6 +133,12 @@ export class BaseTool {
     }
 
     async runTool(compilationInfo, inputFilepath, args, stdin /*, supportedLibraries*/) {
+        if (this.tool.name) {
+            countersPerTool[this.tool.name].inc({
+                language: compilationInfo.compiler.lang,
+                compiler: compilationInfo.compiler.name,
+            });
+        }
         let execOptions = this.getDefaultExecOptions();
         if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);
         execOptions.input = stdin;


### PR DESCRIPTION
As discussed with Matt, adding statistics at the tool level could give precious information to tool developers.