### PR TITLE
Adds way to disable executor recompilation on parameter change

### DIFF
--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -912,25 +912,25 @@ Executor.prototype.shouldEmitExecutionOnFieldChange = function () {
 };
 
 Executor.prototype.onOptionsChange = function (options) {
+    this.options = options;
+    this.saveState();
     if (this.shouldEmitExecutionOnFieldChange()) {
-        this.options = options;
-        this.saveState();
         this.compile();
     }
 };
 
 Executor.prototype.onExecArgsChange = function (args) {
+    this.executionArguments = args;
+    this.saveState();
     if (this.shouldEmitExecutionOnFieldChange()) {
-        this.executionArguments = args;
-        this.saveState();
         this.compile();
     }
 };
 
 Executor.prototype.onExecStdinChange = function (newStdin) {
+    this.executionStdin = newStdin;
+    this.saveState();
     if (this.shouldEmitExecutionOnFieldChange()) {
-        this.executionStdin = newStdin;
-        this.saveState();
         this.compile();
     }
 };

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -806,27 +806,21 @@ Executor.prototype.initCallbacks = function () {
 
     var optionsChange = _.debounce(
         _.bind(function (e) {
-            if (this.settings.executorCompileOnChange) {
-                this.onOptionsChange($(e.target).val());
-            }
+            this.onOptionsChange($(e.target).val());
         }, this),
         800
     );
 
     var execArgsChange = _.debounce(
         _.bind(function (e) {
-            if (this.settings.executorCompileOnChange) {
-                this.onExecArgsChange($(e.target).val());
-            }
+            this.onExecArgsChange($(e.target).val());
         }, this),
         800
     );
 
     var execStdinChange = _.debounce(
         _.bind(function (e) {
-            if (this.settings.executorCompileOnChange) {
-                this.onExecStdinChange($(e.target).val());
-            }
+            this.onExecStdinChange($(e.target).val());
         }, this),
         800
     );
@@ -913,22 +907,32 @@ Executor.prototype.initCallbacks = function () {
     }
 };
 
+Executor.prototype.shouldEmitExecutionOnFieldChange = function () {
+    return this.settings.executorCompileOnChange;
+};
+
 Executor.prototype.onOptionsChange = function (options) {
-    this.options = options;
-    this.saveState();
-    this.compile();
+    if (this.shouldEmitExecutionOnFieldChange()) {
+        this.options = options;
+        this.saveState();
+        this.compile();
+    }
 };
 
 Executor.prototype.onExecArgsChange = function (args) {
-    this.executionArguments = args;
-    this.saveState();
-    this.compile();
+    if (this.shouldEmitExecutionOnFieldChange()) {
+        this.executionArguments = args;
+        this.saveState();
+        this.compile();
+    }
 };
 
 Executor.prototype.onExecStdinChange = function (newStdin) {
-    this.executionStdin = newStdin;
-    this.saveState();
-    this.compile();
+    if (this.shouldEmitExecutionOnFieldChange()) {
+        this.executionStdin = newStdin;
+        this.saveState();
+        this.compile();
+    }
 };
 
 Executor.prototype.onRequestCompilation = function (editorId, treeId) {

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -688,6 +688,8 @@ Executor.prototype.initButtons = function (state) {
     this.wrapButton = this.domRoot.find('.wrap-lines');
     this.wrapTitle = this.wrapButton.prop('title');
 
+    this.triggerCompilationButton = this.bottomBar.find('.trigger-compilation');
+
     this.initToggleButtons(state);
 };
 
@@ -804,21 +806,27 @@ Executor.prototype.initCallbacks = function () {
 
     var optionsChange = _.debounce(
         _.bind(function (e) {
-            this.onOptionsChange($(e.target).val());
+            if (this.settings.executorCompileOnChange) {
+                this.onOptionsChange($(e.target).val());
+            }
         }, this),
         800
     );
 
     var execArgsChange = _.debounce(
         _.bind(function (e) {
-            this.onExecArgsChange($(e.target).val());
+            if (this.settings.executorCompileOnChange) {
+                this.onExecArgsChange($(e.target).val());
+            }
         }, this),
         800
     );
 
     var execStdinChange = _.debounce(
         _.bind(function (e) {
-            this.onExecStdinChange($(e.target).val());
+            if (this.settings.executorCompileOnChange) {
+                this.onExecStdinChange($(e.target).val());
+            }
         }, this),
         800
     );
@@ -872,6 +880,13 @@ Executor.prototype.initCallbacks = function () {
         'click',
         _.bind(function () {
             this.togglePanel(this.toggleCompilerOut, this.compilerOutputSection);
+        }, this)
+    );
+
+    this.triggerCompilationButton.on(
+        'click',
+        _.bind(function () {
+            this.compile(true);
         }, this)
     );
 

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -50,6 +50,7 @@ export interface SiteSettings {
     enableCtrlStree: boolean;
     editorsFFont: string;
     editorsFLigatures: boolean;
+    executorCompileOnChange: boolean;
     defaultFontScale?: number; // the font scale widget can check this setting before the default has been populated
     formatBase: FormatBase;
     formatOnCompile: boolean;
@@ -259,6 +260,7 @@ export class Settings {
             ['.enableCommunityAds', 'enableCommunityAds', true],
             ['.enableCtrlStree', 'enableCtrlStree', true],
             ['.enableSharingPopover', 'enableSharingPopover', true],
+            ['.executorCompileOnChange', 'executorCompileOnChange', true],
             ['.formatOnCompile', 'formatOnCompile', false],
             ['.hoverShowAsmDoc', 'hoverShowAsmDoc', true],
             ['.hoverShowSource', 'hoverShowSource', true],

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -148,10 +148,6 @@
                   label
                     input.compileOnChange(type="checkbox")
                     | Compile automatically when source changes
-                .checkbox
-                  label
-                    input.formatOnCompile(type="checkbox")
-                    | Enable formatting on compilation (for supported languages)
                 div
                   label Delay before compiling:&nbsp;
                     span.delay-current-value &nbsp;
@@ -159,5 +155,13 @@
                     b 0.25s
                     input.delay(type="range")
                     b 3s
+                .checkbox
+                  label
+                    input.formatOnCompile(type="checkbox")
+                    | Enable formatting on compilation (for supported languages)
+                .checkbox
+                  label
+                    input.executorCompileOnChange(type="checkbox")
+                    | Compile executor automatically when arguments change
       .modal-footer
         button.btn.btn-outline-primary(type="button" data-dismiss="modal") Close

--- a/views/templates/panes/executor.pug
+++ b/views/templates/panes/executor.pug
@@ -51,6 +51,8 @@
     .compiler-output
     .execution-output
   .bottom-bar.bg-light
+    button.btn.btn-sm.btn-light.trigger-compilation(title="Trigger compilation")
+      span.fas.fa-redo
     span.short-compiler-name
     button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button")
     span.compile-time(title="Compilation time (Result size)")


### PR DESCRIPTION
Now that this is here, maybe another toggle for tools would also be good
to have. Maybe even for the compiler itself.

And if we go that route, why not 1 for all three kind of panes?

Closes #3783
