### PR TITLE
Fix firejail command options

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -264,7 +264,7 @@ function sandboxFirejail(command, args, options) {
     const jailingOptions = withFirejailTimeout([
         '--quiet',
         '--deterministic-exit-code',
-        '--terminate-orphans',
+        '--deterministic-shutdown',
         '--profile=' + getFirejailProfileFilePath('sandbox'),
         `--private=${execPath}`,
         '--private-cwd',
@@ -446,7 +446,10 @@ async function executeWineDirect(command, args, options) {
 async function executeFirejail(command, args, options) {
     options = _.clone(options) || {};
     const firejail = execProps('firejail');
-    const baseOptions = withFirejailTimeout(['--quiet', '--deterministic-exit-code', '--terminate-orphans'], options);
+    const baseOptions = withFirejailTimeout(
+        ['--quiet', '--deterministic-exit-code', '--deterministic-shutdown'],
+        options,
+    );
     if (needsWine(command)) {
         logger.debug('WINE execution via firejail', {command, args});
         options.env = applyWineEnv(options.env);


### PR DESCRIPTION
Replace `--terminate-orphans` with `--deterministic-shutdown` as it was renamed in the upstream PR https://github.com/netblue30/firejail/pull/4635
