### PR TITLE
Re-enable rescan when launched with pre-discovered compiler list

### DIFF
--- a/app.js
+++ b/app.js
@@ -538,10 +538,14 @@ async function main() {
     const rescanCompilerSecs = ceProps('rescanCompilerSecs', 0);
     if (rescanCompilerSecs) {
         logger.info(`Rescanning compilers every ${rescanCompilerSecs} secs`);
-        setInterval(
-            () => compilerFinder.find().then(result => onCompilerChange(result.compilers)),
-            rescanCompilerSecs * 1000,
-        );
+        let rescanFunction = async () => {
+            let result = await compilerFinder.find();
+            await onCompilerChange(result.compilers);
+        };
+        // initial scan to pick up any changes that happened since the pre-discovery
+        // async so it's non-blocking, delayed so it does not affect boot time
+        setTimeout(rescanFunction, 1000);
+        setInterval(rescanFunction, rescanCompilerSecs * 1000);
     }
 
     const sentrySlowRequestMs = ceProps('sentrySlowRequestMs', 0);

--- a/app.js
+++ b/app.js
@@ -536,7 +536,7 @@ async function main() {
     await onCompilerChange(initialCompilers);
 
     const rescanCompilerSecs = ceProps('rescanCompilerSecs', 0);
-    if (rescanCompilerSecs && !opts.prediscovered) {
+    if (rescanCompilerSecs) {
         logger.info(`Rescanning compilers every ${rescanCompilerSecs} secs`);
         setInterval(
             () => compilerFinder.find().then(result => onCompilerChange(result.compilers)),

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -171,7 +171,10 @@ export class CompileHandler {
         }
     }
 
-    async setCompilers(compilers, clientOptions) {
+    async setCompilers(newCompilers, clientOptions) {
+        const oldCompilers = _.map(_.flatten(_.map(this.compilersById, _.values)), x => x.compiler);
+        // keep both old and new compilers, preferring the new
+        const compilers = _.uniq([...newCompilers, ...oldCompilers], 'id');
         // Be careful not to update this.compilersById until we can replace it entirely.
         const compilersById = {};
         try {

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -174,7 +174,7 @@ export class CompileHandler {
     async setCompilers(newCompilers, clientOptions) {
         const oldCompilers = _.map(_.flatten(_.map(this.compilersById, _.values)), x => x.compiler);
         // keep both old and new compilers, preferring the new
-        const compilers = _.uniq([...newCompilers, ...oldCompilers], 'id');
+        const compilers = _.uniq([...newCompilers, ...oldCompilers], x => [x.lang, x.id]);
         // Be careful not to update this.compilersById until we can replace it entirely.
         const compilersById = {};
         try {


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/3858