### PR TITLE
Add overwrite option to load-save localstorage

### DIFF
--- a/static/widgets/load-save.ts
+++ b/static/widgets/load-save.ts
@@ -95,7 +95,10 @@ export class LoadSave {
         this.modal?.modal('hide');
     }
 
-    private static populate(root: JQuery, list: {name: string; load: () => void; delete?: () => void, overwrite?: () => void}[]) {
+    private static populate(
+        root: JQuery,
+        list: {name: string; load: () => void; delete?: () => void; overwrite?: () => void}[]
+    ) {
         root.find('li:not(.template)').remove();
         const template = root.find('.template');
         for (const elem of list) {

--- a/static/widgets/load-save.ts
+++ b/static/widgets/load-save.ts
@@ -95,15 +95,19 @@ export class LoadSave {
         this.modal?.modal('hide');
     }
 
-    private static populate(root: JQuery, list: {name: string; load: () => void; delete?: () => void}[]) {
+    private static populate(root: JQuery, list: {name: string; load: () => void; delete?: () => void, overwrite?: () => void}[]) {
         root.find('li:not(.template)').remove();
         const template = root.find('.template');
         for (const elem of list) {
             const clone = template.clone();
             clone.removeClass('template').appendTo(root).find('a').text(elem.name).on('click', elem.load);
-            const deleteButton = clone.find('button');
+            const deleteButton = clone.find('button.delete');
             if (elem.delete !== undefined) {
                 deleteButton.on('click', () => elem.delete?.());
+            }
+            const overwriteButton = clone.find('button.overwrite');
+            if (elem.overwrite !== undefined) {
+                overwriteButton.on('click', () => elem.overwrite?.());
             }
         }
     }
@@ -144,6 +148,18 @@ export class LoadSave {
                             {
                                 yes: () => {
                                     LoadSave.removeLocalFile(name);
+                                    this.populateLocalStorage();
+                                },
+                            }
+                        );
+                    },
+                    overwrite: () => {
+                        this.alertSystem.ask(
+                            `Overwrite ${_.escape(name)}?`,
+                            `Do you want to overwrite '${_.escape(name)}'?`,
+                            {
+                                yes: () => {
+                                    LoadSave.setLocalFile(name, this.editorText);
                                     this.populateLocalStorage();
                                 },
                             }

--- a/static/widgets/load-save.ts
+++ b/static/widgets/load-save.ts
@@ -31,6 +31,8 @@ import {Language} from '../../types/languages.interfaces';
 
 const history = require('../history');
 
+type PopulateItem = {name: string; load: () => void; delete?: () => void; overwrite?: () => void};
+
 export class LoadSave {
     private modal: JQuery | null = null;
     private alertSystem: Alert;
@@ -97,7 +99,7 @@ export class LoadSave {
 
     private static populate(
         root: JQuery,
-        list: {name: string; load: () => void; delete?: () => void; overwrite?: () => void}[]
+        list: PopulateItem[]
     ) {
         root.find('li:not(.template)').remove();
         const template = root.find('.template');

--- a/views/popups/load-save.pug
+++ b/views/popups/load-save.pug
@@ -24,7 +24,10 @@
               ul.local-storage.small-v-scrollable
                 li.template
                   a(href="javascript:;")
-                  button.btn.btn-sm.ml-5
+                  button.overwrite.btn.btn-sm.ml-auto
+                    span.fa.fa-edit
+                    | Overwrite
+                  button.delete.btn.btn-sm.ml-5
                     span.fa.fa-trash
               .input-group
                 input.save-name(type="text" size="20" placeholder="Set name of state")

--- a/views/popups/load-save.pug
+++ b/views/popups/load-save.pug
@@ -23,12 +23,13 @@
               h4.card-title Load from browser-local storage:
               ul.local-storage.small-v-scrollable
                 li.template
-                  a(href="javascript:;")
-                  button.overwrite.btn.btn-sm.ml-auto
-                    span.fa.fa-edit
+                  a.mr-3(href="javascript:;")
+                  button.overwrite.btn.btn-sm.btn-light.mr-1
+                    span.fa.fa-edit.mr-1
                     | Overwrite
-                  button.delete.btn.btn-sm.ml-5
-                    span.fa.fa-trash
+                  button.delete.btn.btn-sm.btn-light
+                    span.fa.fa-trash.mr-1
+                    | Delete
               .input-group
                 input.save-name(type="text" size="20" placeholder="Set name of state")
                 .input-group-append


### PR DESCRIPTION
Adds a button to overwrite localstorage entries in load-save.

Needs some UI changes before it can be merged.

Closes #3876 