### PR TITLE
Skip full version button in info pane if not needed

### DIFF
--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2789,7 +2789,7 @@ Compiler.prototype.setCompilerVersionPopover = function (version, notification) 
     var bodyContent = $('<div>');
     var versionContent = $('<div>').html(_.escape(version.version));
     bodyContent.append(versionContent);
-    if (version.fullVersion) {
+    if (version.fullVersion && version.fullVersion.trim() !== version.version.trim()) {
         var hiddenSection = $('<div>');
         var lines = _.map(version.fullVersion.split('\n'), function (line) {
             return _.escape(line);


### PR DESCRIPTION
if the two strings are the same if trimmed, then don't display the button to toggle between them