### PR TITLE
Fix gccdump

### DIFF
--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -290,7 +290,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         this.inhibitPassSelect = true;
 
         selectize.clear(true);
-        selectize.clearOptions(true);
+        selectize.clearOptions();
 
         for (const p of passes) {
             selectize.addOption(p);

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -83,7 +83,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         if (state._treeid) state.treeid = state._treeid;
         super(hub, container, state);
 
-        if (state.selectedPass) {
+        if (state.selectedPass && typeof state.selectedPass === 'string') {
             // To keep URL format stable wrt GccDump, only a string of the form 'r.expand' is stored.
             // Old links also have the pass number prefixed but this can be ignored.
             // Create the object that will be used instead of this bare string.


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/3886

Tom-select recently changed their `clearOptions()` function to add a parameter, previously it did not take any parameters but we still passed `true` to it. https://github.com/orchidjs/tom-select/commit/049f5a65e444e6c861599c8971299ce3ed3a02f7#diff-a5b86ab78740a77920c9adb8e6fbccfab70018b535d22a39d2f2b91d5bd1c21aR1774
