### PR TITLE
Allow having an icon for the tools.

### DIFF
--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -150,6 +150,8 @@ export class ClientOptionsHandler {
                                 languageId: this.compilerProps(lang, toolBaseName + '.languageId'),
                                 stdinHint: this.compilerProps(lang, toolBaseName + '.stdinHint'),
                                 monacoStdin: this.compilerProps(lang, toolBaseName + '.monacoStdin'),
+                                icon: this.compilerProps(lang, toolBaseName + '.icon'),
+                                darkIcon: this.compilerProps(lang, toolBaseName + '.darkIcon'),
                                 compilerLanguage: lang,
                             },
                             {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -47,7 +47,7 @@ var utils = require('../utils');
 var LibUtils = require('../lib-utils');
 var getAssemblyDocumentation = require('../api/api').getAssemblyDocumentation;
 var PaneRenaming = require('../widgets/pane-renaming').PaneRenaming;
-var logos = require.context('../../views/resources/logos', false, /\.(png|svg)$/);
+var toolIcons = require.context('../../views/resources/logos', false, /\.(png|svg)$/);
 
 var OpcodeCache = new LruCache({
     max: 64 * 1024,
@@ -2090,8 +2090,8 @@ Compiler.prototype.initToolButtons = function (togglePannerAdder) {
         btn.addClass('view-' + toolName);
         btn.data('toolname', toolName);
         if (toolIcon) {
-            const light = logos(toolIcon);
-            const dark = toolIconDark ? logos(toolIconDark) : light;
+            const light = toolIcons(toolIcon);
+            const dark = toolIconDark ? toolIcons(toolIconDark) : light;
             btn.append(
                 `<span class="dropdown-icon fas">
                 <img src="${light}" class="theme-light-only" width="16px" style="max-height: 16px"/>

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -47,6 +47,7 @@ var utils = require('../utils');
 var LibUtils = require('../lib-utils');
 var getAssemblyDocumentation = require('../api/api').getAssemblyDocumentation;
 var PaneRenaming = require('../widgets/pane-renaming').PaneRenaming;
+var logos = require.context('../../views/resources/logos', false, /\.(png|svg)$/);
 
 var OpcodeCache = new LruCache({
     max: 64 * 1024,
@@ -2084,11 +2085,23 @@ Compiler.prototype.initToolButtons = function (togglePannerAdder) {
 
     if (!this.compiler) return;
 
-    var addTool = _.bind(function (toolName, title) {
+    var addTool = _.bind(function (toolName, title, toolIcon, toolIconDark) {
         var btn = $("<button class='dropdown-item btn btn-light btn-sm'>");
         btn.addClass('view-' + toolName);
         btn.data('toolname', toolName);
-        btn.append("<span class='dropdown-icon fas fa-cog'></span>" + title);
+        if (toolIcon) {
+            const light = logos(toolIcon);
+            const dark = toolIconDark ? logos(toolIconDark) : light;
+            btn.append(
+                `<span class="dropdown-icon fas">
+                <img src="${light}" class="theme-light-only" width="16px" style="max-height: 16px"/>
+                <img src="${dark}" class="theme-dark-only" width="16px" style="max-height: 16px"/>
+                </span>`
+            );
+        } else {
+            btn.append("<span class='dropdown-icon fas fa-cog'></span>");
+        }
+        btn.append(title);
         this.toolsMenu.append(btn);
 
         if (toolName !== 'none') {
@@ -2103,7 +2116,7 @@ Compiler.prototype.initToolButtons = function (togglePannerAdder) {
             this.compiler.tools,
             _.bind(function (tool) {
                 if (this.isSupportedTool(tool)) {
-                    addTool(tool.tool.id, tool.tool.name);
+                    addTool(tool.tool.id, tool.tool.name, tool.tool.icon, tool.tool.darkIcon);
                 }
             }, this)
         );

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -525,6 +525,8 @@ describe('Options handler', () => {
                         options: [],
                         stdinHint: 'disabled',
                         type: 'independent',
+                        icon: undefined,
+                        darkIcon: undefined,
                     },
                 },
                 someothertool: {
@@ -543,6 +545,8 @@ describe('Options handler', () => {
                         options: [],
                         stdinHint: 'disabled',
                         type: 'independent',
+                        icon: undefined,
+                        darkIcon: undefined,
                     },
                 },
             },


### PR DESCRIPTION
That would allow replacing the default cog icon with a custom 16px high icon (which should probably always be white/black to avoid noise)
![image](https://user-images.githubusercontent.com/95592999/180212315-7c0fd86a-58cc-48cc-9c2f-e688811ad57f.png)
