### PR TITLE
Introduce quick-fixes.

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -35,6 +35,7 @@ var Alert = require('../alert').Alert;
 var ga = require('../analytics').ga;
 var monacoVim = require('monaco-vim');
 var monacoConfig = require('../monaco-config');
+var quickFixesHandler = require('../quick-fixes-handler');
 var TomSelect = require('tom-select');
 var Settings = require('../settings').Settings;
 var utils = require('../utils');
@@ -1374,7 +1375,9 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
     if (!this.ourCompilers[compilerId]) return;
 
     this.busyCompilers[compilerId] = false;
+    const editorModel = this.editor.getModel();
     var output = this.getAllOutputAndErrors(result, compiler.name, compilerId);
+    var fixes = [];
     var widgets = _.compact(
         _.map(
             output,
@@ -1418,7 +1421,7 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                         target: obj.tag.link.url,
                     };
                 }
-                return {
+                const diag = {
                     severity: obj.tag.severity,
                     message: obj.tag.text,
                     source: obj.source,
@@ -1428,11 +1431,33 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                     endColumn: colEnd,
                     code: link,
                 };
+                if (obj.tag.fixes) {
+                    fixes.push(
+                        ...obj.tag.fixes.map((fs, ind) => {
+                            return {
+                                title: fs.title,
+                                diagnostics: [diag],
+                                kind: 'quickfix',
+                                edit: {
+                                    edits: fs.edits.map(f => ({
+                                        resource: editorModel.uri,
+                                        edit: {
+                                            range: new monaco.Range(f.line, f.column, f.endline, f.endcolumn),
+                                            text: f.text,
+                                        },
+                                    })),
+                                },
+                                isPreferred: ind === 0,
+                            };
+                        })
+                    );
+                }
+                return diag;
             },
             this
         )
     );
-    monaco.editor.setModelMarkers(this.editor.getModel(), compilerId, widgets);
+    monaco.editor.setModelMarkers(editorModel, compilerId, widgets);
     this.decorations.tags = _.map(
         widgets,
         function (tag) {
@@ -1446,6 +1471,14 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
         },
         this
     );
+
+    if (fixes.length) {
+        quickFixesHandler.registerQuickFixesForCompiler(this.id, editorModel, fixes);
+        quickFixesHandler.registerProviderForLanguage(editorModel.getLanguageId());
+    } else {
+        quickFixesHandler.unregister(this.id);
+    }
+
     this.updateDecorations();
 
     if (result.result && result.result.asm) {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1375,7 +1375,7 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
     if (!this.ourCompilers[compilerId]) return;
 
     this.busyCompilers[compilerId] = false;
-    const editorModel = this.editor.getModel();
+    var editorModel = this.editor.getModel();
     var output = this.getAllOutputAndErrors(result, compiler.name, compilerId);
     var fixes = [];
     var widgets = _.compact(

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1439,13 +1439,15 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                                 diagnostics: [diag],
                                 kind: 'quickfix',
                                 edit: {
-                                    edits: fs.edits.map(f => ({
-                                        resource: editorModel.uri,
-                                        edit: {
-                                            range: new monaco.Range(f.line, f.column, f.endline, f.endcolumn),
-                                            text: f.text,
-                                        },
-                                    })),
+                                    edits: fs.edits.map(function (f) {
+                                        return {
+                                            resource: editorModel.uri,
+                                            edit: {
+                                                range: new monaco.Range(f.line, f.column, f.endline, f.endcolumn),
+                                                text: f.text,
+                                            },
+                                        };
+                                    }),
                                 },
                                 isPreferred: ind === 0,
                             };

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1432,8 +1432,8 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                     code: link,
                 };
                 if (obj.tag.fixes) {
-                    fixes.push(
-                        ...obj.tag.fixes.map((fs, ind) => {
+                    fixes = fixes.concat(
+                        obj.tag.fixes.map(function (fs, ind) {
                             return {
                                 title: fs.title,
                                 diagnostics: [diag],

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1421,7 +1421,7 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
                         target: obj.tag.link.url,
                     };
                 }
-                const diag = {
+                var diag = {
                     severity: obj.tag.severity,
                     message: obj.tag.text,
                     source: obj.source,

--- a/static/quick-fixes-handler.ts
+++ b/static/quick-fixes-handler.ts
@@ -25,11 +25,11 @@
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 
-interface RegisteredQuickFixes {
+type RegisteredQuickFixes = {
     compilerId: number;
     editorModel: monaco.editor.ITextModel;
     fixes: monaco.languages.CodeAction[];
-}
+};
 
 let registeredQuickFixes: RegisteredQuickFixes[] = [];
 const providersPerLanguage: Record<string, monaco.IDisposable> = {};

--- a/static/quick-fixes-handler.ts
+++ b/static/quick-fixes-handler.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Compiler Explorer Authors
+// Copyright (c) 2022, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/static/quick-fixes-handler.ts
+++ b/static/quick-fixes-handler.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2020, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import _ from 'underscore';
+import * as monaco from 'monaco-editor';
+
+interface RegisteredQuickFixes {
+    compilerId: number;
+    editorModel: monaco.editor.ITextModel;
+    fixes: monaco.languages.CodeAction[];
+}
+
+let registeredQuickFixes: RegisteredQuickFixes[] = [];
+const providersPerLanguage: Record<string, monaco.IDisposable> = {};
+
+export function registerQuickFixesForCompiler(
+    compilerId: number,
+    editorModel: monaco.editor.ITextModel,
+    fixes: monaco.languages.CodeAction[]
+): void {
+    const item = _.find(registeredQuickFixes, (item: RegisteredQuickFixes): boolean => {
+        return item.compilerId === compilerId;
+    });
+
+    if (item) {
+        item.fixes = fixes;
+    } else {
+        registeredQuickFixes.push({
+            compilerId: compilerId,
+            editorModel: editorModel,
+            fixes: fixes,
+        });
+    }
+}
+
+function provide(
+    model: monaco.editor.ITextModel,
+    range: monaco.Range,
+    context: monaco.languages.CodeActionContext
+): monaco.languages.CodeActionList {
+    const item = _.find(registeredQuickFixes, (item: RegisteredQuickFixes): boolean => {
+        return item.editorModel === model;
+    });
+
+    if (item) {
+        return {
+            actions: item.fixes.filter(f =>
+                f.diagnostics?.some(d =>
+                    context.markers.some(m => {
+                        const diagnostic = _.pick(
+                            d,
+                            'message',
+                            'startLineNumber',
+                            'startColumn',
+                            'endLineNumber',
+                            'endColumn'
+                        );
+                        const marker = _.pick(
+                            m,
+                            'message',
+                            'startLineNumber',
+                            'startColumn',
+                            'endLineNumber',
+                            'endColumn'
+                        );
+                        return _.isEqual(marker, diagnostic);
+                    })
+                )
+            ),
+            dispose: function () {},
+        };
+    } else {
+        return {
+            actions: [],
+            dispose: function () {},
+        };
+    }
+}
+
+export function unregister(compilerId: number): void {
+    const item = _.find(registeredQuickFixes, (item: RegisteredQuickFixes): boolean => {
+        return item.compilerId === compilerId;
+    });
+
+    if (item) {
+        registeredQuickFixes = _.without(registeredQuickFixes, item);
+    }
+}
+
+export function registerProviderForLanguage(language: string): void {
+    if (!(language in providersPerLanguage)) {
+        providersPerLanguage[language] = monaco.languages.registerCodeActionProvider(language, {
+            provideCodeActions: provide,
+        });
+    }
+}

--- a/types/resultline/resultline.interfaces.ts
+++ b/types/resultline/resultline.interfaces.ts
@@ -3,6 +3,11 @@ export type Link = {
     url: string;
 };
 
+export type Fix = {
+    title: string;
+    edits: MessageWithLocation[];
+};
+
 export type MessageWithLocation = {
     line?: number;
     column?: number;
@@ -16,6 +21,7 @@ export type ResultLineTag = MessageWithLocation & {
     severity: number;
     link?: Link;
     flow?: MessageWithLocation[];
+    fixes?: Fix[];
 };
 
 export type ResultLine = {


### PR DESCRIPTION
Monaco can provide quick fixes for errors. They appear as a small lightbulb at the beginning of the line, that you can click (or you can press Ctrl + ., or you can use the hover menu). When triggering the quick fix, the error will be fixed automatically.
![image](https://user-images.githubusercontent.com/95592999/180219836-db98e129-932a-4027-8a8e-bd9aedf0e955.png)
![image](https://user-images.githubusercontent.com/95592999/180220172-476396d5-8603-4013-954e-f4878193223d.png)
![image](https://user-images.githubusercontent.com/95592999/180220367-8a0abcce-2a32-454b-bd28-9e02b7047bde.png)
With this PR, it becomes possible to attach fixes to ResultLine tags.
The way to pass information from the editor and the `CodeActionProvider` is inspired by codelens-handler.