### PR TITLE
Use ClangParser for cmdline options for LDC

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2416,7 +2416,7 @@ but nothing was dumped. Possible causes are:
 
     protected getArgumentParser(): any {
         const exe = this.compiler.exe.toLowerCase();
-        if (exe.includes('clang') || exe.includes('icpx') || exe.includes('icx')) {
+        if (exe.includes('clang') || exe.includes('icpx') || exe.includes('icx') || exe.includes('ldc2')) {
             // check this first as "clang++" matches "g++"
             return ClangParser;
         } else if (exe.includes('g++') || exe.includes('gcc')) {


### PR DESCRIPTION
LDC is more likely to copy Clang cmdline options than GCC.

This PR _should_ enable automatically recognizing `-fno-discard-value-names` option when it is added to LDC (https://github.com/ldc-developers/ldc/pull/4012), to be used for the LLVM optimization pipeline view (https://d.godbolt.org/z/zhKa9h6r1).