### PR TITLE
Give LDC its own LDCParser for cmdline options.

### DIFF
--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -199,6 +199,51 @@ export class ClangParser extends BaseParser {
     }
 }
 
+export class LDCParser extends BaseParser {
+    static setCompilerSettingsFromOptions(compiler, options) {
+        if (BaseParser.hasSupport(options, '--fsave-optimization-record')) {
+            compiler.compiler.optArg = '--fsave-optimization-record';
+            compiler.compiler.supportsOptOutput = true;
+        }
+
+        if (
+            BaseParser.hasSupport(options, '--print-before-all') &&
+            BaseParser.hasSupport(options, '--print-after-all')
+        ) {
+            compiler.compiler.supportsLLVMOptPipelineView = true;
+            compiler.compiler.llvmOptArg = ['--print-before-all', '--print-after-all'];
+            compiler.compiler.llvmOptModuleScopeArg = [];
+            compiler.compiler.llvmOptNoDiscardValueNamesArg = [];
+            if (BaseParser.hasSupport(options, '--print-module-scope')) {
+                compiler.compiler.llvmOptModuleScopeArg = ['--print-module-scope'];
+            }
+            if (BaseParser.hasSupport(options, '--fno-discard-value-names')) {
+                compiler.compiler.llvmOptNoDiscardValueNamesArg = ['--fno-discard-value-names'];
+            }
+        }
+
+        if (BaseParser.hasSupport(options, '--enable-color')) {
+            compiler.compiler.options += ' --enable-color';
+        }
+    }
+
+    static async parse(compiler) {
+        const options = await LDCParser.getOptions(compiler, '--help-hidden');
+        this.setCompilerSettingsFromOptions(compiler, options);
+        return compiler;
+    }
+
+    static async getOptions(compiler, helpArg, populate = true) {
+        const optionFinder = /^\s*(--?[\d+,<=>[\]a-z|-]*)\s*(.*)/i;
+        const result = await compiler.execCompilerCached(compiler.compiler.exe, helpArg.split(' '));
+        const options = result.code === 0 ? BaseParser.parseLines(result.stdout + result.stderr, optionFinder) : {};
+        if (populate) {
+            compiler.possibleArguments.populateOptions(options);
+        }
+        return options;
+    }
+}
+
 export class ErlangParser extends BaseParser {
     static async parse(compiler) {
         await ErlangParser.getOptions(compiler, '-help');

--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -30,7 +30,7 @@ import semverParser from 'semver';
 import {BaseCompiler} from '../base-compiler';
 import {logger} from '../logger';
 
-import {ClangParser} from './argument-parsers';
+import {LDCParser} from './argument-parsers';
 
 export class LDCCompiler extends BaseCompiler {
     static get key() {
@@ -42,11 +42,6 @@ export class LDCCompiler extends BaseCompiler {
         this.compiler.supportsIntel = true;
         this.compiler.supportsIrView = true;
         this.compiler.irArg = ['-output-ll'];
-
-        this.compiler.supportsLLVMOptPipelineView = true;
-        this.compiler.llvmOptArg = ['--print-after-all', '--print-before-all'];
-        this.compiler.llvmOptModuleScopeArg = ['--print-module-scope'];
-        this.compiler.llvmOptNoDiscardValueNamesArg = []; // LDC does not have a flag for this yet.
 
         this.asanSymbolizerPath = this.compilerProps('llvmSymbolizer');
     }
@@ -73,7 +68,7 @@ export class LDCCompiler extends BaseCompiler {
     }
 
     getArgumentParser() {
-        return ClangParser;
+        return LDCParser;
     }
 
     filterUserOptions(userOptions) {


### PR DESCRIPTION
LDC does not quite copy Clang cmdline options, so it's best to implement its own parser.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
