### PR TITLE
Temporary fix for #3856

### DIFF
--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -46,9 +46,15 @@ interface DebugLoc {
 
 function DisplayOptInfo(optInfo: LLVMOptInfo) {
     return optInfo.Args.reduce((acc, x) => {
-        return (
-            acc + R.pipe(R.partial(R.pickBy, [(v: any, k: string) => k !== 'DebugLoc']), R.toPairs, R.head, R.last)(x)
-        );
+        let inc = '';
+        for (const [key, value] of Object.entries(x)) {
+            if (key === 'DebugLoc') {
+                inc += ' (' + value['Line'] + ':' + value['Column'] + ')';
+            } else {
+                inc += value;
+            }
+        }
+        return acc + inc;
     }, '');
 }
 


### PR DESCRIPTION
Add DebugLoc data to opt remarks, in the simple form `(Line:Col)`. Eg the "(4:0)" here:
![image](https://user-images.githubusercontent.com/73080/180651284-c4432b8e-d597-40c0-9f8b-53d403df32ad.png)


