### PR TITLE
Make output button bring the pane up if it's already open

### DIFF
--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -34,6 +34,7 @@ import {Motd} from './motd.interfaces';
 // This list comes from executing
 // grep -rPo "eventHub\.(on|emit)\('.*'," static/ | cut -d "'" -f2 | sort | uniq
 export type EventMap = {
+    activateOutputTab: (compilerId: number) => void;
     astViewClosed: (compilerId: number) => void;
     astViewOpened: (compilerId: number) => void;
     broadcastFontScale: (scale: number) => void;

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -229,9 +229,13 @@ Compiler.prototype.initPanerButtons = function () {
     this.container.layoutManager.createDragSource(this.outputBtn, outputConfig);
     this.outputBtn.click(
         _.bind(function () {
-            var insertPoint =
-                this.hub.findParentRowOrColumn(this.container) || this.container.layoutManager.root.contentItems[0];
-            insertPoint.addChild(outputConfig);
+            if (this.isOutputOpened) {
+                this.eventHub.emit('activateOutputTab', this.id);
+            } else {
+                var insertPoint =
+                    this.hub.findParentRowOrColumn(this.container) || this.container.layoutManager.root.contentItems[0];
+                insertPoint.addChild(outputConfig);
+            }
         }, this)
     );
 
@@ -1525,7 +1529,7 @@ Compiler.prototype.onToolClosed = function (compilerId, toolSettings) {
 Compiler.prototype.onOutputOpened = function (compilerId) {
     if (this.id === compilerId) {
         this.isOutputOpened = true;
-        this.outputBtn.prop('disabled', true);
+        //this.outputBtn.prop('disabled', true);
         this.resendResult();
     }
 };
@@ -1533,7 +1537,7 @@ Compiler.prototype.onOutputOpened = function (compilerId) {
 Compiler.prototype.onOutputClosed = function (compilerId) {
     if (this.id === compilerId) {
         this.isOutputOpened = false;
-        this.outputBtn.prop('disabled', false);
+        //this.outputBtn.prop('disabled', false);
     }
 };
 
@@ -2126,6 +2130,8 @@ Compiler.prototype.enableToolButtons = function () {
 // eslint-disable-next-line max-statements
 Compiler.prototype.updateButtons = function () {
     if (!this.compiler) return;
+    //this.outputBtn.prop('disabled', this.isOutputOpened);
+
     var filters = this.getEffectiveFilters();
     // We can support intel output if the compiler supports it, or if we're compiling
     // to binary (as we can disassemble it however we like).

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -131,9 +131,17 @@ export class Output extends Pane<OutputState> {
             this.onKeydownCallback(e);
         };
 
+        this.eventHub.on('activateOutputTab', this.onActivateOutputTab.bind(this));
+
         $(document).on('click', this.clickCallback);
         // domRoot is not sufficient here
         $(document).on('keydown', this.keydownCallback);
+    }
+
+    onActivateOutputTab(compilerId: number) {
+        if (this.compilerInfo.compilerId === compilerId) {
+            this.hub.activateTabForContainer(this.container);
+        }
     }
 
     onOptionsChange() {


### PR DESCRIPTION
I don't really like this approach, as it's 0% reusable with the other panes,
so I'll try to see if I can come up with something better.

The ideal way would be to have something that works for every
"once-per-pane" pane.

Closes #2299