### PR TITLE
Small addition to #3908: Exclude bogus DebugLoc from opt remarks

### DIFF
--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -48,7 +48,7 @@ function DisplayOptInfo(optInfo: LLVMOptInfo) {
     return optInfo.Args.reduce((acc, x) => {
         let inc = '';
         for (const [key, value] of Object.entries(x)) {
-            if (key === 'DebugLoc') {
+            if (key === 'DebugLoc' && value['Line'] !== 0) {
                 inc += ' (' + value['Line'] + ':' + value['Column'] + ')';
             } else {
                 inc += value;


### PR DESCRIPTION
Eliminate artifacts like this `f (0:0)`:
![image](https://user-images.githubusercontent.com/73080/181044789-205b2ca3-b7c5-4eb7-a01d-ecd2ea20e960.png)

The previous PR is closed, gotta open a new one.