### PR TITLE
Add basic CIRCT compiler support.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,9 @@ lang-c++-opencl:
 lang-circle:
   - lib/compilers/circle.js
   - etc/config/circle.*.properties
+lang-circt:
+  - lib/compilers/circt.ts
+  - etc/config/circt.*.properties
 lang-clean:
   - lib/compilers/clean.js
   - etc/config/clean.*.properties

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -120,3 +120,4 @@ From oldest to newest contributor, we would like to thank:
 - [Adam Sandberg Eriksson](https://github.com/adamse)
 - [Ofek Shilon](https://github.com/ofekshilon)
 - [Ross Smyth](https://github.com/RossSmyth)
+- [Mike Urbach](https://github.com/mikeurbach)

--- a/etc/config/circt.amazon.properties
+++ b/etc/config/circt.amazon.properties
@@ -8,6 +8,7 @@ supportsAsmDocs=false
 
 group.circtopt.compilers=circtopt-trunk
 group.circtopt.isSemVer=false
-group.circtopt.baseName=CIRCT opt
+group.circtopt.groupName=CIRCT opt
 
 compiler.circtopt-trunk.exe=/opt/compiler-explorer/circt-trunk/bin/circt-opt
+compiler.circtopt-trunk.name=CIRCT opt (trunk)

--- a/etc/config/circt.amazon.properties
+++ b/etc/config/circt.amazon.properties
@@ -1,13 +1,13 @@
 compilers=&circtopt
-defaultCompiler=circtopt-trunk-20220713
+defaultCompiler=circtopt-trunk
 compilerType=mlir
 
 supportsBinary=false
 supportsExecute=false
 supportsAsmDocs=false
 
-group.circtopt.compilers=circtopt-trunk-20220713
+group.circtopt.compilers=circtopt-trunk
 group.circtopt.isSemVer=false
 group.circtopt.baseName=CIRCT opt
 
-compiler.circtopt-trunk-20220713.exe=/opt/compiler-explorer/circt-circt-trunk-20220713/bin/circt-opt
+compiler.circtopt-trunk.exe=/opt/compiler-explorer/circt-trunk/bin/circt-opt

--- a/etc/config/circt.amazon.properties
+++ b/etc/config/circt.amazon.properties
@@ -1,0 +1,13 @@
+compilers=&circtopt
+defaultCompiler=circtopt-trunk-20220713
+compilerType=mlir
+
+supportsBinary=false
+supportsExecute=false
+supportsAsmDocs=false
+
+group.circtopt.compilers=circtopt-trunk-20220713
+group.circtopt.isSemVer=false
+group.circtopt.baseName=CIRCT opt
+
+compiler.circtopt-trunk-20220713.exe=/opt/compiler-explorer/circt-circt-trunk-20220713/bin/circt-opt

--- a/etc/config/circt.defaults.properties
+++ b/etc/config/circt.defaults.properties
@@ -1,0 +1,13 @@
+compilers=&circtopt
+defaultCompiler=circtopt
+compilerType=mlir
+
+supportsBinary=false
+supportsExecute=false
+supportsAsmDocs=false
+
+group.circtopt.compilers=circtopt
+group.circtopt.isSemVer=false
+group.circtopt.baseName=CIRCT opt
+
+compiler.circtopt.exe=/usr/bin/circt-opt

--- a/examples/circt/default.mlir
+++ b/examples/circt/default.mlir
@@ -1,0 +1,11 @@
+// Example code of a simple counter.
+// CIRCT example code may not always work out of the box because the textual MLIR format is not always stable.
+// The example tries to be compatible with the latest CIRCT version, using relatively stable IR.
+
+hw.module @Counter(%clock: i1, %reset: i1) -> (count: i8) {
+  %c0_i8 = hw.constant 0 : i8
+  %c1_i8 = hw.constant 1 : i8
+  %counter = seq.compreg %0, %clock, %reset, %c0_i8  : i8
+  %0 = comb.add %counter, %c1_i8 : i8
+  hw.output %counter : i8
+}

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -30,6 +30,7 @@ export {NasmCompiler} from './nasm';
 export {CarbonCompiler} from './carbon';
 export {Cc65Compiler} from './cc65';
 export {CircleCompiler} from './circle';
+export {CIRCTCompiler} from './circt';
 export {ClangCompiler} from './clang';
 export {ClangCudaCompiler} from './clang';
 export {ClangHipCompiler} from './clang';

--- a/lib/compilers/circt.ts
+++ b/lib/compilers/circt.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import {ParseFilters} from '../../types/features/filters.interfaces';
+import {BaseCompiler} from '../base-compiler';
+
+import {BaseParser} from './argument-parsers';
+
+export class CIRCTCompiler extends BaseCompiler {
+    static get key() {
+        return 'circt';
+    }
+
+    constructor(compilerInfo, env) {
+        if (!compilerInfo.disabledFilters) {
+            compilerInfo.disabledFilters = [
+                'binary',
+                'execute',
+                'demangle',
+                'intel',
+                'labels',
+                'libraryCode',
+                'directives',
+                'commentOnly',
+                'trim',
+            ];
+        }
+        super(compilerInfo, env);
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {
+        return path.join(dirPath, 'example.out.mlir');
+    }
+
+    override optionsForBackend(backendOptions, outputFilename): string[] {
+        return ['-o', outputFilename];
+    }
+
+    override getArgumentParser(): any {
+        return BaseParser;
+    }
+
+    override optionsForFilter(filters: ParseFilters, outputFilename, userOptions?): any[] {
+        return [];
+    }
+}

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -113,6 +113,16 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         logoUrlDark: null,
         formatter: null,
     },
+    circt: {
+        name: 'CIRCT',
+        monaco: 'mlir',
+        extensions: ['.mlir'],
+        alias: [],
+        logoUrl: 'circt.svg',
+        formatter: null,
+        logoUrlDark: null,
+        previewFilter: null,
+    },
     clean: {
         name: 'Clean',
         monaco: 'clean',

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -57,6 +57,7 @@ export type LanguageKey =
     | 'nim'
     | 'crystal'
     | 'circle'
+    | 'circt'
     | 'ruby'
     | 'cmake'
     | 'csharp'

--- a/views/resources/logos/circt.svg
+++ b/views/resources/logos/circt.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="112" height="112" version="1.1" viewBox="0 0 112 112" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <g fill="#808080">
+  <rect x="64" y="8" width="8" height="48"/>
+  <path d="m80 8v48h8v-24l8 24h8l-8-24h8v-24zm8 8h8v8h-8z"/>
+  <path d="m64 64v8h16v32h8v-32h16v-8z"/>
+  <path d="m55 8c-17 0.2-33 9-41 24-9 15-9 33 0 48 9 15 25 24 42 24h16v-8h-16c-14 0.1-28-8-35-20-7-12-7-28 0-40 7-12 21-20 35-20v-8c-0.3-7e-5 -0.7 0-1 0z"/>
+ </g>
+</svg>


### PR DESCRIPTION
This adds basic support for CIRCT as requested in #3825. The addition
is based on the similar additions for MLIR in #3733 and #3770.