### PR TITLE
Repair http(s) includes after formatting

### DIFF
--- a/lib/formatters/clang-format.ts
+++ b/lib/formatters/clang-format.ts
@@ -36,16 +36,15 @@ export class ClangFormatFormatter extends BaseFormatter {
     override async format(source: string, options: FormatOptions): Promise<UnprocessedExecResult> {
         const tabText = options.useSpaces ? 'Never' : 'AlignWithSpaces';
         const arg = `{BasedOnStyle: ${options.baseStyle}, IndentWidth: ${options.tabWidth}, UseTab: ${tabText}}`;
-        return exec.execute(this.formatterInfo.exe, [`--style=${arg}`], {input: source}).then(result => {
-            if (result.code === 0) {
-                // Repair http(s) includes, i.e., remove the spaces inserted before the hier-part of the URI
-                const includeFind = /^(\s*#\s*include\s*["<]https?:)\s+(\/\/[^">]+[">].*)/;
-                const includeReplacement = '$1$2';
-                const lines = result.stdout.split('\n');
-                for (const idx in lines) lines[idx] = lines[idx].replace(includeFind, includeReplacement);
-                result.stdout = lines.join('\n');
-            }
-            return new Promise((resolve, _reject) => resolve(result));
-        });
+        const result = await exec.execute(this.formatterInfo.exe, [`--style=${arg}`], {input: source});
+        if (result.code === 0) {
+            // Repair http(s) includes, i.e., remove the spaces inserted before the hier-part of the URI
+            const includeFind = /^(\s*#\s*include\s*["<]https?:)\s+(\/\/[^">]+[">].*)/;
+            const includeReplacement = '$1$2';
+            const lines = result.stdout.split('\n');
+            for (const idx in lines) lines[idx] = lines[idx].replace(includeFind, includeReplacement);
+            result.stdout = lines.join('\n');
+        }
+        return result;
     }
 }

--- a/lib/formatters/clang-format.ts
+++ b/lib/formatters/clang-format.ts
@@ -36,6 +36,16 @@ export class ClangFormatFormatter extends BaseFormatter {
     override async format(source: string, options: FormatOptions): Promise<UnprocessedExecResult> {
         const tabText = options.useSpaces ? 'Never' : 'AlignWithSpaces';
         const arg = `{BasedOnStyle: ${options.baseStyle}, IndentWidth: ${options.tabWidth}, UseTab: ${tabText}}`;
-        return await exec.execute(this.formatterInfo.exe, [`--style=${arg}`], {input: source});
+        return exec.execute(this.formatterInfo.exe, [`--style=${arg}`], {input: source}).then(result => {
+            if (result.code === 0) {
+                // Repair http(s) includes, i.e., remove the spaces inserted before the hier-part of the URI
+                const includeFind = /^(\s*#\s*include\s*["<]https?:)\s+(\/\/[^">]+[">].*)/;
+                const includeReplacement = '$1$2';
+                const lines = result.stdout.split('\n');
+                for (const idx in lines) lines[idx] = lines[idx].replace(includeFind, includeReplacement);
+                result.stdout = lines.join('\n');
+            }
+            return new Promise((resolve, _reject) => resolve(result));
+        });
     }
 }


### PR DESCRIPTION
clang-format inserts spaces after the URI scheme and before the hier-part. Remove the spaces to reform a valid URL.

For example, formatting the following code
```cpp
#include <https://localhost:8443/develop/json.hpp>
```
results in a broken https include:
```cpp
#include <https:  //localhost:8443/develop/json.hpp>
```

This could of course be done on the client side but might be a little messy. Let me know if that's preferable.

Fixes #2928.