### PR TITLE
Replace provide-plugin jquery imports with import statements

### DIFF
--- a/static/alert.ts
+++ b/static/alert.ts
@@ -22,9 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
+
 import {AlertAskOptions, AlertEnterTextOptions, AlertNotifyOptions} from './alert.interfaces';
 import {toggleEventListener} from './utils';
-import * as Sentry from '@sentry/browser';
 
 export class Alert {
     yesHandler: ((answer?: string | string[] | number) => void) | null = null;

--- a/static/compiler-picker.ts
+++ b/static/compiler-picker.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import TomSelect from 'tom-select';
 
 import {ga} from './analytics';

--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import * as Sentry from '@sentry/browser';
 import _ from 'underscore';
 import LRU from 'lru-cache';

--- a/static/modes/cpp-for-opencl-mode.ts
+++ b/static/modes/cpp-for-opencl-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 const cppp = require('./cppp-mode');

--- a/static/modes/cppcircle-mode.ts
+++ b/static/modes/cppcircle-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 const cppp = require('./cppp-mode');

--- a/static/modes/cppp-mode.ts
+++ b/static/modes/cppp-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 

--- a/static/modes/cppx-blue-mode.ts
+++ b/static/modes/cppx-blue-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 const cppp = require('./cppp-mode');

--- a/static/modes/cuda-mode.ts
+++ b/static/modes/cuda-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 const cppp = require('./cppp-mode');

--- a/static/modes/ispc-mode.ts
+++ b/static/modes/ispc-mode.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
 
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');

--- a/static/modes/nc-mode.ts
+++ b/static/modes/nc-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 

--- a/static/modes/openclc-mode.ts
+++ b/static/modes/openclc-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const cpp = require('monaco-editor/esm/vs/basic-languages/cpp/cpp');
 const nc = require('./nc-mode');

--- a/static/modes/ptx-mode.ts
+++ b/static/modes/ptx-mode.ts
@@ -22,7 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
+import $ from 'jquery';
+
 const monaco = require('monaco-editor');
 const asm = require('./asm-mode');
 

--- a/static/motd.ts
+++ b/static/motd.ts
@@ -22,8 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {ga} from './analytics';
+import $ from 'jquery';
 
+import {ga} from './analytics';
 import {Ad, Motd} from './motd.interfaces';
 
 function ensureShownMessage(message: string, motdNode: JQuery) {

--- a/static/panes/ast-view.ts
+++ b/static/panes/ast-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/cfg-view.ts
+++ b/static/panes/cfg-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import * as vis from 'vis-network';
 import _ from 'underscore';
 import {ga} from '../analytics';

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import * as monaco from 'monaco-editor';
 import TomSelect from 'tom-select';
 

--- a/static/panes/flags-view.ts
+++ b/static/panes/flags-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import * as monaco from 'monaco-editor';
 import _, {Cancelable} from 'underscore';
 import {MonacoPane} from './pane';

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -23,6 +23,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 
 import {Container} from 'golden-layout';

--- a/static/panes/gnatdebug-view.ts
+++ b/static/panes/gnatdebug-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/gnatdebugtree-view.ts
+++ b/static/panes/gnatdebugtree-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/haskellstg-view.ts
+++ b/static/panes/haskellstg-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/llvm-opt-pipeline.ts
+++ b/static/panes/llvm-opt-pipeline.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {Toggles} from '../widgets/toggles';
 import _ from 'underscore';
 import {Pane} from './pane';

--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import {Container} from 'golden-layout';
 import * as monaco from 'monaco-editor';

--- a/static/panes/pp-view.ts
+++ b/static/panes/pp-view.ts
@@ -22,8 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-'use strict';
-
+import $ from 'jquery';
 import {Toggles} from '../widgets/toggles';
 import * as monaco from 'monaco-editor';
 import _ from 'underscore';

--- a/static/panes/rusthir-view.ts
+++ b/static/panes/rusthir-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/rustmacroexp-view.ts
+++ b/static/panes/rustmacroexp-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/rustmir-view.ts
+++ b/static/panes/rustmir-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/tool-input-view.ts
+++ b/static/panes/tool-input-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import * as monaco from 'monaco-editor';
 import _ from 'underscore';
 import {MonacoPane} from './pane';

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {MultifileFile, MultifileService, MultifileServiceState} from '../multifile-service';
 import {LineColouring} from '../line-colouring';
 import * as utils from '../utils';

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {options} from './options';
 import * as colour from './colour';
 import * as local from './local';

--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import * as Sentry from '@sentry/browser';
 import GoldenLayout from 'golden-layout';
 import _ from 'underscore';

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {editor} from 'monaco-editor';
 import {SiteSettings} from './settings';
 

--- a/static/widgets/fontscale.ts
+++ b/static/widgets/fontscale.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import EventEmitter from 'events';
 import {options} from '../options';
 import {Settings} from '../settings';

--- a/static/widgets/history-widget.ts
+++ b/static/widgets/history-widget.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {pluck} from 'underscore';
 import {ga} from '../analytics';
 import {sortedList, HistoryEntry, EditorSource} from '../history';

--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {options} from '../options';
 import * as local from '../local';
 import {Library, LibraryVersion} from '../options.interfaces';

--- a/static/widgets/load-save.ts
+++ b/static/widgets/load-save.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import {saveAs} from 'file-saver';
 import {Alert} from '../alert';

--- a/static/widgets/pane-renaming.ts
+++ b/static/widgets/pane-renaming.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {Tab} from 'golden-layout';
 import {EventEmitter} from 'events';
 import {Alert} from '../alert';

--- a/static/widgets/simplecook.ts
+++ b/static/widgets/simplecook.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 type SimpleCookieCallback = () => void;
 
 export class SimpleCook {

--- a/static/widgets/site-templates-widget.ts
+++ b/static/widgets/site-templates-widget.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {SiteTemplatesType} from '../../types/features/site-templates.interfaces';
 import {Settings} from '../settings';
 

--- a/static/widgets/timing-info-widget.ts
+++ b/static/widgets/timing-info-widget.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import {Settings} from '../settings';
 import {Chart, ChartData, defaults} from 'chart.js';
 import 'chart.js/auto';

--- a/static/widgets/toggles.ts
+++ b/static/widgets/toggles.ts
@@ -24,6 +24,8 @@
 
 import {EventEmitter} from 'events';
 
+import $ from 'jquery';
+
 const settings = {
     on: {
         icon: 'far fa-check-square',

--- a/webpack.config.esm.js
+++ b/webpack.config.esm.js
@@ -31,7 +31,7 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import MonacoEditorWebpackPlugin from 'monaco-editor-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
-import {DefinePlugin, HotModuleReplacementPlugin, ProvidePlugin} from 'webpack';
+import {DefinePlugin, HotModuleReplacementPlugin} from 'webpack';
 import {WebpackManifestPlugin} from 'webpack-manifest-plugin';
 
 const __dirname = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
@@ -66,10 +66,6 @@ const plugins = [
             'solidity',
         ],
         filename: isDev ? '[name].worker.js' : `[name]${webjackJsHack}worker.[contenthash].js`,
-    }),
-    new ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
     }),
     new MiniCssExtractPlugin({
         filename: isDev ? '[name].css' : `[name]${webjackJsHack}[contenthash].css`,
@@ -115,7 +111,7 @@ export default {
             path: 'path-browserify',
         },
         modules: ['./static', './node_modules'],
-        extensions: ['.tsx', '.ts', '.js'],
+        extensions: ['.ts', '.js'],
     },
     stats: 'normal',
     devtool: 'source-map',
@@ -168,7 +164,7 @@ export default {
                 loader: './etc/scripts/parsed_pug_file.js',
             },
             {
-                test: /\.tsx?$/,
+                test: /\.ts$/,
                 loader: 'ts-loader',
             },
             {


### PR DESCRIPTION
Replaces the $ and jQuery (unused) globals injected by WebPack with manual imports.

This gives us a more defined dependency graph, making it very easy to see where jQuery is used by grepping for `import $ from 'jquery'` or `var $ = require('jquery')`. I would also consider it bad practice to have global variables injected by build tools like this.