### PR TITLE
lib,test: unref tmp files clean interval

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -38,11 +38,7 @@ import * as utils from '../utils';
 
 temp.track();
 
-let hasSetUpAutoClean = false;
-
 function initialise(compilerEnv) {
-    if (hasSetUpAutoClean) return;
-    hasSetUpAutoClean = true;
     const tempDirCleanupSecs = compilerEnv.ceProps('tempDirCleanupSecs', 600);
     logger.info(`Cleaning temp dirs every ${tempDirCleanupSecs} secs`);
 
@@ -63,7 +59,7 @@ function initialise(compilerEnv) {
             if (err) logger.error('temp cleanup error', err);
             if (stats) logger.debug('temp cleanup stats', stats);
         });
-    }, tempDirCleanupSecs * 1000);
+    }, tempDirCleanupSecs * 1000).unref();
 }
 
 export class CompileHandler {
@@ -517,8 +513,4 @@ export class CompileHandler {
                 },
             );
     }
-}
-
-export function SetTestMode() {
-    hasSetUpAutoClean = true;
 }

--- a/test/handlers/compile-tests.js
+++ b/test/handlers/compile-tests.js
@@ -25,10 +25,8 @@
 import bodyParser from 'body-parser';
 import express from 'express';
 
-import {CompileHandler, SetTestMode} from '../../lib/handlers/compile';
+import {CompileHandler} from '../../lib/handlers/compile';
 import {chai, makeCompilationEnvironment} from '../utils';
-
-SetTestMode();
 
 const languages = {
     a: {id: 'a', name: 'A lang'},


### PR DESCRIPTION
By unref the `setInterval` in `lib/handlers/compile.js` the event loop
could stop freely, and with that the `SetTestMode` becomes useless

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
