### PR TITLE
Jakt: Remove -b flag

### DIFF
--- a/etc/config/jakt.amazon.properties
+++ b/etc/config/jakt.amazon.properties
@@ -12,5 +12,5 @@ compilerType=jakt
 
 compiler.selfhosted.exe=/opt/compiler-explorer/jakt-trunk/jakt-selfhost
 compiler.selfhosted.name=jakt (trunk)
-compiler.selfhosted.options=-b --runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.selfhosted.options=--runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.selfhosted.alias=rustbased


### PR DESCRIPTION
The selfhosted compiler now always builds the transpiled C++ file,
so this flag doesn't exist any more.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
