### PR TITLE
Bring hlsl config to same style as other languages

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,13 +1,17 @@
-compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207
+compilers=&dxc
 supportsBinary=false
 defaultCompiler=dxc_1_7_2207
 compilerType=hlsl
 
+
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207
+group.dxc.groupName=DXC
+group.dxc.isSemVer=true
+group.dxc.baseName=DXC
+
 compiler.dxc_trunk.exe=/opt/compiler-explorer/dxc-trunk/bin/dxc
-compiler.dxc_trunk.name=DXC (trunk)
-
+compiler.dxc_trunk.semver=(trunk)
 compiler.dxc_1_6_2112.exe=/opt/compiler-explorer/dxc-1.6.2112/bin/dxc
-compiler.dxc_1_6_2112.name=DXC 1.6.2112
-
+compiler.dxc_1_6_2112.semver=1.6.2112
 compiler.dxc_1_7_2207.exe=/opt/compiler-explorer/dxc-1.7.2207/bin/dxc
-compiler.dxc_1_7_2207.name=DXC 1.7.2207
+compiler.dxc_1_7_2207.semver=1.7.2207


### PR DESCRIPTION
Noticed that the compilers were not being sorted by semver, so checked and saw they just specified the name.
This PR then creates a group, marks it as semver, and gives the compilers proper basenames.