### PR TITLE
Patch missing jquery imports

### DIFF
--- a/static/panes/haskellcmm-view.ts
+++ b/static/panes/haskellcmm-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/haskellcore-view.ts
+++ b/static/panes/haskellcore-view.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
 import {Container} from 'golden-layout';

--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -22,7 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import $ from 'jquery';
 import _ from 'underscore';
 import {Container} from 'golden-layout';
 import * as monaco from 'monaco-editor';


### PR DESCRIPTION
Fixes #3951 

Must have missed them in the jquery webpack replacement PR somehow :cry:

Also removed an unused jquery import