### PR TITLE
Fixes conformance view bug

### DIFF
--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -327,7 +327,7 @@ Conformance.prototype.expandSource = function () {
 };
 
 Conformance.prototype.onEditorChange = function (editorId, newSource, langId) {
-    if (editorId === this.editorId) {
+    if (editorId === this.editorId && this.source !== newSource) {
         this.langId = langId;
         this.source = newSource;
         this.sourceNeedsExpanding = true;
@@ -352,7 +352,7 @@ Conformance.prototype.handleCompileOutIcon = function (element, result) {
     var hasOutput = hasResultAnyOutput(result);
     element.toggleClass('d-none', !hasOutput);
     if (hasOutput) {
-        this.compilerService.handleOutputButtonTitle(element, result);
+        CompilerService.handleOutputButtonTitle(element, result);
     }
 };
 
@@ -419,7 +419,7 @@ Conformance.prototype.compileChild = function (compilerEntry) {
                             asm: '',
                             code: -1,
                             stdout: '',
-                            stderr: x.error,
+                            stderr: x.error || x.message || x,
                         });
                     }, this)
                 );


### PR DESCRIPTION
This was making the error icon not show up

A static TS function was being called as a member function, but the IDE was not complaining :(
Also adds aditional check to avoid recompiling twice when the page loads up for the first time

Releated to the secondary issue reported in #2696 comments.