### PR TITLE
Makes webpack-dev-middleware notify on build finish

### DIFF
--- a/app.js
+++ b/app.js
@@ -300,7 +300,10 @@ async function setupWebPackDevMiddleware(router) {
     router.use(
         webpackDevMiddleware(webpackCompiler, {
             publicPath: '/static',
-            stats: 'errors-only',
+            stats: {
+                preset: 'errors-only',
+                timings: true,
+            },
         }),
     );
 


### PR DESCRIPTION
I've been bitten by 
> [webpack-dev-middleware] wait until bundle finished: /
![imagen](https://user-images.githubusercontent.com/5364255/184986722-86194947-3804-4823-996a-2d56e6cb2927.png)

a few too many times thinking that the compilation would already be done.

Now it outputs an extra message when it stops compiling:
![imagen](https://user-images.githubusercontent.com/5364255/184986572-03c867b8-1e7e-4c7d-969f-e07bb8e1864c.png)
