### PR TITLE
Fix check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "test": "mocha -b",
     "test-min": "mocha -b --config .mocharc-min.yml",
     "fix": "npm run lint && npm run format && npm run ts-check",
-    "check": "npm run npm run ts-check && npm run lint-check && npm run test-min -- --reporter min",
+    "check": "npm run ts-check && npm run lint-check && npm run test-min -- --reporter min",
     "dev": "cross-env NODE_ENV=DEV node -r esm -r ts-node/register app.js",
     "debugger": "cross-env NODE_ENV=DEV node --inspect -r esm -r ts-node/register app.js --debug",
     "debug": "cross-env NODE_ENV=DEV node -r esm -r ts-node/register app.js --debug",


### PR DESCRIPTION
This removes the extra `npm run` from the check script so it can run as expected.

Regressed by https://github.com/compiler-explorer/compiler-explorer/pull/3847