### PR TITLE
Add native GCC 12.2.0

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,20 +1,20 @@
 # Default settings for Ada
 compilers=&gnat:&gnatcross
-defaultCompiler=gnat121
+defaultCompiler=gnat122
 versionFlag=--version
 compilerType=ada
 
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat111:gnat112:gnat113:gnat121:gnatsnapshot
+group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat111:gnat112:gnat113:gnat121:gnat122:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=x86-64
 group.gnat.baseName=x86-64 gnat
 group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
-group.gnat.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
-group.gnat.demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
+group.gnat.objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
+group.gnat.demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
 group.gnat.isSemVer=true
 
 compiler.gnat82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gnatmake
@@ -33,6 +33,8 @@ compiler.gnat113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gnatmake
 compiler.gnat113.semver=11.3
 compiler.gnat121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gnatmake
 compiler.gnat121.semver=12.1
+compiler.gnat122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gnatmake
+compiler.gnat122.semver=12.2
 compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnatmake
 compiler.gnatsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502
-defaultCompiler=g121
-demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+defaultCompiler=g122
+demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -12,7 +12,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g111:g112:g113:g121:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g111:g112:g113:g121:g122:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -132,6 +132,9 @@ compiler.g113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/g++
 compiler.g113.semver=11.3
 compiler.g121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/g++
 compiler.g121.semver=12.1
+compiler.g122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/g++
+compiler.g122.semver=12.2
+
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:www.godbolt.ms@443
-defaultCompiler=cg121
-demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+defaultCompiler=cg122
+demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -12,7 +12,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg111:cg112:cg113:cg121:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg111:cg112:cg113:cg121:cg122:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -113,6 +113,9 @@ compiler.cg113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gcc
 compiler.cg113.semver=11.3
 compiler.cg121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gcc
 compiler.cg121.semver=12.1
+compiler.cg122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gcc
+compiler.cg122.semver=12.2
+
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,13 +1,13 @@
 compilers=&gdc:&ldc:&dmd:&gdccross
 defaultCompiler=ldc1_30
 
-group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc111:gdc113:gdc121:gdctrunk
+group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc111:gdc113:gdc121:gdc122:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
 group.gdc.baseName=gdc
 group.gdc.demangler=/opt/compiler-explorer/ldc1.30.0/ldc2-1.30.0-linux-x86_64/bin/ddemangle
-group.gdc.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+group.gdc.objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
 group.gdc.llvmSymbolizer=/opt/compiler-explorer/clang-14.0.0/bin/llvm-symbolizer
 
 compiler.gdc49.exe=/opt/compiler-explorer/gdc4.9.3/x86_64-pc-linux-gnu/bin/gdc
@@ -36,6 +36,8 @@ compiler.gdc113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gdc
 compiler.gdc113.semver=11.3
 compiler.gdc121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gdc
 compiler.gdc121.semver=12.1
+compiler.gdc122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gdc
+compiler.gdc122.semver=12.2
 compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gdctrunk.semver=(trunk)

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&gfortran_86:&ifort:&ifx:&cross:&clang_llvmflang
-defaultCompiler=gfortran121
-demangler=/opt/compiler-explorer/gcc-12.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
+defaultCompiler=gfortran122
+demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
 compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran111:gfortran112:gfortran113:gfortran121:gfortransnapshot
+group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran111:gfortran112:gfortran113:gfortran121:gfortran122:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -56,6 +56,8 @@ compiler.gfortran113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gfortran
 compiler.gfortran113.semver=11.3
 compiler.gfortran121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gfortran
 compiler.gfortran121.semver=12.1
+compiler.gfortran122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gfortran
+compiler.gfortran122.semver=12.2
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gfortransnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gccgo:&gl:&cross
 defaultCompiler=gl1190
 objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 
-group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo111:gccgo112:gccgo113:gccgo121
+group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo111:gccgo112:gccgo113:gccgo121:gccgo122
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -29,6 +29,8 @@ compiler.gccgo113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gccgo
 compiler.gccgo113.semver=11.3.0
 compiler.gccgo121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gccgo
 compiler.gccgo121.semver=12.1.0
+compiler.gccgo122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gccgo
+compiler.gccgo122.semver=12.2.0
 
 
 group.gl.compilers=&x86gl:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl


### PR DESCRIPTION
Add native GCC 12.2.0 for Ada, C, C++, D, Fortran and Go.

refs #3973

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>