### PR TITLE
Bring back old behaviour of 404 on missing compiler

### DIFF
--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -91,18 +91,11 @@ export class ApiHandler {
         this.handle
             .route('/popularArguments/:compiler')
             .post(compileHandler.handlePopularArguments.bind(compileHandler))
-            .all(methodNotAllowed);
-        this.handle
-            .route('/optimizationArguments/:compiler')
-            .post(compileHandler.handleOptimizationArguments.bind(compileHandler))
-            .all(methodNotAllowed);
-
-        this.handle
-            .route('/popularArguments/:compiler')
             .get(compileHandler.handlePopularArguments.bind(compileHandler))
             .all(methodNotAllowed);
         this.handle
             .route('/optimizationArguments/:compiler')
+            .post(compileHandler.handleOptimizationArguments.bind(compileHandler))
             .get(compileHandler.handleOptimizationArguments.bind(compileHandler))
             .all(methodNotAllowed);
 

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -338,15 +338,19 @@ export class CompileHandler {
         return {source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries};
     }
 
-    handlePopularArguments(req, res, next) {
+    handlePopularArguments(req, res) {
         const compiler = this.compilerFor(req);
-        if (!compiler) return next();
+        if (!compiler) {
+            return res.sendStatus(404);
+        }
         res.send(compiler.possibleArguments.getPopularArguments(this.getUsedOptions(req)));
     }
 
-    handleOptimizationArguments(req, res, next) {
+    handleOptimizationArguments(req, res) {
         const compiler = this.compilerFor(req);
-        if (!compiler) return next();
+        if (!compiler) {
+            return res.sendStatus(404);
+        }
         res.send(compiler.possibleArguments.getOptimizationArguments(this.getUsedOptions(req)));
     }
 
@@ -377,7 +381,7 @@ export class CompileHandler {
     handleCmake(req, res, next) {
         const compiler = this.compilerFor(req);
         if (!compiler) {
-            return next();
+            return res.sendStatus(404);
         }
 
         const remote = compiler.getRemote();
@@ -413,8 +417,9 @@ export class CompileHandler {
     handle(req, res, next) {
         const compiler = this.compilerFor(req);
         if (!compiler) {
-            return next();
+            return res.sendStatus(404);
         }
+
         const remote = compiler.getRemote();
         if (remote) {
             req.url = remote.path;


### PR DESCRIPTION
Now that we return 405 if the method is not supported, calling next() in the handlers will output that instead of 404, so we send those manually.

Also fixes some weird code repetition 
