### PR TITLE
Fixes wrong types in libraries.interfaces.ts

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -751,35 +751,29 @@ export class BaseCompiler {
         );
     }
 
-    getIncludeArguments(libraries) {
+    getIncludeArguments(libraries: SelectedLibraryVersion[]): string[] {
         const includeFlag = this.compiler.includeFlag || '-I';
+        return libraries.flatMap(selectedLib => {
+            const foundVersion = this.findLibVersion(selectedLib);
+            if (!foundVersion) return [];
 
-        return _.flatten(
-            _.map(libraries, selectedLib => {
-                const foundVersion = this.findLibVersion(selectedLib);
-                if (!foundVersion) return false;
-
-                return _.map(foundVersion.path, path => includeFlag + path);
-            }),
-        );
+            return foundVersion.path.map(path => includeFlag + path);
+        });
     }
 
-    getLibraryOptions(libraries) {
-        return _.flatten(
-            _.map(libraries, selectedLib => {
-                const foundVersion = this.findLibVersion(selectedLib);
-                if (!foundVersion) return false;
-
-                return foundVersion.options;
-            }),
-        );
+    getLibraryOptions(libraries: SelectedLibraryVersion[]): string[] {
+        return libraries.flatMap(selectedLib => {
+            const foundVersion = this.findLibVersion(selectedLib);
+            if (!foundVersion) return [];
+            return foundVersion.options;
+        });
     }
 
     orderArguments(
         options: string[],
         inputFilename: string,
-        libIncludes: any[], // TODO: Fix this type
-        libOptions: any[],
+        libIncludes: string[],
+        libOptions: string[],
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],

--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -132,14 +132,12 @@ export class ZigCompiler extends BaseCompiler {
     }
 
     getIncludeArguments(libraries) {
-        return _.flatten(
-            _.map(libraries, selectedLib => {
-                const foundVersion = this.findLibVersion(selectedLib);
-                if (!foundVersion) return false;
-                // Zig should not have more than 1 path
-                return ['--pkg-begin', foundVersion.name, foundVersion.path, '--pkg-end'];
-            }),
-        );
+        return libraries.flatMap(selectedLib => {
+            const foundVersion = this.findLibVersion(selectedLib);
+            if (!foundVersion) return [];
+            // Zig should not have more than 1 path, but it's still an array so spread it
+            return ['--pkg-begin', foundVersion.name, ...foundVersion.path, '--pkg-end'];
+        });
     }
 
     getIrOutputFilename(inputFilename) {

--- a/types/libraries/libraries.interfaces.ts
+++ b/types/libraries/libraries.interfaces.ts
@@ -6,8 +6,8 @@ export type LibraryVersion = {
     dependencies: string[];
     liblink: string[];
     libpath: string[];
-    path: string;
-    options: string;
+    path: string[];
+    options: string[];
 };
 
 export type Library = {


### PR DESCRIPTION
As discussed in #3966, this fixes the types for `.path` and `.options`. They are now properly used as arrays everywhere
