### PR TITLE
Add debug info filter option to LLVM opt pipeline viewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -121,3 +121,4 @@ From oldest to newest contributor, we would like to thank:
 - [Ofek Shilon](https://github.com/ofekshilon)
 - [Ross Smyth](https://github.com/RossSmyth)
 - [Mike Urbach](https://github.com/mikeurbach)
+- [J. Ryan Stinnett](https://github.com/jryans)

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -113,6 +113,7 @@ export class LlvmPassDumpParser {
         this.debugInfoFilters = [
             /^\s+call void @llvm.dbg.value.+$/, // dbg calls
             /^\s+call void @llvm.dbg.declare.+$/, // dbg calls
+            /^\s+DBG_.+$/, // dbg pseudo-instructions
             /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]+?)\)/, // meta
             /^(!\d+) = (?:distinct )?!{.*}/, // meta
             /^(![.A-Z_a-z-]+) = (?:distinct )?!{.*}/, // meta

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -111,8 +111,7 @@ export class LlvmPassDumpParser {
 
         // Additional filters conditionally enabled by `filterDebugInfo`
         this.debugInfoFilters = [
-            /^\s+call void @llvm.dbg.value.+$/, // dbg calls
-            /^\s+call void @llvm.dbg.declare.+$/, // dbg calls
+            /^\s+call void @llvm.dbg.+$/, // dbg calls
             /^\s+DBG_.+$/, // dbg pseudo-instructions
             /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]+?)\)/, // meta
             /^(!\d+) = (?:distinct )?!{.*}/, // meta

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -82,6 +82,8 @@ type SplitPassDump = {
 export class LlvmPassDumpParser {
     filters: RegExp[];
     lineFilters: RegExp[];
+    debugInfoFilters: RegExp[];
+    debugInfoLineFilters: RegExp[];
     irDumpHeader: RegExp;
     machineCodeDumpHeader: RegExp;
     functionDefine: RegExp;
@@ -100,17 +102,23 @@ export class LlvmPassDumpParser {
             /^; ModuleID = '.+'$/, // module id line
             /^(source_filename|target datalayout|target triple) = ".+"$/, // module metadata
             /^; Function Attrs: .+$/, // function attributes
-            /^\s+call void @llvm.dbg.value.+$/, // dbg calls
-            /^\s+call void @llvm.dbg.declare.+$/, // dbg calls
             /^declare .+$/, // declare directives
-            /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]+?)\)/, // meta
-            /^(!\d+) = (?:distinct )?!{.*}/, // meta
-            /^(![.A-Z_a-z-]+) = (?:distinct )?!{.*}/, // meta
             /^attributes #\d+ = { .+ }$/, // attributes directive
         ];
         this.lineFilters = [
-            /,? ![\dA-Za-z]+((?=( {)?$))/, // debug annotation
             /,? #\d+((?=( {)?$))/, // attribute annotation
+        ];
+
+        // Additional filters conditionally enabled by `filterDebugInfo`
+        this.debugInfoFilters = [
+            /^\s+call void @llvm.dbg.value.+$/, // dbg calls
+            /^\s+call void @llvm.dbg.declare.+$/, // dbg calls
+            /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]+?)\)/, // meta
+            /^(!\d+) = (?:distinct )?!{.*}/, // meta
+            /^(![.A-Z_a-z-]+) = (?:distinct )?!{.*}/, // meta
+        ];
+        this.debugInfoLineFilters = [
+            /,? ![\dA-Za-z]+((?=( {)?$))/, // debug annotation
         ];
 
         // Ir dump headers look like "*** IR Dump After XYZ ***"
@@ -435,18 +443,26 @@ export class LlvmPassDumpParser {
     }
 
     process(ir: ResultLine[], _: ParseFilters, llvmOptPipelineOptions: LLVMOptPipelineBackendOptions) {
+        // Additional filters conditionally enabled by `filterDebugInfo`
+        let filters = this.filters;
+        let lineFilters = this.lineFilters;
+        if (llvmOptPipelineOptions.filterDebugInfo) {
+            filters = filters.concat(this.debugInfoFilters);
+            lineFilters = lineFilters.concat(this.debugInfoLineFilters);
+        }
+
         // Filter a lot of junk before processing
         const preprocessed_lines = ir
             .slice(
                 ir.findIndex(line => line.text.match(this.irDumpHeader) || line.text.match(this.machineCodeDumpHeader)),
             )
-            .filter(line => this.filters.every(re => line.text.match(re) === null)) // apply filters
+            .filter(line => filters.every(re => line.text.match(re) === null)) // apply filters
             .map(_line => {
                 let line = _line.text;
                 // eslint-disable-next-line no-constant-condition
                 while (true) {
                     let newLine = line;
-                    for (const re of this.lineFilters) {
+                    for (const re of lineFilters) {
                         newLine = newLine.replace(re, '');
                     }
                     if (newLine === line) {

--- a/static/panes/llvm-opt-pipeline.ts
+++ b/static/panes/llvm-opt-pipeline.ts
@@ -61,6 +61,7 @@ export class LLVMOptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEdi
     options: Toggles;
     state: LLVMOptPipelineViewState;
     lastOptions: LLVMOptPipelineBackendOptions = {
+        filterDebugInfo: true,
         fullModule: false,
         noDiscardValueNames: true,
         demangle: true,
@@ -188,6 +189,7 @@ export class LLVMOptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEdi
         // the backend? Would be a data transfer optimization.
         const newOptions: LLVMOptPipelineBackendOptions = {
             //'filter-inconsequential-passes': options['filter-inconsequential-passes'],
+            filterDebugInfo: options['filter-debug-info'],
             fullModule: options['dump-full-module'],
             noDiscardValueNames: options['-fno-discard-value-names'],
             demangle: options['demangle-symbols'],

--- a/types/compilation/llvm-opt-pipeline-output.interfaces.ts
+++ b/types/compilation/llvm-opt-pipeline-output.interfaces.ts
@@ -36,6 +36,7 @@ export type Pass = {
 export type LLVMOptPipelineOutput = Record<string, Pass[]>;
 
 export type LLVMOptPipelineBackendOptions = {
+    filterDebugInfo: boolean;
     fullModule: boolean;
     noDiscardValueNames: boolean;
     demangle: boolean;

--- a/views/templates/panes/llvm-opt-pipeline.pug
+++ b/views/templates/panes/llvm-opt-pipeline.pug
@@ -11,6 +11,10 @@
             span Filter Inconsequential Passes
           input.d-none(type="checkbox" checked=false)
         .button-checkbox
+          button.dropdown-item.btn.btn-sm.btn-light.filter-debug-info(type="button" title="Filter debug info intrinsics" data-bind="filter-debug-info" aria-pressed="false" aria-label="Filter Debug Info")
+            span Filter Debug Info
+          input.d-none(type="checkbox" checked=true)
+        .button-checkbox
           button.dropdown-item.btn.btn-sm.btn-light.dump-full-module(type="button" title="Dump the entire module for each pass" data-bind="dump-full-module" aria-pressed="false" aria-label="Filter Inconsequential Passes")
             span Dump Full Module
           input.d-none(type="checkbox" checked=false)

--- a/views/templates/panes/llvm-opt-pipeline.pug
+++ b/views/templates/panes/llvm-opt-pipeline.pug
@@ -1,3 +1,9 @@
+mixin optionButton(bind, isActive, text, title)
+  .button-checkbox
+    button(type="button" class="dropdown-item btn btn-sm btn-light" + (isActive ? " active" : "") title=title data-bind=bind aria-pressed=isActive ? "true" : "false")
+      span #{text}
+    input.d-none(type="checkbox" checked=isActive)
+
 #llvm-opt-pipeline
   .top-bar.btn-toolbar.bg-light(role="toolbar")
     include ../../font-size
@@ -6,30 +12,12 @@
         span.fas.fa-anchor
         span.hideable Options
       .dropdown-menu
-        .button-checkbox
-          button.dropdown-item.btn.btn-sm.btn-light.filter-inconsequential-passes(type="button" title="Filter passes which do not make changes" data-bind="filter-inconsequential-passes" aria-pressed="false" aria-label="Filter Inconsequential Passes")
-            span Filter Inconsequential Passes
-          input.d-none(type="checkbox" checked=false)
-        .button-checkbox
-          button.dropdown-item.btn.btn-sm.btn-light.filter-debug-info(type="button" title="Filter debug info intrinsics" data-bind="filter-debug-info" aria-pressed="false" aria-label="Filter Debug Info")
-            span Filter Debug Info
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.dropdown-item.btn.btn-sm.btn-light.dump-full-module(type="button" title="Dump the entire module for each pass" data-bind="dump-full-module" aria-pressed="false" aria-label="Filter Inconsequential Passes")
-            span Dump Full Module
-          input.d-none(type="checkbox" checked=false)
-        .button-checkbox
-          button.dropdown-item.btn.btn-sm.btn-light.dump-full-module(type="button" title="Demangle Symbols" data-bind="demangle-symbols" aria-pressed="false" aria-label="Demangle Symbols")
-            span Demangle Symbols
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.dropdown-item.btn.btn-sm.btn-light.dump-full-module(type="button" title="Keep value names instead of llvm value numbers" data-bind="-fno-discard-value-names" aria-pressed="false" aria-label="-fno-discard-value-names")
-            span -fno-discard-value-names
-          input.d-none(type="checkbox" checked=true)
-        //.button-checkbox
-        //  button.dropdown-item.btn.btn-sm.btn-light.dump-full-module(type="button" title="Filter Library Functions" data-bind="library-functions" aria-pressed="false" aria-label="Filter Library Functions")
-        //    span Filter Library Functions
-        //  input.d-none(type="checkbox" checked=true)
+        +optionButton("filter-inconsequential-passes", false, "Filter Inconsequential Passes", "Filter passes which do not make changes")
+        +optionButton("filter-debug-info", true, "Filter Debug Info", "Filter debug info intrinsics")
+        +optionButton("dump-full-module", false, "Dump Full Module", "Dump the entire module for each pass")
+        +optionButton("demangle-symbols", true, "Demangle Symbols", "Demangle symbols")
+        +optionButton("-fno-discard-value-names", true, "-fno-discard-value-names", "Keep value names instead of LLVM value numbers")
+        //- +optionButton("library-functions", true, "Filter Library Functions", "Filter library functions")
     .btn-group.btn-group-sm
       .input-group.input-group-sm.mb-auto
         .input-group-prepend


### PR DESCRIPTION
This adds a debug info filter option so its possible to see debug info across the opt pipeline when desired. Most people probably do not want to see this info, so the filter is enabled by default (info removed by default), matching the current behaviour.

![image](https://user-images.githubusercontent.com/279572/186530154-ec4f9222-b75f-404b-a928-161b394408c8.png)

CC @jeremy-rifkin 