### PR TITLE
Ensure first MIR pass marked as changed

### DIFF
--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -410,6 +410,17 @@ export class LlvmPassDumpParser {
                     assert(false, 'Unexpected pass header', current_dump.header);
                 }
                 pass.machine = current_dump.machine;
+
+                // The first machine pass outputs the same MIR before and after,
+                // making it seem like it did nothing.
+                // Assuming we ran some IR pass before this, grab its output as
+                // the before text, ensuring the first MIR pass appears when
+                // inconsequential passes are filtered away.
+                const previousPass = passes.at(-1);
+                if (previousPass && previousPass.machine !== pass.machine) {
+                    pass.before = previousPass.after;
+                }
+
                 // check for equality
                 pass.irChanged = pass.before.map(x => x.text).join('\n') !== pass.after.map(x => x.text).join('\n');
                 passes.push(pass);


### PR DESCRIPTION
For the LLVM opt pipeline viewer, the first machine pass that LLVM outputs has the same MIR before and after, making it seem like it did nothing, but really it has transformed the program from IR to MIR. It's helpful to highlight that change and ensure it appears in the passes list.

The diff view is a bit wild (effectively the entire content has changed), but I think that's okay since it reflects reality.

![image](https://user-images.githubusercontent.com/279572/186690173-d411dcc1-8f6b-49cc-aab6-7d4950140db0.png)

CC @jeremy-rifkin 