### PR TITLE
Fix #3989

### DIFF
--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -71,9 +71,11 @@ const FindDocumentEnd = (x: string) => {
 
 export class LLVMOptTransformer extends Transform {
     _buffer: string;
+    _prevOpts: Set<string>; // Avoid duplicate display of remarks
     constructor(options?: object) {
         super(R.merge(options || {}, {objectMode: true}));
         this._buffer = '';
+        this._prevOpts = new Set<string>();
     }
     override _flush(done: TransformCallback) {
         this.processBuffer();
@@ -93,13 +95,18 @@ export class LLVMOptTransformer extends Transform {
                 const [head, tail] = R.splitAt(endpos, this._buffer);
                 const optTypeMatch = head.match(optTypeMatcher);
                 const opt = YAML.parse(head);
-                if (!optTypeMatch) {
-                    console.warn('missing optimization type');
-                } else {
-                    opt.optType = optTypeMatch[1].replace('!', '');
+                const strOpt = JSON.stringify(opt);
+                if (!this._prevOpts.has(strOpt)) {
+                    this._prevOpts.add(strOpt);
+
+                    if (!optTypeMatch) {
+                        console.warn('missing optimization type');
+                    } else {
+                        opt.optType = optTypeMatch[1].replace('!', '');
+                    }
+                    opt.displayString = DisplayOptInfo(opt);
+                    this.push(opt as LLVMOptInfo);
                 }
-                opt.displayString = DisplayOptInfo(opt);
-                this.push(opt as LLVMOptInfo);
                 this._buffer = tail.replace(/^\n/, '');
             } else {
                 break;


### PR DESCRIPTION
Cache stringified opt remarks, avoid displaying newly parsed remarks if they appear in the cache.
