### PR TITLE
oneapi 2022.1 release

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -689,7 +689,7 @@ compiler.icx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 compiler.icx202210.exe=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/bin/icpx
 compiler.icx202210.ldPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin
-compiler.icx202210.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/lib
+compiler.icx202210.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.1.0.137/tbb/2021.6.0/lib/intel64/gcc4.8
 compiler.icx202210.semver=2022.1.0
 compiler.icx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -579,7 +579,7 @@ compiler.wasm32clang.options=-target wasm32
 
 ################################
 # icc for x86
-group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120:icc202130:icc202140:icc202150
+group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120:icc202130:icc202140:icc202150:icc202160
 group.icc.intelAsm=-masm=intel
 group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
@@ -642,9 +642,15 @@ compiler.icc202150.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler
 compiler.icc202150.semver=2021.5.0
 compiler.icc202150.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
+compiler.icc202160.exe=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/bin/intel64/icc
+compiler.icc202160.ldPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icc202160.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc202160.semver=2021.6.0
+compiler.icc202160.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -680,6 +686,12 @@ compiler.icx202200.ldPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/
 compiler.icx202200.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icx202200.semver=2022.0.0
 compiler.icx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.icx202210.exe=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/bin/icpx
+compiler.icx202210.ldPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icx202210.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/lib
+compiler.icx202210.semver=2022.1.0
+compiler.icx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ################################
 # zapcc

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -506,7 +506,7 @@ compiler.ppci055.semver=0.5.5
 compiler.ppci055.exe=/opt/compiler-explorer/ppci-0.5.5/ppci/cli/cc.py
 
 # icc for x86
-group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112:cicc202120:cicc202130:cicc202140:cicc202150
+group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112:cicc202120:cicc202130:cicc202140:cicc202150:cicc202160
 group.cicc.intelAsm=-masm=intel
 group.cicc.options=-x c -gcc-name=/opt/compiler-explorer/gcc-4.7.1/bin/gcc
 group.cicc.groupName=ICC x86-64
@@ -562,8 +562,14 @@ compiler.cicc202150.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compile
 compiler.cicc202150.semver=2021.5.0
 compiler.cicc202150.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
+compiler.cicc202160.exe=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/bin/intel64/icc
+compiler.cicc202160.ldPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc202160.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc202160.semver=2021.6.0
+compiler.cicc202160.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 # icx for x86
-group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200
+group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210
 group.cicx.intelAsm=-masm=intel
 group.cicx.options=
 group.cicx.groupName=ICX x86-64
@@ -599,6 +605,12 @@ compiler.cicx202200.ldPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler
 compiler.cicx202200.libPath=/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.0.1.71/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.cicx202200.semver=2022.0.0
 compiler.cicx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
+
+compiler.cicx202210.exe=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/bin/icx
+compiler.cicx202210.ldPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicx202210.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202210.semver=2022.1.0
+compiler.cicx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -65,7 +65,7 @@ compiler.gfortransnapshot.semver=(trunk)
 
 ###############################
 # Intel Parallel Studio XE for x86
-group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150
+group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150:ifort202160
 group.ifort.intelAsm=-masm=intel
 group.ifort.groupName=IFORT x86-64
 group.ifort.isSemVer=true
@@ -110,9 +110,15 @@ compiler.ifort202150.libPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/co
 compiler.ifort202150.semver=2021.5.0
 compiler.ifort202150.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
 
+compiler.ifort202160.exe=/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/bin/intel64/ifort
+compiler.ifort202160.ldPath=/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifort202160.libPath=/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifort202160.semver=2021.6.0
+compiler.ifort202160.options=-gxx-name=/opt/compiler-explorer/gcc-10.1.0/bin/g++
+
 ###############################
 # Intel oneAPI for x86
-group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200
+group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210
 group.ifx.intelAsm=-masm=intel
 group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
@@ -143,6 +149,11 @@ compiler.ifx202200.exe=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler
 compiler.ifx202200.ldPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/intel64_lin
 compiler.ifx202200.libPath=/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2022.0.1.70/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifx202200.semver=2022.0.0
+
+compiler.ifx202210.exe=/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/bin/ifx
+compiler.ifx202210.ldPath=/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifx202210.libPath=/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2022.1.0.134/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers


### PR DESCRIPTION
Add oneapi 2022.1 release
enable execution of sycl programs by setting libpath. See https://github.com/compiler-explorer/compiler-explorer/issues/2246

Depends on compilers being installed with https://github.com/compiler-explorer/infra/pull/793
