### PR TITLE
Update compiler.exe when resolving relative paths

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -138,6 +138,7 @@ export class CompileHandler {
             const exe = await which(compiler.exe).catch(() => null);
             if (exe) {
                 logger.debug(`Resolved '${compiler.exe}' to path '${exe}'`);
+                compiler.exe = exe;
             } else {
                 // errors resolving to absolute path are not fatal for backwards compatibility sake
                 logger.error(`Unable to resolve '${compiler.exe}'`);


### PR DESCRIPTION
As discussed in #3996, this fixes a divergence in semantics between relative and absolute compiler paths

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
