### PR TITLE
Toggles state

### DIFF
--- a/static/panes/llvm-opt-pipeline.ts
+++ b/static/panes/llvm-opt-pipeline.ts
@@ -370,10 +370,9 @@ export class LLVMOptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEdi
     }
 
     override getCurrentState() {
-        // TODO: Remove _.pick when and if toggles can be updated to not do this state clobbering stuff
         return {
-            ..._.pick(this.options.get(), ['dump-full-module', 'demangle-symbols', '-fno-discard-value-names']),
-            ..._.pick(this.filters.get(), ['filter-inconsequential-passes', 'filter-debug-info']),
+            ...this.options.get(),
+            ...this.filters.get(),
             ...super.getCurrentState(),
             selectedFunction: this.state.selectedFunction,
             selectedIndex: this.state.selectedIndex,

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -159,9 +159,8 @@ export class Output extends Pane<OutputState> {
 
     override getCurrentState() {
         const parent = super.getCurrentState();
-        const options = this.getEffectiveOptions();
         const state = {
-            wrap: options.wrap,
+            ...this.getEffectiveOptions(),
             ...parent,
         };
         this.fontScale.addState(state);

--- a/static/panes/pp-view.ts
+++ b/static/panes/pp-view.ts
@@ -170,14 +170,12 @@ export class PP extends MonacoPane<monaco.editor.IStandaloneCodeEditor, PPViewSt
     }
 
     currentState() {
-        const options = this.options.get();
         const state = {
             id: this.compilerInfo.compilerId,
             editorid: this.compilerInfo.editorId,
             treeid: this.compilerInfo.treeId,
             selection: this.selection,
-            'filter-headers': options['filter-headers'],
-            'clang-format': options['clang-format'],
+            ...this.options.get(),
         };
         this.paneRenaming.addState(state);
         this.fontScale.addState(state);

--- a/static/widgets/toggles.ts
+++ b/static/widgets/toggles.ts
@@ -37,18 +37,20 @@ const settings = {
 
 export class Toggles extends EventEmitter {
     private readonly buttons: JQuery;
-    private readonly state: Record<string, boolean>;
+    private readonly state: Record<string, boolean> = {};
 
     constructor(root: JQuery, state: Record<string, boolean>) {
         super();
         this.buttons = root.find('.button-checkbox');
-        this.state = {...state};
 
         for (const element of this.buttons) {
             const widget = $(element);
             const button = widget.find('button');
             const checkbox = widget.find('input:checkbox');
             const bind = button.data('bind');
+
+            // copy relevant parts of the state
+            this.state[bind] = state[bind];
 
             // Event Handlers
             button.on('click', e => {


### PR DESCRIPTION
This changes Toggles to only take on state for what it controls. Prevents toggles.get() from clobbering other state with stale values later on. There is a chance this might break something but as far as I can tell no component relies on Toggles taking on (and later returning) the full state its given.