### PR TITLE
add parser for spirv debug information

### DIFF
--- a/lib/compilers/spirv.js
+++ b/lib/compilers/spirv.js
@@ -29,7 +29,6 @@ import _ from 'underscore';
 import {BaseCompiler} from '../base-compiler';
 import {logger} from '../logger';
 import {SPIRVAsmParser} from '../parsers/asm-parser-spirv';
-
 import * as utils from '../utils';
 
 export class SPIRVCompiler extends BaseCompiler {

--- a/lib/compilers/spirv.js
+++ b/lib/compilers/spirv.js
@@ -28,6 +28,8 @@ import _ from 'underscore';
 
 import {BaseCompiler} from '../base-compiler';
 import {logger} from '../logger';
+import {SPIRVAsmParser} from '../parsers/asm-parser-spirv';
+
 import * as utils from '../utils';
 
 export class SPIRVCompiler extends BaseCompiler {
@@ -37,6 +39,8 @@ export class SPIRVCompiler extends BaseCompiler {
 
     constructor(compilerInfo, env) {
         super(compilerInfo, env);
+
+        this.asm = new SPIRVAsmParser();
 
         this.translatorPath = this.compilerProps('translatorPath');
         this.disassemblerPath = this.compilerProps('disassemblerPath');

--- a/lib/parsers/asm-parser-spirv.js
+++ b/lib/parsers/asm-parser-spirv.js
@@ -1,0 +1,109 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {AsmParser} from './asm-parser';
+
+import * as utils from '../utils';
+
+export class SPIRVAsmParser extends AsmParser {
+    constructor(compilerProps) {
+        super();
+    }
+
+    parseOpString(asmLines) {
+        const opString = /^\s*%(\d+)\s+=\s+OpString\s+"([^"]+)"$/;
+        const files = {};
+        for (const line of asmLines) {
+            const match = line.match(opString);
+            if (match) {
+                const lineNum = parseInt(match[1]);
+                files[lineNum] = match[2];
+            }
+        }
+        return files;
+    }
+
+    processAsm(asmResult, filters) {
+        const startTime = process.hrtime.bigint();
+
+        const asm = [];
+
+        let asmLines = utils.splitLines(asmResult);
+        const startingLineCount = asmLines.length;
+        if (filters.preProcessLines !== undefined) {
+            asmLines = filters.preProcessLines(asmLines);
+        }
+        const opStrings = this.parseOpString(asmLines);
+
+        const sourceTag = /^\s*OpLine\s+%(\d+)\s+(\d+)\s+(\d*)$/;
+        const endBlock = /OpFunctionEnd/;
+        const comment = /;/;
+        const opLine = /OpLine/;
+        const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;
+        let source = null;
+
+        for (let line of asmLines) {
+            let match = line.match(sourceTag);
+            if (match) {
+                source = {
+                    file: utils.maskRootdir(opStrings[parseInt(match[1])]),
+                    line: parseInt(match[2]),
+                    mainsource: true,
+                };
+                const sourceCol = parseInt(match[3]);
+                if (!isNaN(sourceCol) && sourceCol !== 0) {
+                    source.column = sourceCol;
+                }
+            }
+
+            if (endBlock.test(line)) {
+                source = null;
+            }
+
+            if (filters.commentOnly && comment.test(line)) {
+                continue;
+            }
+            if (filters.directives) {
+                if (opLine.test(line) || opExtDbg.test(line)) {
+                    continue;
+                }
+            }
+
+            line = utils.expandTabs(line);
+            asm.push({
+                text: line,
+                source: source,
+                labels: [],
+            });
+        }
+
+        const endTime = process.hrtime.bigint();
+        return {
+            asm: asm,
+            labelDefinitions: {},
+            parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
+            filteredCount: startingLineCount - asm.length,
+        };
+    }
+}

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -22,9 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {AsmParser} from './asm-parser';
-
 import * as utils from '../utils';
+
+import {AsmParser} from './asm-parser';
 
 export class SPIRVAsmParser extends AsmParser {
     constructor(compilerProps) {
@@ -64,7 +64,7 @@ export class SPIRVAsmParser extends AsmParser {
         let source: any = null;
 
         for (let line of asmLines) {
-            let match = line.match(sourceTag);
+            const match = line.match(sourceTag);
             if (match) {
                 source = {
                     file: utils.maskRootdir(opStrings[parseInt(match[1])]),

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -44,10 +44,10 @@ export class SPIRVAsmParser extends AsmParser {
         return files;
     }
 
-    processAsm(asmResult, filters) {
+    override processAsm(asmResult, filters) {
         const startTime = process.hrtime.bigint();
 
-        const asm = [];
+        const asm: any = [];
 
         let asmLines = utils.splitLines(asmResult);
         const startingLineCount = asmLines.length;
@@ -61,7 +61,7 @@ export class SPIRVAsmParser extends AsmParser {
         const comment = /;/;
         const opLine = /OpLine/;
         const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;
-        let source = null;
+        let source: any = null;
 
         for (let line of asmLines) {
             let match = line.match(sourceTag);


### PR DESCRIPTION
Only look at operator OpLine
Also filter OpLine and 'OpExtInst %void %<> Debug*'

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
