### PR TITLE
add compiler: skeleton for clspv

### DIFF
--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -224,12 +224,12 @@ group.googleclspv.compilers=clspv:clvk
 group.googleclspv.compilerType=clspv
 group.googleclspv.groupName=Google clspv
 
-compiler.clspv.exe=/opt/compiler-explorer/clspv/build/bin/clspv
+compiler.clspv.exe=/opt/compiler-explorer/clspv-main/build/bin/clspv
 compiler.clspv.name=clspv (trunk)
 
 # clvk-like usage of clspv
-compiler.clvk.exe=/opt/compiler-explorer/clspv/build/bin/clspv
-compiler.clvk.name=clvk (based on clspv trunk)
+compiler.clvk.exe=/opt/compiler-explorer/clspv-main/build/bin/clspv
+compiler.clvk.name=clvk-like (based on clspv trunk)
 compiler.clvk.options=-cl-single-precision-constant -cl-kernel-arg-info -fp64=0 -int8 -std430-ubo-layout -spv-version=1.5 -max-pushconstant-size=128 -max-ubo-size=134217728 -global-offset -long-vector -module-constants-in-storage-buffer -cl-arm-non-uniform-work-group-size
 
 #################################

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -221,7 +221,8 @@ compiler.armv8-oclcclang-trunk-assertions-spir64.semver=(assertions trunk)
 
 # Google clspv
 group.googleclspv.compilers=clspv:clvk
-group.googleclspv.compilerType=Google clspv
+group.googleclspv.compilerType=clspv
+group.googleclspv.groupName=Google clspv
 
 compiler.clspv.exe=/opt/compiler-explorer/clspv/build/bin/clspv
 compiler.clspv.name=clspv (trunk)

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&armoclcclang32:&armoclcclang64:&armoclcclang32spir:&armoclcclang64spir
+compilers=&armoclcclang32:&armoclcclang64:&armoclcclang32spir:&armoclcclang64spir:&googleclspv
 defaultCompiler=armv8-oclcclang-trunk
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
@@ -218,6 +218,18 @@ compiler.armv8-oclcclang-trunk-assertions-spir64.exe=/opt/compiler-explorer/clan
 compiler.armv8-oclcclang-trunk-assertions-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-oclcclang-trunk-assertions-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-oclcclang-trunk-assertions-spir64.semver=(assertions trunk)
+
+# Google clspv
+group.googleclspv.compilers=clspv:clvk
+group.googleclspv.compilerType=Google clspv
+
+compiler.clspv.exe=/opt/compiler-explorer/clspv/build/bin/clspv
+compiler.clspv.name=clspv (trunk)
+
+# clvk-like usage of clspv
+compiler.clvk.exe=/opt/compiler-explorer/clspv/build/bin/clspv
+compiler.clvk.name=clvk (based on clspv trunk)
+compiler.clvk.options=-cl-single-precision-constant -cl-kernel-arg-info -fp64=0 -int8 -std430-ubo-layout -spv-version=1.5 -max-pushconstant-size=128 -max-ubo-size=134217728 -global-offset -long-vector -module-constants-in-storage-buffer -cl-arm-non-uniform-work-group-size
 
 #################################
 #################################

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -54,5 +54,5 @@ compiler.spirvclangdefaultspir64.options=-finclude-default-header -fdeclare-open
 group.clspv.compilers=clspv
 group.clspv.compilerType=clspv
 
-compiler.clspv.exe=/usr/bin/clspv
+compiler.clspv.exe=/opt/compiler-explorer/build/bin/clspv
 compiler.clspv.name=clspv

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -51,8 +51,12 @@ compiler.spirvclangdefaultspir64.exe=/usr/bin/clang
 compiler.spirvclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
 compiler.spirvclangdefaultspir64.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
-group.clspv.compilers=clspv
+group.clspv.compilers=clspv:clvk
 group.clspv.compilerType=clspv
 
 compiler.clspv.exe=/opt/compiler-explorer/build/bin/clspv
 compiler.clspv.name=clspv
+
+compiler.clvk.exe=/opt/compiler-explorer/build/bin/clspv
+compiler.clvk.name=clvk
+compiler.clvk.options=-cl-single-precision-constant -cl-kernel-arg-info -fp64=0 -int8 -std430-ubo-layout -spv-version=1.5 -max-pushconstant-size=128 -max-ubo-size=134217728 -global-offset -long-vector -module-constants-in-storage-buffer -cl-arm-non-uniform-work-group-size

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -1,5 +1,5 @@
 # Default settings for OpenCL C
-compilers=&clang:&spirv:&clspv
+compilers=&clang:&spirv:&googleclspv
 defaultCompiler=openclcclangdefault
 postProcess=
 demangler=c++filt
@@ -51,12 +51,12 @@ compiler.spirvclangdefaultspir64.exe=/usr/bin/clang
 compiler.spirvclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
 compiler.spirvclangdefaultspir64.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
-group.clspv.compilers=clspv:clvk
-group.clspv.compilerType=clspv
+group.googleclspv.compilers=clspv:clvk
+group.googleclspv.compilerType=Google clspv
 
-compiler.clspv.exe=/opt/compiler-explorer/build/bin/clspv
-compiler.clspv.name=clspv
+compiler.clspv.exe=/usr/bin/clspv
+compiler.clspv.name=clspv (trunk)
 
-compiler.clvk.exe=/opt/compiler-explorer/build/bin/clspv
-compiler.clvk.name=clvk
+compiler.clvk.exe=/usr/bin/clspv
+compiler.clvk.name=clvk (based on clspv trunk)
 compiler.clvk.options=-cl-single-precision-constant -cl-kernel-arg-info -fp64=0 -int8 -std430-ubo-layout -spv-version=1.5 -max-pushconstant-size=128 -max-ubo-size=134217728 -global-offset -long-vector -module-constants-in-storage-buffer -cl-arm-non-uniform-work-group-size

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -1,5 +1,5 @@
 # Default settings for OpenCL C
-compilers=&clang:&spirv
+compilers=&clang:&spirv:&clspv
 defaultCompiler=openclcclangdefault
 postProcess=
 demangler=c++filt
@@ -50,3 +50,9 @@ compiler.spirvclangdefaultspir.options=-finclude-default-header -fdeclare-opencl
 compiler.spirvclangdefaultspir64.exe=/usr/bin/clang
 compiler.spirvclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
 compiler.spirvclangdefaultspir64.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
+
+group.clspv.compilers=clspv
+group.clspv.compilerType=clspv
+
+compiler.clspv.exe=/usr/bin/clspv
+compiler.clspv.name=clspv

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -52,7 +52,8 @@ compiler.spirvclangdefaultspir64.name=clang default (SPIR-V asm, spir64 triple)
 compiler.spirvclangdefaultspir64.options=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
 group.googleclspv.compilers=clspv:clvk
-group.googleclspv.compilerType=Google clspv
+group.googleclspv.compilerType=clspv
+group.googleclspv.groupName=Google clspv
 
 compiler.clspv.exe=/usr/bin/clspv
 compiler.clspv.name=clspv (trunk)

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -37,6 +37,7 @@ export {ClangHipCompiler} from './clang';
 export {ClangIntelCompiler} from './clang';
 export {CleanCompiler} from './clean';
 export {CprocCompiler} from './cproc';
+export {CLSPVCompiler} from './clspv';
 export {CrystalCompiler} from './crystal';
 export {CSharpCompiler} from './dotnet';
 export {DartCompiler} from './dart';

--- a/lib/compilers/clspv.js
+++ b/lib/compilers/clspv.js
@@ -1,0 +1,133 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import _ from 'underscore';
+
+import {BaseCompiler} from '../base-compiler';
+import {logger} from '../logger';
+import {SPIRVAsmParser} from '../parsers/asm-parser-spirv';
+
+import * as utils from '../utils';
+
+export class CLSPVCompiler extends BaseCompiler {
+    static get key() {
+        return 'clspv';
+    }
+
+    constructor(compilerInfo, env) {
+        super(compilerInfo, env);
+
+        this.asm = new SPIRVAsmParser();
+
+        this.disassemblerPath = this.compilerProps('disassemblerPath');
+    }
+
+    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
+        let options = this.optionsForFilter(filters, outputFilename, userOptions);
+        backendOptions = backendOptions || {};
+
+        if (this.compiler.options) {
+            let compilerOptions = _.filter(
+                utils.splitArguments(this.compiler.options),
+                option => option !== '-fno-crash-diagnostics',
+            );
+
+            options = options.concat(compilerOptions);
+        }
+
+        if (this.compiler.supportsOptOutput && backendOptions.produceOptInfo) {
+            options = options.concat(this.compiler.optArg);
+        }
+
+        const libIncludes = this.getIncludeArguments(libraries);
+        const libOptions = this.getLibraryOptions(libraries);
+        let libLinks = [];
+        let libPaths = [];
+        let staticLibLinks = [];
+
+        if (filters.binary) {
+            libLinks = this.getSharedLibraryLinks(libraries);
+            libPaths = this.getSharedLibraryPathsAsArguments(libraries);
+            staticLibLinks = this.getStaticLibraryLinks(libraries);
+        }
+
+        userOptions = this.filterUserOptions(userOptions) || [];
+        return options.concat(
+            libIncludes,
+            libOptions,
+            libPaths,
+            libLinks,
+            userOptions,
+            [this.filename(inputFilename)],
+            staticLibLinks,
+        );
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        const sourceDir = path.dirname(outputFilename);
+        const spvBinFilename = path.join(sourceDir, this.outputFilebase + '.spv');
+        return ['-o', spvBinFilename];
+    }
+
+    getPrimaryOutputFilename(dirPath, outputFilebase) {
+        return path.join(dirPath, `${outputFilebase}.spv`);
+    }
+
+    // TODO: Check this to see if it needs key
+    getOutputFilename(dirPath, outputFilebase) {
+        return path.join(dirPath, `${outputFilebase}.spvasm`);
+    }
+
+    async runCompiler(compiler, options, inputFilename, execOptions) {
+        const sourceDir = path.dirname(inputFilename);
+        const spvBinFilename = path.join(sourceDir, this.outputFilebase + '.spv');
+
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+        execOptions.customCwd = path.dirname(inputFilename);
+
+        const spvBin = await this.exec(compiler, options, execOptions);
+        if (spvBin.code !== 0) {
+            logger.error('clspv compilation failed', spvBin);
+            spvBin.stdout = utils.parseOutput(spvBin.stdout, spvBinFilename, execOptions.customCwd);
+            spvBin.stderr = utils.parseOutput(spvBin.stderr, spvBinFilename, execOptions.customCwd);
+            return spvBin;
+        }
+
+        const spvasmFilename = path.join(sourceDir, this.outputFilebase + '.spvasm');
+        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename];
+
+        const spvasmOutput = await this.exec(this.disassemblerPath, disassemblerFlags, execOptions);
+        if (spvasmOutput.code !== 0) {
+            logger.error('SPIR-V binary to text failed', spvasmOutput);
+        }
+
+        spvasmOutput.stdout = utils.parseOutput(spvasmOutput.stdout, spvasmFilename, execOptions.customCwd);
+        spvasmOutput.stderr = utils.parseOutput(spvasmOutput.stderr, spvasmFilename, execOptions.customCwd);
+        return spvasmOutput;
+    }
+}

--- a/lib/compilers/clspv.js
+++ b/lib/compilers/clspv.js
@@ -89,7 +89,7 @@ export class CLSPVCompiler extends BaseCompiler {
     optionsForFilter(filters, outputFilename) {
         const sourceDir = path.dirname(outputFilename);
         const spvBinFilename = path.join(sourceDir, this.outputFilebase + '.spv');
-        return ['-o', spvBinFilename];
+        return ['-o', spvBinFilename, '-g'];
     }
 
     getPrimaryOutputFilename(dirPath, outputFilebase) {

--- a/lib/compilers/clspv.ts
+++ b/lib/compilers/clspv.ts
@@ -33,6 +33,8 @@ import {SPIRVAsmParser} from '../parsers/asm-parser-spirv';
 import * as utils from '../utils';
 
 export class CLSPVCompiler extends BaseCompiler {
+    disassemblerPath: any;
+
     static get key() {
         return 'clspv';
     }
@@ -45,8 +47,8 @@ export class CLSPVCompiler extends BaseCompiler {
         this.disassemblerPath = this.compilerProps('disassemblerPath');
     }
 
-    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
-        let options = this.optionsForFilter(filters, outputFilename, userOptions);
+    override prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
+        let options = this.optionsForFilter(filters, outputFilename);
         backendOptions = backendOptions || {};
 
         if (this.compiler.options) {
@@ -64,9 +66,9 @@ export class CLSPVCompiler extends BaseCompiler {
 
         const libIncludes = this.getIncludeArguments(libraries);
         const libOptions = this.getLibraryOptions(libraries);
-        let libLinks = [];
-        let libPaths = [];
-        let staticLibLinks = [];
+        let libLinks: any = [];
+        let libPaths: any = [];
+        let staticLibLinks: any = [];
 
         if (filters.binary) {
             libLinks = this.getSharedLibraryLinks(libraries);
@@ -86,7 +88,7 @@ export class CLSPVCompiler extends BaseCompiler {
         );
     }
 
-    optionsForFilter(filters, outputFilename) {
+    override optionsForFilter(filters, outputFilename) {
         const sourceDir = path.dirname(outputFilename);
         const spvBinFilename = path.join(sourceDir, this.outputFilebase + '.spv');
         return ['-o', spvBinFilename, '-g'];
@@ -97,11 +99,11 @@ export class CLSPVCompiler extends BaseCompiler {
     }
 
     // TODO: Check this to see if it needs key
-    getOutputFilename(dirPath, outputFilebase) {
+    override getOutputFilename(dirPath, outputFilebase) {
         return path.join(dirPath, `${outputFilebase}.spvasm`);
     }
 
-    async runCompiler(compiler, options, inputFilename, execOptions) {
+    override async runCompiler(compiler, options, inputFilename, execOptions) {
         const sourceDir = path.dirname(inputFilename);
         const spvBinFilename = path.join(sourceDir, this.outputFilebase + '.spv');
 

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -27,7 +27,7 @@ import * as utils from '../utils';
 import {AsmParser} from './asm-parser';
 
 export class SPIRVAsmParser extends AsmParser {
-    constructor(compilerProps) {
+    constructor() {
         super();
     }
 

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -60,6 +60,7 @@ export class SPIRVAsmParser extends AsmParser {
         const endBlock = /OpFunctionEnd/;
         const comment = /;/;
         const opLine = /OpLine/;
+        const opNoLine = /OpNoLine/;
         const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;
         let source: any = null;
 
@@ -77,7 +78,7 @@ export class SPIRVAsmParser extends AsmParser {
                 }
             }
 
-            if (endBlock.test(line)) {
+            if (endBlock.test(line) || opNoLine.test(line)) {
                 source = null;
             }
 
@@ -85,7 +86,7 @@ export class SPIRVAsmParser extends AsmParser {
                 continue;
             }
             if (filters.directives) {
-                if (opLine.test(line) || opExtDbg.test(line)) {
+                if (opLine.test(line) || opExtDbg.test(line) || opNoLine.test(line)) {
                     continue;
                 }
             }


### PR DESCRIPTION
This is a PR based on #4013.
It will also need to have clspv built by the nightly jobs.

It is not using the `spirv` workflow it is different:
 - spirv: `cl -> bc -> spv -> spvasm`
 - clspv: `cl -> spv -> spvasm`
 
 Ref #3992

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
