### PR TITLE
use openCL from icx install

### DIFF
--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -34,6 +34,7 @@ export {CIRCTCompiler} from './circt';
 export {ClangCompiler} from './clang';
 export {ClangCudaCompiler} from './clang';
 export {ClangHipCompiler} from './clang';
+export {ClangIntelCompiler} from './clang';
 export {CleanCompiler} from './clean';
 export {CprocCompiler} from './cproc';
 export {CrystalCompiler} from './crystal';

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -192,7 +192,7 @@ export class ClangIntelCompiler extends ClangCompiler {
 
     runExecutable(executable, executeParameters, homeDir) {
         executeParameters.env = {
-            OCL_ICD_FILENAMES: path.dirname(this.compiler.exe) + '/../lib/x64/libintelocl.so',
+            OCL_ICD_FILENAMES: path.resolve(path.dirname(this.compiler.exe) + '/../lib/x64/libintelocl.so'),
             ...executeParameters.env,
         };
         return super.runExecutable(executable, executeParameters, homeDir);

--- a/lib/compilers/clang.js
+++ b/lib/compilers/clang.js
@@ -184,3 +184,17 @@ export class ClangHipCompiler extends ClangCompiler {
         return ['-o', this.filename(outputFilename), '-g1', '--no-gpu-bundle-output', filters.binary ? '-c' : '-S'];
     }
 }
+
+export class ClangIntelCompiler extends ClangCompiler {
+    static get key() {
+        return 'clang-intel';
+    }
+
+    runExecutable(executable, executeParameters, homeDir) {
+        executeParameters.env = {
+            OCL_ICD_FILENAMES: path.dirname(this.compiler.exe) + '/../lib/x64/libintelocl.so',
+            ...executeParameters.env,
+        };
+        return super.runExecutable(executable, executeParameters, homeDir);
+    }
+}


### PR DESCRIPTION
Enable running sycl and openmp offload programs with icx compiler by enabling the opencl that comes with the compiler. Thanks to @partouf for finding the env variable that was missing.

I extended clang because icx is clang based and I also want to enable the device support that is partially implemented for clang.
