### PR TITLE
LLVM opt pipeline improvements with slow execution

### DIFF
--- a/lib/demangler/llvm.ts
+++ b/lib/demangler/llvm.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {LLVMOptPipelineOutput} from '../../types/compilation/llvm-opt-pipeline-output.interfaces';
+import {LLVMOptPipelineResults} from '../../types/compilation/llvm-opt-pipeline-output.interfaces';
 import {ResultLine} from '../../types/resultline/resultline.interfaces';
 import {logger} from '../logger';
 import {SymbolStore} from '../symbol-store';
@@ -59,7 +59,7 @@ export class LLVMIRDemangler extends BaseDemangler {
         }
     }
 
-    processPassOutput(passOutput: LLVMOptPipelineOutput, demanglerOutput) {
+    processPassOutput(passOutput: LLVMOptPipelineResults, demanglerOutput) {
         if (demanglerOutput.stdout.length === 0 && demanglerOutput.stderr.length > 0) {
             logger.error(`Error executing demangler ${this.demanglerExe}`, demanglerOutput);
             return passOutput;
@@ -95,7 +95,7 @@ export class LLVMIRDemangler extends BaseDemangler {
         return passOutput;
     }
 
-    async demangleLLVMPasses(passOutput: LLVMOptPipelineOutput) {
+    async demangleLLVMPasses(passOutput: LLVMOptPipelineResults) {
         const options = {
             input: this.getInput(),
         };

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -64,6 +64,7 @@ export function executeDirect(command, args, options, filenameTransform) {
     }
 
     let okToCache = true;
+    let timedOut = false;
     const cwd = options.customCwd
         ? options.customCwd
         : command.startsWith('/mnt') && process.env.wsl
@@ -97,6 +98,7 @@ export function executeDirect(command, args, options, filenameTransform) {
         timeout = setTimeout(() => {
             logger.warn(`Timeout for ${command} ${args} after ${timeoutMs}ms`);
             okToCache = false;
+            timedOut = true;
             kill();
             streams.stderr += '\nKilled - processing time exceeded';
         }, timeoutMs);
@@ -139,6 +141,7 @@ export function executeDirect(command, args, options, filenameTransform) {
             const result = {
                 code,
                 okToCache,
+                timedOut,
                 filenameTransform,
                 stdout: streams.stdout,
                 stderr: streams.stderr,

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -26,7 +26,7 @@ import _ from 'underscore';
 
 import {
     LLVMOptPipelineBackendOptions,
-    LLVMOptPipelineOutput,
+    LLVMOptPipelineResults,
     Pass,
 } from '../../types/compilation/llvm-opt-pipeline-output.interfaces';
 import {ParseFilters} from '../../types/features/filters.interfaces';
@@ -366,7 +366,7 @@ export class LlvmPassDumpParser {
     matchPassDumps(passDumpsByFunction: Record<string, PassDump[]>) {
         // We have all the passes for each function, now we will go through each function and match the before/after
         // dumps
-        const final_output: LLVMOptPipelineOutput = {};
+        const final_output: LLVMOptPipelineResults = {};
         for (const [function_name, passDumps] of Object.entries(passDumpsByFunction)) {
             // I had a fantastic chunk2 method to iterate the passes in chunks of 2 but I've been foiled by an edge
             // case: At least the "Delete dead loops" may only print a before dump and no after dump

--- a/test/exec-tests.js
+++ b/test/exec-tests.js
@@ -49,6 +49,7 @@ describe('Execution tests', () => {
                     okToCache: true,
                     stderr: '',
                     stdout: 'hello world\n',
+                    timedOut: false,
                 });
             });
             it('limits output', () => {
@@ -60,6 +61,7 @@ describe('Execution tests', () => {
                         okToCache: true,
                         stderr: '',
                         stdout: 'A very ver\n[Truncated]',
+                        timedOut: false,
                     });
             });
             it('handles failing commands', () => {
@@ -68,6 +70,7 @@ describe('Execution tests', () => {
                     okToCache: true,
                     stderr: '',
                     stdout: '',
+                    timedOut: false,
                 });
             });
             it('handles timouts', () => {
@@ -79,6 +82,7 @@ describe('Execution tests', () => {
                         okToCache: false,
                         stderr: '\nKilled - processing time exceeded',
                         stdout: '',
+                        timedOut: true,
                     });
             });
             it('handles missing executables', () => {
@@ -93,6 +97,7 @@ describe('Execution tests', () => {
                         okToCache: true,
                         stderr: '',
                         stdout: 'this is stdin',
+                        timedOut: false,
                     });
             });
         });
@@ -109,6 +114,7 @@ describe('Execution tests', () => {
                         okToCache: true,
                         stderr: '',
                         stdout: 'hello world\r\n',
+                        timedOut: false,
                     });
             });
             it('limits output', () => {
@@ -122,6 +128,7 @@ describe('Execution tests', () => {
                         okToCache: true,
                         stderr: '',
                         stdout: 'A very ver\n[Truncated]',
+                        timedOut: false,
                     });
             });
             it('handles failing commands', () => {
@@ -133,6 +140,7 @@ describe('Execution tests', () => {
                         okToCache: true,
                         stderr: '',
                         stdout: '',
+                        timedOut: false,
                     });
             });
             it('handles timouts', () => {
@@ -144,6 +152,7 @@ describe('Execution tests', () => {
                         okToCache: false,
                         stderr: '\nKilled - processing time exceeded',
                         stdout: '',
+                        timedOut: false,
                     });
             });
             it('handles missing executables', () => {

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -27,6 +27,7 @@ import {ResultLine} from '../resultline/resultline.interfaces';
 
 export type CompilationResult = {
     code: number;
+    timedOut: boolean;
     buildResult?: unknown;
     inputFilename?: string;
     asm?: ResultLine[];

--- a/types/compilation/llvm-opt-pipeline-output.interfaces.ts
+++ b/types/compilation/llvm-opt-pipeline-output.interfaces.ts
@@ -33,7 +33,12 @@ export type Pass = {
     irChanged: boolean;
 };
 
-export type LLVMOptPipelineOutput = Record<string, Pass[]>;
+export type LLVMOptPipelineResults = Record<string, Pass[]>;
+
+export type LLVMOptPipelineOutput = {
+    error?: string;
+    results: LLVMOptPipelineResults;
+};
 
 export type LLVMOptPipelineBackendOptions = {
     filterDebugInfo: boolean;


### PR DESCRIPTION
Updated the llvm opt pipeline and exec.js code to provide better diagnostics for compilations that timeout and other internal errors.

![image](https://user-images.githubusercontent.com/51220084/188237126-51cec336-5096-453f-a5d7-6768ec9676e2.png)


Closes #4007