### PR TITLE
Add AVX 512 types to C++ syntax highlighting

### DIFF
--- a/static/modes/cppp-mode.ts
+++ b/static/modes/cppp-mode.ts
@@ -109,6 +109,10 @@ function definition() {
         'requires',
         'xor',
         'xor_eq',
+        // Quick fix until https://github.com/microsoft/monaco-editor/pull/3286 is merged and released
+        '__m512',
+        '__m512d',
+        '__m512i',
     ]);
 
     return cppp;


### PR DESCRIPTION
Quick fix for #4012 until https://github.com/microsoft/monaco-editor/pull/3286 is merged and deployed

![image](https://user-images.githubusercontent.com/51220084/188237716-19b8b29d-38b0-46c0-b5e0-cadd7043a42c.png)

Fixes #4012