### PR TITLE
Add several GCC 12.2.0 cross compilers

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -50,7 +50,7 @@ group.gnatcross.isSemVer=true
 
 ################################
 # GNAT for riscv64
-group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103:gnatriscv641220
+group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103
 group.gnatriscv64.groupName=riscv64
 group.gnatriscv64.instructionSet=riscv
 
@@ -65,12 +65,6 @@ compiler.gnatriscv64112.demangler=/opt/compiler-explorer/riscv64/gnat-riscv64-el
 compiler.gnatriscv64112.name=riscv64 gnat 11.2.0-3 (Alire)
 compiler.gnatriscv64112.semver=11.2.0
 compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
-
-compiler.gnatriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
-compiler.gnatriscv641220.semver=12.2.0
-compiler.gnatriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
-compiler.gnatriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
-compiler.gnatriscv641220.name=riscv64 gnat 12.2.0.0-3 (Alire)
 
 ################################
 # GNAT for s390x
@@ -209,7 +203,7 @@ compiler.gnatarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64
 
 ################################
 # GNAT for arm
-group.gnatarm.compilers=gnatarm112:gnatarm103:gnatarm1220
+group.gnatarm.compilers=gnatarm112:gnatarm103
 group.gnatarm.groupName=arm
 group.gnatarm.instructionSet=arm32
 
@@ -224,12 +218,6 @@ compiler.gnatarm112.demangler=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11
 compiler.gnatarm112.name=arm gnat 11.2.0-3 (Alire)
 compiler.gnatarm112.semver=11.2.0
 compiler.gnatarm112.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/arm-eabi/lib/gnat/zfp-cortex-m4f/
-
-compiler.gnatarm1220.exe=None
-compiler.gnatarm1220.semver=12.2.0
-compiler.gnatarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
-compiler.gnatarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
-compiler.gnatarm1220.name=arm gnat 12.2.0.0-3 (Alire)
 
 #################################
 #################################

--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -50,7 +50,7 @@ group.gnatcross.isSemVer=true
 
 ################################
 # GNAT for riscv64
-group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103
+group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103:gnatriscv641220
 group.gnatriscv64.groupName=riscv64
 group.gnatriscv64.instructionSet=riscv
 
@@ -66,9 +66,15 @@ compiler.gnatriscv64112.name=riscv64 gnat 11.2.0-3 (Alire)
 compiler.gnatriscv64112.semver=11.2.0
 compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
 
+compiler.gnatriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
+compiler.gnatriscv641220.semver=12.2.0
+compiler.gnatriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gnatriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.gnatriscv641220.name=riscv64 gnat 12.2.0.0-3 (Alire)
+
 ################################
 # GNAT for s390x
-group.gnats390x.compilers=gnats390x1120:gnats390x1210
+group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220
 group.gnats390x.groupName=s390x
 group.gnats390x.instructionSet=s390x
 group.gnats390x.baseName=s390x gnat
@@ -79,6 +85,11 @@ compiler.gnats390x1120.semver=11.2.0
 compiler.gnats390x1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
 compiler.gnats390x1210.semver=12.1.0
 
+compiler.gnats390x1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1220.semver=12.2.0
+compiler.gnats390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gnats390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ################################
 # GNAT for ppc
 group.gnatppcs.compilers=&gnatppc:&gnatppc64:&gnatppc64le
@@ -86,7 +97,7 @@ group.gnatppcs.instructionSet=ppc
 
 ## POWER
 group.gnatppc.groupName=power
-group.gnatppc.compilers=gnatppc1120:gnatppc1210
+group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220
 group.gnatppc.baseName=powerpc gnat
 
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
@@ -97,9 +108,14 @@ compiler.gnatppc1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unkno
 compiler.gnatppc1210.demangler=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 compiler.gnatppc1210.semver=12.1.0
 
+compiler.gnatppc1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1220.semver=12.2.0
+compiler.gnatppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gnatppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ## POWER64
 group.gnatppc64.groupName=power64
-group.gnatppc64.compilers=gnatppc641120:gnatppc641210
+group.gnatppc64.compilers=gnatppc641120:gnatppc641210:gnatppc641220
 group.gnatppc64.baseName=powerpc64 gnat
 
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
@@ -110,9 +126,14 @@ compiler.gnatppc641210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64
 compiler.gnatppc641210.demangler=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 compiler.gnatppc641210.semver=12.1.0
 
+compiler.gnatppc641220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641220.semver=12.2.0
+compiler.gnatppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gnatppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 ## POWER64LE
 group.gnatppc64le.groupName=power64le
-group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210
+group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220
 group.gnatppc64le.baseName=powerpc64le gnat
 
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
@@ -123,6 +144,11 @@ compiler.gnatppc64le1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/power
 compiler.gnatppc64le1210.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 compiler.gnatppc64le1210.semver=12.1.0
 
+compiler.gnatppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1220.semver=12.2.0
+compiler.gnatppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gnatppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for MIPSs
 ## GNAT builds for mipsel and mips64el are broken on 12.1.0
@@ -131,7 +157,7 @@ group.gnatmipss.instructionSet=mips
 
 ## MIPS
 group.gnatmips.groupName=mips
-group.gnatmips.compilers=gnatmips1120:gnatmips1210
+group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220
 group.gnatmips.baseName=mips gnat
 
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
@@ -142,9 +168,14 @@ compiler.gnatmips1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-li
 compiler.gnatmips1210.semver=12.1.0
 compiler.gnatmips1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.gnatmips1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1220.semver=12.2.0
+compiler.gnatmips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gnatmips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS64
 group.gnatmips64.groupName=mips64
-group.gnatmips64.compilers=gnatmips641120:gnatmips641210
+group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220
 group.gnatmips64.baseName=mips64 gnat
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
@@ -155,9 +186,14 @@ compiler.gnatmips641210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unkn
 compiler.gnatmips641210.demangler=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 compiler.gnatmips641210.semver=12.1.0
 
+compiler.gnatmips641220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641220.semver=12.2.0
+compiler.gnatmips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gnatmips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for arm64
-group.gnatarm64.compilers=gnatarm641210
+group.gnatarm64.compilers=gnatarm641210:gnatarm641220
 group.gnatarm64.groupName=arm64
 group.gnatarm64.baseName=arm64 gnat
 group.gnatarm64.instructionSet=arm64
@@ -166,9 +202,14 @@ compiler.gnatarm641210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unkno
 compiler.gnatarm641210.semver=12.1.0
 compiler.gnatarm641210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 
+compiler.gnatarm641220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
+compiler.gnatarm641220.semver=12.2.0
+compiler.gnatarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gnatarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for arm
-group.gnatarm.compilers=gnatarm112:gnatarm103
+group.gnatarm.compilers=gnatarm112:gnatarm103:gnatarm1220
 group.gnatarm.groupName=arm
 group.gnatarm.instructionSet=arm32
 
@@ -183,6 +224,12 @@ compiler.gnatarm112.demangler=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11
 compiler.gnatarm112.name=arm gnat 11.2.0-3 (Alire)
 compiler.gnatarm112.semver=11.2.0
 compiler.gnatarm112.adarts=/opt/compiler-explorer/arm/gnat-arm-elf-linux64-11.2.0-3/arm-eabi/lib/gnat/zfp-cortex-m4f/
+
+compiler.gnatarm1220.exe=None
+compiler.gnatarm1220.semver=12.2.0
+compiler.gnatarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gnatarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.gnatarm1220.name=arm gnat 12.2.0.0-3 (Alire)
 
 #################################
 #################################

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -719,7 +719,7 @@ group.gccs390x.supportsBinary=true
 group.gccs390x.supportsExecute=false
 group.gccs390x.baseName=s390x gcc
 group.gccs390x.groupName=s390x gcc
-group.gccs390x.compilers=gccs390x1120:s390xg1210
+group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
@@ -731,6 +731,11 @@ compiler.s390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-
 compiler.s390xg1210.semver=12.1.0
 compiler.s390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
+compiler.s390xg1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.s390xg1220.semver=12.2.0
+compiler.s390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.s390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # Cross compilers for PPC
 group.ppcs.compilers=&ppc:&ppc64:&ppc64le
@@ -739,7 +744,7 @@ group.ppcs.supportsBinary=true
 group.ppcs.supportsExecute=false
 
 ## POWER
-group.ppc.compilers=ppcg48:ppcg1120:ppcg1210
+group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220
 group.ppc.groupName=POWER
 group.ppc.baseName=power gcc
 
@@ -755,10 +760,15 @@ compiler.ppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-
 compiler.ppcg1210.semver=12.1.0
 compiler.ppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 
+compiler.ppcg1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1220.semver=12.2.0
+compiler.ppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ## POWER64
 group.ppc64.groupName=POWER64
 group.ppc64.baseName=power64 gcc
-group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220
 
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -779,6 +789,11 @@ compiler.ppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-un
 compiler.ppc64g1210.semver=12.1.0
 compiler.ppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 
+compiler.ppc64g1220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1220.semver=12.2.0
+compiler.ppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -789,7 +804,7 @@ compiler.ppc64clang.semver=(snapshot)
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE
-group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220
 group.ppc64le.baseName=power64le gcc
 
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
@@ -817,6 +832,11 @@ compiler.ppc64leg1210.semver=12.1.0
 compiler.ppc64leg1120.name=power64le gcc 12.1.0
 compiler.ppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 
+compiler.ppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1220.semver=12.2.0
+compiler.ppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.ppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -834,7 +854,7 @@ group.gccarm.includeFlag=-I
 
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
-group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:arm1210:armgtrunk
+group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:arm1210:armgtrunk:armg1220
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -877,6 +897,12 @@ compiler.armg820.semver=8.2.0
 compiler.armg850.exe=/opt/compiler-explorer/arm/gcc-8.5.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg850.name=ARM gcc 8.5 (linux)
 compiler.armg850.semver=8.5.0
+
+compiler.armg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1220.semver=12.2.0
+compiler.armg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.armg1220.name=ARM gcc 12.2 (linux)
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)
 compiler.armce820.semver=8.2.0
@@ -933,7 +959,7 @@ compiler.armgtrunk.semver=trunk
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g1020:arm64g1030:arm64g1100:arm64g1120:arm64g1130:arm64g1210:arm64gtrunk
+group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g1020:arm64g1030:arm64g1100:arm64g1120:arm64g1130:arm64g1210:arm64gtrunk:arm64g1220
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -969,6 +995,11 @@ compiler.arm64g1130.semver=11.3
 compiler.arm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1210.semver=12.1
+
+compiler.arm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1220.semver=12.2.0
+compiler.arm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 compiler.arm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64gtrunk.semver=trunk
 
@@ -1050,7 +1081,7 @@ compiler.arduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardw
 
 ################################
 # GCC for MSP
-group.msp.compilers=msp430g453:msp430g530:msp430g621
+group.msp.compilers=msp430g453:msp430g530:msp430g621:msp430g1220
 group.msp.groupName=MSP GCC
 group.msp.baseName=MSP430 gcc
 group.msp.isSemVer=true
@@ -1064,9 +1095,14 @@ compiler.msp430g530.semver=5.3.0
 compiler.msp430g621.exe=/opt/compiler-explorer/msp430-gcc-6.2.1.16_linux64/bin/msp430-elf-g++
 compiler.msp430g621.semver=6.2.1
 
+compiler.msp430g1220.exe=None
+compiler.msp430g1220.semver=12.2.0
+compiler.msp430g1220.objdumper=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.msp430g1220.demangler=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210
+group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -1104,6 +1140,11 @@ compiler.avrg1210.exe=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-g++
 compiler.avrg1210.semver=12.1.0
 compiler.avrg1210.objdumper=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-objdump
 
+compiler.avrg1220.exe=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-g++
+compiler.avrg1220.semver=12.2.0
+compiler.avrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-objdump
+compiler.avrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
+
 ###############################
 # GCC for MIPS
 group.mipss.compilers=&mips:&mipsel:&mips64:&mips64el
@@ -1114,7 +1155,7 @@ group.mipss.supportsExecute=false
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mips930:mips1120:mipsg1210
+group.mips.compilers=mips5:mips930:mips1120:mipsg1210:mipsg1220
 group.mips.baseName=mips gcc
 
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
@@ -1134,9 +1175,14 @@ compiler.mipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux
 compiler.mipsg1210.semver=12.1.0
 compiler.mipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.mipsg1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg1220.semver=12.2.0
+compiler.mipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips564:mips112064:mips64g1210
+group.mips64.compilers=mips564:mips112064:mips64g1210:mips64g1220
 group.mips64.baseName=mips64 gcc
 
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
@@ -1151,9 +1197,14 @@ compiler.mips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown
 compiler.mips64g1210.semver=12.1.0
 compiler.mips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
+compiler.mips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g1220.semver=12.2.0
+compiler.mips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el:mipselg1210
+group.mipsel.compilers=mips5el:mipselg1210:mipselg1220
 group.mipsel.baseName=mipsel gcc
 
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
@@ -1164,9 +1215,14 @@ compiler.mipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multili
 compiler.mipselg1210.semver=12.1.0
 compiler.mipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 
+compiler.mipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.mipselg1220.semver=12.2.0
+compiler.mipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.mipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips564el:mips64elg1210
+group.mips64el.compilers=mips564el:mips64elg1210:mips64elg1220
 group.mips64el.baseName=mips64 (el) gcc
 
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
@@ -1176,6 +1232,11 @@ compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-
 compiler.mips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
 compiler.mips64elg1210.semver=12.1.0
 compiler.mips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+
+compiler.mips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.mips64elg1220.semver=12.2.0
+compiler.mips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.mips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 ###############################
 # GCC for nanoMIPS
@@ -1200,7 +1261,7 @@ compiler.mrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc3
 
 ###############################
 # GCC for RISC-V
-group.rvgcc.compilers=rv64-gcc1210:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcc1210:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
+group.rvgcc.compilers=rv64-gcc1220:rv64-gcc1210:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcc1220:rv32-gcc1210:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
 group.rvgcc.groupName=RISC-V GCC
 group.rvgcc.supportsExecute=false
 group.rvgcc.isSemVer=true
@@ -1246,6 +1307,13 @@ compiler.rv64-gcc1210.name=RISC-V rv64gc gcc 12.1.0
 compiler.rv64-gcc1210.semver=12.1.0
 compiler.rv64-gcc1210.objdumper=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.rv64-gcc1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1220.semver=12.2.0
+compiler.rv64-gcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.rv64-gcc1220.name=riscv64 12.2.0
+
+
 compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
 compiler.rv32-gcc820.semver=8.2.0
@@ -1285,6 +1353,12 @@ compiler.rv32-gcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unkn
 compiler.rv32-gcc1210.name=RISC-V rv32gc gcc 12.1.0
 compiler.rv32-gcc1210.semver=12.1.0
 compiler.rv32-gcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+
+compiler.rv32-gcc1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1220.semver=12.2.0
+compiler.rv32-gcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.rv32-gcc1220.name=RISC-V rv32gc gcc 12.1.0
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1081,7 +1081,7 @@ compiler.arduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardw
 
 ################################
 # GCC for MSP
-group.msp.compilers=msp430g453:msp430g530:msp430g621:msp430g1220
+group.msp.compilers=msp430g453:msp430g530:msp430g621
 group.msp.groupName=MSP GCC
 group.msp.baseName=MSP430 gcc
 group.msp.isSemVer=true
@@ -1094,11 +1094,6 @@ compiler.msp430g530.exe=/opt/compiler-explorer/msp430-gcc-5.3.0.219_linux32/bin/
 compiler.msp430g530.semver=5.3.0
 compiler.msp430g621.exe=/opt/compiler-explorer/msp430-gcc-6.2.1.16_linux64/bin/msp430-elf-g++
 compiler.msp430g621.semver=6.2.1
-
-compiler.msp430g1220.exe=None
-compiler.msp430g1220.semver=12.2.0
-compiler.msp430g1220.objdumper=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
-compiler.msp430g1220.demangler=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
 
 ################################
 # GCC for AVR
@@ -1311,7 +1306,7 @@ compiler.rv64-gcc1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unkn
 compiler.rv64-gcc1220.semver=12.2.0
 compiler.rv64-gcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
-compiler.rv64-gcc1220.name=riscv64 12.2.0
+compiler.rv64-gcc1220.name=RISC-V rv64gc gcc 12.2.0
 
 
 compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
@@ -1358,7 +1353,7 @@ compiler.rv32-gcc1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unkn
 compiler.rv32-gcc1220.semver=12.2.0
 compiler.rv32-gcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
-compiler.rv32-gcc1220.name=RISC-V rv32gc gcc 12.1.0
+compiler.rv32-gcc1220.name=RISC-V rv32gc gcc 12.2.0
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -624,7 +624,7 @@ group.ccross.groupName=Cross GCC
 group.cs390x.compilers=&cgccs390x
 
 # GCC for s390x
-group.cgccs390x.compilers=cgccs390x112:cs390xg1210
+group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220
 group.cgccs390x.supportsBinary=true
 group.cgccs390x.supportsExecute=false
 group.cgccs390x.baseName=s390x gcc
@@ -639,6 +639,11 @@ compiler.cs390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux
 compiler.cs390xg1210.semver=12.1.0
 compiler.cs390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
+compiler.cs390xg1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cs390xg1220.semver=12.2.0
+compiler.cs390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.cs390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # Cross compilers for PPC
 group.cppcs.compilers=&cppc:&cppc64:&cppc64le
@@ -646,7 +651,7 @@ group.cppcs.isSemVer=true
 group.cppcs.supportsBinary=true
 group.cppcs.supportsExecute=false
 
-group.cppc.compilers=cppcg1210:cppcg1120:cppcg48
+group.cppc.compilers=cppcg1210:cppcg1120:cppcg48:cppcg1220
 group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
@@ -662,7 +667,12 @@ compiler.cppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown
 compiler.cppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1210.semver=12.1.0
 
-group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang
+compiler.cppcg1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1220.semver=12.2.0
+compiler.cppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220
 group.cppc64.groupName=POWER64
 compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -682,6 +692,12 @@ compiler.cppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/power
 compiler.cppc64g1210.semver=power64 gcc 12.1.0
 compiler.cppc64g1210.name=power64 gcc 12.1.0
 
+compiler.cppc64g1220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1220.semver=12.2.0
+compiler.cppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.cppc64g1220.name=power64 gcc 12.2.0
+
 compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cppc64clang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -690,7 +706,7 @@ compiler.cppc64clang.options=-target powerpc64
 compiler.cppc64clang.supportsBinary=false
 compiler.cppc64clang.semver=(snapshot)
 
-group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220
 group.cppc64le.groupName=POWER64LE
 
 compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
@@ -718,6 +734,12 @@ compiler.cppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/p
 compiler.cppc64leg1210.name=power64le gcc 12.1.0
 compiler.cppc64leg1210.semver=12.1.0
 
+compiler.cppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1220.semver=12.2.0
+compiler.cppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.cppc64leg1220.name=power64le gcc 12.2.0
+
 compiler.cppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64leclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cppc64leclang.objdumper=/opt/compiler-explorer/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -737,7 +759,7 @@ group.cgccarm.includeFlag=-I
 
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
-group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1031_07:carm1031_10:carm1021:carm1100:carm1120:carm1121:carm1130:carm1210:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1031_07:carm1031_10:carm1021:carm1100:carm1120:carm1121:carm1130:carm1210:carmgtrunk:carmg1220
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -777,6 +799,12 @@ compiler.carmg820.semver=8.2.0
 compiler.carmg850.exe=/opt/compiler-explorer/arm/gcc-8.5.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gcc
 compiler.carmg850.name=ARM gcc 8.5 (linux)
 compiler.carmg850.semver=8.5.0
+
+compiler.carmg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1220.semver=12.2.0
+compiler.carmg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.carmg1220.name=ARM gcc 12.2 (linux)
 compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc
 compiler.carmce820.name=ARM gcc 8.2 (WinCE)
 compiler.carmce820.semver=8.2.0
@@ -833,7 +861,7 @@ compiler.carmgtrunk.semver=trunk
 
 # 64 bit
 group.cgcc64arm.groupName=Arm 64-bit GCC
-group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g1020:carm64g1030:carm64g1100:carm64g1120:carm64g1130:carm64g1210:carm64gtrunk
+group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g1020:carm64g1030:carm64g1100:carm64g1120:carm64g1130:carm64g1210:carm64gtrunk:carm64g1220
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -881,6 +909,12 @@ compiler.carm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown
 compiler.carm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1210.name=ARM64 gcc 12.1
 compiler.carm64g1210.semver=12.1.0
+
+compiler.carm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1220.semver=12.2.0
+compiler.carm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.carm64g1220.name=ARM64 gcc 12.2
 compiler.carm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64gtrunk.name=ARM64 gcc trunk
 compiler.carm64gtrunk.semver=trunk
@@ -970,7 +1004,7 @@ compiler.carduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hard
 
 ################################
 # GCC for MSP
-group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210
+group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220
 group.cmsp.groupName=MSP GCC
 group.cmsp.baseName=MSP430 gcc
 group.cmsp.isSemVer=true
@@ -987,9 +1021,14 @@ compiler.cmsp430g621.semver=6.2.1
 compiler.cmsp430g1210.exe=/opt/compiler-explorer/gcc-12.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
 compiler.cmsp430g1210.semver=12.1.0
 
+compiler.cmsp430g1220.exe=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.cmsp430g1220.semver=12.2.0
+compiler.cmsp430g1220.objdumper=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.cmsp430g1220.demangler=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -1023,6 +1062,11 @@ compiler.cavrg1210.exe=/opt/compiler-explorer/avr/gcc-12.1.0/bin/avr-gcc
 compiler.cavrg1210.semver=12.1.0
 compiler.cavrg1210.objdumper=/opt/compiler-explorer/avr/gcc-12.1.0/bin/avr-objdump
 
+compiler.cavrg1220.exe=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-gcc
+compiler.cavrg1220.semver=12.2.0
+compiler.cavrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-objdump
+compiler.cavrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
+
 ###############################
 # GCC for MIPS
 group.cmipss.compilers=&cmips:&cmipsel:&cmips64:&cmips64el
@@ -1032,7 +1076,7 @@ group.cmipss.supportsBinary=true
 group.cmipss.supportsExecute=false
 
 ## MIPS
-group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210
+group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210:cmipsg1220
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
 
@@ -1053,9 +1097,14 @@ compiler.cmipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linu
 compiler.cmipsg1210.semver=12.1.0
 compiler.cmipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.cmipsg1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg1220.semver=12.2.0
+compiler.cmipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips564:cmips112064:cmips64g1210
+group.cmips64.compilers=cmips564:cmips112064:cmips64g1210:cmips64g1220
 group.cmips64.baseName=mips64 gcc
 
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -1070,9 +1119,14 @@ compiler.cmips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknow
 compiler.cmips64g1210.semver=12.1.0
 compiler.cmips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
+compiler.cmips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g1220.semver=12.2.0
+compiler.cmips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el:cmipselg1210
+group.cmipsel.compilers=cmips5el:cmipselg1210:cmipselg1220
 group.cmipsel.baseName=mips (el) gcc
 
 compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
@@ -1083,9 +1137,14 @@ compiler.cmipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multil
 compiler.cmipselg1210.semver=12.1.0
 compiler.cmipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 
+compiler.cmipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.cmipselg1220.semver=12.2.0
+compiler.cmipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.cmipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips564el:cmips64elg1210
+group.cmips64el.compilers=cmips564el:cmips64elg1210:cmips64elg1220
 group.cmips64el.baseName=mips64 (el) gcc
 
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
@@ -1096,6 +1155,11 @@ compiler.cmips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el
 compiler.cmips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.cmips64elg1210.semver=12.1.0
 compiler.cmips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+
+compiler.cmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.cmips64elg1220.semver=12.2.0
+compiler.cmips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.cmips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 ###############################
 # GCC for nanoMIPS
@@ -1122,7 +1186,7 @@ compiler.cmrisc32-gcc-trunk.instructionSet=mrisc32
 
 ###############################
 # GCC for RISC-V
-group.rvcgcc.compilers=rv64-cgcc1210:rv64-cgcc1130:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcc1210:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
+group.rvcgcc.compilers=rv64-cgcc1210:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
 group.rvcgcc.groupName=RISC-V GCC
 group.rvcgcc.supportsExecute=false
 
@@ -1162,6 +1226,13 @@ compiler.rv64-cgcc1120.name=RISC-V rv64gc gcc 11.2.0
 compiler.rv64-cgcc1120.semver=11.2.0
 compiler.rv64-cgcc1120.objdumper=/opt/compiler-explorer/riscv64/gcc-11.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1120.supportsBinary=true
+
+compiler.rv64-cgcc1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1220.semver=12.2.0
+compiler.rv64-cgcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.rv64-cgcc1220.name=RISC-V rv64gc gcc 12.2.0
+compiler.rv64-cgcc1220.supportsBinary=true
 
 compiler.rv64-cgcc1130.exe=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcc1130.name=RISC-V rv64gc gcc 11.3.0
@@ -1222,6 +1293,13 @@ compiler.rv32-cgcc1210.name=RISC-V rv32gc gcc 12.1.0
 compiler.rv32-cgcc1210.semver=12.1.0
 compiler.rv32-cgcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-cgcc1210.supportsBinary=true
+
+compiler.rv32-cgcc1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1220.name=RISC-V rv32gc gcc 12.2.0
+compiler.rv32-cgcc1220.semver=12.2.0
+compiler.rv32-cgcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.rv32-cgcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1220.supportsBinary=true
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -43,12 +43,65 @@ compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gdctrunk.semver=(trunk)
 
 ## CROSS GDC
-group.gdccross.compilers=&gdcs390x:&gdcppc:&gdcppc64:&gdcppc64le:&gdcmips64:&gdcmips:&gdcmipsel
+group.gdccross.compilers=&gdcs390x:&gdcppc:&gdcppc64:&gdcppc64le:&gdcmips64:&gdcmips:&gdcmipsel:&gdcarm:&gdcarm64:&gdcriscv:&gdcriscv64
 group.gdccross.supportsExecute=false
 group.gdccross.supportsBinary=true
 
+### GDC for RISCV
+group.gdcriscv.compilers=gdcriscv1220
+group.gdcriscv.groupName=GDC riscv
+group.gdcriscv.includeFlag=-isystem
+group.gdcriscv.isSemVer=true
+group.gdcriscv.baseName=gdc riscv
+
+compiler.gdcriscv1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
+compiler.gdcriscv1220.semver=12.2.0
+compiler.gdcriscv1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.gdcriscv1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.gdcriscv1220.name=riscv32 12.2.0
+
+### GDC for RISCV64
+group.gdcriscv64.compilers=gdcriscv641220
+group.gdcriscv64.groupName=GDC riscv64
+group.gdcriscv64.includeFlag=-isystem
+group.gdcriscv64.isSemVer=true
+group.gdcriscv64.baseName=gdc riscv64
+
+compiler.gdcriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
+compiler.gdcriscv641220.semver=12.2.0
+compiler.gdcriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gdcriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.gdcriscv641220.name=riscv64 12.2.0
+
+
+### GDC for ARM64
+group.gdcarm64.compilers=gdcarm641220
+group.gdcarm64.groupName=GDC arm64
+group.gdcarm64.includeFlag=-isystem
+group.gdcarm64.isSemVer=true
+group.gdcarm64.baseName=gdc arm64
+
+compiler.gdcarm641220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gdc
+compiler.gdcarm641220.semver=12.2.0
+compiler.gdcarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gdcarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.gdcarm641220.name=arm64 12.2.0
+
+### GDC for ARM 32-bits
+group.gdcarm.compilers=gdcarm1220
+group.gdcarm.groupName=GDC arm
+group.gdcarm.includeFlag=-isystem
+group.gdcarm.isSemVer=true
+group.gdcarm.baseName=gdc arm
+
+compiler.gdcarm1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gdc
+compiler.gdcarm1220.semver=12.2.0
+compiler.gdcarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gdcarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.gdcarm1220.name=arm 12.2.0
+
 ### GDC for s390x
-group.gdcs390x.compilers=gdcs390x1210
+group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220
 group.gdcs390x.groupName=GDC s390x
 group.gdcs390x.includeFlag=-isystem
 group.gdcs390x.isSemVer=true
@@ -58,8 +111,13 @@ compiler.gdcs390x1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linu
 compiler.gdcs390x1210.semver=12.1.0
 compiler.gdcs390x1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
+compiler.gdcs390x1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
+compiler.gdcs390x1220.semver=12.2.0
+compiler.gdcs390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gdcs390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ### GDC for powerpc
-group.gdcppc.compilers=gdcppc1210
+group.gdcppc.compilers=gdcppc1210:gdcppc1220
 group.gdcppc.groupName=GDC powerpc
 group.gdcppc.includeFlag=-isystem
 group.gdcppc.isSemVer=true
@@ -69,8 +127,13 @@ compiler.gdcppc1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknow
 compiler.gdcppc1210.semver=12.1.0
 compiler.gdcppc1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 
+compiler.gdcppc1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
+compiler.gdcppc1220.semver=12.2.0
+compiler.gdcppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gdcppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ### GDC for powerpc64
-group.gdcppc64.compilers=gdcppc641210
+group.gdcppc64.compilers=gdcppc641210:gdcppc641220
 group.gdcppc64.groupName=GDC powerpc64
 group.gdcppc64.includeFlag=-isystem
 group.gdcppc64.isSemVer=true
@@ -80,8 +143,13 @@ compiler.gdcppc641210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-
 compiler.gdcppc641210.semver=12.1.0
 compiler.gdcppc641210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 
+compiler.gdcppc641220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
+compiler.gdcppc641220.semver=12.2.0
+compiler.gdcppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gdcppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 ### GDC for powerpc64le
-group.gdcppc64le.compilers=gdcppc64le1210
+group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220
 group.gdcppc64le.groupName=GDC powerpc64le
 group.gdcppc64le.includeFlag=-isystem
 group.gdcppc64le.isSemVer=true
@@ -91,8 +159,13 @@ compiler.gdcppc64le1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerp
 compiler.gdcppc64le1210.semver=12.1.0
 compiler.gdcppc64le1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 
+compiler.gdcppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
+compiler.gdcppc64le1220.semver=12.2.0
+compiler.gdcppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gdcppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 ### GDC for mips64
-group.gdcmips64.compilers=gdcmips641210
+group.gdcmips64.compilers=gdcmips641210:gdcmips641220
 group.gdcmips64.groupName=GDC mips64
 group.gdcmips64.includeFlag=-isystem
 group.gdcmips64.isSemVer=true
@@ -102,8 +175,13 @@ compiler.gdcmips641210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unkno
 compiler.gdcmips641210.semver=12.1.0
 compiler.gdcmips641210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
+compiler.gdcmips641220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
+compiler.gdcmips641220.semver=12.2.0
+compiler.gdcmips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gdcmips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ### GDC for mips
-group.gdcmips.compilers=gdcmips1210
+group.gdcmips.compilers=gdcmips1210:gdcmips1220
 group.gdcmips.groupName=GDC mips
 group.gdcmips.includeFlag=-isystem
 group.gdcmips.isSemVer=true
@@ -113,8 +191,13 @@ compiler.gdcmips1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-lin
 compiler.gdcmips1210.semver=12.1.0
 compiler.gdcmips1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.gdcmips1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
+compiler.gdcmips1220.semver=12.2.0
+compiler.gdcmips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gdcmips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ### GDC for mipsel
-group.gdcmipsel.compilers=gdcmipsel1210
+group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220
 group.gdcmipsel.groupName=GDC mipsel
 group.gdcmipsel.includeFlag=-isystem
 group.gdcmipsel.isSemVer=true
@@ -123,6 +206,11 @@ group.gdcmipsel.baseName=gdc mipsel
 compiler.gdcmipsel1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
 compiler.gdcmipsel1210.semver=12.1.0
 compiler.gdcmipsel1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+
+compiler.gdcmipsel1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
+compiler.gdcmipsel1220.semver=12.2.0
+compiler.gdcmipsel1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gdcmipsel1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldc1_28:ldc1_29:ldc1_30:ldcbeta:ldclatestci
 group.ldc.compilerType=ldc

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -157,7 +157,7 @@ compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccrisv:&gccriscv64
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64
 group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
@@ -173,7 +173,6 @@ compiler.friscv64g1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unk
 compiler.friscv64g1220.semver=12.2.0
 compiler.friscv64g1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.friscv64g1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
-compiler.friscv64g1220.name=riscv64 12.2.0
 
 ###############################
 # GCC for RISCV
@@ -185,7 +184,6 @@ compiler.friscvg1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unkno
 compiler.friscvg1220.semver=12.2.0
 compiler.friscvg1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.friscvg1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
-compiler.friscvg1220.name=riscv32 12.2.0
 
 ###############################
 # GCC for ARM

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -157,14 +157,39 @@ compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccrisv:&gccriscv64
 group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
 
+
+###############################
+# GCC for RISCV64
+group.gccriscv64.compilers=friscv64g1220
+group.gccriscv64.groupName=RISCV64 gfortran
+group.gccriscv64.baseName=RISCV64 gfortran
+
+compiler.friscv64g1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.friscv64g1220.semver=12.2.0
+compiler.friscv64g1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.friscv64g1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.friscv64g1220.name=riscv64 12.2.0
+
+###############################
+# GCC for RISCV
+group.gccriscv.compilers=friscvg1220
+group.gccriscv.groupName=RISCV (32bit) gfortran
+group.gccriscv.baseName=RISCV (32bit) gfortran
+
+compiler.friscvg1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
+compiler.friscvg1220.semver=12.2.0
+compiler.friscvg1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.friscvg1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.friscvg1220.name=riscv32 12.2.0
+
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1210
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1210:farmg1220
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
 
@@ -180,15 +205,25 @@ compiler.farmg820.semver=8.2
 compiler.farmg1210.exe=/opt/compiler-explorer/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
 compiler.farmg1210.semver=12.1.0
 
+compiler.farmg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1220.semver=12.2.0
+compiler.farmg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 ###############################
 ## GCC for s390x
-group.gccs390x.compilers=fs390xg1210
+group.gccs390x.compilers=fs390xg1210:fs390xg1220
 group.gccs390x.groupName=s390x gfortran
 group.gccs390x.baseName=s390x gfortran
 
 compiler.fs390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
 compiler.fs390xg1210.semver=12.1.0
 compiler.fs390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+compiler.fs390xg1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
+compiler.fs390xg1220.semver=12.2.0
+compiler.fs390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.fs390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 ###############################
 # LLVM Flang for X86
@@ -209,7 +244,7 @@ compiler.flangtrunknew.supportsBinary=false
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1210
+group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1210:farm64g1220
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 compiler.farm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g640.name=AARCH64 gfortran 6.4
@@ -222,6 +257,12 @@ compiler.farm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown
 compiler.farm64g1210.name=AARCH64 gfortran 12.1.0
 compiler.farm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 
+compiler.farm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1220.semver=12.2.0
+compiler.farm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.farm64g1220.name=AARCH64 gfortran 12.2.0
+
 ###############################
 # GCC for PPCs
 group.ppcs.compilers=&ppc64:&ppc64le:&ppc
@@ -229,7 +270,7 @@ group.ppcs.groupName=POWER Compilers
 
 ###############################
 # GCC for PPC
-group.ppc.compilers=fppcg1210
+group.ppc.compilers=fppcg1210:fppcg1220
 group.ppc.groupName=POWER gfortran
 group.ppc.baseName=POWER gfortran
 
@@ -237,9 +278,14 @@ compiler.fppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown
 compiler.fppcg1210.semver=12.1.0
 compiler.fppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 
+compiler.fppcg1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
+compiler.fppcg1220.semver=12.2.0
+compiler.fppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.fppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for PPC64
-group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210
+group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220
 group.ppc64.groupName=POWER64 gfortran
 group.ppc64.baseName=POWER64 gfortran
 
@@ -255,9 +301,14 @@ compiler.fppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-u
 compiler.fppc64g1210.semver=12.1.0
 compiler.fppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 
+compiler.fppc64g1220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.fppc64g1220.semver=12.2.0
+compiler.fppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.fppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for PPC64LE
-group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210
+group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220
 group.ppc64le.groupName=POWER64le gfortran
 group.ppc64le.baseName=POWER64le gfortran
 
@@ -272,6 +323,11 @@ compiler.fppc64leg9.semver=(snapshot)
 compiler.fppc64leg1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
 compiler.fppc64leg1210.semver=12.1.0
 compiler.fppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+
+compiler.fppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg1220.semver=12.2.0
+compiler.fppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.fppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 ################################
 # GCC for RISC-V 32-bits
@@ -295,7 +351,7 @@ compiler.frv64g1210.exe=/opt/compiler-explorer/gcc-12.1.0/riscv64-unknown-elf/bi
 
 ################################
 # GCC for MIPS
-group.gccmips.compilers=fmipsg1210
+group.gccmips.compilers=fmipsg1210:fmipsg1220
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
 
@@ -303,9 +359,14 @@ compiler.fmipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linu
 compiler.fmipsg1210.semver=12.1.0
 compiler.fmipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 
+compiler.fmipsg1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg1220.semver=12.2.0
+compiler.fmipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ################################
 # GCC for MIPS64
-group.gccmips64.compilers=fmips64g1210
+group.gccmips64.compilers=fmips64g1210:fmips64g1220
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
 
@@ -313,9 +374,14 @@ compiler.fmips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknow
 compiler.fmips64g1210.semver=12.1.0
 compiler.fmips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 
+compiler.fmips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g1220.semver=12.2.0
+compiler.fmips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ################################
 # GCC for MIPSEL
-group.gccmipsel.compilers=fmipselg1210
+group.gccmipsel.compilers=fmipselg1210:fmipselg1220
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
 
@@ -323,15 +389,25 @@ compiler.fmipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multil
 compiler.fmipselg1210.semver=12.1.0
 compiler.fmipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 
+compiler.fmipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
+compiler.fmipselg1220.semver=12.2.0
+compiler.fmipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.fmipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ################################
 # GCC for MIPS64el
-group.gccmips64el.compilers=fmips64elg1210
+group.gccmips64el.compilers=fmips64elg1210:fmips64elg1220
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
 
 compiler.fmips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
 compiler.fmips64elg1210.semver=12.1.0
 compiler.fmips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+
+compiler.fmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
+compiler.fmips64elg1220.semver=12.2.0
+compiler.fmips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.fmips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 #################################
 #################################

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -372,15 +372,144 @@ compiler.wasm_gltip.semver=(tip)
 
 ###############################
 # Cross GO
-group.cross.compilers=&ppc
+group.cross.compilers=&gccgoppc:&gccgoppc64:&gccgoppc64le:&gccgoarm:&gccgoarm64:&gccgomips:&gccgos390x:&gccgoriscv64:&gccgomipsel:&gccgomips64el
 group.cross.supportsBinary=false
 group.cross.groupName=Cross Go
 
 ###############################
+# GCC for mips64el
+group.gccgomips64el.compilers=gccgomips64el1220
+group.gccgomips64el.groupName=GCCGO mips64el
+group.gccgomips64el.isSemVer=true
+
+compiler.gccgomips64el1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
+compiler.gccgomips64el1220.semver=12.2.0
+compiler.gccgomips64el1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gccgomips64el1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+compiler.gccgomips64el1220.name=mips64el 12.2.0
+
+###############################
+# GCC for mipsel
+group.gccgomipsel.compilers=gccgomipsel1220
+group.gccgomipsel.groupName=GCCGO mips64el
+group.gccgomipsel.isSemVer=true
+
+compiler.gccgomipsel1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
+compiler.gccgomipsel1220.semver=12.2.0
+compiler.gccgomipsel1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gccgomipsel1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+compiler.gccgomipsel1220.name=mipsel 12.2.0
+
+###############################
+# GCC for riscv64
+group.gccgorisc64.compilers=gccgoriscv641220
+group.gccgorisc64.groupName=GCCGO riscv64
+group.gccgorisc64.isSemVer=true
+
+compiler.gccgoriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
+compiler.gccgoriscv641220.semver=12.2.0
+compiler.gccgoriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gccgoriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.gccgoriscv641220.name=riscv64 12.2.0
+
+###############################
+# GCC for s390x
+group.gccgos390x.compilers=gccgos390x1220
+group.gccgos390x.groupName=GCCGO s390x
+group.gccgos390x.isSemVer=true
+
+compiler.gccgos390x1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
+compiler.gccgos390x1220.semver=12.2.0
+compiler.gccgos390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gccgos390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+compiler.gccgos390x1220.name=s390x 12.2.0
+
+###############################
+# GCC for MIPS
+group.gccgomips.compilers=gccgomips1220
+group.gccgomips.groupName=GCCGO mips
+group.gccgomips.isSemVer=true
+
+compiler.gccgomips1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
+compiler.gccgomips1220.semver=12.2.0
+compiler.gccgomips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gccgomips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+compiler.gccgomips1220.name=mips 12.2.0
+
+###############################
+# GCC for MIPS64
+group.gccgomips64.compilers=gccgomips641220
+group.gccgomips64.groupName=GCCGO mips64
+group.gccgomips64.isSemVer=true
+
+compiler.gccgomips641220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
+compiler.gccgomips641220.semver=12.2.0
+compiler.gccgomips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gccgomips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+compiler.gccgomips641220.name=mips64 12.2.0
+
+
+###############################
+# GCC for ARM64
+group.gccgoarm64.compilers=gccgoarm641220
+group.gccgoarm64.groupName=GCCGO arm64
+group.gccgoarm64.isSemVer=true
+
+compiler.gccgoarm641220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
+compiler.gccgoarm641220.semver=12.2.0
+compiler.gccgoarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gccgoarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.gccgoarm641220.name=arm64 12.2.0
+
+###############################
+# GCC for ARM
+group.gccgoarm.compilers=gccgoarm1220
+group.gccgoarm.groupName=GCCGO arm
+group.gccgoarm.isSemVer=true
+
+compiler.gccgoarm1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
+compiler.gccgoarm1220.semver=12.2.0
+compiler.gccgoarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gccgoarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.gccgoarm1220.name=arm 12.2.0
+
+###############################
 # GCC for PPC
-group.ppc.compilers=gppc64leg8:gppc64g8:gppc64leg9:gppc64g9
-group.ppc.groupName=POWER Compilers
-group.ppc.isSemVer=true
+group.gccgoppc.compilers=gccgoppc1220
+group.gccgoppc.groupName=POWER Compilers
+group.gccgoppc.isSemVer=true
+
+compiler.gccgoppc1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
+compiler.gccgoppc1220.semver=12.2.0
+compiler.gccgoppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gccgoppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+compiler.gccgoppc1220.name=powerpc 12.2.0
+
+###############################
+# GCC for PPC64
+group.gccgoppc64le.compilers=gccgoppc64le1220
+group.gccgoppc64le.groupName=POWER64LE Compilers
+group.gccgoppc64le.isSemVer=true
+
+compiler.gccgoppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
+compiler.gccgoppc64le1220.semver=12.2.0
+compiler.gccgoppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gccgoppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.gccgoppc64le1220.name=powerpc64le 12.2.0
+
+
+###############################
+# GCC for PPC64
+group.gccgoppc64.compilers=gppc64leg8:gppc64g8:gppc64leg9:gppc64g9:gccgoppc641220
+group.gccgoppc64.groupName=POWER64 Compilers
+group.gccgoppc64.isSemVer=true
+
+compiler.gccgoppc641220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
+compiler.gccgoppc641220.semver=12.2.0
+compiler.gccgoppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gccgoppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.gccgoppc641220.name=powerpc64 12.2.0
+
 compiler.gppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
 compiler.gppc64leg8.name=power64le AT12.0
 compiler.gppc64leg8.semver=(snapshot)

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -372,7 +372,7 @@ compiler.wasm_gltip.semver=(tip)
 
 ###############################
 # Cross GO
-group.cross.compilers=&gccgoppc:&gccgoppc64:&gccgoppc64le:&gccgoarm:&gccgoarm64:&gccgomips:&gccgos390x:&gccgoriscv64:&gccgomipsel:&gccgomips64el
+group.cross.compilers=&gccgoppc:&gccgoppc64:&gccgoppc64le:&gccgoarm:&gccgoarm64:&gccgos390x:&gccgoriscv64:&gccgomipsel:&gccgomips64el:&gccgomips:&gccgomips64
 group.cross.supportsBinary=false
 group.cross.groupName=Cross Go
 
@@ -391,7 +391,7 @@ compiler.gccgomips64el1220.name=mips64el 12.2.0
 ###############################
 # GCC for mipsel
 group.gccgomipsel.compilers=gccgomipsel1220
-group.gccgomipsel.groupName=GCCGO mips64el
+group.gccgomipsel.groupName=GCCGO mips64
 group.gccgomipsel.isSemVer=true
 
 compiler.gccgomipsel1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
@@ -402,9 +402,9 @@ compiler.gccgomipsel1220.name=mipsel 12.2.0
 
 ###############################
 # GCC for riscv64
-group.gccgorisc64.compilers=gccgoriscv641220
-group.gccgorisc64.groupName=GCCGO riscv64
-group.gccgorisc64.isSemVer=true
+group.gccgoriscv64.compilers=gccgoriscv641220
+group.gccgoriscv64.groupName=GCCGO riscv64
+group.gccgoriscv64.isSemVer=true
 
 compiler.gccgoriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
 compiler.gccgoriscv641220.semver=12.2.0
@@ -476,7 +476,7 @@ compiler.gccgoarm1220.name=arm 12.2.0
 ###############################
 # GCC for PPC
 group.gccgoppc.compilers=gccgoppc1220
-group.gccgoppc.groupName=POWER Compilers
+group.gccgoppc.groupName=GCCGO POWER
 group.gccgoppc.isSemVer=true
 
 compiler.gccgoppc1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
@@ -488,7 +488,7 @@ compiler.gccgoppc1220.name=powerpc 12.2.0
 ###############################
 # GCC for PPC64
 group.gccgoppc64le.compilers=gccgoppc64le1220
-group.gccgoppc64le.groupName=POWER64LE Compilers
+group.gccgoppc64le.groupName=GCCGO POWER64LE
 group.gccgoppc64le.isSemVer=true
 
 compiler.gccgoppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
@@ -501,7 +501,7 @@ compiler.gccgoppc64le1220.name=powerpc64le 12.2.0
 ###############################
 # GCC for PPC64
 group.gccgoppc64.compilers=gppc64leg8:gppc64g8:gppc64leg9:gppc64g9:gccgoppc641220
-group.gccgoppc64.groupName=POWER64 Compilers
+group.gccgoppc64.groupName=GCCGO POWER64
 group.gccgoppc64.isSemVer=true
 
 compiler.gccgoppc641220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo


### PR DESCRIPTION
Add newly released GCC 12.2.0 for our existing cross-compilers.
Along with the update, more languages have been enabled where possible.

Tried languages C++, D, Ada, Objective-C, Objective-C++, Fortran and Go.

Updated targets: arm arm64 avr mips mips64 msp430 powerpc powerpc64 powerpc64le
  s390x riscv32 riscv64 mipsel mips64el

closes #3973

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>