### PR TITLE
tsify exec.js

### DIFF
--- a/lib/compilers/beebasm.ts
+++ b/lib/compilers/beebasm.ts
@@ -63,15 +63,15 @@ export class BeebAsmCompiler extends BaseCompiler {
 
         const hasBootOption = options.some(opt => opt.includes('-boot'));
 
-        const result = await this.exec(compiler, options, execOptions);
-        result.inputFilename = inputFilename;
-        const transformedInput = result.filenameTransform(inputFilename);
+        const compilerExecResult = await this.exec(compiler, options, execOptions);
 
-        if (result.stdout.length > 0) {
+        if (compilerExecResult.stdout.length > 0) {
             const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase);
-            fs.writeFileSync(outputFilename, result.stdout);
-            result.stdout = '';
+            fs.writeFileSync(outputFilename, compilerExecResult.stdout);
+            compilerExecResult.stdout = '';
         }
+
+        const result = this.transformToCompilationResult(compilerExecResult, inputFilename);
 
         if (result.code === 0 && options.includes('-v')) {
             const diskfile = path.join(dirPath, 'disk.ssd');
@@ -88,8 +88,6 @@ export class BeebAsmCompiler extends BaseCompiler {
                 }
             }
         }
-
-        this.parseCompilationOutput(result, transformedInput);
 
         const hasNoSaveError = result.stderr.some(opt => opt.text.includes('warning: no SAVE command in source file'));
         if (hasNoSaveError) {

--- a/lib/compilers/pony.ts
+++ b/lib/compilers/pony.ts
@@ -94,10 +94,7 @@ export class PonyCompiler extends BaseCompiler {
         // So we must set the input to the directory rather than a file.
         options = _.map(options, arg => (arg.includes(inputFilename) ? path.dirname(arg) : arg));
 
-        const result = await this.exec(compiler, options, execOptions);
-        result.inputFilename = inputFilename;
-        const transformedInput = result.filenameTransform(inputFilename);
-        this.parseCompilationOutput(result, transformedInput);
-        return result;
+        const compilerExecResult = await this.exec(compiler, options, execOptions);
+        return this.transformToCompilationResult(compilerExecResult, inputFilename);
     }
 }

--- a/lib/compilers/rga.ts
+++ b/lib/compilers/rga.ts
@@ -116,10 +116,7 @@ Please supply an ASIC from the following options:`,
         }
 
         const result = await this.execDXCandRGA(compiler, options, execOptions);
-        result.inputFilename = inputFilename;
-        const transformedInput = result.filenameTransform(inputFilename);
-        this.parseCompilationOutput(result, transformedInput);
-        return result;
+        return this.transformToCompilationResult(result, inputFilename);
     }
 
     async execDXCandRGA(filepath: string, args: string[], execOptions: ExecutionOptions): Promise<any> {
@@ -182,7 +179,7 @@ Please supply an ASIC from the following options:`,
             '-s',
             'vk-spv-txt-offline',
             '-c',
-            asicSelection.asic,
+            asicSelection.asic || '',
             '--isa',
             outputFile,
             '--livereg',

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -26,9 +26,9 @@ import path from 'path';
 
 import _ from 'underscore';
 
+import {BasicExecutionResult, UnprocessedExecResult} from '../../types/execution/execution.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {BuildEnvDownloadInfo} from '../buildenvsetup/buildenv.interfaces';
-import {logger} from '../logger';
 import {parseRustOutput} from '../utils';
 
 import {RustParser} from './argument-parsers';
@@ -160,8 +160,11 @@ export class RustCompiler extends BaseCompiler {
         return true;
     }
 
-    override parseCompilationOutput(result, inputFilename) {
-        result.stdout = parseRustOutput(result.stdout, inputFilename);
-        result.stderr = parseRustOutput(result.stderr, inputFilename);
+    override processExecutionResult(input: UnprocessedExecResult, inputFilename?: string): BasicExecutionResult {
+        return {
+            ...input,
+            stdout: parseRustOutput(input.stdout, inputFilename),
+            stderr: parseRustOutput(input.stderr, inputFilename),
+        };
     }
 }

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -221,7 +221,7 @@ export function getNsJailOptions(
 
     const env = {...options.env, HOME: homeDir};
     if (options.ldPath) {
-        jailingOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath}`);
+        jailingOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath.join(path.delimiter)}`);
         delete options.ldPath;
         delete env.LD_LIBRARY_PATH;
     }
@@ -290,7 +290,7 @@ function sandboxFirejail(command: string, args: string[], options) {
     ]);
 
     if (options.ldPath) {
-        jailingOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath}`);
+        jailingOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath.join(path.delimiter)}`);
         delete options.ldPath;
     }
 
@@ -492,7 +492,7 @@ async function executeFirejail(command, args, options) {
     baseOptions.push('--profile=' + getFirejailProfileFilePath('execute'));
 
     if (options.ldPath) {
-        baseOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath}`);
+        baseOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath.join(path.delimiter)}`);
         delete options.ldPath;
     }
 

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -30,8 +30,17 @@ import Graceful from 'node-graceful';
 import treeKill from 'tree-kill';
 import _ from 'underscore';
 
+import {ExecutionOptions} from '../types/compilation/compilation.interfaces';
+import {FilenameTransformFunc, UnprocessedExecResult} from '../types/execution/execution.interfaces';
+
 import {logger} from './logger';
 import {propsFor} from './properties';
+
+type NsJailOptions = {
+    args: string[];
+    options: ExecutionOptions;
+    filenameTransform: FilenameTransformFunc;
+};
 
 const execProps = propsFor('execution');
 
@@ -42,17 +51,19 @@ function setupOnError(stream, name) {
     });
 }
 
-export function executeDirect(command, args, options, filenameTransform) {
-    // filename transform is expected to have been pre-applied by the caller.
-    // it is passed through here only so clients can see it in the result.
-    filenameTransform = filenameTransform || (x => x);
+export async function executeDirect(
+    command: string,
+    args: string[],
+    options: ExecutionOptions,
+    filenameTransform?: FilenameTransformFunc,
+): Promise<UnprocessedExecResult> {
     options = options || {};
     const maxOutput = options.maxOutput || 1024 * 1024;
     const timeoutMs = options.timeoutMs || 0;
     const env = {...process.env, ...options.env};
 
     if (options.ldPath) {
-        env.LD_LIBRARY_PATH = options.ldPath;
+        env.LD_LIBRARY_PATH = options.ldPath.join(path.delimiter);
     }
 
     if (options.wrapper) {
@@ -85,7 +96,7 @@ export function executeDirect(command, args, options, filenameTransform) {
     const kill =
         options.killChild ||
         (() => {
-            if (running) treeKill(child.pid);
+            if (running && child && child.pid) treeKill(child.pid);
         });
 
     const streams = {
@@ -138,11 +149,11 @@ export function executeDirect(command, args, options, filenameTransform) {
             if (code === null) code = -1;
             if (timeout !== undefined) clearTimeout(timeout);
             const endTime = process.hrtime.bigint();
-            const result = {
+            const result: UnprocessedExecResult = {
                 code,
                 okToCache,
                 timedOut,
-                filenameTransform,
+                filenameTransform: filenameTransform || (x => x),
                 stdout: streams.stdout,
                 stderr: streams.stderr,
                 execTime: ((endTime - startTime) / BigInt(1000000)).toString(),
@@ -157,7 +168,7 @@ export function executeDirect(command, args, options, filenameTransform) {
     });
 }
 
-export function getNsJailCfgFilePath(configName) {
+export function getNsJailCfgFilePath(configName: string): string {
     const propKey = `nsjail.config.${configName}`;
     const configPath = execProps(propKey);
     if (configPath === undefined) {
@@ -167,7 +178,7 @@ export function getNsJailCfgFilePath(configName) {
     return configPath;
 }
 
-export function getFirejailProfileFilePath(profileName) {
+export function getFirejailProfileFilePath(profileName: string): string {
     const propKey = `firejail.profile.${profileName}`;
     const profilePath = execProps(propKey);
     if (profilePath === undefined) {
@@ -177,7 +188,12 @@ export function getFirejailProfileFilePath(profileName) {
     return profilePath;
 }
 
-export function getNsJailOptions(configName, command, args, options) {
+export function getNsJailOptions(
+    configName: string,
+    command: string,
+    args: string[],
+    options: ExecutionOptions,
+): NsJailOptions {
     options = {...options};
     const jailingOptions = ['--config', getNsJailCfgFilePath(configName)];
 
@@ -222,7 +238,7 @@ export function getNsJailOptions(configName, command, args, options) {
     };
 }
 
-export function getSandboxNsjailOptions(command, args, options) {
+export function getSandboxNsjailOptions(command: string, args: string[], options: ExecutionOptions): NsJailOptions {
     // If we already had a custom cwd, use that.
     if (options.customCwd) {
         let relativeCommand = command;
@@ -251,7 +267,7 @@ function executeNsjail(command, args, options) {
     return executeDirect(execProps('nsjail'), nsOpts.args, nsOpts.options, nsOpts.filenameTransform);
 }
 
-function withFirejailTimeout(args, options) {
+function withFirejailTimeout(args: string[], options?) {
     if (options && options.timeoutMs) {
         // const ExtraWallClockLeewayMs = 1000;
         const ExtraCpuLeewayMs = 1500;
@@ -260,7 +276,7 @@ function withFirejailTimeout(args, options) {
     return args;
 }
 
-function sandboxFirejail(command, args, options) {
+function sandboxFirejail(command: string, args: string[], options) {
     logger.info('Sandbox execution via firejail', {command, args});
     const execPath = path.dirname(command);
     const execName = path.basename(command);
@@ -298,7 +314,11 @@ const sandboxDispatchTable = {
     firejail: sandboxFirejail,
 };
 
-export async function sandbox(command, args, options) {
+export async function sandbox(
+    command: string,
+    args: string[],
+    options: ExecutionOptions,
+): Promise<UnprocessedExecResult> {
     const type = execProps('sandboxType', 'firejail');
     const dispatchEntry = sandboxDispatchTable[type];
     if (!dispatchEntry) throw new Error(`Bad sandbox type ${type}`);
@@ -309,7 +329,7 @@ const wineSandboxName = 'ce-wineserver';
 // WINE takes a while to initialise and very often we don't need to run it at
 // all during startup. So, we do just the bare minimum at startup and then make
 // a promise that all subsequent WINE calls wait on.
-let wineInitPromise = null;
+let wineInitPromise: Promise<void> | null;
 
 export function startWineInit() {
     const wine = execProps('wine');
@@ -327,7 +347,7 @@ export function startWineInit() {
 
     logger.info(`Initialising WINE in ${prefix}`);
 
-    const asyncSetup = async () => {
+    const asyncSetup = async (): Promise<void> => {
         if (!(await fs.pathExists(prefix))) {
             logger.info(`Creating directory ${prefix}`);
             await fs.mkdir(prefix);
@@ -374,9 +394,9 @@ export function startWineInit() {
         });
 
         Graceful.on('exit', () => {
-            const waitingPromises = [];
+            const waitingPromises: Promise<void>[] = [];
 
-            function waitForExit(process, name) {
+            function waitForExit(process, name): Promise<void> {
                 return new Promise(resolve => {
                     process.on('close', () => {
                         logger.info(`Process '${name}' closed`);
@@ -507,7 +527,11 @@ const executeDispatchTable = {
         needsWine(command) ? executeFirejail(command, args, options) : executeNsjail(command, args, options),
 };
 
-export async function execute(command, args, options) {
+export async function execute(
+    command: string,
+    args: string[],
+    options: ExecutionOptions,
+): Promise<UnprocessedExecResult> {
     const type = execProps('executionType', 'none');
     const dispatchEntry = executeDispatchTable[type];
     if (!dispatchEntry) throw new Error(`Bad sandbox type ${type}`);

--- a/test/base-compiler-tests.js
+++ b/test/base-compiler-tests.js
@@ -302,7 +302,17 @@ describe('Compiler execution', function () {
         stubOutCallToExec(execStub, compiler, 'This is the output file', fakeExecResults);
         const source = 'Some cacheable source';
         const options = 'Some cacheable options';
-        ceMock.expects('cachePut').withArgs(match({source, options}), match(fakeExecResults)).resolves();
+        ceMock
+            .expects('cachePut')
+            .withArgs(
+                match({source, options}),
+                match({
+                    ...fakeExecResults,
+                    stdout: [{text: 'stdout'}],
+                    stderr: [{text: 'stderr'}],
+                }),
+            )
+            .resolves();
         const uncachedResult = await compiler.compile(source, options, {}, {}, false, [], {}, []);
         uncachedResult.code.should.equal(0);
         ceMock.verify();

--- a/test/exec-tests.js
+++ b/test/exec-tests.js
@@ -224,9 +224,11 @@ describe('Execution tests', () => {
             args.should.include('--time_limit=2');
         });
         it('should handle linker paths', () => {
-            const {args, options} = exec.getNsJailOptions('sandbox', '/path/to/compiler', [], {ldPath: '/a/lib/path'});
+            const {args, options} = exec.getNsJailOptions('sandbox', '/path/to/compiler', [], {
+                ldPath: ['/a/lib/path', '/b/lib2'],
+            });
             options.should.deep.equals({});
-            args.should.include('--env=LD_LIBRARY_PATH=/a/lib/path');
+            args.should.include('--env=LD_LIBRARY_PATH=/a/lib/path:/b/lib2');
         });
         it('should handle envs', () => {
             const {args, options} = exec.getNsJailOptions('sandbox', '/path/to/compiler', [], {

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -80,6 +80,10 @@ export type CompilationResult = {
 
     hasHaskellCmmOutput?: boolean;
     haskellCmmOutput?: any;
+
+    forceBinaryView?: boolean;
+    bbcdiskimage?: string;
+    hints?: string[];
 };
 
 export type ExecutionOptions = {
@@ -92,6 +96,7 @@ export type ExecutionOptions = {
     appHome?: string;
     customCwd?: string;
     input?: any;
+    killChild?: () => void;
 };
 
 export type BuildResult = {

--- a/types/execution/execution.interfaces.ts
+++ b/types/execution/execution.interfaces.ts
@@ -27,3 +27,10 @@ export type BasicExecutionResult = {
     execTime: string;
     timedOut: boolean;
 };
+
+export type ExecutableExecutionOptions = {
+    args: string[];
+    stdin: string;
+    ldPath: string[];
+    env: any;
+};

--- a/types/execution/execution.interfaces.ts
+++ b/types/execution/execution.interfaces.ts
@@ -1,3 +1,5 @@
+import {ResultLine} from '../resultline/resultline.interfaces';
+
 export type FilenameTransformFunc = (filename: string) => string;
 
 export type UnprocessedExecResult = {
@@ -7,6 +9,7 @@ export type UnprocessedExecResult = {
     stdout: string;
     stderr: string;
     execTime: string;
+    timedOut: boolean;
 };
 
 export type TypicalExecutionFunc = (
@@ -14,3 +17,13 @@ export type TypicalExecutionFunc = (
     args: string[],
     execOptions: object,
 ) => Promise<UnprocessedExecResult>;
+
+export type BasicExecutionResult = {
+    code: number;
+    okToCache: boolean;
+    filenameTransform: FilenameTransformFunc;
+    stdout: ResultLine[];
+    stderr: ResultLine[];
+    execTime: string;
+    timedOut: boolean;
+};


### PR DESCRIPTION
Changed `exec.js` to typescript, adding types to at least the exported functions, and then the fallout of those choices.

Things to note:

* base-compiler then required some conversion steps to convert from `UnprocessedExecResult` to `BasicExecutionResult` (`stdout` and `stderr` as arrays) and then to a `CompilationResult`
* I did this with some functions that do `{...input, morestuff}`, which copies the object - probably not the best idea, but not sure if there's a good alternative that is both readable and as fast as before. _Any ideas?_
* Also the names of the functions are not great. `Any ideas?`
* Also noticed either a bug in the code or the test, but I changed the test. I'm not sure how that ever actually worked, because a compiler run always results in `stdout` and `stderr` to be arrays, not strings. Maybe I missed something.
