### PR TITLE
tsify instructionsets

### DIFF
--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -92,6 +92,7 @@ export class InstructionSets {
                     for (const target of method.target) {
                         if (compilerArch.includes(target)) {
                             resolve(instructionSet);
+                            return;
                         }
                     }
                 }
@@ -101,6 +102,7 @@ export class InstructionSets {
                     for (const path of method.path) {
                         if (exe.includes(path)) {
                             resolve(instructionSet);
+                            return;
                         }
                     }
                 }

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -22,20 +22,16 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import _ from 'underscore';
-
 type InstructionSetMethod = {
     target: string[];
     path: string[];
 };
 
 export class InstructionSets {
-    public default: string;
-    private supported: Record<string, InstructionSetMethod>;
+    public default: string = 'amd64';
+    private supported: Record<string, InstructionSetMethod> = {};
 
     constructor() {
-        this.default = 'amd64';
-
         this.supported = {
             aarch64: {
                 target: ['aarch64'],
@@ -91,21 +87,23 @@ export class InstructionSets {
     async getCompilerInstructionSetHint(compilerArch: string | boolean, exe: string): Promise<string> {
         return new Promise(resolve => {
             if (compilerArch && typeof compilerArch === 'string') {
-                _.each(this.supported, (method: InstructionSetMethod, instructionSet: string) => {
+                for (const instructionSet in this.supported) {
+                    const method = this.supported[instructionSet];
                     for (const target of method.target) {
                         if (compilerArch.includes(target)) {
                             resolve(instructionSet);
                         }
                     }
-                });
+                }
             } else {
-                _.each(this.supported, (method: InstructionSetMethod, instructionSet: string) => {
+                for (const instructionSet in this.supported) {
+                    const method = this.supported[instructionSet];
                     for (const path of method.path) {
                         if (exe.includes(path)) {
                             resolve(instructionSet);
                         }
                     }
-                });
+                }
             }
 
             resolve(this.default);

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -28,7 +28,7 @@ type InstructionSetMethod = {
 };
 
 export class InstructionSets {
-    public default: string = 'amd64';
+    private defaultInstructionset = 'amd64';
     private supported: Record<string, InstructionSetMethod> = {};
 
     constructor() {
@@ -106,7 +106,7 @@ export class InstructionSets {
                 }
             }
 
-            resolve(this.default);
+            resolve(this.defaultInstructionset);
         });
     }
 }

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -24,7 +24,15 @@
 
 import _ from 'underscore';
 
+type InstructionSetMethod = {
+    target: string[];
+    path: string[];
+};
+
 export class InstructionSets {
+    public default: string;
+    private supported: Record<string, InstructionSetMethod>;
+
     constructor() {
         this.default = 'amd64';
 
@@ -80,19 +88,19 @@ export class InstructionSets {
         };
     }
 
-    async getCompilerInstructionSetHint(compilerArch, exe) {
+    async getCompilerInstructionSetHint(compilerArch: string | boolean, exe: string): Promise<string> {
         return new Promise(resolve => {
-            if (compilerArch) {
-                _.each(this.supported, (method, instructionSet) => {
-                    for (let target of method.target) {
+            if (compilerArch && typeof compilerArch === 'string') {
+                _.each(this.supported, (method: InstructionSetMethod, instructionSet: string) => {
+                    for (const target of method.target) {
                         if (compilerArch.includes(target)) {
                             resolve(instructionSet);
                         }
                     }
                 });
             } else {
-                _.each(this.supported, (method, instructionSet) => {
-                    for (let path of method.path) {
+                _.each(this.supported, (method: InstructionSetMethod, instructionSet: string) => {
+                    for (const path of method.path) {
                         if (exe.includes(path)) {
                             resolve(instructionSet);
                         }

--- a/test/instructionsets-tests.js
+++ b/test/instructionsets-tests.js
@@ -28,28 +28,27 @@ describe('InstructionSets', async () => {
     it('should recognize aarch64 for clang target', async () => {
         const isets = new InstructionSets();
 
-        return isets.
-            getCompilerInstructionSetHint('aarch64-linux-gnu', '/opt/compiler-explorer/clang-11.0.1/bin/clang++').
-            should.eventually.equal('aarch64');
+        return isets
+            .getCompilerInstructionSetHint('aarch64-linux-gnu', '/opt/compiler-explorer/clang-11.0.1/bin/clang++')
+            .should.eventually.equal('aarch64');
     });
 
     it('should recognize gcc aarch64 from filepath', async () => {
         const isets = new InstructionSets();
 
-        return isets.
-            getCompilerInstructionSetHint(
+        return isets
+            .getCompilerInstructionSetHint(
                 false,
-                '/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++').
-            should.eventually.equal('aarch64');
+                '/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++',
+            )
+            .should.eventually.equal('aarch64');
     });
 
     it('should default to amd64 when not apparant', async () => {
         const isets = new InstructionSets();
 
-        return isets.
-            getCompilerInstructionSetHint(
-                false,
-                '/opt/compiler-explorer/gcc-12.2.0/bin/g++').
-            should.eventually.equal('amd64');
+        return isets
+            .getCompilerInstructionSetHint(false, '/opt/compiler-explorer/gcc-12.2.0/bin/g++')
+            .should.eventually.equal('amd64');
     });
 });

--- a/test/instructionsets-tests.js
+++ b/test/instructionsets-tests.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {InstructionSets} from '../lib/instructionsets';
+
+describe('InstructionSets', async () => {
+    it('should recognize aarch64 for clang target', async () => {
+        const isets = new InstructionSets();
+
+        return isets.
+            getCompilerInstructionSetHint('aarch64-linux-gnu', '/opt/compiler-explorer/clang-11.0.1/bin/clang++').
+            should.eventually.equal('aarch64');
+    });
+
+    it('should recognize gcc aarch64 from filepath', async () => {
+        const isets = new InstructionSets();
+
+        return isets.
+            getCompilerInstructionSetHint(
+                false,
+                '/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++').
+            should.eventually.equal('aarch64');
+    });
+
+    it('should default to amd64 when not apparant', async () => {
+        const isets = new InstructionSets();
+
+        return isets.
+            getCompilerInstructionSetHint(
+                false,
+                '/opt/compiler-explorer/gcc-12.2.0/bin/g++').
+            should.eventually.equal('amd64');
+    });
+});


### PR DESCRIPTION
TLDR: Problem fixed, don't name your properties `default`

I'm getting this error locally and I'm clueless on what's going on:
```
$ npm run test

> compiler-explorer@0.0.3 test
> mocha -b


/opt/compiler-explorer/cemain/lib/instructionsets.ts:26
    default;
           ^

SyntaxError: Invalid or unexpected token
    at Object.m._compile (/opt/compiler-explorer/cemain/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
```