### PR TITLE
Ask git to use LF line endings in windows CI

### DIFF
--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: windows-2019
 
     steps:
+      - name: Ask Git to use LF line endings
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
A better alternative would be to override prettier `endOfLine` setting to `auto` in this case, but that's more convoluted to implement.
This does not change any behaviour for Windows users and should fix the false positives in PR tests