### PR TITLE
Move RE creation outside function scope

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -90,9 +90,10 @@ function parseSeverity(message: string): number {
     return 3;
 }
 
+const SOURCE_RE = /^\s*<source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+const SOURCE_WITH_FILENAME = /^\s*([\w.]*)[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+
 export function parseOutput(lines: string, inputFilename?: string, pathPrefix?: string): ResultLine[] {
-    const re = /^\s*<source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
-    const reWithFilename = /^\s*([\w.]*)[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
     const result: ResultLine[] = [];
     eachLine(lines, line => {
         line = _parseOutputLine(line, inputFilename, pathPrefix);
@@ -102,7 +103,7 @@ export function parseOutput(lines: string, inputFilename?: string, pathPrefix?: 
         if (line !== null) {
             const lineObj: ResultLine = {text: line};
             const filteredline = line.replace(ansiColoursRe, '');
-            let match = filteredline.match(re);
+            let match = filteredline.match(SOURCE_RE);
             if (match) {
                 const message = match[4].trim();
                 lineObj.tag = {
@@ -112,7 +113,7 @@ export function parseOutput(lines: string, inputFilename?: string, pathPrefix?: 
                     severity: parseSeverity(message),
                 };
             } else {
-                match = filteredline.match(reWithFilename);
+                match = filteredline.match(SOURCE_WITH_FILENAME);
                 if (match) {
                     const message = match[5].trim();
                     lineObj.tag = {


### PR DESCRIPTION
No need to recreate the object for every compilation, even if the RE gets compiled only once

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
