### PR TITLE
add compilationinfo and related types

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -29,7 +29,6 @@ import * as PromClient from 'prom-client';
 import temp from 'temp';
 import _ from 'underscore';
 
-import {CompilerInfo} from '../types/compiler.interfaces';
 import {
     BuildResult,
     CompilationCacheKey,
@@ -43,6 +42,7 @@ import {
     LLVMOptPipelineBackendOptions,
     LLVMOptPipelineOutput,
 } from '../types/compilation/llvm-opt-pipeline-output.interfaces';
+import {CompilerInfo} from '../types/compiler.interfaces';
 import {
     BasicExecutionResult,
     ExecutableExecutionOptions,

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -31,7 +31,10 @@ import _ from 'underscore';
 
 import {
     BuildResult,
+    CompilationCacheKey,
+    CompilationInfo,
     CompilationResult,
+    CustomInputForTool,
     ExecutionOptions,
     ToolResult,
 } from '../types/compilation/compilation.interfaces';
@@ -293,7 +296,7 @@ export class BaseCompiler {
         return exec.execute(filepath, args, execOptions);
     }
 
-    protected getCompilerCacheKey(compiler, args, options) {
+    protected getCompilerCacheKey(compiler, args, options): CompilationCacheKey {
         return {mtime: this.mtime, compiler, args, options};
     }
 
@@ -1598,20 +1601,22 @@ export class BaseCompiler {
         return cacheKey;
     }
 
-    getCompilationInfo(key, result, customBuildPath?) {
-        const compilationinfo = Object.assign({}, key, result);
-        compilationinfo.outputFilename = this.getOutputFilename(
-            customBuildPath || result.dirPath,
-            this.outputFilebase,
-            key,
-        );
-        compilationinfo.executableFilename = this.getExecutableFilename(
-            customBuildPath || result.dirPath,
-            this.outputFilebase,
-            key,
-        );
-        compilationinfo.asmParser = this.asm;
-        return compilationinfo;
+    getCompilationInfo(
+        key: CompilationCacheKey,
+        result: CompilationResult | CustomInputForTool,
+        customBuildPath?: string,
+    ): CompilationInfo {
+        return {
+            outputFilename: this.getOutputFilename(customBuildPath || result.dirPath || '', this.outputFilebase, key),
+            executableFilename: this.getExecutableFilename(
+                customBuildPath || result.dirPath || '',
+                this.outputFilebase,
+                key,
+            ),
+            asmParser: this.asm,
+            ...key,
+            ...result,
+        };
     }
 
     tryAutodetectLibraries(libsAndOptions) {

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -29,7 +29,7 @@ import * as PromClient from 'prom-client';
 import temp from 'temp';
 import _ from 'underscore';
 
-import {Compiler} from '../types/compiler.interfaces';
+import {CompilerInfo} from '../types/compiler.interfaces';
 import {
     BuildResult,
     CompilationCacheKey,
@@ -79,7 +79,7 @@ import {ToolTypeKey} from './tooling/base-tool.interface';
 import * as utils from './utils';
 
 export class BaseCompiler {
-    public compiler: Compiler & Record<string, any>; // TODO: Some missing types still present in Compiler type
+    public compiler: CompilerInfo & Record<string, any>; // TODO: Some missing types still present in Compiler type
     public lang: Language;
     protected compileFilename: string;
     protected env: any;

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -29,6 +29,7 @@ import * as PromClient from 'prom-client';
 import temp from 'temp';
 import _ from 'underscore';
 
+import {Compiler} from '../types/compiler.interfaces';
 import {
     BuildResult,
     CompilationCacheKey,
@@ -78,7 +79,7 @@ import {ToolTypeKey} from './tooling/base-tool.interface';
 import * as utils from './utils';
 
 export class BaseCompiler {
-    public compiler: any;
+    public compiler: Compiler & Record<string, any>; // TODO: Some missing types still present in Compiler type
     public lang: Language;
     protected compileFilename: string;
     protected env: any;

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -249,7 +249,9 @@ export class CompilerFinder {
             linkFlag: props('linkFlag', '-l'),
             rpathFlag: props('rpathFlag', '-Wl,-rpath,'),
             libpathFlag: props('libpathFlag', '-L'),
-            libPath: props('libPath', ''),
+            libPath: props('libPath', '')
+                .split(path.delimiter)
+                .filter(p => p !== ''),
             ldPath: props('ldPath', '')
                 .split('|')
                 .map(x => path.normalize(x.replace('${exePath}', exePath))),
@@ -282,9 +284,6 @@ export class CompilerFinder {
             );
             return [];
         }
-
-        // This seems like no longer needed with propscheck.py checks
-        compilerInfo.libPath = compilerInfo.libPath.split(path.delimiter).filter(p => p !== '');
 
         logger.debug('Found compiler', compilerInfo);
         return compilerInfo;

--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -34,7 +34,7 @@ import {ResultLine} from '../types/resultline/resultline.interfaces';
 
 import jqXHR = JQuery.jqXHR;
 import ErrorTextStatus = JQuery.Ajax.ErrorTextStatus;
-import {Compiler} from '../types/compiler.interfaces';
+import {CompilerInfo} from '../types/compiler.interfaces';
 import {CompilationResult} from '../types/compilation/compilation.interfaces';
 
 type CompilationStatus = {
@@ -48,7 +48,7 @@ export class CompilerService {
     private readonly base = window.httpRoot;
     private allowStoreCodeDebug: boolean;
     private cache: LRU;
-    private readonly compilersByLang: Record<string, Record<string, Compiler>>;
+    private readonly compilersByLang: Record<string, Record<string, CompilerInfo>>;
 
     constructor(eventHub: EventEmitter) {
         this.allowStoreCodeDebug = true;
@@ -74,7 +74,7 @@ export class CompilerService {
     public processFromLangAndCompiler(
         langId: string | null,
         compilerId: string
-    ): {langId: string | null; compiler: Compiler | null} | null {
+    ): {langId: string | null; compiler: CompilerInfo | null} | null {
         try {
             if (langId) {
                 if (!compilerId) {
@@ -137,7 +137,7 @@ export class CompilerService {
 
     public getGroupsInUse(langId: string): {value: string; label: string}[] {
         return _.chain(this.getCompilersForLang(langId))
-            .map((compiler: Compiler) => compiler)
+            .map((compiler: CompilerInfo) => compiler)
             .uniq(false, compiler => compiler.group)
             .map(compiler => {
                 return {value: compiler.group, label: compiler.groupName || compiler.group};
@@ -148,11 +148,11 @@ export class CompilerService {
             .value();
     }
 
-    private getCompilersForLang(langId: string): Record<string, Compiler> {
+    private getCompilersForLang(langId: string): Record<string, CompilerInfo> {
         return langId in this.compilersByLang ? this.compilersByLang[langId] : {};
     }
 
-    private findCompilerInList(compilers: Record<string, Compiler>, compilerId: string) {
+    private findCompilerInList(compilers: Record<string, CompilerInfo>, compilerId: string) {
         if (compilerId in compilers) {
             return compilers[compilerId];
         }

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {Language} from '../types/languages.interfaces';
-import {Compiler} from '../types/compiler.interfaces';
+import {CompilerInfo} from '../types/compiler.interfaces';
 
 export type LibraryVersion = {
     alias: string[];
@@ -52,7 +52,7 @@ export type Options = {
     libs: Libs;
     remoteLibs: LibsPerRemote;
     languages: Record<string, Language>;
-    compilers: Compiler[];
+    compilers: CompilerInfo[];
     defaultCompiler: Record<string, string>;
     defaultLibs: Record<string, string | null>;
     defaultFontScale: number;

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -34,7 +34,7 @@ import {MonacoPaneState} from './pane.interfaces';
 import {DiffState, DiffType} from './diff.interfaces';
 import {ResultLine} from '../../types/resultline/resultline.interfaces';
 import {CompilationResult} from '../../types/compilation/compilation.interfaces';
-import {Compiler} from '../../types/compiler.interfaces';
+import {CompilerInfo} from '../../types/compiler.interfaces';
 
 class DiffStateObject {
     // can be undefined if there are no compilers / executors
@@ -109,7 +109,7 @@ type CompilerEntry = {
     options: unknown;
     editorId: number;
     treeId: number;
-    compiler: Compiler;
+    compiler: CompilerInfo;
 };
 
 type SelectizeType = {
@@ -272,7 +272,7 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         this.updateState();
     }
 
-    onCompileResult(id: number | string, compiler: Compiler, result: CompilationResult) {
+    onCompileResult(id: number | string, compiler: CompilerInfo, result: CompilationResult) {
         // both sides must be updated, don't be tempted to rewrite this as
         // var changes = lhs.update() || rhs.update();
         const lhsChanged = this.lhs.update(id, compiler, result);
@@ -282,7 +282,7 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         }
     }
 
-    onExecuteResult(id: number, compiler: Compiler, result: CompilationResult) {
+    onExecuteResult(id: number, compiler: CompilerInfo, result: CompilationResult) {
         const compileResult: any = Object.assign({}, result.buildResult);
         compileResult.execResult = {
             code: result.code,
@@ -314,7 +314,7 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
 
     override onCompiler(
         id: number | string,
-        compiler: Compiler | undefined,
+        compiler: CompilerInfo | undefined,
         options: unknown,
         editorId: number,
         treeId: number
@@ -348,7 +348,7 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         this.updateCompilers();
     }
 
-    onExecutor(id: number, compiler: Compiler, options: unknown, editorId: number, treeId: number) {
+    onExecutor(id: number, compiler: CompilerInfo, options: unknown, editorId: number, treeId: number) {
         this.onCompiler(id + '_exec', compiler, options, editorId, treeId);
     }
 

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -24,9 +24,9 @@
 
 import {BuildEnvDownloadInfo} from '../../lib/buildenvsetup/buildenv.interfaces';
 import {IAsmParser} from '../../lib/parsers/asm-parser.interfaces';
-
 import {LanguageKey} from '../languages.interfaces';
 import {ResultLine} from '../resultline/resultline.interfaces';
+import {Compiler} from '../compiler.interfaces';
 
 export type CompilationResult = {
     code: number;
@@ -127,7 +127,7 @@ export type ToolResult = {
 
 export type CompilationInfo = {
     mtime: Date | null;
-    compiler: any;
+    compiler: Compiler & Record<string, unknown>;
     args: string[];
     options: ExecutionOptions;
     outputFilename: string;

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -26,7 +26,7 @@ import {BuildEnvDownloadInfo} from '../../lib/buildenvsetup/buildenv.interfaces'
 import {IAsmParser} from '../../lib/parsers/asm-parser.interfaces';
 import {LanguageKey} from '../languages.interfaces';
 import {ResultLine} from '../resultline/resultline.interfaces';
-import {Compiler} from '../compiler.interfaces';
+import {CompilerInfo} from '../compiler.interfaces';
 
 export type CompilationResult = {
     code: number;
@@ -127,7 +127,7 @@ export type ToolResult = {
 
 export type CompilationInfo = {
     mtime: Date | null;
-    compiler: Compiler & Record<string, unknown>;
+    compiler: CompilerInfo & Record<string, unknown>;
     args: string[];
     options: ExecutionOptions;
     outputFilename: string;

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -24,9 +24,9 @@
 
 import {BuildEnvDownloadInfo} from '../../lib/buildenvsetup/buildenv.interfaces';
 import {IAsmParser} from '../../lib/parsers/asm-parser.interfaces';
+import {CompilerInfo} from '../compiler.interfaces';
 import {LanguageKey} from '../languages.interfaces';
 import {ResultLine} from '../resultline/resultline.interfaces';
-import {CompilerInfo} from '../compiler.interfaces';
 
 export type CompilationResult = {
     code: number;

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -124,7 +124,7 @@ export type ToolResult = {
 };
 
 export type CompilationInfo = {
-    mtime: any;
+    mtime: Date | null;
     compiler: any;
     args: string[];
     options: ExecutionOptions;

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {BuildEnvDownloadInfo} from '../../lib/buildenvsetup/buildenv.interfaces';
+import {IAsmParser} from '../../lib/parsers/asm-parser.interfaces';
 import {ResultLine} from '../resultline/resultline.interfaces';
 
 export type CompilationResult = {
@@ -120,4 +121,29 @@ export type ToolResult = {
     stderr: ResultLine[];
     stdout: ResultLine[];
     artifact?: Artifact;
+};
+
+export type CompilationInfo = {
+    mtime: any;
+    compiler: any;
+    args: string[];
+    options: ExecutionOptions;
+    outputFilename: string;
+    executableFilename: string;
+    asmParser: IAsmParser;
+    inputFilename?: string;
+    dirPath?: string;
+};
+
+export type CompilationCacheKey = {
+    mtime: any;
+    compiler: any;
+    args: string[];
+    options: ExecutionOptions;
+};
+
+export type CustomInputForTool = {
+    inputFilename: string;
+    dirPath: string;
+    outputFilename: string;
 };

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -78,4 +78,9 @@ export type CompilerInfo = {
         id: string;
         props: (name: string, def: string) => string;
     };
+    license?: {
+        link?: string;
+        name?: string;
+        preamble?: string;
+    },
 };

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -27,7 +27,7 @@ import {ToolInfo} from '../lib/tooling/base-tool.interface';
 
 import {Library} from './libraries/libraries.interfaces';
 
-export type Compiler = {
+export type CompilerInfo = {
     id: string;
     exe: string;
     name: string;

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -82,5 +82,5 @@ export type CompilerInfo = {
         link?: string;
         name?: string;
         preamble?: string;
-    },
+    };
 };

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -23,11 +23,58 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 // Minimal Compiler properties until a better one can be sync'ed with the backend
+import {ToolInfo} from '../lib/tooling/base-tool.interface';
+
+import {Library} from './libraries/libraries.interfaces';
+
 export type Compiler = {
+    id: string;
+    exe: string;
+    name: string;
     alias: string[];
+    options: string;
+    versionFlag?: string;
+    versionRe?: string;
+    explicitVersion?: string;
+    compilerType: string;
+    demangler: string;
+    demanglerType: string;
+    objdumper: string;
+    objdumperType: string;
+    intelAsm: string;
+    supportsAsmDocs: boolean;
+    instructionSet: string;
+    needsMulti: boolean;
+    adarts: string;
+    supportsDemangle: boolean;
+    supportsBinary: boolean;
+    interpreted: boolean;
+    // (interpreted || supportsBinary) && supportsExecute
+    supportsExecute: boolean;
+    executionWrapper: string;
+    supportsLibraryCodeFilter: boolean;
+    postProcess: string[];
+    lang: string;
     group: string;
     groupName: string;
-    id: string;
-    lang: string;
-    name: string;
+    includeFlag: string;
+    includePath: string;
+    linkFlag: string;
+    rpathFlag: string;
+    libpathFlag: string;
+    libPath: string;
+    ldPath: string[];
+    // [env, setting][]
+    envVars: [string, string][];
+    notification: string[];
+    isSemVer: boolean;
+    semver: string;
+    libsArr: Library['id'][];
+    tools: Record<ToolInfo['id'], ToolInfo>;
+    unwiseOptions: string[];
+    hidden: boolean;
+    buildenvsetup: {
+        id: string;
+        props: (name: string, def: string) => string;
+    };
 };

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -48,6 +48,7 @@ export type Compiler = {
     adarts: string;
     supportsDemangle: boolean;
     supportsBinary: boolean;
+    supportsIntel: boolean;
     interpreted: boolean;
     // (interpreted || supportsBinary) && supportsExecute
     supportsExecute: boolean;
@@ -62,7 +63,7 @@ export type Compiler = {
     linkFlag: string;
     rpathFlag: string;
     libpathFlag: string;
-    libPath: string;
+    libPath: string[];
     ldPath: string[];
     // [env, setting][]
     envVars: [string, string][];


### PR DESCRIPTION
As discussed here https://github.com/compiler-explorer/compiler-explorer/pull/4044/files#diff-ad70709cafce13a26acf40e47dced8fe40d1540f4ca54a282aa6afde39675176R140 - some types were missing.

Are now more complete-ish
