### PR TITLE
Add neovim plugin to rest api docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -317,3 +317,4 @@ Here are some examples of projects using the Compiler Explorer API:
 - [CLion plugin by ogrebenyuk](https://github.com/ogrebenyuk/compilerexplorer) (Java)
 - [QCompilerExplorer - frontend in Qt](https://github.com/Waqar144/QCompilerExplorer) (C++)
 - [Emacs client - compiler-explorer.el](https://github.com/mkcms/compiler-explorer.el)
+- [compiler-explorer.nvim by krady21](https://github.com/krady21/compiler-explorer.nvim) (Lua)


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Hi. I've been working on a neovim plugin for compiler explorer lately and it's finally in a state that I am somewhat satisfied with. Hope that it is fine if I add it here near the other editor plugins. At the moment it allows you to do compiles, formats and show tooltips asynchronously.
