### PR TITLE
Update rust.defaults.properties

### DIFF
--- a/etc/config/rust.defaults.properties
+++ b/etc/config/rust.defaults.properties
@@ -1,7 +1,7 @@
-compilers=/usr/local/bin/rustc
+compilers=rustc
 supportsBinary=true
 compilerType=rust
-demangler=${ceToolsPath}/rust/bin/rustfilt
+demangler=${ceToolsPath}/rust/target/release/rustfilt
 objdumper=objdump
 stubRe=\bmain\b
 stubText=pub fn main() {/*stub provided by Compiler Explorer*/}


### PR DESCRIPTION
`rustfilt` ended up at a different path for me, and the "absolute path as compiler name" compatibility kludge seems not to work anymore.

(Also, this way it matters less where rustc is installed.)

I have **no** idea how to reasonably do automated tests of `defaults` config files, but at any rate `make check` seems not to have broken, and I have Rust apparently working on a personal instance of CE where it was not before these changes.