### PR TITLE
"compilertype not found" should be fatal

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -131,7 +131,15 @@ export class CompileHandler {
         const isPrediscovered = !!compiler.version;
 
         const type = compiler.compilerType || 'default';
-        const compilerClass = getCompilerTypeByKey(type);
+        let compilerClass;
+        try {
+            compilerClass = getCompilerTypeByKey(type);
+        } catch (e) {
+            logger.error(`Compiler ID: ${compiler.id}`);
+            logger.error(e);
+            process.exit(1);
+            return;
+        }
 
         // attempt to resolve non absolute exe paths
         if (compiler.exe && !path.isAbsolute(compiler.exe)) {


### PR DESCRIPTION
The website is unusable when this error occurs, but the startup just continues, which is a pain to debug.