### PR TITLE
Fix issue #4060 Add clang15/clang_trunk as HLSL compilers

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&dxc:&rga
+compilers=&dxc:&rga:&clang
 
 group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207
 group.dxc.groupName=DXC
@@ -41,6 +41,16 @@ compiler.rga261_dxc162112.exe=/opt/compiler-explorer/rga-2.6.1.23/rga
 compiler.rga261_dxc162112.semver=2.6.1
 compiler.rga261_dxc162112.dxcPath=/opt/compiler-explorer/dxc-1.6.2112/bin/dxc
 compiler.rga261_dxc162112.name=RGA 2.6.1 (DXC 1.6.2112)
+
+group.clang.compilers=hlsl_clang_trunk
+group.clang.groupName=Clang
+group.clang.baseName=Clang
+group.clang.isSemVer=true
+group.clang.compilerType=clang
+group.clang.options=-emit-llvm
+
+compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.clang_trunk.semver=(trunk)
 
 supportsBinary=false
 defaultCompiler=dxc_1_7_2207

--- a/etc/config/hlsl.defaults.properties
+++ b/etc/config/hlsl.defaults.properties
@@ -1,4 +1,4 @@
-compilers=&dxc:&rga
+compilers=&dxc:&rga:&clang
 
 group.dxc.compilers=dxc_default
 compiler.dxc_default.exe=/usr/dxc-artifacts/bin/dxc
@@ -9,6 +9,11 @@ group.rga.compilerType=rga
 
 compiler.rga_default.exe=/usr/rga/rga
 compiler.rga_default.dxcPath=/usr/dxc-artifacts/bin/dxc
+
+group.clang.compilers=hlsl_clang_default
+group.clang.compilerType=clang
+compiler.clang.exe=/usr/bin/clang-trunk
+compiler.clang.options=-emit-llvm
 
 defaultCompiler=dxc
 supportsBinary=false


### PR DESCRIPTION
N.B I don't really know what I'm here, just copying vaguely what #3961 did, and what is in `etc/config/c.amazon.properties`. What is the `.defaults.properties` and what does it do? do I need to update it too?

cc @llvm-beanz What options should I be setting here? I could add `-triple dxil-pc-shadermodel6.3-library` but that would preclude writing non-library dxil modules wouldn't it?
