### PR TITLE
Add Swift 5.7

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,9 +1,9 @@
 compilers=&swift
-demangler=/opt/compiler-explorer/swift-5.6/usr/bin/swift-demangle
-defaultCompiler=swift56
+demangler=/opt/compiler-explorer/swift-5.7/usr/bin/swift-demangle
+defaultCompiler=swift57
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
-group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57nightly:swiftnightly
+group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swiftnightly
 group.swift.isSemVer=true
 group.swift.baseName=x86-64 swiftc
 compiler.swift311.exe=/opt/compiler-explorer/swift-3.1.1/usr/bin/swiftc
@@ -42,8 +42,8 @@ compiler.swift55.exe=/opt/compiler-explorer/swift-5.5/usr/bin/swiftc
 compiler.swift55.semver=5.5
 compiler.swift56.exe=/opt/compiler-explorer/swift-5.6/usr/bin/swiftc
 compiler.swift56.semver=5.6
-compiler.swift57nightly.exe=/opt/compiler-explorer/swift-5.7/usr/bin/swiftc
-compiler.swift57nightly.semver=5.7 (nightly)
+compiler.swift57.exe=/opt/compiler-explorer/swift-5.7/usr/bin/swiftc
+compiler.swift57.semver=5.7
 compiler.swiftnightly.exe=/opt/compiler-explorer/swift-nightly/usr/bin/swiftc
 compiler.swiftnightly.semver=nightly
 


### PR DESCRIPTION
Adds Swift 5.7 RELEASE as a compiler option, removes the nightly compiler.

The associated infra PR is compiler-explorer/infra#811.
