### PR TITLE
Add Kalray KVX compilers 4.8 and 4.9 and cleanup

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1015,35 +1015,50 @@ compiler.arm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
+group.kalray.compilers=kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
 
 # kvx versions are different from the GCC they wrap
-compiler.kvxg941_v460.exe=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-g++
-compiler.kvxg941_v460.name=KVX gcc 9.4 (ACB 4.6.0)
-compiler.kvxg941_v460.semver=9.4.1
-compiler.kvxg941_v460.objdumper=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-objdump
-compiler.kvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-g++
-compiler.kvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
-compiler.kvxg750_v440.semver=7.5.0
-compiler.kvxg750_v440.objdumper=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-objdump
-compiler.kvxg750_v430.exe=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-g++
-compiler.kvxg750_v430.name=KVX gcc 7.5 (ACB 4.3.0)
-compiler.kvxg750_v430.semver=7.5.0
-compiler.kvxg750_v430.objdumper=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-objdump
-compiler.kvxg750_v420.exe=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-g++
-compiler.kvxg750_v420.name=KVX gcc 7.5 (ACB 4.2.0)
-compiler.kvxg750_v420.semver=7.5.0
-compiler.kvxg750_v420.objdumper=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-objdump
-compiler.kvxg750_v410.exe=/opt/compiler-explorer/kvx-4.1.0-rc6/bin/kvx-elf-g++
-compiler.kvxg750_v410.name=KVX gcc 7.5 (ACB 4.1.0)
-compiler.kvxg750_v410.semver=7.5.0
-compiler.kvxg750_v410.objdumper=/opt/compiler-explorer/kvx-4.1.0-rc6/bin/kvx-elf-objdump
-compiler.kvxg750.exe=/opt/compiler-explorer/kvx-4.1.0-cd1/bin/kvx-elf-g++
-compiler.kvxg750.name=KVX gcc 7.5 (ACB 4.1.0-cd1)
-compiler.kvxg750.semver=7.5.0
-compiler.kvxg750.objdumper=/opt/compiler-explorer/kvx-4.1.0-cd1/bin/kvx-elf-objdump
+
+compiler.kvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-g++
+compiler.kvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)
+compiler.kvxg941_v490.semver=4.9.0
+
+compiler.kvxg941_v480.exe=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-g++
+compiler.kvxg941_v480.name=KVX ACB 4.8.0 (GCC 9.4.1)
+compiler.kvxg941_v480.semver=4.8.0
+
+compiler.kvxg941_v460.exe=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-g++
+compiler.kvxg941_v460.name=KVX ACB 4.6.0 (GCC 9.4.1)
+compiler.kvxg941_v460.semver=4.6.0
+compiler.kvxg941_v460.objdumper=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-objdump
+
+compiler.kvxg750_v440.exe=/opt/compiler-explorer/kvx/acb-4.4.0/bin/kvx-elf-g++
+compiler.kvxg750_v440.name=KVX ACB 4.4.0 (GCC 7.5.0)
+compiler.kvxg750_v440.semver=4.4.0
+compiler.kvxg750_v440.objdumper=/opt/compiler-explorer/kvx/acb-4.4.0/bin/kvx-elf-objdump
+
+compiler.kvxg750_v430.exe=/opt/compiler-explorer/kvx/acb-4.3.0/bin/kvx-elf-g++
+compiler.kvxg750_v430.name=KVX ACB 4.3.0 (GCC 7.5.0)
+compiler.kvxg750_v430.semver=4.3.0
+compiler.kvxg750_v430.objdumper=/opt/compiler-explorer/kvx/acb-4.3.0/bin/kvx-elf-objdump
+
+compiler.kvxg750_v420.exe=/opt/compiler-explorer/kvx/acb-4.2.0-rc5/bin/kvx-elf-g++
+compiler.kvxg750_v420.name=KVX ACB 4.2.0 (GCC 7.5.0)
+compiler.kvxg750_v420.semver=4.2.0
+compiler.kvxg750_v420.objdumper=/opt/compiler-explorer/kvx/acb-4.2.0-rc5/bin/kvx-elf-objdump
+
+compiler.kvxg750_v410.exe=/opt/compiler-explorer/kvx/acb-4.1.0-rc6/bin/kvx-elf-g++
+compiler.kvxg750_v410.name=KVX ACB 4.1.0 (GCC 7.5.0)
+compiler.kvxg750_v410.semver=4.1.0
+compiler.kvxg750_v410.objdumper=/opt/compiler-explorer/kvx/acb-4.1.0-rc6/bin/kvx-elf-objdump
+
+compiler.kvxg750.exe=/opt/compiler-explorer/kvx/acb-4.1.0-cd1/bin/kvx-elf-g++
+compiler.kvxg750.name=KVX ACB 4.1.0-cd1 (GCC 7.5.0)
+compiler.kvxg750.semver=4.1.0-cd1
+compiler.kvxg750.objdumper=/opt/compiler-explorer/kvx/acb-4.1.0-cd1/bin/kvx-elf-objdump
+
 compiler.k1cg741.exe=/opt/compiler-explorer/k1/gcc-7.4.1/k1-unknown-elf/bin/k1-unknown-elf-g++
 compiler.k1cg741.name=K1C gcc 7.4 (obsolete)
 compiler.k1cg741.semver=7.4.1

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -942,34 +942,51 @@ compiler.carm64gm101a1.semver=10.1.0
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
-compiler.ckvxg941_v460.exe=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-gcc
-compiler.ckvxg941_v460.name=KVX gcc 9.4 (ACB 4.6.0)
-compiler.ckvxg941_v460.semver=9.4.1
-compiler.ckvxg941_v460.objdumper=/opt/compiler-explorer/kvx-4.6.0/bin/kvx-elf-objdump
-compiler.ckvxg750_v440.exe=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-gcc
-compiler.ckvxg750_v440.name=KVX gcc 7.5 (ACB 4.4.0)
-compiler.ckvxg750_v440.semver=7.5.0
-compiler.ckvxg750_v440.objdumper=/opt/compiler-explorer/kvx-4.4.0/bin/kvx-elf-objdump
-compiler.ckvxg750_v430.exe=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-gcc
-compiler.ckvxg750_v430.name=KVX gcc 7.5 (ACB 4.3.0)
-compiler.ckvxg750_v430.semver=7.5.0
-compiler.ckvxg750_v430.objdumper=/opt/compiler-explorer/kvx-4.3.0/bin/kvx-elf-objdump
-compiler.ckvxg750_v420.exe=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-gcc
-compiler.ckvxg750_v420.name=KVX gcc 7.5 (ACB 4.2.0)
-compiler.ckvxg750_v420.semver=7.5.0
-compiler.ckvxg750_v420.objdumper=/opt/compiler-explorer/kvx-4.2.0-rc5/bin/kvx-elf-objdump
-compiler.ckvxg750_v410.exe=/opt/compiler-explorer/kvx-4.1.0-rc6/bin/kvx-elf-gcc
-compiler.ckvxg750_v410.name=KVX gcc 7.5 (ACB 4.1.0)
-compiler.ckvxg750_v410.semver=7.5.0
-compiler.ckvxg750_v410.objdumper=/opt/compiler-explorer/kvx-4.1.0-rc6/bin/kvx-elf-objdump
-compiler.ckvxg750.exe=/opt/compiler-explorer/kvx-4.1.0-cd1/bin/kvx-elf-gcc
-compiler.ckvxg750.name=KVX gcc 7.5 (ACB 4.1.0-cd1)
-compiler.ckvxg750.semver=7.5.0
-compiler.ckvxg750.objdumper=/opt/compiler-explorer/kvx-4.1.0-cd1/bin/kvx-elf-objdump
+
+compiler.ckvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-gcc
+compiler.ckvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)
+compiler.ckvxg941_v490.semver=4.9.0
+compiler.ckvxg941_v490.objdumper=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-objdump
+
+compiler.ckvxg941_v480.exe=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-gcc
+compiler.ckvxg941_v480.name=KVX ACB 4.8.0 (GCC 9.4.1)
+compiler.ckvxg941_v480.semver=4.8.0
+compiler.ckvxg941_v460.objdumper=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-objdump
+
+compiler.ckvxg941_v460.exe=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-gcc
+compiler.ckvxg941_v460.name=KVX ACB 4.6.0 (GCC 9.4.1)
+compiler.ckvxg941_v460.semver=4.6.0
+compiler.ckvxg941_v460.objdumper=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-objdump
+
+compiler.ckvxg750_v440.exe=/opt/compiler-explorer/kvx/acb-4.4.0/bin/kvx-elf-gcc
+compiler.ckvxg750_v440.name=KVX ACB 4.4.0 (GCC 7.5.0)
+compiler.ckvxg750_v440.semver=4.4.0
+compiler.ckvxg750_v440.objdumper=/opt/compiler-explorer/kvx/acb-4.4.0/bin/kvx-elf-objdump
+
+compiler.ckvxg750_v430.exe=/opt/compiler-explorer/kvx/acb-4.3.0/bin/kvx-elf-gcc
+compiler.ckvxg750_v430.name=KVX ACB 4.3.0 (GCC 7.5.0)
+compiler.ckvxg750_v430.semver=4.3.0
+compiler.ckvxg750_v430.objdumper=/opt/compiler-explorer/kvx/acb-4.3.0/bin/kvx-elf-objdump
+
+compiler.ckvxg750_v420.exe=/opt/compiler-explorer/kvx/acb-4.2.0-rc5/bin/kvx-elf-gcc
+compiler.ckvxg750_v420.name=KVX ACB 4.2.0 (GCC 7.5.0)
+compiler.ckvxg750_v420.semver=4.2.0
+compiler.ckvxg750_v420.objdumper=/opt/compiler-explorer/kvx/acb-4.2.0-rc5/bin/kvx-elf-objdump
+
+compiler.ckvxg750_v410.exe=/opt/compiler-explorer/kvx/acb-4.1.0-rc6/bin/kvx-elf-gcc
+compiler.ckvxg750_v410.name=KVX ACB 4.1.0 (GCC 7.5.0)
+compiler.ckvxg750_v410.semver=4.1.0
+compiler.ckvxg750_v410.objdumper=/opt/compiler-explorer/kvx/acb-4.1.0-rc6/bin/kvx-elf-objdump
+
+compiler.ckvxg750.exe=/opt/compiler-explorer/kvx/acb-4.1.0-cd1/bin/kvx-elf-gcc
+compiler.ckvxg750.name=KVX ACB 4.1.0-cd1 (GCC 7.5.0)
+compiler.ckvxg750.semver=4.1.0-cd1
+compiler.ckvxg750.objdumper=/opt/compiler-explorer/kvx/acb-4.1.0-cd1/bin/kvx-elf-objdump
+
 compiler.ck1cg741.exe=/opt/compiler-explorer/k1/gcc-7.4.1/k1-unknown-elf/bin/k1-unknown-elf-gcc
 compiler.ck1cg741.name=K1C gcc 7.4
 compiler.ck1cg741.semver=7.4.1


### PR DESCRIPTION
Add Kalray's freshly tagged 4.8 and 4.9 releases.

Also cleanup the install path for these compilers + their versionning.
Kalray is using its own version for its toolchain (4.x.y) and is not
synchronized with the underlying GCC.

fixes https://github.com/compiler-explorer/compiler-explorer/issues/4066

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>