### PR TITLE
Add System theme setting

### DIFF
--- a/static/settings.ts
+++ b/static/settings.ts
@@ -413,9 +413,16 @@ export class Settings {
         enableAllSchemesCheckbox.on('change', this.onThemeChange.bind(this));
 
         $.data(themeSelect, 'last-theme', themeSelect.val() as string);
+        this.onThemeChange();
     }
 
-    private fillThemeSelector(colourSchemeSelect: JQuery, newTheme?: AppTheme) {
+    private fillColourSchemeSelector(colourSchemeSelect: JQuery, newTheme?: AppTheme) {
+        colourSchemeSelect.empty();
+        if (newTheme === 'system') {
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                newTheme = themes.dark.id;
+            }
+        }
         for (const scheme of colour.schemes) {
             if (this.isSchemeUsable(scheme, newTheme)) {
                 colourSchemeSelect.append($(`<option value="${scheme.name}">${scheme.desc}</option>`));
@@ -447,8 +454,7 @@ export class Settings {
         const oldScheme = colourSchemeSelect.val() as string;
         const newTheme = themeSelect.val() as colour.AppTheme;
 
-        colourSchemeSelect.empty();
-        this.fillThemeSelector(colourSchemeSelect, newTheme);
+        this.fillColourSchemeSelector(colourSchemeSelect, newTheme);
         const newThemeStoredScheme = $.data(themeSelect, 'theme-' + newTheme) as colour.AppTheme | undefined;
 
         // If nothing else, set the new scheme to the first of the available ones

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -298,10 +298,7 @@ export class Settings {
         const themesData = (Object.keys(themes) as Themes[]).map((theme: Themes) => {
             return {label: themes[theme].id, desc: themes[theme].name};
         });
-        let defaultThemeId = themes.default.id;
-        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            defaultThemeId = themes.dark.id;
-        }
+        const defaultThemeId = themes.system.id;
 
         const colourSchemesData = colour.schemes
             .filter(scheme => this.isSchemeUsable(scheme, defaultThemeId))

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -421,6 +421,8 @@ export class Settings {
         if (newTheme === 'system') {
             if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 newTheme = themes.dark.id;
+            } else {
+                newTheme = themes.default.id;
             }
         }
         for (const scheme of colour.schemes) {

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -143,6 +143,8 @@ export class Themer {
         if (theme.id === 'system') {
             if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 theme = themes.dark;
+            } else {
+                theme = themes.default;
             }
         }
         $('html').attr('data-theme', theme.path);

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -26,15 +26,15 @@ import $ from 'jquery';
 import {editor} from 'monaco-editor';
 import {SiteSettings} from './settings';
 
-export type Themes = 'default' | 'dark' | 'darkplus';
+export type Themes = 'default' | 'dark' | 'darkplus' | 'system';
 
-export interface Theme {
+export type Theme = {
     path: string;
     id: Themes;
     name: string;
     mainColor: string;
     monaco: string;
-}
+};
 
 export const themes: Record<Themes, Theme> = {
     default: {
@@ -57,6 +57,13 @@ export const themes: Record<Themes, Theme> = {
         name: 'Dark+',
         mainColor: '#333333',
         monaco: 'ce-dark-plus',
+    },
+    system: {
+        id: 'system',
+        name: 'Same as system',
+        path: 'default',
+        mainColor: '#f2f2f2',
+        monaco: 'ce',
     },
 };
 
@@ -133,6 +140,11 @@ export class Themer {
 
     public setTheme(theme: Theme) {
         if (this.currentTheme === theme) return;
+        if (theme.id === 'system') {
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                theme = themes.dark;
+            }
+        }
         $('html').attr('data-theme', theme.path);
         $('#meta-theme').prop('content', theme.mainColor);
         editor.setTheme(theme.monaco);


### PR DESCRIPTION
With this new setting, we query the browser every time the settings change and set default/dark based on the `prefers-color-scheme: dark` response.
Note that this is different from the initial guessing we do to set the site to default/dark based on the same query, as that one does not get updated after being initialized.

My only question now is if this should be the new default, which I dont think is the case, but it's better to ask

Closes #4057 
