### PR TITLE
Add license info button to compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -195,6 +195,8 @@ group.clang.isSemVer=true
 group.clang.compilerType=clang
 group.clang.unwiseOptions=-march=native
 group.clang.supportsPVS-Studio=true
+group.clang.licenseName=LLVM Apache 2
+group.clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 
 # Ancient clangs don't support GCC toolchain option
 compiler.clang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-11_10/bin/clang++

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -273,6 +273,11 @@ export class CompilerFinder {
                     return props(`externalparser.${name}`, def);
                 },
             },
+            license: {
+                link: props('licenseLink'),
+                name: props('licenseName'),
+                preamble: props('licensePreamble'),
+            },
         };
 
         if (props('demanglerClassFile') !== undefined) {

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1949,6 +1949,7 @@ Compiler.prototype.initButtons = function (state) {
     this.prependOptions = this.domRoot.find('.prepend-options');
     this.fullCompilerName = this.domRoot.find('.full-compiler-name');
     this.fullTimingInfo = this.domRoot.find('.full-timing-info');
+    this.compilerLicenseButton = this.domRoot.find('.compiler-license');
     this.setCompilationOptionsPopover(this.compiler ? this.compiler.options : null);
     // Dismiss on any click that isn't either in the opening element, inside
     // the popover or on any alert
@@ -2276,6 +2277,42 @@ Compiler.prototype.handlePopularArgumentsResult = function (result) {
     }
 };
 
+Compiler.prototype.generateLicenseInfo = function () {
+    if (this.compiler) {
+        // MSVC will take a while to add this
+        if (!this.compiler.license) {
+            return 'No license information to display for ' + this.compiler.name;
+        }
+        var result = '';
+        var preamble = this.compiler.license.preamble;
+        if (preamble) {
+            result += preamble + '<br/>';
+        }
+        var name = this.compiler.license.name;
+        var link = this.compiler.license.link;
+
+        if (name || link) {
+            result += this.compiler.name + ' is licensed under its ';
+
+            if (link) {
+                var aText = name ? name : link;
+                result += '<a href="' + link + '" target="_blank">' + aText + '</a>';
+            } else {
+                result += name;
+            }
+
+            result += ' license';
+        }
+
+        if (!result) {
+            result = 'No license information to display for ' + this.compiler.name;
+        }
+
+        return result;
+    }
+    return 'No compiler selected';
+};
+
 Compiler.prototype.onFontScale = function () {
     this.saveState();
 };
@@ -2431,6 +2468,14 @@ Compiler.prototype.initCallbacks = function () {
         _.bind(function () {
             this.compilerService.cache.reset();
             this.compile(true);
+        }, this)
+    );
+
+    this.compilerLicenseButton.on(
+        'click',
+        _.bind(function () {
+            var title = this.compiler ? 'License for ' + this.compiler.name : 'No compiler selected';
+            this.alertSystem.alert(title, this.generateLicenseInfo());
         }, this)
     );
 

--- a/views/templates/panes/compiler.pug
+++ b/views/templates/panes/compiler.pug
@@ -92,3 +92,5 @@ mixin newPaneButton(classId, text, title, icon)
       span.compile-info.mr-1(title="Compilation info")
       button.btn.btn-sm.btn-light.full-timing-info(data-trigger="click" style="cursor: pointer;" role="button")
         span.fas.fa-chart-bar
+      button.btn.btn-sm.btn-light.compiler-license(data-trigger="click" style="cursor: pointer;" role="button")
+        span Compiler License


### PR DESCRIPTION
This solves the issue discussed on Discord about us not having a way to properly show compiler licenses, by adding a button in the bottom bar of the compiler pane that shows an alert with:
- An optional preamble (In case some clarification is needed in a per-case basis)
- The license name and a link to it

Feel free to suggest better wording for the template text