### PR TITLE
add miracle emulator for z88dk sms files

### DIFF
--- a/lib/compilers/z88dk.ts
+++ b/lib/compilers/z88dk.ts
@@ -106,6 +106,10 @@ export class z88dkCompiler extends BaseCompiler {
         return `${this.outputFilebase}.tap`;
     }
 
+    getSmsfilename() {
+        return `${this.outputFilebase}.sms`;
+    }
+
     override async objdump(outputFilename, result: any, maxSize: number, intelAsm, demangle, filters: ParseFilters) {
         outputFilename = this.getObjdumpOutputFilename(outputFilename);
 
@@ -153,6 +157,13 @@ export class z88dkCompiler extends BaseCompiler {
                 const file_buffer = await fs.readFile(tapeFilepath);
                 const binary_base64 = file_buffer.toString('base64');
                 result.speccytape = binary_base64;
+            }
+
+            const smsFilepath = path.join(result.dirPath, this.getSmsfilename());
+            if (await utils.fileExists(smsFilepath)) {
+                const file_buffer = await fs.readFile(smsFilepath);
+                const binary_base64 = file_buffer.toString('base64');
+                result.miraclesms = binary_base64;
             }
         }
 

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1419,7 +1419,33 @@ Compiler.prototype.postCompilationResult = function (request, result, wasCmake) 
         this.emulateBbcDisk(result.bbcdiskimage);
     } else if (result.speccytape) {
         this.emulateSpeccyTape(result.speccytape);
+    } else if (result.miraclesms) {
+        this.emulateMiracleSMS(result.miraclesms);
     }
+};
+
+Compiler.prototype.emulateMiracleSMS = function (image) {
+    var dialog = $('#miracleemu');
+
+    this.alertSystem.notify(
+        'Click ' +
+            '<a target="_blank" id="miracle_emulink" style="cursor:pointer;" click="javascript:;">here</a>' +
+            ' to emulate',
+        {
+            group: 'emulation',
+            collapseSimilar: true,
+            dismissTime: 10000,
+            onBeforeShow: function (elem) {
+                elem.find('#miracle_emulink').on('click', function () {
+                    dialog.modal();
+
+                    var emuwindow = dialog.find('#miracleemuframe')[0].contentWindow;
+                    var tmstr = Date.now();
+                    emuwindow.location = 'https://xania.org/miracle/miracle.html?' + tmstr + '#b64sms=' + image;
+                });
+            },
+        }
+    );
 };
 
 Compiler.prototype.emulateSpeccyTape = function (image) {

--- a/views/popups/miracleemu.pug
+++ b/views/popups/miracleemu.pug
@@ -1,0 +1,5 @@
+#miracleemu.modal.fade.gl_keep(tabindex="-1" role="dialog")
+  .modal-dialog.modal-xl
+    .modal-content
+      .modal-body
+        iframe#miracleemuframe(src="about:blank" width="1024" height="600")

--- a/views/popups/popups.pug
+++ b/views/popups/popups.pug
@@ -24,4 +24,6 @@ include jsbeebemu
 
 include jsspeccyemu
 
+include miracleemu
+
 include site-template-loader


### PR DESCRIPTION
Depends on https://github.com/mattgodbolt/Miracle/pull/13

Debugger half overlaps the screen when activated, but we can probably add some fixes to that at a later time.
![Screenshot from 2022-09-24 16-40-15](https://user-images.githubusercontent.com/442630/192104098-2e19be87-15e5-491b-9a0b-2b511624ac76.png)

Code tested: https://github.com/z88dk/z88dk/blob/master/examples/sms/test.c with just `+sms` as compiler argument + binary mode
