### PR TITLE
Add some initial licenses to C++ compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -23,7 +23,7 @@ group.gcc86.unwiseOptions=-march=native
 group.gcc86.supportsPVS-Studio=true
 group.gcc86.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.gcc86.licenseName=GNU General Public License
-group.gcc86.licensePreamble=Copyright © 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+group.gcc86.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 compiler.g412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/g++
 compiler.g412.semver=4.1.2
@@ -748,7 +748,7 @@ group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
 group.cross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.cross.licenseName=GNU General Public License
-group.cross.licensePreamble=Copyright © 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+group.cross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 ###############################
 # Cross for s390x

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -613,9 +613,7 @@ group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
 group.icc.baseName=x86-64 icc
 group.icc.isSemVer=true
-group.icc.licenseName=LLVM Apache 2
-group.icc.licenseLink=https://github.com/intel/llvm/blob/sycl/LICENSE.TXT
-group.icc.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.icc.licensePreamble=Proprietary, with thanks to Intel for the license
 
 compiler.icc1301.exe=/opt/compiler-explorer/intel/bin/icc
 compiler.icc1301.alias=/opt/intel/bin/icc

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -21,6 +21,9 @@ group.gcc86.baseName=x86-64 gcc
 group.gcc86.isSemVer=true
 group.gcc86.unwiseOptions=-march=native
 group.gcc86.supportsPVS-Studio=true
+group.gcc86.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
+group.gcc86.licenseName=GNU General Public License
+group.gcc86.licensePreamble=Copyright © 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 compiler.g412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/g++
 compiler.g412.semver=4.1.2
@@ -197,6 +200,7 @@ group.clang.unwiseOptions=-march=native
 group.clang.supportsPVS-Studio=true
 group.clang.licenseName=LLVM Apache 2
 group.clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 # Ancient clangs don't support GCC toolchain option
 compiler.clang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-11_10/bin/clang++
@@ -405,6 +409,9 @@ group.armclang32.supportsExecute=false
 group.armclang32.instructionSet=arm32
 group.armclang32.baseName=armv7-a clang
 group.armclang32.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+group.armclang32.licenseName=LLVM Apache 2
+group.armclang32.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.armclang32.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv7-clang1101.semver=11.0.1
@@ -446,6 +453,9 @@ group.armclang64.baseName=armv8-a clang
 group.armclang64.compilerType=clang
 group.armclang64.supportsExecute=false
 group.armclang64.instructionSet=aarch64
+group.armclang64.licenseName=LLVM Apache 2
+group.armclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.armclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 compiler.armv8-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv8-clang1101.semver=11.0.1
@@ -492,6 +502,9 @@ group.rvclang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 group.rvclang.supportsBinary=true
 group.rvclang.supportsExecute=false
 group.rvclang.isSemVer=true
+group.rvclang.licenseName=LLVM Apache 2
+group.rvclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.rvclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 group.rv32clang.compilers=rv32-clang:rv32-clang1500:rv32-clang1400:rv32-clang1301:rv32-clang1300:rv32-clang1201:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
 group.rv32clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
@@ -582,6 +595,9 @@ compiler.rv64-clang.alias=rv64clang
 group.wasmclang.compilers=wasm32clang
 group.wasmclang.groupName=Clang WebAssembly
 group.wasmclang.supportsBinary=false
+group.wasmclang.licenseName=LLVM Apache 2
+group.wasmclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.wasmclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 compiler.wasm32clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.wasm32clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -597,6 +613,9 @@ group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
 group.icc.baseName=x86-64 icc
 group.icc.isSemVer=true
+group.icc.licenseName=LLVM Apache 2
+group.icc.licenseLink=https://github.com/intel/llvm/blob/sycl/LICENSE.TXT
+group.icc.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 compiler.icc1301.exe=/opt/compiler-explorer/intel/bin/icc
 compiler.icc1301.alias=/opt/intel/bin/icc
@@ -669,6 +688,9 @@ group.icx.groupName=ICX x86-64
 group.icx.baseName=x86-64 icx
 group.icx.isSemVer=true
 group.icx.compilerType=clang-intel
+group.icx.licenseName=LLVM Apache 2
+group.icx.licenseLink=https://github.com/intel/llvm/blob/sycl/LICENSE.TXT
+group.icx.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 compiler.icx202112.exe=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/bin/icpx
 compiler.icx202112.ldPath=/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2021.1.2.63/compiler/latest/linux/lib
@@ -711,6 +733,9 @@ compiler.icx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 group.zapcc.compilers=zapcc190308
 group.zapcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zapcc.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
+group.zapcc.licenseName=LLVM Release License
+group.zapcc.licenseLink=https://github.com/yrnkrn/zapcc/blob/master/LICENSE.TXT
+group.zapcc.licensePreamble=Copyright (c) 2003-2017 University of Illinois at Urbana-Champaign.
 compiler.zapcc190308.exe=/opt/compiler-explorer/zapcc-20170226-190308-1.0/bin/zapcc++
 compiler.zapcc190308.name=x86-64 Zapcc 190308
 
@@ -721,6 +746,9 @@ group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
+group.cross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
+group.cross.licenseName=GNU General Public License
+group.cross.licensePreamble=Copyright © 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 ###############################
 # Cross for s390x
@@ -813,6 +841,9 @@ compiler.ppc64clang.name=powerpc64 clang (trunk)
 compiler.ppc64clang.options=-target powerpc64
 compiler.ppc64clang.supportsBinary=false
 compiler.ppc64clang.semver=(snapshot)
+compiler.ppc64clang.licenseName=LLVM Apache 2
+compiler.ppc64clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+compiler.ppc64clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE
@@ -856,6 +887,9 @@ compiler.ppc64leclang.name=power64le clang (trunk)
 compiler.ppc64leclang.options=-target powerpc64le
 compiler.ppc64leclang.supportsBinary=false
 compiler.ppc64leclang.semver=(snapshot)
+compiler.ppc64leclang.licenseName=LLVM Apache 2
+compiler.ppc64leclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+compiler.ppc64leclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 ###############################
 # GCC for ARM
@@ -1078,6 +1112,9 @@ group.platspec.compilers=frc2019:frc2020:raspbian9:raspbian10:arduinouno189:ardu
 group.platspec.groupName=Platform Specific Compilers
 group.platspec.isSemVer=true
 group.platspec.includeFlag=-I
+group.platspec.licenseName=
+group.platspec.licenseLink=
+group.platspec.licensePreamble=
 
 compiler.frc2019.exe=/opt/compiler-explorer/arm/frc2019-6.3.0/roborio/bin/arm-frc2019-linux-gnueabi-g++
 compiler.frc2019.name=FRC 2019
@@ -1550,6 +1587,9 @@ group.zigcxx.isSemVer=true
 group.zigcxx.baseName=zig c++
 group.zigcxx.compilerType=zigcxx
 group.zigcxx.versionFlag=version
+group.zigcxx.licenseLink=https://github.com/ziglang/zig/blob/master/LICENSE
+group.zigcxx.licenseName=The MIT License (Expat)
+group.zigcxx.licensePreamble=Copyright (c) 2015-2022, Zig contributors
 
 compiler.zcxx060.exe=/opt/compiler-explorer/zig-0.6.0/zig
 compiler.zcxx060.semver=0.6.0
@@ -1574,6 +1614,9 @@ group.cxx6502.groupName=6502-c++
 group.cxx6502.isSemVer=true
 group.cxx6502.supportsBinary=false
 group.cxx6502.supportsExecute=false
+group.cxx6502.licenseLink=https://github.com/lefticus/6502-cpp/blob/master/LICENSE
+group.cxx6502.licenseName=The Unlicense
+group.cxx6502.licensePreamble=This is free and unencumbered software released into the public domain.
 
 compiler.gcc6502_1110.exe=/opt/compiler-explorer/6502-c++-trunk/bin/6502-c++
 compiler.gcc6502_1110.semver=11.1.0

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -2240,7 +2240,16 @@ Compiler.prototype.updateButtons = function () {
     this.gnatDebugButton.toggle(!!this.compiler.supportsGnatDebugViews);
     this.executorButton.toggle(!!this.compiler.supportsExecute);
 
+    this.compilerLicenseButton.toggle(this.hasCompilerLicenseInfo());
+
     this.enableToolButtons();
+};
+
+Compiler.prototype.hasCompilerLicenseInfo = function () {
+    return (
+        this.compiler.license &&
+        (this.compiler.license.preamble || this.compiler.license.link || this.compiler.license.name)
+    );
 };
 
 Compiler.prototype.handlePopularArgumentsResult = function (result) {


### PR DESCRIPTION
This is a bit WIP, but I want to merge soon as this file is a rather busy.
For this file, some of the things left to do are:
- [x] Check if ICC is LLVM Apache 2
- [x] Check if ICPX is also LLVM Apache 2 licensed
- [ ] Add Kalray license @dkm 
- [ ] Find `group.platspec` licenses
- [ ] Find if `group.nanomips` & `group.mrisc` compilers are GCC-like licensed
- [ ] Add Xtensa licenses
- [ ] Add Wine compiler licenses
- [ ] Add ELLCC license
- [ ] Add `group.djgpp` license
