### PR TITLE
Move zig compiler files to TS and fix zigc{xx} semver comparisons

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -48,7 +48,7 @@ import {
     ExecutableExecutionOptions,
     UnprocessedExecResult,
 } from '../types/execution/execution.interfaces';
-import {ParseFilters} from '../types/features/filters.interfaces';
+import {CompilerFilters, ParseFilters} from '../types/features/filters.interfaces';
 import {Language} from '../types/languages.interfaces';
 import {Library, LibraryVersion, SelectedLibraryVersion} from '../types/libraries/libraries.interfaces';
 import {ResultLine} from '../types/resultline/resultline.interfaces';
@@ -111,7 +111,7 @@ export class BaseCompiler {
         labelNames: [],
     });
 
-    constructor(compilerInfo, env) {
+    constructor(compilerInfo: CompilerInfo & Record<string, any>, env) {
         // Information about our compiler
         this.compiler = compilerInfo;
         this.lang = languages[compilerInfo.lang];
@@ -2432,7 +2432,7 @@ but nothing was dumped. Possible causes are:
         return this.handlePostProcessResult(result, await this.exec('bash', ['-c', postCommand], {maxOutput: maxSize}));
     }
 
-    preProcess(source, filters) {
+    preProcess(source: string, filters: CompilerFilters): string {
         if (filters.binary && !this.stubRe.test(source)) {
             source += `\n${this.stubText}\n`;
         }

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -59,7 +59,7 @@ export class ZigCompiler extends BaseCompiler {
         return [];
     }
 
-    preProcess(source: string): string {
+    override preProcess(source: string): string {
         if (Semver.eq(asSafeVer(this.compiler.semver), '0.2.0', true)) {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';
@@ -135,7 +135,7 @@ export class ZigCompiler extends BaseCompiler {
         return options;
     }
 
-    getIncludeArguments(libraries: SelectedLibraryVersion[]) {
+    override getIncludeArguments(libraries: SelectedLibraryVersion[]) {
         return libraries.flatMap(selectedLib => {
             const foundVersion = this.findLibVersion(selectedLib);
             if (!foundVersion) return [];

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -27,10 +27,14 @@ import path from 'path';
 import Semver from 'semver';
 import _ from 'underscore';
 
+import {ParseFilters} from '../../types/features/filters.interfaces';
+import {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {asSafeVer} from '../utils';
 
 export class ZigCompiler extends BaseCompiler {
+    private readonly self_hosted_cli: boolean;
+
     static get key() {
         return 'zig';
     }
@@ -51,11 +55,11 @@ export class ZigCompiler extends BaseCompiler {
         }
     }
 
-    getSharedLibraryPathsAsArguments() {
+    override getSharedLibraryPathsAsArguments(): string[] {
         return [];
     }
 
-    preProcess(source) {
+    preProcess(source: string): string {
         if (Semver.eq(asSafeVer(this.compiler.semver), '0.2.0', true)) {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';
@@ -86,7 +90,7 @@ export class ZigCompiler extends BaseCompiler {
         return source;
     }
 
-    optionsForFilter(filters, outputFilename, userOptions) {
+    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions: string[]): string[] {
         let options = [filters.execute ? 'build-exe' : 'build-obj'];
 
         const desiredName = path.basename(outputFilename);
@@ -122,7 +126,7 @@ export class ZigCompiler extends BaseCompiler {
         }
 
         if (!filters.binary) {
-            let userRequestedEmit = _.any(userOptions, opt => opt.includes('--emit'));
+            const userRequestedEmit = _.any(userOptions, opt => opt.includes('--emit'));
             if (!userRequestedEmit) {
                 options = options.concat('--emit', 'asm');
             }
@@ -131,25 +135,30 @@ export class ZigCompiler extends BaseCompiler {
         return options;
     }
 
-    getIncludeArguments(libraries) {
+    getIncludeArguments(libraries: SelectedLibraryVersion[]) {
         return libraries.flatMap(selectedLib => {
             const foundVersion = this.findLibVersion(selectedLib);
             if (!foundVersion) return [];
             // Zig should not have more than 1 path, but it's still an array so spread it
-            return ['--pkg-begin', foundVersion.name, ...foundVersion.path, '--pkg-end'];
+            return [
+                '--pkg-begin',
+                ...(foundVersion.name ? [foundVersion.name] : []),
+                ...foundVersion.path,
+                '--pkg-end',
+            ];
         });
     }
 
-    getIrOutputFilename(inputFilename) {
+    override getIrOutputFilename(inputFilename: string): string {
         return this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase).replace('.s', '.ll');
     }
 
-    filterUserOptions(userOptions) {
+    override filterUserOptions(userOptions: string[]): string[] {
         const forbiddenOptions = /^(((--(cache-dir|name|output|verbose))|(-(mllvm|f(no-)?emit-))).*)$/;
         return _.filter(userOptions, option => !forbiddenOptions.test(option));
     }
 
-    isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler(/*compilerVersion*/): boolean {
         return true;
     }
 }

--- a/lib/compilers/zigcc.ts
+++ b/lib/compilers/zigcc.ts
@@ -32,7 +32,7 @@ import {ClangCompiler} from './clang';
 export class ZigCC extends ClangCompiler {
     private readonly needsForcedBinary: boolean;
 
-    static get key() {
+    static override get key() {
         return 'zigcc';
     }
 

--- a/lib/compilers/zigcc.ts
+++ b/lib/compilers/zigcc.ts
@@ -24,30 +24,41 @@
 
 import Semver from 'semver';
 
+import {CompilerFilters, ParseFilters} from '../../types/features/filters.interfaces';
 import {asSafeVer} from '../utils';
 
 import {ClangCompiler} from './clang';
 
-export class ZigCXX extends ClangCompiler {
+export class ZigCC extends ClangCompiler {
+    private readonly needsForcedBinary: boolean;
+
     static get key() {
-        return 'zigcxx';
+        return 'zigcc';
     }
 
-    preProcess(source, filters) {
-        if (Semver.eq(asSafeVer(this.compiler.semver), '0.6.0', true)) {
+    constructor(info: any, env: any) {
+        super(info, env);
+        this.needsForcedBinary =
+            Semver.gte(asSafeVer(this.compiler.semver), '0.6.0', true) &&
+            Semver.lt(asSafeVer(this.compiler.semver), '0.9.0', true);
+    }
+
+    override preProcess(source: string, filters: CompilerFilters): string {
+        if (this.needsForcedBinary) {
+            // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;
         }
 
         return super.preProcess(source, filters);
     }
 
-    optionsForFilter(filters, outputFilename) {
-        if (Semver.eq(asSafeVer(this.compiler.semver), '0.6.0', true)) {
+    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
+        if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;
         }
 
-        let options = ['c++', '-g', '-o', this.filename(outputFilename)];
+        let options = ['cc', '-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary) {
             options = options.concat(this.compiler.intelAsm.split(' '));
         }

--- a/lib/compilers/zigcxx.ts
+++ b/lib/compilers/zigcxx.ts
@@ -24,30 +24,41 @@
 
 import Semver from 'semver';
 
+import {CompilerFilters, ParseFilters} from '../../types/features/filters.interfaces';
 import {asSafeVer} from '../utils';
 
 import {ClangCompiler} from './clang';
 
-export class ZigCC extends ClangCompiler {
-    static get key() {
-        return 'zigcc';
+export class ZigCXX extends ClangCompiler {
+    private readonly needsForcedBinary: boolean;
+
+    static override get key() {
+        return 'zigcxx';
     }
 
-    preProcess(source, filters) {
-        if (Semver.eq(asSafeVer(this.compiler.semver), '0.6.0', true)) {
+    constructor(info: any, env: any) {
+        super(info, env);
+        this.needsForcedBinary =
+            Semver.gte(asSafeVer(this.compiler.semver), '0.6.0', true) &&
+            Semver.lt(asSafeVer(this.compiler.semver), '0.9.0', true);
+    }
+
+    override preProcess(source: string, filters: CompilerFilters): string {
+        if (this.needsForcedBinary) {
+            // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;
         }
 
         return super.preProcess(source, filters);
     }
 
-    optionsForFilter(filters, outputFilename) {
-        if (Semver.eq(asSafeVer(this.compiler.semver), '0.6.0', true)) {
+    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
+        if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;
         }
 
-        let options = ['cc', '-g', '-o', this.filename(outputFilename)];
+        let options = ['c++', '-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary) {
             options = options.concat(this.compiler.intelAsm.split(' '));
         }


### PR DESCRIPTION
This should fix versions from 0.6.0 to 0.9.0 not being able to emit assembly but we only checking for version 0.6.0. As far as I can tell, 0.9.0 fixed the issue (https://github.com/ziglang/zig/issues/8153), so that one now does not force binary mode
