### PR TITLE
Add sh config

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -773,13 +773,43 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x
+group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
 group.cross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.cross.licenseName=GNU General Public License
 group.cross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
+###############################
+# Cross for sh
+group.sh.compilers=&gccsh
+
+# GCC for sh
+group.gccsh.supportsBinary=true
+group.gccsh.supportsExecute=false
+group.gccsh.baseName=sh gcc
+group.gccsh.groupName=sh gcc
+group.gccsh.compilers=shg494:shg950:shg1220
+group.gccsh.isSemVer=true
+
+compiler.shg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-g++
+compiler.shg494.semver=4.9.4
+compiler.shg494.objdumper=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg494.demangler=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+compiler.shg494.name=sh 4.9.4
+
+compiler.shg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-g++
+compiler.shg950.semver=9.5.0
+compiler.shg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
+compiler.shg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.shg950.name=sh 9.5.0
+
+compiler.shg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-g++
+compiler.shg1220.semver=12.2.0
+compiler.shg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
+compiler.shg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.shg1220.name=sh 12.2.0
 
 ###############################
 # Cross for s390x

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -788,7 +788,7 @@ group.sh.compilers=&gccsh
 # GCC for sh
 group.gccsh.supportsBinary=true
 group.gccsh.supportsExecute=false
-group.gccsh.baseName=sh gcc
+group.gccsh.baseName=sh
 group.gccsh.groupName=sh gcc
 group.gccsh.compilers=shg494:shg950:shg1220
 group.gccsh.isSemVer=true
@@ -797,19 +797,16 @@ compiler.shg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-un
 compiler.shg494.semver=4.9.4
 compiler.shg494.objdumper=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.shg494.demangler=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-c++filt
-compiler.shg494.name=sh 4.9.4
 
 compiler.shg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-g++
 compiler.shg950.semver=9.5.0
 compiler.shg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
 compiler.shg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-compiler.shg950.name=sh 9.5.0
 
 compiler.shg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-g++
 compiler.shg1220.semver=12.2.0
 compiler.shg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
 compiler.shg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-compiler.shg1220.name=sh 12.2.0
 
 ###############################
 # Cross for s390x

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -716,7 +716,7 @@ group.csh.compilers=&cgccsh
 group.cgccsh.compilers=cshg494:cshg950:cshg1220
 group.cgccsh.supportsBinary=true
 group.cgccsh.supportsExecute=false
-group.cgccsh.baseName=sh gcc
+group.cgccsh.baseName=sh
 group.cgccsh.groupName=sh GCC
 group.cgccsh.isSemVer=true
 
@@ -724,19 +724,16 @@ compiler.cshg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-u
 compiler.cshg494.semver=4.9.4
 compiler.cshg494.objdumper=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.cshg494.demangler=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-c++filt
-compiler.cshg494.name=sh 4.9.4
 
 compiler.cshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gcc
 compiler.cshg950.semver=9.5.0
 compiler.cshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
 compiler.cshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-compiler.cshg950.name=sh 9.5.0
 
 compiler.cshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gcc
 compiler.cshg1220.semver=12.2.0
 compiler.cshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
 compiler.cshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-compiler.cshg1220.name=sh 12.2.0
 
 ###############################
 # Cross for s390x

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -703,10 +703,40 @@ compiler.cicx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x
+group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
+
+###############################
+# Cross for sh
+group.csh.compilers=&cgccsh
+
+# GCC for sh
+group.cgccsh.compilers=cshg494:cshg950:cshg1220
+group.cgccsh.supportsBinary=true
+group.cgccsh.supportsExecute=false
+group.cgccsh.baseName=sh gcc
+group.cgccsh.groupName=sh GCC
+group.cgccsh.isSemVer=true
+
+compiler.cshg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.cshg494.semver=4.9.4
+compiler.cshg494.objdumper=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg494.demangler=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+compiler.cshg494.name=sh 4.9.4
+
+compiler.cshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gcc
+compiler.cshg950.semver=9.5.0
+compiler.cshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
+compiler.cshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.cshg950.name=sh 9.5.0
+
+compiler.cshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gcc
+compiler.cshg1220.semver=12.2.0
+compiler.cshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
+compiler.cshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.cshg1220.name=sh 12.2.0
 
 ###############################
 # Cross for s390x

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -157,11 +157,28 @@ compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64:&gccsh
 group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
 
+###############################
+# GCC for sh
+group.gccsh.compilers=fshg950:fshg1220
+group.gccsh.groupName=SH4 gfortran
+group.gccsh.baseName=SH4 gfortran
+
+compiler.fshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gfortran
+compiler.fshg950.semver=9.5.0
+compiler.fshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
+compiler.fshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.fshg950.name=sh 9.5.0
+
+compiler.fshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gfortran
+compiler.fshg1220.semver=12.2.0
+compiler.fshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
+compiler.fshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.fshg1220.name=sh 12.2.0
 
 ###############################
 # GCC for RISCV64

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -165,20 +165,18 @@ group.cross.groupName=Cross GCC
 ###############################
 # GCC for sh
 group.gccsh.compilers=fshg950:fshg1220
-group.gccsh.groupName=SH4 gfortran
-group.gccsh.baseName=SH4 gfortran
+group.gccsh.groupName=SH gfortran
+group.gccsh.baseName=SH
 
 compiler.fshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gfortran
 compiler.fshg950.semver=9.5.0
 compiler.fshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
 compiler.fshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-compiler.fshg950.name=sh 9.5.0
 
 compiler.fshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gfortran
 compiler.fshg1220.semver=12.2.0
 compiler.fshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
 compiler.fshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-compiler.fshg1220.name=sh 12.2.0
 
 ###############################
 # GCC for RISCV64


### PR DESCRIPTION
Add 3 configs for sh targets:
- old 4.9.4 unknown-elf (c/c++)
- 9.5 linux (c/c++/fortran)
- 12.2.0 linux (c/c++/fortran)

Old compiler were specificaly requested for Dreamcast hacking.

Not enabling D as it's not functional.

fixes #94

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>