### PR TITLE
Add basic Racket support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -135,7 +135,7 @@ lang-python:
   - lib/compilers/python.js
   - etc/config/python.*.properties
 lang-racket:
-  - lib/compilers/racket.js
+  - lib/compilers/racket.ts
   - etc/config/racket.*.properties
 lang-ruby:
   - lib/compilers/ruby.js

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -134,6 +134,9 @@ lang-pony:
 lang-python:
   - lib/compilers/python.js
   - etc/config/python.*.properties
+lang-racket:
+  - lib/compilers/racket.js
+  - etc/config/racket.*.properties
 lang-ruby:
   - lib/compilers/ruby.js
   - etc/config/ruby.*.properties

--- a/docs/AddingALanguage.md
+++ b/docs/AddingALanguage.md
@@ -19,7 +19,8 @@ If you want to add a new language to the site, you should follow this steps:
 
   - If the language is supported by Monaco Editor (You can find the list
     [here](https://github.com/microsoft/monaco-editor/tree/main/src/basic-languages)), you should add it to the list of
-    languages inside the `MonacoEditorWebpackPlugin` config in `webpack.config.js`
+    languages inside the `MonacoEditorWebpackPlugin` config in
+    `webpack.config.esm.js`
   - If not, you should implement your own language mode; see `static/modes/asm-mode.js` as an example. Don't forget to
     _require_ your mode file in `static/modes/_all.ts`, in alphabetical order
   - `language-key` is how your language will be referred internally by the code. In the rest of this document, replace

--- a/etc/config/racket.amazon.properties
+++ b/etc/config/racket.amazon.properties
@@ -1,9 +1,12 @@
 compilers=&racket
 defaultCompiler=racket86
 
+group.racket.groupName=Racket
 group.racket.compilers=racket86
 group.racket.isSemVer=true
 group.racket.baseName=Racket
+group.racket.licenseName=MIT and Apache 2
+group.racket.licenseLink=https://docs.racket-lang.org/license/
 compiler.racket86.semver=8.6
 compiler.racket86.exe=/opt/compiler-explorer/racket-8.6/bin/racket
 compiler.racket86.raco=/opt/compiler-explorer/racket-8.6/bin/raco

--- a/etc/config/racket.amazon.properties
+++ b/etc/config/racket.amazon.properties
@@ -8,5 +8,5 @@ group.racket.baseName=Racket
 group.racket.licenseName=MIT and Apache 2
 group.racket.licenseLink=https://docs.racket-lang.org/license/
 compiler.racket86.semver=8.6
-compiler.racket86.exe=/opt/compiler-explorer/racket-8.6/bin/racket
-compiler.racket86.raco=/opt/compiler-explorer/racket-8.6/bin/raco
+compiler.racket86.exe=/opt/compiler-explorer/racket/racket-8.6/bin/racket
+compiler.racket86.raco=/opt/compiler-explorer/racket/racket-8.6/bin/raco

--- a/etc/config/racket.amazon.properties
+++ b/etc/config/racket.amazon.properties
@@ -1,0 +1,9 @@
+compilers=&racket
+defaultCompiler=racket86
+
+group.racket.compilers=racket86
+group.racket.isSemVer=true
+group.racket.baseName=Racket
+compiler.racket86.semver=8.6
+compiler.racket86.exe=/opt/compiler-explorer/racket-8.6/bin/racket
+compiler.racket86.raco=/opt/compiler-explorer/racket-8.6/bin/raco

--- a/etc/config/racket.defaults.properties
+++ b/etc/config/racket.defaults.properties
@@ -1,0 +1,13 @@
+compilers=racket
+compilerType=racket
+
+versionFlag=--version
+versionRe=Racket v\d+\.\d+(\.\d+)?
+
+interpreted=true
+supportsBinary=false
+supportsExecute=false
+
+compiler.racket.name=Racket
+compiler.racket.exe=/usr/local/bin/racket
+compiler.racket.raco=/usr/local/bin/raco

--- a/examples/racket/default.rkt
+++ b/examples/racket/default.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+;; Type your code here, or load an example.
+(define (square num)
+  (* num num))

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -79,6 +79,7 @@ export {PonyCompiler} from './pony';
 export {PPCICompiler} from './ppci';
 export {PtxAssembler} from './ptxas';
 export {PythonCompiler} from './python';
+export {RacketCompiler} from './racket';
 export {RGACompiler} from './rga';
 export {RubyCompiler} from './ruby';
 export {RustcCgGCCCompiler} from './rustc-cg-gcc';

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
+import {ParseFilters} from '../../types/features/filters.interfaces';
+import {BaseCompiler} from '../base-compiler';
+
+export class RacketCompiler extends BaseCompiler {
+    private raco: string;
+
+    static get key() {
+        return 'racket';
+    }
+
+    constructor(info, env) {
+        // Disable output filters, as they currently don't do anything
+        if (!info.disabledFilters) {
+            info.disabledFilters = ['labels', 'directives', 'commentOnly', 'trim'];
+        }
+        super(info, env);
+        this.raco = this.compilerProps(`compiler.${this.compiler.id}.raco`);
+    }
+
+    override optionsForFilter(filters: ParseFilters, outputFilename: any, userOptions?: any): string[] {
+        return [];
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {
+        return path.join(dirPath, `${outputFilebase}.decompiled.rkt`);
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptions,
+    ): Promise<CompilationResult> {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+
+        if (!execOptions.customCwd) {
+            execOptions.customCwd = path.dirname(inputFilename);
+        }
+
+        // Compile via `raco make`
+        options.unshift('make');
+        const makeResult = await this.exec(this.raco, options, execOptions);
+        // TODO: Check `raco make` result
+
+        // Retrieve assembly via `raco decompile` with `disassemble` package
+        const outputFilename = path.join(inputFilename, '..', `${this.outputFilebase}.decompiled.rkt`);
+        const decompilePipeline = `${this.raco} decompile '${inputFilename}' > '${outputFilename}'`;
+        const decompileResult = await this.exec('bash', ['-c', decompilePipeline], execOptions);
+
+        return this.transformToCompilationResult(decompileResult, inputFilename);
+    }
+}

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -45,7 +45,7 @@ export class RacketCompiler extends BaseCompiler {
         this.raco = this.compilerProps(`compiler.${this.compiler.id}.raco`);
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: any, userOptions?: any): string[] {
+    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
         // We currently always compile to bytecode first and then decompile.
         // Forcing `binary` on like this ensures `objdump` will be called for
         // the decompilation phase.
@@ -58,7 +58,7 @@ export class RacketCompiler extends BaseCompiler {
         return true;
     }
 
-    protected override getSharedLibraryPathsAsArguments(libraries: any, libDownloadPath?: any): string[] {
+    override getSharedLibraryPathsAsArguments(libraries: object[], libDownloadPath?: string): string[] {
         return [];
     }
 

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -471,6 +471,17 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
     },
+    racket: {
+        name: 'Racket',
+        monaco: 'scheme',
+        extensions: ['.rkt'],
+        alias: [],
+        logoUrl: 'racket.svg',
+        logoUrlDark: null,
+        formatter: null,
+        previewFilter: null,
+        monacoDisassembly: 'scheme',
+    },
     ruby: {
         name: 'Ruby',
         monaco: 'ruby',

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -62,6 +62,7 @@ export type LanguageKey =
     | 'pascal'
     | 'pony'
     | 'python'
+    | 'racket'
     | 'ruby'
     | 'rust'
     | 'scala'

--- a/views/resources/logos/racket.svg
+++ b/views/resources/logos/racket.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="circle_pieces" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="511.875px" height="511.824px" viewBox="0 0 511.875 511.824" enable-background="new 0 0 511.875 511.824"
+	 xml:space="preserve">
+<circle id="circle" fill="#FFFFFF" cx="256.252" cy="255.986" r="253.093"/>
+<path id="blue-piece" fill="#3E5BA9" d="M455.398,412.197c33.792-43.021,53.946-97.262,53.946-156.211
+	c0-139.779-113.313-253.093-253.093-253.093c-30.406,0-59.558,5.367-86.566,15.197C272.435,71.989,408.349,247.839,455.398,412.197z
+	"/>
+<path id="left-red-piece" fill="#9F1D20" d="M220.003,164.337c-39.481-42.533-83.695-76.312-130.523-98.715
+	C36.573,112.011,3.159,180.092,3.159,255.986c0,63.814,23.626,122.104,62.597,166.623
+	C100.111,319.392,164.697,219.907,220.003,164.337z"/>
+<path id="bottom-red-piece" fill="#9F1D20" d="M266.638,221.727c-54.792,59.051-109.392,162.422-129.152,257.794
+	c35.419,18.857,75.84,29.559,118.766,29.559c44.132,0,85.618-11.306,121.74-31.163C357.171,381.712,317.868,293.604,266.638,221.727
+	z"/>
+</svg>

--- a/webpack.config.esm.js
+++ b/webpack.config.esm.js
@@ -64,6 +64,7 @@ const plugins = [
             'dart',
             'typescript',
             'solidity',
+            'scheme',
         ],
         filename: isDev ? '[name].worker.js' : `[name]${webjackJsHack}worker.[contenthash].js`,
     }),


### PR DESCRIPTION
This adds basic support for the [Racket](https://racket-lang.org/) language and compiler. Most compiler pane options are disabled for now. The user's module is compiled with `raco make` and then decompiled with `raco decompile` (with `disassemble` package installed) to get the assembly for the module.

![image](https://user-images.githubusercontent.com/279572/192906546-8c5a3505-39b0-421a-8ab6-2b321ecabaef.png)

Racket toolchain `infra` PR: https://github.com/compiler-explorer/infra/pull/832