### PR TITLE
Fix comment being recognized as a filename in IAR EW parser

### DIFF
--- a/lib/parsers/asm-parser-ewavr.js
+++ b/lib/parsers/asm-parser-ewavr.js
@@ -32,7 +32,7 @@ export class AsmEWAVRParser extends AsmParser {
     constructor(compilerProps) {
         super(compilerProps);
         this.commentOnly = /^\s*(((#|@|\$|\/\/).*)|(\/\*.*\*\/))$/;
-        this.filenameComment = /^\/\/\s[A-Za-z]?:?(([^/\\]*[/\\])+)([^/\\]+)$/;
+        this.filenameComment = /^\/\/\s[A-Za-z]?:?\S(([^/\\]*[/\\])+)([^/\\]+)$/;
         this.lineNumberComment = /^\/\/\s*(\d+)\s(?!bytes).*/;
 
         // categories of directives. remove if filters.directives set


### PR DESCRIPTION
This PR fixes a bug in the IAR EW assembly parser that broke the filtering if comments are included in the source code.
Previously, it incorrectly detected comments as file names.

I.e...
```cpp
// Type your code here, or load an example.
int square(int num) {
    return num * num;
}
```
...led to an empty assembly.

The PR extends the file name recognition regex in a way that it doesn't match source code comments.

![image](https://user-images.githubusercontent.com/4458720/193269426-10d8e9dd-9b40-4720-a09b-42f81fdb4d41.png)

