### PR TITLE
docs(api): improved clientstate API documentation describing need for unicode conversion

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -123,3 +123,4 @@ From oldest to newest contributor, we would like to thank:
 - [Mike Urbach](https://github.com/mikeurbach)
 - [J. Ryan Stinnett](https://github.com/jryans)
 - [Fábio S. V. Medeiros](https://github.com/fabiosvm)
+- [Jackson Machado](https://github.com/jacksjm)

--- a/docs/API.md
+++ b/docs/API.md
@@ -306,6 +306,8 @@ This call is to open the website with a given state (without having to store the
 Instead of sending the ClientState JSON in the post body, it will have to be encoded with base64 and attached directly
 onto the URL.
 
+To avoid problems in reading base64 by the API, some characters must be kept in unicode. Therefore, before calling the API, it is necessary to replace these characters with their respective unicodes. A suggestion is to use the Regex expression `/[\u007F-\uFFFF]/g` that allows mapping these characters.
+
 # Implementations
 
 Here are some examples of projects using the Compiler Explorer API:


### PR DESCRIPTION
Fixed issue #3075

**Description:**
Improved clientstate API documentation describing need for unicode conversion

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
