### PR TITLE
Fix --emit llvm-ir when asked to emit binary mode

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1011,7 +1011,6 @@ export class BaseCompiler {
         if (output.code !== 0) {
             return [{text: 'Failed to run compiler to get IR code'}];
         }
-        console.log(newOptions, output);
         const ir = await this.processIrOutput(output, filters);
         return ir.asm;
     }

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1001,7 +1001,7 @@ export class BaseCompiler {
 
     async generateIR(inputFilename: string, options: string[], filters: ParseFilters) {
         // These options make Clang produce an IR
-        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics').concat(this.compiler.irArg);
+        const newOptions = options.filter(option => option !== '-fcolor-diagnostics').concat(this.compiler.irArg);
 
         const execOptions = this.getDefaultExecOptions();
         // A higher max output is needed for when the user includes headers
@@ -1011,12 +1011,13 @@ export class BaseCompiler {
         if (output.code !== 0) {
             return [{text: 'Failed to run compiler to get IR code'}];
         }
+        console.log(newOptions, output);
         const ir = await this.processIrOutput(output, filters);
         return ir.asm;
     }
 
     async processIrOutput(output, filters: ParseFilters) {
-        const irPath = this.getIrOutputFilename(output.inputFilename);
+        const irPath = this.getIrOutputFilename(output.inputFilename, filters);
         if (await fs.pathExists(irPath)) {
             const output = await fs.readFile(irPath, 'utf-8');
             // uses same filters as main compiler
@@ -1177,7 +1178,7 @@ export class BaseCompiler {
         return [{text: 'Internal error; unable to open output path'}];
     }
 
-    getIrOutputFilename(inputFilename) {
+    getIrOutputFilename(inputFilename: string, filters: ParseFilters): string {
         return inputFilename.replace(path.extname(inputFilename), '.ll');
     }
 


### PR DESCRIPTION
This _might_ be the fix for the linked issue, as I wrote in the original issue:


The issue is that we expected rustc to always output the llvm-ir in a `output.ll`, as we normally call it with `-o output.s --emit asm --emit llmv-ir`, which makes it warn us with:
```
warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type

warning: 1 warning emitted
```

and then rustc goes ahead and creates both the `output.s` and `output.ll` files.

In the binary case, we only ask it to emit llvm-ir, so it interprets that the passed `-o output.s` is for the llvm-ir. In hindsight it makes some sense, but this flew under our radar until now

Now the issue is that, afaik (Im no expert in llvm), we now get the expected ir:
![imagen](https://user-images.githubusercontent.com/5364255/194694108-b92ce3c6-ce14-490b-8b94-2c5402f82c77.png)

but most of the file is binary nonsense:
![imagen](https://user-images.githubusercontent.com/5364255/194694121-917e1f61-1066-4eaa-a35c-afcf94f73bfd.png)


Closes #4054
