### PR TITLE
Add no-console to eslint checks

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -64,6 +64,7 @@ rules:
   max-statements:
     - error
     - 100 # TODO reduce...was 50
+  no-console: error
   no-control-regex: 0
   no-duplicate-imports: error
   no-useless-call: error

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1029,13 +1029,14 @@ export class BaseCompiler {
     }
 
     async generateLLVMOptPipeline(
-        inputFilename,
-        options,
+        inputFilename: string,
+        options: string[],
         filters: ParseFilters,
         llvmOptPipelineOptions: LLVMOptPipelineBackendOptions,
     ): Promise<LLVMOptPipelineOutput | undefined> {
         // These options make Clang produce the pass dumps
-        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics')
+        const newOptions = options
+            .filter(option => option !== '-fcolor-diagnostics')
             .concat(this.compiler.llvmOptArg)
             .concat(llvmOptPipelineOptions.fullModule ? this.compiler.llvmOptModuleScopeArg : [])
             .concat(llvmOptPipelineOptions.noDiscardValueNames ? this.compiler.llvmOptNoDiscardValueNamesArg : []);

--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -22,6 +22,8 @@ import {Transform, TransformCallback} from 'stream';
 import * as R from 'ramda';
 import * as YAML from 'yamljs';
 
+import {logger} from './logger';
+
 type Path = string;
 type OptType = 'Missed' | 'Passed' | 'Analysis';
 
@@ -100,7 +102,7 @@ export class LLVMOptTransformer extends Transform {
                     this._prevOpts.add(strOpt);
 
                     if (!optTypeMatch) {
-                        console.warn('missing optimization type');
+                        logger.warn('missing optimization type');
                     } else {
                         opt.optType = optTypeMatch[1].replace('!', '');
                     }

--- a/static/.eslint-ce-static.yml
+++ b/static/.eslint-ce-static.yml
@@ -36,6 +36,7 @@ rules:
   max-statements:
     - error
     - 50
+  no-console: error
   no-control-regex: 0
   no-useless-call: error
   no-useless-computed-key: error

--- a/webpack.config.esm.js
+++ b/webpack.config.esm.js
@@ -36,6 +36,7 @@ import {WebpackManifestPlugin} from 'webpack-manifest-plugin';
 
 const __dirname = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
 const isDev = process.env.NODE_ENV !== 'production';
+// eslint-disable-next-line no-console
 console.log(`webpack config for ${isDev ? 'development' : 'production'}.`);
 
 const distPath = path.resolve(__dirname, 'out', 'dist');


### PR DESCRIPTION
@partouf found in https://github.com/compiler-explorer/compiler-explorer/pull/4131#discussion_r990840471 that a console statement passed the eslint checks.
Turns out, the check was not there anymore.
