### PR TITLE
Fix types folder for tsconfig backend

### DIFF
--- a/tsconfig.backend.json
+++ b/tsconfig.backend.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     /* Code generation */
     "outDir": "./out/dist",
-    "typeRoots": ["./typings", "./node_modules/@types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     /* Other options */
     "allowJs": true
   }


### PR DESCRIPTION
It was pointing to a missing `./typings` folder, which I assume is a type and was meant to be `./types`