### PR TITLE
fix: Zig trunk compile error

### DIFF
--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -76,8 +76,8 @@ export class ZigCompiler extends BaseCompiler {
             source += '    zig_panic();\n';
             source += '}\n';
         } else if (
-            Semver.eq(asSafeVer(this.compiler.semver), '0.9.0', true) ||
-            Semver.eq(asSafeVer(this.compiler.semver), '0.8.0', true)
+            Semver.geq(asSafeVer(this.compiler.semver), '0.8.0', true) &&
+            Semver.leq(asSafeVer(this.compiler.semver), '0.9.0', true)
         ) {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -78,11 +78,10 @@ export class ZigCompiler extends BaseCompiler {
         } else {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';
-            source +=
-                'pub fn panic(msg: []const u8, error_return_trace: ' +
-                '?*@import("std").builtin.StackTrace) noreturn {\n';
+            source += 'pub fn panic(msg: []const u8, error_return_trace: ?*@import("std").builtin.StackTrace, ret_addr: ?usize) noreturn {\n';
             source += '    _ = msg;\n';
             source += '    _ = error_return_trace;\n';
+            source += '    _ = ret_addr;\n';
             source += '    zig_panic();\n';
             source += '}\n';
         }

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -75,6 +75,19 @@ export class ZigCompiler extends BaseCompiler {
             source += 'pub fn panic(msg: []const u8, error_return_trace: ?*@import("builtin").StackTrace) noreturn {\n';
             source += '    zig_panic();\n';
             source += '}\n';
+        } else if (
+            Semver.eq(asSafeVer(this.compiler.semver), '0.9.0', true) ||
+            Semver.eq(asSafeVer(this.compiler.semver), '0.8.0', true)
+        ) {
+            source += '\n';
+            source += 'extern fn zig_panic() noreturn;\n';
+            source +=
+                'pub fn panic(msg: []const u8, error_return_trace: ' +
+                '?*@import("std").builtin.StackTrace) noreturn {\n';
+            source += '    _ = msg;\n';
+            source += '    _ = error_return_trace;\n';
+            source += '    zig_panic();\n';
+            source += '}\n';
         } else {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -76,8 +76,8 @@ export class ZigCompiler extends BaseCompiler {
             source += '    zig_panic();\n';
             source += '}\n';
         } else if (
-            Semver.geq(asSafeVer(this.compiler.semver), '0.8.0', true) &&
-            Semver.leq(asSafeVer(this.compiler.semver), '0.9.0', true)
+            Semver.gte(asSafeVer(this.compiler.semver), '0.8.0', true) &&
+            Semver.lte(asSafeVer(this.compiler.semver), '0.9.0', true)
         ) {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -78,7 +78,9 @@ export class ZigCompiler extends BaseCompiler {
         } else {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';
-            source += 'pub fn panic(msg: []const u8, error_return_trace: ?*@import("std").builtin.StackTrace, ret_addr: ?usize) noreturn {\n';
+            source +=
+                'pub fn panic(msg: []const u8, error_return_trace: ' +
+                '?*@import("std").builtin.StackTrace, ret_addr: ?usize) noreturn {\n';
             source += '    _ = msg;\n';
             source += '    _ = error_return_trace;\n';
             source += '    _ = ret_addr;\n';


### PR DESCRIPTION
Compilations that may panic reference this function which now has an additional `ret_addr` parameter. This updates to the new function signature.

See also https://github.com/ziglang/zig/blob/697e22caa49716369dff6c86461b94fe10b0a009/lib/std/builtin.zig#L758 as a reference.