### PR TITLE
Change the name of the "auto NSDMI" branch.

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -358,9 +358,9 @@ compiler.clang_p1144.semver=(experimental P1144)
 compiler.clang_p1144.options=-std=c++2a -stdlib=libc++ -g0
 compiler.clang_p1144.notification=Experimental __is_trivially_relocatable; see <a href="https://wg21.link/p1144" target="_blank" rel="noopener noreferrer">P1144 <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_autonsdmi.exe=/opt/compiler-explorer/clang-autonsdmi-trunk/bin/clang++
-compiler.clang_autonsdmi.semver=(experimental auto NSDMI)
+compiler.clang_autonsdmi.semver=(experimental metaprogramming - P2632)
 compiler.clang_autonsdmi.options=-std=c++2a -stdlib=libc++
-compiler.clang_autonsdmi.notification=Experimental auto NSDMI; see <a href="https://cor3ntin.github.io/posts/auto_nsdmi/" target="_blank" rel="noopener noreferrer">this blog post <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for more information
+compiler.clang_autonsdmi.notification=Experimental Template Meta Programming features; see <a href="https://wg21.link/P2632" target="_blank" rel="noopener noreferrer">this C++ paper <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for more information
 compiler.clang_lifetime.exe=/opt/compiler-explorer/clang-lifetime-trunk/bin/clang++
 compiler.clang_lifetime.semver=(experimental -Wlifetime)
 compiler.clang_lifetime.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 -Wlifetime


### PR DESCRIPTION
The "auto NSDMI" branch has not actually fully supported non static members in a while, as the patch was initially written for clang 9, and I have not gotten around to fix it.

The branch now contains a number of experimentals proposals including
  * parameter pack indexing (https://isocpp.org/files/papers/D2632R0.pdf)
  * magic char8_t cast function
  * _ for variable names
  * non trailing parameter packs
  * constexpr structured bindings
  * constexpr cast from void*
  * And more to come

P2632 is the paper presenting the majority of these features, and the current plan is to implement as much of it in clang as possible.

The wg21.link link will become active at publication of the paper next week.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
