### PR TITLE
Fully specifies rocm compiler names

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -122,24 +122,31 @@ group.cuclang.objdumper=/opt/compiler-explorer/cuda/11.3.1/bin/nvdisasm
 # old. It can be overriden by the user via --no-offload-arch=none
 # --offload-arch=sm_XY.
 compiler.cuclang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
-compiler.cuclang700.semver=7.0.0 sm_70 CUDA-9.1
+compiler.cuclang700.semver=7.0.0
+compiler.cuclang700.name=clang 7.0.0 sm_70 CUDA-9.1
 compiler.cuclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 --cuda-path=/opt/compiler-explorer/cuda/9.1.85 --cuda-gpu-arch=sm_70 --cuda-device-only
 compiler.cuclang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang++
-compiler.cuclang800.semver=8.0.0 sm_75 CUDA-10.0
+compiler.cuclang800.semver=8.0.0
+compiler.cuclang800.name=clang 8.0.0 sm_75 CUDA-10.0
 compiler.cuclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0 --cuda-path=/opt/compiler-explorer/cuda/10.0.130 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
-compiler.cuclang900.semver=9.0.0 sm_75 CUDA-10.1
+compiler.cuclang900.semver=9.0.0
+compiler.cuclang900.name=clang 9.0.0 sm_75 CUDA-10.1
 compiler.cuclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 --cuda-path=/opt/compiler-explorer/cuda/10.1.168 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
-compiler.cuclang1000.semver=10.0.0 sm_75 CUDA-10.2
+compiler.cuclang1000.semver=10.0.0
+compiler.cuclang1000.name=10.0.0 sm_75 CUDA-10.2
 compiler.cuclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/10.2.89 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
-compiler.cuclang1001.semver=10.0.1 sm_75 CUDA-10.2
+compiler.cuclang1001.semver=10.0.1
+compiler.cuclang1001.name=10.0.1 sm_75 CUDA-10.2
 compiler.cuclang1001.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/10.2.89 --cuda-gpu-arch=sm_75 --cuda-device-only
 compiler.cuclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
-compiler.cuclang1100.semver=11.0.0 sm_75 CUDA-10.2
+compiler.cuclang1100.semver=11.0.0
+compiler.cuclang1100.name=11.0.0 sm_75 CUDA-10.2
 compiler.cuclang1100.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0 --cuda-path=/opt/compiler-explorer/cuda/10.2.89 --cuda-gpu-arch=sm_75 --cuda-device-only
-compiler.cltrunk.semver=trunk sm_86 CUDA-11.3
+compiler.cltrunk.semver=trunk
+compiler.cltrunk.name=trunk sm_86 CUDA-11.3
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
@@ -158,19 +165,23 @@ compiler.hiptrunk.hidden=true
 # the clang-hip compiler type adds --gpu-bundle-output which didn't exist in ROCm 4.5
 compiler.hipclang-rocm-40502.compilerType=clang
 compiler.hipclang-rocm-40502.exe=/opt/compiler-explorer/clang-rocm-4.5.2/bin/clang++
-compiler.hipclang-rocm-40502.semver=rocm-4.5.2
+compiler.hipclang-rocm-40502.semver=4.5.2
+compiler.hipclang-rocm-40502.name=clang rocm-4.5.2
 compiler.hipclang-rocm-40502.objdumper=/opt/compiler-explorer/clang-rocm-40502/bin/llvm-objdump
 compiler.hipclang-rocm-40502.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 --rocm-path=/opt/compiler-explorer/libs/rocm/4.5.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-4.5.2/amdgcn/bitcode -include hip/hip_runtime.h
 compiler.hipclang-rocm-50002.exe=/opt/compiler-explorer/clang-rocm-5.0.2/bin/clang++
 compiler.hipclang-rocm-50002.semver=rocm-5.0.2
+compiler.hipclang-rocm-50002.name=clang rocm-5.0.2
 compiler.hipclang-rocm-50002.objdumper=/opt/compiler-explorer/clang-rocm-50002/bin/llvm-objdump
 compiler.hipclang-rocm-50002.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.0.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.0.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.0.2/amdgcn/bitcode -include hip/hip_runtime.h
 compiler.hipclang-rocm-50103.exe=/opt/compiler-explorer/clang-rocm-5.1.3/bin/clang++
 compiler.hipclang-rocm-50103.semver=rocm-5.1.3
+compiler.hipclang-rocm-50103.name=clang rocm-5.1.3
 compiler.hipclang-rocm-50103.objdumper=/opt/compiler-explorer/clang-rocm-50103/bin/llvm-objdump
 compiler.hipclang-rocm-50103.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.1.3/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.1.3 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.1.3/amdgcn/bitcode -include hip/hip_runtime.h
 compiler.hipclang-rocm-50203.exe=/opt/compiler-explorer/clang-rocm-5.2.3/bin/clang++
 compiler.hipclang-rocm-50203.semver=rocm-5.2.3
+compiler.hipclang-rocm-50203.name=clang rocm-5.2.3
 compiler.hipclang-rocm-50203.objdumper=/opt/compiler-explorer/clang-rocm-50203/bin/llvm-objdump
 compiler.hipclang-rocm-50203.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.2.3/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.2.3 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.2.3/amdgcn/bitcode -include hip/hip_runtime.h
 

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -170,17 +170,17 @@ compiler.hipclang-rocm-40502.name=clang rocm-4.5.2
 compiler.hipclang-rocm-40502.objdumper=/opt/compiler-explorer/clang-rocm-40502/bin/llvm-objdump
 compiler.hipclang-rocm-40502.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 --rocm-path=/opt/compiler-explorer/libs/rocm/4.5.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-4.5.2/amdgcn/bitcode -include hip/hip_runtime.h
 compiler.hipclang-rocm-50002.exe=/opt/compiler-explorer/clang-rocm-5.0.2/bin/clang++
-compiler.hipclang-rocm-50002.semver=rocm-5.0.2
+compiler.hipclang-rocm-50002.semver=5.0.2
 compiler.hipclang-rocm-50002.name=clang rocm-5.0.2
 compiler.hipclang-rocm-50002.objdumper=/opt/compiler-explorer/clang-rocm-50002/bin/llvm-objdump
 compiler.hipclang-rocm-50002.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.0.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.0.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.0.2/amdgcn/bitcode -include hip/hip_runtime.h
 compiler.hipclang-rocm-50103.exe=/opt/compiler-explorer/clang-rocm-5.1.3/bin/clang++
-compiler.hipclang-rocm-50103.semver=rocm-5.1.3
+compiler.hipclang-rocm-50103.semver=5.1.3
 compiler.hipclang-rocm-50103.name=clang rocm-5.1.3
 compiler.hipclang-rocm-50103.objdumper=/opt/compiler-explorer/clang-rocm-50103/bin/llvm-objdump
 compiler.hipclang-rocm-50103.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.1.3/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.1.3 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.1.3/amdgcn/bitcode -include hip/hip_runtime.h
 compiler.hipclang-rocm-50203.exe=/opt/compiler-explorer/clang-rocm-5.2.3/bin/clang++
-compiler.hipclang-rocm-50203.semver=rocm-5.2.3
+compiler.hipclang-rocm-50203.semver=5.2.3
 compiler.hipclang-rocm-50203.name=clang rocm-5.2.3
 compiler.hipclang-rocm-50203.objdumper=/opt/compiler-explorer/clang-rocm-50203/bin/llvm-objdump
 compiler.hipclang-rocm-50203.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.2.3/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.2.3 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.2.3/amdgcn/bitcode -include hip/hip_runtime.h


### PR DESCRIPTION
As mentioned in #4097, this needed to be done to allow proper semver ordering
