### PR TITLE
Change SH compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -798,15 +798,15 @@ compiler.shg494.semver=4.9.4
 compiler.shg494.objdumper=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.shg494.demangler=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
-compiler.shg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-g++
+compiler.shg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-g++
 compiler.shg950.semver=9.5.0
-compiler.shg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
-compiler.shg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.shg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
-compiler.shg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-g++
+compiler.shg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-g++
 compiler.shg1220.semver=12.2.0
-compiler.shg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
-compiler.shg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.shg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
 ###############################
 # Cross for s390x

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -725,15 +725,15 @@ compiler.cshg494.semver=4.9.4
 compiler.cshg494.objdumper=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.cshg494.demangler=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
-compiler.cshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gcc
+compiler.cshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
 compiler.cshg950.semver=9.5.0
-compiler.cshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
-compiler.cshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.cshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
-compiler.cshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gcc
+compiler.cshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
 compiler.cshg1220.semver=12.2.0
-compiler.cshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
-compiler.cshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
+compiler.cshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
 ###############################
 # Cross for s390x

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -157,26 +157,10 @@ compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64:&gccsh
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64
 group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
-
-###############################
-# GCC for sh
-group.gccsh.compilers=fshg950:fshg1220
-group.gccsh.groupName=SH gfortran
-group.gccsh.baseName=SH
-
-compiler.fshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gfortran
-compiler.fshg950.semver=9.5.0
-compiler.fshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
-compiler.fshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
-
-compiler.fshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-gfortran
-compiler.fshg1220.semver=12.2.0
-compiler.fshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-objdump
-compiler.fshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-multilib-linux-gnu/bin/sh-multilib-linux-gnu-c++filt
 
 ###############################
 # GCC for RISCV64


### PR DESCRIPTION
SH GCC 9.5 and 12.2 were linux-* and not supporting sh2. We decided to change these compilers to elf-* with sh2 support.

This also causes the removal of fortran as it's not available for elf targets.

refs #94

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>