### PR TITLE
Correct gcc-toolchain for "all architectural features" armv8 clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -474,7 +474,7 @@ compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv7-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv7-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-clang-trunk.semver=(trunk)
-compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 ################################
 # Clang for Arm
@@ -518,13 +518,13 @@ compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-clang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-clang-trunk.semver=(trunk)
-compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-full-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-full-clang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-clang-trunk.semver=(trunk, all architectural features)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 # An alias of the original name for this compiler needs to be maintained to allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -459,7 +459,7 @@ compiler.armv7-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c+
 compiler.armv7-cclang-trunk.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armv7-cclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv8-cclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -467,7 +467,7 @@ compiler.armv8-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c+
 compiler.armv8-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-cclang-trunk.semver=(trunk)
 # Arm v8-a
-compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-full-cclang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -475,7 +475,7 @@ compiler.armv8-full-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/b
 compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 # An alias of the original name for this compiler needs to be maintained to
 # allow old URLs to continue to work
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -475,7 +475,7 @@ compiler.armv8-full-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/b
 compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 # An alias of the original name for this compiler needs to be maintained to
 # allow old URLs to continue to work
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -115,7 +115,7 @@ compiler.armv7-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/
 compiler.armv7-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-cpp4oclclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cpp4oclclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv7-cpp4oclclang-trunk-assertions.name=armv7-a clang (trunk, assertions)
 compiler.armv7-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
@@ -123,7 +123,7 @@ compiler.armv7-cpp4oclclang-trunk-assertions.demangler=/opt/compiler-explorer/gc
 compiler.armv7-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cpp4oclclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv8-cpp4oclclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -131,7 +131,7 @@ compiler.armv8-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/
 compiler.armv8-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-cpp4oclclang-trunk.semver=(trunk)
 # Arm v8-a
-compiler.armv8-cpp4oclclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-cpp4oclclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-cpp4oclclang-trunk-assertions.name=armv8-a clang (trunk, assertions)
 compiler.armv8-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
@@ -139,7 +139,7 @@ compiler.armv8-cpp4oclclang-trunk-assertions.demangler=/opt/compiler-explorer/gc
 compiler.armv8-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
 # Arm v8-a
-compiler.armv8-cpp4oclclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-cpp4oclclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-full-cpp4oclclang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -147,7 +147,7 @@ compiler.armv8-full-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snap
 compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 
 # SPIR-V Assembly
 group.armcpp4oclclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -147,7 +147,7 @@ compiler.armv8-full-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snap
 compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cpp4oclclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 
 # SPIR-V Assembly
 group.armcpp4oclclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -140,7 +140,7 @@ compiler.armv7-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.armv7-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-oclcclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-oclcclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv7-oclcclang-trunk-assertions.name=armv7-a clang (trunk, assertions)
 compiler.armv7-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
@@ -148,7 +148,7 @@ compiler.armv7-oclcclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-s
 compiler.armv7-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-oclcclang-trunk-assertions.semver=(assertions trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-oclcclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 
 compiler.armv8-oclcclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -156,7 +156,7 @@ compiler.armv8-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.armv8-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-oclcclang-trunk.semver=(trunk)
 # Arm v8-a
-compiler.armv8-oclcclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-oclcclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-oclcclang-trunk-assertions.name=armv8-a clang (trunk, assertions)
 compiler.armv8-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
@@ -164,7 +164,7 @@ compiler.armv8-oclcclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-s
 compiler.armv8-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-oclcclang-trunk-assertions.semver=(assertions trunk)
 # Arm v8-a
-compiler.armv8-oclcclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-oclcclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-full-oclcclang-trunk.name=armv8-a clang (trunk, all architectural features)
 compiler.armv8-full-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
@@ -172,7 +172,7 @@ compiler.armv8-full-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapsho
 compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 
 # SPIR-V Assembly
 group.armoclcclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -172,7 +172,7 @@ compiler.armv8-full-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapsho
 compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-oclcclang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 
 # SPIR-V Assembly
 group.armoclcclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)


### PR DESCRIPTION
Fixes #4156, fixes #3166

Previously these were all set to use an x86_64 toolchain which clearly isn't right. This lead to things like uintptr_t being smaller than void*.

Use the same toolchain and sysroot for the "all architectural features" as for the rest of the configurations.

This also changes the -target to "gnu" not "android" to match the new settings.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
