### PR TITLE
Fixes editor annotations showing for unreleated exec panes

### DIFF
--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -1518,13 +1518,17 @@ Editor.prototype.onCompileResponse = function (compilerId, compiler, result) {
 };
 
 Editor.prototype.onExecuteResponse = function (executorId, compiler, result) {
-    var output = this.getAllOutputAndErrors(result, compiler.name, 'Execution ' + executorId);
-    if (result.buildResult) {
-        output = output.concat(this.getAllOutputAndErrors(result.buildResult, compiler.name, 'Executor ' + executorId));
-    }
-    this.setDecorationTags(this.collectOutputWidgets(output).widgets, 'Executor ' + executorId);
+    if (this.ourExecutors[executorId]) {
+        var output = this.getAllOutputAndErrors(result, compiler.name, 'Execution ' + executorId);
+        if (result.buildResult) {
+            output = output.concat(
+                this.getAllOutputAndErrors(result.buildResult, compiler.name, 'Executor ' + executorId)
+            );
+        }
+        this.setDecorationTags(this.collectOutputWidgets(output).widgets, 'Executor ' + executorId);
 
-    this.numberUsedLines();
+        this.numberUsedLines();
+    }
 };
 
 Editor.prototype.onSelectLine = function (id, lineNum) {


### PR DESCRIPTION
We were not checking that the execution response was for one of the editor's executors

Fixes #4137
