### PR TITLE
Add config for Loongarch64

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -773,7 +773,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh
+group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -782,13 +782,30 @@ group.cross.licenseName=GNU General Public License
 group.cross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 ###############################
+# Cross for loongarch64
+group.loongarch64.compilers=&gccloongarch64
+
+# GCC for loongarch64
+group.gccloongarch64.supportsBinary=true
+group.gccloongarch64.supportsExecute=false
+group.gccloongarch64.baseName=loongarch64 gcc
+group.gccloongarch64.groupName=loongarch64 gcc
+group.gccloongarch64.compilers=loongarch64g1220
+group.gccloongarch64.isSemVer=true
+
+compiler.loongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
+compiler.loongarch64g1220.semver=12.2.0
+compiler.loongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.loongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+###############################
 # Cross for sh
 group.sh.compilers=&gccsh
 
 # GCC for sh
 group.gccsh.supportsBinary=true
 group.gccsh.supportsExecute=false
-group.gccsh.baseName=sh
+group.gccsh.baseName=sh gcc
 group.gccsh.groupName=sh gcc
 group.gccsh.compilers=shg494:shg950:shg1220
 group.gccsh.isSemVer=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -703,10 +703,26 @@ compiler.cicx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh
+group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
+###############################
+# Cross for loongarch64
+group.cloongarch64.compilers=&cgccloongarch64
+
+# GCC for loongarch64
+group.cgccloongarch64.compilers=cloongarch64g1220
+group.cgccloongarch64.supportsBinary=true
+group.cgccloongarch64.supportsExecute=false
+group.cgccloongarch64.baseName=loongarch64 gcc
+group.cgccloongarch64.groupName=loongarch64 GCC
+group.cgccloongarch64.isSemVer=true
+
+compiler.cloongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.cloongarch64g1220.semver=12.2.0
+compiler.cloongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.cloongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 ###############################
 # Cross for sh
@@ -716,7 +732,7 @@ group.csh.compilers=&cgccsh
 group.cgccsh.compilers=cshg494:cshg950:cshg1220
 group.cgccsh.supportsBinary=true
 group.cgccsh.supportsExecute=false
-group.cgccsh.baseName=sh
+group.cgccsh.baseName=sh gcc
 group.cgccsh.groupName=sh GCC
 group.cgccsh.isSemVer=true
 

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -157,10 +157,21 @@ compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64:&gccloongarch64
 group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
+
+###############################
+# GCC for LOONGARCH64
+group.gccloongarch64.compilers=floongarch64g1220
+group.gccloongarch64.groupName=LOONGARCH64 gfortran
+group.gccloongarch64.baseName=LOONGARCH64 gfortran
+
+compiler.floongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
+compiler.floongarch64g1220.semver=12.2.0
+compiler.floongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.floongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for RISCV64


### PR DESCRIPTION
Add config for newly supported target: Loongarch64

Our support starts from GCC 12.2.0 for C, C++, Fortran and D.

fixes #4162

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>