### PR TITLE
Add stdexec C++ library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1686,7 +1686,7 @@ compiler.gcc6502_1110.notification=This uses AVR-GCC 11.1.0 to compile C++ and u
 #################################
 #################################
 # Installed libs
-libs=abseil:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:taojson:tbb:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11:avr-libstdcpp:curl:copperspice
+libs=abseil:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:simde:sol2:spdlog:spy:stdexec:taojson:tbb:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdtext:zug:cli11:avr-libstdcpp:curl:copperspice
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -2749,6 +2749,13 @@ libs.spy.versions.v004.path=/opt/compiler-explorer/libs/spy/0.0.4/include
 libs.spy.versions.v004.alias=v003
 libs.spy.versions.v100.version=v1.0.0
 libs.spy.versions.v100.path=/opt/compiler-explorer/libs/spy/1.0.0/include
+
+libs.stdexec.name=std::execution
+libs.stdexec.description=The proposed C++ framework for asynchronous and parallel programming
+libs.stdexec.versions=trunk
+libs.stdexec.url=https://github.com/NVIDIA/stdexec
+libs.stdexec.versions.trunk.version=trunk
+libs.stdexec.versions.trunk.path=/opt/compiler-explorer/libs/stdexec/include
 
 libs.taojson.name=taoJSON
 libs.taojson.description=taoJSON is a C++ header-only JSON library that provides a generic value class, uses type traits to interoperate with C++ types, uses an events interface to convert from and to JSON, JAXN, CBOR, MsgPack and UBJSON, and much more...

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2755,7 +2755,7 @@ libs.stdexec.description=The proposed C++ framework for asynchronous and paralle
 libs.stdexec.versions=trunk
 libs.stdexec.url=https://github.com/NVIDIA/stdexec
 libs.stdexec.versions.trunk.version=trunk
-libs.stdexec.versions.trunk.path=/opt/compiler-explorer/libs/stdexec/include
+libs.stdexec.versions.trunk.path=/opt/compiler-explorer/libs/stdexec/trunk/include
 
 libs.taojson.name=taoJSON
 libs.taojson.description=taoJSON is a C++ header-only JSON library that provides a generic value class, uses type traits to interoperate with C++ types, uses an events interface to convert from and to JSON, JAXN, CBOR, MsgPack and UBJSON, and much more...


### PR DESCRIPTION
Adds [`std::exec`](https://github.com/NVIDIA/stdexec/) as a C++ library.

Related PR: https://github.com/compiler-explorer/infra/pull/854