### PR TITLE
Fixes 6yo variable typo

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3165,8 +3165,8 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
     override onSettingsChange(newSettings: SiteSettings): void {
         const before = this.settings;
-        this.settings = _.clone(newSettings);
-        if (!(before as any).lastHoverShowSource && this.settings.hoverShowSource) {
+        this.settings = {...newSettings};
+        if (!before.hoverShowSource && this.settings.hoverShowSource) {
             this.onCompilerSetDecorations(this.id, []);
         }
         this.editor.updateOptions({


### PR DESCRIPTION
¯\\\_(ツ)_/¯
