### PR TITLE
Fixes compiler init order by using initializeStateDependentProperties

### DIFF
--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {Language} from '../types/languages.interfaces';
+import {Language, LanguageKey} from '../types/languages.interfaces';
 import {CompilerInfo} from '../types/compiler.interfaces';
 
 export type LibraryVersion = {
@@ -51,12 +51,13 @@ export type LibsPerRemote = Record<string, LanguageLibs>;
 export type Options = {
     libs: Libs;
     remoteLibs: LibsPerRemote;
-    languages: Record<string, Language>;
+    languages: Record<LanguageKey, Language>;
     compilers: CompilerInfo[];
-    defaultCompiler: Record<string, string>;
-    defaultLibs: Record<string, string | null>;
+    defaultCompiler: Record<LanguageKey, string>;
+    defaultLibs: Record<LanguageKey, string | null>;
     defaultFontScale: number;
     sentryDsn?: string;
     release?: string;
     sentryEnvironment?: string;
+    compileOptions: Record<LanguageKey, string>
 };

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -195,7 +195,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     private compilerService: CompilerService;
     private readonly id: number;
     private sourceTreeId: number | null;
-    private readonly sourceEditorId: number | null;
+    private sourceEditorId: number | null;
     private originalCompilerId: string;
     private readonly infoByLang: Record<string, {compiler: string; options: string}>;
     private deferCompiles: boolean;
@@ -314,23 +314,15 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     // eslint-disable-next-line max-statements
     constructor(hub: Hub, container: Container, state: MonacoPaneState & CompilerState) {
         super(hub, container, state);
-        this.compilerService = hub.compilerService;
-        this.id = state.id || hub.nextCompilerId();
-        this.sourceTreeId = state.tree ? state.tree : null;
-        if (this.sourceTreeId) {
-            this.sourceEditorId = null;
-        } else {
-            this.sourceEditorId = state.source || 1;
-        }
 
+        this.id = state.id || hub.nextCompilerId();
         this.settings = Settings.getStoredSettings();
-        this.originalCompilerId = state.compiler;
-        this.initLangAndCompiler(state);
+
         this.infoByLang = {};
         this.deferCompiles = hub.deferred;
         this.needsCompile = false;
-        this.deviceViewOpen = !!state.deviceViewOpen;
-        this.options = state.options || (options.compileOptions as any)[this.currentLangId ?? ''];
+        this.initLangAndCompiler(state);
+
         this.source = '';
         this.assembly = [];
         this.colours = [];
@@ -342,9 +334,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         this.nextRequest = null;
         this.nextCMakeRequest = null;
         this.optViewOpen = false;
-        this.flagsViewOpen = state.flagsViewOpen || false;
+
         this.cfgViewOpen = false;
-        this.wantOptInfo = state.wantOptInfo;
+
         this.decorations = {
             labelUsages: [],
         };
@@ -354,7 +346,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         this.alertSystem.prefixMessage = 'Compiler #' + this.id;
 
         this.awaitingInitialResults = false;
-        this.selection = state.selection;
+
 
         this.linkedFadeTimeoutId = null;
         this.toolsMenu = null;
@@ -371,9 +363,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             this.compiler?.id ?? '',
             this.onCompilerChange.bind(this)
         );
-
         this.initLibraries(state);
-
         // MonacoPane's registerCallbacks is not called late enough either
         this.initCallbacks();
         // Handle initial settings
@@ -386,6 +376,23 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         if (this.sourceTreeId) {
             this.compile();
         }
+    }
+
+    override initializeStateDependentProperties(state: MonacoPaneState & CompilerState) {
+        this.compilerService = this.hub.compilerService;
+        this.sourceTreeId = state.tree ? state.tree : null;
+        if (this.sourceTreeId) {
+            this.sourceEditorId = null;
+        } else {
+            this.sourceEditorId = state.source || 1;
+        }
+        this.options = state.options || (options.compileOptions[this.currentLangId ?? ''] ?? '');
+
+        this.deviceViewOpen = !!state.deviceViewOpen;
+        this.flagsViewOpen = state.flagsViewOpen || false;
+        this.wantOptInfo = state.wantOptInfo;
+        this.originalCompilerId = state.compiler;
+        this.selection = state.selection;
     }
 
     override getInitialHTML() {


### PR DESCRIPTION
The options were being properly passed in the state, but the UI was being initialized before the value was set to the member, causing it not to be displayed.

Closes #4207

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
