### PR TITLE
Add clang++ 12, 13, 14 and 15 for aarch64

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -480,7 +480,7 @@ compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/op
 # Clang for Arm
 # Provides 64- menu items for clang-9, clang-10 and trunk
 group.armclang64.groupName=Arm 64-bit clang
-group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang-trunk:armv8-full-clang-trunk
+group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang1200:armv8-clang1300:armv8-clang1400:armv8-clang1500:armv8-clang-trunk:armv8-full-clang-trunk
 group.armclang64.isSemVer=true
 group.armclang64.baseName=armv8-a clang
 group.armclang64.compilerType=clang
@@ -490,6 +490,18 @@ group.armclang64.licenseName=LLVM Apache 2
 group.armclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
+compiler.armv8-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
+compiler.armv8-clang1500.semver=15.0.0
+compiler.armv8-clang1500.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
+compiler.armv8-clang1400.semver=14.0.0
+compiler.armv8-clang1400.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
+compiler.armv8-clang1300.semver=13.0.0
+compiler.armv8-clang1300.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang++
+compiler.armv8-clang1200.semver=12.0.0
+compiler.armv8-clang1200.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 compiler.armv8-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv8-clang1101.semver=11.0.1
 compiler.armv8-clang1101.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot


### PR DESCRIPTION
These configs are missing for C++ (already present for C).

refs #4158

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>