### PR TITLE
Add ROCm 5.3.2

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -398,7 +398,7 @@ compiler.clang_reflection.semver=(reflection)
 compiler.clang_reflection.options=-std=c++20 -freflection-ts -stdlib=libc++
 compiler.clang_reflection.notification=Experimental Reflection Support; see <a href="https://github.com/cplusplus/reflection-ts" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
-group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50301
+group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50302
 group.clang-rocm.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang-rocm.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang-rocm.groupName=ROCm clang x86-64
@@ -430,10 +430,10 @@ compiler.clang-rocm-50203.exe=/opt/compiler-explorer/clang-rocm-5.2.3/bin/clang+
 compiler.clang-rocm-50203.semver=rocm-5.2.3
 compiler.clang-rocm-50203.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.clang-rocm-50203.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
-compiler.clang-rocm-50301.exe=/opt/compiler-explorer/clang-rocm-5.3.1/bin/clang++
-compiler.clang-rocm-50301.semver=rocm-5.3.1
-compiler.clang-rocm-50301.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
-compiler.clang-rocm-50301.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-50302.exe=/opt/compiler-explorer/clang-rocm-5.3.2/bin/clang++
+compiler.clang-rocm-50302.semver=rocm-5.3.2
+compiler.clang-rocm-50302.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
+compiler.clang-rocm-50302.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
 ################################
 # Clang for Arm

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -398,7 +398,7 @@ compiler.clang_reflection.semver=(reflection)
 compiler.clang_reflection.options=-std=c++20 -freflection-ts -stdlib=libc++
 compiler.clang_reflection.notification=Experimental Reflection Support; see <a href="https://github.com/cplusplus/reflection-ts" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
-group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203
+group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50301
 group.clang-rocm.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang-rocm.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang-rocm.groupName=ROCm clang x86-64
@@ -430,6 +430,10 @@ compiler.clang-rocm-50203.exe=/opt/compiler-explorer/clang-rocm-5.2.3/bin/clang+
 compiler.clang-rocm-50203.semver=rocm-5.2.3
 compiler.clang-rocm-50203.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.clang-rocm-50203.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-50301.exe=/opt/compiler-explorer/clang-rocm-5.3.1/bin/clang++
+compiler.clang-rocm-50301.semver=rocm-5.3.1
+compiler.clang-rocm-50301.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
+compiler.clang-rocm-50301.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
 ################################
 # Clang for Arm

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -207,7 +207,7 @@ compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
 
-group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203,hipclang-rocm-50301
+group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203,hipclang-rocm-50302
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang
 group.hipclang.compilerType=clang-hip
@@ -245,12 +245,12 @@ compiler.hipclang-rocm-50203.name=clang rocm-5.2.3
 compiler.hipclang-rocm-50203.nvdisasm=/opt/compiler-explorer/clang-rocm-50203/bin/llvm-objdump
 compiler.hipclang-rocm-50203.objdumper=/opt/compiler-explorer/clang-rocm-50203/bin/llvm-objdump
 compiler.hipclang-rocm-50203.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.2.3/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.2.3 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.2.3/amdgcn/bitcode -include hip/hip_runtime.h
-compiler.hipclang-rocm-50301.exe=/opt/compiler-explorer/clang-rocm-5.3.1/bin/clang++
-compiler.hipclang-rocm-50301.semver=5.3.1
-compiler.hipclang-rocm-50301.name=clang rocm-5.3.1
-compiler.hipclang-rocm-50301.nvdisasm=/opt/compiler-explorer/clang-rocm-50301/bin/llvm-objdump
-compiler.hipclang-rocm-50301.objdumper=/opt/compiler-explorer/clang-rocm-50301/bin/llvm-objdump
-compiler.hipclang-rocm-50301.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.3.1/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.3.1 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.3.1/amdgcn/bitcode -include hip/hip_runtime.h
+compiler.hipclang-rocm-50302.exe=/opt/compiler-explorer/clang-rocm-5.3.2/bin/clang++
+compiler.hipclang-rocm-50302.semver=5.3.2
+compiler.hipclang-rocm-50302.name=clang rocm-5.3.2
+compiler.hipclang-rocm-50302.nvdisasm=/opt/compiler-explorer/clang-rocm-50302/bin/llvm-objdump
+compiler.hipclang-rocm-50302.objdumper=/opt/compiler-explorer/clang-rocm-50302/bin/llvm-objdump
+compiler.hipclang-rocm-50302.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.3.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.3.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.3.2/amdgcn/bitcode -include hip/hip_runtime.h
 
 group.nvrtc.compilers=nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11:nvrtc102:nvrtc101u2:nvrtc101u1:nvrtc101:nvrtc100:nvrtc92:nvrtc91
 group.nvrtc.compilerType=nvcc # nvrtc_cli is sufficiently compatible with nvcc

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -207,7 +207,7 @@ compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
 
-group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203
+group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203,hipclang-rocm-50301
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang
 group.hipclang.compilerType=clang-hip
@@ -245,6 +245,12 @@ compiler.hipclang-rocm-50203.name=clang rocm-5.2.3
 compiler.hipclang-rocm-50203.nvdisasm=/opt/compiler-explorer/clang-rocm-50203/bin/llvm-objdump
 compiler.hipclang-rocm-50203.objdumper=/opt/compiler-explorer/clang-rocm-50203/bin/llvm-objdump
 compiler.hipclang-rocm-50203.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.2.3/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.2.3 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.2.3/amdgcn/bitcode -include hip/hip_runtime.h
+compiler.hipclang-rocm-50301.exe=/opt/compiler-explorer/clang-rocm-5.3.1/bin/clang++
+compiler.hipclang-rocm-50301.semver=5.3.1
+compiler.hipclang-rocm-50301.name=clang rocm-5.3.1
+compiler.hipclang-rocm-50301.nvdisasm=/opt/compiler-explorer/clang-rocm-50301/bin/llvm-objdump
+compiler.hipclang-rocm-50301.objdumper=/opt/compiler-explorer/clang-rocm-50301/bin/llvm-objdump
+compiler.hipclang-rocm-50301.options=-x hip --cuda-device-only -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/5.3.1/include --rocm-path=/opt/compiler-explorer/libs/rocm/5.3.1 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-5.3.1/amdgcn/bitcode -include hip/hip_runtime.h
 
 group.nvrtc.compilers=nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11:nvrtc102:nvrtc101u2:nvrtc101u1:nvrtc101:nvrtc100:nvrtc92:nvrtc91
 group.nvrtc.compilerType=nvcc # nvrtc_cli is sufficiently compatible with nvcc

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -207,7 +207,7 @@ compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
 
-group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203,hipclang-rocm-50302
+group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang
 group.hipclang.compilerType=clang-hip


### PR DESCRIPTION
This change adds ROCm 5.3.2 for C++ and HIP. It depends on:
- https://github.com/compiler-explorer/misc-builder/pull/49
- https://github.com/compiler-explorer/infra/pull/857
