### PR TITLE
Update feature set for "all architectural features" armv8-a clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -540,7 +540,7 @@ compiler.armv8-full-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bi
 compiler.armv8-full-clang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-clang-trunk.semver=(trunk, all architectural features)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 # An alias of the original name for this compiler needs to be maintained to allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -477,7 +477,7 @@ compiler.armv8-full-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/b
 compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 # An alias of the original name for this compiler needs to be maintained to
 # allow old URLs to continue to work
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -147,7 +147,7 @@ compiler.armv8-full-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snap
 compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 
 # SPIR-V Assembly
 group.armcpp4oclclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -172,7 +172,7 @@ compiler.armv8-full-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapsho
 compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 
 # SPIR-V Assembly
 group.armoclcclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)


### PR DESCRIPTION
This updates the command line options to include:
* armv8.8-a as the baseline architecture, which is the latest.
* New extensions:
  * brbe - Branch Record Buffer
  * f32mm - SVE FP32 single-precision floating-point matrix
    multiplication
  * f64mm - SVE FP64 double-precision floating-point matrix
    multiplication
  * fp16fml - Floating-point half-precision multiplication
  * hbc - Hinted conditional branches (implied by v8.8-a)
  * ls64 - Atomic single-copy 64-byte loads and stores
    without return
  * mops - Standardization of memory operations (implied by v8.8-a)
  * sme - Scalable matrix extension
  * sme-f64f64 - Double-precision floating-point outer product
  * sme-i16i64 - 16-bit to 64-bit integer widening outer product
  * sme2 - Extension to SME with multi-vector operations,
    multi-vector predicates, range prefetches amongst other things.

Also +rcpc, +sha3 and +sm4 are now implied by v8.8-a.

This was tested by adapting this LLDB test file
https://github.com/llvm/llvm-project/blob/main/lldb/test/Shell/Commands/command-disassemble-aarch64-extensions.s

This file includes one instructions from every extension
that clang knows about. I added options to the existing
set until this assembled correctly when using an "asm volatile" block
from C.

Demo here: https://godbolt.org/z/cx5Gn85xo