### PR TITLE
Add Python 3.11 and make it the default

### DIFF
--- a/etc/config/python.amazon.properties
+++ b/etc/config/python.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&python3
-defaultCompiler=python310
+defaultCompiler=python311
 
-group.python3.compilers=python35:python36:python37:python38:python39:python310
+group.python3.compilers=python35:python36:python37:python38:python39:python310:python311
 group.python3.isSemVer=true
 group.python3.baseName=Python
 compiler.python35.exe=/opt/compiler-explorer/python-3.5.9/bin/python3.5
@@ -16,3 +16,5 @@ compiler.python39.exe=/opt/compiler-explorer/python-3.9.6/bin/python3.9
 compiler.python39.semver=3.9
 compiler.python310.exe=/opt/compiler-explorer/python-3.10.0/bin/python3.10
 compiler.python310.semver=3.10
+compiler.python311.exe=/opt/compiler-explorer/python-3.11.0/bin/python3.11
+compiler.python311.semver=3.11


### PR DESCRIPTION
Another year, another stable Python has been released. Please double check my changes because I believe I missed something last year.

Related PR in infra: https://github.com/compiler-explorer/infra/pull/860