### PR TITLE
[DRAFT] Attempt to add basic libraries for Assembly

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -266,6 +266,17 @@ compiler.beebasm109.exe=/opt/compiler-explorer/beebasm-1.09/beebasm
 
 #################################
 #################################
+# Libraries
+
+libs=libc
+
+libs.libc.name=libC
+libs.libc.versions=default
+libs.libc.versions.default.version=default
+libs.libc.versions.default.liblink=c
+
+#################################
+#################################
 # Installed tools
 
 tools=readelf

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1858,6 +1858,7 @@ export class BaseCompiler {
     async doBuildstepAndAddToResult(result, name, command, args, execParams) {
         const stepResult = {
             ...(await this.doBuildstep(command, args, execParams)),
+            compilationOptions: args,
             step: name,
         };
         logger.debug(name);


### PR DESCRIPTION
Would fix #4160

Doesn't actually work. Linking with just `ld` to libc results in a bad executable that won't execute. (`bash: ./ce-asm-executable: No such file or directory`)

It might be that you can't actually use `libc` out of context of all the `crt` code and `gcc`.

Examples on the internet seem to just use `gcc` to link, for example
* https://forums.linuxmint.com/viewtopic.php?t=328218
* https://cs.lmu.edu/~ray/notes/nasmtutorial/

But as soon as you link with `gcc`, you cannot provide a `_start`, you have to provide a main and a host of different functions.

http://dbp-consulting.com/tutorials/debugging/linuxProgramStartup.html gives a nice overview, especially with the graph at the end.

Perhaps this is the point where instead we start providing different libc implementations, because gnu's one is just too much spaghetti...
