### PR TITLE
Add `Hide metadata` option to LLVM pipeline

### DIFF
--- a/static/panes/llvm-opt-pipeline.ts
+++ b/static/panes/llvm-opt-pipeline.ts
@@ -64,6 +64,7 @@ export class LLVMOptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEdi
     state: LLVMOptPipelineViewState;
     lastOptions: LLVMOptPipelineBackendOptions = {
         filterDebugInfo: true,
+        filterIRMetadata: false,
         fullModule: false,
         noDiscardValueNames: true,
         demangle: true,
@@ -195,6 +196,7 @@ export class LLVMOptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEdi
         const newOptions: LLVMOptPipelineBackendOptions = {
             //'filter-inconsequential-passes': options['filter-inconsequential-passes'],
             filterDebugInfo: filters['filter-debug-info'],
+            filterIRMetadata: filters['filter-instruction-metadata'],
             fullModule: options['dump-full-module'],
             noDiscardValueNames: options['-fno-discard-value-names'],
             demangle: options['demangle-symbols'],

--- a/test/llvm-pass-dump-parser-tests.js
+++ b/test/llvm-pass-dump-parser-tests.js
@@ -66,4 +66,30 @@ describe('llvm-pass-dump-parser filter', function () {
                 {text: '  ret void'},
             ]);
     });
+
+    it('should filter out instruction metadata and object attribute group, leave debug instructions in place', function () {
+        // 'hide IR metadata' aims to decrease more visual noise than `hide debug info`
+        const options = {filterDebugInfo: false, filterIRMetadata: true};
+        // prettier-ignore
+        llvmPassDumpParser
+            .applyIrFilters(deepCopy(rawFuncIR), options)
+            .should.deep.equal([
+                {text: '  # Machine code for function f(S1&, S2 const&): NoPHIs, TracksLiveness, TiedOpsRewritten'},
+                {text: 'define dso_local void @f(S1&, S2 const&)(%struct.S1* noundef nonnull align 8 dereferenceable(16) %s1, %struct.S2* noundef nonnull align 8 dereferenceable(16) %s2) {'},
+                {text: 'entry:'},
+                {text: '  %s1.addr = alloca %struct.S1*, align 8'},
+                {text: '  store %struct.S1* %s1, %struct.S1** %s1.addr, align 8'},
+                {text: '  call void @llvm.dbg.declare(metadata %struct.S1** %s1.addr, metadata !30, metadata !DIExpression())'},
+                {text: '  call void @llvm.dbg.value(metadata %struct.S1* %s1, metadata !30, metadata !DIExpression())'},
+                {text: '  DBG_VALUE $rdi, $noreg, !"s1", !DIExpression(), debug-location !32; example.cpp:0 line no:7'},
+                {text: '  store %struct.S2* %s2, %struct.S2** %s2.addr, align 8'},
+                {text: '  %0 = load %struct.S2*, %struct.S2** %s2.addr, align 8'},
+                {text: '  %a = getelementptr inbounds %struct.S2, %struct.S2* %0, i32 0, i32 0'},
+                {text: '  %1 = load i64, i64* %t, align 8'},
+                {text: '  %2 = load %struct.S1*, %struct.S1** %s1.addr, align 8'},
+                {text: '  store i64 %1, i64* %t2, align 8'},
+                {text: '  %t3 = getelementptr inbounds %struct.Wrapper2, %struct.Wrapper2* %b, i32 0, i32 0'},
+                {text: '  ret void'},
+            ]);
+    });
 });

--- a/types/compilation/llvm-opt-pipeline-output.interfaces.ts
+++ b/types/compilation/llvm-opt-pipeline-output.interfaces.ts
@@ -42,6 +42,7 @@ export type LLVMOptPipelineOutput = {
 
 export type LLVMOptPipelineBackendOptions = {
     filterDebugInfo: boolean;
+    filterIRMetadata: boolean;
     fullModule: boolean;
     noDiscardValueNames: boolean;
     demangle: boolean;

--- a/views/templates/panes/llvm-opt-pipeline.pug
+++ b/views/templates/panes/llvm-opt-pipeline.pug
@@ -20,8 +20,9 @@ mixin optionButton(bind, isActive, text, title)
         span.fas.fa-filter
         span.hideable Filters
       .dropdown-menu
-        +optionButton("filter-inconsequential-passes", false, "Filter Inconsequential Passes", "Filter passes which do not make changes")
-        +optionButton("filter-debug-info", true, "Filter Debug Info", "Filter debug info intrinsics")
+        +optionButton("filter-inconsequential-passes", false, "Hide Inconsequential Passes", "Filter passes which do not make changes")
+        +optionButton("filter-debug-info", true, "Hide Debug Info", "Filter debug info intrinsics")
+        +optionButton("filter-instruction-metadata", true, "Hide Instruction Metadata", "Filter all IR metadata")
         //- +optionButton("library-functions", true, "Filter Library Functions", "Filter library functions")
     .btn-group.btn-group-sm
       .input-group.input-group-sm.mb-auto


### PR DESCRIPTION
Following [comments ](https://github.com/compiler-explorer/compiler-explorer/pull/4127#issuecomment-1272102949) from @jeremy-rifkin and @jryans, this PR is an addition of an option to hide all IR metadata:

![image](https://user-images.githubusercontent.com/73080/200140205-d1642d12-e51f-43a7-a93c-201523325780.png)


Notes:

1. Names were changed from 'filter' to 'hide', seems more natural UI phrasing.
2. This is _not_ a superset of 'hide debug'. `llvm-debug` intrinsics _are_ unfiltered by the new option - can be filtered by checking both old an new options.
3. This filters also attribute-groups on function definitions, but not individual attributes.
4. There's also a small addition to the 'hide debug' option - hiding rows that include `debug-location` which typically appear in later stages of the pipeline.
5. Added a test too
