### PR TITLE
Use gcc trunk for clang-tidy

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3084,7 +3084,7 @@ tools.clangtidytrunk.name=clang-tidy (trunk)
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.exclude=cl19:cl_new
-tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 tools.clangtidytrunk.stdinHint=disabled
 
 tools.iwyu.exe=/opt/compiler-explorer/iwyu/0.12/bin/include-what-you-use


### PR DESCRIPTION
This seems like the better of the alternatives,
but happy to change if anyone thinks otherwise

Closes #4092

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
