### PR TITLE
Hide gcc static analysis compiler

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -122,6 +122,8 @@ compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cgsnapshot.semver=(trunk)
+
+compiler.cgstatic-analysis.hidden=true
 compiler.cgstatic-analysis.exe=/opt/compiler-explorer/gcc-static-analysis-trunk/bin/gcc
 compiler.cgstatic-analysis.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgstatic-analysis.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
The GCC compiler for "static analysis" was used before the work was merged in GCC's trunk. There's no need to track the `devel/analyzer` branch anymore.

The C++ compiler is already hidden (d5b0e2011a5208e80460b47c63d45bd08fe1e34e). This changes does the same for the C compiler.

fixes #4256

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>