### PR TITLE
Fix popular arguments iteration in UI

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2573,7 +2573,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         }
 
         if (result && !this.flagsViewOpen) {
-            Object.values(result).forEach((arg, key) => {
+            Object.entries(result).forEach(([key, arg]) => {
                 const argumentButton = $(document.createElement('button'));
                 argumentButton.addClass('dropdown-item btn btn-light btn-sm');
                 argumentButton.attr('title', arg.description);


### PR DESCRIPTION
This fixes popular argument iteration to pluck out the argument via the object key instead of showing an array index.

## Before

<img src="https://user-images.githubusercontent.com/279572/201124358-036123f9-ea0f-4669-93ba-c2ee0bb26a45.png" width=300>

## After

<img src="https://user-images.githubusercontent.com/279572/201124452-897b3213-2035-4806-8565-a03db76ebf3b.png" width=300>

Regressed by https://github.com/compiler-explorer/compiler-explorer/pull/4132