### PR TITLE
Fix "stdout is undefined"

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -527,7 +527,7 @@ export class CompileHandler {
                     } else {
                         logger.error('Error during compilation: ', {error});
                     }
-                    res.end(JSON.stringify({code: -1, stderr: [{text: error}]}));
+                    res.end(JSON.stringify({code: -1, stdout: [], stderr: [{text: error}]}));
                 },
             );
     }


### PR DESCRIPTION
Fixes bug found while triaging another bug ![image](https://user-images.githubusercontent.com/51220084/201390683-dabb22f2-bc4a-4f63-9b7d-f438b7235a96.png)

`CompilationResult` expects stdout to never be undefined