### PR TITLE
Add config for sparc, sparc64 and sparc-leon

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -43,10 +43,36 @@ compiler.gnatsnapshot.semver=(trunk)
 
 ################################
 # Cross GNAT
-group.gnatcross.compilers=&gnatriscv64:&gnatarm:&gnatarm64:&gnats390x:&gnatmipss:&gnatppcs
+group.gnatcross.compilers=&gnatriscv64:&gnatarm:&gnatarm64:&gnats390x:&gnatmipss:&gnatppcs:&gnatsparcs:&gnatsparc64s
 group.gnatcross.supportsExecute=false
 group.gnatcross.supportsBinary=false
 group.gnatcross.isSemVer=true
+
+################################
+# GNAT for sparc
+group.gnatsparcs.compilers=gnatsparc1220
+group.gnatsparcs.groupName=sparc
+group.gnatsparcs.baseName=sparc gnat
+#group.gnatsparcs.instructionSet=sparc
+
+compiler.gnatsparc1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
+compiler.gnatsparc1220.semver=12.2.0
+compiler.gnatsparc1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gnatsparc1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+################################
+# GNAT for sparc64
+group.gnatsparc64s.compilers=gnatsparc641220
+group.gnatsparc64s.groupName=sparc64
+group.gnatsparc64s.baseName=sparc64 gnat
+#group.gnatsparcs.instructionSet=sparc
+
+compiler.gnatsparc641220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
+compiler.gnatsparc641220.semver=12.2.0
+compiler.gnatsparc641220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gnatsparc641220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+compiler.gnatsparc641220.name=sparc64 12.2.0
+
 
 ################################
 # GNAT for riscv64

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -789,7 +789,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64:&c6x
+group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64:&c6x:&sparc:&sparc64:&sparcleon
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -798,10 +798,61 @@ group.cross.licenseName=GNU General Public License
 group.cross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 ###############################
+# Cross for SPARC
+group.sparc.compilers=&gccsparc
+
+# GCC for SPARC
+group.gccsparc.compilers=sparcg1220
+group.gccsparc.supportsBinary=true
+group.gccsparc.supportsExecute=false
+group.gccsparc.baseName=SPARC gcc
+group.gccsparc.groupName=SPARC GCC
+group.gccsparc.isSemVer=true
+
+compiler.sparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
+compiler.sparcg1220.semver=12.2.0
+compiler.sparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.sparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+###############################
+# Cross for SPARC64
+group.sparc64.compilers=&gccsparc64
+
+# GCC for SPARC64
+group.gccsparc64.compilers=sparc64g1220
+group.gccsparc64.supportsBinary=true
+group.gccsparc64.supportsExecute=false
+group.gccsparc64.baseName=SPARC64 gcc
+group.gccsparc64.groupName=SPARC64 GCC
+group.gccsparc64.isSemVer=true
+
+compiler.sparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
+compiler.sparc64g1220.semver=12.2.0
+compiler.sparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.sparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+###############################
+# Cross for SPARC-LEON
+group.sparcleon.compilers=&gccsparcleon
+
+# GCC for SPARC-LEON
+group.gccsparcleon.compilers=sparcleong1220
+group.gccsparcleon.supportsBinary=true
+group.gccsparcleon.supportsExecute=false
+group.gccsparcleon.baseName=SPARC LEON gcc
+group.gccsparcleon.groupName=SPARC LEON GCC
+group.gccsparcleon.isSemVer=true
+
+compiler.sparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1220.semver=12.2.0
+compiler.sparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.sparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+###############################
 # Cross for TI C6x
 group.c6x.compilers=&gccc6x
 
-# GCC for loongarch64
+# GCC for TI C6x
 group.gccc6x.compilers=c6xg1220
 group.gccc6x.supportsBinary=true
 group.gccc6x.supportsExecute=false

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -705,15 +705,67 @@ compiler.cicx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x
+group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x:&csparc:&csparc64:&csparcleon
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
+
+###############################
+# Cross for SPARC
+group.csparc.compilers=&cgccsparc
+
+# GCC for SPARC
+group.cgccsparc.compilers=csparcg1220
+group.cgccsparc.supportsBinary=true
+group.cgccsparc.supportsExecute=false
+group.cgccsparc.baseName=SPARC gcc
+group.cgccsparc.groupName=SPARC GCC
+group.cgccsparc.isSemVer=true
+
+compiler.csparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.csparcg1220.semver=12.2.0
+compiler.csparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.csparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+###############################
+# Cross for SPARC64
+group.csparc64.compilers=&cgccsparc64
+
+# GCC for SPARC64
+group.cgccsparc64.compilers=csparc64g1220
+group.cgccsparc64.supportsBinary=true
+group.cgccsparc64.supportsExecute=false
+group.cgccsparc64.baseName=SPARC64 gcc
+group.cgccsparc64.groupName=SPARC64 GCC
+group.cgccsparc64.isSemVer=true
+
+compiler.csparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.csparc64g1220.semver=12.2.0
+compiler.csparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.csparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+###############################
+# Cross for SPARC-LEON
+group.csparcleon.compilers=&cgccsparcleon
+
+# GCC for SPARC-LEON
+group.cgccsparcleon.compilers=csparcleong1220
+group.cgccsparcleon.supportsBinary=true
+group.cgccsparcleon.supportsExecute=false
+group.cgccsparcleon.baseName=SPARC LEON gcc
+group.cgccsparcleon.groupName=SPARC LEON GCC
+group.cgccsparcleon.isSemVer=true
+
+compiler.csparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.csparcleong1220.semver=12.2.0
+compiler.csparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.csparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 
 ###############################
 # Cross for TI C6x
 group.cc6x.compilers=&cgccc6x
 
-# GCC for loongarch64
+# GCC for TI C6x
 group.cgccc6x.compilers=cc6xg1220
 group.cgccc6x.supportsBinary=true
 group.cgccc6x.supportsExecute=false

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -157,10 +157,43 @@ compiler.ifx202210.semver=2022.1.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64:&gccloongarch64
+group.cross.compilers=&gccarm:&gccaarch64:&ppcs:&gccrv32:&gccrv64:&gccmips:&gccmips64:&gccmipsel:&gccmips64el:&gccs390x:&gccriscv:&gccriscv64:&gccloongarch64:&gccsparc:&gccsparc64:&gccsparcleon
 group.cross.isSemVer=true
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
+
+###############################
+# GCC for SPARC
+group.gccsparc.compilers=fsparcg1220
+group.gccsparc.groupName=SPARC gfortran
+group.gccsparc.baseName=SPARC gfortran
+
+compiler.fsparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
+compiler.fsparcg1220.semver=12.2.0
+compiler.fsparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.fsparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+###############################
+# GCC for SPARC64
+group.gccsparc64.compilers=fsparc64g1220
+group.gccsparc64.groupName=SPARC64 gfortran
+group.gccsparc64.baseName=SPARC64 gfortran
+
+compiler.fsparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
+compiler.fsparc64g1220.semver=12.2.0
+compiler.fsparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.fsparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+###############################
+# GCC for SPARC LEON
+group.gccsparcleon.compilers=fsparcleong1220
+group.gccsparcleon.groupName=SPARC LEON gfortran
+group.gccsparcleon.baseName=SPARC LEON gfortran
+
+compiler.fsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
+compiler.fsparcleong1220.semver=12.2.0
+compiler.fsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.fsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 ###############################
 # GCC for LOONGARCH64

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -372,9 +372,33 @@ compiler.wasm_gltip.semver=(tip)
 
 ###############################
 # Cross GO
-group.cross.compilers=&gccgoppc:&gccgoppc64:&gccgoppc64le:&gccgoarm:&gccgoarm64:&gccgos390x:&gccgoriscv64:&gccgomipsel:&gccgomips64el:&gccgomips:&gccgomips64
+group.cross.compilers=&gccgoppc:&gccgoppc64:&gccgoppc64le:&gccgoarm:&gccgoarm64:&gccgos390x:&gccgoriscv64:&gccgomipsel:&gccgomips64el:&gccgomips:&gccgomips64:&gccgosparc:&gccgosparc64
 group.cross.supportsBinary=false
 group.cross.groupName=Cross Go
+
+###############################
+# GCC for sparc
+group.gccgosparc.compilers=gccgosparc1220
+group.gccgosparc.groupName=GCCGO sparc
+group.gccgosparc.isSemVer=true
+group.gccgosparc.baseName=sparc
+
+compiler.gccgosparc1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
+compiler.gccgosparc1220.semver=12.2.0
+compiler.gccgosparc1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gccgosparc1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+###############################
+# GCC for sparc64
+group.gccgosparc64.compilers=gccgosparc641220
+group.gccgosparc64.groupName=GCCGO sparc64
+group.gccgosparc64.isSemVer=true
+group.gccgosparc64.baseName=sparc64
+
+compiler.gccgosparc641220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
+compiler.gccgosparc641220.semver=12.2.0
+compiler.gccgosparc641220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gccgosparc641220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 ###############################
 # GCC for mips64el


### PR DESCRIPTION
Add C, C++, Fortran for sparc, sparc64, sparc-leon.

Add Ada and Go for sparc and sparc64.

Not adding D (same issue as
https://github.com/compiler-explorer/compiler-explorer/pull/4096#issuecomment-1264304330)

Fixes #266

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>