### PR TITLE
Add new version of Kalray' KVX compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1206,19 +1206,26 @@ compiler.arm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
+group.kalray.compilers=kvxg941_v4100:kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
 
 # kvx versions are different from the GCC they wrap
 
+compiler.kvxg941_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-g++
+compiler.kvxg941_v4100.name=KVX ACB 4.10.0 (GCC 9.4.1)
+compiler.kvxg941_v4100.semver=4.10.0
+compiler.kvxg941_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
+
 compiler.kvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-g++
 compiler.kvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)
 compiler.kvxg941_v490.semver=4.9.0
+compiler.kvxg941_v490.objdumper=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-objdump
 
 compiler.kvxg941_v480.exe=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-g++
 compiler.kvxg941_v480.name=KVX ACB 4.8.0 (GCC 9.4.1)
 compiler.kvxg941_v480.semver=4.8.0
+compiler.kvxg941_v480.objdumper=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-objdump
 
 compiler.kvxg941_v460.exe=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-g++
 compiler.kvxg941_v460.name=KVX ACB 4.6.0 (GCC 9.4.1)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1206,16 +1206,16 @@ compiler.arm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=kvxg941_v4100:kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
+group.kalray.compilers=kvxg1031_v4100:kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
 
 # kvx versions are different from the GCC they wrap
 
-compiler.kvxg941_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-g++
-compiler.kvxg941_v4100.name=KVX ACB 4.10.0 (GCC 9.4.1)
-compiler.kvxg941_v4100.semver=4.10.0
-compiler.kvxg941_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
+compiler.kvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-g++
+compiler.kvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)
+compiler.kvxg1031_v4100.semver=4.10.0
+compiler.kvxg1031_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
 
 compiler.kvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-g++
 compiler.kvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1135,15 +1135,15 @@ compiler.carm64gm101a1.semver=10.1.0
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ckvxg941_v4100:ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg1031_v4100:ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
 
-compiler.ckvxg941_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-gcc
-compiler.ckvxg941_v4100.name=KVX ACB 4.10.0 (GCC 9.4.1)
-compiler.ckvxg941_v4100.semver=4.10.0
-compiler.ckvxg941_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
+compiler.ckvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-gcc
+compiler.ckvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)
+compiler.ckvxg1031_v4100.semver=4.10.0
+compiler.ckvxg1031_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
 
 compiler.ckvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-gcc
 compiler.ckvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1135,10 +1135,15 @@ compiler.carm64gm101a1.semver=10.1.0
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg941_v4100:ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
+
+compiler.ckvxg941_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-gcc
+compiler.ckvxg941_v4100.name=KVX ACB 4.10.0 (GCC 9.4.1)
+compiler.ckvxg941_v4100.semver=4.10.0
+compiler.ckvxg941_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
 
 compiler.ckvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-gcc
 compiler.ckvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)


### PR DESCRIPTION
Add new ACB 4.10.0 version.

Also add missing objdumper for c++ compiler for 4.9 and 4.8. It's not a good idea to mix binutils versions for this arch, better stick with coherent versions.

fixes #4280

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>