### PR TITLE
Fix ppc64le gcc names

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -930,8 +930,7 @@ compiler.ppc64g9.semver=(snapshot)
 
 compiler.ppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.ppc64g1120.semver=power64 gcc 11.2.0
-compiler.ppc64g1120.name=power64 gcc 11.2.0
+compiler.ppc64g1120.semver=11.2.0
 
 compiler.ppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g1210.semver=12.1.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -960,7 +960,6 @@ group.ppc64le.baseName=power64le gcc
 
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
-compiler.ppc64leg630.name=power64le gcc 6.3.0
 compiler.ppc64leg630.semver=6.3.0
 
 compiler.ppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
@@ -975,12 +974,10 @@ compiler.ppc64leg9.semver=(snapshot)
 
 compiler.ppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
-compiler.ppc64leg1120.name=power64le gcc 11.2.0
 compiler.ppc64leg1120.semver=11.2.0
 
 compiler.ppc64leg1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg1210.semver=12.1.0
-compiler.ppc64leg1220.name=power64le gcc 12.1.0
 compiler.ppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 
 compiler.ppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++


### PR DESCRIPTION
Incorrect name was used for 12.2.0.

Also removed useless .name properties as baseName+semVer give the same name.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>