### PR TITLE
store compilationOptions so that we can debug buildsteps better

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -31,6 +31,7 @@ import _ from 'underscore';
 
 import {
     BuildResult,
+    BuildStep,
     CompilationCacheKey,
     CompilationInfo,
     CompilationResult,
@@ -1871,9 +1872,10 @@ export class BaseCompiler {
         };
     }
 
-    async doBuildstepAndAddToResult(result, name, command, args, execParams) {
-        const stepResult = {
+    async doBuildstepAndAddToResult(result, name, command, args, execParams): Promise<BuildStep> {
+        const stepResult: BuildStep = {
             ...(await this.doBuildstep(command, args, execParams)),
+            compilationOptions: args,
             step: name,
         };
         logger.debug(name);

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -129,10 +129,11 @@ export type ExecutionOptions = {
 export type BuildResult = CompilationResult & {
     downloads: BuildEnvDownloadInfo[];
     executableFilename: string;
-    compilationOptions: any[];
+    compilationOptions: string[];
 };
 
 export type BuildStep = BasicExecutionResult & {
+    compilationOptions: string[];
     step: string;
 };
 


### PR DESCRIPTION
Taken from https://github.com/compiler-explorer/compiler-explorer/pull/4230 - but that might take a while to merge, while this is useful for more things.
Offers no way to see in the UI, but we can see it in the network traffic so we can debug buildsteps better.
