### PR TITLE
Add llvm-mos trunk.

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -487,6 +487,7 @@ compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 compiler.mosclang.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/clang
 compiler.mosclang.name=llvm-mos (6502) clang trunk
 compiler.mosclang.options=-mllvm -zp-avail=224
+compiler.mosclang.instructionSet=6502
 compiler.mosclang.supportsBinary=false
 compiler.mosclang.supportsExecute=false
 compiler.mosclang.compilerType=clang

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:www.godbolt.ms@443
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:mosclang:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:www.godbolt.ms@443
 defaultCompiler=cg122
 demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
@@ -481,6 +481,17 @@ compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-to
 # An alias of the original name for this compiler needs to be maintained to
 # allow old URLs to continue to work
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
+
+################################
+# LLVM-MOS (6502 Clang
+compiler.mosclang.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/clang
+compiler.mosclang.name=llvm-mos (6502) clang trunk
+compiler.mosclang.options=-mllvm -zp-avail=224
+compiler.mosclang.supportsBinary=false
+compiler.mosclang.supportsExecute=false
+compiler.mosclang.compilerType=clang
+compiler.mosclang.isSemVer=true
+compiler.mosclang.semver=(trunk)
 
 ################################
 # Clang for RISC-V


### PR DESCRIPTION
This adds the llvm-mos 6502 SDK and toolchain. See http://llvm-mos.org and https://github.com/llvm-mos/llvm-mos-sdk for details.

See compiler-explorer/infra#874.