### PR TITLE
Add C++ configuration of llvm-mos trunk.

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_x86_cxx:&nvcxx_arm_cxx
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:mosclang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_x86_cxx:&nvcxx_arm_cxx
 defaultCompiler=g122
 demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
@@ -543,6 +543,18 @@ compiler.armv8-full-clang-trunk.semver=(trunk, all architectural features)
 compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.6-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
 # An alias of the original name for this compiler needs to be maintained to allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
+
+################################
+# LLVM-MOS (6502 Clang)
+compiler.mosclang.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/clang
+compiler.mosclang.name=llvm-mos (6502) clang trunk
+compiler.mosclang.options=-mllvm -zp-avail=224
+compiler.mosclang.instructionSet=6502
+compiler.mosclang.supportsBinary=false
+compiler.mosclang.supportsExecute=false
+compiler.mosclang.compilerType=clang
+compiler.mosclang.isSemVer=true
+compiler.mosclang.semver=(trunk)
 
 ################################
 # Clang for RISC-V

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:mosclang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_x86_cxx:&nvcxx_arm_cxx
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_x86_cxx:&nvcxx_arm_cxx
 defaultCompiler=g122
 demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
@@ -546,15 +546,18 @@ compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 
 ################################
 # LLVM-MOS (6502 Clang)
-compiler.mosclang.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/clang
-compiler.mosclang.name=llvm-mos (6502) clang trunk
-compiler.mosclang.options=-mllvm -zp-avail=224
-compiler.mosclang.instructionSet=6502
-compiler.mosclang.supportsBinary=false
-compiler.mosclang.supportsExecute=false
-compiler.mosclang.compilerType=clang
-compiler.mosclang.isSemVer=true
-compiler.mosclang.semver=(trunk)
+group.mosclang.compilers=mosclang-trunk
+group.mosclang.baseName=llvm-mos (6502) clang
+group.mosclang.groupName=llvm-mos (6502) clang
+group.mosclang.options=-mllvm -zp-avail=224
+group.mosclang.instructionSet=6502
+group.mosclang.supportsBinary=false
+group.mosclang.supportsExecute=false
+group.mosclang.compilerType=clang
+group.mosclang.isSemVer=true
+
+compiler.mosclang-trunk.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/clang
+compiler.mosclang-trunk.semver=(trunk)
 
 ################################
 # Clang for RISC-V


### PR DESCRIPTION
The llvm-mos clang supports freestanding C++ as well, so this adds a corresponding C++ configuration.