### PR TITLE
Fixes nvc++ compilers missing groupName/baseName

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1819,20 +1819,20 @@ group.nvcxx_x86_cxx.supportsBinary=true
 group.nvcxx_x86_cxx.supportsExecute=true
 group.nvcxx_x86_cxx.supportsLibraryCodeFilter=true
 group.nvcxx_x86_cxx.demanglerType=nvhpc
+group.nvcxx_x86_cxx.groupName=nvc++ x86
+group.nvcxx_x86_cxx.baseName=x86 nvc++
+group.nvcxx_x86_cxx.isSemVer=true
 
 compiler.nvcxx_x86_cxx22_7.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvdecode
 compiler.nvcxx_x86_cxx22_7.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc++
-compiler.nvcxx_x86_cxx22_7.name=nvc++ 22.7
 compiler.nvcxx_x86_cxx22_7.semver=22.7
 
 compiler.nvcxx_x86_cxx22_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.9/compilers/bin/nvdecode
 compiler.nvcxx_x86_cxx22_9.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.9/compilers/bin/nvc++
-compiler.nvcxx_x86_cxx22_9.name=nvc++ 22.9
 compiler.nvcxx_x86_cxx22_9.semver=22.9
 
 compiler.nvcxx_x86_cxx22_11.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.11/compilers/bin/nvdecode
 compiler.nvcxx_x86_cxx22_11.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.11/compilers/bin/nvc++
-compiler.nvcxx_x86_cxx22_11.name=nvc++ 22.11
 compiler.nvcxx_x86_cxx22_11.semver=22.11
 
 group.nvcxx_arm_cxx.compilers=nvcxx_arm_cxx22_7:nvcxx_arm_cxx22_9
@@ -1845,15 +1845,17 @@ group.nvcxx_arm_cxx.stubText=int main(void){return 0;/*stub provided by Compiler
 group.nvcxx_arm_cxx.supportsExecute=true
 group.nvcxx_arm_cxx.supportsLibraryCodeFilter=true
 group.nvcxx_arm_cxx.demanglerType=nvhpc
+group.nvcxx_arm_cxx.groupName=nvc++ arm
+group.nvcxx_arm_cxx.baseName=ARM64 nvc++
+group.nvcxx_arm_cxx.isSemVer=true
+group.nvcxx_arm_cxx.instructionSet=aarch64
 
 compiler.nvcxx_arm_cxx22_7.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.7/compilers/bin/nvdecode
 compiler.nvcxx_arm_cxx22_7.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.7/compilers/bin/nvc++
-compiler.nvcxx_arm_cxx22_7.name=nvc++ 22.7
 compiler.nvcxx_arm_cxx22_7.semver=22.7
 
 compiler.nvcxx_arm_cxx22_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.9/compilers/bin/nvdecode
 compiler.nvcxx_arm_cxx22_9.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.9/compilers/bin/nvc++
-compiler.nvcxx_arm_cxx22_9.name=nvc++ 22.9
 compiler.nvcxx_arm_cxx22_9.semver=22.9
 
 #################################


### PR DESCRIPTION
Also adds instructionSet to the aarch64 version