### PR TITLE
Fix llvm-mos clang config file usage.

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -553,7 +553,7 @@ compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 group.mosclang-trunk.compilers=mos-nes-cnrom-trunk:mos-nes-mmc1-trunk:mos-nes-mmc3-trunk:mos-nes-nrom-trunk:mos-atari8-trunk:mos-cx16-trunk:mos-c64-trunk:mos-mega65-trunk:mos-osi-c1p-trunk
 group.mosclang-trunk.baseName=llvm-mos
 group.mosclang-trunk.groupName=llvm-mos (6502) clang
-group.mosclang-trunk.options=--target=mos
+group.mosclang-trunk.options=-fno-lto -mllvm -zp-avail=224
 group.mosclang-trunk.instructionSet=6502
 group.mosclang-trunk.supportsBinary=true
 group.mosclang-trunk.supportsExecute=false

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -503,7 +503,7 @@ compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 group.cmosclang-trunk.compilers=cmos-nes-cnrom-trunk:cmos-nes-mmc1-trunk:cmos-nes-mmc3-trunk:cmos-nes-nrom-trunk:cmos-atari8-trunk:cmos-cx16-trunk:cmos-c64-trunk:cmos-mega65-trunk:cmos-osi-c1p-trunk
 group.cmosclang-trunk.baseName=llvm-mos
 group.cmosclang-trunk.groupName=llvm-mos (6502) clang
-group.mosclang-trunk.options=-fno-lto -mllvm -zp-avail=224
+group.cmosclang-trunk.options=-fno-lto -mllvm -zp-avail=224
 group.cmosclang-trunk.instructionSet=6502
 group.cmosclang-trunk.supportsBinary=true
 group.cmosclang-trunk.supportsExecute=false

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -503,7 +503,7 @@ compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk
 group.cmosclang-trunk.compilers=cmos-nes-cnrom-trunk:cmos-nes-mmc1-trunk:cmos-nes-mmc3-trunk:cmos-nes-nrom-trunk:cmos-atari8-trunk:cmos-cx16-trunk:cmos-c64-trunk:cmos-mega65-trunk:cmos-osi-c1p-trunk
 group.cmosclang-trunk.baseName=llvm-mos
 group.cmosclang-trunk.groupName=llvm-mos (6502) clang
-group.cmosclang-trunk.options=--target=mos
+group.mosclang-trunk.options=-fno-lto -mllvm -zp-avail=224
 group.cmosclang-trunk.instructionSet=6502
 group.cmosclang-trunk.supportsBinary=true
 group.cmosclang-trunk.supportsExecute=false


### PR DESCRIPTION
Manually setting --target=mos on the various llvm-mos targets prevents the clang driver from picking up the configuration files shipped with the llvm-mos SDK. This prevents include files from working.

Instead, this change uses -fno-lto -mllvm -zp-avail=224 to set up a reasonable standalone build configuration. This disables the default LTO so that assembly can be produced, and it configures the compiler to report that the full 256 bytes of zero page are available. (32 bytes of implicit "imaginary registers", and 224 bytes of explictly managed zero page. This isn't accurate per-target, but good for standalone demonstration purposes. It would take some compiler work to add a flag to expose the per-target LTO zero page configurations to a -fno-lto build.)
