### PR TITLE
Fail if compiler discovery fails

### DIFF
--- a/app.js
+++ b/app.js
@@ -529,9 +529,6 @@ async function main() {
         }
         logger.info(`Compiler scan count: ${_.size(compilers)}`);
         logger.debug('Compilers:', compilers);
-        if (compilers.length === 0) {
-            logger.error('#### No compilers found: no compilation will be done!');
-        }
         prevCompilers = compilers;
         await clientOptionsHandler.setCompilers(compilers);
         routeApi.apiHandler.setCompilers(compilers);

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -403,6 +403,10 @@ export class CompilerFinder {
             compilerList.flat(Infinity),
             this.optionsHandler.get(),
         );
+        if (!compilers) {
+            logger.error('#### No compilers found: no compilation will be done!');
+            throw new Error('No compilers found due to error or no configuration');
+        }
         const result = this.ensureDistinct(_.compact(compilers));
         return {foundClash: result.foundClash, compilers: _.sortBy(result.compilers, 'name')};
     }


### PR DESCRIPTION
If discovery fails for whatever reason (no compilers; compiler creation threw an exception) we now see this:

```
error: Exception while processing compilers: ...blah some thing that went wrong goes here...
error: #### No compilers found: no compilation will be done!
error: Top-level error (shutting down): No compilers found due to error or no configuration {"stack":"Error: No compilers found due to error or no configuration\n    at CompilerFinder.find (/home/matthew/dev/ce/compiler-explorer/lib/compiler-finder.js:408:19)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async main (/home/matthew/dev/ce/compiler-explorer/app.js:476:36)"}
```
and the process exits.
