### PR TITLE
Don't test during precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,4 @@
 
 make prereqs
 npx lint-staged
-npm run test
 python3 ./etc/scripts/util/propscheck.py


### PR DESCRIPTION
As briefly discussed on discord, this turns off testing during precommit. Motivation: Our tests our slow which has led to a lot of committing with `-n` and ultimately gets in the way of some more important precommit actions such as linting and formatting files being committed.