### PR TITLE
Fix crossgen2 arguments

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -180,7 +180,7 @@ class DotNetCompiler extends BaseCompiler {
         const crossgen2Options = [
             crossgen2Path,
             '-r',
-            path.join(bclPath, '*.dll'),
+            path.join(bclPath, '/'),
             dllPath,
             '-o',
             'CompilerExplorer.r2r.dll',

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -180,7 +180,7 @@ class DotNetCompiler extends BaseCompiler {
         const crossgen2Options = [
             crossgen2Path,
             '-r',
-            path.join(bclPath, '*'),
+            path.join(bclPath, '*.dll'),
             dllPath,
             '-o',
             'CompilerExplorer.r2r.dll',


### PR DESCRIPTION
We need to pass the directory instead of files as the input to `-r`

/cc: @mattgodbolt 