### PR TITLE
refactor: renames the CompilerFilters type

### DIFF
--- a/lib/compilers/assembly.ts
+++ b/lib/compilers/assembly.ts
@@ -28,7 +28,7 @@ import path from 'path';
 import _ from 'underscore';
 
 import {BuildResult} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {AsmRaw} from '../parsers/asm-raw';
 import {fileExists} from '../utils';
@@ -138,7 +138,7 @@ export class AssemblyCompiler extends BaseCompiler {
 
         const outputFilename = this.getExecutableFilename(dirPath);
 
-        const buildFilters: ParseFilters = Object.assign({}, key.filters);
+        const buildFilters: ParseFiltersAndOutputOptions = Object.assign({}, key.filters);
         buildFilters.binary = true;
         buildFilters.execute = false;
 

--- a/lib/compilers/cc65.ts
+++ b/lib/compilers/cc65.ts
@@ -28,7 +28,7 @@ import fs from 'fs-extra';
 import _ from 'underscore';
 
 import {CompilationResult} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {CC65AsmParser} from '../parsers/asm-parser-cc65';
 import * as utils from '../utils';
@@ -98,7 +98,7 @@ export class Cc65Compiler extends BaseCompiler {
         maxSize: number,
         intelAsm,
         demangle,
-        filters: ParseFilters,
+        filters: ParseFiltersAndOutputOptions,
     ) {
         const res = await super.objdump(outputFilename, result, maxSize, intelAsm, demangle, filters);
 

--- a/lib/compilers/circt.ts
+++ b/lib/compilers/circt.ts
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 import {BaseParser} from './argument-parsers';
@@ -63,7 +63,7 @@ export class CIRCTCompiler extends BaseCompiler {
         return BaseParser;
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename, userOptions?): any[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename, userOptions?): any[] {
         return [];
     }
 }

--- a/lib/compilers/cppfront.ts
+++ b/lib/compilers/cppfront.ts
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {AsmParserCpp} from '../parsers/asm-parser-cpp';
 
@@ -44,7 +44,7 @@ export class CppFrontCompiler extends BaseCompiler {
         return 'cppp';
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: any) {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: any) {
         return [];
     }
 

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -37,7 +37,7 @@ import {
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {DotNetAsmParser} from '../parsers/asm-parser-dotnet';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 
 class DotNetCompiler extends BaseCompiler {
     private targetFramework: string;
@@ -204,7 +204,7 @@ class DotNetCompiler extends BaseCompiler {
         return compilerResult;
     }
 
-    override optionsForFilter(filters: ParseFilters) {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions) {
         if (filters.binary) {
             this.compileToBinary = true;
         }

--- a/lib/compilers/erlang.ts
+++ b/lib/compilers/erlang.ts
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 import {ErlangParser} from './argument-parsers';
@@ -34,7 +34,7 @@ export class ErlangCompiler extends BaseCompiler {
         return 'erlang';
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: string): string[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string): string[] {
         return [
             '-noshell',
             '-eval',

--- a/lib/compilers/hlsl.ts
+++ b/lib/compilers/hlsl.ts
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 export class HLSLCompiler extends BaseCompiler {
@@ -39,7 +39,11 @@ export class HLSLCompiler extends BaseCompiler {
     }
 
     /* eslint-disable no-unused-vars */
-    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
         return [
             '-Zi', // Embed debug information to get DXIL line associations
             '-Qembed_debug', // Silences the warning associated with embedded debug information

--- a/lib/compilers/hook.ts
+++ b/lib/compilers/hook.ts
@@ -25,7 +25,7 @@
 import path from 'path';
 
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 export class HookCompiler extends BaseCompiler {
@@ -33,7 +33,7 @@ export class HookCompiler extends BaseCompiler {
         return 'hook';
     }
 
-    override optionsForFilter(filters: ParseFilters): string[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions): string[] {
         return ['--dump'];
     }
 

--- a/lib/compilers/jakt.ts
+++ b/lib/compilers/jakt.ts
@@ -25,7 +25,7 @@
 import path from 'path';
 
 import {ExecutionOptions} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 export class JaktCompiler extends BaseCompiler {
@@ -43,13 +43,20 @@ export class JaktCompiler extends BaseCompiler {
         return 'cppp';
     }
 
-    override async objdump(outputFilename, result: any, maxSize: number, intelAsm, demangle, filters: ParseFilters) {
+    override async objdump(
+        outputFilename,
+        result: any,
+        maxSize: number,
+        intelAsm,
+        demangle,
+        filters: ParseFiltersAndOutputOptions,
+    ) {
         const objdumpResult = await super.objdump(outputFilename, result, maxSize, intelAsm, demangle, filters);
         objdumpResult.languageId = 'asm';
         return objdumpResult;
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: any) {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: any) {
         return ['--binary-dir', path.dirname(outputFilename)];
     }
 

--- a/lib/compilers/llvm-mos.ts
+++ b/lib/compilers/llvm-mos.ts
@@ -28,7 +28,7 @@ import fs from 'fs-extra';
 import _ from 'underscore';
 
 import {CompilationResult} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import * as utils from '../utils';
 
 import {ClangCompiler} from './clang';
@@ -62,7 +62,7 @@ export class LLVMMOSCompiler extends ClangCompiler {
         maxSize: number,
         intelAsm,
         demangle,
-        filters: ParseFilters,
+        filters: ParseFiltersAndOutputOptions,
     ) {
         if (!outputFilename.endsWith('.elf') && (await utils.fileExists(outputFilename + '.elf'))) {
             outputFilename = outputFilename + '.elf';

--- a/lib/compilers/mlir.ts
+++ b/lib/compilers/mlir.ts
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 import {BaseParser} from './argument-parsers';
@@ -67,7 +67,7 @@ export class MLIRCompiler extends BaseCompiler {
         return BaseParser;
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename, userOptions?): any[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename, userOptions?): any[] {
         return [];
     }
 }

--- a/lib/compilers/nvcc.js
+++ b/lib/compilers/nvcc.js
@@ -51,7 +51,7 @@ export class NvccCompiler extends BaseCompiler {
 
     /**
      *
-     * @param {import('../../types/features/filters.interfaces').ParseFilters} filters
+     * @param {import('../../types/features/filters.interfaces').ParseFiltersAndOutputOptions} filters
      * @param {string} outputFilename
      * @param {string[]?} userOptions
      * @returns {string[]}
@@ -107,7 +107,7 @@ export class NvccCompiler extends BaseCompiler {
      *
      * @param {*} result
      * @param {string} outputFilename
-     * @param {import('../../types/features/filters.interfaces').ParseFilters} filters
+     * @param {import('../../types/features/filters.interfaces').ParseFiltersAndOutputOptions} filters
      */
     async postProcess(result, outputFilename, filters) {
         const maxSize = this.env.ceProps('max-asm-size', 64 * 1024 * 1024);

--- a/lib/compilers/pony.ts
+++ b/lib/compilers/pony.ts
@@ -27,7 +27,7 @@ import path from 'path';
 import _ from 'underscore';
 
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 export class PonyCompiler extends BaseCompiler {
@@ -42,7 +42,7 @@ export class PonyCompiler extends BaseCompiler {
         this.compiler.irArg = ['--pass', 'ir'];
     } */
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: any, userOptions?: any): string[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: any, userOptions?: any): string[] {
         let options = ['-d', '-b', path.parse(outputFilename).name];
 
         if (!filters.binary) {
@@ -61,7 +61,7 @@ export class PonyCompiler extends BaseCompiler {
         return source;
     }
 
-    override async generateIR(inputFilename: string, options: string[], filters: ParseFilters) {
+    override async generateIR(inputFilename: string, options: string[], filters: ParseFiltersAndOutputOptions) {
         const newOptions = _.filter(options, option => !['--pass', 'asm'].includes(option)).concat(this.compiler.irArg);
 
         const execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -25,7 +25,7 @@
 import path from 'path';
 
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {logger} from '../logger';
 
@@ -45,7 +45,11 @@ export class RacketCompiler extends BaseCompiler {
         this.raco = this.compilerProps<string>(`compiler.${this.compiler.id}.raco`);
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
         // We currently always compile to bytecode first and then decompile.
         // Forcing `binary` on like this ensures `objdump` will be called for
         // the decompilation phase.
@@ -93,7 +97,7 @@ export class RacketCompiler extends BaseCompiler {
         maxSize: number,
         intelAsm: any,
         demangle: any,
-        filters: ParseFilters,
+        filters: ParseFiltersAndOutputOptions,
     ): Promise<any> {
         // Decompile to assembly via `raco decompile` with `disassemble` package
         const execOptions: ExecutionOptions = {

--- a/lib/compilers/rga.ts
+++ b/lib/compilers/rga.ts
@@ -27,7 +27,7 @@ import path from 'path';
 import {readdir, readFile, rename, writeFile} from 'fs-extra';
 
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import * as exec from '../exec';
 import {logger} from '../logger';
@@ -54,7 +54,7 @@ export class RGACompiler extends BaseCompiler {
         logger.debug(`RGA compiler ${this.compiler.id} configured to use DXC at ${this.dxcPath}`);
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: any, userOptions?: any): any[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: any, userOptions?: any): any[] {
         return [outputFilename];
     }
 

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -27,7 +27,7 @@ import path from 'path';
 import _ from 'underscore';
 
 import {BasicExecutionResult, UnprocessedExecResult} from '../../types/execution/execution.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {BuildEnvDownloadInfo} from '../buildenvsetup/buildenv.interfaces';
 import {parseRustOutput} from '../utils';
@@ -149,7 +149,7 @@ export class RustCompiler extends BaseCompiler {
     }
 
     // Override the IR file name method for rustc because the output file is different from clang.
-    override getIrOutputFilename(inputFilename: string, filters: ParseFilters): string {
+    override getIrOutputFilename(inputFilename: string, filters: ParseFiltersAndOutputOptions): string {
         const outputFilename = this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase);
         // As per #4054, if we are asked for binary mode, the output will be in the .s file, no .ll will be emited
         if (!filters.binary) {

--- a/lib/compilers/toit.ts
+++ b/lib/compilers/toit.ts
@@ -24,7 +24,7 @@
 
 import _ from 'underscore';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 import {ToitParser} from './argument-parsers';
@@ -43,7 +43,7 @@ export class ToitCompiler extends BaseCompiler {
         return outputFilename + '.cache';
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename, userOptions?): string[] {
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename, userOptions?): string[] {
         if (!filters.binary) return ['execute', outputFilename];
         return [outputFilename];
     }

--- a/lib/compilers/z88dk.ts
+++ b/lib/compilers/z88dk.ts
@@ -27,7 +27,7 @@ import path from 'path';
 import fs from 'fs-extra';
 
 import {ExecutionOptions} from '../../types/compilation/compilation.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {logger} from '../logger';
 import {AsmParserZ88dk} from '../parsers/asm-parser-z88dk';
@@ -82,7 +82,7 @@ export class z88dkCompiler extends BaseCompiler {
         );
     }
 
-    protected override optionsForFilter(filters: ParseFilters, outputFilename: string): string[] {
+    protected override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string): string[] {
         if (!filters.binary) {
             return ['-S'];
         } else {
@@ -110,7 +110,14 @@ export class z88dkCompiler extends BaseCompiler {
         return `${this.outputFilebase}.sms`;
     }
 
-    override async objdump(outputFilename, result: any, maxSize: number, intelAsm, demangle, filters: ParseFilters) {
+    override async objdump(
+        outputFilename,
+        result: any,
+        maxSize: number,
+        intelAsm,
+        demangle,
+        filters: ParseFiltersAndOutputOptions,
+    ) {
         outputFilename = this.getObjdumpOutputFilename(outputFilename);
 
         // sometimes (with +z80 for example) the .bin file is written and the .s file is empty

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -27,7 +27,7 @@ import path from 'path';
 import Semver from 'semver';
 import _ from 'underscore';
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {asSafeVer} from '../utils';
@@ -104,7 +104,11 @@ export class ZigCompiler extends BaseCompiler {
         return source;
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions: string[]): string[] {
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions: string[],
+    ): string[] {
         let options = [filters.execute ? 'build-exe' : 'build-obj'];
 
         const desiredName = path.basename(outputFilename);

--- a/lib/compilers/zigcc.ts
+++ b/lib/compilers/zigcc.ts
@@ -24,7 +24,7 @@
 
 import Semver from 'semver';
 
-import {CompilerFilters, ParseFilters} from '../../types/features/filters.interfaces';
+import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {asSafeVer} from '../utils';
 
 import {ClangCompiler} from './clang';
@@ -43,7 +43,7 @@ export class ZigCC extends ClangCompiler {
             Semver.lt(asSafeVer(this.compiler.semver), '0.9.0', true);
     }
 
-    override preProcess(source: string, filters: CompilerFilters): string {
+    override preProcess(source: string, filters: CompilerOutputOptions): string {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;
@@ -52,7 +52,11 @@ export class ZigCC extends ClangCompiler {
         return super.preProcess(source, filters);
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;

--- a/lib/compilers/zigcxx.ts
+++ b/lib/compilers/zigcxx.ts
@@ -24,7 +24,7 @@
 
 import Semver from 'semver';
 
-import {CompilerFilters, ParseFilters} from '../../types/features/filters.interfaces';
+import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {asSafeVer} from '../utils';
 
 import {ClangCompiler} from './clang';
@@ -43,7 +43,7 @@ export class ZigCXX extends ClangCompiler {
             Semver.lt(asSafeVer(this.compiler.semver), '0.9.0', true);
     }
 
-    override preProcess(source: string, filters: CompilerFilters): string {
+    override preProcess(source: string, filters: CompilerOutputOptions): string {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;
@@ -52,7 +52,11 @@ export class ZigCXX extends ClangCompiler {
         return super.preProcess(source, filters);
     }
 
-    override optionsForFilter(filters: ParseFilters, outputFilename: string, userOptions?: string[]): string[] {
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;

--- a/lib/external-parsers/base.ts
+++ b/lib/external-parsers/base.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces';
 import {TypicalExecutionFunc, UnprocessedExecResult} from '../../types/execution/execution.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {maskRootdir} from '../utils';
 
 import {IExternalParser} from './external-parser.interface';
@@ -25,7 +25,7 @@ export class ExternalParserBase implements IExternalParser {
         this.execFunc = execFunc;
     }
 
-    private getParserArguments(filters: ParseFilters, fromStdin: boolean): string[] {
+    private getParserArguments(filters: ParseFiltersAndOutputOptions, fromStdin: boolean): string[] {
         const parameters = ['-plt'];
 
         if (fromStdin) parameters.push('-stdin');
@@ -40,7 +40,7 @@ export class ExternalParserBase implements IExternalParser {
         return parameters;
     }
 
-    private getObjdumpStarterScriptContent(filters: ParseFilters) {
+    private getObjdumpStarterScriptContent(filters: ParseFiltersAndOutputOptions) {
         const parserArgs = this.getParserArguments(filters, true);
 
         return (
@@ -51,7 +51,10 @@ export class ExternalParserBase implements IExternalParser {
         );
     }
 
-    private async writeStarterScriptObjdump(buildfolder: string, filters: ParseFilters): Promise<string> {
+    private async writeStarterScriptObjdump(
+        buildfolder: string,
+        filters: ParseFiltersAndOutputOptions,
+    ): Promise<string> {
         const scriptFilepath = path.join(buildfolder, starterScriptName);
 
         return new Promise(resolve => {
@@ -80,7 +83,7 @@ export class ExternalParserBase implements IExternalParser {
     public async objdumpAndParseAssembly(
         buildfolder: string,
         objdumpArgs: string[],
-        filters: ParseFilters,
+        filters: ParseFiltersAndOutputOptions,
     ): Promise<ParsedAsmResult> {
         objdumpArgs = objdumpArgs.map(v => {
             return maskRootdir(v);
@@ -95,7 +98,7 @@ export class ExternalParserBase implements IExternalParser {
         return this.parseAsmExecResult(execResult);
     }
 
-    public async parseAssembly(filepath: string, filters: ParseFilters): Promise<ParsedAsmResult> {
+    public async parseAssembly(filepath: string, filters: ParseFiltersAndOutputOptions): Promise<ParsedAsmResult> {
         const execOptions = {
             env: this.envInfo.getEnv(this.compilerInfo.needsMulti),
         };

--- a/lib/external-parsers/external-parser.interface.ts
+++ b/lib/external-parsers/external-parser.interface.ts
@@ -1,11 +1,11 @@
 import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 
 export interface IExternalParser {
     objdumpAndParseAssembly(
         buildfolder: string,
         objdumpArgs: string[],
-        filters: ParseFilters,
+        filters: ParseFiltersAndOutputOptions,
     ): Promise<ParsedAsmResult>;
-    parseAssembly(filepath: string, filters: ParseFilters): Promise<ParsedAsmResult>;
+    parseAssembly(filepath: string, filters: ParseFiltersAndOutputOptions): Promise<ParsedAsmResult>;
 }

--- a/lib/parsers/asm-parser-cc65.ts
+++ b/lib/parsers/asm-parser-cc65.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {AsmResultLabel, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 
 import {AsmParser} from './asm-parser';
 
@@ -69,7 +69,7 @@ export class CC65AsmParser extends AsmParser {
         return undefined;
     }
 
-    override processBinaryAsm(asm, filters: ParseFilters) {
+    override processBinaryAsm(asm, filters: ParseFiltersAndOutputOptions) {
         const result: ParsedAsmResultLine[] = [];
         const asmLines = asm.split('\n');
 

--- a/lib/parsers/asm-parser-cpp.ts
+++ b/lib/parsers/asm-parser-cpp.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import * as utils from '../utils';
 
 import {IAsmParser} from './asm-parser.interfaces';
@@ -33,7 +33,7 @@ type Source = {file: string | null; line: number};
 const lineRe = /^\s*#line\s+(?<line>\d+)\s+"(?<file>[^"]+)"/;
 
 export class AsmParserCpp implements IAsmParser {
-    process(asmResult: string, filters: ParseFilters) {
+    process(asmResult: string, filters: ParseFiltersAndOutputOptions) {
         const startTime = process.hrtime.bigint();
 
         const asm: {

--- a/lib/parsers/asm-parser.interfaces.ts
+++ b/lib/parsers/asm-parser.interfaces.ts
@@ -1,5 +1,5 @@
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 
 export interface IAsmParser {
-    process(asm: string, filters: ParseFilters);
+    process(asm: string, filters: ParseFiltersAndOutputOptions);
 }

--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -30,7 +30,7 @@ import {
     ParsedAsmResult,
     ParsedAsmResultLine,
 } from '../../types/asmresult/asmresult.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import * as utils from '../utils';
 
 import {AsmRegex} from './asmregex';
@@ -322,7 +322,7 @@ export class AsmParser extends AsmRegex {
         return labelsInLine;
     }
 
-    processAsm(asmResult, filters: ParseFilters): ParsedAsmResult {
+    processAsm(asmResult, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
         if (filters.binary) return this.processBinaryAsm(asmResult, filters);
 
         const startTime = process.hrtime.bigint();

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -29,7 +29,7 @@ import {
     LLVMOptPipelineResults,
     Pass,
 } from '../../types/compilation/llvm-opt-pipeline-output.interfaces';
-import {ParseFilters} from '../../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {ResultLine} from '../../types/resultline/resultline.interfaces';
 
 // Note(jeremy-rifkin):
@@ -497,7 +497,11 @@ export class LlvmPassDumpParser {
         );
     }
 
-    process(output: ResultLine[], _: ParseFilters, llvmOptPipelineOptions: LLVMOptPipelineBackendOptions) {
+    process(
+        output: ResultLine[],
+        _: ParseFiltersAndOutputOptions,
+        llvmOptPipelineOptions: LLVMOptPipelineBackendOptions,
+    ) {
         // Crop out any junk before the pass dumps (e.g. warnings)
         const ir = output.slice(
             output.findIndex(line => line.text.match(this.irDumpHeader) || line.text.match(this.machineCodeDumpHeader)),

--- a/static/components.interfaces.ts
+++ b/static/components.interfaces.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces';
+import {CompilerOutputOptions} from '../types/features/filters.interfaces';
 import {LLVMOptPipelineViewState} from './panes/llvm-opt-pipeline.interfaces';
 export const COMPILER_COMPONENT_NAME = 'compiler';
 export const EXECUTOR_COMPONENT_NAME = 'executor';

--- a/static/components.interfaces.ts
+++ b/static/components.interfaces.ts
@@ -22,9 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {CompilerFilters} from '../types/features/filters.interfaces';
+import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces';
 import {LLVMOptPipelineViewState} from './panes/llvm-opt-pipeline.interfaces';
-
 export const COMPILER_COMPONENT_NAME = 'compiler';
 export const EXECUTOR_COMPONENT_NAME = 'executor';
 export const EDITOR_COMPONENT_NAME = 'codeEditor';
@@ -67,7 +66,7 @@ type EmptyState = Record<never, never>;
 
 export type EmptyCompilerState = StateWithLanguage & StateWithEditor;
 export type PopulatedCompilerState = StateWithEditor & {
-    filters: CompilerFilters;
+    filters: CompilerOutputOptions;
     options: unknown;
     compiler: string;
     libs?: unknown;

--- a/static/components.ts
+++ b/static/components.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {CompilerFilters} from '../types/features/filters.interfaces';
+import {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces';
 import {
     EmptyCompilerState,
     ComponentConfig,
@@ -126,7 +126,7 @@ export function getCompiler(editorId: number, lang: string): ComponentConfig<Emp
  */
 export function getCompilerWith(
     editorId: number,
-    filters: CompilerFilters,
+    filters: ParseFiltersAndOutputOptions,
     options: unknown,
     compilerId: string,
     langId?: string,
@@ -222,7 +222,11 @@ export function getEditor(id?: number, langId?: string): ComponentConfig<EmptyEd
 }
 
 /** Get an editor component with the given configuration. */
-export function getEditorWith(id: number, source: string, options): ComponentConfig<PopulatedEditorState> {
+export function getEditorWith(
+    id: number,
+    source: string,
+    options: ParseFiltersAndOutputOptions
+): ComponentConfig<PopulatedEditorState> {
     return {
         type: 'component',
         componentName: EDITOR_COMPONENT_NAME,

--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {Language} from '../types/languages.interfaces';
-import {CompilerFilters} from '../types/features/filters.interfaces';
+import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces';
 import {MessageWithLocation} from '../types/resultline/resultline.interfaces';
 import {SiteSettings} from './settings';
 import {Theme} from './themes';
@@ -86,13 +86,17 @@ export type EventMap = {
     ) => void;
     executorClose: (executorId: number) => void;
     executorOpen: (executorId: number, editorId: boolean | number) => void;
-    filtersChange: (compilerId: number, filters: CompilerFilters) => void;
+    filtersChange: (compilerId: number, filters: CompilerOutputOptions) => void;
     findCompilers: () => void;
     findEditors: () => void;
     findExecutors: () => void;
     flagsViewClosed: (compilerId: number, options: string) => void;
     flagsViewOpened: (compilerId: number) => void;
-    gccDumpFiltersChanged: (compilerId: number, filters: CompilerFilters, recompile: boolean) => void;
+    gccDumpFiltersChanged: (
+        compilerId: number,
+        filters: CompilerOutputOptions,
+        recompile: boolean
+    ) => void;
     gccDumpPassSelected: (compilerId: number, pass: GccSelectedPass, recompile: boolean) => void;
     gccDumpUIInit: (compilerId: number) => void;
     gccDumpViewClosed: (compilerId: number) => void;

--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {Language} from '../types/languages.interfaces';
-import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces';
+import {CompilerOutputOptions} from '../types/features/filters.interfaces';
 import {MessageWithLocation} from '../types/resultline/resultline.interfaces';
 import {SiteSettings} from './settings';
 import {Theme} from './themes';

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -51,8 +51,8 @@ import {CompilerState} from './compiler.interfaces';
 import {ComponentConfig, ToolViewState} from '../components.interfaces';
 import {FiledataPair} from '../multifile-service';
 import {LanguageLibs} from '../options.interfaces';
-import {CompilerFilters} from '../../types/features/filters.interfaces';
 import {GccSelectedPass} from './gccdump-view.interfaces';
+import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {Tool} from '../../lib/tooling/base-tool.interface';
 import {AssemblyInstructionInfo} from '../../lib/asm-docs/base';
 import {PPOptions} from './pp-view.interfaces';
@@ -2155,9 +2155,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
     onGccDumpFiltersChanged(
         id: number,
-        filters: CompilerFilters & Record<string, boolean | undefined>,
+        filters: CompilerOutputOptions & Record<string, boolean | undefined>,
         reqCompile: boolean
     ): void {
+
         if (this.id === id) {
             this.treeDumpEnabled = filters.treeDump !== false;
             this.rtlDumpEnabled = filters.rtlDump !== false;

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -52,7 +52,7 @@ import {ComponentConfig, ToolViewState} from '../components.interfaces';
 import {FiledataPair} from '../multifile-service';
 import {LanguageLibs} from '../options.interfaces';
 import {GccSelectedPass} from './gccdump-view.interfaces';
-import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {CompilerOutputOptions} from '../../types/features/filters.interfaces';
 import {Tool} from '../../lib/tooling/base-tool.interface';
 import {AssemblyInstructionInfo} from '../../lib/asm-docs/base';
 import {PPOptions} from './pp-view.interfaces';

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -40,7 +40,7 @@ import * as monacoConfig from '../monaco-config';
 import {GccDumpFilters, GccDumpState} from './gccdump-view.interfaces';
 
 import {ga} from '../analytics';
-import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {CompilerOutputOptions} from '../../types/features/filters.interfaces';
 
 export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, GccDumpState> {
     selectize: TomSelect;

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -40,7 +40,7 @@ import * as monacoConfig from '../monaco-config';
 import {GccDumpFilters, GccDumpState} from './gccdump-view.interfaces';
 
 import {ga} from '../analytics';
-import {CompilerFilters} from '../../types/features/filters.interfaces';
+import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 
 export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, GccDumpState> {
     selectize: TomSelect;
@@ -114,7 +114,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         this.eventHub.emit(
             'gccDumpFiltersChanged',
             this.compilerInfo.compilerId,
-            this.getEffectiveFilters() as CompilerFilters,
+            this.getEffectiveFilters() as CompilerOutputOptions,
             false
         );
 
@@ -397,7 +397,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
             this.eventHub.emit(
                 'gccDumpFiltersChanged',
                 this.compilerInfo.compilerId,
-                this.getEffectiveFilters() as unknown as CompilerFilters,
+                this.getEffectiveFilters() as unknown as CompilerOutputOptions,
                 true
             );
         }

--- a/types/features/filters.interfaces.ts
+++ b/types/features/filters.interfaces.ts
@@ -22,22 +22,25 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-export type CompilerFilters = {
+// These options are used both for the output options and our filtering passes
+// applied to the compiler output. They correspond to the "Compiler output
+// options" and "Compiler output filters" drop down menu in a compiler pane.
+
+export type CompilerOutputOptions = {
     binary: boolean;
     execute: boolean;
     demangle: boolean;
     intel: boolean;
+};
+
+export type preProcessLinesFunc = (lines: string[]) => string[];
+export type ParseFiltersAndOutputOptions = {
     labels: boolean;
     libraryCode: boolean;
     directives: boolean;
     commentOnly: boolean;
     trim: boolean;
-};
-
-export type preProcessLinesFunc = (lines: string[]) => string[];
-
-export type ParseFilters = CompilerFilters & {
     dontMaskFilenames?: boolean;
     optOutput: boolean;
     preProcessLines?: preProcessLinesFunc;
-};
+} & CompilerOutputOptions;


### PR DESCRIPTION
The type which probably started as a real enum of possible post filtering options now also includes options used for compilers' invocations.

The type was already split, but the naming was not reflecting this in the other part of the code.

This changes tries to apply a simple renaming to the type only (correponding variables are left as 'filters').

While doing so, some typing error were discovered around the GccDump feature. A fix for this will follow in a different PR.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>