### PR TITLE
Support trunk and execution for .NET

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -21,7 +21,7 @@ compiler.dotnet700csharp.buildConfig=Release
 compiler.dotnet700csharp.langVersion=latest
 
 compiler.dotnettrunkcsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharp.name=.NET (trunk)
+compiler.dotnettrunkcsharp.name=.NET (main)
 compiler.dotnettrunkcsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharp.targetFramework=net8.0
 compiler.dotnettrunkcsharp.buildConfig=Release

--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -4,7 +4,7 @@ needsMulti=false
 compilerType=csharp
 defaultCompiler=dotnet700csharp
 
-group.csharp.compilers=dotnet6011csharp:dotnet700csharp:dotnettrunkcsharp
+group.csharp.compilers=dotnettrunkcsharp:dotnet700csharp:dotnet6011csharp
 
 compiler.dotnet6011csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011csharp.name=.NET 6.0.403

--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&csharp
-supportsBinary=false
+supportsBinary=true
 needsMulti=false
 compilerType=csharp
 defaultCompiler=dotnet700csharp
 
-group.csharp.compilers=dotnet6011csharp:dotnet700csharp
+group.csharp.compilers=dotnet6011csharp:dotnet700csharp:dotnettrunkcsharp
 
 compiler.dotnet6011csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011csharp.name=.NET 6.0.403
@@ -19,3 +19,10 @@ compiler.dotnet700csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
 compiler.dotnet700csharp.targetFramework=net7.0
 compiler.dotnet700csharp.buildConfig=Release
 compiler.dotnet700csharp.langVersion=latest
+
+compiler.dotnettrunkcsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharp.name=.NET (trunk)
+compiler.dotnettrunkcsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharp.targetFramework=net8.0
+compiler.dotnettrunkcsharp.buildConfig=Release
+compiler.dotnettrunkcsharp.langVersion=preview

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -1,5 +1,5 @@
 compilers=dotnet6csharp:dotnet7csharp
-supportsBinary=false
+supportsBinary=true
 needsMulti=false
 compilerType=csharp
 defaultCompiler=dotnet7csharp

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&fsharp
-supportsBinary=false
+supportsBinary=true
 needsMulti=false
 compilerType=fsharp
 defaultCompiler=dotnet700fsharp
 
-group.fsharp.compilers=dotnet6011fsharp:dotnet700fsharp
+group.fsharp.compilers=dotnet6011fsharp:dotnet700fsharp:dotnettrunkfsharp
 
 compiler.dotnet6011fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011fsharp.name=.NET 6.0.403
@@ -19,3 +19,10 @@ compiler.dotnet700fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
 compiler.dotnet700fsharp.targetFramework=net7.0
 compiler.dotnet700fsharp.buildConfig=Release
 compiler.dotnet700fsharp.langVersion=latest
+
+compiler.dotnettrunkfsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharp.name=.NET (trunk)
+compiler.dotnettrunkfsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharp.targetFramework=net8.0
+compiler.dotnettrunkfsharp.buildConfig=Release
+compiler.dotnettrunkfsharp.langVersion=preview

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -21,7 +21,7 @@ compiler.dotnet700fsharp.buildConfig=Release
 compiler.dotnet700fsharp.langVersion=latest
 
 compiler.dotnettrunkfsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharp.name=.NET (trunk)
+compiler.dotnettrunkfsharp.name=.NET (main)
 compiler.dotnettrunkfsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharp.targetFramework=net8.0
 compiler.dotnettrunkfsharp.buildConfig=Release

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -4,7 +4,7 @@ needsMulti=false
 compilerType=fsharp
 defaultCompiler=dotnet700fsharp
 
-group.fsharp.compilers=dotnet6011fsharp:dotnet700fsharp:dotnettrunkfsharp
+group.fsharp.compilers=dotnettrunkfsharp:dotnet700fsharp:dotnet6011fsharp
 
 compiler.dotnet6011fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011fsharp.name=.NET 6.0.403

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -1,5 +1,5 @@
 compilers=dotnet6fsharp:dotnet7fsharp
-supportsBinary=false
+supportsBinary=true
 needsMulti=false
 compilerType=fsharp
 defaultCompiler=dotnet7fsharp

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -21,7 +21,7 @@ compiler.dotnet700vb.buildConfig=Release
 compiler.dotnet700vb.langVersion=latest
 
 compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvb.name=.NET (trunk)
+compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvb.targetFramework=net8.0
 compiler.dotnettrunkvb.buildConfig=Release

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&vb
-supportsBinary=false
+supportsBinary=true
 needsMulti=false
 compilerType=vb
 defaultCompiler=dotnet700vb
 
-group.vb.compilers=dotnet6011vb:dotnet700vb
+group.vb.compilers=dotnet6011vb:dotnet700vb:dotnettrunkvb
 
 compiler.dotnet6011vb.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011vb.name=.NET 6.0.403
@@ -19,3 +19,10 @@ compiler.dotnet700vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
 compiler.dotnet700vb.targetFramework=net7.0
 compiler.dotnet700vb.buildConfig=Release
 compiler.dotnet700vb.langVersion=latest
+
+compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvb.name=.NET (trunk)
+compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvb.targetFramework=net8.0
+compiler.dotnettrunkvb.buildConfig=Release
+compiler.dotnettrunkvb.langVersion=latest

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -4,7 +4,7 @@ needsMulti=false
 compilerType=vb
 defaultCompiler=dotnet700vb
 
-group.vb.compilers=dotnet6011vb:dotnet700vb:dotnettrunkvb
+group.vb.compilers=dotnettrunkvb:dotnet700vb:dotnet6011vb
 
 compiler.dotnet6011vb.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011vb.name=.NET 6.0.403

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -1,5 +1,5 @@
 compilers=dotnet6vb:dotnet7vb
-supportsBinary=false
+supportsBinary=true
 needsMulti=false
 compilerType=vb
 defaultCompiler=dotnet7vb

--- a/examples/csharp/default.cs
+++ b/examples/csharp/default.cs
@@ -1,4 +1,7 @@
+using System;
+
 class Program
 {
     static int Square(int num) => num * num;
+    static void Main() => Console.WriteLine(Sqaure(42));
 }

--- a/examples/fsharp/default.fs
+++ b/examples/fsharp/default.fs
@@ -1,3 +1,8 @@
 module Program
 
 let square num = num * num
+
+[<EntryPoint>]
+let main _ = 
+    printfn "%d" (square 42)
+    0

--- a/examples/vb/default.vb
+++ b/examples/vb/default.vb
@@ -1,5 +1,11 @@
+Imports System
+
 Module Program
     Function Square(num As Integer) As Integer
         Return num * num
     End Function
+    
+    Sub Main()
+        Console.WriteLine(Square(42))
+    End Sub
 End Module

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -381,7 +381,7 @@ export class BaseCompiler {
     }
 
     supportsObjdump() {
-        return this.objdumperClass !== '';
+        return !!this.objdumperClass;
     }
 
     getObjdumpOutputFilename(defaultOutputFilename) {

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -231,7 +231,7 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.env.DOTNET_EnableWriteXorExecute = '0';
         execOptions.env.DOTNET_CLI_HOME = programDir;
         execOptions.env.CORE_ROOT = this.clrBuildDir;
-        const execArgs = [...executeParameters.args, programDllPath];
+        const execArgs = ['-p', 'System.Runtime.TieredCompilation=false', programDllPath, ...executeParameters.args];
         const corerun = path.join(this.clrBuildDir, 'corerun');
         try {
             const execResult: UnprocessedExecResult = await exec.sandbox(corerun, execArgs, execOptions);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -225,12 +225,13 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.maxOutput = maxSize;
         execOptions.timeoutMs = this.env.ceProps('binaryExecTimeoutMs', 2000);
         execOptions.ldPath = _.union(this.compiler.ldPath, executeParameters.ldPath);
-        execOptions.env = executeParameters.env;
         execOptions.customCwd = homeDir;
         execOptions.appHome = homeDir;
+        execOptions.env = executeParameters.env;
         execOptions.env.DOTNET_EnableWriteXorExecute = '0';
         execOptions.env.DOTNET_CLI_HOME = programDir;
         execOptions.env.CORE_ROOT = this.clrBuildDir;
+        execOptions.input = executeParameters.stdin;
         const execArgs = ['-p', 'System.Runtime.TieredCompilation=false', programDllPath, ...executeParameters.args];
         const corerun = path.join(this.clrBuildDir, 'corerun');
         try {

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -22,19 +22,29 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import path from 'path';
-
 import fs from 'fs-extra';
+import path from 'path';
+import _ from 'underscore';
 
+import * as exec from '../exec';
+import * as utils from '../utils';
+
+import {
+    BasicExecutionResult,
+    ExecutableExecutionOptions,
+    UnprocessedExecResult,
+} from '../../types/execution/execution.interfaces';
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {DotNetAsmParser} from '../parsers/asm-parser-dotnet';
+import {ParseFilters} from '../../types/features/filters.interfaces';
 
 class DotNetCompiler extends BaseCompiler {
     private targetFramework: string;
     private buildConfig: string;
     private clrBuildDir: string;
     private langVersion: string;
+    private compileToBinary = false;
 
     constructor(compilerInfo, env) {
         super(compilerInfo, env);
@@ -104,6 +114,7 @@ class DotNetCompiler extends BaseCompiler {
                 <LangVersion>${this.langVersion}</LangVersion>
                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
                 <Nullable>enable</Nullable>
+                <OutputType>${this.compileToBinary ? 'Exe' : 'Library'}</OutputType>
             </PropertyGroup>
             <ItemGroup>
                 <Compile Include="${sourceFile}" />
@@ -193,8 +204,50 @@ class DotNetCompiler extends BaseCompiler {
         return compilerResult;
     }
 
-    override optionsForFilter() {
+    override optionsForFilter(filters: ParseFilters) {
+        if (filters.binary) {
+            this.compileToBinary = true;
+        }
+
         return this.compilerOptions;
+    }
+
+    override async execBinary(
+        executable: string,
+        maxSize: number | undefined,
+        executeParameters: ExecutableExecutionOptions,
+        homeDir: string | undefined,
+    ): Promise<BasicExecutionResult> {
+        const programDir = path.dirname(executable);
+        const programOutputPath = path.join(programDir, 'bin', this.buildConfig, this.targetFramework);
+        const programDllPath = path.join(programOutputPath, 'CompilerExplorer.dll');
+        const execOptions = this.getDefaultExecOptions();
+        execOptions.maxOutput = maxSize;
+        execOptions.timeoutMs = this.env.ceProps('binaryExecTimeoutMs', 2000);
+        execOptions.ldPath = _.union(this.compiler.ldPath, executeParameters.ldPath);
+        execOptions.env = executeParameters.env;
+        execOptions.customCwd = homeDir;
+        execOptions.appHome = homeDir;
+        execOptions.env.DOTNET_EnableWriteXorExecute = '0';
+        execOptions.env.DOTNET_CLI_HOME = programDir;
+        execOptions.env.CORE_ROOT = this.clrBuildDir;
+        const execArgs = [programDllPath, ...executeParameters.args];
+        const corerun = path.join(this.clrBuildDir, 'corerun');
+        try {
+            const execResult: UnprocessedExecResult = await exec.sandbox(corerun, execArgs, execOptions);
+            return this.processExecutionResult(execResult);
+        } catch (err: UnprocessedExecResult | any) {
+            if (err.code && err.stderr) {
+                return this.processExecutionResult(err);
+            } else {
+                return {
+                    ...this.getEmptyExecutionResult(),
+                    stdout: err.stdout ? utils.parseOutput(err.stdout) : [],
+                    stderr: err.stderr ? utils.parseOutput(err.stderr) : [],
+                    code: err.code !== undefined ? err.code : -1,
+                };
+            }
+        }
     }
 
     async runCrossgen2(compiler, execOptions, crossgen2Path, bclPath, dllPath, options, outputPath) {

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -231,7 +231,7 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.env.DOTNET_EnableWriteXorExecute = '0';
         execOptions.env.DOTNET_CLI_HOME = programDir;
         execOptions.env.CORE_ROOT = this.clrBuildDir;
-        const execArgs = [programDllPath, ...executeParameters.args];
+        const execArgs = [...executeParameters.args, programDllPath];
         const corerun = path.join(this.clrBuildDir, 'corerun');
         try {
             const execResult: UnprocessedExecResult = await exec.sandbox(corerun, execArgs, execOptions);


### PR DESCRIPTION
- Support trunk version for .NET
- Support execution for .NET
- Change how we detect supportsObjdump (the value can be `undefined`)

This time it should be pretty straightforward.

![image](https://user-images.githubusercontent.com/14960345/204137726-ec555856-ab13-4757-a69d-411128152306.png)

/cc: @mattgodbolt 