### PR TITLE
Support backticks in labels

### DIFF
--- a/static/modes/asm-mode.ts
+++ b/static/modes/asm-mode.ts
@@ -96,8 +96,8 @@ function definition() {
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
                 [/'/, 'string.invalid'],
 
-                // Assume anything else is a label reference
-                [/%?[.?_$a-zA-Z@][.?_$a-zA-Z0-9@]*/, 'type.identifier'],
+                // Assume anything else is a label reference. .NET uses ` in some identifiers
+                [/%?[.?_$a-zA-Z@][.?_$a-zA-Z0-9@`]*/, 'type.identifier'],
 
                 // whitespace
                 {include: '@whitespace'},


### PR DESCRIPTION
.NET uses them, it seems. Closes #4350

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
