### PR TITLE
.net - compileToBinary fix

### DIFF
--- a/etc/nsjail/execute.cfg
+++ b/etc/nsjail/execute.cfg
@@ -28,7 +28,7 @@ cgroup_net_cls_parent: "ce-compile"
 cgroup_cpu_parent: "ce-compile"
 
 cgroup_mem_max: 1342177280 # 1.25 GiB
-cgroup_pids_max: 72  # go uses a bunch (probably one per CPU, on my desktop)
+cgroup_pids_max: 72
 cgroup_cpu_ms_per_sec: 1000
 
 mount {

--- a/etc/nsjail/execute.cfg
+++ b/etc/nsjail/execute.cfg
@@ -28,7 +28,7 @@ cgroup_net_cls_parent: "ce-compile"
 cgroup_cpu_parent: "ce-compile"
 
 cgroup_mem_max: 1342177280 # 1.25 GiB
-cgroup_pids_max: 64  # go uses a bunch (probably one per CPU, on my desktop)
+cgroup_pids_max: 72  # go uses a bunch (probably one per CPU, on my desktop)
 cgroup_cpu_ms_per_sec: 1000
 
 mount {

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -107,6 +107,15 @@ class DotNetCompiler extends BaseCompiler {
         await fs.writeFile(projectFilePath, projectFileContent);
     }
 
+    override async buildExecutable(compiler, options, inputFilename, execOptions) {
+        const dirPath = path.dirname(inputFilename);
+        const inputFilenameSafe = this.filename(inputFilename);
+        const sourceFile = path.basename(inputFilenameSafe);
+        await this.writeProjectfile(dirPath, true, sourceFile);
+
+        return super.buildExecutable(compiler, options, inputFilename, execOptions);
+    }
+
     override async doCompilation(inputFilename, dirPath, key, options, filters, backendOptions, libraries, tools) {
         const inputFilenameSafe = this.filename(inputFilename);
         const sourceFile = path.basename(inputFilenameSafe);


### PR DESCRIPTION
Removes shared variable that would conflict with simultaneous compilations

Also ups pids max because of an issue I was hitting locally