### PR TITLE
dynamically set targetFramework

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -9,20 +9,17 @@ group.csharp.compilers=dotnettrunkcsharp:dotnet700csharp:dotnet6011csharp
 compiler.dotnet6011csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011csharp.name=.NET 6.0.403
 compiler.dotnet6011csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6011csharp.targetFramework=net6.0
 compiler.dotnet6011csharp.buildConfig=Release
 compiler.dotnet6011csharp.langVersion=latest
 
 compiler.dotnet700csharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
 compiler.dotnet700csharp.name=.NET 7.0.100
 compiler.dotnet700csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700csharp.targetFramework=net7.0
 compiler.dotnet700csharp.buildConfig=Release
 compiler.dotnet700csharp.langVersion=latest
 
 compiler.dotnettrunkcsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkcsharp.name=.NET (main)
 compiler.dotnettrunkcsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
-compiler.dotnettrunkcsharp.targetFramework=net8.0
 compiler.dotnettrunkcsharp.buildConfig=Release
 compiler.dotnettrunkcsharp.langVersion=preview

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -7,13 +7,11 @@ defaultCompiler=dotnet7csharp
 compiler.dotnet6csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6csharp.name=.NET 6.0.403
 compiler.dotnet6csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6csharp.targetFramework=net6.0
 compiler.dotnet6csharp.buildConfig=Release
 compiler.dotnet6csharp.langVersion=latest
 
 compiler.dotnet7csharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
 compiler.dotnet7csharp.name=.NET 7.0.100
 compiler.dotnet7csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet7csharp.targetFramework=net7.0
 compiler.dotnet7csharp.buildConfig=Release
 compiler.dotnet7csharp.langVersion=latest

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -9,20 +9,17 @@ group.fsharp.compilers=dotnettrunkfsharp:dotnet700fsharp:dotnet6011fsharp
 compiler.dotnet6011fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011fsharp.name=.NET 6.0.403
 compiler.dotnet6011fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6011fsharp.targetFramework=net6.0
 compiler.dotnet6011fsharp.buildConfig=Release
 compiler.dotnet6011fsharp.langVersion=latest
 
 compiler.dotnet700fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
 compiler.dotnet700fsharp.name=.NET 7.0.100
 compiler.dotnet700fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700fsharp.targetFramework=net7.0
 compiler.dotnet700fsharp.buildConfig=Release
 compiler.dotnet700fsharp.langVersion=latest
 
 compiler.dotnettrunkfsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkfsharp.name=.NET (main)
 compiler.dotnettrunkfsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
-compiler.dotnettrunkfsharp.targetFramework=net8.0
 compiler.dotnettrunkfsharp.buildConfig=Release
 compiler.dotnettrunkfsharp.langVersion=preview

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -7,13 +7,11 @@ defaultCompiler=dotnet7fsharp
 compiler.dotnet6fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6fsharp.name=.NET 6.0.403
 compiler.dotnet6fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6fsharp.targetFramework=net6.0
 compiler.dotnet6fsharp.buildConfig=Release
 compiler.dotnet6fsharp.langVersion=latest
 
 compiler.dotnet7fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
 compiler.dotnet7fsharp.name=.NET 7.0.100
 compiler.dotnet7fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet7fsharp.targetFramework=net7.0
 compiler.dotnet7fsharp.buildConfig=Release
 compiler.dotnet7fsharp.langVersion=latest

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -9,20 +9,17 @@ group.vb.compilers=dotnettrunkvb:dotnet700vb:dotnet6011vb
 compiler.dotnet6011vb.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6011vb.name=.NET 6.0.403
 compiler.dotnet6011vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6011vb.targetFramework=net6.0
 compiler.dotnet6011vb.buildConfig=Release
 compiler.dotnet6011vb.langVersion=latest
 
 compiler.dotnet700vb.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
 compiler.dotnet700vb.name=.NET 7.0.100
 compiler.dotnet700vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700vb.targetFramework=net7.0
 compiler.dotnet700vb.buildConfig=Release
 compiler.dotnet700vb.langVersion=latest
 
 compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
-compiler.dotnettrunkvb.targetFramework=net8.0
 compiler.dotnettrunkvb.buildConfig=Release
 compiler.dotnettrunkvb.langVersion=latest

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -7,13 +7,11 @@ defaultCompiler=dotnet7vb
 compiler.dotnet6vb.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
 compiler.dotnet6vb.name=.NET 6.0.403
 compiler.dotnet6vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6vb.targetFramework=net6.0
 compiler.dotnet6vb.buildConfig=Release
 compiler.dotnet6vb.langVersion=latest
 
 compiler.dotnet7vb.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
 compiler.dotnet7vb.name=.NET 7.0.100
-compiler.dotnet7vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.0/
-compiler.dotnet7vb.targetFramework=net7.0
+compiler.dotnet7vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
 compiler.dotnet7vb.buildConfig=Release
 compiler.dotnet7vb.langVersion=latest

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -40,6 +40,8 @@ import {DotNetAsmParser} from '../parsers/asm-parser-dotnet';
 import {ParseFilters} from '../../types/features/filters.interfaces';
 
 class DotNetCompiler extends BaseCompiler {
+    private sdkBaseDir: string;
+    private sdkVersion: string;
     private targetFramework: string;
     private buildConfig: string;
     private clrBuildDir: string;
@@ -49,7 +51,12 @@ class DotNetCompiler extends BaseCompiler {
     constructor(compilerInfo, env) {
         super(compilerInfo, env);
 
-        this.targetFramework = this.compilerProps<string>(`compiler.${this.compiler.id}.targetFramework`);
+        this.sdkBaseDir = path.join(path.dirname(compilerInfo.exe), 'sdk');
+        this.sdkVersion = fs.readdirSync(this.sdkBaseDir)[0];
+
+        const parts = this.sdkVersion.split('.');
+        this.targetFramework = `net${parts[0]}.${parts[1]}`;
+
         this.buildConfig = this.compilerProps<string>(`compiler.${this.compiler.id}.buildConfig`);
         this.clrBuildDir = this.compilerProps<string>(`compiler.${this.compiler.id}.clrDir`);
         this.langVersion = this.compilerProps<string>(`compiler.${this.compiler.id}.langVersion`);
@@ -121,15 +128,14 @@ class DotNetCompiler extends BaseCompiler {
             </ItemGroup>
          </Project>
         `;
-        const sdkBaseDir = path.join(path.dirname(compiler), 'sdk');
-        const sdkVersions = await fs.readdir(sdkBaseDir);
+
         const nugetConfigFileContent = `<?xml version="1.0" encoding="utf-8"?>
         <configuration>
             <packageSources>
                 <clear />
                 <packageSource key="fsharp" value="${path.join(
-                    sdkBaseDir,
-                    sdkVersions[0],
+                    this.sdkBaseDir,
+                    this.sdkVersion,
                     '/FSharp/library-packs/',
                 )}" />
             </packageSources>


### PR DESCRIPTION
we are tied to `sdk.version` internally used by runtime repo https://github.com/dotnet/runtime/blob/main/global.json#L3  so we can't use `net8.0` yet.

it is "possible" to build daily build of sdk (or download binaries directly from https://github.com/dotnet/installer#table), but we don't need that because all we build an msil using the sdk, then crossgen with given runtime (in this case the bleeding edge version), so sdk doesn't matter.

fix error:
<img width="746" alt="image" src="https://user-images.githubusercontent.com/83082615/204159748-22dcd479-da48-4858-9045-dc79f5858c6b.png">
