### PR TITLE
Add Multi library to CUDA compiler

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -301,7 +301,13 @@ compiler.nvrtc114u1.semver=11.4.1
 compiler.nvrtc114u1.exe=/opt/compiler-explorer/cuda/11.4.1/bin/nvrtc_cli
 compiler.nvrtc115.semver=11.5.0
 compiler.nvrtc115.exe=/opt/compiler-explorer/cuda/11.5.0/bin/nvrtc_cli
-libs=cueigen:thrustcub:cucub:cudacxx:nvtx:nsimd:cuco:hip-amd
+libs=bmulti:cueigen:thrustcub:cucub:cudacxx:nvtx:nsimd:cuco:hip-amd
+libs.bmulti.name=B-Multi
+libs.bmulti.url=https://gitlab.com/correaa/boost-multi
+libs.bmulti.versions=trunk
+libs.bmulti.description=Modern C++ multidimensional arrays in CPU and GPU (with Thrust and/or CUDA)
+libs.bmulti.versions.trunk.version=trunk
+libs.bmulti.versions.trunk.path=/opt/compiler-explorer/libs/bmulti/trunk/include
 libs.cueigen.name=Eigen
 libs.cueigen.versions=trunk:340:339:337:334
 libs.cueigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page


### PR DESCRIPTION
This library with C++ compiler already

library source and details here: https://gitlab.com/correaa/boost-multi

Corresponding changes in infra don't seem to be necessary since they were already in place for C++ and Circle compiler.
