### PR TITLE
Add support for clang-cl and llvm-undname

### DIFF
--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -32,6 +32,7 @@ export {Cc65Compiler} from './cc65';
 export {CircleCompiler} from './circle';
 export {CIRCTCompiler} from './circt';
 export {ClangCompiler} from './clang';
+export {ClangCLCompiler} from './clangcl';
 export {ClangCudaCompiler} from './clang';
 export {ClangHipCompiler} from './clang';
 export {ClangIntelCompiler} from './clang';

--- a/lib/compilers/clangcl.ts
+++ b/lib/compilers/clangcl.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+
+import {Win32Compiler} from './win32';
+
+export class ClangCLCompiler extends Win32Compiler {
+    static override get key() {
+        return 'clang-cl';
+    }
+
+    constructor(info, env) {
+        super(info, env);
+
+        this.compiler.supportsIrView = true;
+        this.compiler.irArg = ['-Xclang', '-emit-llvm'];
+        this.compiler.supportsIntel = false;
+        this.compiler.includeFlag = '/clang:-isystem';
+    }
+
+    override async generateIR(inputFilename: string, options: string[], filters: ParseFiltersAndOutputOptions) {
+        // These options make Clang produce an IR
+        const newOptions = options
+            .filter(option => option !== '/FA' && !option.startsWith('/Fa'))
+            .concat(this.compiler.irArg);
+
+        const execOptions = this.getDefaultExecOptions();
+        // A higher max output is needed for when the user includes headers
+        execOptions.maxOutput = 1024 * 1024 * 1024;
+
+        const output = await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
+        if (output.code !== 0) {
+            return [{text: 'Failed to run compiler to get IR code'}];
+        }
+        const ir = await this.processIrOutput(output, filters);
+        return ir.asm;
+    }
+
+    override getIrOutputFilename(inputFilename: string, filters: ParseFiltersAndOutputOptions): string {
+        return this.filename(path.dirname(inputFilename) + '/output.s.obj');
+    }
+
+    override optionsForFilter(filters, outputFilename) {
+        const options = super.optionsForFilter(filters, outputFilename);
+
+        // Force the debugging info flag or we can't source locations.
+        return ['/Z7'].concat(options);
+    }
+}

--- a/lib/demangler/_all.js
+++ b/lib/demangler/_all.js
@@ -27,3 +27,4 @@ export {DefaultDemangler} from './default';
 export {PascalDemangler} from './pascal';
 export {Win32Demangler} from './win32';
 export {NVHPCDemangler} from './nvhpc';
+export {LLVMWin32Demangler} from './win32-llvm';

--- a/lib/demangler/win32-llvm.js
+++ b/lib/demangler/win32-llvm.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as utils from '../utils';
+
+import {Win32Demangler} from './win32';
+
+export class LLVMWin32Demangler extends Win32Demangler {
+    static get key() {
+        // this should be used for llvm-undname
+        return 'win32-llvm';
+    }
+
+    async execDemangler() {
+        const translations = {};
+        const flags = ['--no-access-specifier', '--no-calling-convention'];
+
+        const demangleFromStdin = async stdin => {
+            const args = [...flags];
+            const execOptions = this.compiler.getDefaultExecOptions();
+            execOptions.input = stdin;
+            const output = await this.compiler.exec(this.demanglerExe, args, execOptions);
+            const oArray = utils.splitLines(output.stdout);
+            const outputArray = oArray.filter(n => n);
+
+            // llvm-undname just output:
+            // mangledName
+            // unmangledName
+            for (let i = 0; i < outputArray.length; ++i) {
+                if (this.hasQuotesAroundDecoratedLabels) {
+                    translations[`"${outputArray[i]}"`] = outputArray[++i];
+                } else {
+                    translations[outputArray[i]] = outputArray[++i];
+                }
+            }
+        };
+
+        this.win32RawSymbols.sort();
+
+        let lastSymbol = null;
+        let symbolArray = [];
+        for (const symb of this.win32RawSymbols) {
+            if (symb === lastSymbol) {
+                continue;
+            }
+            lastSymbol = symb;
+            symbolArray.push(symb);
+        }
+
+        const stdin = symbolArray.join('\n') + '\n';
+        await demangleFromStdin(stdin);
+
+        return translations;
+    }
+}

--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -31,6 +31,7 @@ import {
     ParsedAsmResultLine,
 } from '../../types/asmresult/asmresult.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {logger} from '../logger';
 import * as utils from '../utils';
 
 import {IAsmParser} from './asm-parser.interfaces';
@@ -280,7 +281,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
             const match = line.match(this.fileFind);
             if (match) {
                 const lineNum = parseInt(match[1]);
-                if (match[4]) {
+                if (match[4] && !line.includes('.cv_file')) {
                     // Clang-style file directive '.file X "dir" "filename"'
                     files[lineNum] = match[2] + '/' + match[4];
                 } else {


### PR DESCRIPTION
This PR adds support for clang-cl and llvm-undname.

This makes it possible to cross-compile from linux to windows with clang-cl and make it behave like msvc.

There is also a bugfix that fixes the parsing of `.cv_file`.

Here is an example configuration for cross-compiling with clang-cl:

```
group.clangcl.compilers=clangcl
group.clangcl.groupName=clang-cl win64
group.clangcl.instructionSet=amd64
group.clangcl.compilerType=clang-cl
group.clangcl.options=/winsdkversion 10.0.22000.0 /winsysroot /path/to/sysroot
group.clangcl.demangler=/usr/local/bin/llvm-undname
group.clangcl.demanglerType=win32-llvm
group.clangcl.supportsBinary=false
```
