### PR TITLE
Clean up OpenCL compilation into SPIR-V.

### DIFF
--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&armcpp4oclclang32:&armcpp4oclclang64:&armcpp4oclclang32spir:&armcpp4oclclang64spir
+compilers=&armcpp4oclclang32:&armcpp4oclclang64:&spirv32cpp4oclclang:&spirv64cpp4oclclang
 defaultCompiler=armv8-cpp4oclclang-trunk
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
@@ -176,49 +176,53 @@ compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
 compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 
 # SPIR-V Assembly
-group.armcpp4oclclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)
-group.armcpp4oclclang32spir.compilers=armv7-cpp4oclclang-trunk-spir:armv7-cpp4oclclang-trunk-assertions-spir
-group.armcpp4oclclang32spir.isSemVer=true
-group.armcpp4oclclang32spir.compilerType=spirv
-group.armcpp4oclclang32spir.supportsExecute=false
-group.armcpp4oclclang32spir.instructionSet=arm32
-# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armcpp4oclclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
+group.spirv32cpp4oclclang.groupName=SPIR-V 32-bit clang (with llvm-spirv)
+group.spirv32cpp4oclclang.compilers=spirv32-cpp4oclclang-trunk:spirv32-cpp4oclclang-trunk-assertions
+group.spirv32cpp4oclclang.isSemVer=true
+group.spirv32cpp4oclclang.compilerType=spirv
+group.spirv32cpp4oclclang.supportsExecute=false
+group.spirv32cpp4oclclang.instructionSet=spirv
+# The latest llvm-spirv accepts translation with spirv32 target.
+group.spirv32cpp4oclclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
-group.armcpp4oclclang64spir.groupName=Arm 64-bit clang (SPIR-V asm)
-group.armcpp4oclclang64spir.compilers=armv8-cpp4oclclang-trunk-spir64:armv8-cpp4oclclang-trunk-assertions-spir64
-group.armcpp4oclclang64spir.isSemVer=true
-group.armcpp4oclclang64spir.compilerType=spirv
-group.armcpp4oclclang64spir.supportsExecute=false
-group.armcpp4oclclang64spir.instructionSet=aarch64
-# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armcpp4oclclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
+group.spirv64cpp4oclclang.groupName=SPIR-V 64-bit clang (with llvm-spirv)
+group.spirv64cpp4oclclang.compilers=spirv64-cpp4oclclang-trunk:spirv64-cpp4oclclang-trunk-assertions
+group.spirv64cpp4oclclang.isSemVer=true
+group.spirv64cpp4oclclang.compilerType=spirv
+group.spirv64cpp4oclclang.supportsExecute=false
+group.spirv64cpp4oclclang.instructionSet=spirv
+# The latest llvm-spirv accepts translation with spirv64 target.
+group.spirv64cpp4oclclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
-# Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang-trunk-spir.name=armv7-a clang (trunk, SPIR-V asm)
-compiler.armv7-cpp4oclclang-trunk-spir.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv7-cpp4oclclang-trunk-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv7-cpp4oclclang-trunk-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv7-cpp4oclclang-trunk-spir.semver=(trunk)
+# 32 bits
+compiler.spirv32-cpp4oclclang-trunk.alias=armv7-cpp4oclclang-trunk-spir
+compiler.spirv32-cpp4oclclang-trunk.name=clang & llvm-spirv (trunk)
+compiler.spirv32-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.spirv32-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv32-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv32-cpp4oclclang-trunk.semver=(trunk)
 
-compiler.armv7-cpp4oclclang-trunk-assertions-spir.name=armv7-a clang (trunk, assertions, SPIR-V asm)
-compiler.armv7-cpp4oclclang-trunk-assertions-spir.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
-compiler.armv7-cpp4oclclang-trunk-assertions-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv7-cpp4oclclang-trunk-assertions-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv7-cpp4oclclang-trunk-assertions-spir.semver=(assertions trunk)
+compiler.spirv32-cpp4oclclang-trunk-assertions.alias=armv7-cpp4oclclang-trunk-assertions-spir
+compiler.spirv32-cpp4oclclang-trunk-assertions.name=clang & llvm-spirv (trunk, assertions)
+compiler.spirv32-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.spirv32-cpp4oclclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv32-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv32-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
 
-# Arm v8-a
-compiler.armv8-cpp4oclclang-trunk-spir64.name=armv8-a clang (trunk, SPIR-V asm)
-compiler.armv8-cpp4oclclang-trunk-spir64.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv8-cpp4oclclang-trunk-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-cpp4oclclang-trunk-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv8-cpp4oclclang-trunk-spir64.semver=(trunk)
+# 64 bits
+compiler.spirv64-cpp4oclclang-trunk.alias=armv8-cpp4oclclang-trunk-spir64
+compiler.spirv64-cpp4oclclang-trunk.name=clang & llvm-spirv (trunk)
+compiler.spirv64-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.spirv64-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv64-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv64-cpp4oclclang-trunk.semver=(trunk)
 
-compiler.armv8-cpp4oclclang-trunk-assertions-spir64.name=armv8-a clang (trunk, assertions, SPIR-V asm)
-compiler.armv8-cpp4oclclang-trunk-assertions-spir64.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
-compiler.armv8-cpp4oclclang-trunk-assertions-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-cpp4oclclang-trunk-assertions-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv8-cpp4oclclang-trunk-assertions-spir64.semver=(assertions trunk)
+compiler.spirv64-cpp4oclclang-trunk-assertions.alias=armv8-cpp4oclclang-trunk-assertions-spir64
+compiler.spirv64-cpp4oclclang-trunk-assertions.name=clang & llvm-spirv (trunk, assertions)
+compiler.spirv64-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.spirv64-cpp4oclclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv64-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv64-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
 
 #################################
 #################################

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&armoclcclang32:&armoclcclang64:&armoclcclang32spir:&armoclcclang64spir:&googleclspv
+compilers=&armoclcclang32:&armoclcclang64:&spirv32oclcclang:&spirv64oclcclang:&googleclspv
 defaultCompiler=armv8-oclcclang-trunk
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
@@ -201,49 +201,53 @@ compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
 compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 
 # SPIR-V Assembly
-group.armoclcclang32spir.groupName=Arm 32-bit clang (SPIR-V asm)
-group.armoclcclang32spir.compilers=armv7-oclcclang-trunk-spir:armv7-oclcclang-trunk-assertions-spir
-group.armoclcclang32spir.isSemVer=true
-group.armoclcclang32spir.compilerType=spirv
-group.armoclcclang32spir.supportsExecute=false
-group.armoclcclang32spir.instructionSet=arm32
-# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armoclcclang32spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
+group.spirv32oclcclang.groupName=SPIR-V 32-bit clang (with llvm-spirv)
+group.spirv32oclcclang.compilers=spirv32-oclcclang-trunk:spirv32-oclcclang-trunk-assertions
+group.spirv32oclcclang.isSemVer=true
+group.spirv32oclcclang.compilerType=spirv
+group.spirv32oclcclang.supportsExecute=false
+group.spirv32oclcclang.instructionSet=spirv
+# The latest llvm-spirv accepts translation with spirv32 target.
+group.spirv32oclcclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
 
-group.armoclcclang64spir.groupName=Arm 64-bit clang (SPIR-V asm)
-group.armoclcclang64spir.compilers=armv8-oclcclang-trunk-spir64:armv8-oclcclang-trunk-assertions-spir64
-group.armoclcclang64spir.isSemVer=true
-group.armoclcclang64spir.compilerType=spirv
-group.armoclcclang64spir.supportsExecute=false
-group.armoclcclang64spir.instructionSet=aarch64
-# The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
-group.armoclcclang64spir.baseOptions=-Dkernel= -D__kernel= -finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
+group.spirv64oclcclang.groupName=SPIR-V 64-bit clang (with llvm-spirv)
+group.spirv64oclcclang.compilers=spirv64-oclcclang-trunk:spirv64-oclcclang-trunk-assertions
+group.spirv64oclcclang.isSemVer=true
+group.spirv64oclcclang.compilerType=spirv
+group.spirv64oclcclang.supportsExecute=false
+group.spirv64oclcclang.instructionSet=spirv
+# The latest llvm-spirv accepts translation with spirv64 target.
+group.spirv64oclcclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
 
-# Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang-trunk-spir.name=armv7-a clang (trunk, SPIR-V asm)
-compiler.armv7-oclcclang-trunk-spir.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv7-oclcclang-trunk-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv7-oclcclang-trunk-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv7-oclcclang-trunk-spir.semver=(trunk)
+# 32 bits
+compiler.spirv32-oclcclang-trunk.alias=armv7-oclcclang-trunk-spir
+compiler.spirv32-oclcclang-trunk.name=clang & llvm-spirv (trunk)
+compiler.spirv32-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.spirv32-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv32-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv32-oclcclang-trunk.semver=(trunk)
 
-compiler.armv7-oclcclang-trunk-assertions-spir.name=armv7-a clang (trunk, assertions, SPIR-V asm)
-compiler.armv7-oclcclang-trunk-assertions-spir.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
-compiler.armv7-oclcclang-trunk-assertions-spir.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv7-oclcclang-trunk-assertions-spir.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv7-oclcclang-trunk-assertions-spir.semver=(assertions trunk)
+compiler.spirv32-oclcclang-trunk-assertions.alias=armv7-oclcclang-trunk-assertions-spir
+compiler.spirv32-oclcclang-trunk-assertions.name=clang & llvm-spirv (trunk, assertions)
+compiler.spirv32-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.spirv32-oclcclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv32-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv32-oclcclang-trunk-assertions.semver=(assertions trunk)
 
-# Arm v8-a
-compiler.armv8-oclcclang-trunk-spir64.name=armv8-a clang (trunk, SPIR-V asm)
-compiler.armv8-oclcclang-trunk-spir64.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv8-oclcclang-trunk-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-oclcclang-trunk-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv8-oclcclang-trunk-spir64.semver=(trunk)
+# 64 bits
+compiler.spirv64-oclcclang-trunk.alias=armv8-oclcclang-trunk-spir64
+compiler.spirv64-oclcclang-trunk.name=clang & llvm-spirv (trunk)
+compiler.spirv64-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.spirv64-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv64-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv64-oclcclang-trunk.semver=(trunk)
 
-compiler.armv8-oclcclang-trunk-assertions-spir64.name=armv8-a clang (trunk, assertions, SPIR-V asm)
-compiler.armv8-oclcclang-trunk-assertions-spir64.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
-compiler.armv8-oclcclang-trunk-assertions-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.armv8-oclcclang-trunk-assertions-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.armv8-oclcclang-trunk-assertions-spir64.semver=(assertions trunk)
+compiler.spirv64-oclcclang-trunk-assertions.alias=armv8-oclcclang-trunk-assertions-spir64
+compiler.spirv64-oclcclang-trunk-assertions.name=clang & llvm-spirv (trunk, assertions)
+compiler.spirv64-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
+compiler.spirv64-oclcclang-trunk-assertions.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.spirv64-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.spirv64-oclcclang-trunk-assertions.semver=(assertions trunk)
 
 # Google clspv
 group.googleclspv.compilers=clspv:clvk


### PR DESCRIPTION
This change removes any references to Arm in SPIR-V compiler for OpenCL as there isn't anything specific to Arm in the compilation process. It also avoids using Arm specific workaround because SPIR-V compilation in clang doesn't suffer from the same limitation.

This change also makes explicit the fact that compilation uses llvm-spirv as clang now has internal SPIR-V support too which should be added here once it matures.