### PR TITLE
Add clspv compiler to C++ for OpenCL.

### DIFF
--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&armcpp4oclclang32:&armcpp4oclclang64:&armcpp4oclclang32spir:&armcpp4oclclang64spir
+compilers=&armcpp4oclclang32:&armcpp4oclclang64:&armcpp4oclclang32spir:&armcpp4oclclang64spir:&cpp4oclgoogleclspv
 defaultCompiler=armv8-cpp4oclclang-trunk
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
@@ -219,6 +219,21 @@ compiler.armv8-cpp4oclclang-trunk-assertions-spir64.exe=/opt/compiler-explorer/c
 compiler.armv8-cpp4oclclang-trunk-assertions-spir64.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-cpp4oclclang-trunk-assertions-spir64.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-cpp4oclclang-trunk-assertions-spir64.semver=(assertions trunk)
+
+# Google clspv
+group.cpp4oclgoogleclspv.compilers=cpp4oclclspv:cpp4oclclvk
+group.cpp4oclgoogleclspv.compilerType=clspv
+group.cpp4oclgoogleclspv.groupName=Google clspv
+group.cpp4oclgoogleclspv.baseOptions=-cl-std=CLC++ -inline-entry-points
+
+compiler.cpp4oclclspv.exe=/opt/compiler-explorer/clspv-main/bin/clspv
+compiler.cpp4oclclspv.name=clspv (trunk)
+
+# clvk-like usage of clspv
+compiler.cpp4oclclvk.exe=/opt/compiler-explorer/clspv-main/bin/clspv
+compiler.cpp4oclclvk.name=clvk-like (based on clspv trunk)
+compiler.cpp4oclclvk.options=-cl-single-precision-constant -cl-kernel-arg-info -fp64=0 -int8 -std430-ubo-layout -spv-version=1.5 -max-pushconstant-size=128 -max-ubo-size=134217728 -global-offset -long-vector -module-constants-in-storage-buffer -cl-arm-non-uniform-work-group-size
+
 
 #################################
 #################################


### PR DESCRIPTION
Since clspv compiler supports C++ for OpenCL add this compiler mode to the language just the same way as it's done for OpenCL C.

Note that the use of C++ for OpenCL with clspv at present requires extra flags: "-cl-std=CLC++" and
"-inline-entry-points".