### PR TITLE
Invoke lint-staged with --verbose

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 make prereqs
-npx lint-staged
+npx lint-staged --verbose
 python3 ./etc/scripts/util/propscheck.py


### PR DESCRIPTION
`lint-staged --verbose` will print eslint output even when it fails so the dev is notified about linter warnings during pre-commit