### PR TITLE
Integrate zksolc

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -322,6 +322,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'lib/compilers/solidity.ts'
+          - 'lib/compilers/solidity-eravm.ts'
           - 'etc/config/solidity.*.properties'
 
 'lang-spice':

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -31,6 +31,7 @@ group.zksolc.instructionSet=eravm
 compiler.zksolc140.exe=/opt/compiler-explorer/zksolc-1.4.0/zksolc
 compiler.zksolc140.semver=1.4.0
 compiler.zksolc140.name=zksolc 1.4.0
+compiler.zksolc140.options=--solc /opt/compiler-explorer/solc-0.8.21/solc
 
 #################################
 #################################

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -24,13 +24,13 @@ compiler.solc0821.exe=/opt/compiler-explorer/solc-0.8.21/solc
 compiler.solc0821.semver=0.8.21
 compiler.solc0821.name=solc 0.8.21
 
-group.zksolc.compilers=zksolc141
+group.zksolc.compilers=zksolc140
 group.zksolc.compilerType=solidity-eravm
 group.zksolc.supportsBinary=false
 group.zksolc.instructionSet=eravm
-compiler.zksolc141.exe=/opt/compiler-explorer/zksolc-1.4.1/zksolc
-compiler.zksolc141.semver=1.4.1
-compiler.zksolc141.name=zksolc 1.4.1
+compiler.zksolc140.exe=/opt/compiler-explorer/zksolc-1.4.0/zksolc
+compiler.zksolc140.semver=1.4.0
+compiler.zksolc140.name=zksolc 1.4.0
 
 #################################
 #################################

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&solc
+compilers=&solc:&zksolc
 defaultCompiler=solc0821
 
 group.solc.compilers=solc036:solc0426:solc0517:solc0612:solc076:solc0821
@@ -23,6 +23,14 @@ compiler.solc076.name=solc 0.7.6
 compiler.solc0821.exe=/opt/compiler-explorer/solc-0.8.21/solc
 compiler.solc0821.semver=0.8.21
 compiler.solc0821.name=solc 0.8.21
+
+group.zksolc.compilers=zksolc141
+group.zksolc.compilerType=solidity-eravm
+group.zksolc.supportsBinary=false
+group.zksolc.instructionSet=eravm
+compiler.zksolc141.exe=/opt/compiler-explorer/zksolc-1.4.1/zksolc
+compiler.zksolc141.semver=1.4.1
+compiler.zksolc141.name=zksolc 1.4.1
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -9,7 +9,7 @@ compiler.solc.compilerType=solidity
 compiler.solc.instructionSet=evm
 compiler.solc.isSemVer=true
 
-compiler.zksolc.exe=zksolc
+compiler.zksolc.exe=/usr/bin/zksolc
 compiler.zksolc.semver=1.4.1
 compiler.zksolc.name=zksolc 1.4.1
 compiler.zksolc.compilerType=solidity-eravm

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -10,8 +10,8 @@ compiler.solc.instructionSet=evm
 compiler.solc.isSemVer=true
 
 compiler.zksolc.exe=/usr/bin/zksolc
-compiler.zksolc.semver=1.4.1
-compiler.zksolc.name=zksolc 1.4.1
+compiler.zksolc.semver=1.4.0
+compiler.zksolc.name=zksolc 1.4.0
 compiler.zksolc.compilerType=solidity-eravm
 compiler.zksolc.instructionSet=eravm
 compiler.zksolc.isSemVer=true

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -1,9 +1,20 @@
-compilers=/usr/bin/solc
+compilers=solc:zksolc
 compilerType=solidity
-supportsBinary=false
-instructionSet=evm
+defaultCompiler=solc
 
-isSemVer=true
+compiler.solc.exe=/usr/bin/solc
+compiler.solc.semver=0.8.21
+compiler.solc.name=solc 0.8.21
+compiler.solc.compilerType=solidity
+compiler.solc.instructionSet=evm
+compiler.solc.isSemVer=true
+
+compiler.zksolc.exe=zksolc
+compiler.zksolc.semver=1.4.1
+compiler.zksolc.name=zksolc 1.4.1
+compiler.zksolc.compilerType=solidity-eravm
+compiler.zksolc.instructionSet=eravm
+compiler.zksolc.isSemVer=true
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -112,6 +112,7 @@ export {RustCompiler} from './rust.js';
 export {ScalaCompiler} from './scala.js';
 export {SdccCompiler} from './sdcc.js';
 export {SolidityCompiler} from './solidity.js';
+export {SolidityEravmCompiler} from './solidity-eravm.js';
 export {SpiceCompiler} from './spice.js';
 export {SPIRVCompiler} from './spirv.js';
 export {SwiftCompiler} from './swift.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -877,6 +877,14 @@ export class RustParser extends BaseParser {
     }
 }
 
+export class ZksolcParser extends RustParser {
+    static override async parse(compiler) {
+        const options = await this.getOptions(compiler, '--help');
+        await this.setCompilerSettingsFromOptions(compiler, options);
+        return compiler;
+    }
+}
+
 export class MrustcParser extends BaseParser {
     static override async parse(compiler) {
         await this.getOptions(compiler, '--help');

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -155,6 +155,10 @@ export class InstructionSets {
                 target: [],
                 path: [],
             },
+            eravm: {
+                target: [],
+                path: [],
+            },
             mos6502: {
                 target: [],
                 path: [],


### PR DESCRIPTION
`zksolc` is the Solidity compiler of the zkSync L2 solution for Ethereum.

It introduces the new instruction set created by Matter Labs for the zkSync's zkEVM.

Dependencies:
1. The **zksolc** binary, which can be downloaded from [here](https://github.com/matter-labs/zksolc-bin) and put at `/usr/bin/zksolc` just like `solc`.
2. `solc`, which is called by `zksolc` via `$PATH` as a subprocess, and the `solc` is already expected to be at `/usr/bin/solc` by the Solidity integration.