### PR TITLE
Add special option for gccrs

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -161,6 +161,8 @@ compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
 group.rustgcc.compilerType=gccrs
 group.rustgcc.compilers=gccrs-snapshot
 group.rustgcc.groupName=Rust-GCC
+## needed, until its support is on-par with rustc (at some arbitrary version).
+group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
 
 group.rustccggcc.compilers=rustccggcc-master
 compiler.rustccggcc-master.exe=/opt/compiler-explorer/rustc-cg-gcc-master/bin/rustc


### PR DESCRIPTION
gccrs is still in heavy dev and to avoid anyone missing this crucial info, it has introduced a very explicit option and required option:

 -frust-incomplete-and-experimental-compiler-do-not-use

The compiler emits a very verbose error if this option is missing.

refs https://github.com/Rust-GCC/gccrs/pull/1540

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>