### PR TITLE
add: gcc bpf cross compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -885,7 +885,6 @@ compiler.bpfg1220.exe=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin
 compiler.bpfg1220.semver=12.2.0
 compiler.bpfg1220.objdumper=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.bpfg1220.demangler=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
-compiler.bpfg1220.name=bpf 12.2.0
 
 ###############################
 # Cross for SPARC

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -861,13 +861,31 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64:&c6x:&sparc:&sparc64:&sparcleon
+group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64:&c6x:&sparc:&sparc64:&sparcleon:&bpf
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
 group.cross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.cross.licenseName=GNU General Public License
 group.cross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
+###############################
+# Cross for BPF
+group.bpf.compilers=&gccbpf
+
+# GCC for BPF
+group.gccbpf.compilers=bpfg1220
+group.gccbpf.supportsBinary=true
+group.gccbpf.supportsExecute=false
+group.gccbpf.baseName=BPF gcc
+group.gccbpf.groupName=BPF GCC
+group.gccbpf.isSemVer=true
+
+compiler.bpfg1220.exe=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-g++
+compiler.bpfg1220.semver=12.2.0
+compiler.bpfg1220.objdumper=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.bpfg1220.demangler=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.bpfg1220.name=bpf 12.2.0
 
 ###############################
 # Cross for SPARC

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -874,17 +874,17 @@ group.cross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a
 group.bpf.compilers=&gccbpf
 
 # GCC for BPF
-group.gccbpf.compilers=bpfg1220
+group.gccbpf.compilers=bpfgtrunk
 group.gccbpf.supportsBinary=true
 group.gccbpf.supportsExecute=false
 group.gccbpf.baseName=BPF gcc
 group.gccbpf.groupName=BPF GCC
 group.gccbpf.isSemVer=true
 
-compiler.bpfg1220.exe=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-g++
-compiler.bpfg1220.semver=12.2.0
-compiler.bpfg1220.objdumper=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
-compiler.bpfg1220.demangler=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.bpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-g++
+compiler.bpfgtrunk.semver=trunk
+compiler.bpfgtrunk.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.bpfgtrunk.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 ###############################
 # Cross for SPARC

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -800,12 +800,30 @@ compiler.cicx202221.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x:&csparc:&csparc64:&csparcleon
+group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x:&csparc:&csparc64:&csparcleon:&cbpf
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 group.ccross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.ccross.licenseName=GNU General Public License
 group.ccross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
+###############################
+# Cross for BPF
+group.cbpf.compilers=&cgccbpf
+
+# GCC for BPF
+group.cgccbpf.compilers=cbpfg1220
+group.cgccbpf.supportsBinary=true
+group.cgccbpf.supportsExecute=false
+group.cgccbpf.baseName=BPF gcc
+group.cgccbpf.groupName=BPF GCC
+group.cgccbpf.isSemVer=true
+
+compiler.cbpfg1220.exe=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.cbpfg1220.semver=12.2.0
+compiler.cbpfg1220.objdumper=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.cbpfg1220.demangler=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.cbpfg1220.name=bpf 12.2.0
 
 ###############################
 # Cross for SPARC

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -812,17 +812,17 @@ group.ccross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <
 group.cbpf.compilers=&cgccbpf
 
 # GCC for BPF
-group.cgccbpf.compilers=cbpfg1220
+group.cgccbpf.compilers=cbpfgtrunk
 group.cgccbpf.supportsBinary=true
 group.cgccbpf.supportsExecute=false
 group.cgccbpf.baseName=BPF gcc
 group.cgccbpf.groupName=BPF GCC
 group.cgccbpf.isSemVer=true
 
-compiler.cbpfg1220.exe=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-gcc
-compiler.cbpfg1220.semver=12.2.0
-compiler.cbpfg1220.objdumper=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
-compiler.cbpfg1220.demangler=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.cbpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.cbpfgtrunk.semver=trunk
+compiler.cbpfgtrunk.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.cbpfgtrunk.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 ###############################
 # Cross for SPARC

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -823,7 +823,6 @@ compiler.cbpfg1220.exe=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bi
 compiler.cbpfg1220.semver=12.2.0
 compiler.cbpfg1220.objdumper=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.cbpfg1220.demangler=/opt/compiler-explorer/bpf/gcc-12.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
-compiler.cbpfg1220.name=bpf 12.2.0
 
 ###############################
 # Cross for SPARC


### PR DESCRIPTION
Add GCC for C and C++, for BPF target.

fixes #4408

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>