### PR TITLE
Add more dart versions

### DIFF
--- a/etc/config/dart.amazon.properties
+++ b/etc/config/dart.amazon.properties
@@ -5,14 +5,14 @@ supportsExecute=true
 compilerType=dart
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 
-group.dart.compilers=dev:dart2185:dart2171:dart2161:dart2151:dart2144:dart2134:dart2124:dart2105:dart293:dart284
+group.dart.compilers=dartdev:dart2185:dart2171:dart2161:dart2151:dart2144:dart2134:dart2124:dart2105:dart293:dart284
 group.dart.isSemVer=true
 group.dart.baseName=Dart
 group.dart.groupName=Dart
 
-compiler.dev.semver=dev
-compiler.dev.exe=/opt/compiler-explorer/dart-dev/bin/dart
-compiler.dev.executionWrapper=/opt/compiler-explorer/dart-dev/bin/dartaotruntime
+compiler.dartdev.semver=dev
+compiler.dartdev.exe=/opt/compiler-explorer/dart-dev/bin/dart
+compiler.dartdev.executionWrapper=/opt/compiler-explorer/dart-dev/bin/dartaotruntime
 
 compiler.dart2185.semver=2.18.5
 compiler.dart2185.exe=/opt/compiler-explorer/dart-2.18.5/bin/dart

--- a/etc/config/dart.amazon.properties
+++ b/etc/config/dart.amazon.properties
@@ -5,10 +5,18 @@ supportsExecute=true
 compilerType=dart
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 
-group.dart.compilers=dart2171:dart2161:dart2151:dart2144:dart2134:dart2124:dart2105:dart293:dart284
+group.dart.compilers=dev:dart2185:dart2171:dart2161:dart2151:dart2144:dart2134:dart2124:dart2105:dart293:dart284
 group.dart.isSemVer=true
 group.dart.baseName=Dart
 group.dart.groupName=Dart
+
+compiler.dev.semver=dev
+compiler.dev.exe=/opt/compiler-explorer/dart-dev/bin/dart
+compiler.dev.executionWrapper=/opt/compiler-explorer/dart-dev/bin/dartaotruntime
+
+compiler.dart2185.semver=2.18.5
+compiler.dart2185.exe=/opt/compiler-explorer/dart-2.18.5/bin/dart
+compiler.dart2185.executionWrapper=/opt/compiler-explorer/dart-2.18.5/bin/dartaotruntime
 
 compiler.dart2171.semver=2.17.1
 compiler.dart2171.exe=/opt/compiler-explorer/dart-2.17.1/bin/dart


### PR DESCRIPTION
Infra PR: https://github.com/compiler-explorer/infra/pull/895

Adds dart version 2.18.5 (I think it makes sense not to include all patch versions) and the latest dev channel build (currently version 3.0).