### PR TITLE
Support patched clang for faster opt-view

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -350,6 +350,7 @@ group.clangx86trunk.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-li
 
 compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.clang_trunk.semver=(trunk)
+compiler.clang_trunk.debugPatched=true
 compiler.clang_assertions_trunk.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
 compiler.clang_assertions_trunk.semver=(assertions trunk)
 compiler.clang_concepts.exe=/opt/compiler-explorer/clang-concepts-trunk/bin/clang++

--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -243,6 +243,7 @@ export class CompilerFinder {
             versionRe: props('versionRe'),
             explicitVersion: props('explicitVersion'),
             compilerType: props('compilerType', ''),
+            debugPatched: props('debugPatched', false),
             demangler: demangler,
             demanglerType: props('demanglerType', ''),
             nvdisasm: props('nvdisasm', ''),

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -38,6 +38,7 @@ export type CompilerInfo = {
     versionRe?: string;
     explicitVersion?: string;
     compilerType: string;
+    debugPatched: boolean;
     demangler: string;
     demanglerType: string;
     objdumper: string;


### PR DESCRIPTION
`--debug-to-stdout` is currently the parameter name to change the llvm ir pass output to (buffered) stdout instead of the default unbuffer stderr

Speeds up opt pipeline view from 12+ seconds to 4-5ish seconds.

requires this to be patched into llvm https://github.com/llvm/llvm-project/compare/main...compiler-explorer:llvm-project:dbg-to-stdout?expand=1