### PR TITLE
Don't try and hack the compilation results

### DIFF
--- a/etc/config/carbon.defaults.properties
+++ b/etc/config/carbon.defaults.properties
@@ -6,7 +6,7 @@ needsMulti=false
 supportsExecute=false
 supportsBinary=false
 
-compiler.carbon-trunkdef.exe=todo-default-path
+compiler.carbon-trunkdef.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon-explorer
 compiler.carbon-trunkdef.name=Explorer (trunk)
 compiler.carbon-trunkdef.alias=carbon-trunk
 

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2324,6 +2324,8 @@ export class BaseCompiler implements ICompiler {
 
         if (!backendOptions.skipPopArgs) result.popularArguments = this.possibleArguments.getPopularArguments(options);
 
+        result = this.postCompilationPreCacheHook(result);
+
         if (result.okToCache) {
             await this.env.cachePut(key, result);
         }
@@ -2335,6 +2337,10 @@ export class BaseCompiler implements ICompiler {
                 this.doTempfolderCleanup(result.execResult.buildResult);
             }
         }
+        return result;
+    }
+
+    postCompilationPreCacheHook(result: CompilationResult): CompilationResult {
         return result;
     }
 

--- a/lib/compilers/carbon.ts
+++ b/lib/compilers/carbon.ts
@@ -23,8 +23,10 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces';
+import {CompilationResult} from '../../types/compilation/compilation.interfaces';
 import {CompilerInfo} from '../../types/compiler.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {ResultLine} from '../../types/resultline/resultline.interfaces';
 import {BaseCompiler} from '../base-compiler';
 
 import {BaseParser} from './argument-parsers';
@@ -65,41 +67,33 @@ export class CarbonCompiler extends BaseCompiler {
         );
     }
 
-    override async afterCompilation(
-        result,
-        doExecute,
-        key,
-        executeParameters,
-        tools,
-        backendOptions,
-        filters,
-        options,
-        optOutput,
-        customBuildPath,
-    ) {
-        result = await super.afterCompilation(
-            result,
-            doExecute,
-            key,
-            executeParameters,
-            tools,
-            backendOptions,
-            filters,
-            options,
-            optOutput,
-            customBuildPath,
-        );
+    lastLine(lines?: ResultLine[]): string {
+        if (!lines) return '';
+        const lastLine = lines.at(-1);
+        if (!lastLine) return '';
+        return lastLine.text;
+    }
+
+    override postCompilationPreCacheHook(result: CompilationResult): CompilationResult {
         if (result.code === 0) {
             // Hook to parse out the "result: 123" line at the end of the interpreted execution run.
             const re = /^result: (\d+)$/;
-            const match = re.exec(result.asm.at(-1).text);
+            const match = re.exec(this.lastLine(result.asm));
             const code = match ? parseInt(match[1]) : -1;
             result.execResult = {
                 stdout: result.stdout,
                 stderr: [],
                 code: code,
                 didExecute: true,
-                buildResult: {code: 0},
+                buildResult: {
+                    code: 0,
+                    timedOut: false,
+                    stdout: [],
+                    stderr: [],
+                    downloads: [],
+                    executableFilename: '',
+                    compilationOptions: [],
+                },
             };
             result.stdout = [];
         }

--- a/lib/compilers/carbon.ts
+++ b/lib/compilers/carbon.ts
@@ -68,10 +68,8 @@ export class CarbonCompiler extends BaseCompiler {
     }
 
     lastLine(lines?: ResultLine[]): string {
-        if (!lines) return '';
-        const lastLine = lines.at(-1);
-        if (!lastLine) return '';
-        return lastLine.text;
+        if (!lines || lines.length === 0) return '';
+        return (lines.at(-1) as ResultLine).text;
     }
 
     override postCompilationPreCacheHook(result: CompilationResult): CompilationResult {

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -130,6 +130,9 @@ export type BuildResult = CompilationResult & {
     downloads: BuildEnvDownloadInfo[];
     executableFilename: string;
     compilationOptions: string[];
+    stdout: ResultLine[];
+    stderr: ResultLine[];
+    code: number;
 };
 
 export type BuildStep = BasicExecutionResult & {


### PR DESCRIPTION
Carbon tried to synthesize "having run" by overriding and hacking a result routine...but did so _after_ it had been cached. So cached results were broken, but live results not.

This "fixes" by adding a post-compilation, but pre-cache hook and uses that instead. Naming is terrible.

I also took the time to fix the `CompilationResult`'s `buildResult`

Closes #4426

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
