### PR TITLE
Makefile: Split run into new prebuild and run-only targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,19 @@ pre-commit: $(NODE_MODULES) test-min lint
 clean:  ## Cleans up everything
 	rm -rf node_modules .*-updated .*-bin out
 
-.PHONY: run
-run: prereqs  ## Runs the site like it runs in production
+.PHONY: prebuild
+prebuild: prereqs
 	$(NPM) run webpack
 	$(NPM) run ts-compile
+
+.PHONY: run-only
+run-only: node-installed  ## Runs the site like it runs in production without building it
 	env NODE_ENV=production $(NODE) $(NODE_ARGS) -r esm ./out/dist/app.js --webpackContent ./out/webpack/static $(EXTRA_ARGS)
+
+.PHONY: run
+run:  ## Runs the site like it runs in production
+	$(MAKE) prebuild
+	$(MAKE) run-only
 
 .PHONY: dev
 dev: prereqs ## Runs the site as a developer; including live reload support and installation of git hooks


### PR DESCRIPTION
This provides a simple interface for build scripts that want to pre-run the webpack and ts-compile steps (e.g. when producing a container image) ahead of time rather, without requiring them to copy the current set of commands needed for each part and hope they don't change.

Fixes https://github.com/compiler-explorer/compiler-explorer/issues/3287
