### PR TITLE
Handle undefined theme in the site template widget

### DIFF
--- a/static/settings.ts
+++ b/static/settings.ts
@@ -64,7 +64,7 @@ export interface SiteSettings {
     showMinimap: boolean;
     showQuickSuggestions: boolean;
     tabWidth: number;
-    theme: Themes;
+    theme: Themes | undefined;
     useCustomContextMenu: boolean;
     useSpaces: boolean;
     useVim: boolean;

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -155,7 +155,7 @@ export class Themer {
     }
 
     private onSettingsChange(newSettings: SiteSettings) {
-        const newTheme = newSettings.theme in themes ? themes[newSettings.theme] : themes.default;
+        const newTheme = newSettings.theme && newSettings.theme in themes ? themes[newSettings.theme] : themes.default;
         if (!newTheme.monaco) newTheme.monaco = 'vs';
         this.setTheme(newTheme);
     }

--- a/static/widgets/site-templates-widget.ts
+++ b/static/widgets/site-templates-widget.ts
@@ -48,7 +48,8 @@ class SiteTemplatesWidget {
     getCurrentTheme() {
         const theme = Settings.getStoredSettings()['theme'];
         if (!theme) {
-            return 'default'; // just default to dark if undefined, apparently this can happen
+            // apparently this can happen
+            return 'default';
         } else if (theme === 'system') {
             if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 return 'dark';

--- a/static/widgets/site-templates-widget.ts
+++ b/static/widgets/site-templates-widget.ts
@@ -47,7 +47,9 @@ class SiteTemplatesWidget {
     }
     getCurrentTheme() {
         const theme = Settings.getStoredSettings()['theme'];
-        if (theme === 'system') {
+        if (!theme) {
+            return 'default'; // just default to dark if undefined, apparently this can happen
+        } else if (theme === 'system') {
             if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 return 'dark';
             } else {


### PR DESCRIPTION
Apparently it's possible for the theme to be `undefined` which is causing errors like `Error: Cannot find module './LLVMIR.undefined.png'`, see COMPILER-EXPLORER-9D4 in sentry. Previously addressed a similar issue in #4107/#4108.