### PR TITLE
Fix binary lable issue

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1501,9 +1501,8 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                         },
                         id: address,
                         command: {
-                            id: address,
                             title: obj.opcodes.join(' '),
-                        },
+                        } as any, // This any cast fixes a bug
                     });
                 }
             });


### PR DESCRIPTION
This fixes the the bug with the hex labels being colored blue (in light mode they look fine until you hover)
![image](https://user-images.githubusercontent.com/51220084/208313335-3e308164-3bc2-46df-9a56-aa1c6e238b0e.png)

They are also clickable, but when you click them they error:
![image](https://user-images.githubusercontent.com/51220084/208313381-a3e3a47f-5d0f-45d4-b3b4-6f2d01d3b05a.png)

I think this has come up in sentry, I'll have to look for which issue.

This was an inadvertent change during the ts conversion, [`monaco.languages.Command`][1] expects an `id` which we didn't use to pass. Passing it makes the code lens decorations clickable.

[1]: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.languages.Command.html