### PR TITLE
Mark Assembly compilers cfg-able

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2386,7 +2386,7 @@ export class BaseCompiler implements ICompiler {
         return output;
     }
 
-    couldSupportASTDump(version) {
+    couldSupportASTDump(version: string) {
         const versionRegex = /version (\d+.\d+)/;
         const versionMatch = versionRegex.exec(version);
 
@@ -2398,7 +2398,7 @@ export class BaseCompiler implements ICompiler {
         return false;
     }
 
-    isCfgCompiler(compilerVersion) {
+    isCfgCompiler(compilerVersion: string) {
         return compilerVersion.includes('clang') || compilerVersion.match(/^([\w-]*-)?g((\+\+)|(cc)|(dc))/g) !== null;
     }
 

--- a/lib/compilers/assembly.ts
+++ b/lib/compilers/assembly.ts
@@ -185,4 +185,8 @@ export class AssemblyCompiler extends BaseCompiler {
     override getObjdumpOutputFilename(defaultOutputFilename) {
         return this.getGeneratedOutputFilename(defaultOutputFilename);
     }
+
+    override isCfgCompiler(/* compilerVersion */) {
+        return true;
+    }
 }

--- a/lib/compilers/beebasm.ts
+++ b/lib/compilers/beebasm.ts
@@ -101,4 +101,8 @@ export class BeebAsmCompiler extends BaseCompiler {
 
         return result;
     }
+
+    override isCfgCompiler(/*compilerVersion: string*/): boolean {
+        return true;
+    }
 }


### PR DESCRIPTION
I think this should be enough for most compilers under the assembly language that would have good support out-of-the-box
For #4399 
