### PR TITLE
Fix type of tool id

### DIFF
--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -151,13 +151,13 @@ export type EventMap = {
     // TODO: There are no emitters for this event
     selectLine: (editorId: number, lineNumber: number) => void;
     settingsChange: (newSettings: SiteSettings) => void;
-    setToolInput: (compilerId: number, toolId: number, string: string) => void;
+    setToolInput: (compilerId: number, toolId: string, string: string) => void;
     shown: () => void;
     themeChange: (newTheme: Theme | null) => void;
     toolClosed: (compilerId: number, toolState: unknown) => void;
-    toolInputChange: (compilerId: number, toolId: number, input: string) => void;
-    toolInputViewClosed: (compilerId: number, toolId: number, input: string) => void;
-    toolInputViewCloseRequest: (compilerId: number, toolId: number) => void;
+    toolInputChange: (compilerId: number, toolId: string, input: string) => void;
+    toolInputViewClosed: (compilerId: number, toolId: string, input: string) => void;
+    toolInputViewCloseRequest: (compilerId: number, toolId: string) => void;
     toolOpened: (compilerId: number, toolState: unknown) => void;
     toolSettingsChange: (compilerId: number) => void;
     treeClose: (treeId: number) => void;

--- a/static/panes/tool-input-view.interfaces.ts
+++ b/static/panes/tool-input-view.interfaces.ts
@@ -23,6 +23,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 export interface ToolInputViewState {
-    toolId: number;
+    toolId: string;
     toolName: string;
 }

--- a/static/panes/tool-input-view.ts
+++ b/static/panes/tool-input-view.ts
@@ -32,10 +32,9 @@ import {Container} from 'golden-layout';
 import {MonacoPaneState} from './pane.interfaces';
 import {Hub} from '../hub';
 import {ToolInputViewState} from './tool-input-view.interfaces';
-import {Settings} from '../settings';
 
 export class ToolInputView extends MonacoPane<monaco.editor.IStandaloneCodeEditor, ToolInputViewState> {
-    _toolId: number;
+    _toolId: string;
     _toolName: string;
     shouldSetSelectionInitially: boolean;
     debouncedEmitChange: (() => void) & _.Cancelable;


### PR DESCRIPTION
Observed through the debugger it seems the tool id is a `string`, which leads to all sorts of downstream complaints comparing strings to ints when converting tools.js to ts (see #4166)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
