### PR TITLE
Separate shareable tool type from server ITool

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -76,8 +76,9 @@ import {IAsmParser} from './parsers/asm-parser.interfaces';
 import {LlvmPassDumpParser} from './parsers/llvm-pass-dump-parser';
 import {PropertyGetter} from './properties.interfaces';
 import {getToolchainPath} from './toolchain-utils';
-import {Tool, ToolResult, ToolTypeKey} from './tooling/base-tool.interface';
+import {ITool, ToolResult} from './tooling/base-tool.interface';
 import * as utils from './utils';
+import {Tool, ToolTypeKey} from '../types/tool.interfaces';
 
 export class BaseCompiler implements ICompiler {
     protected compiler: CompilerInfo & Record<string, any>; // TODO: Some missing types still present in Compiler type
@@ -96,7 +97,7 @@ export class BaseCompiler implements ICompiler {
     protected llvmAst: LlvmAstParser;
     protected toolchainPath: any;
     public possibleArguments: CompilerArguments;
-    protected possibleTools: Tool[];
+    protected possibleTools: ITool[];
     protected demanglerClass: any;
     protected objdumperClass: any;
     public outputFilebase: string;
@@ -147,7 +148,7 @@ export class BaseCompiler implements ICompiler {
         this.toolchainPath = getToolchainPath(this.compiler.exe, this.compiler.options);
 
         this.possibleArguments = new CompilerArguments(this.compiler.id);
-        this.possibleTools = _.values(compilerInfo.tools);
+        this.possibleTools = _.values(compilerInfo.tools) as ITool[];
         const demanglerExe = this.compiler.demangler;
         if (demanglerExe && this.compiler.demanglerType) {
             this.demanglerClass = getDemanglerTypeByKey(this.compiler.demanglerType);
@@ -1361,7 +1362,7 @@ export class BaseCompiler implements ICompiler {
         if (tools) {
             for (const tool of tools) {
                 const matches = this.possibleTools.find(possibleTool => {
-                    return possibleTool.getId() === tool.id && possibleTool.getType() === type;
+                    return possibleTool.id === tool.id && possibleTool.type === type;
                 });
 
                 if (matches) {

--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -36,8 +36,8 @@ import {CompilerProps} from './properties';
 import {PropertyGetter, PropertyValue} from './properties.interfaces';
 import {Source} from './sources';
 import {BaseTool, getToolTypeByKey} from './tooling';
-import {ToolTypeKey} from './tooling/base-tool.interface';
 import {asSafeVer, getHash, splitArguments, splitIntoArray} from './utils';
+import {ToolTypeKey} from '../types/tool.interfaces';
 
 // TODO: There is surely a better name for this type. Used both here and in the compiler finder.
 export type OptionHandlerArguments = {

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -35,7 +35,8 @@ import * as exec from '../exec';
 import {logger} from '../logger';
 import {parseOutput} from '../utils';
 
-import {Tool, ToolEnv, ToolInfo, ToolResult, ToolTypeKey} from './base-tool.interface';
+import {ITool, ToolEnv, ToolResult} from './base-tool.interface';
+import {ToolInfo, ToolTypeKey} from '../../types/tool.interfaces';
 
 const toolCounter = new PromClient.Counter({
     name: 'tool_invocations_total',
@@ -43,23 +44,19 @@ const toolCounter = new PromClient.Counter({
     labelNames: ['language', 'name'],
 });
 
-export class BaseTool implements Tool {
+export class BaseTool implements ITool {
     public readonly tool: ToolInfo;
     private env: ToolEnv;
     protected addOptionsToToolArgs = true;
+    public readonly id: string;
+    public readonly type: string;
 
     constructor(toolInfo: ToolInfo, env: ToolEnv) {
         this.tool = toolInfo;
         this.env = env;
         this.addOptionsToToolArgs = true;
-    }
-
-    getId() {
-        return this.tool.id;
-    }
-
-    getType(): ToolTypeKey {
-        return this.tool.type || 'independent';
+        this.id = toolInfo.id;
+        this.type = toolInfo.type || 'independent';
     }
 
     getUniqueFilePrefix() {

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -52,7 +52,6 @@ import {ComponentConfig, ToolViewState} from '../components.interfaces';
 import {FiledataPair} from '../multifile-service';
 import {LanguageLibs} from '../options.interfaces';
 import {GccDumpFiltersState, GccDumpViewSelectedPass} from './gccdump-view.interfaces';
-import {Tool} from '../../lib/tooling/base-tool.interface';
 import {AssemblyInstructionInfo} from '../../lib/asm-docs/base';
 import {PPOptions} from './pp-view.interfaces';
 import {CompilationStatus} from '../compiler-service.interfaces';
@@ -64,6 +63,7 @@ import * as utils from '../utils';
 import * as Sentry from '@sentry/browser';
 import {editor} from 'monaco-editor';
 import IEditorMouseEvent = editor.IEditorMouseEvent;
+import {Tool} from '../../types/tool.interfaces';
 
 const toolIcons = require.context('../../views/resources/logos', false, /\.(png|svg)$/);
 

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -515,6 +515,8 @@ describe('Options handler', () => {
         tools.should.deep.equal({
             fake: {
                 faketool: {
+                    id: 'faketool',
+                    type: 'independent',
                     addOptionsToToolArgs: true,
                     tool: {
                         args: undefined,
@@ -534,6 +536,8 @@ describe('Options handler', () => {
                     },
                 },
                 someothertool: {
+                    id: 'someothertool',
+                    type: 'independent',
                     addOptionsToToolArgs: true,
                     tool: {
                         args: undefined,

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -23,10 +23,10 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {CompilerArguments} from '../lib/compiler-arguments';
-import {Tool, ToolInfo} from '../lib/tooling/base-tool.interface';
 
 import {Language} from './languages.interfaces';
 import {Library} from './libraries/libraries.interfaces';
+import {Tool, ToolInfo} from './tool.interfaces';
 
 export type CompilerInfo = {
     id: string;

--- a/types/tool.interfaces.ts
+++ b/types/tool.interfaces.ts
@@ -22,39 +22,29 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {LanguageKey} from '../../types/languages.interfaces';
-import {Library} from '../../types/libraries/libraries.interfaces';
-import {ResultLine} from '../../types/resultline/resultline.interfaces';
-import {Tool, ToolInfo} from '../../types/tool.interfaces';
+import {LanguageKey} from './languages.interfaces';
 
-export type ToolEnv = {
-    ceProps: (key: string, defaultValue?: any) => string | boolean | number | undefined;
-    compilerProps: (key: string, defaultValue?: any) => string | boolean | number | undefined;
-};
+export type ToolTypeKey = 'independent' | 'postcompilation';
 
-export type Artifact = {
-    content: string;
-    type: string;
-    name: string;
-    title: string;
-};
-
-export type ToolResult = {
+export type ToolInfo = {
     id: string;
     name?: string;
-    code: number;
-    languageId?: LanguageKey | 'stderr';
-    stderr: ResultLine[];
-    stdout: ResultLine[];
-    artifact?: Artifact;
+    type?: ToolTypeKey;
+    exe: string;
+    exclude: string[];
+    includeKey?: string;
+    options: string[];
+    args?: string;
+    languageId?: LanguageKey;
+    stdinHint?: string;
+    monacoStdin?: string;
+    icon?: string;
+    darkIcon?: string;
+    compilerLanguage: LanguageKey;
 };
 
-export interface ITool extends Tool {
-    runTool(
-        compilationInfo: Record<any, any>,
-        inputFilepath?: string,
-        args?: string[],
-        stdin?: string,
-        supportedLibraries?: Record<string, Library>,
-    ): Promise<ToolResult>;
-}
+export type Tool = {
+    readonly tool: ToolInfo;
+    readonly id: string;
+    readonly type: string;
+};


### PR DESCRIPTION
I realised we were using the "Tool" on both client and server, but the client only has the JSON-able data of Tool, not the interface/object Tool (now renamed to `ITool`).

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
