### PR TITLE
Fix #4469

### DIFF
--- a/lib/external-parsers/base.ts
+++ b/lib/external-parsers/base.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces';
 import {TypicalExecutionFunc, UnprocessedExecResult} from '../../types/execution/execution.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {logger} from '../logger';
 import {maskRootdir} from '../utils';
 
 import {IExternalParser} from './external-parser.interface';
@@ -22,6 +23,10 @@ export class ExternalParserBase implements IExternalParser {
         this.envInfo = envInfo;
         this.objdumperPath = compilerInfo.objdumper;
         this.parserPath = compilerInfo.externalparser.props('exe', '');
+        if (!fs.existsSync(this.parserPath)) {
+            logger.error(`External parser ${this.parserPath} does not exist`);
+            process.exit(1);
+        }
         this.execFunc = execFunc;
     }
 

--- a/lib/external-parsers/base.ts
+++ b/lib/external-parsers/base.ts
@@ -73,6 +73,9 @@ export class ExternalParserBase implements IExternalParser {
     }
 
     private parseAsmExecResult(execResult: UnprocessedExecResult): ParsedAsmResult {
+        if (execResult.code !== 0) {
+            throw new Error(`Internal error running asm parser: ${execResult.stdout}\n${execResult.stderr}`);
+        }
         const result = Object.assign({}, execResult, JSON.parse(execResult.stdout));
         delete result.stdout;
         delete result.stderr;


### PR DESCRIPTION
Errors now look like:

```
Internal Compiler Explorer error: Error: Internal error running asm parser:
./dump-and-parse.sh: line 4: /usr/local/bin/asm-parser: No such file or directory

    at CEAsmParser.parseAsmExecResult (/home/matthew/dev/ce/compiler-explorer/lib/external-parsers/base.ts:77:19)
    at CEAsmParser.objdumpAndParseAssembly (/home/matthew/dev/ce/compiler-explorer/lib/external-parsers/base.ts:101:21)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async DefaultCompiler.objdump (/home/matthew/dev/ce/compiler-explorer/lib/base-compiler.ts:414:31)
    at async Promise.all (index 0)
    at async DefaultCompiler.checkOutputFileAndDoPostProcess (/home/matthew/dev/ce/compiler-explorer/lib/base-compiler.ts:1356:16)
    at async /home/matthew/dev/ce/compiler-explorer/lib/base-compiler.ts:2236:41
    at async run (/home/matthew/dev/ce/compiler-explorer/node_modules/p-queue/dist/index.js:163:29)
Compiler returned: -1
```

which at least gives context on why the parsing failed.

Closes #4469