### PR TITLE
Type fixes for tools an compilation results

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -52,6 +52,7 @@ import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../types/feat
 import {Language} from '../types/languages.interfaces';
 import {Library, LibraryVersion, SelectedLibraryVersion} from '../types/libraries/libraries.interfaces';
 import {ResultLine} from '../types/resultline/resultline.interfaces';
+import {ToolResult, ToolTypeKey} from '../types/tool.interfaces';
 
 import {BuildEnvSetupBase, getBuildEnvTypeByKey} from './buildenvsetup';
 import {BuildEnvDownloadInfo} from './buildenvsetup/buildenv.interfaces';
@@ -76,9 +77,8 @@ import {IAsmParser} from './parsers/asm-parser.interfaces';
 import {LlvmPassDumpParser} from './parsers/llvm-pass-dump-parser';
 import {PropertyGetter} from './properties.interfaces';
 import {getToolchainPath} from './toolchain-utils';
-import {ITool, ToolResult} from './tooling/base-tool.interface';
+import {ITool} from './tooling/base-tool.interface';
 import * as utils from './utils';
-import {Tool, ToolTypeKey} from '../types/tool.interfaces';
 
 export class BaseCompiler implements ICompiler {
     protected compiler: CompilerInfo & Record<string, any>; // TODO: Some missing types still present in Compiler type

--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -30,6 +30,7 @@ import semverParser from 'semver';
 import _ from 'underscore';
 
 import {LanguageKey} from '../types/languages.interfaces';
+import {ToolTypeKey} from '../types/tool.interfaces';
 
 import {logger} from './logger';
 import {CompilerProps} from './properties';
@@ -37,7 +38,6 @@ import {PropertyGetter, PropertyValue} from './properties.interfaces';
 import {Source} from './sources';
 import {BaseTool, getToolTypeByKey} from './tooling';
 import {asSafeVer, getHash, splitArguments, splitIntoArray} from './utils';
-import {ToolTypeKey} from '../types/tool.interfaces';
 
 // TODO: There is surely a better name for this type. Used both here and in the compiler finder.
 export type OptionHandlerArguments = {

--- a/lib/tooling/base-tool.interface.ts
+++ b/lib/tooling/base-tool.interface.ts
@@ -22,31 +22,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {LanguageKey} from '../../types/languages.interfaces';
 import {Library} from '../../types/libraries/libraries.interfaces';
-import {ResultLine} from '../../types/resultline/resultline.interfaces';
-import {Tool, ToolInfo} from '../../types/tool.interfaces';
+import {Tool, ToolResult} from '../../types/tool.interfaces';
 
 export type ToolEnv = {
     ceProps: (key: string, defaultValue?: any) => string | boolean | number | undefined;
     compilerProps: (key: string, defaultValue?: any) => string | boolean | number | undefined;
-};
-
-export type Artifact = {
-    content: string;
-    type: string;
-    name: string;
-    title: string;
-};
-
-export type ToolResult = {
-    id: string;
-    name?: string;
-    code: number;
-    languageId?: LanguageKey | 'stderr';
-    stderr: ResultLine[];
-    stdout: ResultLine[];
-    artifact?: Artifact;
 };
 
 export interface ITool extends Tool {

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -31,12 +31,12 @@ import {ExecutionOptions} from '../../types/compilation/compilation.interfaces';
 import {UnprocessedExecResult} from '../../types/execution/execution.interfaces';
 import {Library, SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces';
 import {ResultLine} from '../../types/resultline/resultline.interfaces';
+import {ToolInfo, ToolResult, ToolTypeKey} from '../../types/tool.interfaces';
 import * as exec from '../exec';
 import {logger} from '../logger';
 import {parseOutput} from '../utils';
 
-import {ITool, ToolEnv, ToolResult} from './base-tool.interface';
-import {ToolInfo, ToolTypeKey} from '../../types/tool.interfaces';
+import {ITool, ToolEnv} from './base-tool.interface';
 
 const toolCounter = new PromClient.Counter({
     name: 'tool_invocations_total',

--- a/lib/tooling/compiler-dropin-tool.ts
+++ b/lib/tooling/compiler-dropin-tool.ts
@@ -25,11 +25,11 @@
 import _ from 'underscore';
 
 import {Library} from '../../types/libraries/libraries.interfaces';
+import {ToolResult} from '../../types/tool.interfaces';
 import {getToolchainPath} from '../toolchain-utils';
 import * as utils from '../utils';
 
 import {BaseTool} from './base-tool';
-import {ToolResult} from './base-tool.interface';
 
 export class CompilerDropinTool extends BaseTool {
     static get key() {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -36,7 +36,7 @@ import * as monacoVim from 'monaco-vim';
 import * as monacoConfig from '../monaco-config';
 import * as quickFixesHandler from '../quick-fixes-handler';
 import TomSelect from 'tom-select';
-import {Settings, SiteSettings} from '../settings';
+import {SiteSettings} from '../settings';
 import '../formatter-registry';
 import '../modes/_all';
 import {MonacoPane} from './pane';
@@ -1582,9 +1582,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
 
         let asm: ResultLine[] = [];
 
-        // @ts-expect-error: result has no property 'result'
         if (result.result && result.result.asm) {
-            // @ts-expect-error: result has no property 'result'
             asm = result.result.asm;
         } else if (result.asm) {
             asm = result.asm;

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -27,6 +27,7 @@ import {IAsmParser} from '../../lib/parsers/asm-parser.interfaces';
 import {CompilerInfo} from '../compiler.interfaces';
 import {BasicExecutionResult} from '../execution/execution.interfaces';
 import {ResultLine} from '../resultline/resultline.interfaces';
+import {ToolResult} from '../tool.interfaces';
 
 import {LLVMOptPipelineOutput} from './llvm-opt-pipeline-output.interfaces';
 
@@ -53,12 +54,13 @@ export type CompilationResult = {
     gnatDebugOutput?: ResultLine[];
     hasGnatDebugTreeOutput?: boolean;
     gnatDebugTreeOutput?: ResultLine[];
-    tools?: any;
+    tools?: ToolResult[];
     dirPath?: string;
     compilationOptions?: string[];
     downloads?: BuildEnvDownloadInfo[];
     gccDumpOutput?: any;
     languageId?: string;
+    result?: CompilationResult; // cmake inner result
 
     hasPpOutput?: boolean;
     ppOutput?: any;

--- a/types/tool.interfaces.ts
+++ b/types/tool.interfaces.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {LanguageKey} from './languages.interfaces';
+import {ResultLine} from './resultline/resultline.interfaces';
 
 export type ToolTypeKey = 'independent' | 'postcompilation';
 
@@ -47,4 +48,21 @@ export type Tool = {
     readonly tool: ToolInfo;
     readonly id: string;
     readonly type: string;
+};
+
+export type Artifact = {
+    content: string;
+    type: string;
+    name: string;
+    title: string;
+};
+
+export type ToolResult = {
+    id: string;
+    name?: string;
+    code: number;
+    languageId?: LanguageKey | 'stderr';
+    stderr: ResultLine[];
+    stdout: ResultLine[];
+    artifact?: Artifact;
 };


### PR DESCRIPTION
- Add the `result` inside the `CompilationResult`
- Move the ToolResult to types and use it in the `tools`