### PR TITLE
Avoid flash on pageload for System and Dark+ themes

### DIFF
--- a/views/_layout.pug
+++ b/views/_layout.pug
@@ -31,7 +31,8 @@ html(lang="en")
       | (function () {
       |   try {
       |     var settings = window.localStorage.getItem("!{localStoragePrefix}settings") || '{}';
-      |     var theme = JSON.parse(settings).theme || 'default';
+      |     var theme = JSON.parse(settings).theme;
+      |     if (theme !== 'default') theme = 'dark';
       |     document.documentElement.setAttribute('data-theme', theme);
       |   } catch (e) {
       |     document.documentElement.setAttribute('data-theme', 'default');


### PR DESCRIPTION
The logic to avoid the flash assumed only "default" or "dark" theme, so it was not ready for the new ones. Avoids white flashes by assuming that anything not "default" will be "dark"
Closes #4487 