### PR TITLE
Don't rely on git if .git isn't there during build

### DIFF
--- a/etc/scripts/parsed_pug_file.js
+++ b/etc/scripts/parsed_pug_file.js
@@ -12,7 +12,7 @@ const expectedHashes = {
     privacy: '014c73c485dd3625',
 };
 
-function execGit(command) {
+function _execGit(command) {
     const gitResult = execSync(command);
     if (!gitResult) {
         throw new Error(`Failed to execute ${command}`);
@@ -20,17 +20,22 @@ function execGit(command) {
     return gitResult.toString();
 }
 
-const gitChanges = execGit('git log --date=local --after="3 months ago" "--grep=(#[0-9]*)" --oneline')
-    .split('\n')
-    .map(line => line.match(/(?<hash>\w+) (?<description>.*)/))
-    .filter(x => x)
-    .map(match => match.groups);
-
 export default function(content) {
     const filePath = this.resourcePath;
     const filename = path.basename(filePath, '.pug');
+    const options = this.getOptions();
+    if (!options.useGit) {
+        this.emitWarning(new Error(`Running without git: file contents for ${filePath} will be wrong`));
+    }
+    const execGit = options.useGit ? _execGit : () => 'no-git-available';
     const lastTime = execGit(`git log -1 --format=%cd "${filePath}"`).trimEnd();
     const lastCommit = execGit(`git log -1 --format=%h "${filePath}"`).trimEnd();
+    const gitChanges = execGit('git log --date=local --after="3 months ago" "--grep=(#[0-9]*)" --oneline')
+        .split('\n')
+        .map(line => line.match(/(?<hash>\w+) (?<description>.*)/))
+        .filter(x => x)
+        .map(match => match.groups);
+
     const compiled = pug.compile(content.toString(), {filename: filePath});
 
     // When calculating the hash we ignore the hard-to-predict values like lastTime and lastCommit, else every time
@@ -38,7 +43,7 @@ export default function(content) {
     const htmlTextForHash = compiled({gitChanges, lastTime:'some-last-time', lastCommit:'some-last-commit'});
     const hashDigest = getHashDigest(htmlTextForHash, 'sha256', 'hex', 16);
     const expectedHash = expectedHashes[filename];
-    if (expectedHash !== undefined && expectedHash !== hashDigest) {
+    if (options.useGit && expectedHash !== undefined && expectedHash !== hashDigest) {
         this.emitError(
             new Error(
                 `Hash for file '${filePath}' changed from '${expectedHash}' to '${hashDigest}'` +

--- a/webpack.config.esm.js
+++ b/webpack.config.esm.js
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
 
@@ -41,6 +42,7 @@ console.log(`webpack config for ${isDev ? 'development' : 'production'}.`);
 
 const distPath = path.resolve(__dirname, 'out', 'dist');
 const staticPath = path.resolve(__dirname, 'out', 'webpack', 'static');
+const hasGit = fs.existsSync(path.resolve(__dirname, '.git'));
 
 // Hack alert: due to a variety of issues, sometimes we need to change
 // the name here. Mostly it's things like webpack changes that affect
@@ -164,6 +166,9 @@ export default {
             {
                 test: /\.pug$/,
                 loader: './etc/scripts/parsed_pug_file.js',
+                options: {
+                    useGit: hasGit,
+                },
             },
             {
                 test: /\.ts$/,


### PR DESCRIPTION
If we don't have a `.git` directory during build, then don't try and run `git` commands to get e.g. history and last changed for policy files and changelog.

Closes #4497

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
