### PR TITLE
Jakt: Ensure cxx-compiler-path matches the compiler that compiled jakt

### DIFF
--- a/etc/config/jakt.amazon.properties
+++ b/etc/config/jakt.amazon.properties
@@ -16,5 +16,4 @@ licensePreamble=Copyright (c) 2022, JT, Andreas Kling. All rights reserved.
 
 compiler.selfhosted.exe=/opt/compiler-explorer/jakt-trunk/bin/jakt
 compiler.selfhosted.name=jakt (trunk)
-compiler.selfhosted.options=--runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/clang-trunk/bin/clang++
-compiler.selfhosted.alias=rustbased
+compiler.selfhosted.options=--runtime-path /opt/compiler-explorer/jakt-trunk/runtime --prettify-cpp-source --clang-format-path /opt/compiler-explorer/clang-trunk/bin/clang-format --dot-clang-format-path /opt/compiler-explorer/jakt-trunk/.clang-format --cxx-compiler-path /opt/compiler-explorer/gcc-12.1.0/bin/g++


### PR DESCRIPTION
The way that jakt calls out to a C++ compiler to compile the C++ source files it generates is sensitive to which compiler compiled its runtime library. Rather than using clang-trunk, use the same compiler that was used in misc-builder: gcc-12.1.0. This does cause a warning or two, as it seems gcc 12.1.0 doesn't implement [[unlikely]] yet, but that's better than not being able to link executables at all.

This issue will likely come up again if the compiler used in misc-builder to build the jakt compiler changes.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This will likely make jakt main work again on CE, after https://github.com/SerenityOS/jakt/pull/1298 is pulled in. The version that last built properly on the live site should also work after this change, it just won't be main :)
