### PR TITLE
display crossgen2 version in asm output

### DIFF
--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -1,19 +1,25 @@
-compilers=&csharpdef
+compilers=&csharp
 supportsBinary=true
 needsMulti=false
 compilerType=csharp
-defaultCompiler=dotnet7csharpdef
+defaultCompiler=dotnet700csharp
 
-group.csharpdef.compilers=dotnet6csharpdef:dotnet7csharpdef
+group.csharp.compilers=dotnettrunkcsharp:dotnet700csharp:dotnet6011csharp
 
-compiler.dotnet6csharpdef.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6csharpdef.name=.NET 6.0.403
-compiler.dotnet6csharpdef.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6csharpdef.buildConfig=Release
-compiler.dotnet6csharpdef.langVersion=latest
+compiler.dotnet6011csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
+compiler.dotnet6011csharp.name=.NET 6.0.403
+compiler.dotnet6011csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
+compiler.dotnet6011csharp.buildConfig=Release
+compiler.dotnet6011csharp.langVersion=latest
 
-compiler.dotnet7csharpdef.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet7csharpdef.name=.NET 7.0.100
-compiler.dotnet7csharpdef.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet7csharpdef.buildConfig=Release
-compiler.dotnet7csharpdef.langVersion=latest
+compiler.dotnet700csharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
+compiler.dotnet700csharp.name=.NET 7.0.100
+compiler.dotnet700csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
+compiler.dotnet700csharp.buildConfig=Release
+compiler.dotnet700csharp.langVersion=latest
+
+compiler.dotnettrunkcsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharp.name=.NET (main)
+compiler.dotnettrunkcsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharp.buildConfig=Release
+compiler.dotnettrunkcsharp.langVersion=preview

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -134,6 +134,7 @@ class DotNetCompiler extends BaseCompiler {
         // Some versions of .NET complain if they can't work out what the user's directory is. We force it to the output
         // directory here.
         execOptions.env.DOTNET_CLI_HOME = programDir;
+        execOptions.env.DOTNET_ROOT = path.join(this.clrBuildDir, '.dotnet');
         // Place nuget packages in the output directory.
         execOptions.env.NUGET_PACKAGES = path.join(programDir, '.nuget');
         // Try to be less chatty


### PR DESCRIPTION
follow up https://github.com/compiler-explorer/misc-builder/pull/55

* the version shown in the info box
    <img width="400" alt="image" src="https://user-images.githubusercontent.com/83082615/210156894-b9912586-7948-4a97-a15e-2974ee9deb67.png">
    is sdk version used by dotnet/runtime repo. it updates once or twice a year. it is not very useful for user interested in assembly codegen...
* comment added here is for crossgen2 version, which has useful version+commit info of dotnet/runtime repo
    <img width="1719" alt="image" src="https://user-images.githubusercontent.com/83082615/210156862-c7d8b09b-841f-4295-b208-cb5a913e51e3.png">

dotnet 6 and 7 will also show the version once there is a new deployment. for now they are showing `7.0.0-dev` and `<unknown version>` respectively