### PR TITLE
dont query conan if library is autodetect

### DIFF
--- a/lib/buildenvsetup/ceconan.ts
+++ b/lib/buildenvsetup/ceconan.ts
@@ -265,7 +265,11 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
     }
 
     hasBinariesToLink(details) {
-        return details.libpath.length === 0 && (details.staticliblink.length > 0 || details.liblink.length > 0);
+        return (
+            details.libpath.length === 0 &&
+            (details.staticliblink.length > 0 || details.liblink.length > 0) &&
+            details.version !== 'autodetect'
+        );
     }
 
     hasAtLeastOneBinaryToLink(libraryDetails) {


### PR DESCRIPTION
To fix issue where conan server is being spammed with /v1/conans/gnulibbacktrace/autodetect/gnulibbacktrace/autodetect/search which obviously doesn't exist