### PR TITLE
Handle zero-sized files

### DIFF
--- a/lib/buildenvsetup/ceconan.ts
+++ b/lib/buildenvsetup/ceconan.ts
@@ -175,12 +175,20 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
                 encoding: null,
             };
 
-            request(packageUrl, settings)
+            // https://stackoverflow.com/questions/49277790/how-to-pipe-npm-request-only-if-http-200-is-received
+            const req = request(packageUrl, settings)
                 .on('error', error => {
                     logger.error(`Error in request handling: ${error}`);
                     reject(error);
                 })
-                .pipe(gunzip);
+                .on('response', async res => {
+                    if (res.statusCode === 200) {
+                        req.pipe(gunzip);
+                    } else {
+                        logger.error(`Error requesting package from conan: ${res.statusCode}`);
+                        reject(new Error(`Unable to request library from conan: ${res.statusCode}`));
+                    }
+                });
         });
     }
 

--- a/lib/buildenvsetup/ceconan.ts
+++ b/lib/buildenvsetup/ceconan.ts
@@ -185,7 +185,7 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
                     if (res.statusCode === 200) {
                         req.pipe(gunzip);
                     } else {
-                        logger.error(`Error requesting package from conan: ${res.statusCode}`);
+                        logger.error(`Error requesting package from conan: ${res.statusCode} for ${packageUrl}`);
                         reject(new Error(`Unable to request library from conan: ${res.statusCode}`));
                     }
                 });

--- a/lib/buildenvsetup/ceconan.ts
+++ b/lib/buildenvsetup/ceconan.ts
@@ -181,7 +181,7 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
                     logger.error(`Error in request handling: ${error}`);
                     reject(error);
                 })
-                .on('response', async res => {
+                .on('response', res => {
                     if (res.statusCode === 200) {
                         req.pipe(gunzip);
                     } else {


### PR DESCRIPTION
Handle zero-sized files

It appears that having a zero-sized file won't call our `next()` handler which means we wedge forever and eventually time out.

This is a workaround. Upstream issue filed as https://github.com/mafintosh/tar-stream/issues/145
