### PR TITLE
Show error when not loading a zip through the IDE - Project - load from file

### DIFF
--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -573,6 +573,11 @@ export class Tree {
     }
 
     private async openZipFile(htmlfile) {
+        if (!htmlfile.name.toLowerCase().endsWith('.zip')) {
+            this.alertSystem.alert('Load project file', 'Projects can only be loaded from .zip files');
+            return;
+        }
+
         this.multifileService.forEachFile((file: MultifileFile) => {
             this.removeFile(file.fileId);
         });


### PR DESCRIPTION
Does not solve issues with corrupt .zip files (will result in console errors), but is a thing for in case people think they can load any file with the option