### PR TITLE
fix: use Kalray's ACB 4.11.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1306,6 +1306,7 @@ compiler.kvxg1031_v4111.exe=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-g+
 compiler.kvxg1031_v4111.name=KVX ACB 4.11.1 (GCC 10.3.1)
 compiler.kvxg1031_v4111.semver=4.11.1
 compiler.kvxg1031_v4111.objdumper=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-objdump
+compiler.kvxg1031_v4111.alias=kvxg1031_v4110
 
 compiler.kvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-g++
 compiler.kvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1296,16 +1296,16 @@ compiler.arm64gtrunk.semver=trunk
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=kvxg1031_v4110:kvxg1031_v4100:kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
+group.kalray.compilers=kvxg1031_v4111:kvxg1031_v4100:kvxg941_v490:kvxg941_v480:kvxg941_v460:kvxg750_v440:kvxg750_v430:kvxg750_v420:kvxg750_v410:kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
 
 # kvx versions are different from the GCC they wrap
 
-compiler.kvxg1031_v4110.exe=/opt/compiler-explorer/kvx/acb-4.11.0/bin/kvx-elf-g++
-compiler.kvxg1031_v4110.name=KVX ACB 4.11.0 (GCC 10.3.1)
-compiler.kvxg1031_v4110.semver=4.11.0
-compiler.kvxg1031_v4110.objdumper=/opt/compiler-explorer/kvx/acb-4.11.0/bin/kvx-elf-objdump
+compiler.kvxg1031_v4111.exe=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-g++
+compiler.kvxg1031_v4111.name=KVX ACB 4.11.1 (GCC 10.3.1)
+compiler.kvxg1031_v4111.semver=4.11.1
+compiler.kvxg1031_v4111.objdumper=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-objdump
 
 compiler.kvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-g++
 compiler.kvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1250,15 +1250,15 @@ compiler.carm64gm101a1.semver=10.1.0
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ckvxg1031_v4110:ckvxg1031_v4100:ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg1031_v4111:ckvxg1031_v4100:ckvxg941_v490:ckvxg941_v480:ckvxg941_v460:ckvxg750_v440:ckvxg750_v430:ckvxg750_v420:ckvxg750_v410:ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
 # kvx versions are different from the GCC they wrap
 
-compiler.ckvxg1031_v4110.exe=/opt/compiler-explorer/kvx/acb-4.11.0/bin/kvx-elf-gcc
-compiler.ckvxg1031_v4110.name=KVX ACB 4.11.0 (GCC 10.3.1)
-compiler.ckvxg1031_v4110.semver=4.11.0
-compiler.ckvxg1031_v4110.objdumper=/opt/compiler-explorer/kvx/acb-4.11.0/bin/kvx-elf-objdump
+compiler.ckvxg1031_v4111.exe=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-gcc
+compiler.ckvxg1031_v4111.name=KVX ACB 4.11.1 (GCC 10.3.1)
+compiler.ckvxg1031_v4111.semver=4.11.1
+compiler.ckvxg1031_v4111.objdumper=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-objdump
 
 compiler.ckvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-gcc
 compiler.ckvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1259,6 +1259,7 @@ compiler.ckvxg1031_v4111.exe=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-g
 compiler.ckvxg1031_v4111.name=KVX ACB 4.11.1 (GCC 10.3.1)
 compiler.ckvxg1031_v4111.semver=4.11.1
 compiler.ckvxg1031_v4111.objdumper=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-objdump
+compiler.ckvxg1031_v4111.alias=ckvxg1031_v4110
 
 compiler.ckvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-gcc
 compiler.ckvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)


### PR DESCRIPTION
4.11.0 as published on github is not compatible with ubuntu 18.04. Use their new release build for 20.04 instead of one for 22.04.

We don't usually remove a compiler to preserve existing links. But ACB 4.11.0 has never been working, so we can forget about it.

fixes #4523

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>