### PR TITLE
fix: empty exclude value in option file badly handled

### DIFF
--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -73,6 +73,12 @@ export class BaseTool implements ITool {
             }
             // Even if the include key is truthy, we fall back to the exclusion list.
         }
+
+        // an empty value (e.g. 'tool.foo.exclude=') yields a single empty
+        // string in the array, not an empty array.
+        if (this.tool.exclude.length == 1 && this.tool.exclude[0] == "")
+            return false;
+
         return this.tool.exclude.find(excl => compilerId.includes(excl)) !== undefined;
     }
 

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -76,7 +76,7 @@ export class BaseTool implements ITool {
 
         // an empty value (e.g. 'tool.foo.exclude=') yields a single empty
         // string in the array, not an empty array.
-        if (this.tool.exclude.length == 1 && this.tool.exclude[0] === '')
+        if (this.tool.exclude.length === 1 && this.tool.exclude[0] === '')
             return false;
 
         return this.tool.exclude.find(excl => compilerId.includes(excl)) !== undefined;

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -76,7 +76,7 @@ export class BaseTool implements ITool {
 
         // an empty value (e.g. 'tool.foo.exclude=') yields a single empty
         // string in the array, not an empty array.
-        if (this.tool.exclude.length == 1 && this.tool.exclude[0] == "")
+        if (this.tool.exclude.length == 1 && this.tool.exclude[0] === '')
             return false;
 
         return this.tool.exclude.find(excl => compilerId.includes(excl)) !== undefined;


### PR DESCRIPTION
An empty value for exclude prop for tool ends up being interpreted as a * wildcard. The variable is a string[] and is set to a single empty string.

fixes #4544

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>