### PR TITLE
bpf: use gcc for linking BPF binaries

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -885,6 +885,7 @@ group.clangbpf.isSemVer=true
 group.clangbpf.options=-target bpf
 group.clangbpf.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.clangbpf.objdumperType=llvm
+group.clangbpf.options=--gcc-toolchain=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/
 
 compiler.bpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.bpfclangtrunk.semver=(trunk)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -822,6 +822,7 @@ group.cclangbpf.isSemVer=true
 group.cclangbpf.options=-target bpf
 group.cclangbpf.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.cclangbpf.objdumperType=llvm
+group.cclangbpf.options=--gcc-toolchain=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/
 
 compiler.cbpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cbpfclangtrunk.semver=(trunk)


### PR DESCRIPTION
Use cross GCC for driving a link to binary.

refs #4408

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>