### PR TITLE
bpf: disable binary support for Clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -877,15 +877,14 @@ group.bpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bp
 
 # Clang for BPF
 group.clangbpf.compilers=bpfclangtrunk:bpfclang1500:bpfclang1400:bpfclang1300
-group.clangbpf.supportsBinary=true
+group.clangbpf.supportsBinary=false
 group.clangbpf.supportsExecute=false
-group.clangbpf.baseName=BPF CLANG
+group.clangbpf.baseName=BPF clang
 group.clangbpf.groupName=BPF CLANG
 group.clangbpf.isSemVer=true
 group.clangbpf.options=-target bpf
 group.clangbpf.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.clangbpf.objdumperType=llvm
-group.clangbpf.options=--gcc-toolchain=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/
 
 compiler.bpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.bpfclangtrunk.semver=(trunk)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -814,15 +814,14 @@ group.cbpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/b
 
 # Clang for BPF
 group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang1500:cbpfclang1400:cbpfclang1300
-group.cclangbpf.supportsBinary=true
+group.cclangbpf.supportsBinary=false
 group.cclangbpf.supportsExecute=false
-group.cclangbpf.baseName=BPF CLANG
+group.cclangbpf.baseName=BPF clang
 group.cclangbpf.groupName=BPF CLANG
 group.cclangbpf.isSemVer=true
 group.cclangbpf.options=-target bpf
 group.cclangbpf.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.cclangbpf.objdumperType=llvm
-group.cclangbpf.options=--gcc-toolchain=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/
 
 compiler.cbpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cbpfclangtrunk.semver=(trunk)


### PR DESCRIPTION
... until we have a fix for either:
 - calling gcc to drive the link
 - don't link to get an object file

Downcase CLANG name, no need to shout.

refs #4408

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>