### PR TITLE
Move emulation related fields to artifact system

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -52,7 +52,7 @@ import {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../types/feat
 import {Language} from '../types/languages.interfaces';
 import {Library, LibraryVersion, SelectedLibraryVersion} from '../types/libraries/libraries.interfaces';
 import {ResultLine} from '../types/resultline/resultline.interfaces';
-import {Tool, ToolResult, ToolTypeKey} from '../types/tool.interfaces';
+import {Artifact, ToolResult, ToolTypeKey} from '../types/tool.interfaces';
 
 import {BuildEnvSetupBase, getBuildEnvTypeByKey} from './buildenvsetup';
 import {BuildEnvDownloadInfo} from './buildenvsetup/buildenv.interfaces';
@@ -1401,6 +1401,21 @@ export class BaseCompiler implements ICompiler {
         } else {
             return [];
         }
+    }
+
+    async addArtifactToResult(result: CompilationResult, filepath: string, customType?: string, customTitle?: string) {
+        const file_buffer = await fs.readFile(filepath);
+
+        const artifact: Artifact = {
+            content: file_buffer.toString('base64'),
+            type: customType || 'application/octet-stream',
+            name: path.basename(filepath),
+            title: customTitle || path.basename(filepath),
+        };
+
+        if (!result.artifacts) result.artifacts = [];
+
+        result.artifacts.push(artifact);
     }
 
     protected async writeMultipleFiles(files, dirPath) {

--- a/lib/compilers/beebasm.ts
+++ b/lib/compilers/beebasm.ts
@@ -26,6 +26,7 @@ import path from 'path';
 
 import fs from 'fs-extra';
 
+import {ArtifactType} from '../../types/tool.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {AsmParserBeebAsm} from '../parsers/asm-parser-beebasm';
 import * as utils from '../utils';
@@ -76,9 +77,7 @@ export class BeebAsmCompiler extends BaseCompiler {
         if (result.code === 0 && options.includes('-v')) {
             const diskfile = path.join(dirPath, 'disk.ssd');
             if (await utils.fileExists(diskfile)) {
-                const file_buffer = await fs.readFile(diskfile);
-                const binary_base64 = file_buffer.toString('base64');
-                result.bbcdiskimage = binary_base64;
+                await this.addArtifactToResult(result, diskfile, ArtifactType.bbcdiskimage);
 
                 if (!hasBootOption) {
                     if (!result.hints) result.hints = [];

--- a/lib/compilers/cc65.ts
+++ b/lib/compilers/cc65.ts
@@ -29,6 +29,7 @@ import _ from 'underscore';
 
 import {CompilationResult} from '../../types/compilation/compilation.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {ArtifactType} from '../../types/tool.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {CC65AsmParser} from '../parsers/asm-parser-cc65';
 import * as utils from '../utils';
@@ -105,9 +106,7 @@ export class Cc65Compiler extends BaseCompiler {
         const dirPath = path.dirname(outputFilename);
         const nesFile = path.join(dirPath, 'example.nes');
         if (await utils.fileExists(nesFile)) {
-            const file_buffer = await fs.readFile(nesFile);
-            const binary_base64 = file_buffer.toString('base64');
-            result.jsnesrom = binary_base64;
+            await this.addArtifactToResult(res, nesFile, ArtifactType.nesrom);
         }
 
         return res;

--- a/lib/compilers/llvm-mos.ts
+++ b/lib/compilers/llvm-mos.ts
@@ -24,11 +24,11 @@
 
 import path from 'path';
 
-import fs from 'fs-extra';
 import _ from 'underscore';
 
 import {CompilationResult} from '../../types/compilation/compilation.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {ArtifactType} from '../../types/tool.interfaces';
 import * as utils from '../utils';
 
 import {ClangCompiler} from './clang';
@@ -78,9 +78,7 @@ export class LLVMMOSCompiler extends ClangCompiler {
             }
 
             if (await utils.fileExists(nesFile)) {
-                const file_buffer = await fs.readFile(nesFile);
-                const binary_base64 = file_buffer.toString('base64');
-                result.jsnesrom = binary_base64;
+                await this.addArtifactToResult(res, nesFile, ArtifactType.nesrom);
             }
         }
 

--- a/lib/compilers/z88dk.ts
+++ b/lib/compilers/z88dk.ts
@@ -28,6 +28,7 @@ import fs from 'fs-extra';
 
 import {ExecutionOptions} from '../../types/compilation/compilation.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
+import {ArtifactType} from '../../types/tool.interfaces';
 import {BaseCompiler} from '../base-compiler';
 import {logger} from '../logger';
 import {AsmParserZ88dk} from '../parsers/asm-parser-z88dk';
@@ -161,16 +162,12 @@ export class z88dkCompiler extends BaseCompiler {
         if (result.code === 0 && filters.binary) {
             const tapeFilepath = path.join(result.dirPath, this.getTapefilename());
             if (await utils.fileExists(tapeFilepath)) {
-                const file_buffer = await fs.readFile(tapeFilepath);
-                const binary_base64 = file_buffer.toString('base64');
-                result.speccytape = binary_base64;
+                await this.addArtifactToResult(result, tapeFilepath, ArtifactType.zxtape);
             }
 
             const smsFilepath = path.join(result.dirPath, this.getSmsfilename());
             if (await utils.fileExists(smsFilepath)) {
-                const file_buffer = await fs.readFile(smsFilepath);
-                const binary_base64 = file_buffer.toString('base64');
-                result.miraclesms = binary_base64;
+                await this.addArtifactToResult(result, smsFilepath, ArtifactType.smsrom);
             }
         }
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -63,7 +63,7 @@ import * as utils from '../utils';
 import * as Sentry from '@sentry/browser';
 import {editor} from 'monaco-editor';
 import IEditorMouseEvent = editor.IEditorMouseEvent;
-import {Tool} from '../../types/tool.interfaces';
+import {ArtifactType, Tool} from '../../types/tool.interfaces';
 
 const toolIcons = require.context('../../views/resources/logos', false, /\.(png|svg)$/);
 
@@ -1701,14 +1701,18 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     }
 
     offerEmulationIfPossible(result: CompilationResult) {
-        if (result.bbcdiskimage) {
-            this.emulateBbcDisk(result.bbcdiskimage);
-        } else if (result.speccytape) {
-            this.emulateSpeccyTape(result.speccytape);
-        } else if (result.miraclesms) {
-            this.emulateMiracleSMS(result.miraclesms);
-        } else if (result.jsnesrom) {
-            this.emulateNESROM(result.jsnesrom);
+        if (result.artifacts) {
+            for (const artifact of result.artifacts) {
+                if (artifact.type === ArtifactType.nesrom) {
+                    this.emulateNESROM(artifact.content);
+                } else if (artifact.type === ArtifactType.bbcdiskimage) {
+                    this.emulateBbcDisk(artifact.content);
+                } else if (artifact.type === ArtifactType.zxtape) {
+                    this.emulateSpeccyTape(artifact.content);
+                } else if (artifact.type === ArtifactType.smsrom) {
+                    this.emulateMiracleSMS(artifact.content);
+                }
+            }
         }
     }
 

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -27,7 +27,7 @@ import {IAsmParser} from '../../lib/parsers/asm-parser.interfaces';
 import {CompilerInfo} from '../compiler.interfaces';
 import {BasicExecutionResult} from '../execution/execution.interfaces';
 import {ResultLine} from '../resultline/resultline.interfaces';
-import {ToolResult} from '../tool.interfaces';
+import {Artifact, ToolResult} from '../tool.interfaces';
 
 import {LLVMOptPipelineOutput} from './llvm-opt-pipeline-output.interfaces';
 
@@ -98,10 +98,7 @@ export type CompilationResult = {
 
     forceBinaryView?: boolean;
 
-    bbcdiskimage?: string;
-    speccytape?: string;
-    miraclesms?: string;
-    jsnesrom?: string;
+    artifacts?: Artifact[];
 
     hints?: string[];
 

--- a/types/tool.interfaces.ts
+++ b/types/tool.interfaces.ts
@@ -50,6 +50,14 @@ export type Tool = {
     readonly type: string;
 };
 
+export enum ArtifactType {
+    download = 'application/octet-stream',
+    nesrom = 'nesrom',
+    bbcdiskimage = 'bbcdiskimage',
+    zxtape = 'zxtape',
+    smsrom = 'smsrom',
+}
+
 export type Artifact = {
     content: string;
     type: string;


### PR DESCRIPTION
As discussed a while ago in discord, this breaks API, but I think it's acceptable in this case.

Tested:
* [x] NES (both by llvm-mos and cc65)
* [x] SMS (z88dk)
* [x] ZX (z88dk)
* [x] BBC (beebasm)
