### PR TITLE
rename: compile to binary -> link to binary

### DIFF
--- a/views/options-output.pug
+++ b/views/options-output.pug
@@ -14,7 +14,9 @@ mixin outputoption(name, longdescription, shortdescription, defaultchecked)
       input.d-none(type="checkbox" checked=defaultchecked)
 // If you modify this, update types/features/filters.interfaces.ts
 +outputoption('binaryObject', 'Compile to binary object and disassemble the output', 'Compile to binary object', false)
-+outputoption('binary', 'Compile to binary and disassemble the output', 'Compile to binary', false)
+// the field needs to keep being "binary" and not "link" or something closer to the description as it is part of
+// our interface and we can't break it.
++outputoption('binary', 'Link to binary and disassemble the output', 'Link to binary', false)
 +outputoption('execute', 'Execute code and show its output', 'Execute the code', false)
 +outputoption('intel', 'Output disassembly in Intel syntax', 'Intel asm syntax', true)
 +outputoption('demangle', 'Demangle output', 'Demangle identifiers', true)


### PR DESCRIPTION
With the merge of #3232, we need to distinguish "compile to binary object" (compiler + assembler) and "compile to binary" (compiler + assembler + linker).

Renaming "compile to binary" as "link to binary" is more correct in this context and less confusing.

We don't rename the internal field (kept as 'binary') because it's part of the API and we can't break it.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>