### PR TITLE
fix: pahole wrongly refuses to do anything

### DIFF
--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -32,7 +32,7 @@ export class PaholeTool extends BaseTool {
     }
 
     async runTool(compilationInfo, inputFilepath, args) {
-        if (!compilationInfo.filters.binary || !compilationInfo.filters.binaryObject) {
+        if (!compilationInfo.filters.binary && !compilationInfo.filters.binaryObject) {
             return this.createErrorResponse('Pahole requires a binary output');
         }
 


### PR DESCRIPTION
Condition was badly changed in #3232 (compiling to binary objects)