### PR TITLE
Fix #4585

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2393,7 +2393,11 @@ export class BaseCompiler implements ICompiler {
             .pipe(new compilerOptInfo.LLVMOptTransformer());
 
         for await (const opt of optStream) {
-            if (opt.DebugLoc && opt.DebugLoc.File && opt.DebugLoc.File.includes(this.compileFilename)) {
+            if (
+                opt.DebugLoc &&
+                opt.DebugLoc.File &&
+                (opt.DebugLoc.File === '<stdin>' || opt.DebugLoc.File.includes(this.compileFilename))
+            ) {
                 output.push(opt);
             }
         }


### PR DESCRIPTION
This suggested simple fix doesn't try to suppress opt-remarks from headers when headers and example.cpp are unified into `stdin`. Better ideas are very welcome - but this is certainly acceptable for me as a user.
