### PR TITLE
Use double quotes for embed iframes

### DIFF
--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -391,7 +391,8 @@ export class Sharing {
 
     private static getEmbeddedHtml(config, root, isReadOnly, extraOptions): string {
         const embedUrl = Sharing.getEmbeddedUrl(config, root, isReadOnly, extraOptions);
-        return `<iframe width='800px' height='200px' src='${embedUrl}'></iframe>`;
+        // The attributes must be double quoted, the full url's rison contains single quotes
+        return `<iframe width="800px" height="200px" src="${embedUrl}"></iframe>`;
     }
 
     private static getEmbeddedUrl(config: any, root: string, readOnly: boolean, extraOptions: object): string {


### PR DESCRIPTION
This fixes the core issue with #4541 and closes #4541, separately I'll add better diagnostics for the user for when things go wrong