### PR TITLE
Ignore trim filter for Hook

### DIFF
--- a/etc/config/hook.amazon.properties
+++ b/etc/config/hook.amazon.properties
@@ -14,6 +14,7 @@ group.hook.isSemVer=true
 group.hook.baseName=Hook
 group.hook.licenseName=MIT
 group.hook.licenseLink=https://github.com/fabiosvm/hook-lang/blob/main/LICENSE
+group.hook.instructionSet=hook
 
 compiler.hook010.exe=/opt/compiler-explorer/hook/hook-0.1.0/bin/hook
 compiler.hook010.semver=0.1.0

--- a/etc/config/hook.defaults.properties
+++ b/etc/config/hook.defaults.properties
@@ -14,6 +14,7 @@ group.hook.isSemVer=true
 group.hook.baseName=Hook
 group.hook.licenseName=MIT
 group.hook.licenseLink=https://github.com/fabiosvm/hook-lang/blob/main/LICENSE
+group.hook.instructionSet=hook
 
 compiler.hook010def.exe=hook
 compiler.hook010def.semver=0.1.0

--- a/lib/compilers/hook.ts
+++ b/lib/compilers/hook.ts
@@ -47,6 +47,8 @@ export class HookCompiler extends BaseCompiler {
         inputFilename: string,
         execOptions: ExecutionOptions,
     ): Promise<CompilationResult> {
+        const compilerPath = path.dirname(compiler);
+        execOptions.env.HOOK_HOME = path.join(compilerPath, '..');
         const dirPath = path.dirname(inputFilename);
         const outputFilename = this.getOutputFilename(dirPath);
         options.push(outputFilename);

--- a/lib/compilers/hook.ts
+++ b/lib/compilers/hook.ts
@@ -24,7 +24,6 @@
 
 import path from 'path';
 
-import {ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces';
 import {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces';
 import {BaseCompiler} from '../base-compiler';
@@ -54,32 +53,36 @@ export class HookCompiler extends BaseCompiler {
         return super.runCompiler(compiler, options, inputFilename, execOptions);
     }
 
-    override processAsm(result) {
+    override processAsm(result, filters, options) {
+        // Ignoring `trim` filter because it is not supported by Hook.
+        filters.trim = false;
+        const _result = super.processAsm(result, filters, options);
         const commentRegex = /^\s*;(.*)/;
         const instructionRegex = /^\s{2}(\d+)(.*)/;
-        const lines = result.asm.split('\n');
-        const asm: ParsedAsmResultLine[] = [];
+        const asm = _result.asm;
         let lastLineNo: number | undefined;
-        for (const line of lines) {
-            if (commentRegex.test(line)) {
-                asm.push({text: line, source: {line: undefined, file: null}});
+        for (const item of asm) {
+            const text = item.text;
+            if (commentRegex.test(text)) {
+                item.source = {line: undefined, file: null};
                 lastLineNo = undefined;
                 continue;
             }
-            const match = line.match(instructionRegex);
+            const match = text.match(instructionRegex);
             if (match) {
                 const lineNo = parseInt(match[1]);
-                asm.push({text: line, source: {line: lineNo, file: null}});
+                item.source = {line: lineNo, file: null};
                 lastLineNo = lineNo;
                 continue;
             }
-            if (line) {
-                asm.push({text: line, source: {line: lastLineNo, file: null}});
+            if (text) {
+                item.source = {line: lastLineNo, file: null};
                 continue;
             }
-            asm.push({text: line, source: {line: undefined, file: null}});
+            item.source = {line: undefined, file: null};
             lastLineNo = undefined;
         }
-        return {asm: asm};
+        _result.asm = asm;
+        return _result;
     }
 }

--- a/test/compilers/hook-tests.js
+++ b/test/compilers/hook-tests.js
@@ -59,6 +59,7 @@ describe('Hook compiler', () => {
         const expected = {
             asm: [
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: undefined,
@@ -66,6 +67,7 @@ describe('Hook compiler', () => {
                     text: '; main in /app/example.hk at 0x56554a556550',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: undefined,
@@ -73,6 +75,7 @@ describe('Hook compiler', () => {
                     text: '; 0 parameter(s), 0 non-local(s), 0 constant(s), 0 function(s)',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: 1,
@@ -80,6 +83,7 @@ describe('Hook compiler', () => {
                     text: '  1         0 Int                       2',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: 1,
@@ -87,6 +91,7 @@ describe('Hook compiler', () => {
                     text: '            3 Int                       2',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: 1,
@@ -94,6 +99,7 @@ describe('Hook compiler', () => {
                     text: '            6 Multiply',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: 2,
@@ -101,6 +107,7 @@ describe('Hook compiler', () => {
                     text: '  2         7 Load                      2',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: 2,
@@ -108,6 +115,7 @@ describe('Hook compiler', () => {
                     text: '            9 Return',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: 2,
@@ -115,22 +123,20 @@ describe('Hook compiler', () => {
                     text: '           10 ReturnNil',
                 },
                 {
+                    labels: [],
                     source: {
                         file: null,
                         line: undefined,
                     },
                     text: '; 6 instruction(s)',
                 },
-                {
-                    source: {
-                        file: null,
-                        line: undefined,
-                    },
-                    text: '',
-                },
             ],
+            filteredCount: 0,
+            labelDefinitions: {},
         };
-        const result = hook.processAsm({asm: asm});
+        const filters = {trim: false};
+        const result = hook.processAsm({asm: asm}, filters, null);
+        delete result.parsingTime;
         result.should.deep.equal(expected);
     });
 });


### PR DESCRIPTION
* Ignore trim (Horizontal whitespace) filter;
* Update instructionSet, and
* Fix core module loading