### PR TITLE
rust: add cross gcc for BPF

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -159,16 +159,35 @@ compiler.nightly.semver=nightly
 compiler.beta.exe=/opt/compiler-explorer/rust-beta/bin/rustc
 compiler.beta.semver=beta
 
+# gccrs: main development for the Rust GCC Frontend (github)
+# gcc: regular gcc dev/releases
+
+group.rustgcc.compilers=&gcc86:&gcccross
+group.rustgcc.supportsBinary=true
+group.rustgcc.supportsBinaryObject=true
+group.rustgcc.compilerType=gccrs
+## needed, until its support is on-par with rustc (at some arbitrary version).
+group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
+
+# native compiler
+group.gcc86.compilers=gccrs-snapshot
+group.gcc86.groupName=x86-64 GCCRS
+
 compiler.gccrs-snapshot.exe=/opt/compiler-explorer/gcc-gccrs-master/bin/gccrs
 compiler.gccrs-snapshot.semver=(GCCRS)
 compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
-group.rustgcc.compilerType=gccrs
-group.rustgcc.compilers=gccrs-snapshot
-group.rustgcc.groupName=Rust-GCC
-group.rustgcc.supportsBinary=true
-group.rustgcc.supportsBinaryObject=true
-## needed, until its support is on-par with rustc (at some arbitrary version).
-group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
+
+# cross compilers
+group.gcccross.compilers=&rustgccbpf
+group.gcccross.supportsExecute=false
+group.rustgccbpf.compilers=rustbpfgtrunk
+group.rustgccbpf.groupName=BPF GCC
+
+compiler.rustbpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.rustbpfgtrunk.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.rustbpfgtrunk.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.rustbpfgtrunk.notification=Rust GCC Frontend - Very early snapshot
+compiler.rustbpfgtrunk.semver=trunk
 
 group.rustccggcc.compilers=rustccggcc-master
 compiler.rustccggcc-master.exe=/opt/compiler-explorer/rustc-cg-gcc-master/bin/rustc

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -166,27 +166,30 @@ group.rustgcc.compilers=&gcc86:&gcccross
 group.rustgcc.supportsBinary=true
 group.rustgcc.supportsBinaryObject=true
 group.rustgcc.compilerType=gccrs
+group.rustgcc.isSemVer=true
 ## needed, until its support is on-par with rustc (at some arbitrary version).
 group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
+group.rustgcc.notification=Rust GCC Frontend - Very early snapshot
 
 # native compiler
 group.gcc86.compilers=gccrs-snapshot
 group.gcc86.groupName=x86-64 GCCRS
+group.gcc86.baseName=x86-64 GCCRS
 
 compiler.gccrs-snapshot.exe=/opt/compiler-explorer/gcc-gccrs-master/bin/gccrs
 compiler.gccrs-snapshot.semver=(GCCRS)
-compiler.gccrs-snapshot.notification=Rust GCC Frontend - Very early snapshot
 
 # cross compilers
 group.gcccross.compilers=&rustgccbpf
 group.gcccross.supportsExecute=false
+
 group.rustgccbpf.compilers=rustbpfgtrunk
 group.rustgccbpf.groupName=BPF GCC
+group.rustgccbpf.baseName=BPF gcc
 
 compiler.rustbpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-gcc
 compiler.rustbpfgtrunk.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.rustbpfgtrunk.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
-compiler.rustbpfgtrunk.notification=Rust GCC Frontend - Very early snapshot
 compiler.rustbpfgtrunk.semver=trunk
 
 group.rustccggcc.compilers=rustccggcc-master


### PR DESCRIPTION
Add a cross-gcc targeting BPF.
Also do some cleaning of group names.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>