### PR TITLE
Add cross clang config for MIPS

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1489,9 +1489,84 @@ compiler.avrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-ob
 compiler.avrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
 
 ###############################
-# GCC for MIPS
-group.mipss.compilers=&mips:&mipsel:&mips64:&mips64el
+# Cross compiler for MIPS
+group.mipss.compilers=&mips:&mipsel:&mips64:&mips64el:&mips-clang:&mipsel-clang:&mips64-clang:&mips64el-clang
 group.mipss.isSemVer=true
+
+# Clang for all MIPS
+
+## MIPS
+group.mips-clang.compilers=mips-clang1500:mips-clang1400:mips-clang1300
+group.mips-clang.groupName=MIPS clang
+group.mips-clang.baseName=mips clang
+group.mips-clang.supportsBinary=false
+group.mips-clang.supportsBinaryObject=false
+group.mips-clang.supportsExecute=false
+group.mips-clang.options=-target mips-elf
+
+compiler.mips-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips-clang1500.semver=15.0.0
+
+compiler.mips-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips-clang1400.semver=14.0.0
+
+compiler.mips-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips-clang1300.semver=13.0.0
+
+## MIPSEL
+group.mipsel-clang.compilers=mipsel-clang1500:mipsel-clang1400:mipsel-clang1300
+group.mipsel-clang.groupName=MIPSEL clang
+group.mipsel-clang.baseName=mipsel clang
+group.mipsel-clang.supportsBinary=false
+group.mipsel-clang.supportsBinaryObject=false
+group.mipsel-clang.supportsExecute=false
+group.mipsel-clang.options=-target mipsel-elf
+
+compiler.mipsel-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mipsel-clang1500.semver=15.0.0
+
+compiler.mipsel-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mipsel-clang1400.semver=14.0.0
+
+compiler.mipsel-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mipsel-clang1300.semver=13.0.0
+
+## MIPS64
+group.mips64-clang.compilers=mips64-clang1500:mips64-clang1400:mips64-clang1300
+group.mips64-clang.groupName=MIPS64 clang
+group.mips64-clang.baseName=mips64 clang
+group.mips64-clang.supportsBinary=false
+group.mips64-clang.supportsBinaryObject=false
+group.mips64-clang.supportsExecute=false
+group.mips64-clang.options=-target mips64-elf
+
+compiler.mips64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips64-clang1500.semver=15.0.0
+
+compiler.mips64-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips64-clang1400.semver=14.0.0
+
+compiler.mips64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips64-clang1300.semver=13.0.0
+
+## MIPS64EL
+group.mips64el-clang.compilers=mips64el-clang1500:mips64el-clang1400:mips64el-clang1300
+group.mips64el-clang.groupName=MIPS64EL clang
+group.mips64el-clang.baseName=mips64el clang
+group.mips64el-clang.supportsBinary=false
+group.mips64el-clang.supportsBinaryObject=false
+group.mips64el-clang.supportsExecute=false
+group.mips64el-clang.options=-target mips64el-elf
+
+compiler.mips64el-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips64el-clang1500.semver=15.0.0
+
+compiler.mips64el-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips64el-clang1400.semver=14.0.0
+
+compiler.mips64el-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips64el-clang1300.semver=13.0.0
+
 
 ## MIPS
 group.mips.groupName=MIPS GCC

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1457,13 +1457,88 @@ compiler.cavrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-o
 compiler.cavrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
 
 ###############################
-# GCC for MIPS
-group.cmipss.compilers=&cmips:&cmipsel:&cmips64:&cmips64el
+# Cross compilers for MIPS
+group.cmipss.compilers=&cmips:&cmipsel:&cmips64:&cmips64el:&mips-cclang:&mipsel-cclang:&mips64-cclang:&mips64el-cclang
 
 group.cmipss.isSemVer=true
 group.cmipss.supportsBinary=true
 group.cmipss.supportsExecute=false
 
+# Clang for all MIPS
+
+## MIPS
+group.mips-cclang.compilers=mips-cclang1500:mips-cclang1400:mips-cclang1300
+group.mips-cclang.groupName=MIPS clang
+group.mips-cclang.baseName=mips clang
+group.mips-cclang.supportsBinary=false
+group.mips-cclang.supportsBinaryObject=false
+group.mips-cclang.supportsExecute=false
+group.mips-cclang.options=-target mips-elf
+
+compiler.mips-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips-cclang1500.semver=15.0.0
+
+compiler.mips-cclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips-cclang1400.semver=14.0.0
+
+compiler.mips-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips-cclang1300.semver=13.0.0
+
+## MIPSEL
+group.mipsel-cclang.compilers=mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
+group.mipsel-cclang.groupName=MIPSEL clang
+group.mipsel-cclang.baseName=mipsel clang
+group.mipsel-cclang.supportsBinary=false
+group.mipsel-cclang.supportsBinaryObject=false
+group.mipsel-cclang.supportsExecute=false
+group.mipsel-cclang.options=-target mipsel-elf
+
+compiler.mipsel-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mipsel-cclang1500.semver=15.0.0
+
+compiler.mipsel-cclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mipsel-cclang1400.semver=14.0.0
+
+compiler.mipsel-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mipsel-cclang1300.semver=13.0.0
+
+## MIPS64
+group.mips64-cclang.compilers=mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
+group.mips64-cclang.groupName=MIPS64 clang
+group.mips64-cclang.baseName=mips64 clang
+group.mips64-cclang.supportsBinary=false
+group.mips64-cclang.supportsBinaryObject=false
+group.mips64-cclang.supportsExecute=false
+group.mips64-cclang.options=-target mips64-elf
+
+compiler.mips64-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips64-cclang1500.semver=15.0.0
+
+compiler.mips64-cclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips64-cclang1400.semver=14.0.0
+
+compiler.mips64-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips64-cclang1300.semver=13.0.0
+
+## MIPS64EL
+group.mips64el-cclang.compilers=mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
+group.mips64el-cclang.groupName=MIPS64EL clang
+group.mips64el-cclang.baseName=mips64el clang
+group.mips64el-cclang.supportsBinary=false
+group.mips64el-cclang.supportsBinaryObject=false
+group.mips64el-cclang.supportsExecute=false
+group.mips64el-cclang.options=-target mips64el-elf
+
+compiler.mips64el-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips64el-cclang1500.semver=15.0.0
+
+compiler.mips64el-cclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips64el-cclang1400.semver=14.0.0
+
+compiler.mips64el-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips64el-cclang1300.semver=13.0.0
+
+# GCC for all MIPS
 ## MIPS
 group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210:cmipsg1220
 group.cmips.groupName=MIPS GCC


### PR DESCRIPTION
Adjust config for aliasing clang 15, 14 and 13 for targeting MIPS, MIPS64, MIPSEL and MIPS64EL.

Disabling binary support as it's causing errors when reusing gcc toolchain.

fixes #3282

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>