### PR TITLE
Add GCC 9.4, 9.5, 10.4 for Arm and AArch64 and And Morello Alpha 2

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1148,14 +1148,14 @@ compiler.ppc64leclang.licensePreamble=The LLVM Project is under the Apache Licen
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=&gcc32arm:&gcc64arm
+group.gccarm.compilers=&gcc32arm:&gcc64arm:&gcc64marm
 # Some of the compilers don't like -isystem (as they assume the code must be C).
 # See https://github.com/compiler-explorer/compiler-explorer/issues/989 for discussion
 group.gccarm.includeFlag=-I
 
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
-group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:arm1210:armgtrunk:armg1220
+group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1040:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:arm1210:armgtrunk:armg1220
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -1235,12 +1235,21 @@ compiler.arm1121.supportsBinary=false
 compiler.arm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm930.name=ARM gcc 9.3 (linux)
 compiler.arm930.semver=9.3.0
+compiler.arm940.exe=/opt/compiler-explorer/arm/gcc-9.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.arm940.name=ARM gcc 9.4 (linux)
+compiler.arm940.semver=9.4.0
+compiler.arm950.exe=/opt/compiler-explorer/arm/gcc-9.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.arm950.name=ARM gcc 9.5 (linux)
+compiler.arm950.semver=9.5.0
 compiler.arm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm1020.name=ARM gcc 10.2 (linux)
 compiler.arm1020.semver=10.2.0
 compiler.arm1030.exe=/opt/compiler-explorer/arm/gcc-10.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm1030.name=ARM gcc 10.3 (linux)
 compiler.arm1030.semver=10.3.0
+compiler.arm1040.exe=/opt/compiler-explorer/arm/gcc-10.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.arm1040.name=ARM gcc 10.4 (linux)
+compiler.arm1040.semver=10.4.0
 compiler.arm1100.exe=/opt/compiler-explorer/arm/gcc-11.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm1100.name=ARM gcc 11.1 (linux)
 compiler.arm1100.semver=11.1.0
@@ -1260,7 +1269,7 @@ compiler.armgtrunk.semver=trunk
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g1020:arm64g1030:arm64g1100:arm64g1120:arm64g1130:arm64g1210:arm64gtrunk:arm64g1220
+group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1210:arm64gtrunk:arm64g1220
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -1283,10 +1292,16 @@ compiler.arm64g850.exe=/opt/compiler-explorer/arm64/gcc-8.5.0/aarch64-unknown-li
 compiler.arm64g850.semver=8.5
 compiler.arm64g930.exe=/opt/compiler-explorer/arm64/gcc-9.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g930.semver=9.3
+compiler.arm64g940.exe=/opt/compiler-explorer/arm64/gcc-9.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g940.semver=9.4
+compiler.arm64g950.exe=/opt/compiler-explorer/arm64/gcc-9.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g950.semver=9.5
 compiler.arm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1020.semver=10.2
 compiler.arm64g1030.exe=/opt/compiler-explorer/arm64/gcc-10.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1030.semver=10.3
+compiler.arm64g1040.exe=/opt/compiler-explorer/arm64/gcc-10.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1040.semver=10.4
 compiler.arm64g1100.exe=/opt/compiler-explorer/arm64/gcc-11.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1100.semver=11.1
 compiler.arm64g1120.exe=/opt/compiler-explorer/arm64/gcc-11.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
@@ -1303,6 +1318,19 @@ compiler.arm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-un
 compiler.arm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 compiler.arm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64gtrunk.semver=trunk
+
+###############################
+# GCC Morello
+group.gcc64marm.groupName=Arm Morello GCC
+group.gcc64marm.compilers=arm64gm101a2
+group.gcc64marm.isSemVer=true
+group.gcc64marm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/aarch64-none-elf/bin/objdump
+group.gcc64marm.demangler=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/aarch64-none-elf/bin/c++filt
+group.gcc64marm.instructionSet=aarch64
+
+compiler.arm64gm101a2.exe=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-g++
+compiler.arm64gm101a2.name=ARM64 Morello gcc 10.1 Alpha 2
+compiler.arm64gm101a2.semver=10.1.2
 
 ###############################
 # GCC for Kalray

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1325,7 +1325,7 @@ group.gcc64marm.groupName=Arm Morello GCC
 group.gcc64marm.compilers=arm64gm101a2
 group.gcc64marm.isSemVer=true
 group.gcc64marm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/aarch64-none-elf/bin/objdump
-group.gcc64marm.demangler=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/aarch64-none-elf/bin/c++filt
+group.gcc64marm.demangler=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-c++filt
 group.gcc64marm.instructionSet=aarch64
 
 compiler.arm64gm101a2.exe=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-g++

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1324,7 +1324,7 @@ compiler.arm64gtrunk.semver=trunk
 group.gcc64marm.groupName=Arm Morello GCC
 group.gcc64marm.compilers=arm64gm101a2
 group.gcc64marm.isSemVer=true
-group.gcc64marm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/aarch64-none-elf/bin/objdump
+group.gcc64marm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-objdump
 group.gcc64marm.demangler=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-c++filt
 group.gcc64marm.instructionSet=aarch64
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1200,7 +1200,7 @@ compiler.carmgtrunk.semver=trunk
 
 # 64 bit
 group.cgcc64arm.groupName=Arm 64-bit GCC
-group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g1020:carm64g1030:carm64g1100:carm64g1120:carm64g1130:carm64g1210:carm64gtrunk:carm64g1220
+group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1210:carm64gtrunk:carm64g1220
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -1229,12 +1229,21 @@ compiler.carm64g850.semver=8.5.0
 compiler.carm64g930.exe=/opt/compiler-explorer/arm64/gcc-9.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g930.name=ARM64 gcc 9.3
 compiler.carm64g930.semver=9.3.0
+compiler.carm64g940.exe=/opt/compiler-explorer/arm64/gcc-9.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g940.name=ARM64 gcc 9.4
+compiler.carm64g940.semver=9.4.0
+compiler.carm64g950.exe=/opt/compiler-explorer/arm64/gcc-9.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g950.name=ARM64 gcc 9.5
+compiler.carm64g950.semver=9.5.0
 compiler.carm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1020.name=ARM64 gcc 10.2
 compiler.carm64g1020.semver=10.2.0
 compiler.carm64g1030.exe=/opt/compiler-explorer/arm64/gcc-10.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1030.name=ARM64 gcc 10.3
 compiler.carm64g1030.semver=10.3.0
+compiler.carm64g1040.exe=/opt/compiler-explorer/arm64/gcc-10.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1040.name=ARM64 gcc 10.4
+compiler.carm64g1040.semver=10.4.0
 compiler.carm64g1100.exe=/opt/compiler-explorer/arm64/gcc-11.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1100.name=ARM64 gcc 11.1
 compiler.carm64g1100.semver=11.1.0
@@ -1260,14 +1269,17 @@ compiler.carm64gtrunk.semver=trunk
 
 # GCC Morello
 group.cgcc64marm.groupName=Arm Morello GCC
-group.cgcc64marm.compilers=carm64gm101a1
+group.cgcc64marm.compilers=carm64gm101a1:carm64gm101a2
 group.cgcc64marm.isSemVer=true
-group.cgcc64marm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp1-x86_64/aarch64-none-elf/bin/objdump
+group.cgcc64marm.objdumper=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/aarch64-none-elf/bin/objdump
 group.cgcc64marm.instructionSet=aarch64
 
 compiler.carm64gm101a1.exe=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp1-x86_64/bin/aarch64-none-elf-gcc
 compiler.carm64gm101a1.name=ARM64 Morello gcc 10.1 Alpha 1
 compiler.carm64gm101a1.semver=10.1.0
+compiler.carm64gm101a2.exe=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-gcc
+compiler.carm64gm101a2.name=ARM64 Morello gcc 10.1 Alpha 2
+compiler.carm64gm101a2.semver=10.1.2
 
 ###############################
 # GCC for Kalray


### PR DESCRIPTION
Final CC part for new toolchains

Related infra patch https://github.com/compiler-explorer/infra/pull/935
Related cross-gcc patch https://github.com/compiler-explorer/gcc-cross-builder/pull/50