### PR TITLE
Tsify asm-docs-tests to typescript with utils

### DIFF
--- a/docs/AddingAssemblyDocumentation.md
+++ b/docs/AddingAssemblyDocumentation.md
@@ -76,4 +76,4 @@ Finally we want to tell CE that the new documentation provider exists. This is d
 ## 4. Testing
 
 Testing new assembly documentation providers is really easy. It is just a matter of modifying the `TEST_MATRIX` variable
-found in the `/test/handlers/asm-docs-tests.js` file.
+found in the `/test/handlers/asm-docs-tests.ts` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@sentry/browser": "^7.28.1",
         "@sentry/node": "^7.28.1",
         "@types/body-parser": "^1.19.2",
+        "@types/chai-as-promised": "^7.1.5",
+        "@types/deep-equal-in-any-order": "^1.0.1",
         "@types/file-saver": "^2.0.5",
         "@types/http-proxy": "^1.17.9",
         "@types/js-cookie": "^3.0.2",
@@ -90,6 +92,7 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.16.5",
         "@types/bootstrap": "^5.1.6",
+        "@types/chai": "^4.3.4",
         "@types/express": "^4.17.14",
         "@types/fs-extra": "^9.0.13",
         "@types/jquery": "^3.5.10",
@@ -1765,8 +1768,15 @@
     "node_modules/@types/chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw=="
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dependencies": {
+        "@types/chai": "*"
+      }
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
@@ -1791,6 +1801,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
+    },
+    "node_modules/@types/deep-equal-in-any-order": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.1.tgz",
+      "integrity": "sha512-hUWUUE53WjKfcCncSmWmNXVNNT+0Iz7gYFnov3zdCXrX3Thxp1Cnmfd5LwWOeCVUV5LhpiFgS05vaAG72doo9w=="
     },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
@@ -16920,8 +16935,15 @@
     "@types/chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw=="
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "requires": {
+        "@types/chai": "*"
+      }
     },
     "@types/connect": {
       "version": "3.4.35",
@@ -16946,6 +16968,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
+    },
+    "@types/deep-equal-in-any-order": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.1.tgz",
+      "integrity": "sha512-hUWUUE53WjKfcCncSmWmNXVNNT+0Iz7gYFnov3zdCXrX3Thxp1Cnmfd5LwWOeCVUV5LhpiFgS05vaAG72doo9w=="
     },
     "@types/eslint": {
       "version": "8.4.10",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.16.5",
     "@types/bootstrap": "^5.1.6",
+    "@types/chai": "^4.3.4",
     "@types/express": "^4.17.14",
     "@types/fs-extra": "^9.0.13",
     "@types/jquery": "^3.5.10",

--- a/test/handlers/asm-docs-tests.ts
+++ b/test/handlers/asm-docs-tests.ts
@@ -29,7 +29,7 @@ import {withAssemblyDocumentationProviders} from '../../lib/handlers/assembly-do
 import {chai} from '../utils';
 
 /** Test matrix of architecture to [opcode, tooptip, html, url] */
-export const TEST_MATRIX = {
+export const TEST_MATRIX: Record<PropertyKey, [string, string, string, string][]> = {
     6502: [
         [
             'lda',
@@ -82,7 +82,7 @@ export const TEST_MATRIX = {
 };
 
 describe('Assembly Documentation API', () => {
-    let app;
+    let app: express.Express;
 
     before(() => {
         app = express();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -26,12 +26,14 @@ import path from 'path';
 import {fileURLToPath} from 'url';
 
 import chai from 'chai';
+import fs from 'fs-extra';
 
 import {CompilationEnvironment} from '../lib/compilation-env';
 import {CompilationQueue} from '../lib/compilation-queue';
 import {CompilerProps, fakeProps} from '../lib/properties';
 
-export function makeCompilationEnvironment(options) {
+// TODO: Find proper type for options
+export function makeCompilationEnvironment(options: Record<string, any>): CompilationEnvironment {
     const compilerProps = new CompilerProps(options.languages, fakeProps(options.props || {}));
     const compilationQueue = options.queue || new CompilationQueue(options.concurrency || 1, options.timeout);
     return new CompilationEnvironment(compilerProps, compilationQueue, options.doCache);
@@ -44,10 +46,9 @@ export const should = chai.should();
  */
 export const TEST_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
 
-export function resolvePathFromTestRoot(...args) {
+export function resolvePathFromTestRoot(...args: string[]): string {
     return path.resolve(TEST_ROOT, ...args);
 }
 
-export {default as fs} from 'fs-extra';
-export {default as chai} from 'chai';
-export {default as path} from 'path';
+// eslint-disable-next-line -- do not rewrite exports
+export { chai, path, fs }

--- a/tsconfig.backend.json
+++ b/tsconfig.backend.json
@@ -11,6 +11,7 @@
     /* Code generation */
     "outDir": "./out/dist",
     "typeRoots": ["./typings", "./node_modules/@types"],
+    "types": ["mocha", "chai", "chai-http"],
     /* Other options */
     "allowJs": true
   }


### PR DESCRIPTION
Adds the final few bits needed in tsconfig to properly run the chai-http test infrastructure as well as turning the asm docs tests into ts