### PR TITLE
Scala fix

### DIFF
--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -382,10 +382,13 @@ export class JavaCompiler extends BaseCompiler {
         }
         return {
             // Used for sorting
-            firstSourceLine: methods.reduce(
-                (p, m) => (p === -1 ? unwrap(m.startLine) : Math.min(p, unwrap(m.startLine))),
-                -1,
-            ),
+            firstSourceLine: methods.reduce((prev, method) => {
+                if (method.startLine) {
+                    return prev === -1 ? method.startLine : Math.min(prev, method.startLine);
+                } else {
+                    return prev;
+                }
+            }, -1),
             methods: methods,
             textsBeforeMethod,
         };


### PR DESCRIPTION
Haven't tested locally, this fixes the exception we see when trying to compile scala:

```
Internal Compiler Explorer error: Error: Unwrap failed, at lib/compilers/java.js:341 `firstSourceLine: methods.reduce((p, m) => (p === -1 ? unwrap(m.startLine) : Math.min(p, unwrap(m.startLine))), -1),`
    at fail (/infra/.deploy/lib/assert.js:78:15)
    at unwrap (/infra/.deploy/lib/assert.js:91:9)
    at /infra/.deploy/lib/compilers/java.js:341:67
    at Array.reduce (<anonymous>)
    at ScalaCompiler.parseAsmForClass (/infra/.deploy/lib/compilers/java.js:341:38)
    at /infra/.deploy/lib/compilers/java.js:210:52
    at Array.map (<anonymous>)
    at ScalaCompiler.processAsm (/infra/.deploy/lib/compilers/java.js:210:36)
    at ScalaCompiler.afterCompilation (/infra/.deploy/lib/base-compiler.js:1861:38)
    at runMicrotasks (<anonymous>)
Compiler returned: -1
```

Other exceptions may exist after this.