### PR TITLE
Converted cache-tests to typescript

### DIFF
--- a/lib/cache/from-config.ts
+++ b/lib/cache/from-config.ts
@@ -70,8 +70,9 @@ function createInternal(name: string, config: string): Cache {
     }
 }
 
-export function createCacheFromConfig(name: string, config: string): Cache {
+// Added some type casting to make cache-tests a little more typesafe
+export function createCacheFromConfig<TCache extends Cache = Cache>(name: string, config: string): TCache {
     const result = createInternal(name, config);
     logger.info(`Created cache ${name} of type ${result.details}`);
-    return result;
+    return result as TCache;
 }

--- a/test/nim-tests.ts
+++ b/test/nim-tests.ts
@@ -26,9 +26,9 @@ import path from 'path';
 
 import {unwrap} from '../lib/assert';
 import {NimCompiler} from '../lib/compilers/nim';
+import {LanguageKey} from '../types/languages.interfaces';
 
 import {makeCompilationEnvironment, makeFakeCompilerInfo, should} from './utils';
-import {LanguageKey} from '../types/languages.interfaces';
 
 const languages = {
     nim: {id: 'nim' as LanguageKey},


### PR DESCRIPTION
Added generic typing to lib/cache/from-config
nim-tests got added after a make lint (--fix)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
