### PR TITLE
fix: GO compiler names

### DIFF
--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -528,11 +528,9 @@ compiler.gccgoppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.
 compiler.gccgoppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
-compiler.gppc64leg9.name=power64le AT13.0
 compiler.gppc64leg9.semver=AT13.0
 
 compiler.gppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
-compiler.gppc64leg8.name=power64le AT12.0
 compiler.gppc64leg8.semver=AT12.0
 
 ###############################

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -103,8 +103,8 @@ compiler.gltip.semver=(tip)
 compiler.gltip.goroot=/opt/compiler-explorer/go-tip
 
 group.386gl.compilers=386_gl114:386_gl115:386_gl116:386_gl117:386_gl118:386_gl119:386_gltip
-group.386gl.baseName=x86 gc
 group.386gl.groupName=x86 GC
+group.386gl.baseName=x86 gc
 group.386gl.goarch=386
 
 compiler.386_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
@@ -128,7 +128,7 @@ group.armgl.compilers=&arm32gl:&arm64gl
 group.armgl.supportsBinary=false
 
 group.arm32gl.compilers=arm_gl114:arm_gl115:arm_gl116:arm_gl117:arm_gl118:arm_gl119:arm_gltip
-group.armgl.groupName=ARM GC
+group.arm32gl.groupName=ARM GC
 group.arm32gl.baseName=ARM gc
 group.arm32gl.goarch=arm
 
@@ -175,8 +175,8 @@ group.mipsgl.supportsBinary=false
 group.mips32gl.compilers=&mips32legl:&mips32begl
 
 group.mips32legl.compilers=mipsle_gl114:mipsle_gl115:mipsle_gl116:mipsle_gl117:mipsle_gl118:mipsle_gl119:mipsle_gltip
-group.mips32legl.groupName=MIPSLE GC
 group.mips32legl.goarch=mipsle
+group.mips32legl.groupName=MIPSLE GC
 group.mips32legl.baseName=MIPSLE gc
 
 compiler.mipsle_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
@@ -218,8 +218,8 @@ group.mips64gl.compilers=&mips64legl:&mips64begl
 
 group.mips64begl.compilers=mips64_gl114:mips64_gl115:mips64_gl116:mips64_gl117:mips64_gl118:mips64_gl119:mips64_gltip
 group.mips64begl.goarch=mips64
-group.mips64begl.baseName=MIPS64 gc
 group.mips64begl.groupName=MIPS64 GC
+group.mips64begl.baseName=MIPS64 gc
 
 compiler.mips64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mips64_gl114.semver=1.14
@@ -239,8 +239,9 @@ compiler.mips64_gltip.semver=(tip)
 
 group.mips64legl.compilers=mips64le_gl114:mips64le_gl115:mips64le_gl116:mips64le_gl117:mips64le_gl118:mips64le_gl119:mips64le_gltip
 group.mips64legl.goarch=mips64le
-group.mips64legl.baseName=MIPS64LE gc
 group.mips64legl.groupName=MIPS64LE GC
+group.mips64legl.baseName=MIPS64LE gc
+
 
 compiler.mips64le_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mips64le_gl114.semver=1.14
@@ -264,8 +265,8 @@ group.ppcgl.supportsBinary=false
 
 group.ppc64legl.compilers=ppc64le_gl114:ppc64le_gl115:ppc64le_gl116:ppc64le_gl117:ppc64le_gl118:ppc64le_gl119:ppc64le_gltip
 group.ppc64legl.goarch=ppc64le
-group.ppc64legl.baseName=POWER64LE gc
 group.ppc64legl.groupName=POWER64LE GC
+group.ppc64legl.baseName=POWER64LE gc
 
 compiler.ppc64le_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.ppc64le_gl114.semver=1.14
@@ -285,8 +286,8 @@ compiler.ppc64le_gltip.semver=(tip)
 
 group.ppc64begl.compilers=ppc64_gl114:ppc64_gl115:ppc64_gl116:ppc64_gl117:ppc64_gl118:ppc64_gl119:ppc64_gltip
 group.ppc64begl.goarch=ppc64
+group.ppc64begl.groupName=POWER64 GC
 group.ppc64begl.baseName=POWER64 gc
-group.ppc64begl.groupName=POWER64 gc
 
 compiler.ppc64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.ppc64_gl114.semver=1.14
@@ -331,8 +332,9 @@ compiler.riscv64_gltip.semver=(tip)
 group.s390xgl.compilers=s390x_gl114:s390x_gl115:s390x_gl116:s390x_gl117:s390x_gl118:s390x_gl119:s390x_gltip
 group.s390xgl.supportsBinary=false
 group.s390xgl.goarch=s390x
-group.s390xgl.baseName=S390X gc
 group.s390xgl.groupName=S390X GC
+group.s390xgl.baseName=S390X gc
+
 
 compiler.s390x_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.s390x_gl114.semver=1.14
@@ -384,8 +386,8 @@ group.cross.groupName=Cross Go
 # GCC for sparc
 group.gccgosparc.compilers=gccgosparc1220
 group.gccgosparc.groupName=SPARC GCCGO
-group.gccgosparc.isSemVer=true
 group.gccgosparc.baseName=SPARC gccgo
+group.gccgosparc.isSemVer=true
 
 compiler.gccgosparc1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
 compiler.gccgosparc1220.semver=12.2.0
@@ -396,8 +398,9 @@ compiler.gccgosparc1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-
 # GCC for sparc64
 group.gccgosparc64.compilers=gccgosparc641220
 group.gccgosparc64.groupName=SPARC64 GCCGO
+group.gccgosparc64.baseName=SPARC64 gccgo
 group.gccgosparc64.isSemVer=true
-group.gccgosparc64.baseName=SPARC64 GCCGO
+
 
 compiler.gccgosparc641220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
 compiler.gccgosparc641220.semver=12.2.0
@@ -444,7 +447,7 @@ compiler.gccgoriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/ri
 # GCC for s390x
 group.gccgos390x.compilers=gccgos390x1220
 group.gccgos390x.groupName=S390X GCCGO
-group.gccgos390x.baseName=s390x gccgo
+group.gccgos390x.baseName=S390X gccgo
 group.gccgos390x.isSemVer=true
 
 compiler.gccgos390x1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -40,10 +40,10 @@ group.gl.isSemVer=true
 
 ###### x86 GC ######
 group.x86gl.compilers=&amd64gl:&386gl
-group.x86gl.groupName=x86 GC
 
 group.amd64gl.compilers=6g141:gl172:gl185:gl187:gl192:gl194:gl1100:gl1101:gl1110:gl1120:gl1130:gl1140:gl1150:gl1160:gl1170:gl1180:gl1190:gltip
-group.amd64gl.baseName=amd64 gc
+group.amd64gl.groupName=x86-64 GC
+group.amd64gl.baseName=x86-64 gc
 
 compiler.6g141.exe=/opt/compiler-explorer/golang-1.4.1/go/bin/go
 compiler.6g141.semver=1.4.1
@@ -103,7 +103,7 @@ compiler.gltip.semver=(tip)
 compiler.gltip.goroot=/opt/compiler-explorer/go-tip
 
 group.386gl.compilers=386_gl114:386_gl115:386_gl116:386_gl117:386_gl118:386_gl119:386_gltip
-group.386gl.baseName=386 gc
+group.386gl.baseName=x86 gc
 group.386gl.groupName=x86 GC
 group.386gl.goarch=386
 
@@ -125,10 +125,10 @@ compiler.386_gltip.semver=(tip)
 
 ###### ARM GC ######
 group.armgl.compilers=&arm32gl:&arm64gl
-group.armgl.groupName=GC ARM
 group.armgl.supportsBinary=false
 
 group.arm32gl.compilers=arm_gl114:arm_gl115:arm_gl116:arm_gl117:arm_gl118:arm_gl119:arm_gltip
+group.armgl.groupName=ARM GC
 group.arm32gl.baseName=ARM gc
 group.arm32gl.goarch=arm
 
@@ -148,6 +148,7 @@ compiler.arm_gltip.exe=/opt/compiler-explorer/go-tip/bin/go
 compiler.arm_gltip.semver=(tip)
 
 group.arm64gl.compilers=arm64_gl114:arm64_gl115:arm64_gl116:arm64_gl117:arm64_gl118:arm64_gl119:arm64_gltip
+group.arm64gl.groupName=ARM64 GC
 group.arm64gl.baseName=ARM64 gc
 group.arm64gl.goarch=arm64
 
@@ -170,11 +171,11 @@ compiler.arm64_gltip.semver=(tip)
 ###### MIPS GC ######
 group.mipsgl.compilers=&mips32gl:&mips64gl
 group.mipsgl.supportsBinary=false
-group.mipsgl.groupName=GC MIPS
 
 group.mips32gl.compilers=&mips32legl:&mips32begl
 
 group.mips32legl.compilers=mipsle_gl114:mipsle_gl115:mipsle_gl116:mipsle_gl117:mipsle_gl118:mipsle_gl119:mipsle_gltip
+group.mips32legl.groupName=MIPSLE GC
 group.mips32legl.goarch=mipsle
 group.mips32legl.baseName=MIPSLE gc
 
@@ -195,6 +196,7 @@ compiler.mipsle_gltip.semver=(tip)
 
 group.mips32begl.compilers=mips_gl114:mips_gl115:mips_gl116:mips_gl117:mips_gl118:mips_gl119:mips_gltip
 group.mips32begl.goarch=mips
+group.mips32begl.groupName=MIPS GC
 group.mips32begl.baseName=MIPS gc
 
 compiler.mips_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
@@ -212,12 +214,12 @@ compiler.mips_gl119.semver=1.19
 compiler.mips_gltip.exe=/opt/compiler-explorer/go-tip/bin/go
 compiler.mips_gltip.semver=(tip)
 
-
 group.mips64gl.compilers=&mips64legl:&mips64begl
 
 group.mips64begl.compilers=mips64_gl114:mips64_gl115:mips64_gl116:mips64_gl117:mips64_gl118:mips64_gl119:mips64_gltip
 group.mips64begl.goarch=mips64
 group.mips64begl.baseName=MIPS64 gc
+group.mips64begl.groupName=MIPS64 GC
 
 compiler.mips64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mips64_gl114.semver=1.14
@@ -238,6 +240,7 @@ compiler.mips64_gltip.semver=(tip)
 group.mips64legl.compilers=mips64le_gl114:mips64le_gl115:mips64le_gl116:mips64le_gl117:mips64le_gl118:mips64le_gl119:mips64le_gltip
 group.mips64legl.goarch=mips64le
 group.mips64legl.baseName=MIPS64LE gc
+group.mips64legl.groupName=MIPS64LE GC
 
 compiler.mips64le_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mips64le_gl114.semver=1.14
@@ -257,12 +260,12 @@ compiler.mips64le_gltip.semver=(tip)
 
 ##### PPC GL #####
 group.ppcgl.compilers=&ppc64legl:&ppc64begl
-group.ppcgl.groupName=GC PPC
 group.ppcgl.supportsBinary=false
 
 group.ppc64legl.compilers=ppc64le_gl114:ppc64le_gl115:ppc64le_gl116:ppc64le_gl117:ppc64le_gl118:ppc64le_gl119:ppc64le_gltip
 group.ppc64legl.goarch=ppc64le
-group.ppc64legl.baseName=PPC64LE gc
+group.ppc64legl.baseName=POWER64LE gc
+group.ppc64legl.groupName=POWER64LE GC
 
 compiler.ppc64le_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.ppc64le_gl114.semver=1.14
@@ -282,7 +285,8 @@ compiler.ppc64le_gltip.semver=(tip)
 
 group.ppc64begl.compilers=ppc64_gl114:ppc64_gl115:ppc64_gl116:ppc64_gl117:ppc64_gl118:ppc64_gl119:ppc64_gltip
 group.ppc64begl.goarch=ppc64
-group.ppc64begl.baseName=PPC64 gc
+group.ppc64begl.baseName=POWER64 gc
+group.ppc64begl.groupName=POWER64 gc
 
 compiler.ppc64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.ppc64_gl114.semver=1.14
@@ -303,8 +307,8 @@ compiler.ppc64_gltip.semver=(tip)
 ###### RSICV GL ######
 group.riscvgl.compilers=riscv64_gl114:riscv64_gl115:riscv64_gl116:riscv64_gl117:riscv64_gl118:riscv64_gl119:riscv64_gltip
 group.riscvgl.supportsBinary=false
-group.riscvgl.groupName=GC RISC-V
-group.riscvgl.baseName=RISCV64 gc
+group.riscvgl.groupName=RISC-V 64 GC
+group.riscvgl.baseName=RISC-V 64 gc
 group.riscvgl.goarch=riscv64
 
 compiler.riscv64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
@@ -328,7 +332,7 @@ group.s390xgl.compilers=s390x_gl114:s390x_gl115:s390x_gl116:s390x_gl117:s390x_gl
 group.s390xgl.supportsBinary=false
 group.s390xgl.goarch=s390x
 group.s390xgl.baseName=S390X gc
-group.s390xgl.groupName=GC S390X
+group.s390xgl.groupName=S390X GC
 
 compiler.s390x_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.s390x_gl114.semver=1.14
@@ -350,7 +354,7 @@ compiler.s390x_gltip.semver=(tip)
 # WASM GO
 group.wasmgl.compilers=wasm_gl114:wasm_gl115:wasm_gl116:wasm_gl117:wasm_gl118:wasm_gl119:wasm_gltip
 group.wasmgl.supportsBinary=false
-group.wasmgl.groupName=GC WASM
+group.wasmgl.groupName=WASM GC
 group.wasmgl.goarch=wasm
 group.wasmgl.goos=js
 group.wasmgl.baseName=WASM gc
@@ -379,9 +383,9 @@ group.cross.groupName=Cross Go
 ###############################
 # GCC for sparc
 group.gccgosparc.compilers=gccgosparc1220
-group.gccgosparc.groupName=GCCGO sparc
+group.gccgosparc.groupName=SPARC GCCGO
 group.gccgosparc.isSemVer=true
-group.gccgosparc.baseName=sparc
+group.gccgosparc.baseName=SPARC gccgo
 
 compiler.gccgosparc1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
 compiler.gccgosparc1220.semver=12.2.0
@@ -391,9 +395,9 @@ compiler.gccgosparc1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-
 ###############################
 # GCC for sparc64
 group.gccgosparc64.compilers=gccgosparc641220
-group.gccgosparc64.groupName=GCCGO sparc64
+group.gccgosparc64.groupName=SPARC64 GCCGO
 group.gccgosparc64.isSemVer=true
-group.gccgosparc64.baseName=sparc64
+group.gccgosparc64.baseName=SPARC64 GCCGO
 
 compiler.gccgosparc641220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
 compiler.gccgosparc641220.semver=12.2.0
@@ -403,150 +407,147 @@ compiler.gccgosparc641220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sp
 ###############################
 # GCC for mips64el
 group.gccgomips64el.compilers=gccgomips64el1220
-group.gccgomips64el.groupName=GCCGO mips64el
+group.gccgomips64el.groupName=MIPS64EL GCCGO
+group.gccgomips64el.baseName=MIPS64EL gccgo
 group.gccgomips64el.isSemVer=true
 
 compiler.gccgomips64el1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
 compiler.gccgomips64el1220.semver=12.2.0
 compiler.gccgomips64el1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.gccgomips64el1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
-compiler.gccgomips64el1220.name=mips64el 12.2.0
 
 ###############################
 # GCC for mipsel
 group.gccgomipsel.compilers=gccgomipsel1220
-group.gccgomipsel.groupName=GCCGO mips64
+group.gccgomipsel.groupName=MIPSEL GCCGO
+group.gccgomipsel.baseName=MIPSEL gccgo
 group.gccgomipsel.isSemVer=true
 
 compiler.gccgomipsel1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
 compiler.gccgomipsel1220.semver=12.2.0
 compiler.gccgomipsel1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gccgomipsel1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
-compiler.gccgomipsel1220.name=mipsel 12.2.0
 
 ###############################
 # GCC for riscv64
 group.gccgoriscv64.compilers=gccgoriscv641220
-group.gccgoriscv64.groupName=GCCGO riscv64
+group.gccgoriscv64.groupName=RISC-V 64 GCCGO
+group.gccgoriscv64.baseName=RISC-V 64 gccgo
 group.gccgoriscv64.isSemVer=true
 
 compiler.gccgoriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
 compiler.gccgoriscv641220.semver=12.2.0
 compiler.gccgoriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gccgoriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
-compiler.gccgoriscv641220.name=riscv64 12.2.0
 
 ###############################
 # GCC for s390x
 group.gccgos390x.compilers=gccgos390x1220
-group.gccgos390x.groupName=GCCGO s390x
+group.gccgos390x.groupName=S390X GCCGO
+group.gccgos390x.baseName=s390x gccgo
 group.gccgos390x.isSemVer=true
 
 compiler.gccgos390x1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
 compiler.gccgos390x1220.semver=12.2.0
 compiler.gccgos390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gccgos390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
-compiler.gccgos390x1220.name=s390x 12.2.0
 
 ###############################
 # GCC for MIPS
 group.gccgomips.compilers=gccgomips1220
-group.gccgomips.groupName=GCCGO mips
+group.gccgomips.groupName=MIPS GCCGO
+group.gccgomips.baseName=MIPS gccgo
 group.gccgomips.isSemVer=true
 
 compiler.gccgomips1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
 compiler.gccgomips1220.semver=12.2.0
 compiler.gccgomips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gccgomips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
-compiler.gccgomips1220.name=mips 12.2.0
 
 ###############################
 # GCC for MIPS64
 group.gccgomips64.compilers=gccgomips641220
-group.gccgomips64.groupName=GCCGO mips64
+group.gccgomips64.groupName=MIPS64 GCCGO
+group.gccgomips64.baseName=MIPS64 gccgo
 group.gccgomips64.isSemVer=true
 
 compiler.gccgomips641220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
 compiler.gccgomips641220.semver=12.2.0
 compiler.gccgomips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gccgomips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
-compiler.gccgomips641220.name=mips64 12.2.0
-
 
 ###############################
 # GCC for ARM64
 group.gccgoarm64.compilers=gccgoarm641220
-group.gccgoarm64.groupName=GCCGO arm64
+group.gccgoarm64.groupName=ARM64 GCCGO
+group.gccgoarm64.baseName=ARM64 gccgo
 group.gccgoarm64.isSemVer=true
 
 compiler.gccgoarm641220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
 compiler.gccgoarm641220.semver=12.2.0
 compiler.gccgoarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gccgoarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
-compiler.gccgoarm641220.name=arm64 12.2.0
 
 ###############################
 # GCC for ARM
 group.gccgoarm.compilers=gccgoarm1220
-group.gccgoarm.groupName=GCCGO arm
+group.gccgoarm.groupName=ARM GCCGO
+group.gccgoarm.baseName=ARM gccgo
 group.gccgoarm.isSemVer=true
 
 compiler.gccgoarm1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
 compiler.gccgoarm1220.semver=12.2.0
 compiler.gccgoarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gccgoarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
-compiler.gccgoarm1220.name=arm 12.2.0
 
 ###############################
 # GCC for PPC
 group.gccgoppc.compilers=gccgoppc1220
-group.gccgoppc.groupName=GCCGO POWER
+group.gccgoppc.groupName=POWER GCCGO
+group.gccgoppc.baseName=POWER gccgo
 group.gccgoppc.isSemVer=true
 
 compiler.gccgoppc1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
 compiler.gccgoppc1220.semver=12.2.0
 compiler.gccgoppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gccgoppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
-compiler.gccgoppc1220.name=powerpc 12.2.0
 
 ###############################
-# GCC for PPC64
-group.gccgoppc64le.compilers=gccgoppc64le1220
-group.gccgoppc64le.groupName=GCCGO POWER64LE
+# GCC for PPC64LE
+group.gccgoppc64le.compilers=gccgoppc64le1220:gppc64leg9:gppc64leg8
+group.gccgoppc64le.groupName=POWER64LE GCCGO
+group.gccgoppc64le.baseName=POWER64LE gccgo
 group.gccgoppc64le.isSemVer=true
 
 compiler.gccgoppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
 compiler.gccgoppc64le1220.semver=12.2.0
 compiler.gccgoppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gccgoppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
-compiler.gccgoppc64le1220.name=powerpc64le 12.2.0
 
+compiler.gppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
+compiler.gppc64leg9.name=power64le AT13.0
+compiler.gppc64leg9.semver=AT13.0
+
+compiler.gppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
+compiler.gppc64leg8.name=power64le AT12.0
+compiler.gppc64leg8.semver=AT12.0
 
 ###############################
 # GCC for PPC64
-group.gccgoppc64.compilers=gppc64leg8:gppc64g8:gppc64leg9:gppc64g9:gccgoppc641220
-group.gccgoppc64.groupName=GCCGO POWER64
+group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc641220
+group.gccgoppc64.groupName=POWER64 GCCGO
+group.gccgoppc64.baseName=POWER64 gccgo
 group.gccgoppc64.isSemVer=true
 
 compiler.gccgoppc641220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
 compiler.gccgoppc641220.semver=12.2.0
 compiler.gccgoppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gccgoppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
-compiler.gccgoppc641220.name=powerpc64 12.2.0
 
-compiler.gppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
-compiler.gppc64leg8.name=power64le AT12.0
-compiler.gppc64leg8.semver=(snapshot)
 compiler.gppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
-compiler.gppc64g8.name=power64 AT12.0
-compiler.gppc64g8.semver=(snapshot)
-compiler.gppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
-compiler.gppc64leg9.name=power64le AT13.0
-compiler.gppc64leg9.semver=(snapshot)
+compiler.gppc64g8.semver=AT12.0
 compiler.gppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
-compiler.gppc64g9.name=power64 AT13.0
-compiler.gppc64g9.semver=(snapshot)
-
+compiler.gppc64g9.semver=AT13.0
 
 #################################
 #################################


### PR DESCRIPTION
GO compiler naming was not coherent (and some were incorrect). Try to make them more homogeneous.

fixes #4733