### PR TITLE
 Initial support for Modula-2 language

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -117,6 +117,10 @@ lang-llvm:
   - lib/tooling/llvm-mca-tool.js
   - etc/config/llvm.*.properties
   - static/modes/llvm-ir-mode.ts
+lang-modula2:
+  - lib/compilers/gm2.js
+  - etc/config/modula2.*.properties
+  - static/modes/modula2-mode.ts
 lang-nim:
   - lib/compilers/nim.js
   - etc/config/nim.*.properties

--- a/etc/config/modula2.amazon.properties
+++ b/etc/config/modula2.amazon.properties
@@ -1,0 +1,24 @@
+# Default settings for modula2
+compilers=&gm2
+defaultCompiler=gm2snapshot
+
+demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+postProcess=
+supportsBinary=true
+supportsBinaryObject=true
+supportsExecute=true
+binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*)$
+supportsLibraryCodeFilter=true
+needsMulti=false
+
+externalparser=CEAsmParser
+externalparser.exe=/usr/local/bin/asm-parser
+
+group.gm2.compilers=gm2snapshot
+group.gm2.instructionSet=amd64
+group.gm2.isSemVer=true
+group.gm2.baseName=x86-64 gcc gm2
+
+compiler.gm2snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gm2
+compiler.gm2snapshot.semver=(snapshot)

--- a/etc/config/modula2.defaults.properties
+++ b/etc/config/modula2.defaults.properties
@@ -1,0 +1,15 @@
+# Default settings for modula2
+compilers=:&gcc
+defaultCompiler=gdefault
+demangler=c++filt
+objdumper=objdump
+postProcess=
+supportsBinary=true
+supportsBinaryObject=true
+binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*)$
+supportsLibraryCodeFilter=true
+
+group.gcc.compilers=cgdefault
+compiler.cgdefault.exe=/usr/bin/gm2
+compiler.cgdefault.name=gcc default
+

--- a/examples/modula2/default.mod
+++ b/examples/modula2/default.mod
@@ -1,0 +1,10 @@
+MODULE PrintHelloWorld;
+
+(*This program prints "Hello world!" on the standard output device*)
+
+FROM InOut IMPORT WriteString, WriteLn;
+
+BEGIN
+	WriteString('Hello world!');
+	WriteLn;
+END PrintHelloWorld.

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -71,6 +71,7 @@ export {LLCCompiler} from './llc';
 export {LLVMmcaTool} from './llvm-mca';
 export {LLVMMOSCompiler} from './llvm-mos';
 export {MLIRCompiler} from './mlir';
+export {GM2Compiler} from './gm2';
 export {MrustcCompiler} from './mrustc';
 export {NasmCompiler} from './nasm';
 export {NimCompiler} from './nim';

--- a/lib/compilers/gm2.ts
+++ b/lib/compilers/gm2.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Compiler Explorer Authors
+// Copyright (c) 2023, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -22,37 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import './ada-mode';
-import './asm6502-mode';
-import './asm-mode';
-import './asmruby-mode';
-import './carbon-mode';
-import './clean-mode';
-import './cmake-mode';
-import './cppcircle-mode';
-import './cpp-for-opencl-mode';
-import './cppfront-mode';
-import './cppp-mode';
-import './cppx-blue-mode';
-import './cppx-gold-mode';
-import './crystal-mode';
-import './cuda-mode';
-import './d-mode';
-import './erlang-mode';
-import './fortran-mode';
-import './gccdump-rtl-gimple-mode';
-import './haskell-mode';
-import './hlsl-mode';
-import './hook-mode';
-import './ispc-mode';
-import './jakt-mode';
-import './llvm-ir-mode';
-import './mlir-mode';
-import './modula2-mode';
-import './nc-mode';
-import './nim-mode';
-import './ocaml-mode';
-import './openclc-mode';
-import './ptx-mode';
-import './spirv-mode';
-import './zig-mode';
+import {GCCCompiler} from './gcc';
+
+export class GM2Compiler extends GCCCompiler {
+    static override get key() {
+        return 'gm2';
+    }
+}

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -418,6 +418,17 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
     },
+    modula2: {
+        name: 'modula2',
+        monaco: 'modula2',
+        extensions: ['.mod'],
+        alias: [],
+        logoUrl: null,
+        logoUrlDark: null,
+        formatter: null,
+        previewFilter: null,
+        monacoDisassembly: null,
+    },
     nim: {
         name: 'Nim',
         monaco: 'nim',

--- a/static/modes/modula2-mode.ts
+++ b/static/modes/modula2-mode.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2018, Eugen Bulavin
+// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+import * as monaco from 'monaco-editor';
+
+function definition(): monaco.languages.IMonarchLanguage {
+    return {
+        keywords: [
+            'AND',
+            'ARRAY',
+            'BEGIN',
+            'BY',
+            'CASE',
+            'CONST',
+            'DEFINITION',
+            'DIV',
+            'DO',
+            'ELSE',
+            'ELSIF',
+            'END',
+            'EXCEPT',
+            'EXIT',
+            'EXPORT',
+            'FINALLY',
+            'FOR',
+            'FROM',
+            'IF',
+            'IMPLEMENTATION',
+            'IMPORT',
+            'IN',
+            'LOOP',
+            'MOD',
+            'MODULE',
+            'NOT',
+            'OF',
+            'OR',
+            'PACKEDSET',
+            'POINTER',
+            'PROCEDURE',
+            'QUALIFIED',
+            'UNQUALIFIED',
+            'RECORD',
+            'REM',
+            'REPEAT',
+            'RETRY',
+            'RETURN',
+            'SET',
+            'THEN',
+            'TO',
+            'TYPE',
+            'UNTIL',
+            'VAR',
+            'WHILE',
+            'WITH',
+            'ASM',
+            'VOLATILE',
+        ],
+
+        typeKeywords: ['integer number', 'real number', 'identifier', 'string'],
+
+        numbers: /-?[0-9.]/,
+
+        tokenizer: {
+            root: [
+                // identifiers and keywords
+                [
+                    /[A-Za-z_$][\w$]*/,
+                    {
+                        cases: {
+                            '@typeKeywords': 'keyword',
+                            '@keywords': 'keyword',
+                            '@default': 'identifier',
+                        },
+                    },
+                ],
+
+                {include: '@whitespace'},
+
+                [/@numbers/, 'number'],
+
+                [/[+\-*/=<>$@]/, 'operators'],
+
+                [/(")(.*)(")/, ['string', 'string', 'string']],
+            ],
+
+            comment: [
+                [/[^(*]+/, 'comment'],
+                [/\*\)/, 'comment', '@pop'],
+            ],
+
+            whitespace: [
+                [/[ \t\r\n]+/, 'white'],
+                [/\(\*/, 'comment', '@comment'],
+            ],
+        },
+    };
+}
+
+monaco.languages.register({id: 'modula2'});
+monaco.languages.setMonarchTokensProvider('modula2', definition());
+
+export {};

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -57,6 +57,7 @@ export type LanguageKey =
     | 'kotlin'
     | 'llvm'
     | 'mlir'
+    | 'modula2'
     | 'nim'
     | 'ocaml'
     | 'objc'


### PR DESCRIPTION
With the upcoming gcc 13 release and it's shiny Modula-2 frontend, we
are introducing Modula-2 support in Compiler Explorer :)

Currently, only the gcc-snapshot build supports modula-2.

fixes #4688

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>