### PR TITLE
Turn some auto-fixable eslint rules back on

### DIFF
--- a/lib/.eslint-ce-lib.yml
+++ b/lib/.eslint-ce-lib.yml
@@ -11,25 +11,23 @@ env:
   node: true
   es6: false
 rules:
-  # TODO: Disabled for now
-  #comma-dangle:
-  #  - error
-  #  - arrays: always-multiline
-  #    objects: always-multiline
-  #    imports: always-multiline
-  #    exports: always-multiline
-  #    functions: never
+  comma-dangle:
+    - error
+    - arrays: always-multiline
+      objects: always-multiline
+      imports: always-multiline
+      exports: always-multiline
+      functions: never
   eol-last:
     - error
     - always
   eqeqeq:
     - error
     - smart
-  # TODO: Disabled for now
-  #indent:
-  #  - error
-  #  - 4
-  #  - SwitchCase: 1
+  indent:
+    - error
+    - 4
+    - SwitchCase: 1
   max-len:
     - error
     - 120

--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
             rules: {
                 '@typescript-eslint/no-empty-function': 'off',
                 '@typescript-eslint/no-unused-vars': 'off',
-                '@typescript-eslint/no-var-requires': 'off', // Needed for now, can't move some
+                '@typescript-eslint/no-var-requires': 'error',
                 '@typescript-eslint/no-explicit-any': 'off', // Too much js code still exists
                 '@typescript-eslint/ban-ts-comment': 'error',
                 // TODO: Disabled for now

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -367,7 +367,7 @@ export class BaseCompiler implements ICompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
@@ -420,7 +420,7 @@ export class BaseCompiler implements ICompiler {
         demangle,
         staticReloc: boolean,
         dynamicReloc: boolean,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         outputFilename = this.getObjdumpOutputFilename(outputFilename);
 
@@ -498,7 +498,7 @@ export class BaseCompiler implements ICompiler {
         executable,
         maxSize,
         executeParameters: ExecutableExecutionOptions,
-        homeDir,
+        homeDir
     ): Promise<BasicExecutionResult> {
         // We might want to save this in the compilation environment once execution is made available
         const timeoutMs = this.env.ceProps('binaryExecTimeoutMs', 2000);
@@ -617,7 +617,7 @@ export class BaseCompiler implements ICompiler {
     protected optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): string[] {
         let options = ['-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary && !filters.binaryObject) {
@@ -640,7 +640,7 @@ export class BaseCompiler implements ICompiler {
             (o: LibraryVersion, versionId: string): boolean => {
                 if (versionId === selectedLib.version) return true;
                 return !!(o.alias && o.alias.includes(selectedLib.version));
-            },
+            }
         );
 
         if (!result) return false;
@@ -681,8 +681,8 @@ export class BaseCompiler implements ICompiler {
                             return false;
                         }
                     });
-                }),
-            ),
+                })
+            )
         );
 
         const sortedlinks: string[] = [];
@@ -774,7 +774,7 @@ export class BaseCompiler implements ICompiler {
                         return false;
                     }
                 });
-            }),
+            })
         ) as string[];
     }
 
@@ -785,7 +785,7 @@ export class BaseCompiler implements ICompiler {
                 if (!foundVersion) return false;
 
                 return foundVersion.libpath;
-            }),
+            })
         ) as string[];
     }
 
@@ -808,7 +808,7 @@ export class BaseCompiler implements ICompiler {
             this.compiler.libPath.map(path => pathFlag + path),
             toolchainLibraryPaths.map(path => pathFlag + path),
             this.getSharedLibraryPaths(libraries).map(path => pathFlag + path),
-            this.getSharedLibraryPaths(libraries).map(path => libPathFlag + path),
+            this.getSharedLibraryPaths(libraries).map(path => libPathFlag + path)
         ) as string[];
     }
 
@@ -820,7 +820,7 @@ export class BaseCompiler implements ICompiler {
         return _.union(
             paths.split(path.delimiter).filter(p => !!p),
             this.compiler.ldPath,
-            this.getSharedLibraryPaths(libraries),
+            this.getSharedLibraryPaths(libraries)
         ) as string[];
     }
 
@@ -833,7 +833,7 @@ export class BaseCompiler implements ICompiler {
             paths.split(path.delimiter).filter(p => !!p),
             this.compiler.ldPath,
             this.compiler.libPath,
-            this.getSharedLibraryPaths(libraries),
+            this.getSharedLibraryPaths(libraries)
         );
     }
 
@@ -863,7 +863,7 @@ export class BaseCompiler implements ICompiler {
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],
-        staticLibLinks: string[],
+        staticLibLinks: string[]
     ) {
         return options.concat(
             userOptions,
@@ -872,7 +872,7 @@ export class BaseCompiler implements ICompiler {
             libOptions,
             libPaths,
             libLinks,
-            staticLibLinks,
+            staticLibLinks
         );
     }
 
@@ -882,7 +882,7 @@ export class BaseCompiler implements ICompiler {
         backendOptions: Record<string, any>,
         inputFilename: string,
         outputFilename: string,
-        libraries,
+        libraries
     ) {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
         backendOptions = backendOptions || {};
@@ -919,7 +919,7 @@ export class BaseCompiler implements ICompiler {
             libPaths,
             libLinks,
             userOptions,
-            staticLibLinks,
+            staticLibLinks
         );
     }
 
@@ -944,7 +944,7 @@ export class BaseCompiler implements ICompiler {
         execOptions.maxOutput = 1024 * 1024 * 1024;
 
         return this.llvmAst.processAst(
-            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions),
+            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
         );
     }
 
@@ -960,7 +960,7 @@ export class BaseCompiler implements ICompiler {
                 'filter-headers': false,
                 'clang-format': false,
             },
-            rawPpOptions,
+            rawPpOptions
         );
 
         const execOptions = this.getDefaultExecOptions();
@@ -970,7 +970,7 @@ export class BaseCompiler implements ICompiler {
             this.compiler.exe,
             compilerOptions,
             this.filename(inputFilename),
-            execOptions,
+            execOptions
         );
         let output = result.stdout;
 
@@ -1078,7 +1078,7 @@ export class BaseCompiler implements ICompiler {
         inputFilename: string,
         options: string[],
         filters: ParseFiltersAndOutputOptions,
-        llvmOptPipelineOptions: LLVMOptPipelineBackendOptions,
+        llvmOptPipelineOptions: LLVMOptPipelineBackendOptions
     ): Promise<LLVMOptPipelineOutput | undefined> {
         // These options make Clang produce the pass dumps
         const newOptions = options
@@ -1086,7 +1086,7 @@ export class BaseCompiler implements ICompiler {
             .concat(unwrap(this.compiler.llvmOptArg))
             .concat(llvmOptPipelineOptions.fullModule ? unwrap(this.compiler.llvmOptModuleScopeArg) : [])
             .concat(
-                llvmOptPipelineOptions.noDiscardValueNames ? unwrap(this.compiler.llvmOptNoDiscardValueNamesArg) : [],
+                llvmOptPipelineOptions.noDiscardValueNames ? unwrap(this.compiler.llvmOptNoDiscardValueNamesArg) : []
             )
             .concat(this.compiler.debugPatched ? ['-mllvm', '--debug-to-stdout'] : []);
 
@@ -1115,7 +1115,7 @@ export class BaseCompiler implements ICompiler {
                 output,
                 filters,
                 llvmOptPipelineOptions,
-                this.compiler.debugPatched,
+                this.compiler.debugPatched
             );
             const parseEnd = performance.now();
 
@@ -1154,12 +1154,12 @@ export class BaseCompiler implements ICompiler {
         output,
         filters: ParseFiltersAndOutputOptions,
         llvmOptPipelineOptions: LLVMOptPipelineBackendOptions,
-        debugPatched?: boolean,
+        debugPatched?: boolean
     ) {
         return this.llvmPassDumpParser.process(
             debugPatched ? output.stdout : output.stderr,
             filters,
-            llvmOptPipelineOptions,
+            llvmOptPipelineOptions
         );
     }
 
@@ -1395,7 +1395,7 @@ export class BaseCompiler implements ICompiler {
                         compilationInfo.inputFilename,
                         tool.args,
                         tool.stdin,
-                        this.supportedLibraries,
+                        this.supportedLibraries
                     );
                     tooling.push(toolPromise);
                 }
@@ -1460,7 +1460,7 @@ export class BaseCompiler implements ICompiler {
         dirPath: string,
         source: string,
         files: any[],
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         if (!source) throw new Error(`File ${this.compileFilename} has no content or file is missing`);
 
@@ -1511,8 +1511,8 @@ export class BaseCompiler implements ICompiler {
                 key.backendOptions,
                 inputFilename,
                 outputFilename,
-                key.libraries,
-            ),
+                key.libraries
+            )
         );
 
         const execOptions = this.getDefaultExecOptions();
@@ -1722,14 +1722,14 @@ export class BaseCompiler implements ICompiler {
     getCompilationInfo(
         key: CompilationCacheKey,
         result: CompilationResult | CustomInputForTool,
-        customBuildPath?: string,
+        customBuildPath?: string
     ): CompilationInfo {
         return {
             outputFilename: this.getOutputFilename(customBuildPath || result.dirPath || '', this.outputFilebase, key),
             executableFilename: this.getExecutableFilename(
                 customBuildPath || result.dirPath || '',
                 this.outputFilebase,
-                key,
+                key
             ),
             asmParser: this.asm,
             ...key,
@@ -1768,7 +1768,7 @@ export class BaseCompiler implements ICompiler {
         const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase, key);
 
         options = _.compact(
-            this.prepareArguments(options, filters, backendOptions, inputFilename, outputFilename, libraries),
+            this.prepareArguments(options, filters, backendOptions, inputFilename, outputFilename, libraries)
         );
 
         const execOptions = this.getDefaultExecOptions();
@@ -1817,8 +1817,8 @@ export class BaseCompiler implements ICompiler {
                         inputFilename,
                         dirPath,
                         outputFilename,
-                    }),
-                ),
+                    })
+                )
             ),
         ]);
 
@@ -1829,11 +1829,11 @@ export class BaseCompiler implements ICompiler {
 
         const gccDumpResult = makeGccDump
             ? await this.processGccDumpOutput(
-                  backendOptions.produceGccDump,
-                  asmResult,
-                  this.compiler.removeEmptyGccDump,
-                  outputFilename,
-              )
+                backendOptions.produceGccDump,
+                asmResult,
+                this.compiler.removeEmptyGccDump,
+                outputFilename
+            )
             : '';
         const rustMirResult = makeRustMir ? await this.processRustMirOutput(outputFilename, asmResult) : '';
 
@@ -2095,7 +2095,7 @@ export class BaseCompiler implements ICompiler {
                 'cmake',
                 this.env.ceProps('cmake'),
                 fullArgs,
-                makeExecParams,
+                makeExecParams
             );
 
             if (cmakeStepResult.code !== 0) {
@@ -2113,7 +2113,7 @@ export class BaseCompiler implements ICompiler {
                 'build',
                 this.env.ceProps('cmake'),
                 ['--build', '.'],
-                execParams,
+                execParams
             );
 
             if (makeStepResult.code !== 0) {
@@ -2135,7 +2135,7 @@ export class BaseCompiler implements ICompiler {
                 const [asmResult] = await this.checkOutputFileAndDoPostProcess(
                     fullResult.result,
                     outputFilename,
-                    cacheKey.filters,
+                    cacheKey.filters
                 );
                 fullResult.result = asmResult;
             }
@@ -2174,7 +2174,7 @@ export class BaseCompiler implements ICompiler {
             cacheKey.filters,
             libsAndOptions.options,
             optOutput,
-            path.join(dirPath, 'build'),
+            path.join(dirPath, 'build')
         );
 
         delete fullResult.result.dirPath;
@@ -2307,7 +2307,7 @@ export class BaseCompiler implements ICompiler {
                     filters,
                     backendOptions,
                     libraries,
-                    tools,
+                    tools
                 );
 
                 return await this.afterCompilation(
@@ -2319,7 +2319,7 @@ export class BaseCompiler implements ICompiler {
                     backendOptions,
                     filters,
                     options,
-                    optOutput,
+                    optOutput
                 );
             })();
             compilationTimeHistogram.observe((performance.now() - start) / 1000);
@@ -2337,7 +2337,7 @@ export class BaseCompiler implements ICompiler {
         filters,
         options,
         optOutput,
-        customBuildPath?,
+        customBuildPath?
     ) {
         // Start the execution as soon as we can, but only await it at the end.
         const execPromise = doExecute ? this.handleExecution(key, executeParameters) : null;
@@ -2351,7 +2351,7 @@ export class BaseCompiler implements ICompiler {
 
         result.tools = _.union(
             result.tools,
-            await Promise.all(this.runToolsOfType(tools, 'postcompilation', compilationInfo)),
+            await Promise.all(this.runToolsOfType(tools, 'postcompilation', compilationInfo))
         );
 
         result = await this.extractDeviceCode(result, filters, compilationInfo);
@@ -2515,7 +2515,7 @@ export class BaseCompiler implements ICompiler {
                         name: 'gimple (tree)',
                         command_prefix: '-fdump-tree-gimple',
                     },
-                ],
+                ]
             );
         }
 
@@ -2535,7 +2535,7 @@ export class BaseCompiler implements ICompiler {
             (Object.values(result.stderr) as ResultLine[]).map(x => [
                 x,
                 this.fromInternalGccDumpName(x.text, selectedPasses),
-            ]),
+            ])
         );
 
         for (const [obj, selectizeObject] of dumpPassesLines) {
@@ -2606,34 +2606,34 @@ but nothing was dumped. Possible causes are:
         const asmPromise =
             (filters.binary || filters.binaryObject) && this.supportsObjdump()
                 ? this.objdump(
-                      outputFilename,
-                      result,
-                      maxSize,
-                      filters.intel,
-                      filters.demangle,
-                      filters.binaryObject,
-                      false,
-                      filters,
-                  )
+                    outputFilename,
+                    result,
+                    maxSize,
+                    filters.intel,
+                    filters.demangle,
+                    filters.binaryObject,
+                    false,
+                    filters
+                )
                 : (async () => {
-                      if (result.asmSize === undefined) {
-                          result.asm = '<No output file>';
-                          return result;
-                      }
-                      if (result.asmSize >= maxSize) {
-                          result.asm =
+                    if (result.asmSize === undefined) {
+                        result.asm = '<No output file>';
+                        return result;
+                    }
+                    if (result.asmSize >= maxSize) {
+                        result.asm =
                               '<No output: generated assembly was too large' +
                               ` (${result.asmSize} > ${maxSize} bytes)>`;
-                          return result;
-                      }
-                      if (postProcess.length > 0) {
-                          return await this.execPostProcess(result, postProcess, outputFilename, maxSize);
-                      } else {
-                          const contents = await fs.readFile(outputFilename);
-                          result.asm = contents.toString();
-                          return result;
-                      }
-                  })();
+                        return result;
+                    }
+                    if (postProcess.length > 0) {
+                        return await this.execPostProcess(result, postProcess, outputFilename, maxSize);
+                    } else {
+                        const contents = await fs.readFile(outputFilename);
+                        result.asm = contents.toString();
+                        return result;
+                    }
+                })();
         return Promise.all([asmPromise, optPromise]);
     }
 

--- a/lib/buildenvsetup/ceconan.ts
+++ b/lib/buildenvsetup/ceconan.ts
@@ -260,7 +260,7 @@ export class BuildEnvSetupCeConanDirect extends BuildEnvSetupBase {
                     allDownloads.push(
                         this.getPackageUrl(libVerBuilds.id, lookupversion, hash).then(downloadUrl => {
                             return this.downloadAndExtractPackage(libVerBuilds.id, lookupversion, dirPath, downloadUrl);
-                        }),
+                        })
                     );
                 } else {
                     logger.warn(`No build found for ${libVer} matching ${JSON.stringify(buildProperties)}`);

--- a/lib/buildenvsetup/cliconan.ts
+++ b/lib/buildenvsetup/cliconan.ts
@@ -102,7 +102,7 @@ export class BuildEnvSetupCliConan extends BuildEnvSetupBase {
             '-s', `compiler.libcxx=${libcxx}`,
             '-s', `arch=${arch}`,
             '-s', `stdver=${stdver}`,
-            '-s', `flagcollection=${flagcollection}`,
+            '-s', `flagcollection=${flagcollection}`
         );
 
         logger.info('Conan install: ', args);

--- a/lib/cfg/cfg.ts
+++ b/lib/cfg/cfg.ts
@@ -46,7 +46,7 @@ const parsers = makeDefaultedKeyedTypeGetter(
         ClangCFGParser,
         GccCFGParser,
     },
-    BaseCFGParser,
+    BaseCFGParser
 );
 const instructionSets = makeDefaultedKeyedTypeGetter('instruction set info provider', {}, BaseInstructionSetInfo);
 

--- a/lib/clientstate-normalizer.ts
+++ b/lib/clientstate-normalizer.ts
@@ -192,13 +192,13 @@ export class ClientStateNormalizer {
             this.addSpecialOutputToCompiler(
                 component.componentState._compilerid,
                 'gccdump',
-                component.componentState._editorid,
+                component.componentState._editorid
             );
         } else if (component.componentName === 'output') {
             this.addSpecialOutputToCompiler(
                 component.componentState.compiler,
                 'compilerOutput',
-                component.componentState.editor,
+                component.componentState.editor
             );
         } else if (component.componentName === 'conformance') {
             const session = this.normalized.findOrCreateSession(component.componentState.editorid);
@@ -209,7 +209,7 @@ export class ClientStateNormalizer {
                 component.componentState.editor,
                 component.componentState.toolId,
                 component.componentState.args,
-                component.componentState.stdin,
+                component.componentState.stdin
             );
         } else if (component.content) {
             this.fromGoldenLayoutContent(component.content);
@@ -594,14 +594,14 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
     newToolStackFromCompiler(session, compilerIndex, toolId, args, stdin, width) {
         return this.newStackWithOneComponent(
             width,
-            this.createToolComponent(session, compilerIndex, toolId, args, stdin),
+            this.createToolComponent(session, compilerIndex, toolId, args, stdin)
         );
     }
 
     newConformanceViewStack(session, width, conformanceview) {
         const stack = this.newStackWithOneComponent(
             width,
-            this.createConformanceViewComponent(session, conformanceview),
+            this.createConformanceViewComponent(session, conformanceview)
         );
 
         for (const compiler of conformanceview.compilers) {
@@ -619,7 +619,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
     newCompilerStackFromSession(session, compiler, width) {
         return this.newStackWithOneComponent(
             width,
-            this.createCompilerComponent(session, compiler, false, compiler._internalId),
+            this.createCompilerComponent(session, compiler, false, compiler._internalId)
         );
     }
 
@@ -746,7 +746,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
 
             for (const tool of compiler.tools) {
                 stack.content.push(
-                    this.createToolComponentForTreeCompiler(tree, idxCompiler + 1, tool.id, tool.args, tool.stdin),
+                    this.createToolComponentForTreeCompiler(tree, idxCompiler + 1, tool.id, tool.args, tool.stdin)
                 );
             }
         }
@@ -800,7 +800,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
 
             for (const tool of compiler.tools) {
                 stack.content.push(
-                    this.createToolComponent(false, idxCompiler + 1, tool.id, tool.args, tool.stdin, customSessionId),
+                    this.createToolComponent(false, idxCompiler + 1, tool.id, tool.args, tool.stdin, customSessionId)
                 );
             }
         }
@@ -954,7 +954,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
                     for (const viewtype of compiler.specialoutputs) {
                         const stack = this.newStackWithOneComponent(
                             compilerWidth,
-                            this.createSpecialOutputComponent(viewtype, session, idxCompiler),
+                            this.createSpecialOutputComponent(viewtype, session, idxCompiler)
                         );
 
                         if (stack) {
@@ -969,7 +969,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
                             tool.id,
                             tool.args,
                             tool.stdin,
-                            compilerWidth,
+                            compilerWidth
                         );
                         this.golden.content[0].content[idxSession].content[1].content.push(stack);
                     }
@@ -1009,7 +1009,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
                 for (const viewtype of compiler.specialoutputs) {
                     const stack = this.newStackWithOneComponent(
                         width,
-                        this.createSpecialOutputComponent(viewtype, session, idxCompiler),
+                        this.createSpecialOutputComponent(viewtype, session, idxCompiler)
                     );
 
                     if (stack) {
@@ -1024,7 +1024,7 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
                         tool.id,
                         tool.args,
                         tool.stdin,
-                        width,
+                        width
                     );
                     this.golden.content[0].content.push(stack);
                 }

--- a/lib/compilation-env.ts
+++ b/lib/compilation-env.ts
@@ -64,15 +64,15 @@ export class CompilationEnvironment {
         this.badOptions = new RegExp(this.ceProps('optionsForbiddenRe', deprecatedForbidden));
         this.cache = createCacheFromConfig(
             'default',
-            doCache === undefined || doCache ? this.ceProps('cacheConfig', '') : '',
+            doCache === undefined || doCache ? this.ceProps('cacheConfig', '') : ''
         );
         this.executableCache = createCacheFromConfig(
             'executable',
-            doCache === undefined || doCache ? this.ceProps('executableCacheConfig', '') : '',
+            doCache === undefined || doCache ? this.ceProps('executableCacheConfig', '') : ''
         );
         this.compilerCache = createCacheFromConfig(
             'compiler',
-            doCache === undefined || doCache ? this.ceProps('compilerCacheConfig', '') : '',
+            doCache === undefined || doCache ? this.ceProps('compilerCacheConfig', '') : ''
         );
         this.reportCacheEvery = this.ceProps('cacheReportEvery', 100);
         this.multiarch = null;

--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -63,7 +63,7 @@ export class CompilerFinder {
         compilerProps: CompilerProps,
         awsProps: PropertyGetter,
         args: OptionHandlerArguments,
-        optionsHandler: ClientOptionsHandler,
+        optionsHandler: ClientOptionsHandler
     ) {
         this.compilerProps = compilerProps.get.bind(compilerProps);
         this.ceProps = compilerProps.ceProps;
@@ -85,7 +85,7 @@ export class CompilerFinder {
         port: number,
         uriBase: string,
         props: PropertyGetter,
-        langId: string | null,
+        langId: string | null
     ): Promise<CompilerInfo[] | null> {
         const requestLib = port === 443 ? https : http;
         const uriSchema = port === 443 ? 'https' : 'http';
@@ -116,12 +116,12 @@ export class CompilerFinder {
                                     error = new Error(
                                         'Failed fetching remote compilers from ' +
                                             `${uriSchema}://${host}:${port}${apiPath}\n` +
-                                            `Status Code: ${statusCode}`,
+                                            `Status Code: ${statusCode}`
                                     );
                                 } else if (!contentType || !/^application\/json/.test(contentType)) {
                                     error = new Error(
                                         'Invalid content-type.\n' +
-                                            `Expected application/json but received ${contentType}`,
+                                            `Expected application/json but received ${contentType}`
                                     );
                                 }
                                 if (error) {
@@ -157,7 +157,7 @@ export class CompilerFinder {
                                         reject(e);
                                     }
                                 });
-                            },
+                            }
                         )
                         .on('error', reject)
                         .on('timeout', () => reject('timeout'));
@@ -166,7 +166,7 @@ export class CompilerFinder {
             },
             `${host}:${port}`,
             props('proxyRetries', 5),
-            props('proxyRetryMs', 500),
+            props('proxyRetryMs', 500)
         ).catch(() => {
             logger.warn(`Unable to contact ${host}:${port}; skipping`);
             return [];
@@ -185,17 +185,17 @@ export class CompilerFinder {
                             ? instance.PublicDnsName
                             : instance.PrivateDnsName;
                         return this.fetchRemote(unwrap(address), this.args.port, '', this.awsProps, null);
-                    }),
+                    })
                 )
             ).flat(),
-            null,
+            null
         );
     }
 
     async compilerConfigFor(
         langId: string,
         compilerId: string,
-        parentProps: CompilerProps['get'],
+        parentProps: CompilerProps['get']
     ): Promise<PreliminaryCompilerInfo | null> {
         const base = `compiler.${compilerId}.`;
 
@@ -325,7 +325,7 @@ export class CompilerFinder {
         if (props('demanglerClassFile') !== undefined) {
             logger.error(
                 `Error in compiler.${compilerId}: ` +
-                    'demanglerClassFile is no longer supported, please use demanglerType',
+                    'demanglerClassFile is no longer supported, please use demanglerType'
             );
             return null;
         }
@@ -343,7 +343,7 @@ export class CompilerFinder {
     async recurseGetCompilers(
         langId: string,
         compilerName: string,
-        parentProps: CompilerProps['get'],
+        parentProps: CompilerProps['get']
     ): Promise<PreliminaryCompilerInfo[]> {
         // Don't treat @ in paths as remote addresses if requested
         if (this.args.fetchCompilersFromRemote && compilerName.includes('@')) {
@@ -396,7 +396,7 @@ export class CompilerFinder {
                 logger.error(
                     `Compiler ID clash for '${id}' - used by ${list
                         .map(o => `lang:${o.lang} name:${o.name}`)
-                        .join(', ')}`,
+                        .join(', ')}`
                 );
             }
         }
@@ -422,7 +422,7 @@ export class CompilerFinder {
 
     getExes() {
         const langToCompilers = this.compilerProps(this.languages, 'compilers', '', exs =>
-            exs.split(':').filter(s => s !== ''),
+            exs.split(':').filter(s => s !== '')
         );
         this.addNdkExes(langToCompilers);
         logger.info('Exes found:', langToCompilers);

--- a/lib/compilers/ada.ts
+++ b/lib/compilers/ada.ts
@@ -75,7 +75,7 @@ export class AdaCompiler extends BaseCompiler {
         backendOptions: Record<string, any>,
         inputFilename: string,
         outputFilename: string,
-        libraries,
+        libraries
     ) {
         backendOptions = backendOptions || {};
 
@@ -111,14 +111,14 @@ export class AdaCompiler extends BaseCompiler {
             '-g',
             '-fdiagnostics-color=always',
             '-eS', // output commands to stdout, they are not errors
-            inputFilename,
+            inputFilename
         );
 
         if (!filters.execute && !filters.binary && !filters.binaryObject) {
             gnatmake_opts.push(
                 '-S', // Generate ASM
                 '-c', // Compile only
-                '-fverbose-asm', // Generate verbose ASM showing variables
+                '-fverbose-asm' // Generate verbose ASM showing variables
             );
 
             // produce assembly output in outputFilename
@@ -131,7 +131,7 @@ export class AdaCompiler extends BaseCompiler {
             }
         } else if (filters.binaryObject) {
             gnatmake_opts.push(
-                '-c', // Compile only
+                '-c' // Compile only
             );
 
             // produce assembly output in outputFilename

--- a/lib/compilers/analysis-tool.ts
+++ b/lib/compilers/analysis-tool.ts
@@ -38,7 +38,7 @@ export class AnalysisTool extends BaseCompiler {
                 disabledFilters: ['labels', 'directives', 'commentOnly', 'trim'],
                 ...info,
             },
-            env,
+            env
         );
     }
 

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -180,7 +180,7 @@ export class ClangParser extends BaseParser {
             if (!path.isAbsolute(filename)) filename = path.join(process.cwd(), filename);
 
             this.mllvmOptions = new Set(
-                _.keys(await ClangParser.getOptions(compiler, `-mllvm --help-list-hidden ${filename} -c`, false)),
+                _.keys(await ClangParser.getOptions(compiler, `-mllvm --help-list-hidden ${filename} -c`, false))
             );
             this.setCompilerSettingsFromOptions(compiler, options);
             return compiler;

--- a/lib/compilers/assembly.ts
+++ b/lib/compilers/assembly.ts
@@ -85,7 +85,7 @@ export class AssemblyCompiler extends BaseCompiler {
             'readelf',
             this.env.ceProps('readelf'),
             ['-h', objectFilename],
-            execOptions,
+            execOptions
         );
     }
 
@@ -150,8 +150,8 @@ export class AssemblyCompiler extends BaseCompiler {
                 key.backendOptions,
                 inputFilename,
                 outputFilename,
-                key.libraries,
-            ),
+                key.libraries
+            )
         );
 
         const execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/avrgcc6502.ts
+++ b/lib/compilers/avrgcc6502.ts
@@ -70,7 +70,7 @@ export class AvrGcc6502Compiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/beebasm.ts
+++ b/lib/compilers/beebasm.ts
@@ -56,7 +56,7 @@ export class BeebAsmCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
@@ -89,7 +89,7 @@ export class BeebAsmCompiler extends BaseCompiler {
                 if (!hasBootOption) {
                     if (!result.hints) result.hints = [];
                     result.hints.push(
-                        'Try using the "-boot <filename>" option so you don\'t have to manually run your file',
+                        'Try using the "-boot <filename>" option so you don\'t have to manually run your file'
                     );
                 }
             }
@@ -99,7 +99,7 @@ export class BeebAsmCompiler extends BaseCompiler {
         if (hasNoSaveError) {
             if (!result.hints) result.hints = [];
             result.hints.push(
-                'You should SAVE your code to a file using\nSAVE "filename", start, end [, exec [, reload] ]',
+                'You should SAVE your code to a file using\nSAVE "filename", start, end [, exec [, reload] ]'
             );
         }
 

--- a/lib/compilers/carbon.ts
+++ b/lib/compilers/carbon.ts
@@ -64,7 +64,7 @@ export class CarbonCompiler extends BaseCompiler {
                 libraryCode: false,
                 trim: false,
             },
-            options,
+            options
         );
     }
 

--- a/lib/compilers/cc65.ts
+++ b/lib/compilers/cc65.ts
@@ -57,7 +57,7 @@ export class Cc65Compiler extends BaseCompiler {
         return _.union(
             [libPathFlag + libDownloadPath],
             this.compiler.libPath.map(path => libPathFlag + path),
-            this.getSharedLibraryPaths(libraries).map(path => libPathFlag + path),
+            this.getSharedLibraryPaths(libraries).map(path => libPathFlag + path)
         ) as string[];
     }
 
@@ -102,7 +102,7 @@ export class Cc65Compiler extends BaseCompiler {
         demangle,
         staticReloc: boolean,
         dynamicReloc: boolean,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         const res = await super.objdump(
             outputFilename,
@@ -112,7 +112,7 @@ export class Cc65Compiler extends BaseCompiler {
             demangle,
             staticReloc,
             dynamicReloc,
-            filters,
+            filters
         );
 
         const dirPath = path.dirname(outputFilename);

--- a/lib/compilers/circt.ts
+++ b/lib/compilers/circt.ts
@@ -51,7 +51,7 @@ export class CIRCTCompiler extends BaseCompiler {
                 ],
                 ...compilerInfo,
             },
-            env,
+            env
         );
     }
 

--- a/lib/compilers/cl430.ts
+++ b/lib/compilers/cl430.ts
@@ -41,7 +41,7 @@ export class CL430Compiler extends BaseCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): string[] {
         return [
             // -g AKA --symdebug:dwarf generates too much noise for the default parser to deal with

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -145,7 +145,7 @@ export class ClangCompiler extends BaseCompiler {
             const unbundleResult: UnprocessedExecResult = await this.exec(
                 this.offloadBundlerPath,
                 ['-unbundle', '--type', 's', '--inputs', bundlefile, '--outputs', bcfile, '--targets', devicename],
-                env,
+                env
             );
             if (unbundleResult.code !== 0) {
                 return unbundleResult.stderr;

--- a/lib/compilers/clean.ts
+++ b/lib/compilers/clean.ts
@@ -106,7 +106,7 @@ export class CleanCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         const tmpDir = path.dirname(inputFilename);
         const moduleName = path.basename(inputFilename, '.icl');

--- a/lib/compilers/clspv.ts
+++ b/lib/compilers/clspv.ts
@@ -68,7 +68,7 @@ export class CLSPVCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         const sourceDir = path.dirname(inputFilename);
         const spvBinFilename = this.getPrimaryOutputFilename(sourceDir, this.outputFilebase);

--- a/lib/compilers/dart.ts
+++ b/lib/compilers/dart.ts
@@ -48,7 +48,7 @@ export class DartCompiler extends BaseCompiler {
         backendOptions: Record<string, any>,
         inputFilename: string,
         outputFilename: string,
-        libraries,
+        libraries
     ) {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
 

--- a/lib/compilers/dmd.ts
+++ b/lib/compilers/dmd.ts
@@ -55,7 +55,7 @@ export class DMDCompiler extends BaseCompiler {
         const lPath = path.basename(outputFilename);
         return this.handlePostProcessResult(
             result,
-            await this.exec(postProcesses[0], ['-l', lPath], {customCwd: dirPath, maxOutput: maxSize}),
+            await this.exec(postProcesses[0], ['-l', lPath], {customCwd: dirPath, maxOutput: maxSize})
         );
     }
 

--- a/lib/compilers/dosbox-compiler.ts
+++ b/lib/compilers/dosbox-compiler.ts
@@ -155,7 +155,7 @@ export class DosboxCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         return super.runCompiler(
             compiler,
@@ -167,7 +167,7 @@ export class DosboxCompiler extends BaseCompiler {
                 }
             }),
             inputFilename,
-            execOptions,
+            execOptions
         );
     }
 }

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -164,7 +164,7 @@ class DotNetCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         const programDir = path.dirname(inputFilename);
         const nugetConfigPath = path.join(programDir, 'nuget.config');
@@ -196,7 +196,7 @@ class DotNetCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         const crossgen2Options: string[] = [];
         const configurableOptions = this.configurableOptions;
@@ -232,7 +232,7 @@ class DotNetCompiler extends BaseCompiler {
             this.clrBuildDir,
             programDllPath,
             crossgen2Options,
-            this.getOutputFilename(programDir, this.outputFilebase),
+            this.getOutputFilename(programDir, this.outputFilebase)
         );
 
         if (crossgen2Result.code !== 0) {
@@ -250,7 +250,7 @@ class DotNetCompiler extends BaseCompiler {
         executable: string,
         maxSize: number | undefined,
         executeParameters: ExecutableExecutionOptions,
-        homeDir: string | undefined,
+        homeDir: string | undefined
     ): Promise<BasicExecutionResult> {
         const programDir = path.dirname(executable);
         const programOutputPath = path.join(programDir, 'bin', this.buildConfig, this.targetFramework);
@@ -307,7 +307,7 @@ class DotNetCompiler extends BaseCompiler {
         bclPath: string,
         dllPath: string,
         options: string[],
-        outputPath: string,
+        outputPath: string
     ) {
         await this.ensureCrossgen2Version(execOptions);
 
@@ -334,7 +334,7 @@ class DotNetCompiler extends BaseCompiler {
 
         await fs.writeFile(
             outputPath,
-            `${this.crossgen2VersionString}\n\n${result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`, '')}`,
+            `${this.crossgen2VersionString}\n\n${result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`, '')}`
         );
 
         return result;

--- a/lib/compilers/erlang.ts
+++ b/lib/compilers/erlang.ts
@@ -55,7 +55,7 @@ export class ErlangCompiler extends BaseCompiler {
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],
-        staticLibLinks: string[],
+        staticLibLinks: string[]
     ): string[] {
         options.push('-input', inputFilename);
         return options.concat(libIncludes, libOptions, libPaths, libLinks, userOptions, staticLibLinks);

--- a/lib/compilers/fake-for-test.ts
+++ b/lib/compilers/fake-for-test.ts
@@ -45,7 +45,7 @@ export class FakeCompiler implements ICompiler {
                 lang: 'fake-lang',
                 options: '',
             },
-            info,
+            info
         );
         this.lang = {id: this.compiler.lang, name: `Language ${this.compiler.lang}`};
         this.info = info;
@@ -91,7 +91,7 @@ export class FakeCompiler implements ICompiler {
                     files: files,
                     options: options,
                 },
-            }),
+            })
         );
     }
 }

--- a/lib/compilers/fortran.ts
+++ b/lib/compilers/fortran.ts
@@ -37,7 +37,7 @@ export class FortranCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/golang.ts
+++ b/lib/compilers/golang.ts
@@ -176,7 +176,7 @@ export class GolangCompiler extends BaseCompiler {
         collisions: number,
         ins: string,
         args: string,
-        usedLabels: Record<string, boolean>,
+        usedLabels: Record<string, boolean>
     ): string {
         // Check if last argument is a decimal number.
         const match = args.match(DECIMAL_RE);

--- a/lib/compilers/hlsl.ts
+++ b/lib/compilers/hlsl.ts
@@ -42,7 +42,7 @@ export class HLSLCompiler extends BaseCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): string[] {
         return [
             '-Zi', // Embed debug information to get DXIL line associations

--- a/lib/compilers/hook.ts
+++ b/lib/compilers/hook.ts
@@ -64,7 +64,7 @@ export class HookCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         const dirPath = path.dirname(inputFilename);
         const outputFilename = this.getOutputFilename(dirPath);

--- a/lib/compilers/ispc.ts
+++ b/lib/compilers/ispc.ts
@@ -74,7 +74,7 @@ export class ISPCCompiler extends BaseCompiler {
         execOptions.maxOutput = 1024 * 1024 * 1024;
 
         return this.llvmAst.processAst(
-            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions),
+            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
         );
     }
 

--- a/lib/compilers/jakt.ts
+++ b/lib/compilers/jakt.ts
@@ -52,7 +52,7 @@ export class JaktCompiler extends BaseCompiler {
         demangle,
         staticReloc: boolean,
         dynamicReloc: boolean,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         const objdumpResult = await super.objdump(
             outputFilename,
@@ -62,7 +62,7 @@ export class JaktCompiler extends BaseCompiler {
             demangle,
             staticReloc,
             dynamicReloc,
-            filters,
+            filters
         );
 
         objdumpResult.languageId = 'asm';

--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -51,7 +51,7 @@ export class JavaCompiler extends BaseCompiler {
                 disabledFilters: ['labels', 'directives', 'commentOnly', 'trim'],
                 ...compilerInfo,
             },
-            env,
+            env
         );
         this.javaRuntime = this.compilerProps<string>(`compiler.${this.compiler.id}.runtime`);
         this.mainRegex = /public static ?(.*?) void main\(java\.lang\.String\[]\)/;
@@ -105,7 +105,7 @@ export class JavaCompiler extends BaseCompiler {
                         ];
                     }
                     return oneResult;
-                }),
+                })
         );
 
         const merged: ParsedAsmResult = {asm: []};
@@ -178,7 +178,7 @@ export class JavaCompiler extends BaseCompiler {
                         return classFile;
                     }
                     return null;
-                }),
+                })
         );
 
         const candidates = results.filter(file => file !== null);

--- a/lib/compilers/julia.ts
+++ b/lib/compilers/julia.ts
@@ -108,7 +108,7 @@ export class JuliaCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/kotlin.ts
+++ b/lib/compilers/kotlin.ts
@@ -56,7 +56,7 @@ export class KotlinCompiler extends JavaCompiler {
     override filterUserOptions(userOptions: string[]) {
         // filter options without extra arguments
         userOptions = (userOptions || []).filter(
-            option => option !== '-script' && option !== '-progressive' && !option.startsWith('-Xjavac'),
+            option => option !== '-script' && option !== '-progressive' && !option.startsWith('-Xjavac')
         );
 
         const oneArgForbiddenList = new Set([

--- a/lib/compilers/ldc.ts
+++ b/lib/compilers/ldc.ts
@@ -105,7 +105,7 @@ export class LDCCompiler extends BaseCompiler {
         const execOptions = this.getDefaultExecOptions();
         // TODO(#4654) generateAST expects to return a ResultLine[] not a string
         return this.loadASTOutput(
-            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions),
+            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
         ) as any;
     }
 

--- a/lib/compilers/llvm-mos.ts
+++ b/lib/compilers/llvm-mos.ts
@@ -65,7 +65,7 @@ export class LLVMMOSCompiler extends ClangCompiler {
         demangle,
         staticReloc: boolean,
         dynamicReloc: boolean,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         if (!outputFilename.endsWith('.elf') && (await utils.fileExists(outputFilename + '.elf'))) {
             outputFilename = outputFilename + '.elf';
@@ -80,7 +80,7 @@ export class LLVMMOSCompiler extends ClangCompiler {
             demangle,
             staticReloc,
             dynamicReloc,
-            filters,
+            filters
         );
 
         if (this.compiler.exe.includes('nes')) {

--- a/lib/compilers/mlir.ts
+++ b/lib/compilers/mlir.ts
@@ -51,7 +51,7 @@ export class MLIRCompiler extends BaseCompiler {
                 ],
                 ...compilerInfo,
             },
-            env,
+            env
         );
     }
 
@@ -74,7 +74,7 @@ export class MLIRCompiler extends BaseCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): any[] {
         return [];
     }

--- a/lib/compilers/mrustc.ts
+++ b/lib/compilers/mrustc.ts
@@ -42,7 +42,7 @@ export class MrustcCompiler extends BaseCompiler {
         // Craft the 'outname' to have the intermediate .c file writen in outputFilename.
         const outname = path.join(
             path.dirname(this.filename(outputFilename)),
-            path.basename(this.filename(outputFilename), '.c'),
+            path.basename(this.filename(outputFilename), '.c')
         );
 
         // Currently always targets a rlib, no binary support at the moment.
@@ -60,7 +60,7 @@ export class MrustcCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         // mrustc will always invoke a C compiler on its C output to create a final exec/object.
         // There's no easy way to disable this last step, so simply faking it with 'true' works.

--- a/lib/compilers/nasm.ts
+++ b/lib/compilers/nasm.ts
@@ -40,7 +40,7 @@ export class NasmCompiler extends AssemblyCompiler {
         backendOptions: Record<string, any>,
         inputFilename: string,
         outputFilename: string,
-        libraries,
+        libraries
     ) {
         let options = super.prepareArguments(
             userOptions,
@@ -48,7 +48,7 @@ export class NasmCompiler extends AssemblyCompiler {
             backendOptions,
             inputFilename,
             outputFilename,
-            libraries,
+            libraries
         );
 
         let fmode;

--- a/lib/compilers/nim.ts
+++ b/lib/compilers/nim.ts
@@ -126,7 +126,7 @@ export class NimCompiler extends BaseCompiler {
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],
-        staticLibLinks: string[],
+        staticLibLinks: string[]
     ) {
         return options.concat(
             libIncludes,
@@ -135,7 +135,7 @@ export class NimCompiler extends BaseCompiler {
             libLinks,
             userOptions,
             [this.filename(inputFilename)],
-            staticLibLinks,
+            staticLibLinks
         );
     }
 }

--- a/lib/compilers/nvcc.ts
+++ b/lib/compilers/nvcc.ts
@@ -137,10 +137,10 @@ export class NvccCompiler extends BaseCompiler {
                                     okToCache: demangle,
                                     ...this.deviceAsmParser.process(asm, {...filters, binary: type === 'SASS'}),
                                 },
-                                {...filters, binary: type === 'SASS'},
+                                {...filters, binary: type === 'SASS'}
                             ),
                         });
-                    }),
+                    })
             );
             result.devices = devices;
         }

--- a/lib/compilers/pascal-win.ts
+++ b/lib/compilers/pascal-win.ts
@@ -119,7 +119,7 @@ export class PascalWinCompiler extends BaseCompiler {
             'program prog;\n' +
             'uses ' + unitName + ' in \'' + unitPath + '\';\n' +
             'begin\n' +
-            'end.\n',
+            'end.\n'
         );
     }
 
@@ -151,7 +151,7 @@ export class PascalWinCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/pascal.ts
+++ b/lib/compilers/pascal.ts
@@ -115,7 +115,7 @@ export class FPCCompiler extends BaseCompiler {
         demangle,
         staticReloc: boolean,
         dynamicReloc: boolean,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         const dirPath = path.dirname(outputFilename);
         const execBinary = this.getExecutableFilename(dirPath);
@@ -152,7 +152,7 @@ export class FPCCompiler extends BaseCompiler {
             'program prog;\n' +
             'uses ' + unitName + ' in \'' + unitPath + '\';\n' +
             'begin\n' +
-            'end.\n',
+            'end.\n'
         );
     }
 
@@ -186,7 +186,7 @@ export class FPCCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/pony.ts
+++ b/lib/compilers/pony.ts
@@ -64,7 +64,7 @@ export class PonyCompiler extends BaseCompiler {
 
     override async generateIR(inputFilename: string, options: string[], filters: ParseFiltersAndOutputOptions) {
         const newOptions = _.filter(options, option => !['--pass', 'asm'].includes(option)).concat(
-            unwrap(this.compiler.irArg),
+            unwrap(this.compiler.irArg)
         );
 
         const execOptions = this.getDefaultExecOptions();
@@ -83,7 +83,7 @@ export class PonyCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/ptxas.ts
+++ b/lib/compilers/ptxas.ts
@@ -93,7 +93,7 @@ export class PtxAssembler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/python.ts
+++ b/lib/compilers/python.ts
@@ -91,7 +91,7 @@ export class PythonCompiler extends BaseCompiler {
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],
-        staticLibLinks: string[],
+        staticLibLinks: string[]
     ) {
         return options.concat(
             [this.filename(inputFilename)],
@@ -100,7 +100,7 @@ export class PythonCompiler extends BaseCompiler {
             libPaths,
             libLinks,
             userOptions,
-            staticLibLinks,
+            staticLibLinks
         );
     }
 }

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -44,7 +44,7 @@ export class RacketCompiler extends BaseCompiler {
                 disabledFilters: ['labels', 'directives', 'commentOnly', 'trim'],
                 ...info,
             },
-            env,
+            env
         );
         this.raco = this.compilerProps<string>(`compiler.${this.compiler.id}.raco`);
     }
@@ -52,7 +52,7 @@ export class RacketCompiler extends BaseCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): string[] {
         // We currently always compile to bytecode first and then decompile.
         // Forcing `binary` on like this ensures `objdump` will be called for
@@ -74,7 +74,7 @@ export class RacketCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
@@ -103,7 +103,7 @@ export class RacketCompiler extends BaseCompiler {
         demangle: any,
         staticReloc,
         dynamicReloc,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ): Promise<any> {
         // Decompile to assembly via `raco decompile` with `disassemble` package
         const execOptions: ExecutionOptions = {

--- a/lib/compilers/rga.ts
+++ b/lib/compilers/rga.ts
@@ -105,7 +105,7 @@ Please supply an ASIC from the following options:`,
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -96,7 +96,7 @@ export class RustCompiler extends BaseCompiler {
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],
-        staticLibLinks: string[],
+        staticLibLinks: string[]
     ) {
         return options.concat(userOptions, libIncludes, libOptions, libPaths, libLinks, staticLibLinks, [
             this.filename(inputFilename),

--- a/lib/compilers/spirv.ts
+++ b/lib/compilers/spirv.ts
@@ -58,7 +58,7 @@ export class SPIRVCompiler extends BaseCompiler {
         backendOptions: Record<string, any>,
         inputFilename: string,
         outputFilename: string,
-        libraries,
+        libraries
     ) {
         let options = this.optionsForFilter(filters, outputFilename);
         backendOptions = backendOptions || {};
@@ -66,7 +66,7 @@ export class SPIRVCompiler extends BaseCompiler {
         if (this.compiler.options) {
             const compilerOptions = _.filter(
                 utils.splitArguments(this.compiler.options),
-                option => option !== '-fno-crash-diagnostics',
+                option => option !== '-fno-crash-diagnostics'
             );
 
             options = options.concat(compilerOptions);
@@ -96,7 +96,7 @@ export class SPIRVCompiler extends BaseCompiler {
             libLinks,
             userOptions,
             [this.filename(inputFilename)],
-            staticLibLinks,
+            staticLibLinks
         );
     }
 
@@ -118,7 +118,7 @@ export class SPIRVCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         const sourceDir = path.dirname(inputFilename);
         const bitcodeFilename = path.join(sourceDir, this.outputFilebase + '.bc');
@@ -166,7 +166,7 @@ export class SPIRVCompiler extends BaseCompiler {
         compiler: string,
         options: any[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ) {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
@@ -195,7 +195,7 @@ export class SPIRVCompiler extends BaseCompiler {
         execOptions.maxOutput = 1024 * 1024 * 1024;
 
         return this.llvmAst.processAst(
-            await this.runCompilerForASTOrIR(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions),
+            await this.runCompilerForASTOrIR(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
         );
     }
 
@@ -209,7 +209,7 @@ export class SPIRVCompiler extends BaseCompiler {
             this.compiler.exe,
             newOptions,
             this.filename(inputFilename),
-            execOptions,
+            execOptions
         );
         if (output.code !== 0) {
             logger.error('Failed to run compiler to get IR code');

--- a/lib/compilers/typescript-native.ts
+++ b/lib/compilers/typescript-native.ts
@@ -69,7 +69,7 @@ export class TypeScriptNativeCompiler extends BaseCompiler {
         compiler: string,
         options: string[],
         inputFilename: string,
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptions
     ): Promise<CompilationResult> {
         // These options make Clang produce an IR
         const newOptions = ['--emit=mlir-llvm', inputFilename];
@@ -82,7 +82,7 @@ export class TypeScriptNativeCompiler extends BaseCompiler {
             this.tscJit,
             newOptions,
             this.filename(inputFilename),
-            execOptions,
+            execOptions
         );
         if (output.code !== 0) {
             return {
@@ -116,7 +116,7 @@ export class TypeScriptNativeCompiler extends BaseCompiler {
             this.tscJit,
             newOptions,
             this.filename(inputFilename),
-            execOptions,
+            execOptions
         );
         if (output.code !== 0) {
             return [{text: 'Failed to run compiler to get IR code'}];

--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -81,7 +81,7 @@ export class Win32Compiler extends BaseCompiler {
                 .map(([selectedLib, foundVersion]) => {
                     return foundVersion.liblink.filter(Boolean).map(lib => `"${lib}.lib"`);
                 })
-                .map(([selectedLib, foundVersion]) => selectedLib),
+                .map(([selectedLib, foundVersion]) => selectedLib)
         );
     }
 
@@ -97,7 +97,7 @@ export class Win32Compiler extends BaseCompiler {
         backendOptions: Record<string, any>,
         inputFilename: string,
         outputFilename: string,
-        libraries,
+        libraries
     ) {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
         backendOptions = backendOptions || {};
@@ -133,7 +133,7 @@ export class Win32Compiler extends BaseCompiler {
             preLink,
             libPaths,
             libLinks,
-            staticlibLinks,
+            staticlibLinks
         );
     }
 

--- a/lib/compilers/z88dk.ts
+++ b/lib/compilers/z88dk.ts
@@ -71,7 +71,7 @@ export class z88dkCompiler extends BaseCompiler {
         libPaths: string[],
         libLinks: string[],
         userOptions: string[],
-        staticLibLinks: string[],
+        staticLibLinks: string[]
     ) {
         return userOptions.concat(
             options,
@@ -80,7 +80,7 @@ export class z88dkCompiler extends BaseCompiler {
             libOptions,
             libPaths,
             libLinks,
-            staticLibLinks,
+            staticLibLinks
         );
     }
 
@@ -120,7 +120,7 @@ export class z88dkCompiler extends BaseCompiler {
         demangle,
         staticReloc: boolean,
         dynamicReloc: boolean,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ) {
         outputFilename = this.getObjdumpOutputFilename(outputFilename);
 

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -108,7 +108,7 @@ export class ZigCompiler extends BaseCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions: string[],
+        userOptions: string[]
     ): string[] {
         let options = [filters.execute ? 'build-exe' : 'build-obj'];
 
@@ -140,7 +140,7 @@ export class ZigCompiler extends BaseCompiler {
                 '--output',
                 this.filename(outputFilename),
                 '--output-h',
-                '/dev/null',
+                '/dev/null'
             );
         }
 

--- a/lib/compilers/zigcc.ts
+++ b/lib/compilers/zigcc.ts
@@ -55,7 +55,7 @@ export class ZigCC extends ClangCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): string[] {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153

--- a/lib/compilers/zigcxx.ts
+++ b/lib/compilers/zigcxx.ts
@@ -55,7 +55,7 @@ export class ZigCXX extends ClangCompiler {
     override optionsForFilter(
         filters: ParseFiltersAndOutputOptions,
         outputFilename: string,
-        userOptions?: string[],
+        userOptions?: string[]
     ): string[] {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153

--- a/lib/demangler/llvm.ts
+++ b/lib/demangler/llvm.ts
@@ -74,7 +74,7 @@ export class LLVMIRDemangler extends BaseDemangler {
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const translations = [...this.symbolstore!.listTranslations(), ...this.othersymbols.listTranslations()].filter(
-            elem => elem[0] !== elem[1],
+            elem => elem[0] !== elem[1]
         );
         if (translations.length > 0) {
             const tree = new PrefixTree(translations);

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -55,7 +55,7 @@ export function executeDirect(
     command: string,
     args: string[],
     options: ExecutionOptions,
-    filenameTransform?: FilenameTransformFunc,
+    filenameTransform?: FilenameTransformFunc
 ): Promise<UnprocessedExecResult> {
     options = options || {};
     const maxOutput = options.maxOutput || 1024 * 1024;
@@ -189,7 +189,7 @@ export function getNsJailOptions(
     configName: string,
     command: string,
     args: string[],
-    options: ExecutionOptions,
+    options: ExecutionOptions
 ): NsJailOptions {
     options = {...options};
     const jailingOptions = ['--config', getNsJailCfgFilePath(configName)];
@@ -314,7 +314,7 @@ const sandboxDispatchTable = {
 export async function sandbox(
     command: string,
     args: string[],
-    options: ExecutionOptions,
+    options: ExecutionOptions
 ): Promise<UnprocessedExecResult> {
     const type = execProps('sandboxType', 'firejail');
     const dispatchEntry = sandboxDispatchTable[type];
@@ -377,7 +377,7 @@ export function startWineInit() {
                     wine,
                     'cmd',
                 ],
-                {env: env, detached: true},
+                {env: env, detached: true}
             );
             logger.info(`firejailed pid=${wineServer.pid}`);
         } else {
@@ -429,7 +429,7 @@ export function startWineInit() {
                 }
             });
             wineServer.stderr.on('data', data =>
-                logger.info(`stderr output from wine server complex: ${data.toString().trim()}`),
+                logger.info(`stderr output from wine server complex: ${data.toString().trim()}`)
             );
             wineServer.on('error', e => {
                 logger.error(`WINE server complex exited with error ${e}`);
@@ -471,7 +471,7 @@ async function executeFirejail(command, args, options) {
     const firejail = execProps<string>('firejail');
     const baseOptions = withFirejailTimeout(
         ['--quiet', '--deterministic-exit-code', '--deterministic-shutdown'],
-        options,
+        options
     );
     if (needsWine(command)) {
         logger.debug('WINE execution via firejail', {command, args});
@@ -527,7 +527,7 @@ const executeDispatchTable = {
 export async function execute(
     command: string,
     args: string[],
-    options: ExecutionOptions,
+    options: ExecutionOptions
 ): Promise<UnprocessedExecResult> {
     const type = execProps('executionType', 'none');
     const dispatchEntry = executeDispatchTable[type];

--- a/lib/external-parsers/base.ts
+++ b/lib/external-parsers/base.ts
@@ -59,7 +59,7 @@ export class ExternalParserBase implements IExternalParser {
 
     private async writeStarterScriptObjdump(
         buildfolder: string,
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ): Promise<string> {
         const scriptFilepath = path.join(buildfolder, starterScriptName);
 
@@ -73,7 +73,7 @@ export class ExternalParserBase implements IExternalParser {
                 },
                 () => {
                     resolve(maskRootdir(scriptFilepath));
-                },
+                }
             );
         });
     }
@@ -92,7 +92,7 @@ export class ExternalParserBase implements IExternalParser {
     public async objdumpAndParseAssembly(
         buildfolder: string,
         objdumpArgs: string[],
-        filters: ParseFiltersAndOutputOptions,
+        filters: ParseFiltersAndOutputOptions
     ): Promise<ParsedAsmResult> {
         objdumpArgs = objdumpArgs.map(v => {
             return maskRootdir(v);

--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -65,7 +65,7 @@ export class ApiHandler {
         compileHandler: CompileHandler,
         ceProps: PropertyGetter,
         private readonly storageHandler: StorageBase,
-        urlShortenService: string,
+        urlShortenService: string
     ) {
         this.handle = express.Router();
         const cacheHeader = `public, max-age=${ceProps('apiMaxAgeSecs', 24 * 60 * 60)}`;
@@ -224,13 +224,13 @@ export class ApiHandler {
             ...list
                 .map(item => item.id)
                 .concat([title])
-                .map(item => item.length),
+                .map(item => item.length)
         );
         res.set('Content-Type', 'text/plain');
         res.send(
             utils.padRight(title, maxLength) +
                 ' | Name\n' +
-                list.map(lang => utils.padRight(lang.id, maxLength) + ' | ' + lang.name).join('\n'),
+                list.map(lang => utils.padRight(lang.id, maxLength) + ' | ' + lang.name).join('\n')
         );
     }
 

--- a/lib/handlers/assembly-documentation.ts
+++ b/lib/handlers/assembly-documentation.ts
@@ -32,7 +32,7 @@ const MAX_STATIC_AGE = propsFor('asm-docs')('staticMaxAgeSecs', 10);
 const onDocumentationProviderRequest = (
     provider: BaseAssemblyDocumentationProvider,
     request: express.Request,
-    response: express.Response,
+    response: express.Response
 ) => {
     // If the request had no opcode parameter, we should fail. This assumes
     // no assembly language has a __unknown_opcode instruction.

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -66,7 +66,7 @@ function initialise(compilerEnv: CompilationEnvironment) {
         if (status.busy) {
             cyclesBusy++;
             logger.warn(
-                `temp cleanup skipped, pending: ${status.pending}, waiting: ${status.size}, cycles: ${cyclesBusy}`,
+                `temp cleanup skipped, pending: ${status.pending}, waiting: ${status.size}, cycles: ${cyclesBusy}`
             );
             return;
         }
@@ -157,13 +157,13 @@ export class CompileHandler {
                     options: body.userArguments,
                     filters: Object.fromEntries(
                         ['commentOnly', 'directives', 'libraryCode', 'labels', 'demangle', 'intel', 'execute'].map(
-                            key => [key, body[key] === 'true'],
-                        ),
+                            key => [key, body[key] === 'true']
+                        )
                     ),
                 });
             } else {
                 Sentry.captureException(
-                    new Error(`Unexpected Content-Type received by /compiler/:compiler/compile: ${contentType}`),
+                    new Error(`Unexpected Content-Type received by /compiler/:compiler/compile: ${contentType}`)
                 );
                 proxyReq.write('Unexpected Content-Type');
             }
@@ -256,7 +256,7 @@ export class CompileHandler {
             if (this.awsProps) {
                 logger.info('Fetching possible arguments from storage');
                 await Promise.all(
-                    createdCompilers.map(compiler => compiler.possibleArguments.loadFromStorage(this.awsProps)),
+                    createdCompilers.map(compiler => compiler.possibleArguments.loadFromStorage(this.awsProps))
                 );
             }
             this.compilersById = compilersById;
@@ -382,7 +382,7 @@ export class CompileHandler {
             // If specified exactly, we'll take that with ?filters=a,b,c
             if (query.filters) {
                 filters = _.object(
-                    _.map(query.filters.split(','), filter => [filter, true]),
+                    _.map(query.filters.split(','), filter => [filter, true])
                 ) as any as ParseFiltersAndOutputOptions;
             }
             // Add a filter. ?addFilters=binary
@@ -547,7 +547,7 @@ export class CompileHandler {
                 tools,
                 executionParameters,
                 libraries,
-                files,
+                files
             )
             .then(
                 result => {
@@ -602,7 +602,7 @@ export class CompileHandler {
                         error = `Internal Compiler Explorer error: ${error.stack || error}`;
                     }
                     res.end(JSON.stringify({code: -1, stdout: [], stderr: [{text: error}]}));
-                },
+                }
             );
     }
 }

--- a/lib/handlers/formatting.ts
+++ b/lib/handlers/formatting.ts
@@ -64,8 +64,8 @@ export class FormattingHandler {
             const version = hasExplicitVersion
                 ? this.ceProps<string>(`formatter.${formatterName}.explicitVersion`)
                 : match
-                ? match[0]
-                : result.stdout;
+                    ? match[0]
+                    : result.stdout;
             this.formatters[formatterName] = new formatterClass({
                 name: this.ceProps(`formatter.${formatterName}.name`, exe),
                 exe,

--- a/lib/handlers/noscript.ts
+++ b/lib/handlers/noscript.ts
@@ -87,8 +87,8 @@ export class NoScriptHandler {
                             embedded: false,
                             mobileViewer: isMobileViewer(req),
                         },
-                        req.query,
-                    ),
+                        req.query
+                    )
                 );
             })
             .get('/noscript/:language', (req, res) => {
@@ -183,8 +183,8 @@ export class NoScriptHandler {
                     clientstate: state,
                     storedStateId: req.params.id || false,
                 },
-                req.query,
-            ),
+                req.query
+            )
         );
     }
 }

--- a/lib/handlers/route-api.ts
+++ b/lib/handlers/route-api.ts
@@ -64,7 +64,7 @@ export class RouteAPI {
                 config.compileHandler,
                 config.ceProps,
                 config.storageHandler,
-                config.clientOptionsHandler.options.urlShortenService,
+                config.clientOptionsHandler.options.urlShortenService
             );
 
             this.apiHandler.setReleaseInfo(config.defArgs.gitReleaseName, config.defArgs.releaseBuildNumber);

--- a/lib/handlers/site-templates.ts
+++ b/lib/handlers/site-templates.ts
@@ -56,7 +56,7 @@ export function loadSiteTemplates(configDir: string) {
             .filter(l => l !== '')
             .map(splitProperty)
             .map(pair => [pair[0], pair[1].replace(/^https:\/\/godbolt.org\/#/, '')]),
-        ([name, _]) => name.startsWith('meta.'),
+        ([name, _]) => name.startsWith('meta.')
     );
     siteTemplates.meta = Object.fromEntries(meta);
     siteTemplates.templates = Object.fromEntries(templates);

--- a/lib/keyed-type.ts
+++ b/lib/keyed-type.ts
@@ -58,7 +58,7 @@ function makeKeyMap<T extends Keyable>(typeName: string, objects: Record<string,
 
 export function makeKeyedTypeGetter<T extends Keyable>(
     typeName: string,
-    objects: Record<string, T>,
+    objects: Record<string, T>
 ): (key: string) => T {
     const keyMap = makeKeyMap(typeName, objects);
 
@@ -74,7 +74,7 @@ export function makeKeyedTypeGetter<T extends Keyable>(
 export function makeDefaultedKeyedTypeGetter<T extends Keyable>(
     typeName: string,
     objects: Record<string, T>,
-    defaultObject: T,
+    defaultObject: T
 ): (key: string) => T {
     const keyMap = makeKeyMap(typeName, objects);
 

--- a/lib/llvm-ast.ts
+++ b/lib/llvm-ast.ts
@@ -67,7 +67,7 @@ export class LlvmAstParser {
     // reused when only a column specified.
     parseSpan(
         line: string,
-        lastLineNo: number | null,
+        lastLineNo: number | null
     ):
         | {type: typeof LlvmAstParser.locTypes.SPAN; begin: Point; end: Point}
         | {type: typeof LlvmAstParser.locTypes.POINT; loc: Point}

--- a/lib/mapfiles/map-file-vs.ts
+++ b/lib/mapfiles/map-file-vs.ts
@@ -79,7 +79,7 @@ export class MapFileReaderVS extends MapFileReader {
 
             const segment = this.getSegmentInfoAddressWithoutOffsetIsIn(
                 symbolObject.segment,
-                symbolObject.addressWithoutOffset,
+                symbolObject.addressWithoutOffset
             );
             if (segment && !segment.unitName) {
                 segment.unitName = matches[6];

--- a/lib/objdumper/base.ts
+++ b/lib/objdumper/base.ts
@@ -30,7 +30,7 @@ export abstract class BaseObjdumper {
         demangle?: boolean,
         intelAsm?: boolean,
         staticReloc?: boolean,
-        dynamicReloc?: boolean,
+        dynamicReloc?: boolean
     ) {
         const args = ['-d', outputFilename, '-l', ...this.widthOptions];
 

--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -138,7 +138,7 @@ export class ClientOptionsHandler {
             fileSources.map(source => {
                 return {name: source.name, urlpart: source.urlpart};
             }),
-            'name',
+            'name'
         );
 
         /***
@@ -239,7 +239,7 @@ export class ClientOptionsHandler {
                                 args: this.compilerProps<string>(lang, toolBaseName + '.args'),
                                 languageId: this.compilerProps<string>(
                                     lang,
-                                    toolBaseName + '.languageId',
+                                    toolBaseName + '.languageId'
                                 ) as LanguageKey,
                                 stdinHint: this.compilerProps<string>(lang, toolBaseName + '.stdinHint'),
                                 monacoStdin: this.compilerProps<string>(lang, toolBaseName + '.monacoStdin'),
@@ -250,7 +250,7 @@ export class ClientOptionsHandler {
                             {
                                 ceProps: this.ceProps,
                                 compilerProps: propname => this.compilerProps(lang, propname),
-                            },
+                            }
                         );
                     } else {
                         logger.warn(`Unable to stat ${toolBaseName} tool binary`);
@@ -311,18 +311,18 @@ export class ClientOptionsHandler {
                                 version: this.compilerProps<string>(lang, libVersionName + '.version'),
                                 staticliblink: splitIntoArray(
                                     this.compilerProps<string>(lang, libVersionName + '.staticliblink'),
-                                    libraries[lang][lib].staticliblink,
+                                    libraries[lang][lib].staticliblink
                                 ),
                                 alias: splitIntoArray(this.compilerProps<string>(lang, libVersionName + '.alias')),
                                 dependencies: splitIntoArray(
                                     this.compilerProps<string>(lang, libVersionName + '.dependencies'),
-                                    libraries[lang][lib].dependencies,
+                                    libraries[lang][lib].dependencies
                                 ),
                                 path: [],
                                 libpath: [],
                                 liblink: splitIntoArray(
                                     this.compilerProps<string>(lang, libVersionName + '.liblink'),
-                                    libraries[lang][lib].liblink,
+                                    libraries[lang][lib].liblink
                                 ),
                                 // Library options might get overridden later
                                 options: libraries[lang][lib].options,
@@ -365,7 +365,7 @@ export class ClientOptionsHandler {
                 // TODO: A and B don't contain any property called semver here. It's probably leftover from old code
                 // and should be removed in the future.
                 versions.sort((a, b) =>
-                    semverParser.compare(asSafeVer((a as any).semver), asSafeVer((b as any).semver), true),
+                    semverParser.compare(asSafeVer((a as any).semver), asSafeVer((b as any).semver), true)
                 );
                 let order = 0;
                 // Set $order to index on array. As group is an array, iteration order is guaranteed.

--- a/lib/parsers/asm-parser-ewavr.ts
+++ b/lib/parsers/asm-parser-ewavr.ts
@@ -261,7 +261,7 @@ export class AsmEWAVRParser extends AsmParser {
     resultObjectIntoArray(
         obj: ResultObject,
         filters: ParseFiltersAndOutputOptions,
-        ddefLabels: Record<string, number>,
+        ddefLabels: Record<string, number>
     ): ParsedAsmResult {
         // NOTES on EWAVR function and labels:
         // - template functions are not mangled with type info.

--- a/lib/parsers/asm-parser-vc.ts
+++ b/lib/parsers/asm-parser-vc.ts
@@ -288,7 +288,7 @@ export class VcAsmParser extends AsmParser {
     resultObjectIntoArray(
         obj: ResultObject,
         filters: ParseFiltersAndOutputOptions,
-        ddefLabelsUsed: string[],
+        ddefLabelsUsed: string[]
     ): ParsedAsmResult {
         const collator = new Intl.Collator();
 

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -321,7 +321,7 @@ export class LlvmPassDumpParser {
                         affectedFunction: fn,
                         machine,
                         lines,
-                    }),
+                    })
                 );
                 previousFunction = fn;
             } else {
@@ -370,7 +370,7 @@ export class LlvmPassDumpParser {
                             passesMatch(current_dump.header, next_dump.header),
                             '',
                             current_dump.header,
-                            next_dump.header,
+                            next_dump.header
                         );
                         assert(current_dump.machine === next_dump.machine);
                         pass.name = current_dump.header.slice('IR Dump Before '.length);
@@ -470,11 +470,11 @@ export class LlvmPassDumpParser {
     process(
         output: ResultLine[],
         _: ParseFiltersAndOutputOptions,
-        llvmOptPipelineOptions: LLVMOptPipelineBackendOptions,
+        llvmOptPipelineOptions: LLVMOptPipelineBackendOptions
     ) {
         // Crop out any junk before the pass dumps (e.g. warnings)
         const ir = output.slice(
-            output.findIndex(line => line.text.match(this.irDumpHeader) || line.text.match(this.machineCodeDumpHeader)),
+            output.findIndex(line => line.text.match(this.irDumpHeader) || line.text.match(this.machineCodeDumpHeader))
         );
         const preprocessed_lines = this.applyIrFilters(ir, llvmOptPipelineOptions);
         return this.breakdownOutput(preprocessed_lines, llvmOptPipelineOptions);

--- a/lib/pe32-support.ts
+++ b/lib/pe32-support.ts
@@ -39,7 +39,7 @@ export class PELabelReconstructor {
         asmLines: string[],
         dontLabelUnmappedAddresses: boolean,
         mapFileReader: MapFileReader,
-        needsReconstruction = true,
+        needsReconstruction = true
     ) {
         this.asmLines = asmLines;
         this.addressesToLabel = [];
@@ -110,7 +110,7 @@ export class PELabelReconstructor {
                             !this.mapFileReader.isWithinAddressSpace(
                                 unitAddressSpaces,
                                 info.addressInt,
-                                info.segmentLength,
+                                info.segmentLength
                             )
                         ) {
                             this.deleteLinesBetweenAddresses(info.addressInt, info.addressInt + info.segmentLength);

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -252,7 +252,7 @@ export class CompilerProps {
         langs: string | LanguageDef[] | Record<string, any>,
         key: string,
         defaultValue?: PropertyValue,
-        fn?: (item: PropertyValue, language?: any) => unknown,
+        fn?: (item: PropertyValue, language?: any) => unknown
     ) {
         const map_fn = fn || _.identity;
         if (_.isEmpty(langs)) {

--- a/lib/sponsors.ts
+++ b/lib/sponsors.ts
@@ -70,7 +70,7 @@ function standardDeviation(values: number[]): number {
 function sponsorIconSetsOk(
     sponsorAppearanceCount: Map<Sponsor, number>,
     totalAppearances: number,
-    maxStandardDeviation: number,
+    maxStandardDeviation: number
 ): boolean {
     const countsByShowEvery: Map<number, number[]> = new Map();
     for (const [icon, count] of sponsorAppearanceCount.entries()) {
@@ -89,7 +89,7 @@ export function makeIconSets(
     icons: Sponsor[],
     maxIcons: number,
     maxIters = 100,
-    maxStandardDeviation = 0.5,
+    maxStandardDeviation = 0.5
 ): Sponsor[][] {
     const result: Sponsor[][] = [];
     const sponsorAppearanceCount: Map<Sponsor, number> = new Map();

--- a/lib/storage/base.ts
+++ b/lib/storage/base.ts
@@ -104,7 +104,7 @@ export abstract class StorageBase {
             .then(result => {
                 logger.info(
                     `Unique subhash '${result.uniqueSubHash}' ` +
-                        `(${result.alreadyPresent ? 'was already present' : 'newly-created'})`,
+                        `(${result.alreadyPresent ? 'was already present' : 'newly-created'})`
                 );
                 if (result.alreadyPresent) {
                     return result;

--- a/lib/storage/remote.ts
+++ b/lib/storage/remote.ts
@@ -51,10 +51,10 @@ export class StorageRemote extends StorageBase {
 
         // Workaround for ts type shenanigans with defaulting to the last overload
         this.get = promisify((uri: string, options?: request.CoreOptions, callback?: request.RequestCallback) =>
-            req.get(uri, options, callback),
+            req.get(uri, options, callback)
         );
         this.post = promisify((uri: string, options?: request.CoreOptions, callback?: request.RequestCallback) =>
-            req.post(uri, options, callback),
+            req.post(uri, options, callback)
         );
     }
 

--- a/lib/storage/s3.ts
+++ b/lib/storage/s3.ts
@@ -72,7 +72,7 @@ export class StorageS3 extends StorageBase {
         this.table = awsProps('storageDynamoTable');
         logger.info(
             `Using s3 storage solution on ${region}, bucket ${bucket}, ` +
-                `prefix ${this.prefix}, dynamo table ${this.table}`,
+                `prefix ${this.prefix}, dynamo table ${this.table}`
         );
         AWS.config.update({region: region});
         this.s3 = new S3Bucket(bucket, region);

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -143,7 +143,7 @@ export class BaseTool implements ITool {
         inputFilepath?: string,
         args?: string[],
         stdin?: string,
-        supportedLibraries?: Record<string, Library>,
+        supportedLibraries?: Record<string, Library>
     ) {
         if (this.tool.name) {
             toolCounter.inc({

--- a/lib/tooling/clang-tidy-tool.ts
+++ b/lib/tooling/clang-tidy-tool.ts
@@ -47,7 +47,7 @@ export class ClangTidyTool extends BaseTool {
         inputFilepath: string,
         args?: string[],
         stdin?: string,
-        supportedLibraries?: Record<string, Library>,
+        supportedLibraries?: Record<string, Library>
     ) {
         const sourcefile = inputFilepath;
         const options = compilationInfo.options;

--- a/lib/tooling/compiler-dropin-tool.ts
+++ b/lib/tooling/compiler-dropin-tool.ts
@@ -104,7 +104,7 @@ export class CompilerDropinTool extends BaseTool {
         inputFilepath?: string,
         args?: string[],
         stdin?: string,
-        supportedLibraries?: Record<string, Library>,
+        supportedLibraries?: Record<string, Library>
     ): Promise<ToolResult> {
         const sourcefile = inputFilepath;
 

--- a/lib/tooling/llvm-cov-tool.ts
+++ b/lib/tooling/llvm-cov-tool.ts
@@ -55,12 +55,12 @@ export class LLVMCovTool extends BaseTool {
             const compilationResult = await this.exec(
                 compilationInfo.compiler.exe,
                 compilationArgs,
-                compilationExecOptions,
+                compilationExecOptions
             );
 
             if (compilationResult.code !== 0) {
                 return this.createErrorResponse(
-                    `<Compilation error>\n${compilationResult.stdout}\n${compilationResult.stderr}`,
+                    `<Compilation error>\n${compilationResult.stdout}\n${compilationResult.stderr}`
                 );
             }
 
@@ -79,11 +79,11 @@ export class LLVMCovTool extends BaseTool {
             const profdataResult = await this.exec(
                 profdataPath,
                 ['merge', '-sparse', './default.profraw', '-o', './' + generatedProfdataName],
-                runExecOptions,
+                runExecOptions
             );
             if (profdataResult.code !== 0) {
                 return this.createErrorResponse(
-                    `<llvm-profdata error>\n${profdataResult.stdout}\n${profdataResult.stderr}`,
+                    `<llvm-profdata error>\n${profdataResult.stdout}\n${profdataResult.stderr}`
                 );
             }
 
@@ -99,7 +99,7 @@ export class LLVMCovTool extends BaseTool {
                     '-compilation-dir=./',
                     ...args,
                 ],
-                runExecOptions,
+                runExecOptions
             );
             if (covResult.code === 0) {
                 return this.convertResult(covResult, inputFilepath, path.dirname(this.tool.exe));

--- a/lib/tooling/microsoft-analysis-tool.ts
+++ b/lib/tooling/microsoft-analysis-tool.ts
@@ -81,7 +81,7 @@ export class MicrosoftAnalysisTool extends BaseTool {
         inputFilepath?: string,
         args?: string[],
         stdin?: string,
-        supportedLibraries?: Record<string, Library>,
+        supportedLibraries?: Record<string, Library>
     ) {
         const sourcefile = inputFilepath;
         const options = compilationInfo.options;
@@ -100,7 +100,7 @@ export class MicrosoftAnalysisTool extends BaseTool {
             '/analyze:external-',
             '/external:env:INCLUDE',
             '/external:W0',
-            this.tool.options,
+            this.tool.options
         );
 
         return await this.runCompilerTool(compilationInfo, sourcefile, compileFlags, stdin);

--- a/lib/tooling/osaca-tool.ts
+++ b/lib/tooling/osaca-tool.ts
@@ -56,7 +56,7 @@ export class OSACATool extends BaseTool {
             compilationInfo.asmParser,
             compilationInfo.asm,
             compilationInfo.filters,
-            rewrittenOutputFilename,
+            rewrittenOutputFilename
         );
         return super.runTool(compilationInfo, rewrittenOutputFilename, args);
     }

--- a/lib/tooling/pvs-studio-tool.ts
+++ b/lib/tooling/pvs-studio-tool.ts
@@ -92,7 +92,7 @@ export class PvsStudioTool extends BaseTool {
             path.dirname(this.tool.exe) + '/pvs-studio',
             // TODO: expand this to switch() for all supported compilers:
             // visualcpp, clang, gcc, bcc, bcc_clang64, iar, keil5, keil5_gnu
-            '--preprocessor',
+            '--preprocessor'
         );
         if (compilationInfo.compiler.group.includes('clang')) args.push('clang');
         else args.push('gcc');
@@ -124,7 +124,7 @@ export class PvsStudioTool extends BaseTool {
             'FAIL:1,2,3;GA:1,2,3',
             '-o',
             plogConverterOutputFilePath,
-            'pvs-studio-log.log',
+            'pvs-studio-log.log'
         );
 
         const plogExecOptions = this.getDefaultExecOptions();


### PR DESCRIPTION
This PR turns comma-dangle and indent eslint rules on for lib/. These are rules inherited from the eslint config for static/, this PR just makes things more consistent. Also turned @typescript-eslint/no-var-requires back on while I was here.