### PR TITLE
Align <dist|static>Path.

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,7 +124,8 @@ if (opts.tmpDir) {
     process.env.winTmp = path.join('/mnt', driveLetter, directoryPath);
 }
 
-const distPath = utils.resolvePathFromAppRoot('.');
+const __dirname = utils.resolvePathFromAppRoot('.');
+const distPath = path.resolve(__dirname, 'out', 'dist');
 
 const gitReleaseName = (() => {
     // Use the canned git_hash if provided
@@ -237,7 +238,7 @@ if (Object.keys(languages).length === 0) {
 
 const compilerProps = new props.CompilerProps(languages, ceProps);
 
-const staticPath = opts.webpackContent || path.join(distPath, 'static');
+const staticPath = opts.webpackContent || path.resolve(__dirname, 'out', 'webpack', 'static');
 const staticMaxAgeSecs = ceProps('staticMaxAgeSecs', 0);
 const maxUploadSize = ceProps('maxUploadSize', '1mb');
 const extraBodyClass = ceProps('extraBodyClass', isDevMode() ? 'dev' : '');


### PR DESCRIPTION
Fixes issues with the path for `manifest.json` being incorrect when running `npm run webpack && NODE_ENV=production node -r esm -r ts-node/register app.js`.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
