### PR TITLE
compiler.clang_p1144: get libstdc++ headers from trunk, remove -std=c++2a

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -361,7 +361,7 @@ compiler.clang_concepts.options=-std=c++2a -Xclang -fconcepts-ts -stdlib=libc++
 compiler.clang_concepts.notification=<span style="color:red"><b>WARNING</b>: Concepts support has been merged to Clang trunk: use <code>-std=c++2a</code> for the most up-to-date support</span>
 compiler.clang_p1144.exe=/opt/compiler-explorer/clang-relocatable-trunk/bin/clang++
 compiler.clang_p1144.semver=(experimental P1144)
-compiler.clang_p1144.options=-std=c++2a -stdlib=libc++ -g0
+compiler.clang_p1144.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -stdlib=libc++ -g0
 compiler.clang_p1144.notification=Experimental __is_trivially_relocatable; see <a href="https://wg21.link/p1144" target="_blank" rel="noopener noreferrer">P1144 <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_autonsdmi.exe=/opt/compiler-explorer/clang-autonsdmi-trunk/bin/clang++
 compiler.clang_autonsdmi.semver=(experimental metaprogramming - P2632)


### PR DESCRIPTION
- The old version was getting libstdc++ from gcc-9.2.0 instead of trunk (13.x). After this patch, passing `-stdlib=libstdc++` will get you libstdc++ trunk, which includes things like `<ranges>` that are missing from 9.x.

- While I'm in the vicinity, let's stop defaulting to -std=c++2a; this was more appealing when Clang trunk defaulted to -std=c++98, but now that trunk defaults to -std=c++17, I don't think the divergence buys me anything.

- For the record, I added `-g0` in 4128fcc57 (back in 2019) to fix a crash with DWARF info, and never got around to investigating it. It's probably no longer needed, but I don't know, so I'm leaving it in place.