### PR TITLE
Fix cypress timeout issue

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -26,5 +26,6 @@ jobs:
         with:
           start: npm run dev
           wait-on: 'http://localhost:10240'
+          wait-on-timeout: 120
           config: screenshotOnRunFailure=false,video=false
           browser: ${{ matrix.browser }}


### PR DESCRIPTION
This should fix the issue of cypress CI frequently timing out and having to manually re-run to get checks to be OK
