### PR TITLE
Add name to binary tools error response

### DIFF
--- a/lib/tooling/pahole-tool.ts
+++ b/lib/tooling/pahole-tool.ts
@@ -33,7 +33,7 @@ export class PaholeTool extends BaseTool {
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
         if (!compilationInfo.filters.binary && !compilationInfo.filters.binaryObject) {
-            return this.createErrorResponse('Pahole requires a binary output');
+            return this.createErrorResponse(`${this.tool.name ?? 'Pahole'} requires an executable`);
         }
 
         if (await fs.pathExists(compilationInfo.executableFilename)) {

--- a/lib/tooling/pahole-tool.ts
+++ b/lib/tooling/pahole-tool.ts
@@ -33,7 +33,7 @@ export class PaholeTool extends BaseTool {
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
         if (!compilationInfo.filters.binary && !compilationInfo.filters.binaryObject) {
-            return this.createErrorResponse(`${this.tool.name ?? 'Pahole'} requires an executable`);
+            return this.createErrorResponse(`${this.tool.name ? this.tool.name : 'Pahole'} requires an executable`);
         }
 
         if (await fs.pathExists(compilationInfo.executableFilename)) {

--- a/lib/tooling/readelf-tool.ts
+++ b/lib/tooling/readelf-tool.ts
@@ -33,7 +33,7 @@ export class ReadElfTool extends BaseTool {
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
         if (!compilationInfo.filters.binary && !compilationInfo.filters.binaryObject) {
-            return this.createErrorResponse('readelf requires an executable');
+            return this.createErrorResponse(`${this.tool.name ?? 'readelf'} requires an executable`);
         }
 
         if (await fileExists(compilationInfo.executableFilename)) {

--- a/lib/tooling/readelf-tool.ts
+++ b/lib/tooling/readelf-tool.ts
@@ -33,7 +33,7 @@ export class ReadElfTool extends BaseTool {
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
         if (!compilationInfo.filters.binary && !compilationInfo.filters.binaryObject) {
-            return this.createErrorResponse(`${this.tool.name ?? 'readelf'} requires an executable`);
+            return this.createErrorResponse(`${this.tool.name ? this.tool.name : 'readelf'} requires an executable`);
         }
 
         if (await fileExists(compilationInfo.executableFilename)) {

--- a/lib/tooling/strings-tool.ts
+++ b/lib/tooling/strings-tool.ts
@@ -33,7 +33,7 @@ export class StringsTool extends BaseTool {
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
         if (!compilationInfo.filters.binary) {
-            return this.createErrorResponse(`${this.tool.name ?? 'Strings'} requires an executable`);
+            return this.createErrorResponse(`${this.tool.name ? this.tool.name : 'Strings'} requires an executable`);
         }
         if (await fileExists(compilationInfo.executableFilename)) {
             return super.runTool(compilationInfo, compilationInfo.executableFilename, args);

--- a/lib/tooling/strings-tool.ts
+++ b/lib/tooling/strings-tool.ts
@@ -33,7 +33,7 @@ export class StringsTool extends BaseTool {
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
         if (!compilationInfo.filters.binary) {
-            return this.createErrorResponse('Strings requires a binary output');
+            return this.createErrorResponse(`${this.tool.name ?? 'Strings'} requires an executable`);
         }
         if (await fileExists(compilationInfo.executableFilename)) {
             return super.runTool(compilationInfo, compilationInfo.executableFilename, args);


### PR DESCRIPTION
Closes #4772 by outputing the `.name` property if it exists, falling back to the class specific one if not.