### PR TITLE
update dotnet versions

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -2,21 +2,34 @@ compilers=&csharp
 supportsBinary=true
 needsMulti=false
 compilerType=csharp
-defaultCompiler=dotnet700csharp
+defaultCompiler=dotnet703csharp
 
-group.csharp.compilers=dotnettrunkcsharp:dotnet700csharp:dotnet6011csharp
+group.csharp.compilers=dotnettrunkcsharp:dotnet703csharp:dotnet701csharp:dotnet6014csharp:dotnet6011csharp
 
 compiler.dotnet6011csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6011csharp.name=.NET 6.0.403
+compiler.dotnet6011csharp.name=.NET 6.0.110
 compiler.dotnet6011csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
 compiler.dotnet6011csharp.buildConfig=Release
 compiler.dotnet6011csharp.langVersion=latest
 
-compiler.dotnet700csharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet700csharp.name=.NET 7.0.100
-compiler.dotnet700csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700csharp.buildConfig=Release
-compiler.dotnet700csharp.langVersion=latest
+compiler.dotnet6014csharp.exe=/opt/compiler-explorer/dotnet-v6.0.14/.dotnet/dotnet
+compiler.dotnet6014csharp.name=.NET 6.0.113
+compiler.dotnet6014csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.14
+compiler.dotnet6014csharp.buildConfig=Release
+compiler.dotnet6014csharp.langVersion=latest
+
+compiler.dotnet701csharp.exe=/opt/compiler-explorer/dotnet-v7.0.1/.dotnet/dotnet
+compiler.dotnet701csharp.name=.NET 7.0.100
+compiler.dotnet701csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.1
+compiler.dotnet701csharp.buildConfig=Release
+compiler.dotnet701csharp.langVersion=latest
+compiler.dotnet701csharp.alias=dotnet700csharp
+
+compiler.dotnet703csharp.exe=/opt/compiler-explorer/dotnet-v7.0.3/.dotnet/dotnet
+compiler.dotnet703csharp.name=.NET 7.0.102
+compiler.dotnet703csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.3
+compiler.dotnet703csharp.buildConfig=Release
+compiler.dotnet703csharp.langVersion=latest
 
 compiler.dotnettrunkcsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkcsharp.name=.NET (main)

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -2,21 +2,33 @@ compilers=&csharp
 supportsBinary=true
 needsMulti=false
 compilerType=csharp
-defaultCompiler=dotnet700csharp
+defaultCompiler=dotnet703csharp
 
-group.csharp.compilers=dotnettrunkcsharp:dotnet700csharp:dotnet6011csharp
+group.csharp.compilers=dotnettrunkcsharp:dotnet703csharp:dotnet701csharp:dotnet6014csharp:dotnet6011csharp
 
 compiler.dotnet6011csharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6011csharp.name=.NET 6.0.403
+compiler.dotnet6011csharp.name=.NET 6.0.110
 compiler.dotnet6011csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
 compiler.dotnet6011csharp.buildConfig=Release
 compiler.dotnet6011csharp.langVersion=latest
 
-compiler.dotnet700csharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet700csharp.name=.NET 7.0.100
-compiler.dotnet700csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700csharp.buildConfig=Release
-compiler.dotnet700csharp.langVersion=latest
+compiler.dotnet6014csharp.exe=/opt/compiler-explorer/dotnet-v6.0.14/.dotnet/dotnet
+compiler.dotnet6014csharp.name=.NET 6.0.113
+compiler.dotnet6014csharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.14
+compiler.dotnet6014csharp.buildConfig=Release
+compiler.dotnet6014csharp.langVersion=latest
+
+compiler.dotnet701csharp.exe=/opt/compiler-explorer/dotnet-v7.0.1/.dotnet/dotnet
+compiler.dotnet701csharp.name=.NET 7.0.100
+compiler.dotnet701csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.1
+compiler.dotnet701csharp.buildConfig=Release
+compiler.dotnet701csharp.langVersion=latest
+
+compiler.dotnet703csharp.exe=/opt/compiler-explorer/dotnet-v7.0.3/.dotnet/dotnet
+compiler.dotnet703csharp.name=.NET 7.0.102
+compiler.dotnet703csharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.3
+compiler.dotnet703csharp.buildConfig=Release
+compiler.dotnet703csharp.langVersion=latest
 
 compiler.dotnettrunkcsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkcsharp.name=.NET (main)

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -2,21 +2,34 @@ compilers=&fsharp
 supportsBinary=true
 needsMulti=false
 compilerType=fsharp
-defaultCompiler=dotnet700fsharp
+defaultCompiler=dotnet703fsharp
 
-group.fsharp.compilers=dotnettrunkfsharp:dotnet700fsharp:dotnet6011fsharp
+group.fsharp.compilers=dotnettrunkfsharp:dotnet703fsharp:dotnet701fsharp:dotnet6014fsharp:dotnet6011fsharp
 
 compiler.dotnet6011fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6011fsharp.name=.NET 6.0.403
+compiler.dotnet6011fsharp.name=.NET 6.0.110
 compiler.dotnet6011fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
 compiler.dotnet6011fsharp.buildConfig=Release
 compiler.dotnet6011fsharp.langVersion=latest
 
-compiler.dotnet700fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet700fsharp.name=.NET 7.0.100
-compiler.dotnet700fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700fsharp.buildConfig=Release
-compiler.dotnet700fsharp.langVersion=latest
+compiler.dotnet6014fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.14/.dotnet/dotnet
+compiler.dotnet6014fsharp.name=.NET 6.0.113
+compiler.dotnet6014fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.14
+compiler.dotnet6014fsharp.buildConfig=Release
+compiler.dotnet6014fsharp.langVersion=latest
+
+compiler.dotnet701fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.1/.dotnet/dotnet
+compiler.dotnet701fsharp.name=.NET 7.0.100
+compiler.dotnet701fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.1
+compiler.dotnet701fsharp.buildConfig=Release
+compiler.dotnet701fsharp.langVersion=latest
+compiler.dotnet701fsharp.alias=dotnet700fsharp
+
+compiler.dotnet703fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.3/.dotnet/dotnet
+compiler.dotnet703fsharp.name=.NET 7.0.102
+compiler.dotnet703fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.3
+compiler.dotnet703fsharp.buildConfig=Release
+compiler.dotnet703fsharp.langVersion=latest
 
 compiler.dotnettrunkfsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkfsharp.name=.NET (main)

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -1,19 +1,37 @@
-compilers=&fsharpdef
+compilers=&fsharp
 supportsBinary=true
 needsMulti=false
 compilerType=fsharp
-defaultCompiler=dotnet7fsharpdef
+defaultCompiler=dotnet703fsharp
 
-group.fsharpdef.compilers=dotnet6fsharpdef:dotnet7fsharpdef
+group.fsharp.compilers=dotnettrunkfsharp:dotnet703fsharp:dotnet701fsharp:dotnet6014fsharp:dotnet6014fsharp
 
-compiler.dotnet6fsharpdef.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6fsharpdef.name=.NET 6.0.403
-compiler.dotnet6fsharpdef.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6fsharpdef.buildConfig=Release
-compiler.dotnet6fsharpdef.langVersion=latest
+compiler.dotnet6011fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
+compiler.dotnet6011fsharp.name=.NET 6.0.110
+compiler.dotnet6011fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
+compiler.dotnet6011fsharp.buildConfig=Release
+compiler.dotnet6011fsharp.langVersion=latest
 
-compiler.dotnet7fsharpdef.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet7fsharpdef.name=.NET 7.0.100
-compiler.dotnet7fsharpdef.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet7fsharpdef.buildConfig=Release
-compiler.dotnet7fsharpdef.langVersion=latest
+compiler.dotnet6014fsharp.exe=/opt/compiler-explorer/dotnet-v6.0.14/.dotnet/dotnet
+compiler.dotnet6014fsharp.name=.NET 6.0.113
+compiler.dotnet6014fsharp.clrDir=/opt/compiler-explorer/dotnet-v6.0.14
+compiler.dotnet6014fsharp.buildConfig=Release
+compiler.dotnet6014fsharp.langVersion=latest
+
+compiler.dotnet701fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.1/.dotnet/dotnet
+compiler.dotnet701fsharp.name=.NET 7.0.100
+compiler.dotnet701fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.1
+compiler.dotnet701fsharp.buildConfig=Release
+compiler.dotnet701fsharp.langVersion=latest
+
+compiler.dotnet703fsharp.exe=/opt/compiler-explorer/dotnet-v7.0.3/.dotnet/dotnet
+compiler.dotnet703fsharp.name=.NET 7.0.102
+compiler.dotnet703fsharp.clrDir=/opt/compiler-explorer/dotnet-v7.0.3
+compiler.dotnet703fsharp.buildConfig=Release
+compiler.dotnet703fsharp.langVersion=latest
+
+compiler.dotnettrunkfsharp.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharp.name=.NET (main)
+compiler.dotnettrunkfsharp.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharp.buildConfig=Release
+compiler.dotnettrunkfsharp.langVersion=preview

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -2,24 +2,37 @@ compilers=&vb
 supportsBinary=true
 needsMulti=false
 compilerType=vb
-defaultCompiler=dotnet700vb
+defaultCompiler=dotnet703vb
 
-group.vb.compilers=dotnettrunkvb:dotnet700vb:dotnet6011vb
+group.vb.compilers=dotnettrunkvb:dotnet703vb:dotnet701vb:dotnet6014vb:dotnet6011vb
 
 compiler.dotnet6011vb.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6011vb.name=.NET 6.0.403
+compiler.dotnet6011vb.name=.NET 6.0.110
 compiler.dotnet6011vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
 compiler.dotnet6011vb.buildConfig=Release
 compiler.dotnet6011vb.langVersion=latest
 
-compiler.dotnet700vb.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet700vb.name=.NET 7.0.100
-compiler.dotnet700vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet700vb.buildConfig=Release
-compiler.dotnet700vb.langVersion=latest
+compiler.dotnet6014vb.exe=/opt/compiler-explorer/dotnet-v6.0.14/.dotnet/dotnet
+compiler.dotnet6014vb.name=.NET 6.0.113
+compiler.dotnet6014vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.14
+compiler.dotnet6014vb.buildConfig=Release
+compiler.dotnet6014vb.langVersion=latest
+
+compiler.dotnet701vb.exe=/opt/compiler-explorer/dotnet-v7.0.1/.dotnet/dotnet
+compiler.dotnet701vb.name=.NET 7.0.100
+compiler.dotnet701vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.1
+compiler.dotnet701vb.buildConfig=Release
+compiler.dotnet701vb.langVersion=latest
+compiler.dotnet701vb.alias=dotnet700vb
+
+compiler.dotnet703vb.exe=/opt/compiler-explorer/dotnet-v7.0.3/.dotnet/dotnet
+compiler.dotnet703vb.name=.NET 7.0.102
+compiler.dotnet703vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.3
+compiler.dotnet703vb.buildConfig=Release
+compiler.dotnet703vb.langVersion=latest
 
 compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvb.buildConfig=Release
-compiler.dotnettrunkvb.langVersion=latest
+compiler.dotnettrunkvb.langVersion=preview

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -1,19 +1,37 @@
-compilers=&vbdef
+compilers=&vb
 supportsBinary=true
 needsMulti=false
 compilerType=vb
-defaultCompiler=dotnet7vbdef
+defaultCompiler=dotnet703vb
 
-group.vbdef.compilers=dotnet6vbdef:dotnet7vbdef
+group.vb.compilers=dotnettrunkvb:dotnet703vb:dotnet701vb:dotnet6014vb:dotnet6011vb
 
-compiler.dotnet6vbdef.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
-compiler.dotnet6vbdef.name=.NET 6.0.403
-compiler.dotnet6vbdef.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
-compiler.dotnet6vbdef.buildConfig=Release
-compiler.dotnet6vbdef.langVersion=latest
+compiler.dotnet6011vb.exe=/opt/compiler-explorer/dotnet-v6.0.11/.dotnet/dotnet
+compiler.dotnet6011vb.name=.NET 6.0.110
+compiler.dotnet6011vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.11
+compiler.dotnet6011vb.buildConfig=Release
+compiler.dotnet6011vb.langVersion=latest
 
-compiler.dotnet7vbdef.exe=/opt/compiler-explorer/dotnet-v7.0.0/.dotnet/dotnet
-compiler.dotnet7vbdef.name=.NET 7.0.100
-compiler.dotnet7vbdef.clrDir=/opt/compiler-explorer/dotnet-v7.0.0
-compiler.dotnet7vbdef.buildConfig=Release
-compiler.dotnet7vbdef.langVersion=latest
+compiler.dotnet6014vb.exe=/opt/compiler-explorer/dotnet-v6.0.14/.dotnet/dotnet
+compiler.dotnet6014vb.name=.NET 6.0.113
+compiler.dotnet6014vb.clrDir=/opt/compiler-explorer/dotnet-v6.0.14
+compiler.dotnet6014vb.buildConfig=Release
+compiler.dotnet6014vb.langVersion=latest
+
+compiler.dotnet701vb.exe=/opt/compiler-explorer/dotnet-v7.0.1/.dotnet/dotnet
+compiler.dotnet701vb.name=.NET 7.0.100
+compiler.dotnet701vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.1
+compiler.dotnet701vb.buildConfig=Release
+compiler.dotnet701vb.langVersion=latest
+
+compiler.dotnet703vb.exe=/opt/compiler-explorer/dotnet-v7.0.3/.dotnet/dotnet
+compiler.dotnet703vb.name=.NET 7.0.102
+compiler.dotnet703vb.clrDir=/opt/compiler-explorer/dotnet-v7.0.3
+compiler.dotnet703vb.buildConfig=Release
+compiler.dotnet703vb.langVersion=latest
+
+compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvb.name=.NET (main)
+compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvb.buildConfig=Release
+compiler.dotnettrunkvb.langVersion=preview


### PR DESCRIPTION
adding new versions without hiding the old ones. when we will reach about 10+ versions, then we can hide the oldest ones (.hidden=true) to keep the permalinks. right now there is no point in hiding few months old versions as the dropdown is pretty much empty