### PR TITLE
Add ISPC v1.19.0

### DIFF
--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -1,9 +1,11 @@
 compilers=&ispc
-defaultCompiler=ispc1180
+defaultCompiler=ispc1190
 
-group.ispc.compilers=ispc1180:ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk:ispc-templates_new-trunk
+group.ispc.compilers=ispc1190:ispc1180:ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk:ispc-templates_new-trunk
 group.ispc.isSemVer=true
 group.ispc.baseName=ispc
+compiler.ispc1190.exe=/opt/compiler-explorer/ispc-1.19.0/bin/ispc
+compiler.ispc1190.semver=1.19.0
 compiler.ispc1180.exe=/opt/compiler-explorer/ispc-1.18.0/bin/ispc
 compiler.ispc1180.semver=1.18.0
 compiler.ispc1170.exe=/opt/compiler-explorer/ispc-1.17.0/bin/ispc


### PR DESCRIPTION
Adding ISPC v1.19.0.

Corresponding infra commit PR, which needs to be merged before this PR: https://github.com/compiler-explorer/infra/pull/950 (so ISPC v1.19.0 is available in the infra).