### PR TITLE
Pass compiler options to cmake

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -612,39 +612,39 @@ group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unkn
 group.rv32clang.baseName=RISC-V rv32gc clang
 group.rv32clang.groupName=RISC-V 32 Clang
 
-compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.rv32-clang900.semver=9.0.0
 compiler.rv32-clang900.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang900.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.rv32-clang901.semver=9.0.1
 compiler.rv32-clang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.rv32-clang1000.semver=10.0.0
 compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
 compiler.rv32-clang1001.semver=10.0.1
 compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
-compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.rv32-clang1100.semver=11.0.0
-compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv32-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.rv32-clang1101.semver=11.0.1
-compiler.rv32-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.rv32-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang++
 compiler.rv32-clang1200.semver=12.0.0
-compiler.rv32-clang1201.exe=/opt/compiler-explorer/clang-12.0.1/bin/clang
+compiler.rv32-clang1201.exe=/opt/compiler-explorer/clang-12.0.1/bin/clang++
 compiler.rv32-clang1201.semver=12.0.1
-compiler.rv32-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.rv32-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.rv32-clang1300.semver=13.0.0
-compiler.rv32-clang1301.exe=/opt/compiler-explorer/clang-13.0.1/bin/clang
+compiler.rv32-clang1301.exe=/opt/compiler-explorer/clang-13.0.1/bin/clang++
 compiler.rv32-clang1301.semver=13.0.1
-compiler.rv32-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.rv32-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.rv32-clang1400.semver=14.0.0
-compiler.rv32-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.rv32-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.rv32-clang1500.semver=15.0.0
-compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv32-clang.semver=(trunk)
 compiler.rv32-clang.alias=rv32clang
 
@@ -654,39 +654,39 @@ group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unkn
 group.rv64clang.baseName=RISC-V rv64gc clang
 group.rv64clang.groupName=RISC-V 64 Clang
 
-compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
+compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.rv64-clang900.semver=9.0.0
 compiler.rv64-clang900.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
+compiler.rv64-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.rv64-clang901.semver=9.0.1
 compiler.rv64-clang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.rv64-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.rv64-clang1000.semver=10.0.0
 compiler.rv64-clang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
+compiler.rv64-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
 compiler.rv64-clang1001.semver=10.0.1
 compiler.rv64-clang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
+compiler.rv64-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.rv64-clang1100.semver=11.0.0
-compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang
+compiler.rv64-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.rv64-clang1101.semver=11.0.1
-compiler.rv64-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang
+compiler.rv64-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang++
 compiler.rv64-clang1200.semver=12.0.0
-compiler.rv64-clang1201.exe=/opt/compiler-explorer/clang-12.0.1/bin/clang
+compiler.rv64-clang1201.exe=/opt/compiler-explorer/clang-12.0.1/bin/clang++
 compiler.rv64-clang1201.semver=12.0.1
-compiler.rv64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.rv64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.rv64-clang1300.semver=13.0.0
-compiler.rv64-clang1301.exe=/opt/compiler-explorer/clang-13.0.1/bin/clang
+compiler.rv64-clang1301.exe=/opt/compiler-explorer/clang-13.0.1/bin/clang++
 compiler.rv64-clang1301.semver=13.0.1
-compiler.rv64-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.rv64-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.rv64-clang1400.semver=14.0.0
-compiler.rv64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.rv64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.rv64-clang1500.semver=15.0.0
-compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv64-clang.semver=(trunk)
 compiler.rv64-clang.alias=rv64clang
 
@@ -889,16 +889,16 @@ group.clangbpf.options=-target bpf
 group.clangbpf.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.clangbpf.objdumperType=llvm
 
-compiler.bpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.bpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.bpfclangtrunk.semver=(trunk)
 
-compiler.bpfclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.bpfclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.bpfclang1500.semver=15.0.0
 
-compiler.bpfclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.bpfclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.bpfclang1400.semver=14.0.0
 
-compiler.bpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.bpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.bpfclang1300.semver=13.0.0
 
 # GCC for BPF
@@ -1532,13 +1532,13 @@ group.mips-clang.supportsBinaryObject=false
 group.mips-clang.supportsExecute=false
 group.mips-clang.options=-target mips-elf
 
-compiler.mips-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mips-clang1500.semver=15.0.0
 
-compiler.mips-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.mips-clang1400.semver=14.0.0
 
-compiler.mips-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips-clang1300.semver=13.0.0
 
 ## MIPSEL
@@ -1550,13 +1550,13 @@ group.mipsel-clang.supportsBinaryObject=false
 group.mipsel-clang.supportsExecute=false
 group.mipsel-clang.options=-target mipsel-elf
 
-compiler.mipsel-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mipsel-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mipsel-clang1500.semver=15.0.0
 
-compiler.mipsel-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mipsel-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.mipsel-clang1400.semver=14.0.0
 
-compiler.mipsel-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mipsel-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mipsel-clang1300.semver=13.0.0
 
 ## MIPS64
@@ -1568,13 +1568,13 @@ group.mips64-clang.supportsBinaryObject=false
 group.mips64-clang.supportsExecute=false
 group.mips64-clang.options=-target mips64-elf
 
-compiler.mips64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mips64-clang1500.semver=15.0.0
 
-compiler.mips64-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips64-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.mips64-clang1400.semver=14.0.0
 
-compiler.mips64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips64-clang1300.semver=13.0.0
 
 ## MIPS64EL
@@ -1586,13 +1586,13 @@ group.mips64el-clang.supportsBinaryObject=false
 group.mips64el-clang.supportsExecute=false
 group.mips64el-clang.options=-target mips64el-elf
 
-compiler.mips64el-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
+compiler.mips64el-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mips64el-clang1500.semver=15.0.0
 
-compiler.mips64el-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
+compiler.mips64el-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.mips64el-clang1400.semver=14.0.0
 
-compiler.mips64el-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
+compiler.mips64el-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips64el-clang1300.semver=13.0.0
 
 

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -77,7 +77,7 @@ import {AsmParser} from './parsers/asm-parser.js';
 import type {IAsmParser} from './parsers/asm-parser.interfaces.js';
 import {LlvmPassDumpParser} from './parsers/llvm-pass-dump-parser.js';
 import type {PropertyGetter} from './properties.interfaces.js';
-import {getToolchainPath} from './toolchain-utils.js';
+import {getToolchainPath, removeToolchainArg} from './toolchain-utils.js';
 import type {ITool} from './tooling/base-tool.interface.js';
 import * as utils from './utils.js';
 import {unwrap} from './assert.js';
@@ -1978,7 +1978,14 @@ export class BaseCompiler implements ICompiler {
         const cmakeExecParams = Object.assign({}, execParams);
 
         const libIncludes = this.getIncludeArguments(libsAndOptions.libraries);
-        const options = libsAndOptions.options.concat(libIncludes);
+
+        const options: string[] = [];
+        if (this.compiler.options) {
+            const compilerOptions = utils.splitArguments(this.compiler.options);
+            options.push(...removeToolchainArg(compilerOptions));
+        }
+        options.push(...libsAndOptions.options);
+        options.push(...libIncludes);
 
         _.extend(cmakeExecParams.env, this.getCompilerEnvironmentVariables(options.join(' ')));
 

--- a/lib/toolchain-utils.ts
+++ b/lib/toolchain-utils.ts
@@ -24,8 +24,10 @@
 
 import path from 'path';
 
+import {splitArguments} from './utils.js';
+
 export function getToolchainPath(compilerExe: string | null, compilerOptions?: string): string | false {
-    const options = compilerOptions ? compilerOptions.split(' ') : [];
+    const options = compilerOptions ? splitArguments(compilerOptions) : [];
     const existingChain = options.find(elem => elem.includes('--gcc-toolchain='));
     if (existingChain) return existingChain.substring(16);
 
@@ -37,4 +39,8 @@ export function getToolchainPath(compilerExe: string | null, compilerOptions?: s
     } else {
         return false;
     }
+}
+
+export function removeToolchainArg(compilerOptions: string[]): string[] {
+    return compilerOptions.filter(elem => !elem.includes('--gcc-toolchain=') && !elem.includes('--gxx-name='));
 }


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/4827

Seems to not break anything.

Toolchain is filtered out because that's passed as `-DCMAKE_TOOLCHAIN_etc`

Can always be overridden by https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html#variable:CMAKE_%3CLANG%3E_FLAGS (`-DCMAKE_CXX_FLAGS=etc` as cmake arg or `set(CMAKE_CXX_FLAGS "etc")`)

