### PR TITLE
Add default cmake arg

### DIFF
--- a/static/components.interfaces.ts
+++ b/static/components.interfaces.ts
@@ -103,7 +103,8 @@ export type PopulatedEditorState = StateWithId & {
     options: unknown;
 };
 
-export type EmptyTreeState = Partial<StateWithId>;
+type CmakeArgsState = {cmakeArgs: string};
+export type EmptyTreeState = Partial<StateWithId & CmakeArgsState>;
 
 export type OutputState = StateWithTree & {
     compiler: number; // CompilerID

--- a/static/components.ts
+++ b/static/components.ts
@@ -256,6 +256,7 @@ export function getTree(id?: number): ComponentConfig<EmptyTreeState> {
         componentName: TREE_COMPONENT_NAME,
         componentState: {
             id,
+            cmakeArgs: '-DCMAKE_BUILD_TYPE=Debug',
         },
     };
 }


### PR DESCRIPTION
When adding the Tree, cmake_build_type is automically set to debug

Fixes https://github.com/compiler-explorer/compiler-explorer/issues/4825