### PR TITLE
Cache S3Bucket clients by region

### DIFF
--- a/lib/s3-handler.ts
+++ b/lib/s3-handler.ts
@@ -28,13 +28,21 @@ import type {GetResult} from '../types/cache.interfaces.js';
 
 import type {S3HandlerOptions} from './s3-handler.interfaces.js';
 
+const clientsByRegion: Map<string, S3> = new Map();
+
 export class S3Bucket {
     private readonly instance: S3;
     readonly bucket: string;
     readonly region: string;
 
     constructor(bucket: string, region: string) {
-        this.instance = new S3({region});
+        const maybeInstance = clientsByRegion.get(region);
+        if (maybeInstance) {
+            this.instance = maybeInstance;
+        } else {
+            this.instance = new S3({region});
+            clientsByRegion.set(region, this.instance);
+        }
         this.bucket = bucket;
         this.region = region;
     }


### PR DESCRIPTION
I hope it's OK to reuse the same client for multiple in-flight requests, as effectively this means we'll have one client only. I'm pretty sure we're effectively doing this already in the cache where multiple in-flight requests from users will be served from the one cache's S3 client, but couldn't find any documentation about this.