### PR TITLE
Bump to latest monaco

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "^7.18.3",
         "lz-string": "^1.4.4",
-        "monaco-editor": "^0.34.1",
+        "monaco-editor": "^0.36.1",
         "monaco-vim": "^0.3.5",
         "morgan": "^1.10.0",
         "node-targz": "^0.2.0",
@@ -11598,9 +11598,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
-      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.36.1.tgz",
+      "integrity": "sha512-/CaclMHKQ3A6rnzBzOADfwdSJ25BFoFT0Emxsc4zYVyav5SkK9iA6lEtIeuN/oRYbwPgviJT+t3l+sjFa28jYg=="
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "^7.18.3",
     "lz-string": "^1.4.4",
-    "monaco-editor": "^0.34.1",
+    "monaco-editor": "^0.36.1",
     "monaco-vim": "^0.3.5",
     "morgan": "^1.10.0",
     "node-targz": "^0.2.0",

--- a/static/modes/cppp-mode.ts
+++ b/static/modes/cppp-mode.ts
@@ -109,10 +109,6 @@ function definition(): monaco.languages.IMonarchLanguage {
         'requires',
         'xor',
         'xor_eq',
-        // Quick fix until https://github.com/microsoft/monaco-editor/pull/3286 is merged and released
-        '__m512',
-        '__m512d',
-        '__m512i',
     ]);
 
     return cppp;

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -130,7 +130,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             setTimeout(() => {
                 this.editor.setSelection(new monaco.Selection(1, 1, 1, 1));
                 this.editor.focus();
-                this.editor.getAction('editor.fold').run();
+                unwrap(this.editor.getAction('editor.fold')).run();
                 //this.editor.clearSelection();
             }, 500);
         }
@@ -1015,7 +1015,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         });
 
         this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, () => {
-            this.editor.getAction('editor.action.duplicateSelection').run();
+            unwrap(this.editor.getAction('editor.action.duplicateSelection')).run();
         });
     }
 
@@ -1028,7 +1028,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     }
 
     runFormatDocumentAction(): void {
-        this.editor.getAction('editor.action.formatDocument').run();
+        unwrap(this.editor.getAction('editor.action.formatDocument')).run();
     }
 
     searchOnCppreference(ed: monaco.editor.ICodeEditor): void {


### PR DESCRIPTION
Currently blocked as during dev we see:

```
ERROR in ./node_modules/monaco-editor/esm/vs/editor/editor.api.js 76:0-57
Module not found: Error: Can't resolve './contrib/stickyScroll/browser/stickyScroll.js' in '/home/matthew/dev/ce/compiler-explorer/node_modules/monaco-editor/esm/vs/editor'
 @ ./static/themes.ts 29:22-46
 @ ./static/main.ts 47:34-56

ERROR in ./node_modules/monaco-editor/esm/vs/editor/editor.api.js 84:0-77
Module not found: Error: Can't resolve './contrib/viewportSemanticTokens/browser/viewportSemanticTokens.js' in '/home/matthew/dev/ce/compiler-explorer/node_modules/monaco-editor/esm/vs/editor'
 @ ./static/themes.ts 29:22-46
 @ ./static/main.ts 47:34-56
```

which seem to be related to newer features in monaco. Filed https://github.com/microsoft/monaco-editor/issues/3796 to hopefully get help on what's going on.