### PR TITLE
Update cobol.amazon.properties

### DIFF
--- a/etc/config/cobol.amazon.properties
+++ b/etc/config/cobol.amazon.properties
@@ -1,8 +1,8 @@
 compilers=&gnucobol
-defaultCompiler=gnucobol32rc2
+defaultCompiler=gnucobol31
 
 group.gnucobol.groupName=GnuCOBOL
-group.gnucobol.compilers=gnucobol32rc2:gnucobol31rc1
+group.gnucobol.compilers=gnucobol32rc2:gnucobol31:gnucobol22:gnucobol11
 group.gnucobol.isSemVer=true
 group.gnucobol.baseName=GnuCOBOL
 group.gnucobol.licenseName=GPLv3
@@ -10,6 +10,12 @@ group.gnucobol.licenseLink=https://sourceforge.net/p/gnucobol/code/HEAD/tree/tru
 compiler.gnucobol32rc2.exe=/opt/compiler-explorer/cobol/gnucobol-3.2-rc2/bin/cobc
 compiler.gnucobol32rc2.name=GnuCOBOL 3.2 rc2
 compiler.gnucobol32rc2.version=3.2 rc2
-compiler.gnucobol31rc1.exe=/opt/compiler-explorer/cobol/gnucobol-3.1-rc1/bin/cobc
-compiler.gnucobol31rc1.name=GnuCOBOL 3.1 rc1
-compiler.gnucobol31rc1.version=3.1 rc1
+compiler.gnucobol31.exe=/opt/compiler-explorer/cobol/gnucobol-3.1/bin/cobc
+compiler.gnucobol31.name=GnuCOBOL 3.1
+compiler.gnucobol31.version=3.1
+compiler.gnucobol22.exe=/opt/compiler-explorer/cobol/gnucobol-2.2/bin/cobc
+compiler.gnucobol22.name=GnuCOBOL 2.2
+compiler.gnucobol22.version=2.2
+compiler.gnucobol11.exe=/opt/compiler-explorer/cobol/gnucobol-1.1/bin/cobc
+compiler.gnucobol11.name=GnuCOBOL 1.1
+compiler.gnucobol11.version=1.1


### PR DESCRIPTION
add stable versions, prefer stable over pre-release by using last stable as default

Note: GnuCOBOL 1.1 is actually GPLv2+ while the newer ones are GPLv3+.

Should the license identifier be adjusted?
In any case - maybe the license URL should point to https://www.gnu.org/licenses/gpl-3.0?

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
