### PR TITLE
Give an error when no editor language is specified

### DIFF
--- a/static/panes/editor.interfaces.ts
+++ b/static/panes/editor.interfaces.ts
@@ -30,7 +30,7 @@ export type EditorState = {
         readOnly?: boolean;
     };
     source?: string;
-    lang?: string;
+    lang: string;
 };
 
 export type LanguageSelectData = Language & {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -114,6 +114,13 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.alertSystem = new Alert();
         this.alertSystem.prefixMessage = 'Editor #' + this.id;
 
+        if ((state.lang as any) === undefined) {
+            // Primarily a diagnostic for urls created outside CE. Addresses #4817.
+            this.alertSystem.alert('State Error', 'No language specified for editor', {isError: true});
+        } else if (!(state.lang in languages)) {
+            this.alertSystem.alert('State Error', 'Unknown language specified for editor', {isError: true});
+        }
+
         if (this.currentLanguage) this.onLanguageChange(this.currentLanguage.id, true);
 
         if (state.source !== undefined) {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -114,10 +114,10 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.alertSystem = new Alert();
         this.alertSystem.prefixMessage = 'Editor #' + this.id;
 
-        if ((state.lang as any) === undefined) {
+        if ((state.lang as any) === undefined && Object.keys(languages).length > 0) {
             // Primarily a diagnostic for urls created outside CE. Addresses #4817.
             this.alertSystem.alert('State Error', 'No language specified for editor', {isError: true});
-        } else if (!(state.lang in languages)) {
+        } else if (!(state.lang in languages) && Object.keys(languages).length > 0) {
             this.alertSystem.alert('State Error', 'Unknown language specified for editor', {isError: true});
         }
 


### PR DESCRIPTION
Following discussion at #4817 and with partouf/matt. An editor's state.lang being undefined should probably always be an error since it'll be susceptible to the same default language shenanigans. 

Closes #4817