### PR TITLE
Support for CompCert

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:www.godbolt.ms@443
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:www.godbolt.ms@443
 defaultCompiler=cg122
 demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
@@ -2090,6 +2090,46 @@ compiler.chibicc-trunk.name=Chibicc 2020-12-07
 compiler.chibicc-trunk.exe=/opt/compiler-explorer/chibicc-main/chibicc
 compiler.chibicc-trunk.semver=(trunk)
 compiler.chibicc-trunk.explicitVersion=90d1f7f199cc55b13c7fdb5839d1409806633fdb
+
+
+################################
+## CompCert
+################################
+group.compcert.isSemVer=true
+group.compcert.compilerType=compcert
+group.compcert.supportsExecute=true
+group.compcert.supportsBinary=true
+group.compcert.supportsBinaryObject=true
+group.compcert.licenseLink=https://github.com/AbsInt/CompCert/blob/master/LICENSE
+group.compcert.compilers=&compcertx8664:&compcertx86
+
+## compcert for x86_64
+group.compcertx8664.compilers=ccx8664_312:ccx8664_311:ccx8664_310:ccx8664_309
+group.compcertx8664.groupName=x86_64 CompCert
+group.compcertx8664.baseName=x86_64 CompCert
+
+compiler.ccx8664_312.exe=/opt/compiler-explorer/compcert/CompCert-x86_64-3.12/bin/ccomp
+compiler.ccx8664_312.semver=3.12
+compiler.ccx8664_311.exe=/opt/compiler-explorer/compcert/CompCert-x86_64-3.11/bin/ccomp
+compiler.ccx8664_311.semver=3.11
+compiler.ccx8664_310.exe=/opt/compiler-explorer/compcert/CompCert-x86_64-3.10/bin/ccomp
+compiler.ccx8664_310.semver=3.10
+compiler.ccx8664_309.exe=/opt/compiler-explorer/compcert/CompCert-x86_64-3.9/bin/ccomp
+compiler.ccx8664_309.semver=3.9
+
+## compcert for x86
+group.compcertx86.compilers=ccx8632_312:ccx8632_311:ccx8632_310:ccx8632_309
+group.compcertx86.groupName=x86 CompCert
+group.compcertx86.baseName=x86 CompCert
+
+compiler.ccx8632_312.exe=/opt/compiler-explorer/compcert/CompCert-x86_32-3.12/bin/ccomp
+compiler.ccx8632_312.semver=3.12
+compiler.ccx8632_311.exe=/opt/compiler-explorer/compcert/CompCert-x86_32-3.11/bin/ccomp
+compiler.ccx8632_311.semver=3.11
+compiler.ccx8632_310.exe=/opt/compiler-explorer/compcert/CompCert-x86_32-3.10/bin/ccomp
+compiler.ccx8632_310.semver=3.10
+compiler.ccx8632_309.exe=/opt/compiler-explorer/compcert/CompCert-x86_32-3.9/bin/ccomp
+compiler.ccx8632_309.semver=3.9
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -38,6 +38,7 @@ export {ClangCudaCompiler} from './clang.js';
 export {ClangHipCompiler} from './clang.js';
 export {ClangIntelCompiler} from './clang.js';
 export {CleanCompiler} from './clean.js';
+export {CompCertCompiler} from './compcert.js';
 export {CppFrontCompiler} from './cppfront.js';
 export {CprocCompiler} from './cproc.js';
 export {CLSPVCompiler} from './clspv.js';

--- a/lib/compilers/compcert.ts
+++ b/lib/compilers/compcert.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Compiler Explorer Authors
+// Copyright (c) 2023, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/lib/compilers/compcert.ts
+++ b/lib/compilers/compcert.ts
@@ -22,10 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {GCCCompiler} from './gcc.js';
+import {BaseCompiler} from '../base-compiler.js';
 
-export class CompCertCompiler extends GCCCompiler {
-    static override get key() {
+export class CompCertCompiler extends BaseCompiler {
+    static get key() {
         return 'compcert';
     }
 }

--- a/lib/compilers/compcert.ts
+++ b/lib/compilers/compcert.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {GCCCompiler} from './gcc.js';
+
+export class CompCertCompiler extends GCCCompiler {
+    static override get key() {
+        return 'compcert';
+    }
+}


### PR DESCRIPTION
Add support for CompCert (https://github.com/AbsInt/CompCert) from AbsInt.

As a first step, only x86 and x86_64 are supported.

fixes #595