### PR TITLE
Support configuring extra arguments for the demangler, objdumper and execution wrapper

### DIFF
--- a/docs/AddingACompiler.md
+++ b/docs/AddingACompiler.md
@@ -100,6 +100,11 @@ once the site runs on the Amazon environment, the `&clang` group **will not** ha
 | compilerType         | String     | The name of the class handling this compiler                                                                     |
 | interpreted          | Boolean    | Whether this is an interpreted language, and so the "compiler" is really an interpreter                          |
 | executionWrapper     | Path       | Path to script that can execute the compiler's output (e.g. could run under `qemu` or `mpi_run` or similar)      |
+| executionWrapperArgs | String     | List of arguments passed to the execution wrapper (separated by `| ` character)                                  |
+| demangler            | String     | Path to the demangler tool                                                                                       |
+| demanglerArgs        | String     | List of arguments passed to the demangler binary (separated by `| ` character)                                   |
+| objdumper            | String     | Path to the object dump tool                                                                                     |
+| objdumperArgs        | String     | List of arguments passed to the object dump tool (separated by `| ` character)                                   |
 
 The `compilerType` option is special: it refers to the Javascript class in `lib/compilers/*.js` which handles running
 and handling output for this compiler type.

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -430,7 +430,14 @@ export class BaseCompiler implements ICompiler {
         }
 
         const objdumper = new this.objdumperClass();
-        const args = objdumper.getDefaultArgs(outputFilename, demangle, intelAsm, staticReloc, dynamicReloc);
+        const args = objdumper.getDefaultArgs(
+            outputFilename,
+            demangle,
+            intelAsm,
+            staticReloc,
+            dynamicReloc,
+            this.compiler.objdumperArgs,
+        );
 
         if (this.externalparser) {
             const objResult = await this.externalparser.objdumpAndParseAssembly(result.dirPath, args, filters);
@@ -1601,7 +1608,7 @@ export class BaseCompiler implements ICompiler {
         }
     }
 
-    runExecutable(executable, executeParameters: ExecutableExecutionOptions, homeDir) {
+    runExecutable(executable: string, executeParameters: ExecutableExecutionOptions, homeDir) {
         const maxExecOutputSize = this.env.ceProps('max-executable-output-size', 32 * 1024);
         // Hardcoded fix for #2339. Ideally I'd have a config option for this, but for now this is plenty good enough.
         executeParameters.env = {
@@ -1612,7 +1619,7 @@ export class BaseCompiler implements ICompiler {
             ...executeParameters.env,
         };
         if (this.compiler.executionWrapper) {
-            executeParameters.args.unshift(executable);
+            executeParameters.args = [...this.compiler.executionWrapperArgs, executable, ...executeParameters.args];
             executable = this.compiler.executionWrapper;
         }
         return this.execBinary(executable, maxExecOutputSize, executeParameters, homeDir);
@@ -2430,7 +2437,7 @@ export class BaseCompiler implements ICompiler {
 
     async postProcessAsm(result, filters?: ParseFiltersAndOutputOptions) {
         if (!result.okToCache || !this.demanglerClass || !result.asm) return result;
-        const demangler = new this.demanglerClass(this.compiler.demangler, this);
+        const demangler = new this.demanglerClass(this.compiler.demangler, this, this.compiler.demanglerArgs);
 
         return await demangler.process(result);
     }
@@ -2451,7 +2458,11 @@ export class BaseCompiler implements ICompiler {
         if (this.compiler.demangler) {
             const result = JSON.stringify(output, null, 4);
             try {
-                const demangleResult = await this.exec(this.compiler.demangler, ['-n', '-p'], {input: result});
+                const demangleResult = await this.exec(
+                    this.compiler.demangler,
+                    [...this.compiler.demanglerArgs, '-n', '-p'],
+                    {input: result},
+                );
                 return JSON.parse(demangleResult.stdout);
             } catch (exception) {
                 // swallow exception and return non-demangled output
@@ -2695,12 +2706,12 @@ but nothing was dumped. Possible causes are:
             return {stdout: [this.compiler.explicitVersion], stderr: [], code: 0};
         }
         const execOptions = this.getDefaultExecOptions();
-        const versionFlag = this.compiler.versionFlag || '--version';
+        const versionFlag = this.compiler.versionFlag || ['--version'];
         execOptions.timeoutMs = 0; // No timeout for --version. A sort of workaround for slow EFS/NFS on the prod site
         execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         try {
-            return await this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions);
+            return await this.execCompilerCached(this.compiler.exe, versionFlag, execOptions);
         } catch (err) {
             logger.error(`Unable to get version for compiler '${this.compiler.exe}' - ${err}`);
             return null;

--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -212,6 +212,7 @@ export class CompilerFinder {
         const interpreted = !!props('interpreted', false);
         const supportsExecute = (interpreted || supportsBinary) && !!props('supportsExecute', true);
         const executionWrapper = props('executionWrapper', '');
+        const executionWrapperArgs = props('executionWrapperArgs', '').split('|');
         const supportsLibraryCodeFilter = !!props('supportsLibraryCodeFilter', true);
 
         const group = props('group', '');
@@ -257,7 +258,7 @@ export class CompilerFinder {
                 .split(':')
                 .filter(a => a !== ''),
             options: actualOptions,
-            versionFlag: props<string>('versionFlag'),
+            versionFlag: props('versionFlag', '').split('|'),
             versionRe: props<string>('versionRe'),
             explicitVersion: props<string>('explicitVersion'),
             compilerType: props('compilerType', ''),
@@ -265,9 +266,11 @@ export class CompilerFinder {
             debugPatched: props('debugPatched', false),
             demangler: demangler,
             demanglerType: props('demanglerType', ''),
+            demanglerArgs: props('demanglerArgs', '').split('|'),
             nvdisasm: props('nvdisasm', ''),
             objdumper: props('objdumper', ''),
             objdumperType: props('objdumperType', ''),
+            objdumperArgs: props('objdumperArgs', '').split('|'),
             intelAsm: props('intelAsm', ''),
             supportsAsmDocs: props('supportsAsmDocs', true),
             instructionSet: props<string | number>('instructionSet', '').toString(),
@@ -279,6 +282,7 @@ export class CompilerFinder {
             interpreted,
             supportsExecute,
             executionWrapper,
+            executionWrapperArgs,
             supportsLibraryCodeFilter: supportsLibraryCodeFilter,
             postProcess: props('postProcess', '').split('|'),
             lang: langId as LanguageKey,

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -200,7 +200,7 @@ export class ClangCudaCompiler extends ClangCompiler {
 
     override async objdump(outputFilename, result, maxSize) {
         // For nvdisasm.
-        const args = [outputFilename, '-c', '-g', '-hex'];
+        const args = [...this.compiler.objdumperArgs, outputFilename, '-c', '-g', '-hex'];
         const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
 
         const objResult = await this.exec(this.compiler.objdumper, args, execOptions);

--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -70,6 +70,7 @@ export class JavaCompiler extends BaseCompiler {
                 .filter(f => f.endsWith('.class'))
                 .map(async classFile => {
                     const args = [
+                        ...this.compiler.objdumperArgs,
                         // Prints out disassembled code, i.e., the instructions that comprise the Java bytecodes,
                         // for each of the methods in the class.
                         '-c',

--- a/lib/compilers/pascal-win.ts
+++ b/lib/compilers/pascal-win.ts
@@ -99,7 +99,7 @@ export class PascalWinCompiler extends BaseCompiler {
             outputFilename = this.getOutputFilename(path.dirname(outputFilename));
         }
 
-        let args = ['-d', outputFilename];
+        let args = [...this.compiler.objdumperArgs, '-d', outputFilename];
         if (intelAsm) args = args.concat(['-M', 'intel']);
         return this.exec(this.compiler.objdumper, args, {maxOutput: 1024 * 1024 * 1024}).then(objResult => {
             if (objResult.code === 0) {

--- a/lib/compilers/ptxas.ts
+++ b/lib/compilers/ptxas.ts
@@ -121,7 +121,7 @@ export class PtxAssembler extends BaseCompiler {
 
     override async objdump(outputFilename, result: any, maxSize: number) {
         const dirPath = path.dirname(outputFilename);
-        const args = ['-c', '-g', '-hex', outputFilename];
+        const args = [...this.compiler.objdumperArgs, '-c', '-g', '-hex', outputFilename];
         const objResult = await this.exec(this.compiler.objdumper, args, {maxOutput: maxSize, customCwd: dirPath});
         result.asm = objResult.stdout;
         if (objResult.code === 0) {

--- a/lib/compilers/turboc.ts
+++ b/lib/compilers/turboc.ts
@@ -53,12 +53,12 @@ export class TurboCCompiler extends DosboxCompiler {
             return {stdout: [this.compiler.explicitVersion], stderr: [], code: 0};
         }
         const execOptions = this.getDefaultExecOptions();
-        const versionFlag = '';
+        const versionFlag = [];
         execOptions.timeoutMs = 0;
         execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
 
         try {
-            return this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions);
+            return this.execCompilerCached(this.compiler.exe, versionFlag, execOptions);
         } catch (err) {
             logger.error(`Unable to get version for compiler '${this.compiler.exe}' - ${err}`);
             return null;

--- a/lib/compilers/z88dk.ts
+++ b/lib/compilers/z88dk.ts
@@ -134,7 +134,7 @@ export class z88dkCompiler extends BaseCompiler {
             }
         }
 
-        const args = [outputFilename];
+        const args = [...this.compiler.objdumperArgs, outputFilename];
 
         if (this.externalparser) {
             const objResult = await this.externalparser.objdumpAndParseAssembly(result.dirPath, args, filters);

--- a/lib/demangler/base.ts
+++ b/lib/demangler/base.ts
@@ -64,11 +64,11 @@ export class BaseDemangler extends AsmRegex {
     readonly ptxVarDef =
         /^\.(global|const)\s+(?:\.(tex|sampler|surf)ref\s+)?(?:\.attribute\([^)]*\)\s+)?(?:\.align\s+\d+\s+)?(?:\.v\d+\s+)?(?:\.[a-z]\d+\s+)?([$.A-Z_a-z][\w$.]*)/;
 
-    constructor(demanglerExe: string, compiler: BaseCompiler) {
+    constructor(demanglerExe: string, compiler: BaseCompiler, demanglerArguments: string[] = []) {
         super();
 
         this.demanglerExe = demanglerExe;
-        this.demanglerArguments = [];
+        this.demanglerArguments = demanglerArguments;
         this.symbolstore = null;
         this.othersymbols = new SymbolStore();
         this.result = {

--- a/lib/demangler/nvhpc.ts
+++ b/lib/demangler/nvhpc.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {BaseCompiler} from '../base-compiler.js';
 import {BaseDemangler} from './base.js';
 import {LLVMIRDemangler} from './llvm.js';
 
@@ -32,8 +33,8 @@ export class NVHPCDemangler extends BaseDemangler {
         return 'nvhpc';
     }
 
-    constructor(demanglerExe, compiler) {
-        super(demanglerExe, compiler);
+    constructor(demanglerExe: string, compiler: BaseCompiler, demanglerArguments: string[] = []) {
+        super(demanglerExe, compiler, demanglerArguments);
         this.llvmDemangler = new LLVMIRDemangler(demanglerExe, compiler);
     }
 

--- a/lib/demangler/pascal.ts
+++ b/lib/demangler/pascal.ts
@@ -24,6 +24,7 @@
 
 import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
 import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
 import {SymbolStore} from '../symbol-store.js';
 
 import {BaseDemangler} from './base.js';
@@ -37,8 +38,8 @@ export class PascalDemangler extends BaseDemangler {
     fixedsymbols: Record<string, string>;
     ignoredsymbols: string[];
 
-    constructor(demanglerExe, compiler) {
-        super(demanglerExe, compiler);
+    constructor(demanglerExe: string, compiler: BaseCompiler, demanglerArguments: string[] = []) {
+        super(demanglerExe, compiler, demanglerArguments);
 
         this.symbolStore = new SymbolStore();
         this.fixedsymbols = {};

--- a/lib/demangler/win32.ts
+++ b/lib/demangler/win32.ts
@@ -25,6 +25,7 @@
 import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
 import type {UnprocessedExecResult} from '../../types/execution/execution.interfaces.js';
 import {assert, unwrap} from '../assert.js';
+import {BaseCompiler} from '../base-compiler.js';
 import {logger} from '../logger.js';
 import * as utils from '../utils.js';
 
@@ -41,8 +42,8 @@ export class Win32Demangler extends CppDemangler {
     hasQuotesAroundDecoratedLabels: null | boolean;
     win32RawSymbols?: string[];
 
-    constructor(demanglerExe, compiler) {
-        super(demanglerExe, compiler);
+    constructor(demanglerExe: string, compiler: BaseCompiler, demanglerArguments: string[] = []) {
+        super(demanglerExe, compiler, demanglerArguments);
 
         // 0x28090 stands for:
         //   - 0x00010 : Disable expansion of the declaration language specifier

--- a/lib/objdumper/base.ts
+++ b/lib/objdumper/base.ts
@@ -31,6 +31,7 @@ export abstract class BaseObjdumper {
         intelAsm?: boolean,
         staticReloc?: boolean,
         dynamicReloc?: boolean,
+        objdumperArguments?: string[],
     ) {
         const args = ['-d', outputFilename, '-l', ...this.widthOptions];
 
@@ -38,6 +39,7 @@ export abstract class BaseObjdumper {
         if (dynamicReloc) args.push('-R');
         if (demangle) args.push('-C');
         if (intelAsm) args.push(...this.intelAsmOptions);
+        if (objdumperArguments) args.push(...objdumperArguments);
 
         return args;
     }

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -36,7 +36,7 @@ export type CompilerInfo = {
     baseName: string;
     alias: string[];
     options: string;
-    versionFlag?: string;
+    versionFlag?: string[];
     versionRe?: string;
     explicitVersion?: string;
     compilerType: string;
@@ -46,8 +46,10 @@ export type CompilerInfo = {
     debugPatched: boolean;
     demangler: string;
     demanglerType: string;
+    demanglerArgs: string[];
     objdumper: string;
     objdumperType: string;
+    objdumperArgs: string[];
     intelAsm: string;
     supportsAsmDocs: boolean;
     instructionSet: string;
@@ -78,6 +80,7 @@ export type CompilerInfo = {
     supportsGnatDebugViews?: boolean;
     supportsLibraryCodeFilter?: boolean;
     executionWrapper: string;
+    executionWrapperArgs: string[];
     postProcess: string[];
     lang: LanguageKey;
     group: string;


### PR DESCRIPTION
Some toolchains require passing non-standard, mandatory arguments to the CLI tools in order to execute them (configuring licenses, selecting CPU targets, etc.). This PR allows configuring extra command-line arguments for the demangler, object dumper and the execution wrapper. The version flag argument has been refactored into an array, so that more than one argument can be passed, if necessary.

The changes are fully backwards compatible.