### PR TITLE
LLVM 16

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -98,7 +98,7 @@ compiler.gnuasarm64g1020.name=AArch64 binutils 2.35.1
 compiler.gnuasarm64g1020.semver=2.35.1
 
 
-group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas_trunk:llvmas_assertions_trunk
+group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version
 group.llvmas.options=-filetype=obj -o example.o
 group.llvmas.versionRe=LLVM version .*
@@ -167,6 +167,8 @@ compiler.llvmas1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/llvm-mc
 compiler.llvmas1400.semver=14.0.0
 compiler.llvmas1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/llvm-mc
 compiler.llvmas1500.semver=15.0.0
+compiler.llvmas1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/llvm-mc
+compiler.llvmas1600.semver=16.0.0
 compiler.llvmas_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mc
 compiler.llvmas_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llvmas_trunk.semver=(trunk)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -194,7 +194,7 @@ compiler.g72.needsMulti=true
 
 ################################
 # Clang for x86
-group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang502:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang1200:clang1201:clang1300:clang1301:clang1400:clang1500
+group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang502:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang1200:clang1201:clang1300:clang1301:clang1400:clang1500:clang1600
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang.groupName=Clang x86-64
@@ -339,6 +339,10 @@ compiler.clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.clang1500.semver=15.0.0
 compiler.clang1500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 compiler.clang1500.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.clang1600.semver=16.0.0
+compiler.clang1600.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
+compiler.clang1600.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
 group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_widberg:clang_resugar
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
@@ -503,7 +507,7 @@ compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/op
 # Clang for Arm
 # Provides 64- menu items for clang-9, clang-10 and trunk
 group.armclang64.groupName=Arm 64-bit clang
-group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang1200:armv8-clang1300:armv8-clang1400:armv8-clang1500:armv8-clang-trunk:armv8-full-clang-trunk
+group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang1200:armv8-clang1300:armv8-clang1400:armv8-clang1500:armv8-clang1600:armv8-clang-trunk:armv8-full-clang-trunk
 group.armclang64.isSemVer=true
 group.armclang64.baseName=armv8-a clang
 group.armclang64.compilerType=clang
@@ -515,6 +519,9 @@ group.armclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICE
 group.armclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armclang64.compilerCategories=clang
 
+compiler.armv8-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.armv8-clang1600.semver=16.0.0
+compiler.armv8-clang1600.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 compiler.armv8-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.armv8-clang1500.semver=15.0.0
 compiler.armv8-clang1500.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
@@ -618,7 +625,7 @@ group.rvclang.licenseName=LLVM Apache 2
 group.rvclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.rvclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.rv32clang.compilers=rv32-clang:rv32-clang1500:rv32-clang1400:rv32-clang1301:rv32-clang1300:rv32-clang1201:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
+group.rv32clang.compilers=rv32-clang:rv32-clang1600:rv32-clang1500:rv32-clang1400:rv32-clang1301:rv32-clang1300:rv32-clang1201:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
 group.rv32clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 group.rv32clang.baseName=RISC-V rv32gc clang
@@ -657,11 +664,13 @@ compiler.rv32-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.rv32-clang1400.semver=14.0.0
 compiler.rv32-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.rv32-clang1500.semver=15.0.0
+compiler.rv32-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.rv32-clang1600.semver=16.0.0
 compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv32-clang.semver=(trunk)
 compiler.rv32-clang.alias=rv32clang
 
-group.rv64clang.compilers=rv64-clang:rv64-clang1500:rv64-clang1400:rv64-clang1301:rv64-clang1300:rv64-clang1201:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
+group.rv64clang.compilers=rv64-clang:rv64-clang1600:rv64-clang1500:rv64-clang1400:rv64-clang1301:rv64-clang1300:rv64-clang1201:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
 group.rv64clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64clang.baseName=RISC-V rv64gc clang
@@ -700,6 +709,8 @@ compiler.rv64-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.rv64-clang1400.semver=14.0.0
 compiler.rv64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.rv64-clang1500.semver=15.0.0
+compiler.rv64-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.rv64-clang1600.semver=16.0.0
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv64-clang.semver=(trunk)
 compiler.rv64-clang.alias=rv64clang
@@ -899,7 +910,7 @@ group.bpf.compilers=&gccbpf:&clangbpf
 group.bpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 # Clang for BPF
-group.clangbpf.compilers=bpfclangtrunk:bpfclang1500:bpfclang1400:bpfclang1300
+group.clangbpf.compilers=bpfclangtrunk:bpfclang1600:bpfclang1500:bpfclang1400:bpfclang1300
 group.clangbpf.supportsBinary=false
 group.clangbpf.supportsExecute=false
 group.clangbpf.baseName=BPF clang
@@ -912,6 +923,9 @@ group.clangbpf.compilerCategories=clang
 
 compiler.bpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.bpfclangtrunk.semver=(trunk)
+
+compiler.bpfclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.bpfclang1600.semver=16.0.0
 
 compiler.bpfclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.bpfclang1500.semver=15.0.0
@@ -1545,7 +1559,7 @@ group.mipss.isSemVer=true
 # Clang for all MIPS
 
 ## MIPS
-group.mips-clang.compilers=mips-clang1500:mips-clang1400:mips-clang1300
+group.mips-clang.compilers=mips-clang1600:mips-clang1500:mips-clang1400:mips-clang1300
 group.mips-clang.groupName=MIPS clang
 group.mips-clang.baseName=mips clang
 group.mips-clang.supportsBinary=false
@@ -1553,6 +1567,9 @@ group.mips-clang.supportsBinaryObject=false
 group.mips-clang.supportsExecute=false
 group.mips-clang.options=-target mips-elf
 group.mips-clang.compilerCategories=clang
+
+compiler.mips-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.mips-clang1600.semver=16.0.0
 
 compiler.mips-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mips-clang1500.semver=15.0.0
@@ -1564,7 +1581,7 @@ compiler.mips-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips-clang1300.semver=13.0.0
 
 ## MIPSEL
-group.mipsel-clang.compilers=mipsel-clang1500:mipsel-clang1400:mipsel-clang1300
+group.mipsel-clang.compilers=mipsel-clang1600:mipsel-clang1500:mipsel-clang1400:mipsel-clang1300
 group.mipsel-clang.groupName=MIPSEL clang
 group.mipsel-clang.baseName=mipsel clang
 group.mipsel-clang.supportsBinary=false
@@ -1572,6 +1589,9 @@ group.mipsel-clang.supportsBinaryObject=false
 group.mipsel-clang.supportsExecute=false
 group.mipsel-clang.options=-target mipsel-elf
 group.mipsel-clang.compilerCategories=clang
+
+compiler.mipsel-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.mipsel-clang1600.semver=16.0.0
 
 compiler.mipsel-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mipsel-clang1500.semver=15.0.0
@@ -1583,7 +1603,7 @@ compiler.mipsel-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mipsel-clang1300.semver=13.0.0
 
 ## MIPS64
-group.mips64-clang.compilers=mips64-clang1500:mips64-clang1400:mips64-clang1300
+group.mips64-clang.compilers=mips64-clang1600:mips64-clang1500:mips64-clang1400:mips64-clang1300
 group.mips64-clang.groupName=MIPS64 clang
 group.mips64-clang.baseName=mips64 clang
 group.mips64-clang.supportsBinary=false
@@ -1591,6 +1611,9 @@ group.mips64-clang.supportsBinaryObject=false
 group.mips64-clang.supportsExecute=false
 group.mips64-clang.options=-target mips64-elf
 group.mips64-clang.compilerCategories=clang
+
+compiler.mips64-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.mips64-clang1600.semver=16.0.0
 
 compiler.mips64-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mips64-clang1500.semver=15.0.0
@@ -1602,7 +1625,7 @@ compiler.mips64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips64-clang1300.semver=13.0.0
 
 ## MIPS64EL
-group.mips64el-clang.compilers=mips64el-clang1500:mips64el-clang1400:mips64el-clang1300
+group.mips64el-clang.compilers=mips64el-clang1600:mips64el-clang1500:mips64el-clang1400:mips64el-clang1300
 group.mips64el-clang.groupName=MIPS64EL clang
 group.mips64el-clang.baseName=mips64el clang
 group.mips64el-clang.supportsBinary=false
@@ -1610,6 +1633,9 @@ group.mips64el-clang.supportsBinaryObject=false
 group.mips64el-clang.supportsExecute=false
 group.mips64el-clang.options=-target mips64el-elf
 group.mips64el-clang.compilerCategories=clang
+
+compiler.mips64el-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.mips64el-clang1600.semver=16.0.0
 
 compiler.mips64el-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.mips64el-clang1500.semver=15.0.0
@@ -2889,7 +2915,7 @@ libs.libuv.versions.1381.libpath=/opt/compiler-explorer/libs/libuv/v1.38.1/x86_6
 
 libs.llvm.name=LLVM
 libs.llvm.description=LLVM
-libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000:1001:1100:1200:1201:1300:1301:1400:1500
+libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000:1001:1100:1200:1201:1300:1301:1400:1500:1600
 libs.llvm.url=https://llvm.org/
 libs.llvm.versions.trunk.version=trunk
 libs.llvm.versions.trunk.path=/opt/compiler-explorer/libs/llvm/trunk/include
@@ -2931,6 +2957,8 @@ libs.llvm.versions.1400.version=14.0.0
 libs.llvm.versions.1400.path=/opt/compiler-explorer/libs/llvm/14.0.0/include
 libs.llvm.versions.1500.version=15.0.0
 libs.llvm.versions.1500.path=/opt/compiler-explorer/libs/llvm/15.0.0/include
+libs.llvm.versions.1600.version=16.0.0
+libs.llvm.versions.1600.path=/opt/compiler-explorer/libs/llvm/16.0.0/include
 
 libs.llvmfs.name=Filesystem (LLVM)
 libs.llvmfs.versions=autodetect

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -156,7 +156,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang1500:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_widberg
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang1500:cclang1600:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_widberg
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -270,6 +270,9 @@ compiler.cclang1400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.cclang1500.semver=15.0.0
 compiler.cclang1500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
+compiler.cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.cclang1600.semver=16.0.0
+compiler.cclang1600.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 compiler.cclang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cclang_trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -293,7 +296,7 @@ compiler.cclang_widberg.notification=Experimental Reverse Engineering Compiler; 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk
 group.armcclang32.groupName=Arm 32-bit clang
-group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang1200:armv7-cclang1201:armv7-cclang1300:armv7-cclang1301:armv7-cclang1400:armv7-cclang1500:armv7-cclang-trunk
+group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang1200:armv7-cclang1201:armv7-cclang1300:armv7-cclang1301:armv7-cclang1400:armv7-cclang1500:armv7-cclang1600:armv7-cclang-trunk
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
 group.armcclang32.supportsExecute=false
@@ -304,7 +307,7 @@ group.armcclang32.licensePreamble=The LLVM Project is under the Apache License v
 group.armcclang32.compilerCategories=clang
 
 group.armcclang64.groupName=Arm 64-bit clang
-group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang-trunk:armv8-full-cclang-trunk
+group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang-trunk:armv8-full-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
@@ -313,6 +316,19 @@ group.armcclang64.licenseName=LLVM Apache 2
 group.armcclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armcclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang64.compilerCategories=clang
+
+compiler.armv7-cclang1600.name=armv7-a clang 16.0.0
+compiler.armv7-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.armv7-cclang1600.semver=16.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cclang1600.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+
+compiler.armv8-cclang1600.name=armv8-a clang 16.0.0
+compiler.armv8-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.armv8-cclang1600.semver=16.0.0
+# Arm v8-a
+compiler.armv8-cclang1600.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
 
 compiler.armv7-cclang1500.name=armv7-a clang 15.0.0
 compiler.armv7-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
@@ -559,7 +575,7 @@ group.rvcclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENS
 group.rvcclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.rvcclang.compilerCategories=clang
 
-group.rv32cclang.compilers=rv32-cclang:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
+group.rv32cclang.compilers=rv32-cclang:rv32-cclang1600:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
 group.rv32cclang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 group.rv32cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 group.rv32cclang.baseName=RISC-V rv32gc clang
@@ -601,11 +617,13 @@ compiler.rv32-cclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
 compiler.rv32-cclang1400.semver=14.0.0
 compiler.rv32-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.rv32-cclang1500.semver=15.0.0
+compiler.rv32-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.rv32-cclang1600.semver=16.0.0
 compiler.rv32-cclang.alias=rv32cclang
 compiler.rv32-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv32-cclang.semver=(trunk)
 
-group.rv64cclang.compilers=rv64-cclang:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
+group.rv64cclang.compilers=rv64-cclang:rv64-cclang1600:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
 group.rv64cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 group.rv64cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64cclang.baseName=RISC-V rv64gc clang
@@ -644,6 +662,8 @@ compiler.rv64-cclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
 compiler.rv64-cclang1400.semver=14.0.0
 compiler.rv64-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.rv64-cclang1500.semver=15.0.0
+compiler.rv64-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.rv64-cclang1600.semver=16.0.0
 compiler.rv64-cclang.alias=rv64cclang
 compiler.rv64-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv64-cclang.semver=(trunk)
@@ -834,7 +854,7 @@ group.cbpf.compilers=&cgccbpf:&cclangbpf
 group.cbpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 # Clang for BPF
-group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang1500:cbpfclang1400:cbpfclang1300
+group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang1600:cbpfclang1500:cbpfclang1400:cbpfclang1300
 group.cclangbpf.supportsBinary=false
 group.cclangbpf.supportsExecute=false
 group.cclangbpf.baseName=BPF clang
@@ -846,6 +866,9 @@ group.cclangbpf.objdumperType=llvm
 
 compiler.cbpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cbpfclangtrunk.semver=(trunk)
+
+compiler.cbpfclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.cbpfclang1600.semver=16.0.0
 
 compiler.cbpfclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.cbpfclang1500.semver=15.0.0
@@ -1494,13 +1517,16 @@ group.cmipss.supportsExecute=false
 # Clang for all MIPS
 
 ## MIPS
-group.mips-cclang.compilers=mips-cclang1500:mips-cclang1400:mips-cclang1300
+group.mips-cclang.compilers=mips-cclang1600:mips-cclang1500:mips-cclang1400:mips-cclang1300
 group.mips-cclang.groupName=MIPS clang
 group.mips-cclang.baseName=mips clang
 group.mips-cclang.supportsBinary=false
 group.mips-cclang.supportsBinaryObject=false
 group.mips-cclang.supportsExecute=false
 group.mips-cclang.options=-target mips-elf
+
+compiler.mips-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.mips-cclang1600.semver=16.0.0
 
 compiler.mips-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.mips-cclang1500.semver=15.0.0
@@ -1512,13 +1538,16 @@ compiler.mips-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mips-cclang1300.semver=13.0.0
 
 ## MIPSEL
-group.mipsel-cclang.compilers=mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
+group.mipsel-cclang.compilers=mipsel-cclang1600:mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
 group.mipsel-cclang.groupName=MIPSEL clang
 group.mipsel-cclang.baseName=mipsel clang
 group.mipsel-cclang.supportsBinary=false
 group.mipsel-cclang.supportsBinaryObject=false
 group.mipsel-cclang.supportsExecute=false
 group.mipsel-cclang.options=-target mipsel-elf
+
+compiler.mipsel-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.mipsel-cclang1600.semver=16.0.0
 
 compiler.mipsel-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.mipsel-cclang1500.semver=15.0.0
@@ -1530,13 +1559,16 @@ compiler.mipsel-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mipsel-cclang1300.semver=13.0.0
 
 ## MIPS64
-group.mips64-cclang.compilers=mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
+group.mips64-cclang.compilers=mips64-cclang1600:mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
 group.mips64-cclang.groupName=MIPS64 clang
 group.mips64-cclang.baseName=mips64 clang
 group.mips64-cclang.supportsBinary=false
 group.mips64-cclang.supportsBinaryObject=false
 group.mips64-cclang.supportsExecute=false
 group.mips64-cclang.options=-target mips64-elf
+
+compiler.mips64-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.mips64-cclang1600.semver=16.0.0
 
 compiler.mips64-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.mips64-cclang1500.semver=15.0.0
@@ -1548,13 +1580,16 @@ compiler.mips64-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mips64-cclang1300.semver=13.0.0
 
 ## MIPS64EL
-group.mips64el-cclang.compilers=mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
+group.mips64el-cclang.compilers=mips64el-cclang1600:mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
 group.mips64el-cclang.groupName=MIPS64EL clang
 group.mips64el-cclang.baseName=mips64el clang
 group.mips64el-cclang.supportsBinary=false
 group.mips64el-cclang.supportsBinaryObject=false
 group.mips64el-cclang.supportsExecute=false
 group.mips64el-cclang.options=-target mips64el-elf
+
+compiler.mips64el-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
+compiler.mips64el-cclang1600.semver=16.0.0
 
 compiler.mips64el-cclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.mips64el-cclang1500.semver=15.0.0

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -8,7 +8,7 @@ licenseName=LLVM Apache 2
 licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.irclang.compilers=irclang401:irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclang1001:irclang1100:irclang1101:irclang1200:irclang1201:irclang1300:irclang1400:irclang1500:irclangtrunk:irclang-assertions-trunk
+group.irclang.compilers=irclang401:irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclang1001:irclang1100:irclang1101:irclang1200:irclang1201:irclang1300:irclang1400:irclang1500:irclang1600:irclangtrunk:irclang-assertions-trunk
 group.irclang.intelAsm=-masm=intel
 group.irclang.groupName=Clang x86-64
 group.irclang.options=-x ir
@@ -45,6 +45,8 @@ compiler.irclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.irclang1400.semver=14.0.0
 compiler.irclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.irclang1500.semver=15.0.0
+compiler.irclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.irclang1600.semver=16.0.0
 compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.irclangtrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.irclangtrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -54,7 +56,7 @@ compiler.irclang-assertions-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/
 compiler.irclang-assertions-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.irclang-assertions-trunk.semver=(assertions trunk)
 
-group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llctrunk:llc-assertions-trunk
+group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llc1600:llctrunk:llc-assertions-trunk
 group.llc.compilerType=llc
 group.llc.supportsExecute=false
 group.llc.intelAsm=-masm=intel
@@ -101,6 +103,8 @@ compiler.llc1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/llc
 compiler.llc1400.semver=14.0.0
 compiler.llc1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/llc
 compiler.llc1500.semver=15.0.0
+compiler.llc1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/llc
+compiler.llc1600.semver=16.0.0
 compiler.llctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.llctrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.llctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -110,7 +114,7 @@ compiler.llc-assertions-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/
 compiler.llc-assertions-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llc-assertions-trunk.semver=(assertions trunk)
 
-group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opt1001:opt1100:opt1101:opt1200:opt1201:opt1300:opt1400:opt1500:opttrunk:opt-assertions-trunk
+group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opt1001:opt1100:opt1101:opt1200:opt1201:opt1300:opt1400:opt1500:opt1600:opttrunk:opt-assertions-trunk
 group.opt.compilerType=opt
 group.opt.supportsBinary=false
 group.opt.supportsExecute=false
@@ -159,6 +163,8 @@ compiler.opt1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/opt
 compiler.opt1400.semver=14.0.0
 compiler.opt1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/opt
 compiler.opt1500.semver=15.0.0
+compiler.opt1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/opt
+compiler.opt1600.semver=16.0.0
 compiler.opttrunk.exe=/opt/compiler-explorer/clang-trunk/bin/opt
 compiler.opttrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.opttrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
Infra: https://github.com/compiler-explorer/infra/pull/968.

The [`llvmorg-16.0.0`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.0) tag has just been published, but it hasn't been announced yet. Edit: [announced](https://discourse.llvm.org/t/llvm-16-0-0-release/69326).