### PR TITLE
First support for VAX cross compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -894,7 +894,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64:&c6x:&sparc:&sparc64:&sparcleon:&bpf
+group.cross.compilers=&ppcs:&mipss:&nanomips:&mrisc32:&msp:&gccarm:&avr:&rvgcc:&xtensaesp32:&xtensaesp32s2:&xtensaesp32s3:&platspec:&kalray:&s390x:&sh:&loongarch64:&c6x:&sparc:&sparc64:&sparcleon:&bpf:&vax
 group.cross.supportsBinaryObject=true
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
@@ -1079,7 +1079,7 @@ group.ppcs.isSemVer=true
 
 ## POWER
 group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220
-group.ppc.groupName=POWER
+group.ppc.groupName=POWER GCC
 group.ppc.baseName=power gcc
 
 compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
@@ -1100,7 +1100,7 @@ compiler.ppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-un
 compiler.ppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 ## POWER64
-group.ppc64.groupName=POWER64
+group.ppc64.groupName=POWER64 GCC
 group.ppc64.baseName=power64 gcc
 group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220
 
@@ -1139,7 +1139,7 @@ compiler.ppc64clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/L
 compiler.ppc64clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 ## POWER64LE
-group.ppc64le.groupName=POWER64LE
+group.ppc64le.groupName=POWER64LE GCC
 group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220
 group.ppc64le.baseName=power64le gcc
 
@@ -1441,6 +1441,23 @@ compiler.k1cg750.name=K1C gcc 7.5 (obsolete)
 compiler.k1cg750.semver=7.5.0
 compiler.k1cg750.objdumper=/opt/compiler-explorer/k1/gcc-7.5.0/k1-unknown-elf/bin/k1-unknown-elf-objdump
 compiler.k1cg750.hidden=true
+
+###############################
+# GCC for VAX
+#
+group.vax.compilers=vaxg1040
+group.vax.groupName=VAX GCC
+group.vax.baseName=vax gcc
+group.vax.isSemVer=true
+group.vax.supportsBinary=true
+group.vax.supportsBinaryObject=true
+
+compiler.vaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-g++
+compiler.vaxg1040.options=--sysroot opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbdself-gcc
+compiler.vaxg1040.objdumper=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-objdump
+compiler.vaxg1040.demangler=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-c++filt
+compiler.vaxg1040.name=VAX NetBSDELF
+compiler.vaxg1040.semver=10.4.0
 
 ###############################
 # Platform Specific Cross Compilers

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -839,7 +839,7 @@ compiler.cicx202221.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x:&csparc:&csparc64:&csparcleon:&cbpf
+group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x:&csparc:&csparc64:&csparcleon:&cbpf:&cvax
 group.ccross.supportsBinary=false
 group.ccross.supportsBinaryObject=true
 group.ccross.groupName=Cross GCC
@@ -1390,6 +1390,22 @@ compiler.ck1cg750.exe=/opt/compiler-explorer/k1/gcc-7.5.0/k1-unknown-elf/bin/k1-
 compiler.ck1cg750.name=K1C gcc 7.5
 compiler.ck1cg750.semver=7.5.0
 compiler.ck1cg750.objdumper=/opt/compiler-explorer/k1/gcc-7.5.0/k1-unknown-elf/bin/k1-unknown-elf-objdump
+
+###############################
+# GCC for VAX
+#
+group.cvax.compilers=cvaxg1040
+group.cvax.groupName=VAX GCC
+group.cvax.baseName=vax gcc
+group.cvax.isSemVer=true
+group.cvax.supportsBinary=true
+group.cvax.supportsBinaryObject=true
+
+compiler.cvaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-gcc
+compiler.cvaxg1040.options=--sysroot opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbdself-gcc
+compiler.cvaxg1040.objdumper=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-objdump
+compiler.cvaxg1040.name=VAX NetBSDELF
+compiler.cvaxg1040.semver=10.4.0
 
 ###############################
 # Platform Specific Cross Compilers

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -29,7 +29,7 @@ compiler.objcgsnapshot.semver=(trunk)
 
 ###############################
 # Cross Compilers
-group.objccross.compilers=&objcppcs:&objcmipss:&objcgccarm:&objcrv:&objcs390x:&objcloongarch64:&objcsparc:&objcsparc64:&objcsparcleon
+group.objccross.compilers=&objcppcs:&objcmipss:&objcgccarm:&objcrv:&objcs390x:&objcloongarch64:&objcsparc:&objcsparc64:&objcsparcleon:&objcvax
 group.objccross.supportsBinary=false
 group.objccross.supportsBinaryObject=true
 group.objccross.groupName=Cross GCC
@@ -274,6 +274,23 @@ compiler.objcrv64g1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unk
 compiler.objcrv64g1220.semver=12.2.0
 compiler.objcrv64g1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.objcrv64g1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+###############################
+# GCC for VAX
+#
+group.objcvax.compilers=objcvaxg1040
+group.objcvax.groupName=VAX GCC
+group.objcvax.baseName=vax gcc
+group.objcvax.isSemVer=true
+group.objcvax.supportsBinary=true
+group.objcvax.supportsBinaryObject=true
+
+compiler.objcvaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-gcc
+compiler.objcvaxg1040.options=--sysroot opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbdself-gcc
+compiler.objcvaxg1040.objdumper=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-objdump
+compiler.objcvaxg1040.demangler=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-c++filt
+compiler.objcvaxg1040.name=VAX NetBSDELF
+compiler.objcvaxg1040.semver=10.4.0
 
 #################################
 #################################


### PR DESCRIPTION
Add vax-netbsdelf cross compilers for C, C++ and Objective-C.

fixes #4783