### PR TITLE
Minor tweak in github labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -129,6 +129,10 @@ lang-nim:
   - lib/compilers/nim.js
   - etc/config/nim.*.properties
   - static/modes/nim-mode.ts
+lang-objc:
+  - etc/config/objc.*.properties
+lang-objc++:
+  - etc/config/objc++.*.properties
 lang-ocaml:
   - lib/compilers/ocaml.js
   - etc/config/ocaml.*.properties


### PR DESCRIPTION
Automatically add lang-objc and lang-objc++ labels when modifying respective config files.