### PR TITLE
Initial support for GCC cobol

### DIFF
--- a/etc/config/cobol.amazon.properties
+++ b/etc/config/cobol.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gnucobol
+compilers=&gnucobol:&gcccobol
 defaultCompiler=gnucobol31
 
 group.gnucobol.groupName=GnuCOBOL
@@ -16,3 +16,15 @@ compiler.gnucobol31.version=3.1
 compiler.gnucobol22.exe=/opt/compiler-explorer/cobol/gnucobol-2.2/bin/cobc
 compiler.gnucobol22.name=GnuCOBOL 2.2
 compiler.gnucobol22.version=2.2
+
+group.gcccobol.compilerType=gcccobol
+group.gcccobol.groupName=GCC
+group.gcccobol.compilers=gcccobolsnapshot
+group.gcccobol.isSemVer=true
+group.gcccobol.baseName=GCC
+group.gcccobol.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
+group.gcccobol.licenseName=GNU General Public License
+group.gcccobol.licensePreamble=Copyright (c) 2023 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
+compiler.gcccobolsnapshot.exe=/opt/compiler-explorer/cobol/gcc-cobol-master/bin/gcobol
+compiler.gcccobolsnapshot.semver=(cobol+master)

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -58,6 +58,7 @@ export {FPCCompiler} from './pascal.js';
 export {FSharpCompiler} from './dotnet.js';
 export {GCCCompiler} from './gcc.js';
 export {GCCRSCompiler} from './gccrs.js';
+export {GCCCobolCompiler} from './gcccobol.js';
 export {GnuCobolCompiler} from './gnucobol.js';
 export {GolangCompiler} from './golang.js';
 export {HaskellCompiler} from './haskell.js';

--- a/lib/compilers/gcccobol.ts
+++ b/lib/compilers/gcccobol.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {GCCCompiler} from './gcc.js';
+
+export class GCCCobolCompiler extends GCCCompiler {
+    static override get key() {
+        return 'gcccobol';
+    }
+}


### PR DESCRIPTION
Support for GCC cobol snapshot for external repository (until it is
merged in GCC, someday).

fixes https://github.com/compiler-explorer/compiler-explorer/issues/4893

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>