### PR TITLE
Fix unset versionFlags

### DIFF
--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -258,7 +258,7 @@ export class CompilerFinder {
                 .split(':')
                 .filter(a => a !== ''),
             options: actualOptions,
-            versionFlag: props('versionFlag', '').split('|'),
+            versionFlag: props<string>('versionFlag')?.split('|'),
             versionRe: props<string>('versionRe'),
             explicitVersion: props<string>('explicitVersion'),
             compilerType: props('compilerType', ''),

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -36,7 +36,7 @@ export type CompilerInfo = {
     baseName: string;
     alias: string[];
     options: string;
-    versionFlag?: string[];
+    versionFlag: string[] | undefined;
     versionRe?: string;
     explicitVersion?: string;
     compilerType: string;


### PR DESCRIPTION
Closes #4921

```
> a = ("")?.split("|")
[ '' ]
> a = (undefined)?.split("|")
undefined
> a = ("a|b")?.split("|")
[ 'a', 'b' ]
```
