### PR TITLE
Kind of ISA cleanup

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -79,7 +79,6 @@ compiler.gnatsparcleon1310.demangler=/opt/compiler-explorer/sparc-leon/gcc-13.1.
 group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1310
 group.gnatsparcs.groupName=SPARC GNAT
 group.gnatsparcs.baseName=sparc gnat
-#group.gnatsparcs.instructionSet=sparc
 
 compiler.gnatsparc1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
 compiler.gnatsparc1220.semver=12.2.0
@@ -101,7 +100,6 @@ compiler.gnatsparc1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-u
 group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641310
 group.gnatsparc64s.groupName=SPARC64 GNAT
 group.gnatsparc64s.baseName=sparc64 gnat
-#group.gnatsparcs.instructionSet=sparc
 
 compiler.gnatsparc641220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
 compiler.gnatsparc641220.semver=12.2.0
@@ -123,7 +121,7 @@ compiler.gnatsparc641310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/spa
 group.gnatriscv64.compilers=gnatriscv64112:gnatriscv641230:gnatriscv64103:gnatriscv641310
 group.gnatriscv64.groupName=RISCV64 GNAT
 group.gnatriscv64.baseName=riscv64 gnat
-group.gnatriscv64.instructionSet=riscv
+group.gnatriscv64.instructionSet=riscv64
 
 compiler.gnatriscv64103.exe=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-gnatmake
 compiler.gnatriscv64103.demangler=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-10.3.0-2/bin/riscv64-elf-c++filt
@@ -150,7 +148,6 @@ compiler.gnatriscv641310.demangler=/opt/compiler-explorer/riscv64/gcc-13.1.0/ris
 group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1310
 group.gnats390x.groupName=S390X GNAT
 group.gnats390x.baseName=S390X GNAT
-group.gnats390x.instructionSet=s390x
 
 compiler.gnats390x1120.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
 compiler.gnats390x1120.demangler=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
@@ -177,7 +174,6 @@ compiler.gnats390x1310.demangler=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-i
 ################################
 # GNAT for ppc
 group.gnatppcs.compilers=&gnatppc:&gnatppc64:&gnatppc64le
-group.gnatppcs.instructionSet=ppc
 
 ## POWER
 group.gnatppc.groupName=POWERPC GNAT
@@ -267,7 +263,6 @@ compiler.gnatppc64le1310.demangler=/opt/compiler-explorer/powerpc64le/gcc-13.1.0
 # GNAT for MIPSs
 ## GNAT builds for mipsel and mips64el are broken on 12.1.0
 group.gnatmipss.compilers=&gnatmips:&gnatmips64
-group.gnatmipss.instructionSet=mips
 
 ## MIPS
 group.gnatmips.groupName=MIPS GNAT
@@ -330,7 +325,7 @@ compiler.gnatmips641310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips6
 group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641310
 group.gnatarm64.groupName=ARM64 GNAT
 group.gnatarm64.baseName=arm64 gnat
-group.gnatarm64.instructionSet=arm64
+group.gnatarm64.instructionSet=aarch64
 
 compiler.gnatarm641210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
 compiler.gnatarm641210.semver=12.1.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1708,9 +1708,9 @@ compiler.msp430g621.semver=6.2.1
 ################################
 # CL430 (Texas Instruments MSP430 compiler)
 group.cl430.compilers=cl4302161
+group.cl430.instructionSet=msp430
 group.cl430.baseName=TI CL430
 group.cl430.groupName=TI CL430
-group.cl430.instructionSet=msp430
 group.cl430.isSemVer=true
 group.cl430.supportsBinary=false
 
@@ -1792,6 +1792,7 @@ group.mips-clang.supportsBinaryObject=false
 group.mips-clang.supportsExecute=false
 group.mips-clang.options=-target mips-elf
 group.mips-clang.compilerCategories=clang
+group.mips-clang.instructionSet=mips
 
 compiler.mips-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
 compiler.mips-clang1600.semver=16.0.0
@@ -1807,6 +1808,7 @@ compiler.mips-clang1300.semver=13.0.0
 
 ## MIPSEL
 group.mipsel-clang.compilers=mipsel-clang1600:mipsel-clang1500:mipsel-clang1400:mipsel-clang1300
+group.mipsel-clang.instructionSet=mips
 group.mipsel-clang.groupName=MIPSEL clang
 group.mipsel-clang.baseName=mipsel clang
 group.mipsel-clang.supportsBinary=false
@@ -1829,6 +1831,7 @@ compiler.mipsel-clang1300.semver=13.0.0
 
 ## MIPS64
 group.mips64-clang.compilers=mips64-clang1600:mips64-clang1500:mips64-clang1400:mips64-clang1300
+group.mips64-clang.instructionSet=mips
 group.mips64-clang.groupName=MIPS64 clang
 group.mips64-clang.baseName=mips64 clang
 group.mips64-clang.supportsBinary=false
@@ -1851,6 +1854,7 @@ compiler.mips64-clang1300.semver=13.0.0
 
 ## MIPS64EL
 group.mips64el-clang.compilers=mips64el-clang1600:mips64el-clang1500:mips64el-clang1400:mips64el-clang1300
+group.mips64el-clang.instructionSet=mips
 group.mips64el-clang.groupName=MIPS64EL clang
 group.mips64el-clang.baseName=mips64el clang
 group.mips64el-clang.supportsBinary=false
@@ -2002,6 +2006,7 @@ compiler.mips64elg1310.demangler=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips
 # GCC for nanoMIPS
 group.nanomips.compilers=nanomips630
 group.nanomips.groupName=nanoMIPS GCC
+group.nanomips.instructionSet=mips
 group.nanomips.isSemVer=true
 compiler.nanomips630.exe=/opt/compiler-explorer/nanomips/nanomips-linux-musl/2021.11-02/bin/nanomips-linux-musl-g++
 compiler.nanomips630.name=nanoMIPS gcc 6.3.0 (mtk)
@@ -2013,6 +2018,7 @@ compiler.nanomips630.objdumper=/opt/compiler-explorer/nanomips/nanomips-linux-mu
 group.mrisc32.compilers=mrisc32-gcc-trunk
 group.mrisc32.groupName=MRISC32 GCC
 group.mrisc32.isSemVer=true
+group.mrisc32.instructionSet=mrisc32
 
 compiler.mrisc32-gcc-trunk.exe=/opt/compiler-explorer/mrisc32-trunk/mrisc32-gnu-toolchain/bin/mrisc32-elf-g++
 compiler.mrisc32-gcc-trunk.name=MRISC32 gcc (trunk)
@@ -2021,7 +2027,7 @@ compiler.mrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc3
 
 ###############################
 # GCC for RISC-V
-group.rvgcc.compilers=&rv64gcc:&rv32gcc
+group.rvgcc.compilers=&rv32gcc:&rv64gcc
 group.rvgcc.groupName=RISC-V GCC
 group.rvgcc.isSemVer=true
 group.rvgcc.supportsExecute=false

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1707,6 +1707,7 @@ group.cmipss.supportsExecute=false
 
 ## MIPS
 group.mips-cclang.compilers=mips-cclang1600:mips-cclang1500:mips-cclang1400:mips-cclang1300
+group.mips-cclang.instructionSet=mips
 group.mips-cclang.groupName=MIPS clang
 group.mips-cclang.baseName=mips clang
 group.mips-cclang.supportsBinary=false
@@ -1729,6 +1730,7 @@ compiler.mips-cclang1300.semver=13.0.0
 
 ## MIPSEL
 group.mipsel-cclang.compilers=mipsel-cclang1600:mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
+group.mipsel-cclang.instructionSet=mips
 group.mipsel-cclang.groupName=MIPSEL clang
 group.mipsel-cclang.baseName=mipsel clang
 group.mipsel-cclang.supportsBinary=false
@@ -1752,6 +1754,7 @@ compiler.mipsel-cclang1300.semver=13.0.0
 ## MIPS64
 group.mips64-cclang.compilers=mips64-cclang1600:mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
 group.mips64-cclang.groupName=MIPS64 clang
+group.mips64-cclang.instructionSet=mips
 group.mips64-cclang.baseName=mips64 clang
 group.mips64-cclang.supportsBinary=false
 group.mips64-cclang.supportsBinaryObject=false
@@ -1774,6 +1777,7 @@ compiler.mips64-cclang1300.semver=13.0.0
 ## MIPS64EL
 group.mips64el-cclang.compilers=mips64el-cclang1600:mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
 group.mips64el-cclang.groupName=MIPS64EL clang
+group.mips64el-cclang.instructionSet=mips
 group.mips64el-cclang.baseName=mips64el clang
 group.mips64el-cclang.supportsBinary=false
 group.mips64el-cclang.supportsBinaryObject=false

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -41,6 +41,42 @@ export class InstructionSets {
                 target: ['arm'],
                 path: ['/arm-'],
             },
+            avr: {
+                target: ['avr'],
+                path: ['/avr-'],
+            },
+            c6x: {
+                target: ['c6x'],
+                path: ['/c6x-'],
+            },
+            ebpf: {
+                target: ['ebpf'],
+                path: ['/bpf-'],
+            },
+            kvx: {
+                target: ['kvx'],
+                path: ['/kvx-', '/k1-'],
+            },
+            loongarch: {
+                target: ['loongarch'],
+                path: ['/loongarch64-'],
+            },
+            mips: {
+                target: ['mips'],
+                path: ['/mips', '/mipsel-', '/mips64el-', '/mips64-'],
+            },
+            mrisc32: {
+                target: ['mrisc32'],
+                path: [],
+            },
+            msp430: {
+                target: ['msp430'],
+                path: ['/msp430-'],
+            },
+            powerpc: {
+                target: ['powerpc'],
+                path: ['/powerpc-', '/powerpc64-', '/powerpc64le-'],
+            },
             riscv64: {
                 target: ['rv64'],
                 path: ['/riscv64-'],
@@ -49,17 +85,21 @@ export class InstructionSets {
                 target: ['rv32'],
                 path: ['/riscv32-'],
             },
-            avr: {
-                target: ['avr'],
-                path: ['/avr-'],
+            sh : {
+                target: ['sh'],
+                path: ['/sh-'],
             },
-            msp430: {
-                target: ['msp430'],
-                path: ['/msp430-'],
+            sparc: {
+                target: ['sparc', 'sparc64'],
+                path: ['/sparc-', '/sparc64-'],
             },
-            mips: {
-                target: ['mips'],
-                path: ['/mips-'],
+            s390x: {
+                target: ['s390x'],
+                path: ['/s390x-'],
+            },
+            vax: {
+                target: ['vax'],
+                path: ['/vax-'],
             },
             wasm32: {
                 target: ['wasm32'],
@@ -69,17 +109,17 @@ export class InstructionSets {
                 target: ['wasm64'],
                 path: [],
             },
+            xstensa: {
+                target: ['xtensa'],
+                path: ['/xtensa-'],
+            },
+            z80: {
+                target: ['z80'],
+                path: [],
+            },
             6502: {
                 target: [],
                 path: [],
-            },
-            powerpc64le: {
-                target: ['powerpc64le'],
-                path: ['/powerpc64le-'],
-            },
-            powerpc64: {
-                target: ['powerpc64'],
-                path: ['/powerpc64-'],
             },
         };
     }


### PR DESCRIPTION

Initially wanted to simply add 'vax' in the compiler picker, but ended
up trying to cleanup a bit how ISA property is set.

For gcc compilers, I've tried to rely on the executable name matching
mechanism instead of having the property set all around in .properties
files.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>