### PR TITLE
tools: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Update browerslist
@@ -17,7 +17,7 @@ jobs:
           npm run update-browserslist
           git commit -am "Automated checkin - update browsers list"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           title: '[bot] Update browsers list'
           body: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/deploy-win.yml
+++ b/.github/workflows/deploy-win.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          check-latest: true
           cache: npm
       - name: Build distribution
         id: build_dist
@@ -35,7 +36,7 @@ jobs:
 
   deploy:
     needs: [build_dist]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +46,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          check-latest: true
           cache: npm
       - name: Download the built distribution
         uses: actions/download-artifact@v3

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          check-latest: true
           cache: npm
       - name: Install prerequisites
         run: make prereqs
@@ -41,6 +42,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          check-latest: true
           cache: npm
       - name: Build distribution
         id: build_dist
@@ -63,6 +65,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          check-latest: true
           cache: npm
       - name: Download the built distribution
         uses: actions/download-artifact@v3

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Install prerequisites
         run: make prereqs
       - name: Setup Firefox
-        uses: browser-actions/setup-firefox@latest
+        uses: browser-actions/setup-firefox@v1
         if: matrix.browser == 'firefox'
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@latest
+        uses: browser-actions/setup-chrome@v1
         if: matrix.browser == 'chrome'
       - name: Cypress run
         uses: cypress-io/github-action@v5

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          check-latest: true
           cache: npm
       - name: Install prerequisites
         run: make prereqs

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -127,3 +127,4 @@ From oldest to newest contributor, we would like to thank:
 - [Cordell Bloor](https://github.com/cgmb)
 - [Sebastian Büttner](https://github.com/bueddl)
 - [Madhur Chauhan](https://github.com/madhur4127)
+- [VoltrexKeyva](https://github.com/VoltrexKeyva)


### PR DESCRIPTION
- Update the actions in the GitHub Actions workflows to their latest versions.
- Run the workflows on the latest versions of the platforms where appropriate.
- Set the `check-latest` field of the `actions/setup-node` action to `true` to use the latest release of the specified Node.js version instead of using the cached one when there's a new release available.
- Explicitly specify the action versions instead of using the `latest` tag.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
