### PR TITLE
Add nightly riscv32 and riscv64 compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1779,7 +1779,7 @@ compiler.mrisc32-gcc-trunk.objdumper=/opt/compiler-explorer/mrisc32-trunk/mrisc3
 
 ###############################
 # GCC for RISC-V
-group.rvgcc.compilers=rv64-gcc1220:rv64-gcc1210:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcc1220:rv32-gcc1210:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
+group.rvgcc.compilers=rv64-gcctrunk:rv64-gcc1220:rv64-gcc1210:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv32-gcctrunk:rv32-gcc1220:rv32-gcc1210:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820
 group.rvgcc.groupName=RISC-V GCC
 group.rvgcc.isSemVer=true
 
@@ -1830,6 +1830,10 @@ compiler.rv64-gcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv6
 compiler.rv64-gcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 compiler.rv64-gcc1220.name=RISC-V rv64gc gcc 12.2.0
 
+compiler.rv64-gcctrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcctrunk.semver=(trunk)
+compiler.rv64-gcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.rv32-gcc820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-gcc820.name=RISC-V rv32gc gcc 8.2.0
@@ -1876,6 +1880,11 @@ compiler.rv32-gcc1220.semver=12.2.0
 compiler.rv32-gcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 compiler.rv32-gcc1220.name=RISC-V rv32gc gcc 12.2.0
+
+compiler.rv32-gcctrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcctrunk.semver=(trunk)
+compiler.rv32-gcctrunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcctrunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1735,7 +1735,7 @@ compiler.cmrisc32-gcc-trunk.instructionSet=mrisc32
 
 ###############################
 # GCC for RISC-V
-group.rvcgcc.compilers=rv64-cgcc1210:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
+group.rvcgcc.compilers=rv64-cgcctrunk:rv64-cgcc1210:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820
 group.rvcgcc.groupName=RISC-V GCC
 group.rvcgcc.supportsExecute=false
 
@@ -1784,6 +1784,13 @@ compiler.rv64-cgcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv
 compiler.rv64-cgcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 compiler.rv64-cgcc1220.name=RISC-V rv64gc gcc 12.2.0
 compiler.rv64-cgcc1220.supportsBinary=true
+
+compiler.rv64-cgcctrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcctrunk.semver=(trunk)
+compiler.rv64-cgcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.rv64-cgcctrunk.name=RISC-V rv64gc gcc (trunk)
+compiler.rv64-cgcctrunk.supportsBinary=true
 
 compiler.rv64-cgcc1130.exe=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcc1130.name=RISC-V rv64gc gcc 11.3.0
@@ -1853,6 +1860,13 @@ compiler.rv32-cgcc1220.semver=12.2.0
 compiler.rv32-cgcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 compiler.rv32-cgcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-cgcc1220.supportsBinary=true
+
+compiler.rv32-cgcctrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcctrunk.semver=(trunk)
+compiler.rv32-cgcctrunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcctrunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.rv32-cgcctrunk.name=RISC-V rv32gc gcc (trunk)
+compiler.rv32-cgcctrunk.supportsBinary=true
 
 ################################
 # GCC for Xtensa ESP32

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -49,7 +49,7 @@ group.gdccross.supportsBinary=true
 group.gdccross.supportsBinaryObject=true
 
 ### GDC for RISCV
-group.gdcriscv.compilers=gdcriscv1220
+group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220
 group.gdcriscv.groupName=GDC riscv
 group.gdcriscv.includeFlag=-isystem
 group.gdcriscv.isSemVer=true
@@ -61,8 +61,14 @@ compiler.gdcriscv1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv3
 compiler.gdcriscv1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 compiler.gdcriscv1220.name=riscv32 12.2.0
 
+compiler.gdcriscv32trunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
+compiler.gdcriscv32trunk.semver=trunk
+compiler.gdcriscv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.gdcriscv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.gdcriscv32trunk.name=riscv32 (trunk)
+
 ### GDC for RISCV64
-group.gdcriscv64.compilers=gdcriscv641220
+group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220
 group.gdcriscv64.groupName=GDC riscv64
 group.gdcriscv64.includeFlag=-isystem
 group.gdcriscv64.isSemVer=true
@@ -74,6 +80,11 @@ compiler.gdcriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/risc
 compiler.gdcriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 compiler.gdcriscv641220.name=riscv64 12.2.0
 
+compiler.gdcriscv64trunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
+compiler.gdcriscv64trunk.semver=trunk
+compiler.gdcriscv64trunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gdcriscv64trunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.gdcriscv64trunk.name=riscv64 (trunk)
 
 ### GDC for ARM64
 group.gdcarm64.compilers=gdcarm641220

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -397,23 +397,31 @@ compiler.fppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/p
 
 ################################
 # GCC for RISC-V 32-bits
-group.gccrv32.compilers=frv32g1210
+group.gccrv32.compilers=frv32gtrunk:frv32g1210
 group.gccrv32.groupName=RISC-V 32-bits gfortran
 group.gccrv32.baseName=RISC-V 32-bits gfortran
 
-compiler.frv32g1210.exe=/opt/compiler-explorer/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gfortran
+compiler.frv32g1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gfortran
 compiler.frv32g1210.semver=12.1.0
 compiler.frv32g1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
+compiler.frv32gtrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
+compiler.frv32gtrunk.semver=(trunk)
+compiler.frv32gtrunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
 ################################
 # GCC for RISC-V 64-bits
-group.gccrv64.compilers=frv64g1210
+group.gccrv64.compilers=frv64gtrunk:frv64g1210
 group.gccrv64.groupName=RISC-V 64-bits gfortran
 group.gccrv64.baseName=RISC-V 64-bits gfortran
 
 compiler.frv64g1210.exe=/opt/compiler-explorer/gcc-12.1.0/riscv64-unknown-elf/bin/riscv64-unknown-elf-gfortran
 compiler.frv64g1210.semver=12.1.0
 compiler.frv64g1210.objdumper=/opt/compiler-explorer/gcc-12.1.0/riscv64-unknown-elf/bin/riscv64-unknown-elf-objdump
+
+compiler.frv64gtrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.frv64gtrunk.semver=(trunk)
+compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 ################################
 # GCC for MIPS

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&objcppgcc86
+compilers=&objcppgcc86:&objcppgccrvs
 defaultCompiler=objcppg122
 demangler=/opt/compiler-explorer/gcc-12.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
@@ -33,6 +33,22 @@ compiler.objcppgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.objcppgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.objcppgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.objcppgsnapshot.semver=(trunk)
+
+group.objcppgccrvs.compilers=&objcppgccrv32:&objcppgccrv64
+group.objcppgccrvs.isSemVer=true
+
+group.objcppgccrv32.compilers=objcppgccrv32trunk
+group.objcppgccrv64.compilers=objcppgccrv64trunk
+
+compiler.objcppgccrv32trunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.objcppgccrv32trunk.semver=(trunk)
+compiler.objcppgccrv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.objcppgccrv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.objcppgccrv64trunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.objcppgccrv64trunk.semver=(trunk)
+compiler.objcppgccrv64trunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.objcppgccrv64trunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 #################################
 #################################

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -259,21 +259,31 @@ group.objcrv.supportsBinary=true
 
 group.objcrv32.groupName=RISC-V 32-bits
 group.objcrv32.baseName=RISC-V 32 GCC
-group.objcrv32.compilers=objcrv32g1220
+group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220
 
 compiler.objcrv32g1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32g1220.semver=12.2.0
 compiler.objcrv32g1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 compiler.objcrv32g1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
+compiler.objcrv32gtrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.objcrv32gtrunk.semver=(trunk)
+compiler.objcrv32gtrunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.objcrv32gtrunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
 group.objcrv64.groupName=RISC-V 64-bits
 group.objcrv64.baseName=RISC-V 64 GCC
-group.objcrv64.compilers=objcrv64g1220
+group.objcrv64.compilers=objcrv64gtrunk:objcrv64g1220
 
 compiler.objcrv64g1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.objcrv64g1220.semver=12.2.0
 compiler.objcrv64g1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.objcrv64g1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.objcrv64gtrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.objcrv64gtrunk.semver=(trunk)
+compiler.objcrv64gtrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.objcrv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 ###############################
 # GCC for VAX


### PR DESCRIPTION
refs https://github.com/compiler-explorer/compiler-explorer/issues/4900

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>

-------

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->