### PR TITLE
tools: update GitHub Actions platforms

### DIFF
--- a/.github/workflows/deploy-win.yml
+++ b/.github/workflows/deploy-win.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_dist:
-    runs-on: windows-2019
+    runs-on: windows-latest
     outputs:
       release_name: ${{ steps.build_dist.outputs.release_name }}
       branch: ${{ steps.build_dist.outputs.branch }}

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
 
   build_dist:
     if: github.repository_owner == 'compiler-explorer' && github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       release_name: ${{ steps.build_dist.outputs.release_name }}
       branch: ${{ steps.build_dist.outputs.branch }}
@@ -55,7 +55,7 @@ jobs:
   deploy:
     if: github.repository_owner == 'compiler-explorer' && github.event_name == 'push'
     needs: [test, build_dist]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   cypress-run:
     if: github.repository_owner == 'compiler-explorer'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         browser: ['chrome']

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
       - name: Ask Git to use LF line endings


### PR DESCRIPTION
Update the platforms of GitHub Actions workflows to their latest versions.

Refs: https://github.com/compiler-explorer/compiler-explorer/pull/4943#pullrequestreview-1371857582

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
