### PR TITLE
vala: Add an option to set PKG_CONFIG_PATH envvar

### DIFF
--- a/etc/config/vala.amazon.properties
+++ b/etc/config/vala.amazon.properties
@@ -16,3 +16,4 @@ group.vala.licenseLink=https://gitlab.gnome.org/GNOME/vala/-/raw/main/COPYING
 compiler.valac05606.exe=/opt/compiler-explorer/vala-0.56.6/bin/valac
 compiler.valac05606.name=Vala 0.56.6
 compiler.valac05606.cc=/opt/compiler-explorer/gcc-12.1.0/bin/gcc
+compiler.valac05606.pkgconfigpath=/opt/compiler-explorer/vala-0.56.6/lib/pkgconfig:/opt/compiler-explorer/vala-0.56.6/lib/x86_64-linux-gnu/pkgconfig

--- a/lib/compilers/vala.ts
+++ b/lib/compilers/vala.ts
@@ -34,10 +34,12 @@ export class ValaCompiler extends BaseCompiler {
     }
 
     ccPath: string;
+    pkgconfigPath: string;
 
     constructor(compiler: PreliminaryCompilerInfo, env) {
         super(compiler, env);
         this.ccPath = this.compilerProps<string>(`compiler.${this.compiler.id}.cc`);
+        this.pkgconfigPath = this.compilerProps<string>(`compiler.${this.compiler.id}.pkgconfigpath`);
     }
 
     override getCompilerResultLanguageId() {
@@ -49,6 +51,11 @@ export class ValaCompiler extends BaseCompiler {
         if (this.ccPath) {
             execOptions.env.CC = this.ccPath;
         }
+
+        if (this.pkgconfigPath) {
+            execOptions.env.PKG_CONFIG_PATH = this.pkgconfigPath;
+        }
+
         return execOptions;
     }
 


### PR DESCRIPTION
In conjunction with https://github.com/compiler-explorer/vala-builder/pull/1, this should fix #4958 

Vala uses `pkg-config` to locate libraries to link with and then passes the relevant args to `CC`, so in the live environment, we need to provide the `pkg-config` files for the minimum required libraries in the compiler prefix, and then use this environment variable to allow `pkg-config` to locate them.