### PR TITLE
Offer timetrace json to view somewhere

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -30,6 +30,7 @@ import temp from 'temp';
 import _ from 'underscore';
 
 import type {
+    BufferOkFunc,
     BuildResult,
     BuildStep,
     CompilationCacheKey,
@@ -1451,8 +1452,16 @@ export class BaseCompiler implements ICompiler {
         }
     }
 
-    async addArtifactToResult(result: CompilationResult, filepath: string, customType?: string, customTitle?: string) {
+    async addArtifactToResult(
+        result: CompilationResult,
+        filepath: string,
+        customType?: string,
+        customTitle?: string,
+        checkFunc?: BufferOkFunc,
+    ) {
         const file_buffer = await fs.readFile(filepath);
+
+        if (checkFunc && !checkFunc(file_buffer)) return;
 
         const artifact: Artifact = {
             content: file_buffer.toString('base64'),

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -27,13 +27,15 @@ import path from 'path';
 
 import _ from 'underscore';
 
-import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import type {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ExecutableExecutionOptions, UnprocessedExecResult} from '../../types/execution/execution.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {AmdgpuAsmParser} from '../parsers/asm-parser-amdgpu.js';
 import {SassAsmParser} from '../parsers/asm-parser-sass.js';
+import * as utils from '../utils.js';
+import {ArtifactType} from '../../types/tool.interfaces.js';
 
 const offloadRegexp = /^#\s+__CLANG_OFFLOAD_BUNDLE__(__START__|__END__)\s+(.*)$/gm;
 
@@ -68,6 +70,28 @@ export class ClangCompiler extends BaseCompiler {
         }
     }
 
+    async addTimeTraceToResult(result: CompilationResult, dirPath: string, outputFilename: string) {
+        let timeTraceJson = '';
+        const outputExt = path.extname(outputFilename);
+        if (outputExt) {
+            timeTraceJson = outputFilename.replace(outputExt, '.json');
+        } else {
+            timeTraceJson += '.json';
+        }
+        const jsonFilepath = path.join(dirPath, timeTraceJson);
+        if (await utils.fileExists(jsonFilepath)) {
+            this.addArtifactToResult(
+                result,
+                jsonFilepath,
+                ArtifactType.download,
+                'Trace events JSON',
+                (buffer: Buffer) => {
+                    return buffer.toString('utf-8').startsWith('{"traceEvents":[');
+                },
+            );
+        }
+    }
+
     override runExecutable(executable, executeParameters: ExecutableExecutionOptions, homeDir) {
         if (this.asanSymbolizerPath) {
             executeParameters.env = {
@@ -92,6 +116,38 @@ export class ClangCompiler extends BaseCompiler {
         const options = super.optionsForFilter(filters, outputFilename);
 
         return this.forceDwarf4UnlessOverridden(options);
+    }
+
+    override async afterCompilation(
+        result,
+        doExecute,
+        key,
+        executeParameters,
+        tools,
+        backendOptions,
+        filters,
+        options,
+        optOutput,
+        customBuildPath?,
+    ) {
+        const compilationInfo = this.getCompilationInfo(key, result, customBuildPath);
+
+        const dirPath = path.dirname(compilationInfo.outputFilename);
+        const filename = path.basename(compilationInfo.outputFilename);
+        await this.addTimeTraceToResult(result, dirPath, filename);
+
+        return super.afterCompilation(
+            result,
+            doExecute,
+            key,
+            executeParameters,
+            tools,
+            backendOptions,
+            filters,
+            options,
+            optOutput,
+            customBuildPath,
+        );
     }
 
     override runCompiler(compiler: string, options: string[], inputFilename: string, execOptions: ExecutionOptions) {

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -83,7 +83,7 @@ export class ClangCompiler extends BaseCompiler {
             this.addArtifactToResult(
                 result,
                 jsonFilepath,
-                ArtifactType.download,
+                ArtifactType.timetrace,
                 'Trace events JSON',
                 (buffer: Buffer) => {
                     return buffer.toString('utf-8').startsWith('{"traceEvents":[');

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1740,17 +1740,17 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 } else if (artifact.type === ArtifactType.smsrom) {
                     this.emulateMiracleSMS(artifact.content);
                 } else if (artifact.type === ArtifactType.download) {
-                    this.offerDownload(artifact);
+                    this.offerViewInPerfetto(artifact);
                 }
             }
         }
     }
 
-    offerDownload(artifact: Artifact): void {
+    offerViewInPerfetto(artifact: Artifact): void {
         this.alertSystem.notify(
             'Click ' +
                 '<a target="_blank" id="download_link" style="cursor:pointer;" click="javascript:;">here</a>' +
-                ' to download ' +
+                ' to show in Perfetto ' +
                 artifact.title,
             {
                 group: 'emulation',
@@ -1758,17 +1758,16 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 dismissTime: 10000,
                 onBeforeShow: function (elem) {
                     elem.find('#download_link').on('click', () => {
-                        if (artifact.type === 'application/octet-stream') {
-                            fetch('data:application/octet-stream;base64,' + artifact.content)
-                                .then(res => res.blob())
-                                .then(blob => fileSaver.saveAs(blob, artifact.name));
-                        } else {
-                            fileSaver.saveAs(
-                                new Blob([artifact.content], {
-                                    type: artifact.type,
-                                }),
-                                artifact.name,
-                            );
+                        const handle = window.open('https://ui.perfetto.dev');
+                        if (handle) {
+                            const data = {
+                                perfetto: {
+                                    buffer: Buffer.from(artifact.content, 'base64'),
+                                    title: artifact.name,
+                                    filename: artifact.name,
+                                },
+                            };
+                            handle.postMessage(data);
                         }
                     });
                 },

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1740,7 +1740,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                     this.emulateSpeccyTape(artifact.content);
                 } else if (artifact.type === ArtifactType.smsrom) {
                     this.emulateMiracleSMS(artifact.content);
-                } else if (artifact.type === ArtifactType.download) {
+                } else if (artifact.type === ArtifactType.timetrace) {
                     this.offerViewInPerfetto(artifact);
                 }
             }

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1760,16 +1760,25 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 dismissTime: 10000,
                 onBeforeShow: function (elem) {
                     elem.find('#download_link').on('click', () => {
-                        const handle = window.open('https://ui.perfetto.dev');
-                        if (handle) {
-                            const data = {
-                                perfetto: {
-                                    buffer: Buffer.from(artifact.content, 'base64'),
-                                    title: artifact.name,
-                                    filename: artifact.name,
-                                },
+                        const perfetto_url = 'https://ui.perfetto.dev';
+                        const win = window.open(perfetto_url);
+                        if (win) {
+                            const timer = setInterval(() => win.postMessage('PING', perfetto_url), 50);
+
+                            const onMessageHandler = evt => {
+                                if (evt.data !== 'PONG') return;
+                                clearInterval(timer);
+
+                                const data = {
+                                    perfetto: {
+                                        buffer: Buffer.from(artifact.content, 'base64'),
+                                        title: artifact.name,
+                                        filename: artifact.name,
+                                    },
+                                };
+                                win.postMessage(data, perfetto_url);
                             };
-                            handle.postMessage(data);
+                            window.addEventListener('message', onMessageHandler);
                         }
                     });
                 },

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -24,6 +24,7 @@
 
 import _ from 'underscore';
 import $ from 'jquery';
+import {Buffer} from 'buffer';
 import {ga} from '../analytics.js';
 import * as colour from '../colour.js';
 import {Toggles} from '../widgets/toggles.js';
@@ -1750,8 +1751,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         this.alertSystem.notify(
             'Click ' +
                 '<a target="_blank" id="download_link" style="cursor:pointer;" click="javascript:;">here</a>' +
-                ' to show in Perfetto ' +
-                artifact.title,
+                ' to view ' +
+                artifact.title +
+                ' in Perfetto',
             {
                 group: 'emulation',
                 collapseSimilar: true,

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -171,3 +171,5 @@ export type FiledataPair = {
     filename: string;
     contents: string;
 };
+
+export type BufferOkFunc = (buffer: Buffer) => boolean;

--- a/types/tool.interfaces.ts
+++ b/types/tool.interfaces.ts
@@ -56,6 +56,7 @@ export enum ArtifactType {
     bbcdiskimage = 'bbcdiskimage',
     zxtape = 'zxtape',
     smsrom = 'smsrom',
+    timetrace = 'timetracejson',
 }
 
 export type Artifact = {


### PR DESCRIPTION
When you do `-ftime-trace` with clang, a file is generated called `output.json` or however you named your executable/objectfile dot json (I think).
Checks if it's actually the expected json and then offers it to the user as a download.

If you drag the downloaded json to https://www.speedscope.app/ - you can see the things.

Would be an option to fix https://github.com/compiler-explorer/compiler-explorer/issues/1186
