### PR TITLE
solidity dont fail on missing generatedSources

### DIFF
--- a/lib/compilers/solidity.ts
+++ b/lib/compilers/solidity.ts
@@ -235,7 +235,7 @@ export class SolidityCompiler extends BaseCompiler {
 
                                 processPossibleTagOpcode(opcode, contractFunctions);
                             } else {
-                                processPossibleTagOpcode(opcode, generatedSources[opcode.source]);
+                                processPossibleTagOpcode(opcode, generatedSources[opcode.source] || []);
                             }
                         }
 


### PR DESCRIPTION
fixes https://github.com/compiler-explorer/compiler-explorer/issues/4938