### PR TITLE
Fix sparc-leon gcc 12.2.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -996,7 +996,6 @@ compiler.sparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/s
 compiler.sparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.sparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
-compiler.sparcleong1220-1.hidden=true
 compiler.sparcleong1220-1.semver=12.2.0
 compiler.sparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -983,15 +983,23 @@ compiler.sparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc6
 group.sparcleon.compilers=&gccsparcleon
 
 # GCC for SPARC-LEON
-group.gccsparcleon.compilers=sparcleong1220
+group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1
 group.gccsparcleon.baseName=SPARC LEON gcc
 group.gccsparcleon.groupName=SPARC LEON GCC
 group.gccsparcleon.isSemVer=true
 
+# this one was wrongly built using 'master', not 12.2.0 release.
 compiler.sparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1220.hidden=true
 compiler.sparcleong1220.semver=12.2.0
 compiler.sparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.sparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1220-1.hidden=true
+compiler.sparcleong1220-1.semver=12.2.0
+compiler.sparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.sparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 ###############################
 # Cross for TI C6x

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -991,7 +991,7 @@ group.gccsparcleon.isSemVer=true
 # this one was wrongly built using 'master', not 12.2.0 release.
 compiler.sparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
 compiler.sparcleong1220.hidden=true
-compiler.sparcleong1220.semver=12.2.0
+compiler.sparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
 compiler.sparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -938,7 +938,7 @@ group.cgccsparcleon.isSemVer=true
 # this one was wrongly built using 'master', not 12.2.0 release.
 compiler.csparcleong1220.hidden=true
 compiler.csparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
-compiler.csparcleong1220.semver=12.2.0
+compiler.csparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
 compiler.csparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.csparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -930,16 +930,22 @@ compiler.csparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc
 group.csparcleon.compilers=&cgccsparcleon
 
 # GCC for SPARC-LEON
-group.cgccsparcleon.compilers=csparcleong1220
+group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1
 group.cgccsparcleon.baseName=SPARC LEON gcc
 group.cgccsparcleon.groupName=SPARC LEON GCC
 group.cgccsparcleon.isSemVer=true
 
+# this one was wrongly built using 'master', not 12.2.0 release.
+compiler.csparcleong1220.hidden=true
 compiler.csparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.csparcleong1220.semver=12.2.0
 compiler.csparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.csparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
+compiler.csparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.csparcleong1220-1.semver=12.2.0
+compiler.csparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.csparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 ###############################
 # Cross for TI C6x

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -212,14 +212,21 @@ compiler.fsparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc
 
 ###############################
 # GCC for SPARC LEON
-group.gccsparcleon.compilers=fsparcleong1220
+group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1
 group.gccsparcleon.groupName=SPARC LEON gfortran
 group.gccsparcleon.baseName=SPARC LEON gfortran
 
+# this one was wrongly built using 'master', not 12.2.0 release.
+compiler.fsparcleong1220
 compiler.fsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
 compiler.fsparcleong1220.semver=12.2.0
 compiler.fsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.fsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.fsparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
+compiler.fsparcleong1220-1.semver=12.2.0
+compiler.fsparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.fsparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 ###############################
 # GCC for LOONGARCH64

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -219,7 +219,8 @@ group.gccsparcleon.baseName=SPARC LEON gfortran
 # this one was wrongly built using 'master', not 12.2.0 release.
 compiler.fsparcleong1220
 compiler.fsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
-compiler.fsparcleong1220.semver=12.2.0
+compiler.fsparcleong1220.hidden=true
+compiler.fsparcleong1220.name=SPARC LEON gfortran 13.x (incorrectly named 12.2.0 in the past)
 compiler.fsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.fsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -86,7 +86,7 @@ group.objcgccsparcleon.isSemVer=true
 # this one was wrongly built using 'master', not 12.2.0 release.
 compiler.objcsparcleong1220.hidden=true
 compiler.objcsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
-compiler.objcsparcleong1220.semver=12.2.0
+compiler.objcsparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
 compiler.objcsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.objcsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -76,17 +76,24 @@ compiler.objcsparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sp
 group.objcsparcleon.compilers=&objcgccsparcleon
 
 # GCC for SPARC-LEON
-group.objcgccsparcleon.compilers=objcsparcleong1220
+group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1
 group.objcgccsparcleon.supportsBinary=true
 group.objcgccsparcleon.supportsExecute=false
 group.objcgccsparcleon.baseName=SPARC LEON gcc
 group.objcgccsparcleon.groupName=SPARC LEON GCC
 group.objcgccsparcleon.isSemVer=true
 
+# this one was wrongly built using 'master', not 12.2.0 release.
+compiler.objcsparcleong1220.hidden=true
 compiler.objcsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.objcsparcleong1220.semver=12.2.0
 compiler.objcsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.objcsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.objcsparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.objcsparcleong1220-1.semver=12.2.0
+compiler.objcsparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.objcsparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 ###############################
 # Cross for loongarch64


### PR DESCRIPTION
The compiler was incorrectly built using gcc's master branch instead of
12.2.0 release tarball.
A correct 12.2.0 is now avail as 12.2.0-1. The previous one is kept, but
hidden to preserve possible existing shared link.

fixes #4994

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>