### PR TITLE
m68k clang: add gcc-toolchain option

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -921,13 +921,12 @@ group.clangm68k.supportsExecute=false
 group.clangm68k.baseName=M68k clang
 group.clangm68k.groupName=M68k CLANG
 group.clangm68k.isSemVer=true
-group.clangm68k.options=-target m68k
+group.clangm68k.options=-target m68k --gcc-toolchain=/opt/compiler-explorer/m68k/gcc-13.1.0/
 group.clangm68k.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.clangm68k.objdumperType=llvm
 group.clangm68k.compilerCategories=clang
 
 compiler.m68kclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
-compiler.m68kclangtrunk.options=--gcc-toolchain=/opt/compiler-explorer/m68k/gcc-13.1.0/
 compiler.m68kclangtrunk.semver=(trunk)
 
 # GCC for m68k

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -927,6 +927,7 @@ group.clangm68k.objdumperType=llvm
 group.clangm68k.compilerCategories=clang
 
 compiler.m68kclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.m68kclangtrunk.options=--gcc-toolchain=/opt/compiler-explorer/m68k/gcc-13.1.0/
 compiler.m68kclangtrunk.semver=(trunk)
 
 # GCC for m68k

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -923,6 +923,7 @@ group.cclangm68k.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.cclangm68k.objdumperType=llvm
 
 compiler.cm68kclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.cm68kclangtrunk.options=--gcc-toolchain=/opt/compiler-explorer/m68k/gcc-13.1.0/
 compiler.cm68kclangtrunk.semver=(trunk)
 
 # GCC for m68k

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -918,12 +918,11 @@ group.cclangm68k.supportsExecute=false
 group.cclangm68k.baseName=M68K clang
 group.cclangm68k.groupName=M68K CLANG
 group.cclangm68k.isSemVer=true
-group.cclangm68k.options=-target m68k
+group.cclangm68k.options=-target m68k --gcc-toolchain=/opt/compiler-explorer/m68k/gcc-13.1.0/
 group.cclangm68k.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.cclangm68k.objdumperType=llvm
 
 compiler.cm68kclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.cm68kclangtrunk.options=--gcc-toolchain=/opt/compiler-explorer/m68k/gcc-13.1.0/
 compiler.cm68kclangtrunk.semver=(trunk)
 
 # GCC for m68k


### PR DESCRIPTION
Have clang point to gcc to get required dev files.

refs #5037

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>