### PR TITLE
Add feature to save assembly output on Ctrl+s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
         "@types/jquery": "^3.5.10",
         "@types/js-cookie": "^3.0.2",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^20.1.2",
         "@types/node-targz": "^0.2.0",
         "@types/qs": "^6.9.7",
         "@types/request": "^2.48.8",
@@ -4357,9 +4356,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.2.tgz",
-      "integrity": "sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g=="
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/@types/node-targz": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "@types/jquery": "^3.5.10",
         "@types/js-cookie": "^3.0.2",
         "@types/mocha": "^10.0.1",
+        "@types/node": "^20.1.2",
         "@types/node-targz": "^0.2.0",
         "@types/qs": "^6.9.7",
         "@types/request": "^2.48.8",
@@ -4356,9 +4357,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.2.tgz",
+      "integrity": "sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g=="
     },
     "node_modules/@types/node-targz": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@types/jquery": "^3.5.10",
     "@types/js-cookie": "^3.0.2",
     "@types/mocha": "^10.0.1",
+    "@types/node": "^20.1.2",
     "@types/node-targz": "^0.2.0",
     "@types/qs": "^6.9.7",
     "@types/request": "^2.48.8",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "@types/jquery": "^3.5.10",
     "@types/js-cookie": "^3.0.2",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^20.1.2",
     "@types/node-targz": "^0.2.0",
     "@types/qs": "^6.9.7",
     "@types/request": "^2.48.8",

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2423,7 +2423,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 if (this.assembly.length > 0) {
                     const texts = this.assembly.map(asm => (asm.text ? asm.text : ''));
                     const blob = new Blob([texts.join('\n')], {type: 'text/plain;charset=utf-8'});
-                    fileSaver.saveAs(blob, 'assembly.txt');
+                    fileSaver.saveAs(blob, this.id + '.asm');
                 }
             }
         });

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2416,6 +2416,17 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         this.statusIcon = this.domRoot.find('.status-icon');
 
         this.monacoPlaceholder = this.domRoot.find('.monaco-placeholder');
+
+        $(this.domRoot).on('keydown', event => {
+            if ((event.ctrlKey || event.metaKey) && String.fromCharCode(event.which).toLowerCase() === 's') {
+                event.preventDefault();
+                if (this.assembly.length > 0) {
+                    const texts = this.assembly.map(asm => (asm.text ? asm.text : ''));
+                    const blob = new Blob([texts.join('\n')], {type: 'text/plain;charset=utf-8'});
+                    fileSaver.saveAs(blob, 'assembly.txt');
+                }
+            }
+        });
     }
 
     onLibsChanged(): void {


### PR DESCRIPTION
Solving the issue #3695 @jeremy-rifkin 
Yet I have a question in mind, why u mentioned getting the source from the editor?
https://github.com/compiler-explorer/compiler-explorer/blob/8262e2be5e0506a1f5af0b6e7235afe450b2b8ba/static/panes/editor.ts#L302-L304

Shouldn't we save the assembly instead of the source?
In my current implementation, I map and reduce the `this.assembly`.
```js

        $(this.domRoot).on('keydown', event => {
            if ((event.ctrlKey || event.metaKey) && String.fromCharCode(event.which).toLowerCase() === 's') {
                event.preventDefault();
                if (this.assembly.length > 0) {
                    const texts = this.assembly.map(asm => (asm.text ? asm.text : ''));
                    const blob = new Blob([texts.join('\n')], {type: 'text/plain;charset=utf-8'});
                    fileSaver.saveAs(blob, this.id + '.asm');
                }
            }
        });
```