### PR TITLE
Assembly syntax highlight of comments after code

### DIFF
--- a/static/modes/asm-mode.ts
+++ b/static/modes/asm-mode.ts
@@ -39,6 +39,8 @@ function definition(): monaco.languages.IMonarchLanguage {
             root: [
                 // Error document
                 [/^<.*>$/, {token: 'annotation'}],
+                // inline comments
+                [/\/\*/, 'comment', '@comment'],
                 // Label definition
                 [/^[.a-zA-Z0-9_$?@].*:/, {token: 'type.identifier'}],
                 // Label definition (quoted)
@@ -66,6 +68,9 @@ function definition(): monaco.languages.IMonarchLanguage {
 
                 [/@registers/, 'variable.predefined'],
                 [/@intelOperators/, 'annotation'],
+                // inline comments
+                [/\/\*/, 'comment', '@comment'],
+
                 // brackets
                 [/[{}<>()[\]]/, '@brackets'],
 


### PR DESCRIPTION
Solving the issue #4876 @jeremy-rifkin 
![Screenshot 2023-05-11 at 9 44 19 AM](https://github.com/compiler-explorer/compiler-explorer/assets/113857408/742c610b-632e-4e8a-a533-082abbbd6e51)
