### PR TITLE
Add FRC 2023 Compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1576,7 +1576,7 @@ compiler.vaxg1040.semver=10.4.0
 
 ###############################
 # Platform Specific Cross Compilers
-group.platspec.compilers=frc2019:frc2020:raspbian9:raspbian10:arduinouno189:arduinomega189:&cl430
+group.platspec.compilers=frc2019:frc2020:frc2023:raspbian9:raspbian10:arduinouno189:arduinomega189:&cl430
 group.platspec.groupName=Platform Specific Compilers
 group.platspec.isSemVer=true
 group.platspec.includeFlag=-I
@@ -1592,6 +1592,10 @@ compiler.frc2020.exe=/opt/compiler-explorer/arm/frc2020-7.3.0/roborio/bin/arm-fr
 compiler.frc2020.name=FRC 2020
 compiler.frc2020.semver=7.3
 compiler.frc2020.objdumper=/opt/compiler-explorer/arm/frc2020-7.3.0/roborio/bin/arm-frc2020-linux-gnueabi-objdump
+compiler.frc2023.exe=/opt/compiler-explorer/arm/frc2023-12.1.0/bin/arm-frc2023-linux-gnueabi-g++
+compiler.frc2023.name=FRC 2023
+compiler.frc2023.semver=12.1
+compiler.frc2023.objdumper=/opt/compiler-explorer/arm/frc2023-12.1.0/bin/arm-frc2023-linux-gnueabi-objdump
 compiler.raspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-g++
 compiler.raspbian9.name=Raspbian Stretch
 compiler.raspbian9.semver=6.3

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1505,7 +1505,7 @@ compiler.cvaxg1040.semver=10.4.0
 
 ###############################
 # Platform Specific Cross Compilers
-group.cplatspec.compilers=cfrc2019:cfrc2020:craspbian9:craspbian10:carduinouno189:carduinomega189:&ccl430
+group.cplatspec.compilers=cfrc2019:cfrc2020:cfrc2023:craspbian9:craspbian10:carduinouno189:carduinomega189:&ccl430
 group.cplatspec.groupName=Platform Specific Compilers
 group.cplatspec.isSemVer=true
 group.cplatspec.includeFlag=-I
@@ -1521,6 +1521,10 @@ compiler.cfrc2020.exe=/opt/compiler-explorer/arm/frc2020-7.3.0/roborio/bin/arm-f
 compiler.cfrc2020.name=FRC 2020
 compiler.cfrc2020.semver=7.3
 compiler.cfrc2020.objdumper=/opt/compiler-explorer/arm/frc2020-7.3.0/roborio/bin/arm-frc2020-linux-gnueabi-objdump
+compiler.cfrc2023.exe=/opt/compiler-explorer/arm/frc2023-12.1.0/bin/arm-frc2023-linux-gnueabi-gcc
+compiler.cfrc2023.name=FRC 2023
+compiler.cfrc2023.semver=12.1
+compiler.cfrc2023.objdumper=/opt/compiler-explorer/arm/frc2023-12.1.0/bin/arm-frc2023-linux-gnueabi-objdump
 compiler.craspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-gcc
 compiler.craspbian9.name=Raspbian Stretch
 compiler.craspbian9.semver=6.3


### PR DESCRIPTION
Restores the reverted #4568, as the latest version is built on Ubuntu 20.04.

Depends on compiler-explorer/infra#1012 to pull in the latest version.
