### PR TITLE
Add something to the context menu in place of paste when not supported

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -932,6 +932,21 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             },
         });
 
+        // Same check from upstream
+        // https://github.com/microsoft/vscode/blob/1052813be23485fd9c17ac77b517241479c21142/src/vs/editor/contrib/clipboard/browser/clipboard.ts#L27-L30
+        const supportsPaste =
+            typeof navigator.clipboard === 'undefined' || navigator.userAgent.includes('Firefox')
+                ? document.queryCommandSupported('paste')
+                : true;
+        if (!supportsPaste) {
+            this.editor.addAction({
+                id: 'firefoxDoesntSupportPaste',
+                label: "Firefox doesn't support context-menu paste",
+                contextMenuGroupId: '9_cutcopypaste',
+                run: () => {},
+            });
+        }
+
         this.revealJumpStackHasElementsCtxKey = this.editor.createContextKey('hasRevealJumpStackElements', false);
 
         this.editor.addAction({


### PR DESCRIPTION
In case anyone asks why "Paste" is missing from the context menu in the future:

![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/32070502-fa17-44e3-ba5c-8924294b7e74)

Paste is present in chrome and other browsers that support the clipboard api, just not firefox. This should change upstream some day. https://github.com/microsoft/vscode/blob/1052813be23485fd9c17ac77b517241479c21142/src/vs/editor/contrib/clipboard/browser/clipboard.ts#L27-L30 

Closes #3113