### PR TITLE
Add native GCC 11.4.0

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -7,7 +7,7 @@ compilerType=ada
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat111:gnat112:gnat113:gnat121:gnat122:gnat123:gnat131:gnatsnapshot
+group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat131:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=X86-64 GNAT
 group.gnat.baseName=x86-64 gnat
@@ -37,6 +37,8 @@ compiler.gnat112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gnatmake
 compiler.gnat112.semver=11.2
 compiler.gnat113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gnatmake
 compiler.gnat113.semver=11.3
+compiler.gnat114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gnatmake
+compiler.gnat114.semver=11.4
 compiler.gnat121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gnatmake
 compiler.gnat121.semver=12.1
 compiler.gnat122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gnatmake

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -17,7 +17,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g111:g112:g113:g121:g122:g123:g131:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g111:g112:g113:g114:g121:g122:g123:g131:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -141,6 +141,8 @@ compiler.g112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/g++
 compiler.g112.semver=11.2
 compiler.g113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/g++
 compiler.g113.semver=11.3
+compiler.g114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/g++
+compiler.g114.semver=11.4
 compiler.g121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/g++
 compiler.g121.semver=12.1
 compiler.g122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/g++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg111:cg112:cg113:cg121:cg122:cg123:cg131:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -119,6 +119,8 @@ compiler.cg112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gcc
 compiler.cg112.semver=11.2
 compiler.cg113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gcc
 compiler.cg113.semver=11.3
+compiler.cg114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gcc
+compiler.cg114.semver=11.4
 compiler.cg121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gcc
 compiler.cg121.semver=12.1
 compiler.cg122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gcc

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gdc:&ldc:&dmd:&gdccross
 defaultCompiler=ldc1_32
 
-group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc111:gdc113:gdc121:gdc122:gdc123:gdc131:gdctrunk
+group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc131:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
@@ -34,6 +34,8 @@ compiler.gdc111.exe=/opt/compiler-explorer/gcc-11.1.0/bin/gdc
 compiler.gdc111.semver=11.1
 compiler.gdc113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gdc
 compiler.gdc113.semver=11.3
+compiler.gdc114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gdc
+compiler.gdc114.semver=11.4
 compiler.gdc121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gdc
 compiler.gdc121.semver=12.1
 compiler.gdc122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gdc

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -6,7 +6,7 @@ compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran111:gfortran112:gfortran113:gfortran121:gfortran122:gfortran123:gfortran131:gfortransnapshot
+group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran131:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -54,6 +54,8 @@ compiler.gfortran112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gfortran
 compiler.gfortran112.semver=11.2
 compiler.gfortran113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gfortran
 compiler.gfortran113.semver=11.3
+compiler.gfortran114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gfortran
+compiler.gfortran114.semver=11.4
 compiler.gfortran121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gfortran
 compiler.gfortran121.semver=12.1
 compiler.gfortran122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gfortran

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gccgo:&gl:&cross
 defaultCompiler=gl1200
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 
-group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo111:gccgo112:gccgo113:gccgo121:gccgo122:gccgo123:gccgo131
+group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo131
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -27,6 +27,8 @@ compiler.gccgo112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/gccgo
 compiler.gccgo112.semver=11.2.0
 compiler.gccgo113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gccgo
 compiler.gccgo113.semver=11.3.0
+compiler.gccgo114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gccgo
+compiler.gccgo114.semver=11.4.0
 compiler.gccgo121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gccgo
 compiler.gccgo121.semver=12.1.0
 compiler.gccgo122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gccgo

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.objcppgcc86.compilers=objcppg122:objcppg123:objcppg131:objcppgsnapshot
+group.objcppgcc86.compilers=objcppg114:objcppg122:objcppg123:objcppg131:objcppgsnapshot
 group.objcppgcc86.groupName=GCC x86-64
 group.objcppgcc86.instructionSet=amd64
 group.objcppgcc86.baseName=x86-64 gcc
@@ -25,6 +25,9 @@ group.objcppgcc86.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.objcppgcc86.licenseName=GNU General Public License
 group.objcppgcc86.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 group.objcppgcc86.supportsBinaryObject=true
+
+compiler.objcppg114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/g++
+compiler.objcppg114.semver=11.4
 
 compiler.objcppg122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/g++
 compiler.objcppg122.semver=12.2

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -9,7 +9,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.objcgcc86.compilers=objcg122:objcg123:objcg131:objcgsnapshot
+group.objcgcc86.compilers=objcg114:objcg122:objcg123:objcg131:objcgsnapshot
 group.objcgcc86.groupName=GCC x86-64
 group.objcgcc86.instructionSet=amd64
 group.objcgcc86.isSemVer=true
@@ -18,6 +18,9 @@ group.objcgcc86.supportsPVS-Studio=true
 group.objcgcc86.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.objcgcc86.licenseName=GNU General Public License
 group.objcgcc86.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
+compiler.objcg114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gcc
+compiler.objcg114.semver=11.4
 
 compiler.objcg122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gcc
 compiler.objcg122.semver=12.2


### PR DESCRIPTION
GCC 11.4.0 has been released:

https://inbox.sourceware.org/gcc/20230529101203.u1gOJtp3gjkZM4Kahj3TgGmIRlZDagFSKcgleNN33_U@z/T/#t

fixes #5089

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>