### PR TITLE
Add -gcc-toolchain option for Clang 3.1, 3.2, and 3.3

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -130,3 +130,4 @@ From oldest to newest contributor, we would like to thank:
 - [VoltrexKeyva](https://github.com/VoltrexKeyva)
 - [Johel Ernesto Guerrero Peña](https://github.com/JohelEGP)
 - [Ali](https://github.com/aliaegik)
+- [Vlad Serebrennikov](https://github.com/endilll)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -223,20 +223,20 @@ compiler.clang30.alias=/usr/bin/clang++
 compiler.clang30.semver=3.0.0
 compiler.clang30.options=
 compiler.clang30.supportsBinary=false
+# Older clangs don't support anything newer than GCC's 6.3
 compiler.clang31.exe=/opt/compiler-explorer/clang+llvm-3.1-x86_64-linux-ubuntu_12.04/bin/clang++
 compiler.clang31.semver=3.1
-compiler.clang31.options=
+compiler.clang31.options=-gcc-toolchain /opt/compiler-explorer/gcc-6.3.0
 compiler.clang31.supportsBinary=false
 compiler.clang32.exe=/opt/compiler-explorer/clang-3.2/bin/clang++
 compiler.clang32.alias=/opt/clang-3.2/bin/clang++
 compiler.clang32.semver=3.2
-compiler.clang32.options=
+compiler.clang32.options=-gcc-toolchain /opt/compiler-explorer/gcc-6.3.0
 compiler.clang32.supportsBinary=false
 compiler.clang33.exe=/opt/compiler-explorer/clang-3.3/bin/clang++
 compiler.clang33.alias=/opt/clang-3.3/bin/clang++
 compiler.clang33.semver=3.3
-compiler.clang33.options=
-# Older clangs don't support anything newer than GCC's 6.3
+compiler.clang33.options=-gcc-toolchain /opt/compiler-explorer/gcc-6.3.0
 compiler.clang341.exe=/opt/compiler-explorer/clang+llvm-3.4.1-x86_64-unknown-ubuntu12.04/bin/clang++
 compiler.clang341.alias=/opt/clang+llvm-3.4.1-x86_64-unknown-ubuntu12.04/bin/clang++
 compiler.clang341.semver=3.4.1


### PR DESCRIPTION
This patch specifies path to GCC toolchain for those ancient Clang versions. Ancient Clang versions are still very useful when revisiting equally ancient bug reports, or figuring out when an ancient C or C++ defect report was implemented.

Note that modern spelling of this option is `--gcc-toolchain=`, which is used for Clang 3.4 onwards, but those ancient versions has it in a slightly different form.
