### PR TITLE
RFC: Work in progress in more structured logging of compiles

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -62,3 +62,8 @@ formatter.dartformat.type=dartformat
 
 thirdPartyIntegrationEnabled=true
 statusTrackingEnabled=true
+
+compilationStatsNotifierFlushMs=300000
+# TODO consider a nice S3(...) configuration for these, like the cache? consistency, eh?
+compilationStatsNotifierS3Bucket=compiler-explorer-logs
+compilationStatsNotifierS3Path=compile-stats

--- a/lib/compilation-env.ts
+++ b/lib/compilation-env.ts
@@ -39,6 +39,7 @@ import {CompilerProps} from './properties.js';
 import type {PropertyGetter} from './properties.interfaces.js';
 import {unwrap} from './assert.js';
 import {CompilerOverrideOptions} from '../types/compilation/compiler-overrides.interfaces.js';
+import {createStatsNoter, IStatsNoter} from './stats.js';
 
 export class CompilationEnvironment {
     ceProps: PropertyGetter;
@@ -54,6 +55,7 @@ export class CompilationEnvironment {
     baseEnv: Record<string, string | undefined>;
     formatHandler: FormattingHandler;
     possibleToolchains?: CompilerOverrideOptions;
+    statsNoter: IStatsNoter;
     private logCompilerCacheAccesses: boolean;
 
     constructor(compilerProps, compilationQueue, doCache) {
@@ -101,6 +103,7 @@ export class CompilationEnvironment {
         // handler, and passing it in from the outside is a pain as each compiler's constructor needs it.
         this.formatHandler = new FormattingHandler(this.ceProps);
         this.logCompilerCacheAccesses = this.ceProps('logCompilerCacheAccesses', false);
+        this.statsNoter = createStatsNoter(this.ceProps);
     }
 
     getEnv(needsMulti: boolean) {

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -86,7 +86,7 @@ export type ExecutionParams = {
     stdin: string;
 };
 
-type ParsedRequest = {
+export type ParsedRequest = {
     source: string;
     options: string[];
     backendOptions: Record<string, any>;
@@ -548,6 +548,7 @@ export class CompileHandler {
         }
 
         this.compileCounter.inc({language: compiler.lang.id});
+        this.compilerEnv.statsNoter.noteCompilation(parsedRequest);
         // eslint-disable-next-line promise/catch-or-return
         compiler
             .compile(

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {ExecutionParams, ParsedRequest} from './handlers/compile.js';
+import {getHash} from './utils.js';
+import {logger} from './logger.js';
+import {PropertyGetter} from './properties.interfaces.js';
+import {S3Bucket} from './s3-handler.js';
+import {StorageClass} from '@aws-sdk/client-s3';
+import {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
+
+export interface IStatsNoter {
+    noteCompilation(request: ParsedRequest);
+}
+
+class NullStatsNoter implements IStatsNoter {
+    noteCompilation(request: ParsedRequest) {}
+}
+
+// A type for storing only compilation information deemed non-identifying; that is, no source or execution options.
+// This started out as a `Omit<ParsedRequest, ...>` but really in order to be more useful it needs to be more specialised.
+type CompilationRecord = {
+    time: string;
+    sourceHash: string;
+    executionParamsHash: string;
+    options: string[];
+    filters: Record<string, boolean>;
+    bypassCache: boolean;
+    // tools: any;
+    // libraries: any[];
+};
+
+// TODO test!
+function makeSafe(time: Date, request: ParsedRequest): CompilationRecord {
+    return {
+        time: time.toISOString(),
+        sourceHash: getHash(request.source),
+        executionParamsHash: getHash(JSON.stringify(request.executionParameters)),
+        options: request.options,
+        filters: Object.fromEntries(
+            Object.entries(request.filters).filter(value => typeof value[1] === 'boolean'),
+        ) as Record<string, boolean>,
+        bypassCache: request.bypassCache,
+        // todo: tools and libraries once we know what types they are and can guarantee they're json serialisable
+    };
+}
+
+function makeKey(now: Date): string {
+    return `year=${now.getUTCFullYear()}/month=${now.getUTCMonth()}/date=${now.getUTCDate()}/${now.toISOString()}.json`;
+}
+
+class StatsNoter implements IStatsNoter {
+    private _statsQueue: CompilationRecord[];
+    private readonly _flushAfterMs: number;
+    private _flushJob: NodeJS.Timeout | undefined;
+    private readonly _s3: S3Bucket;
+    private readonly _path: string;
+
+    constructor(props: PropertyGetter) {
+        this._statsQueue = [];
+        this._flushAfterMs = props('compilationStatsNotifierFlushMs', 5 * 60 * 1000);
+        this._flushJob = undefined;
+        const bucket = props<string>('compilationStatsNotifierS3Bucket');
+        this._s3 = new S3Bucket(bucket, props('compilationStatsNotifierS3Region', 'us-east-1'));
+        this._path = props('compilationStatsNotifierS3Path', 'compile-stats');
+        logger.info(`Flushing stats to ${bucket}/${this._path} every ${this._flushAfterMs}ms`);
+    }
+
+    private flush() {
+        const toFlush = this._statsQueue;
+        this._statsQueue = [];
+        if (toFlush) {
+            // async write to S3
+            this._s3
+                .put(makeKey(new Date()), Buffer.from(toFlush.map(x => JSON.stringify(x)).join('\n')), this._path, {
+                    redundancy: StorageClass.REDUCED_REDUNDANCY,
+                })
+                .then(() => {})
+                .catch(e => {
+                    logger.warn(`Caught exception trying to log compilations to ${makeKey(new Date())}: ${e}`);
+                });
+        }
+        if (this._flushJob !== undefined) {
+            clearTimeout(this._flushJob);
+            this._flushJob = undefined;
+        }
+    }
+
+    noteCompilation(request: ParsedRequest) {
+        this._statsQueue.push(makeSafe(new Date(), request));
+        if (!this._flushJob) this._flushJob = setTimeout(() => this.flush(), this._flushAfterMs);
+    }
+}
+
+export function createStatsNoter(props: PropertyGetter): IStatsNoter {
+    const type = props('compilationStatsNotifier', '');
+    switch (type) {
+        case 'none':
+            return new NullStatsNoter();
+        case 'S3':
+            return new StatsNoter(props);
+    }
+    throw new Error(`Unknown stats type '${type}'`);
+}


### PR DESCRIPTION
- logs to S3 (configurably) only non-PII information

DRAFT! Needs testing, and more thought. Importantly, trying to make sure we don't log anything we will regret later.

Will need some infra setup too to ensure things work out. We _COULD_ leverage the SQS lambda instead to have this all go through "one" code path (aggregating etc) but as we're already a full app we can configure us to be able to write to the log bucket (but not list/read/anything else) instead.

Example queries:
```
SELECT COUNT(*) from compile_stats where filters.binary;  -- count number of binary
SELECT option FROM compile_stats CROSS JOIN UNNEST(options) as t(option); -- bust out options separately into a larger table of one-option-per-line
```
