### PR TITLE
enable CPU asm docs for CUDA C++

### DIFF
--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -284,7 +284,7 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         logoUrlDark: 'cuda-dark.svg',
         formatter: null,
         previewFilter: null,
-        monacoDisassembly: 'ptx',
+        monacoDisassembly: null,
     },
     d: {
         name: 'D',


### PR DESCRIPTION
Currently, asm docs are not enabled on the CPU assembly generated by the CUDA compiler, this PR attempts to fix that.
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
