### PR TITLE
Fix ordering in the compiler picker popup

### DIFF
--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -334,6 +334,7 @@ export class CompilerFinder {
                 preamble: props<string>('licensePreamble'),
             },
             possibleOverrides: [],
+            $order: undefined as unknown as number, // TODO(jeremy-rifkin): Very dirty
         };
 
         if (props('demanglerClassFile') !== undefined) {

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -131,6 +131,7 @@ export type CompilerInfo = {
     cachedPossibleArguments?: any;
     nvdisasm?: string;
     mtime?: any;
+    $order: number;
 };
 
 // Compiler information collected by the compiler-finder


### PR DESCRIPTION
No more of this nonsense, long overdue fix

![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/bf55a8bb-63a9-47dc-802e-d24df465d422)
