### PR TITLE
Add GCC 11.4.0 and 12.3.0 for cross targets

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -76,7 +76,7 @@ compiler.gnatsparcleon1310.demangler=/opt/compiler-explorer/sparc-leon/gcc-13.1.
 
 ################################
 # GNAT for sparc
-group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1310
+group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1310
 group.gnatsparcs.groupName=SPARC GNAT
 group.gnatsparcs.baseName=sparc gnat
 #group.gnatsparcs.instructionSet=sparc
@@ -86,6 +86,11 @@ compiler.gnatsparc1220.semver=12.2.0
 compiler.gnatsparc1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gnatsparc1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.gnatsparc1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
+compiler.gnatsparc1230.semver=12.3.0
+compiler.gnatsparc1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gnatsparc1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 compiler.gnatsparc1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
 compiler.gnatsparc1310.semver=13.1.0
 compiler.gnatsparc1310.objdumper=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
@@ -93,7 +98,7 @@ compiler.gnatsparc1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-u
 
 ################################
 # GNAT for sparc64
-group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641310
+group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641310
 group.gnatsparc64s.groupName=SPARC64 GNAT
 group.gnatsparc64s.baseName=sparc64 gnat
 #group.gnatsparcs.instructionSet=sparc
@@ -103,6 +108,11 @@ compiler.gnatsparc641220.semver=12.2.0
 compiler.gnatsparc641220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gnatsparc641220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.gnatsparc641230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
+compiler.gnatsparc641230.semver=12.3.0
+compiler.gnatsparc641230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gnatsparc641230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 compiler.gnatsparc641310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
 compiler.gnatsparc641310.semver=13.1.0
 compiler.gnatsparc641310.objdumper=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
@@ -110,7 +120,7 @@ compiler.gnatsparc641310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/spa
 
 ################################
 # GNAT for riscv64
-group.gnatriscv64.compilers=gnatriscv64112:gnatriscv64103:gnatriscv641310
+group.gnatriscv64.compilers=gnatriscv64112:gnatriscv641230:gnatriscv64103:gnatriscv641310
 group.gnatriscv64.groupName=RISCV64 GNAT
 group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.instructionSet=riscv
@@ -125,6 +135,11 @@ compiler.gnatriscv64112.demangler=/opt/compiler-explorer/riscv64/gnat-riscv64-el
 compiler.gnatriscv64112.semver=11.2.0-3 (Alire)
 compiler.gnatriscv64112.adarts=/opt/compiler-explorer/riscv64/gnat-riscv64-elf-linux64-11.2.0-3/riscv64-elf/lib/gnat/zfp-rv64imac
 
+compiler.gnatriscv641230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
+compiler.gnatriscv641230.semver=12.3.0
+compiler.gnatriscv641230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gnatriscv641230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.gnatriscv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
 compiler.gnatriscv641310.semver=13.1.0
 compiler.gnatriscv641310.objdumper=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -132,7 +147,7 @@ compiler.gnatriscv641310.demangler=/opt/compiler-explorer/riscv64/gcc-13.1.0/ris
 
 ################################
 # GNAT for s390x
-group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1310
+group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1310
 group.gnats390x.groupName=S390X GNAT
 group.gnats390x.baseName=S390X GNAT
 group.gnats390x.instructionSet=s390x
@@ -149,6 +164,11 @@ compiler.gnats390x1220.semver=12.2.0
 compiler.gnats390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gnats390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.gnats390x1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1230.semver=12.3.0
+compiler.gnats390x1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gnats390x1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 compiler.gnats390x1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
 compiler.gnats390x1310.semver=13.1.0
 compiler.gnats390x1310.objdumper=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
@@ -161,7 +181,7 @@ group.gnatppcs.instructionSet=ppc
 
 ## POWER
 group.gnatppc.groupName=POWERPC GNAT
-group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1310
+group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1310
 group.gnatppc.baseName=powerpc gnat
 
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
@@ -177,6 +197,11 @@ compiler.gnatppc1220.semver=12.2.0
 compiler.gnatppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gnatppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.gnatppc1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1230.semver=12.3.0
+compiler.gnatppc1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gnatppc1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.gnatppc1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
 compiler.gnatppc1310.semver=13.1.0
 compiler.gnatppc1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
@@ -185,7 +210,7 @@ compiler.gnatppc1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc
 ## POWER64
 group.gnatppc64.groupName=POWER64 GNAT
 group.gnatppc64.baseName=powerpc64 gnat
-group.gnatppc64.compilers=gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641310
+group.gnatppc64.compilers=gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641310
 
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
@@ -200,6 +225,11 @@ compiler.gnatppc641220.semver=12.2.0
 compiler.gnatppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gnatppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.gnatppc641230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641230.semver=12.3.0
+compiler.gnatppc641230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gnatppc641230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.gnatppc641310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641310.semver=13.1.0
 compiler.gnatppc641310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -208,7 +238,7 @@ compiler.gnatppc641310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/pow
 ## POWER64LE
 group.gnatppc64le.groupName=POWER64LE GNAT
 group.gnatppc64le.baseName=powerpc64le gnat
-group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1310
+group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310
 
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1120.demangler=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
@@ -222,6 +252,11 @@ compiler.gnatppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/power
 compiler.gnatppc64le1220.semver=12.2.0
 compiler.gnatppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gnatppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gnatppc64le1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1230.semver=12.3.0
+compiler.gnatppc64le1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gnatppc64le1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gnatppc64le1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1310.semver=13.1.0
@@ -237,7 +272,7 @@ group.gnatmipss.instructionSet=mips
 ## MIPS
 group.gnatmips.groupName=MIPS GNAT
 group.gnatmips.baseName=mips gnat
-group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1310
+group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1310
 
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1120.demangler=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
@@ -252,6 +287,11 @@ compiler.gnatmips1220.semver=12.2.0
 compiler.gnatmips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gnatmips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.gnatmips1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1230.semver=12.3.0
+compiler.gnatmips1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gnatmips1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.gnatmips1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1310.semver=13.1.0
 compiler.gnatmips1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -260,7 +300,7 @@ compiler.gnatmips1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unkn
 ## MIPS64
 group.gnatmips64.groupName=MIPS64 GNAT
 group.gnatmips64.baseName=mips64 gnat
-group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641310
+group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641310
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641120.demangler=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
@@ -275,6 +315,11 @@ compiler.gnatmips641220.semver=12.2.0
 compiler.gnatmips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gnatmips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.gnatmips641230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641230.semver=12.3.0
+compiler.gnatmips641230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gnatmips641230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.gnatmips641310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641310.semver=13.1.0
 compiler.gnatmips641310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -282,7 +327,7 @@ compiler.gnatmips641310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips6
 
 ################################
 # GNAT for arm64
-group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641310
+group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641310
 group.gnatarm64.groupName=ARM64 GNAT
 group.gnatarm64.baseName=arm64 gnat
 group.gnatarm64.instructionSet=arm64
@@ -295,6 +340,11 @@ compiler.gnatarm641220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unkno
 compiler.gnatarm641220.semver=12.2.0
 compiler.gnatarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gnatarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.gnatarm641230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
+compiler.gnatarm641230.semver=12.3.0
+compiler.gnatarm641230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gnatarm641230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.gnatarm641310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
 compiler.gnatarm641310.semver=13.1.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -999,7 +999,7 @@ compiler.bpfgtrunk.semver=trunk
 group.sparc.compilers=&gccsparc
 
 # GCC for SPARC
-group.gccsparc.compilers=sparcg1220:sparcg1310
+group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1310
 group.gccsparc.baseName=SPARC gcc
 group.gccsparc.groupName=SPARC GCC
 group.gccsparc.isSemVer=true
@@ -1008,6 +1008,11 @@ compiler.sparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-li
 compiler.sparcg1220.semver=12.2.0
 compiler.sparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.sparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.sparcg1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
+compiler.sparcg1230.semver=12.3.0
+compiler.sparcg1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.sparcg1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.sparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
 compiler.sparcg1310.semver=13.1.0
@@ -1019,7 +1024,7 @@ compiler.sparcg1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unkn
 group.sparc64.compilers=&gccsparc64
 
 # GCC for SPARC64
-group.gccsparc64.compilers=sparc64g1220:sparc64g1310
+group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310
 group.gccsparc64.baseName=SPARC64 gcc
 group.gccsparc64.groupName=SPARC64 GCC
 group.gccsparc64.isSemVer=true
@@ -1028,6 +1033,11 @@ compiler.sparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-mult
 compiler.sparc64g1220.semver=12.2.0
 compiler.sparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.sparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.sparc64g1230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
+compiler.sparc64g1230.semver=12.3.0
+compiler.sparc64g1230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.sparc64g1230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.sparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
 compiler.sparc64g1310.semver=13.1.0
@@ -1039,7 +1049,7 @@ compiler.sparc64g1310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc6
 group.sparcleon.compilers=&gccsparcleon
 
 # GCC for SPARC-LEON
-group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1310
+group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1310
 group.gccsparcleon.baseName=SPARC LEON gcc
 group.gccsparcleon.groupName=SPARC LEON GCC
 group.gccsparcleon.isSemVer=true
@@ -1050,6 +1060,11 @@ compiler.sparcleong1220.hidden=true
 compiler.sparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
 compiler.sparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.sparcleong1230.exe=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1230.semver=12.3.0
+compiler.sparcleong1230.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.sparcleong1230.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.sparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
 compiler.sparcleong1310.semver=13.1.0
@@ -1066,7 +1081,7 @@ compiler.sparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0
 group.c6x.compilers=&gccc6x
 
 # GCC for TI C6x
-group.gccc6x.compilers=c6xg1220:c6xg1310
+group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310
 group.gccc6x.baseName=TI C6x gcc
 group.gccc6x.groupName=TI C6x GCC
 group.gccc6x.isSemVer=true
@@ -1075,6 +1090,11 @@ compiler.c6xg1220.exe=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-
 compiler.c6xg1220.semver=12.2.0
 compiler.c6xg1220.objdumper=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.c6xg1220.demangler=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.c6xg1230.exe=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-g++
+compiler.c6xg1230.semver=12.3.0
+compiler.c6xg1230.objdumper=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.c6xg1230.demangler=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-c++filt
 
 compiler.c6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-g++
 compiler.c6xg1310.semver=13.1.0
@@ -1088,13 +1108,18 @@ group.loongarch64.compilers=&gccloongarch64
 # GCC for loongarch64
 group.gccloongarch64.baseName=loongarch64 gcc
 group.gccloongarch64.groupName=loongarch64 gcc
-group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1310
+group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310
 group.gccloongarch64.isSemVer=true
 
 compiler.loongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
 compiler.loongarch64g1220.semver=12.2.0
 compiler.loongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.loongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.loongarch64g1230.exe=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
+compiler.loongarch64g1230.semver=12.3.0
+compiler.loongarch64g1230.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.loongarch64g1230.demangler=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.loongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
 compiler.loongarch64g1310.semver=13.1.0
@@ -1108,7 +1133,7 @@ group.sh.compilers=&gccsh
 # GCC for sh
 group.gccsh.baseName=sh gcc
 group.gccsh.groupName=sh gcc
-group.gccsh.compilers=shg494:shg950:shg1220:shg1310
+group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1310
 group.gccsh.isSemVer=true
 
 compiler.shg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-g++
@@ -1126,6 +1151,11 @@ compiler.shg1220.semver=12.2.0
 compiler.shg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.shg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
+compiler.shg1230.exe=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-g++
+compiler.shg1230.semver=12.3.0
+compiler.shg1230.objdumper=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg1230.demangler=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
 compiler.shg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-g++
 compiler.shg1310.semver=13.1.0
 compiler.shg1310.objdumper=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
@@ -1138,7 +1168,7 @@ group.s390x.compilers=&gccs390x
 # GCC for s390x
 group.gccs390x.baseName=s390x gcc
 group.gccs390x.groupName=s390x gcc
-group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1310
+group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
@@ -1155,6 +1185,11 @@ compiler.s390xg1220.semver=12.2.0
 compiler.s390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.s390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.s390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.s390xg1230.semver=12.3.0
+compiler.s390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.s390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 compiler.s390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
 compiler.s390xg1310.semver=13.1.0
 compiler.s390xg1310.objdumper=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
@@ -1166,7 +1201,7 @@ group.ppcs.compilers=&ppc:&ppc64:&ppc64le
 group.ppcs.isSemVer=true
 
 ## POWER
-group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1310
+group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1310
 group.ppc.groupName=POWER GCC
 group.ppc.baseName=power gcc
 
@@ -1187,6 +1222,11 @@ compiler.ppcg1220.semver=12.2.0
 compiler.ppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.ppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1230.semver=12.3.0
+compiler.ppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.ppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
 compiler.ppcg1310.semver=13.1.0
 compiler.ppcg1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
@@ -1195,7 +1235,7 @@ compiler.ppcg1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-un
 ## POWER64
 group.ppc64.groupName=POWER64 GCC
 group.ppc64.baseName=power64 gcc
-group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1310
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310
 
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -1220,6 +1260,11 @@ compiler.ppc64g1220.semver=12.2.0
 compiler.ppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.ppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1230.semver=12.3.0
+compiler.ppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.ppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g1310.semver=13.1.0
 compiler.ppc64g1310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -1239,7 +1284,7 @@ compiler.ppc64clang.compilerCategories=clang
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE GCC
-group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1310
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310
 group.ppc64le.baseName=power64le gcc
 
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
@@ -1269,6 +1314,11 @@ compiler.ppc64leg1220.semver=12.2.0
 compiler.ppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.ppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1230.semver=12.3.0
+compiler.ppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.ppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg1310.semver=13.1.0
 compiler.ppc64leg1310.objdumper=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -1295,7 +1345,7 @@ group.gccarm.includeFlag=-I
 
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
-group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1040:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:arm1210:armgtrunk:armg1220:armg1310
+group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1040:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armgtrunk:armg1220:armg1230:armg1310
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -1339,11 +1389,23 @@ compiler.armg850.exe=/opt/compiler-explorer/arm/gcc-8.5.0/arm-unknown-linux-gnue
 compiler.armg850.name=ARM gcc 8.5 (linux)
 compiler.armg850.semver=8.5.0
 
+compiler.armg1140.exe=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1140.semver=11.4.0
+compiler.armg1140.objdumper=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1140.demangler=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.armg1140.name=ARM gcc 11.4 (linux)
+
 compiler.armg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1220.semver=12.2.0
 compiler.armg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 compiler.armg1220.name=ARM gcc 12.2 (linux)
+
+compiler.armg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1230.semver=12.3.0
+compiler.armg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.armg1230.name=ARM gcc 12.3 (linux)
 
 compiler.armg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1310.semver=13.1.0
@@ -1415,7 +1477,7 @@ compiler.armgtrunk.semver=trunk
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1210:arm64gtrunk:arm64g1220:arm64g1310
+group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -1454,6 +1516,11 @@ compiler.arm64g1120.exe=/opt/compiler-explorer/arm64/gcc-11.2.0/aarch64-unknown-
 compiler.arm64g1120.semver=11.2
 compiler.arm64g1130.exe=/opt/compiler-explorer/arm64/gcc-11.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1130.semver=11.3
+
+compiler.arm64g1140.exe=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1140.semver=11.4.0
+compiler.arm64g1140.objdumper=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1140.demangler=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 compiler.arm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1210.semver=12.1
@@ -1462,6 +1529,11 @@ compiler.arm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-
 compiler.arm64g1220.semver=12.2.0
 compiler.arm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.arm64g1230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1230.semver=12.3.0
+compiler.arm64g1230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.arm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1310.semver=13.1.0
@@ -1651,7 +1723,7 @@ compiler.cl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1310
+group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1310
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -1693,6 +1765,11 @@ compiler.avrg1220.exe=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-g++
 compiler.avrg1220.semver=12.2.0
 compiler.avrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-objdump
 compiler.avrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
+
+compiler.avrg1230.exe=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-g++
+compiler.avrg1230.semver=12.3.0
+compiler.avrg1230.objdumper=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-objdump
+compiler.avrg1230.demangler=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-c++filt
 
 compiler.avrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-g++
 compiler.avrg1310.semver=13.1.0
@@ -1797,7 +1874,7 @@ compiler.mips64el-clang1300.semver=13.0.0
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mips930:mips1120:mipsg1210:mipsg1220:mipsg1310
+group.mips.compilers=mips5:mips930:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1310
 group.mips.baseName=mips gcc
 
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
@@ -1822,6 +1899,11 @@ compiler.mipsg1220.semver=12.2.0
 compiler.mipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.mipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.mipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg1230.semver=12.3.0
+compiler.mipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.mipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mipsg1310.semver=13.1.0
 compiler.mipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -1829,7 +1911,7 @@ compiler.mipsg1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown
 
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips564:mips112064:mips64g1210:mips64g1220:mips64g1310
+group.mips64.compilers=mips564:mips112064:mips64g1210:mips64g1220:mips64g1230:mips64g1310
 group.mips64.baseName=mips64 gcc
 
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
@@ -1849,6 +1931,11 @@ compiler.mips64g1220.semver=12.2.0
 compiler.mips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.mips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.mips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g1230.semver=12.3.0
+compiler.mips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.mips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips64g1310.semver=13.1.0
 compiler.mips64g1310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -1856,7 +1943,7 @@ compiler.mips64g1310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-u
 
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el:mipselg1210:mipselg1220:mipselg1310
+group.mipsel.compilers=mips5el:mipselg1210:mipselg1220:mipselg1230:mipselg1310
 group.mipsel.baseName=mipsel gcc
 
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
@@ -1872,6 +1959,11 @@ compiler.mipselg1220.semver=12.2.0
 compiler.mipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.mipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.mipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.mipselg1230.semver=12.3.0
+compiler.mipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.mipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 compiler.mipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
 compiler.mipselg1310.semver=13.1.0
 compiler.mipselg1310.objdumper=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
@@ -1879,7 +1971,7 @@ compiler.mipselg1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-m
 
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips564el:mips64elg1210:mips64elg1220:mips64elg1310
+group.mips64el.compilers=mips564el:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310
 group.mips64el.baseName=mips64 (el) gcc
 group.mips64el.compilerCategories=gcc
 
@@ -1895,6 +1987,11 @@ compiler.mips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-m
 compiler.mips64elg1220.semver=12.2.0
 compiler.mips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.mips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.mips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.mips64elg1230.semver=12.3.0
+compiler.mips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.mips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.mips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
 compiler.mips64elg1310.semver=13.1.0
@@ -1932,7 +2029,7 @@ group.rvgcc.supportsBinary=true
 group.rvgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 32-bits
-group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1220:rv64-gcc1210:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310
+group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310
 group.rv64gcc.groupName=RISC-V (64-bits) gcc
 group.rv64gcc.baseName=RISC-V (64-bits) gcc
 
@@ -1965,6 +2062,11 @@ compiler.rv64-gcc1130.exe=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unkn
 compiler.rv64-gcc1130.semver=11.3.0
 compiler.rv64-gcc1130.objdumper=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.rv64-gcc1140.exe=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1140.semver=11.4.0
+compiler.rv64-gcc1140.objdumper=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc1140.demangler=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.rv64-gcc1210.exe=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcc1210.semver=12.1.0
 compiler.rv64-gcc1210.objdumper=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -1973,6 +2075,11 @@ compiler.rv64-gcc1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unkn
 compiler.rv64-gcc1220.semver=12.2.0
 compiler.rv64-gcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.rv64-gcc1230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1230.semver=12.3.0
+compiler.rv64-gcc1230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc1230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.rv64-gcc1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcc1310.semver=13.1.0
@@ -1985,7 +2092,7 @@ compiler.rv64-gcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv6
 compiler.rv64-gcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ## GCC for RISC-V 32-bits
-group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1220:rv32-gcc1210:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310
+group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310
 group.rv32gcc.groupName=RISC-V (32-bits) gcc
 group.rv32gcc.baseName=RISC-V (32-bits) gcc
 
@@ -2017,6 +2124,11 @@ compiler.rv32-gcc1130.exe=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unkn
 compiler.rv32-gcc1130.semver=11.3.0
 compiler.rv32-gcc1130.objdumper=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
+compiler.rv32-gcc1140.exe=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
+compiler.rv32-gcc1140.semver=11.4.0
+compiler.rv32-gcc1140.objdumper=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-gcc1140.demangler=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-c++filt
+
 compiler.rv32-gcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-g++
 compiler.rv32-gcc1210.semver=12.1.0
 compiler.rv32-gcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
@@ -2025,6 +2137,11 @@ compiler.rv32-gcc1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unkn
 compiler.rv32-gcc1220.semver=12.2.0
 compiler.rv32-gcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-gcc1230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1230.semver=12.3.0
+compiler.rv32-gcc1230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-gcc1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.rv32-gcc1310.semver=13.1.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -946,7 +946,7 @@ compiler.cm68kg1310.demangler=/opt/compiler-explorer/m68k/gcc-13.1.0/m68k-unknow
 group.csparc.compilers=&cgccsparc
 
 # GCC for SPARC
-group.cgccsparc.compilers=csparcg1220:csparcg1310
+group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1310
 group.cgccsparc.baseName=SPARC gcc
 group.cgccsparc.groupName=SPARC GCC
 group.cgccsparc.isSemVer=true
@@ -955,6 +955,11 @@ compiler.csparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-l
 compiler.csparcg1220.semver=12.2.0
 compiler.csparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.csparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.csparcg1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.csparcg1230.semver=12.3.0
+compiler.csparcg1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.csparcg1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.csparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
 compiler.csparcg1310.semver=13.1.0
@@ -966,7 +971,7 @@ compiler.csparcg1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unk
 group.csparc64.compilers=&cgccsparc64
 
 # GCC for SPARC64
-group.cgccsparc64.compilers=csparc64g1220:csparc64g1310
+group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310
 group.cgccsparc64.baseName=SPARC64 gcc
 group.cgccsparc64.groupName=SPARC64 GCC
 group.cgccsparc64.isSemVer=true
@@ -975,6 +980,11 @@ compiler.csparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-mul
 compiler.csparc64g1220.semver=12.2.0
 compiler.csparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.csparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.csparc64g1230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.csparc64g1230.semver=12.3.0
+compiler.csparc64g1230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.csparc64g1230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.csparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
 compiler.csparc64g1310.semver=13.1.0
@@ -986,7 +996,7 @@ compiler.csparc64g1310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc
 group.csparcleon.compilers=&cgccsparcleon
 
 # GCC for SPARC-LEON
-group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1310
+group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1310
 group.cgccsparcleon.baseName=SPARC LEON gcc
 group.cgccsparcleon.groupName=SPARC LEON GCC
 group.cgccsparcleon.isSemVer=true
@@ -997,6 +1007,11 @@ compiler.csparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-
 compiler.csparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
 compiler.csparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.csparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.csparcleong1230.exe=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.csparcleong1230.semver=12.3.0
+compiler.csparcleong1230.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.csparcleong1230.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.csparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.csparcleong1310.semver=13.1.0
@@ -1013,7 +1028,7 @@ compiler.csparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.
 group.cc6x.compilers=&cgccc6x
 
 # GCC for TI C6x
-group.cgccc6x.compilers=cc6xg1220:cc6xg1310
+group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310
 group.cgccc6x.baseName=TI C6x gcc
 group.cgccc6x.groupName=TI C6x GCC
 group.cgccc6x.isSemVer=true
@@ -1022,6 +1037,11 @@ compiler.cc6xg1220.exe=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x
 compiler.cc6xg1220.semver=12.2.0
 compiler.cc6xg1220.objdumper=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.cc6xg1220.demangler=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.cc6xg1230.exe=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.cc6xg1230.semver=12.3.0
+compiler.cc6xg1230.objdumper=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.cc6xg1230.demangler=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-c++filt
 
 compiler.cc6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-gcc
 compiler.cc6xg1310.semver=13.1.0
@@ -1033,7 +1053,7 @@ compiler.cc6xg1310.demangler=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin
 group.cloongarch64.compilers=&cgccloongarch64
 
 # GCC for loongarch64
-group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1310
+group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310
 group.cgccloongarch64.baseName=loongarch64 gcc
 group.cgccloongarch64.groupName=loongarch64 GCC
 group.cgccloongarch64.isSemVer=true
@@ -1042,6 +1062,11 @@ compiler.cloongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loo
 compiler.cloongarch64g1220.semver=12.2.0
 compiler.cloongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.cloongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.cloongarch64g1230.exe=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.cloongarch64g1230.semver=12.3.0
+compiler.cloongarch64g1230.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.cloongarch64g1230.demangler=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.cloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
 compiler.cloongarch64g1310.semver=13.1.0
@@ -1053,7 +1078,7 @@ compiler.cloongarch64g1310.demangler=/opt/compiler-explorer/loongarch64/gcc-13.1
 group.csh.compilers=&cgccsh
 
 # GCC for sh
-group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1310
+group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1310
 group.cgccsh.baseName=sh gcc
 group.cgccsh.groupName=sh GCC
 group.cgccsh.isSemVer=true
@@ -1073,6 +1098,11 @@ compiler.cshg1220.semver=12.2.0
 compiler.cshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.cshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
+compiler.cshg1230.exe=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.cshg1230.semver=12.3.0
+compiler.cshg1230.objdumper=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg1230.demangler=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
 compiler.cshg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
 compiler.cshg1310.semver=13.1.0
 compiler.cshg1310.objdumper=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
@@ -1083,7 +1113,7 @@ compiler.cshg1310.demangler=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/
 group.cs390x.compilers=&cgccs390x
 
 # GCC for s390x
-group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1310
+group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310
 group.cgccs390x.baseName=s390x gcc
 group.cgccs390x.groupName=s390x GCC
 group.cgccs390x.isSemVer=true
@@ -1101,6 +1131,11 @@ compiler.cs390xg1220.semver=12.2.0
 compiler.cs390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.cs390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.cs390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cs390xg1230.semver=12.3.0
+compiler.cs390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.cs390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 compiler.cs390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
 compiler.cs390xg1310.semver=13.1.0
 compiler.cs390xg1310.objdumper=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
@@ -1111,7 +1146,7 @@ compiler.cs390xg1310.demangler=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm
 group.cppcs.compilers=&cppc:&cppc64:&cppc64le
 group.cppcs.isSemVer=true
 
-group.cppc.compilers=cppcg1210:cppcg1120:cppcg48:cppcg1220:cppcg1310
+group.cppc.compilers=cppcg1210:cppcg1120:cppcg48:cppcg1220:cppcg1230:cppcg1310
 group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
@@ -1132,42 +1167,52 @@ compiler.cppcg1220.semver=12.2.0
 compiler.cppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.cppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1230.semver=12.3.0
+compiler.cppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.cppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.cppcg1310.semver=13.1.0
 compiler.cppcg1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1310
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310
 group.cppc64.groupName=POWER64
+group.cppc64.baseName=POWER64 gcc
+
 compiler.cppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g8.name=power64 AT12.0 (gcc8)
 compiler.cppc64g8.semver=(snapshot)
+
 compiler.cppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g9.name=power64 AT13.0 (gcc9)
 compiler.cppc64g9.semver=(snapshot)
+
 compiler.cppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.cppc64g1120.semver=power64 gcc 11.2.0
-compiler.cppc64g1120.name=power64 gcc 11.2.0
+compiler.cppc64g1120.semver=11.2.0
 
 compiler.cppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
-compiler.cppc64g1210.semver=power64 gcc 12.1.0
-compiler.cppc64g1210.name=power64 gcc 12.1.0
+compiler.cppc64g1210.semver=12.1.0
 
 compiler.cppc64g1220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g1220.semver=12.2.0
 compiler.cppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
-compiler.cppc64g1220.name=power64 gcc 12.2.0
+
+compiler.cppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1230.semver=12.3.0
+compiler.cppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.cppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g1310.semver=13.1.0
 compiler.cppc64g1310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
-compiler.cppc64g1310.name=power64 gcc 13.1.0
 
 compiler.cppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cppc64clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -1178,7 +1223,7 @@ compiler.cppc64clang.supportsBinary=false
 compiler.cppc64clang.semver=(snapshot)
 compiler.cppc64clang.compilerCategories=clang
 
-group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1310
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310
 group.cppc64le.groupName=POWER64LE GCC
 
 compiler.cppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
@@ -1208,6 +1253,11 @@ compiler.cppc64leg1220.semver=12.2.0
 compiler.cppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.cppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1230.semver=12.3.0
+compiler.cppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.cppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg1310.semver=13.1.0
 compiler.cppc64leg1310.objdumper=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -1234,7 +1284,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1031_07:carm1031_10:carm1021:carm1100:carm1120:carm1121:carm1130:carm1210:carmgtrunk:carmg1220:carmg1310
+group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1031_07:carm1031_10:carm1021:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmgtrunk:carmg1220:carmg1230:carmg1310
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -1266,10 +1316,20 @@ compiler.carmg820.semver=8.2.0 (linux)
 compiler.carmg850.exe=/opt/compiler-explorer/arm/gcc-8.5.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gcc
 compiler.carmg850.semver=8.5.0 (linux)
 
+compiler.carmg1140.exe=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1140.semver=11.4.0
+compiler.carmg1140.objdumper=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1140.demangler=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.carmg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carmg1220.semver=12.2.0 (linux)
 compiler.carmg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.carmg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.carmg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1230.semver=12.3.0
+compiler.carmg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.carmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carmg1310.semver=13.1.0 (linux)
@@ -1321,7 +1381,7 @@ compiler.carmgtrunk.semver=trunk (linux)
 # 64 bit
 group.cgcc64arm.groupName=ARM64 gcc
 group.cgcc64arm.baseName=ARM64 GCC
-group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1210:carm64gtrunk:carm64g1220:carm64g1310
+group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -1358,6 +1418,12 @@ compiler.carm64g1120.exe=/opt/compiler-explorer/arm64/gcc-11.2.0/aarch64-unknown
 compiler.carm64g1120.semver=11.2.0
 compiler.carm64g1130.exe=/opt/compiler-explorer/arm64/gcc-11.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1130.semver=11.3.0
+
+compiler.carm64g1140.exe=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1140.semver=11.4.0
+compiler.carm64g1140.objdumper=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1140.demangler=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 compiler.carm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1210.semver=12.1.0
@@ -1366,6 +1432,11 @@ compiler.carm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown
 compiler.carm64g1220.semver=12.2.0
 compiler.carm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.carm64g1230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1230.semver=12.3.0
+compiler.carm64g1230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.carm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1310.semver=13.1.0
@@ -1521,7 +1592,7 @@ compiler.carduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hard
 
 ################################
 # GCC for MSP
-group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220:cmsp430g1310
+group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220:cmsp430g1230:cmsp430g1310
 group.cmsp.groupName=MSP GCC
 group.cmsp.baseName=MSP430 gcc
 group.cmsp.isSemVer=true
@@ -1544,6 +1615,11 @@ compiler.cmsp430g1220.exe=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknow
 compiler.cmsp430g1220.semver=12.2.0
 compiler.cmsp430g1220.objdumper=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
 compiler.cmsp430g1220.demangler=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.cmsp430g1230.exe=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.cmsp430g1230.semver=12.3.0
+compiler.cmsp430g1230.objdumper=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.cmsp430g1230.demangler=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
 
 compiler.cmsp430g1310.exe=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
 compiler.cmsp430g1310.semver=13.1.0
@@ -1568,7 +1644,7 @@ compiler.ccl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1310
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1310
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -1608,6 +1684,11 @@ compiler.cavrg1220.exe=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-gcc
 compiler.cavrg1220.semver=12.2.0
 compiler.cavrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-objdump
 compiler.cavrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
+
+compiler.cavrg1230.exe=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-gcc
+compiler.cavrg1230.semver=12.3.0
+compiler.cavrg1230.objdumper=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-objdump
+compiler.cavrg1230.demangler=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-c++filt
 
 compiler.cavrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-gcc
 compiler.cavrg1310.semver=13.1.0
@@ -1714,7 +1795,7 @@ compiler.mips64el-cclang1300.semver=13.0.0
 
 # GCC for all MIPS
 ## MIPS
-group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210:cmipsg1220:cmipsg1310
+group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1310
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
 
@@ -1740,6 +1821,11 @@ compiler.cmipsg1220.semver=12.2.0
 compiler.cmipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.cmipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.cmipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg1230.semver=12.3.0
+compiler.cmipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.cmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmipsg1310.semver=13.1.0
 compiler.cmipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -1747,7 +1833,7 @@ compiler.cmipsg1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknow
 
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips564:cmips112064:cmips64g1210:cmips64g1220:cmips64g1310
+group.cmips64.compilers=cmips564:cmips112064:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310
 group.cmips64.baseName=mips64 gcc
 
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -1767,6 +1853,11 @@ compiler.cmips64g1220.semver=12.2.0
 compiler.cmips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.cmips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.cmips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g1230.semver=12.3.0
+compiler.cmips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.cmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.cmips64g1310.semver=13.1.0
 compiler.cmips64g1310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -1774,7 +1865,7 @@ compiler.cmips64g1310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-
 
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el:cmipselg1210:cmipselg1220:cmipselg1310
+group.cmipsel.compilers=cmips5el:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1310
 group.cmipsel.baseName=mips (el) gcc
 
 compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
@@ -1790,6 +1881,11 @@ compiler.cmipselg1220.semver=12.2.0
 compiler.cmipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.cmipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.cmipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.cmipselg1230.semver=12.3.0
+compiler.cmipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.cmipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 compiler.cmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.cmipselg1310.semver=13.1.0
 compiler.cmipselg1310.objdumper=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
@@ -1797,7 +1893,7 @@ compiler.cmipselg1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-
 
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips564el:cmips64elg1210:cmips64elg1220:cmips64elg1310
+group.cmips64el.compilers=cmips564el:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310
 group.cmips64el.baseName=mips64 (el) gcc
 
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
@@ -1813,6 +1909,11 @@ compiler.cmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-
 compiler.cmips64elg1220.semver=12.2.0
 compiler.cmips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.cmips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.cmips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.cmips64elg1230.semver=12.3.0
+compiler.cmips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.cmips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.cmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.cmips64elg1310.semver=13.1.0
@@ -1853,7 +1954,7 @@ group.rvcgcc.supportsBinary=true
 group.rvcgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 64-bits
-group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1210:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310
+group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310
 group.rv64-cgccs.groupName=RISC-V (64-bits) gcc
 group.rv64-cgccs.baseName=RISC-V (64-bits) gcc
 
@@ -1886,6 +1987,11 @@ compiler.rv64-cgcc1130.exe=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unk
 compiler.rv64-cgcc1130.semver=11.3.0
 compiler.rv64-cgcc1130.objdumper=/opt/compiler-explorer/riscv64/gcc-11.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.rv64-cgcc1140.exe=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1140.semver=11.4.0
+compiler.rv64-cgcc1140.objdumper=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1140.demangler=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.rv64-cgcc1210.exe=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcc1210.semver=12.1.0
 compiler.rv64-cgcc1210.objdumper=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -1894,6 +2000,11 @@ compiler.rv64-cgcc1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unk
 compiler.rv64-cgcc1220.semver=12.2.0
 compiler.rv64-cgcc1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.rv64-cgcc1230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1230.semver=12.3.0
+compiler.rv64-cgcc1230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.rv64-cgcc1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcc1310.semver=13.1.0
@@ -1906,7 +2017,7 @@ compiler.rv64-cgcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv
 compiler.rv64-cgcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ## GCC for RISC-V 32-bits
-group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310
+group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230
 group.rv32-cgccs.groupName=RISC-V (32-bits) gcc
 group.rv32-cgccs.baseName=RISC-V (32-bits) gcc
 
@@ -1938,6 +2049,11 @@ compiler.rv32-cgcc1130.exe=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unk
 compiler.rv32-cgcc1130.semver=11.3.0
 compiler.rv32-cgcc1130.objdumper=/opt/compiler-explorer/riscv32/gcc-11.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
+compiler.rv32-cgcc1140.exe=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
+compiler.rv32-cgcc1140.semver=11.4.0
+compiler.rv32-cgcc1140.objdumper=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-cgcc1140.demangler=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-c++filt
+
 compiler.rv32-cgcc1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc1210.semver=12.1.0
 compiler.rv32-cgcc1210.objdumper=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
@@ -1946,6 +2062,11 @@ compiler.rv32-cgcc1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unk
 compiler.rv32-cgcc1220.semver=12.2.0
 compiler.rv32-cgcc1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 compiler.rv32-cgcc1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.rv32-cgcc1230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1230.semver=12.3.0
+compiler.rv32-cgcc1230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-cgcc1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.rv32-cgcc1310.semver=13.1.0

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -55,7 +55,7 @@ group.gdccross.supportsBinary=true
 group.gdccross.supportsBinaryObject=true
 
 ### GDC for RISCV32
-group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220:gdcriscv1310
+group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220:gdcriscv1230:gdcriscv1310
 group.gdcriscv.groupName=GDC riscv
 group.gdcriscv.includeFlag=-isystem
 group.gdcriscv.isSemVer=true
@@ -65,6 +65,11 @@ compiler.gdcriscv1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unkn
 compiler.gdcriscv1220.semver=12.2.0
 compiler.gdcriscv1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.gdcriscv1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.gdcriscv1230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
+compiler.gdcriscv1230.semver=12.3.0
+compiler.gdcriscv1230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.gdcriscv1230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.gdcriscv1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
 compiler.gdcriscv1310.semver=13.1.0
@@ -77,7 +82,7 @@ compiler.gdcriscv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/risc
 compiler.gdcriscv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 ### GDC for RISCV64
-group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220:gdcriscv641310
+group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220:gdcriscv641230:gdcriscv641310
 group.gdcriscv64.groupName=GDC riscv64
 group.gdcriscv64.includeFlag=-isystem
 group.gdcriscv64.isSemVer=true
@@ -87,6 +92,11 @@ compiler.gdcriscv641220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-un
 compiler.gdcriscv641220.semver=12.2.0
 compiler.gdcriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gdcriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.gdcriscv641230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
+compiler.gdcriscv641230.semver=12.3.0
+compiler.gdcriscv641230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gdcriscv641230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.gdcriscv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
 compiler.gdcriscv641310.semver=13.1.0
@@ -99,7 +109,7 @@ compiler.gdcriscv64trunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/risc
 compiler.gdcriscv64trunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ### GDC for ARM64
-group.gdcarm64.compilers=gdcarm641220:gdcarm641310
+group.gdcarm64.compilers=gdcarm641220:gdcarm641230:gdcarm641310
 group.gdcarm64.groupName=GDC arm64
 group.gdcarm64.includeFlag=-isystem
 group.gdcarm64.isSemVer=true
@@ -110,13 +120,18 @@ compiler.gdcarm641220.semver=12.2.0
 compiler.gdcarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gdcarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.gdcarm641230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gdc
+compiler.gdcarm641230.semver=12.3.0
+compiler.gdcarm641230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gdcarm641230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 compiler.gdcarm641310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gdc
 compiler.gdcarm641310.semver=13.1.0
 compiler.gdcarm641310.objdumper=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gdcarm641310.demangler=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 ### GDC for ARM 32-bits
-group.gdcarm.compilers=gdcarm1220:gdcarm1310
+group.gdcarm.compilers=gdcarm1220:gdcarm1230:gdcarm1310
 group.gdcarm.groupName=GDC arm
 group.gdcarm.includeFlag=-isystem
 group.gdcarm.isSemVer=true
@@ -127,13 +142,18 @@ compiler.gdcarm1220.semver=12.2.0
 compiler.gdcarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gdcarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.gdcarm1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gdc
+compiler.gdcarm1230.semver=12.3.0
+compiler.gdcarm1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gdcarm1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.gdcarm1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gdc
 compiler.gdcarm1310.semver=13.1.0
 compiler.gdcarm1310.objdumper=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gdcarm1310.demangler=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 ### GDC for s390x
-group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220:gdcs390x1310
+group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220:gdcs390x1230:gdcs390x1310
 group.gdcs390x.groupName=GDC s390x
 group.gdcs390x.includeFlag=-isystem
 group.gdcs390x.isSemVer=true
@@ -148,13 +168,18 @@ compiler.gdcs390x1220.semver=12.2.0
 compiler.gdcs390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gdcs390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.gdcs390x1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
+compiler.gdcs390x1230.semver=12.3.0
+compiler.gdcs390x1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gdcs390x1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 compiler.gdcs390x1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
 compiler.gdcs390x1310.semver=13.1.0
 compiler.gdcs390x1310.objdumper=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gdcs390x1310.demangler=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 ### GDC for powerpc
-group.gdcppc.compilers=gdcppc1210:gdcppc1220:gdcppc1310
+group.gdcppc.compilers=gdcppc1210:gdcppc1220:gdcppc1230:gdcppc1310
 group.gdcppc.groupName=GDC powerpc
 group.gdcppc.includeFlag=-isystem
 group.gdcppc.isSemVer=true
@@ -169,13 +194,18 @@ compiler.gdcppc1220.semver=12.2.0
 compiler.gdcppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gdcppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.gdcppc1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
+compiler.gdcppc1230.semver=12.3.0
+compiler.gdcppc1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gdcppc1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.gdcppc1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
 compiler.gdcppc1310.semver=13.1.0
 compiler.gdcppc1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gdcppc1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 ### GDC for powerpc64
-group.gdcppc64.compilers=gdcppc641210:gdcppc641220:gdcppc641310
+group.gdcppc64.compilers=gdcppc641210:gdcppc641220:gdcppc641230:gdcppc641310
 group.gdcppc64.groupName=GDC powerpc64
 group.gdcppc64.includeFlag=-isystem
 group.gdcppc64.isSemVer=true
@@ -190,13 +220,18 @@ compiler.gdcppc641220.semver=12.2.0
 compiler.gdcppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gdcppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.gdcppc641230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
+compiler.gdcppc641230.semver=12.3.0
+compiler.gdcppc641230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gdcppc641230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.gdcppc641310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
 compiler.gdcppc641310.semver=13.1.0
 compiler.gdcppc641310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gdcppc641310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 ### GDC for powerpc64le
-group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220:gdcppc64le1310
+group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220:gdcppc64le1230:gdcppc64le1310
 group.gdcppc64le.groupName=GDC powerpc64le
 group.gdcppc64le.includeFlag=-isystem
 group.gdcppc64le.isSemVer=true
@@ -211,13 +246,18 @@ compiler.gdcppc64le1220.semver=12.2.0
 compiler.gdcppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gdcppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.gdcppc64le1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
+compiler.gdcppc64le1230.semver=12.3.0
+compiler.gdcppc64le1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gdcppc64le1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.gdcppc64le1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
 compiler.gdcppc64le1310.semver=13.1.0
 compiler.gdcppc64le1310.objdumper=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gdcppc64le1310.demangler=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 ### GDC for mips64
-group.gdcmips64.compilers=gdcmips641210:gdcmips641220:gdcmips641310
+group.gdcmips64.compilers=gdcmips641210:gdcmips641220:gdcmips641230:gdcmips641310
 group.gdcmips64.groupName=GDC mips64
 group.gdcmips64.includeFlag=-isystem
 group.gdcmips64.isSemVer=true
@@ -232,13 +272,18 @@ compiler.gdcmips641220.semver=12.2.0
 compiler.gdcmips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gdcmips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.gdcmips641230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
+compiler.gdcmips641230.semver=12.3.0
+compiler.gdcmips641230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gdcmips641230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.gdcmips641310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
 compiler.gdcmips641310.semver=13.1.0
 compiler.gdcmips641310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gdcmips641310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 ### GDC for mips
-group.gdcmips.compilers=gdcmips1210:gdcmips1220:gdcmips1310
+group.gdcmips.compilers=gdcmips1210:gdcmips1220:gdcmips1230:gdcmips1310
 group.gdcmips.groupName=GDC mips
 group.gdcmips.includeFlag=-isystem
 group.gdcmips.isSemVer=true
@@ -253,13 +298,18 @@ compiler.gdcmips1220.semver=12.2.0
 compiler.gdcmips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gdcmips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.gdcmips1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
+compiler.gdcmips1230.semver=12.3.0
+compiler.gdcmips1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gdcmips1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.gdcmips1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
 compiler.gdcmips1310.semver=13.1.0
 compiler.gdcmips1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gdcmips1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 ### GDC for mipsel
-group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220:gdcmipsel1310
+group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220:gdcmipsel1230:gdcmipsel1310
 group.gdcmipsel.groupName=GDC mipsel
 group.gdcmipsel.includeFlag=-isystem
 group.gdcmipsel.isSemVer=true
@@ -273,6 +323,11 @@ compiler.gdcmipsel1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multi
 compiler.gdcmipsel1220.semver=12.2.0
 compiler.gdcmipsel1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gdcmipsel1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gdcmipsel1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
+compiler.gdcmipsel1230.semver=12.3.0
+compiler.gdcmipsel1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gdcmipsel1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.gdcmipsel1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
 compiler.gdcmipsel1310.semver=13.1.0

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -197,7 +197,7 @@ group.cross.groupName=Cross GCC
 
 ###############################
 # GCC for SPARC
-group.gccsparc.compilers=fsparcg1220:fsparcg1310
+group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1310
 group.gccsparc.groupName=SPARC gfortran
 group.gccsparc.baseName=SPARC gfortran
 
@@ -206,6 +206,11 @@ compiler.fsparcg1220.semver=12.2.0
 compiler.fsparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.fsparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.fsparcg1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
+compiler.fsparcg1230.semver=12.3.0
+compiler.fsparcg1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.fsparcg1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 compiler.fsparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
 compiler.fsparcg1310.semver=13.1.0
 compiler.fsparcg1310.objdumper=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
@@ -213,7 +218,7 @@ compiler.fsparcg1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unk
 
 ###############################
 # GCC for SPARC64
-group.gccsparc64.compilers=fsparc64g1220:fsparc64g1310
+group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310
 group.gccsparc64.groupName=SPARC64 gfortran
 group.gccsparc64.baseName=SPARC64 gfortran
 
@@ -222,6 +227,11 @@ compiler.fsparc64g1220.semver=12.2.0
 compiler.fsparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.fsparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.fsparc64g1230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
+compiler.fsparc64g1230.semver=12.3.0
+compiler.fsparc64g1230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.fsparc64g1230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 compiler.fsparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
 compiler.fsparc64g1310.semver=13.1.0
 compiler.fsparc64g1310.objdumper=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
@@ -229,7 +239,7 @@ compiler.fsparc64g1310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc
 
 ###############################
 # GCC for SPARC LEON
-group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1310
+group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1310
 group.gccsparcleon.groupName=SPARC LEON gfortran
 group.gccsparcleon.baseName=SPARC LEON gfortran
 
@@ -239,6 +249,11 @@ compiler.fsparcleong1220.hidden=true
 compiler.fsparcleong1220.name=SPARC LEON gfortran 13.x (incorrectly named 12.2.0 in the past)
 compiler.fsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.fsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.fsparcleong1230.exe=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
+compiler.fsparcleong1230.semver=12.3.0
+compiler.fsparcleong1230.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.fsparcleong1230.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.fsparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
 compiler.fsparcleong1220-1.semver=12.2.0
@@ -252,7 +267,7 @@ compiler.fsparcleong1310.demangler=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/
 
 ###############################
 # GCC for LOONGARCH64
-group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1310
+group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310
 group.gccloongarch64.groupName=LOONGARCH64 gfortran
 group.gccloongarch64.baseName=LOONGARCH64 gfortran
 
@@ -261,6 +276,11 @@ compiler.floongarch64g1220.semver=12.2.0
 compiler.floongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.floongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.floongarch64g1230.exe=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
+compiler.floongarch64g1230.semver=12.3.0
+compiler.floongarch64g1230.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.floongarch64g1230.demangler=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 compiler.floongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
 compiler.floongarch64g1310.semver=13.1.0
 compiler.floongarch64g1310.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
@@ -268,14 +288,24 @@ compiler.floongarch64g1310.demangler=/opt/compiler-explorer/loongarch64/gcc-13.1
 
 ###############################
 # GCC for RISCV64
-group.gccriscv64.compilers=friscv64g1220:friscv64g1310
+group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310
 group.gccriscv64.groupName=RISCV64 gfortran
 group.gccriscv64.baseName=RISCV64 gfortran
+
+compiler.friscv64g1140.exe=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.friscv64g1140.semver=11.4.0
+compiler.friscv64g1140.objdumper=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.friscv64g1140.demangler=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.friscv64g1220.exe=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
 compiler.friscv64g1220.semver=12.2.0
 compiler.friscv64g1220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.friscv64g1220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.friscv64g1230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.friscv64g1230.semver=12.3.0
+compiler.friscv64g1230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.friscv64g1230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.friscv64g1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
 compiler.friscv64g1310.semver=13.1.0
@@ -284,14 +314,24 @@ compiler.friscv64g1310.demangler=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv
 
 ###############################
 # GCC for RISCV
-group.gccriscv.compilers=friscvg1220:friscvg1310
+group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1310
 group.gccriscv.groupName=RISCV (32bit) gfortran
 group.gccriscv.baseName=RISCV (32bit) gfortran
+
+compiler.friscvg1140.exe=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gfortran
+compiler.friscvg1140.semver=11.4.0
+compiler.friscvg1140.objdumper=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.friscvg1140.demangler=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-c++filt
 
 compiler.friscvg1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
 compiler.friscvg1220.semver=12.2.0
 compiler.friscvg1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.friscvg1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.friscvg1230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
+compiler.friscvg1230.semver=12.3.0
+compiler.friscvg1230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.friscvg1230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.friscvg1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
 compiler.friscvg1310.semver=13.1.0
@@ -300,7 +340,7 @@ compiler.friscvg1310.demangler=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1210:farmg1220:farmg1310
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1210:farmg1220:farmg1230:farmg1310:farmg1140
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
 
@@ -313,6 +353,11 @@ compiler.farmg730.semver=7.3
 compiler.farmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
 compiler.farmg820.semver=8.2
 
+compiler.farmg1140.exe=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1140.semver=11.4.0
+compiler.farmg1140.objdumper=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1140.demangler=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.farmg1210.exe=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
 compiler.farmg1210.semver=12.1.0
 
@@ -321,6 +366,11 @@ compiler.farmg1220.semver=12.2.0
 compiler.farmg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.farmg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.farmg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1230.semver=12.3.0
+compiler.farmg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.farmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
 compiler.farmg1310.semver=13.1.0
 compiler.farmg1310.objdumper=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
@@ -328,7 +378,7 @@ compiler.farmg1310.demangler=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-l
 
 ###############################
 ## GCC for s390x
-group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1310
+group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310
 group.gccs390x.groupName=s390x gfortran
 group.gccs390x.baseName=s390x gfortran
 
@@ -340,6 +390,11 @@ compiler.fs390xg1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux
 compiler.fs390xg1220.semver=12.2.0
 compiler.fs390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.fs390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.fs390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
+compiler.fs390xg1230.semver=12.3.0
+compiler.fs390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.fs390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.fs390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
 compiler.fs390xg1310.semver=13.1.0
@@ -365,7 +420,7 @@ compiler.flangtrunknew.supportsBinary=false
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1210:farm64g1220:farm64g1310
+group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 group.gccaarch64.baseName=AARCH64 gfortran
 compiler.farm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
@@ -374,6 +429,11 @@ compiler.farm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-l
 compiler.farm64g730.semver=7.3
 compiler.farm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g820.semver=8.2
+
+compiler.farm64g1140.exe=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1140.semver=11.4.0
+compiler.farm64g1140.objdumper=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1140.demangler=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.farm64g1210.exe=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g1210.objdumper=/opt/compiler-explorer/arm64/gcc-12.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
@@ -384,6 +444,11 @@ compiler.farm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown
 compiler.farm64g1220.semver=12.2.0
 compiler.farm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.farm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.farm64g1230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1230.semver=12.3.0
+compiler.farm64g1230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.farm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g1310.semver=13.1.0
@@ -397,7 +462,7 @@ group.ppcs.groupName=POWER Compilers
 
 ###############################
 # GCC for PPC
-group.ppc.compilers=fppcg1210:fppcg1220:fppcg1310
+group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1310
 group.ppc.groupName=POWER gfortran
 group.ppc.baseName=POWER gfortran
 
@@ -410,6 +475,11 @@ compiler.fppcg1220.semver=12.2.0
 compiler.fppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.fppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.fppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
+compiler.fppcg1230.semver=12.3.0
+compiler.fppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.fppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.fppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
 compiler.fppcg1310.semver=13.1.0
 compiler.fppcg1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
@@ -417,7 +487,7 @@ compiler.fppcg1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-u
 
 ###############################
 # GCC for PPC64
-group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1310
+group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310
 group.ppc64.groupName=POWER64 gfortran
 group.ppc64.baseName=POWER64 gfortran
 
@@ -438,6 +508,11 @@ compiler.fppc64g1220.semver=12.2.0
 compiler.fppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.fppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.fppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.fppc64g1230.semver=12.3.0
+compiler.fppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.fppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.fppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64g1310.semver=13.1.0
 compiler.fppc64g1310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -445,7 +520,7 @@ compiler.fppc64g1310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/power
 
 ###############################
 # GCC for PPC64LE
-group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1310
+group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310
 group.ppc64le.groupName=POWER64le gfortran
 group.ppc64le.baseName=POWER64le gfortran
 
@@ -465,6 +540,11 @@ compiler.fppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc
 compiler.fppc64leg1220.semver=12.2.0
 compiler.fppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.fppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.fppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg1230.semver=12.3.0
+compiler.fppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.fppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.fppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
 compiler.fppc64leg1310.semver=13.1.0
@@ -506,7 +586,7 @@ compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-
 
 ################################
 # GCC for MIPS
-group.gccmips.compilers=fmipsg1210:fmipsg1220:fmipsg1310
+group.gccmips.compilers=fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1310
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
 
@@ -519,6 +599,11 @@ compiler.fmipsg1220.semver=12.2.0
 compiler.fmipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.fmipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.fmipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg1230.semver=12.3.0
+compiler.fmipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.fmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
 compiler.fmipsg1310.semver=13.1.0
 compiler.fmipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -526,7 +611,7 @@ compiler.fmipsg1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknow
 
 ################################
 # GCC for MIPS64
-group.gccmips64.compilers=fmips64g1210:fmips64g1220:fmips64g1310
+group.gccmips64.compilers=fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
 
@@ -539,6 +624,11 @@ compiler.fmips64g1220.semver=12.2.0
 compiler.fmips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.fmips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.fmips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g1230.semver=12.3.0
+compiler.fmips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.fmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
 compiler.fmips64g1310.semver=13.1.0
 compiler.fmips64g1310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -546,7 +636,7 @@ compiler.fmips64g1310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-
 
 ################################
 # GCC for MIPSEL
-group.gccmipsel.compilers=fmipselg1210:fmipselg1220:fmipselg1310
+group.gccmipsel.compilers=fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1310
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
 
@@ -559,6 +649,11 @@ compiler.fmipselg1220.semver=12.2.0
 compiler.fmipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.fmipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.fmipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
+compiler.fmipselg1230.semver=12.3.0
+compiler.fmipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.fmipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 compiler.fmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
 compiler.fmipselg1310.semver=13.1.0
 compiler.fmipselg1310.objdumper=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
@@ -566,7 +661,7 @@ compiler.fmipselg1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-
 
 ################################
 # GCC for MIPS64el
-group.gccmips64el.compilers=fmips64elg1210:fmips64elg1220:fmips64elg1310
+group.gccmips64el.compilers=fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
 
@@ -578,6 +673,11 @@ compiler.fmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-
 compiler.fmips64elg1220.semver=12.2.0
 compiler.fmips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.fmips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.fmips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
+compiler.fmips64elg1230.semver=12.3.0
+compiler.fmips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.fmips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.fmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
 compiler.fmips64elg1310.semver=13.1.0

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -416,7 +416,7 @@ group.cross.groupName=Cross Go
 
 ###############################
 # GCC for sparc
-group.gccgosparc.compilers=gccgosparc1220:gccgosparc1310
+group.gccgosparc.compilers=gccgosparc1220:gccgosparc1230:gccgosparc1310
 group.gccgosparc.groupName=SPARC GCCGO
 group.gccgosparc.baseName=SPARC gccgo
 group.gccgosparc.isSemVer=true
@@ -426,6 +426,11 @@ compiler.gccgosparc1220.semver=12.2.0
 compiler.gccgosparc1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gccgosparc1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.gccgosparc1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
+compiler.gccgosparc1230.semver=12.3.0
+compiler.gccgosparc1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gccgosparc1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 compiler.gccgosparc1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
 compiler.gccgosparc1310.semver=13.1.0
 compiler.gccgosparc1310.objdumper=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
@@ -433,7 +438,7 @@ compiler.gccgosparc1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-
 
 ###############################
 # GCC for sparc64
-group.gccgosparc64.compilers=gccgosparc641220:gccgosparc641310
+group.gccgosparc64.compilers=gccgosparc641220:gccgosparc641230:gccgosparc641310
 group.gccgosparc64.groupName=SPARC64 GCCGO
 group.gccgosparc64.baseName=SPARC64 gccgo
 group.gccgosparc64.isSemVer=true
@@ -444,6 +449,11 @@ compiler.gccgosparc641220.semver=12.2.0
 compiler.gccgosparc641220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gccgosparc641220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.gccgosparc641230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
+compiler.gccgosparc641230.semver=12.3.0
+compiler.gccgosparc641230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gccgosparc641230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 compiler.gccgosparc641310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
 compiler.gccgosparc641310.semver=13.1.0
 compiler.gccgosparc641310.objdumper=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
@@ -451,7 +461,7 @@ compiler.gccgosparc641310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/sp
 
 ###############################
 # GCC for mips64el
-group.gccgomips64el.compilers=gccgomips64el1220:gccgomips64el1310
+group.gccgomips64el.compilers=gccgomips64el1220:gccgomips64el1230:gccgomips64el1310
 group.gccgomips64el.groupName=MIPS64EL GCCGO
 group.gccgomips64el.baseName=MIPS64EL gccgo
 group.gccgomips64el.isSemVer=true
@@ -461,6 +471,11 @@ compiler.gccgomips64el1220.semver=12.2.0
 compiler.gccgomips64el1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.gccgomips64el1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
+compiler.gccgomips64el1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
+compiler.gccgomips64el1230.semver=12.3.0
+compiler.gccgomips64el1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gccgomips64el1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 compiler.gccgomips64el1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
 compiler.gccgomips64el1310.semver=13.1.0
 compiler.gccgomips64el1310.objdumper=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
@@ -468,7 +483,7 @@ compiler.gccgomips64el1310.demangler=/opt/compiler-explorer/mips64el/gcc-13.1.0/
 
 ###############################
 # GCC for mipsel
-group.gccgomipsel.compilers=gccgomipsel1220:gccgomipsel1310
+group.gccgomipsel.compilers=gccgomipsel1220:gccgomipsel1230:gccgomipsel1310
 group.gccgomipsel.groupName=MIPSEL GCCGO
 group.gccgomipsel.baseName=MIPSEL gccgo
 group.gccgomipsel.isSemVer=true
@@ -478,6 +493,11 @@ compiler.gccgomipsel1220.semver=12.2.0
 compiler.gccgomipsel1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gccgomipsel1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.gccgomipsel1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
+compiler.gccgomipsel1230.semver=12.3.0
+compiler.gccgomipsel1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gccgomipsel1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 compiler.gccgomipsel1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
 compiler.gccgomipsel1310.semver=13.1.0
 compiler.gccgomipsel1310.objdumper=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
@@ -485,7 +505,7 @@ compiler.gccgomipsel1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mips
 
 ###############################
 # GCC for riscv64
-group.gccgoriscv64.compilers=gccgoriscv641220:gccgoriscv641310
+group.gccgoriscv64.compilers=gccgoriscv641220:gccgoriscv641230:gccgoriscv641310
 group.gccgoriscv64.groupName=RISC-V 64 GCCGO
 group.gccgoriscv64.baseName=RISC-V 64 gccgo
 group.gccgoriscv64.isSemVer=true
@@ -495,6 +515,11 @@ compiler.gccgoriscv641220.semver=12.2.0
 compiler.gccgoriscv641220.objdumper=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gccgoriscv641220.demangler=/opt/compiler-explorer/riscv64/gcc-12.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.gccgoriscv641230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
+compiler.gccgoriscv641230.semver=12.3.0
+compiler.gccgoriscv641230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gccgoriscv641230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.gccgoriscv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
 compiler.gccgoriscv641310.semver=13.1.0
 compiler.gccgoriscv641310.objdumper=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -502,7 +527,7 @@ compiler.gccgoriscv641310.demangler=/opt/compiler-explorer/riscv64/gcc-13.1.0/ri
 
 ###############################
 # GCC for s390x
-group.gccgos390x.compilers=gccgos390x1220:gccgos390x1310
+group.gccgos390x.compilers=gccgos390x1220:gccgos390x1230:gccgos390x1310
 group.gccgos390x.groupName=S390X GCCGO
 group.gccgos390x.baseName=S390X gccgo
 group.gccgos390x.isSemVer=true
@@ -512,6 +537,11 @@ compiler.gccgos390x1220.semver=12.2.0
 compiler.gccgos390x1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gccgos390x1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.gccgos390x1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
+compiler.gccgos390x1230.semver=12.3.0
+compiler.gccgos390x1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gccgos390x1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 compiler.gccgos390x1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
 compiler.gccgos390x1310.semver=13.1.0
 compiler.gccgos390x1310.objdumper=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
@@ -519,7 +549,7 @@ compiler.gccgos390x1310.demangler=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-
 
 ###############################
 # GCC for MIPS
-group.gccgomips.compilers=gccgomips1220:gccgomips1310
+group.gccgomips.compilers=gccgomips1220:gccgomips1230:gccgomips1310
 group.gccgomips.groupName=MIPS GCCGO
 group.gccgomips.baseName=MIPS gccgo
 group.gccgomips.isSemVer=true
@@ -529,6 +559,11 @@ compiler.gccgomips1220.semver=12.2.0
 compiler.gccgomips1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gccgomips1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.gccgomips1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
+compiler.gccgomips1230.semver=12.3.0
+compiler.gccgomips1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gccgomips1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.gccgomips1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
 compiler.gccgomips1310.semver=13.1.0
 compiler.gccgomips1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -536,7 +571,7 @@ compiler.gccgomips1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unk
 
 ###############################
 # GCC for MIPS64
-group.gccgomips64.compilers=gccgomips641220:gccgomips641310
+group.gccgomips64.compilers=gccgomips641220:gccgomips641230:gccgomips641310
 group.gccgomips64.groupName=MIPS64 GCCGO
 group.gccgomips64.baseName=MIPS64 gccgo
 group.gccgomips64.isSemVer=true
@@ -546,6 +581,11 @@ compiler.gccgomips641220.semver=12.2.0
 compiler.gccgomips641220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gccgomips641220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.gccgomips641230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
+compiler.gccgomips641230.semver=12.3.0
+compiler.gccgomips641230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gccgomips641230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.gccgomips641310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
 compiler.gccgomips641310.semver=13.1.0
 compiler.gccgomips641310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -553,7 +593,7 @@ compiler.gccgomips641310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips
 
 ###############################
 # GCC for ARM64
-group.gccgoarm64.compilers=gccgoarm641220:gccgoarm641310
+group.gccgoarm64.compilers=gccgoarm641220:gccgoarm641230:gccgoarm641310
 group.gccgoarm64.groupName=ARM64 GCCGO
 group.gccgoarm64.baseName=ARM64 gccgo
 group.gccgoarm64.isSemVer=true
@@ -563,6 +603,11 @@ compiler.gccgoarm641220.semver=12.2.0
 compiler.gccgoarm641220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gccgoarm641220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.gccgoarm641230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
+compiler.gccgoarm641230.semver=12.3.0
+compiler.gccgoarm641230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gccgoarm641230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 compiler.gccgoarm641310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
 compiler.gccgoarm641310.semver=13.1.0
 compiler.gccgoarm641310.objdumper=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
@@ -570,7 +615,7 @@ compiler.gccgoarm641310.demangler=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch6
 
 ###############################
 # GCC for ARM
-group.gccgoarm.compilers=gccgoarm1220:gccgoarm1310
+group.gccgoarm.compilers=gccgoarm1220:gccgoarm1230:gccgoarm1310
 group.gccgoarm.groupName=ARM GCCGO
 group.gccgoarm.baseName=ARM gccgo
 group.gccgoarm.isSemVer=true
@@ -580,6 +625,11 @@ compiler.gccgoarm1220.semver=12.2.0
 compiler.gccgoarm1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gccgoarm1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.gccgoarm1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
+compiler.gccgoarm1230.semver=12.3.0
+compiler.gccgoarm1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gccgoarm1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.gccgoarm1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
 compiler.gccgoarm1310.semver=13.1.0
 compiler.gccgoarm1310.objdumper=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
@@ -587,7 +637,7 @@ compiler.gccgoarm1310.demangler=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknow
 
 ###############################
 # GCC for PPC
-group.gccgoppc.compilers=gccgoppc1220:gccgoppc1310
+group.gccgoppc.compilers=gccgoppc1220:gccgoppc1230:gccgoppc1310
 group.gccgoppc.groupName=POWER GCCGO
 group.gccgoppc.baseName=POWER gccgo
 group.gccgoppc.isSemVer=true
@@ -597,6 +647,11 @@ compiler.gccgoppc1220.semver=12.2.0
 compiler.gccgoppc1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gccgoppc1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.gccgoppc1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
+compiler.gccgoppc1230.semver=12.3.0
+compiler.gccgoppc1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gccgoppc1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.gccgoppc1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
 compiler.gccgoppc1310.semver=13.1.0
 compiler.gccgoppc1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
@@ -604,7 +659,7 @@ compiler.gccgoppc1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerp
 
 ###############################
 # GCC for PPC64LE
-group.gccgoppc64le.compilers=gccgoppc64le1220:gppc64leg9:gppc64leg8:gccgoppc64le1310
+group.gccgoppc64le.compilers=gccgoppc64le1220:gccgoppc64le1230:gppc64leg9:gppc64leg8:gccgoppc64le1310
 group.gccgoppc64le.groupName=POWER64LE GCCGO
 group.gccgoppc64le.baseName=POWER64LE gccgo
 group.gccgoppc64le.isSemVer=true
@@ -613,6 +668,11 @@ compiler.gccgoppc64le1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powe
 compiler.gccgoppc64le1220.semver=12.2.0
 compiler.gccgoppc64le1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gccgoppc64le1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gccgoppc64le1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
+compiler.gccgoppc64le1230.semver=12.3.0
+compiler.gccgoppc64le1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gccgoppc64le1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gccgoppc64le1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
 compiler.gccgoppc64le1310.semver=13.1.0
@@ -627,7 +687,7 @@ compiler.gppc64leg8.semver=AT12.0
 
 ###############################
 # GCC for PPC64
-group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc641220:gccgoppc641310
+group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc641220:gccgoppc641230:gccgoppc641310
 group.gccgoppc64.groupName=POWER64 GCCGO
 group.gccgoppc64.baseName=POWER64 gccgo
 group.gccgoppc64.isSemVer=true
@@ -636,6 +696,11 @@ compiler.gccgoppc641220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc6
 compiler.gccgoppc641220.semver=12.2.0
 compiler.gccgoppc641220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gccgoppc641220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gccgoppc641230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
+compiler.gccgoppc641230.semver=12.3.0
+compiler.gccgoppc641230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gccgoppc641230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gccgoppc641310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
 compiler.gccgoppc641310.semver=13.1.0

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -211,13 +211,18 @@ compiler.objcpps390xg1310.demangler=/opt/compiler-explorer/s390x/gcc-13.1.0/s390
 
 ###############################
 # GCC for ARM
-group.objcppgccarm.compilers=objcpparmg1310
+group.objcppgccarm.compilers=objcpparmg1230:objcpparmg1310
 group.objcppgccarm.groupName=ARM GCC
 group.objcppgccarm.baseName=ARM GCC
 group.objcppgccarm.isSemVer=true
 group.objcppgccarm.supportsExecute=false
 group.objcppgccarm.supportsBinary=true
 group.objcppgccarm.supportsBinaryObject=true
+
+compiler.objcpparmg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.objcpparmg1230.semver=12.3.0
+compiler.objcpparmg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.objcpparmg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.objcpparmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.objcpparmg1310.semver=13.1.0
@@ -227,13 +232,18 @@ compiler.objcpparmg1310.demangler=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unkn
 ###############################
 # GCC for ARM64
 
-group.objcppgccarm64.compilers=objcpparm64g1310
+group.objcppgccarm64.compilers=objcpparm64g1230:objcpparm64g1310
 group.objcppgccarm64.groupName=ARM64 GCC
 group.objcppgccarm64.baseName=ARM64 GCC
 group.objcppgccarm64.isSemVer=true
 group.objcppgccarm64.supportsExecute=false
 group.objcppgccarm64.supportsBinary=true
 group.objcppgccarm64.supportsBinaryObject=true
+
+compiler.objcpparm64g1230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.objcpparm64g1230.semver=12.3.0
+compiler.objcpparm64g1230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.objcpparm64g1230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.objcpparm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.objcpparm64g1310.semver=13.1.0

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -50,13 +50,18 @@ group.objcppgccs.compilers=&objcppgccrvs:&objcppgccarm:&objcppgccarm64:&objcppgc
 
 ###############################
 # GCC for POWERPC64LE
-group.objcppgccpowerpc64le.compilers=objcppppc64leg1310
+group.objcppgccpowerpc64le.compilers=objcppppc64leg1230:objcppppc64leg1310
 group.objcppgccpowerpc64le.groupName=POWERPC64LE GCC
 group.objcppgccpowerpc64le.baseName=POWERPC64LE GCC
 group.objcppgccpowerpc64le.isSemVer=true
 group.objcppgccpowerpc64le.supportsExecute=false
 group.objcppgccpowerpc64le.supportsBinary=true
 group.objcppgccpowerpc64le.supportsBinaryObject=true
+
+compiler.objcppppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.objcppppc64leg1230.semver=12.3.0
+compiler.objcppppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.objcppppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.objcppppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.objcppppc64leg1310.semver=13.1.0
@@ -65,13 +70,18 @@ compiler.objcppppc64leg1310.demangler=/opt/compiler-explorer/powerpc64le/gcc-13.
 
 ###############################
 # GCC for POWERPC64
-group.objcppgccpowerpc64.compilers=objcppppc64g1310
+group.objcppgccpowerpc64.compilers=objcppppc64g1230:objcppppc64g1310
 group.objcppgccpowerpc64.groupName=POWERPC64 GCC
 group.objcppgccpowerpc64.baseName=POWERPC64 GCC
 group.objcppgccpowerpc64.isSemVer=true
 group.objcppgccpowerpc64.supportsExecute=false
 group.objcppgccpowerpc64.supportsBinary=true
 group.objcppgccpowerpc64.supportsBinaryObject=true
+
+compiler.objcppppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.objcppppc64g1230.semver=12.3.0
+compiler.objcppppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.objcppppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.objcppppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.objcppppc64g1310.semver=13.1.0
@@ -80,13 +90,18 @@ compiler.objcppppc64g1310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/
 
 ###############################
 # GCC for POWERPC
-group.objcppgccpowerpc.compilers=objcppppcg1310
+group.objcppgccpowerpc.compilers=objcppppcg1230:objcppppcg1310
 group.objcppgccpowerpc.groupName=POWERPC GCC
 group.objcppgccpowerpc.baseName=POWERPC GCC
 group.objcppgccpowerpc.isSemVer=true
 group.objcppgccpowerpc.supportsExecute=false
 group.objcppgccpowerpc.supportsBinary=true
 group.objcppgccpowerpc.supportsBinaryObject=true
+
+compiler.objcppppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.objcppppcg1230.semver=12.3.0
+compiler.objcppppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.objcppppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.objcppppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
 compiler.objcppppcg1310.semver=13.1.0
@@ -95,13 +110,18 @@ compiler.objcppppcg1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powe
 
 ###############################
 # GCC for MIPSEL
-group.objcppgccmipsel.compilers=objcppmipselg1310
+group.objcppgccmipsel.compilers=objcppmipselg1230:objcppmipselg1310
 group.objcppgccmipsel.groupName=MIPS (EL) GCC
 group.objcppgccmipsel.baseName=MIPS (EL) GCC
 group.objcppgccmipsel.isSemVer=true
 group.objcppgccmipsel.supportsExecute=false
 group.objcppgccmipsel.supportsBinary=true
 group.objcppgccmipsel.supportsBinaryObject=true
+
+compiler.objcppmipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.objcppmipselg1230.semver=12.3.0
+compiler.objcppmipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.objcppmipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.objcppmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
 compiler.objcppmipselg1310.semver=13.1.0
@@ -110,13 +130,18 @@ compiler.objcppmipselg1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mi
 
 ###############################
 # GCC for MIPS64EL
-group.objcppgccmips64el.compilers=objcppmips64elg1310
+group.objcppgccmips64el.compilers=objcppmips64elg1230:objcppmips64elg1310
 group.objcppgccmips64el.groupName=MIPS64 (EL) GCC
 group.objcppgccmips64el.baseName=MIPS64 (EL) GCC
 group.objcppgccmips64el.isSemVer=true
 group.objcppgccmips64el.supportsExecute=false
 group.objcppgccmips64el.supportsBinary=true
 group.objcppgccmips64el.supportsBinaryObject=true
+
+compiler.objcppmips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.objcppmips64elg1230.semver=12.3.0
+compiler.objcppmips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.objcppmips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.objcppmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
 compiler.objcppmips64elg1310.semver=13.1.0
@@ -125,13 +150,18 @@ compiler.objcppmips64elg1310.demangler=/opt/compiler-explorer/mips64el/gcc-13.1.
 
 ###############################
 # GCC for MIPS64
-group.objcppgccmips64.compilers=objcppmips64g1310
+group.objcppgccmips64.compilers=objcppmips64g1230:objcppmips64g1310
 group.objcppgccmips64.groupName=MIPS64 GCC
 group.objcppgccmips64.baseName=MIPS64 GCC
 group.objcppgccmips64.isSemVer=true
 group.objcppgccmips64.supportsExecute=false
 group.objcppgccmips64.supportsBinary=true
 group.objcppgccmips64.supportsBinaryObject=true
+
+compiler.objcppmips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.objcppmips64g1230.semver=12.3.0
+compiler.objcppmips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.objcppmips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.objcppmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.objcppmips64g1310.semver=13.1.0
@@ -141,13 +171,18 @@ compiler.objcppmips64g1310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mi
 
 ###############################
 # GCC for MIPS
-group.objcppgccmips.compilers=objcppmipsg1310
+group.objcppgccmips.compilers=objcppmipsg1230:objcppmipsg1310
 group.objcppgccmips.groupName=MIPS GCC
 group.objcppgccmips.baseName=MIPS GCC
 group.objcppgccmips.isSemVer=true
 group.objcppgccmips.supportsExecute=false
 group.objcppgccmips.supportsBinary=true
 group.objcppgccmips.supportsBinaryObject=true
+
+compiler.objcppmipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.objcppmipsg1230.semver=12.3.0
+compiler.objcppmipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.objcppmipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.objcppmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.objcppmipsg1310.semver=13.1.0
@@ -156,13 +191,18 @@ compiler.objcppmipsg1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-u
 
 ###############################
 # GCC for s390
-group.objcppgccs390x.compilers=objcpps390xg1310
+group.objcppgccs390x.compilers=objcpps390xg1230:objcpps390xg1310
 group.objcppgccs390x.groupName=S390X GCC
 group.objcppgccs390x.baseName=S390X GCC
 group.objcppgccs390x.isSemVer=true
 group.objcppgccs390x.supportsExecute=false
 group.objcppgccs390x.supportsBinary=true
 group.objcppgccs390x.supportsBinaryObject=true
+
+compiler.objcpps390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.objcpps390xg1230.semver=12.3.0
+compiler.objcpps390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.objcpps390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.objcpps390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
 compiler.objcpps390xg1310.semver=13.1.0
@@ -211,9 +251,14 @@ group.objcppgccrvs.supportsBinary=true
 group.objcppgccrvs.supportsBinaryObject=true
 
 ## Subgroup for riscv32
-group.objcppgccrv32.compilers=objcppgccrv32trunk:objcppgccrv321310
+group.objcppgccrv32.compilers=objcppgccrv32trunk:objcppgccrv321230:objcppgccrv321310
 group.objcppgccrv32.groupName=RISC-V 32-bits
 group.objcppgccrv32.baseName=RISC-V 32 GCC
+
+compiler.objcppgccrv321230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.objcppgccrv321230.semver=12.3.0
+compiler.objcppgccrv321230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.objcppgccrv321230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.objcppgccrv321310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.objcppgccrv321310.semver=13.1.0
@@ -226,9 +271,14 @@ compiler.objcppgccrv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/r
 compiler.objcppgccrv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 ## Subgroup for riscv64
-group.objcppgccrv64.compilers=objcppgccrv64trunk:objcppgccrv641310
+group.objcppgccrv64.compilers=objcppgccrv64trunk:objcppgccrv641230:objcppgccrv641310
 group.objcppgccrv64.groupName=RISC-V 64-bits
 group.objcppgccrv64.baseName=RISC-V 64 GCC
+
+compiler.objcppgccrv641230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.objcppgccrv641230.semver=12.3.0
+compiler.objcppgccrv641230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.objcppgccrv641230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.objcppgccrv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.objcppgccrv641310.semver=13.1.0

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -51,7 +51,7 @@ group.objccross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc
 group.objcsparc.compilers=&objcgccsparc
 
 # GCC for SPARC
-group.objcgccsparc.compilers=objcsparcg1220:objcsparcg1310
+group.objcgccsparc.compilers=objcsparcg1220:objcsparcg1230:objcsparcg1310
 group.objcgccsparc.supportsBinary=true
 group.objcgccsparc.supportsExecute=false
 group.objcgccsparc.baseName=SPARC gcc
@@ -63,6 +63,11 @@ compiler.objcsparcg1220.semver=12.2.0
 compiler.objcsparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.objcsparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.objcsparcg1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.objcsparcg1230.semver=12.3.0
+compiler.objcsparcg1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.objcsparcg1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 compiler.objcsparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
 compiler.objcsparcg1310.semver=13.1.0
 compiler.objcsparcg1310.objdumper=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
@@ -73,7 +78,7 @@ compiler.objcsparcg1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-
 group.objcsparc64.compilers=&objcgccsparc64
 
 # GCC for SPARC64
-group.objcgccsparc64.compilers=objcsparc64g1220:objcsparc64g1310
+group.objcgccsparc64.compilers=objcsparc64g1220:objcsparc64g1230:objcsparc64g1310
 group.objcgccsparc64.supportsBinary=true
 group.objcgccsparc64.supportsExecute=false
 group.objcgccsparc64.baseName=SPARC64 gcc
@@ -85,6 +90,11 @@ compiler.objcsparc64g1220.semver=12.2.0
 compiler.objcsparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.objcsparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.objcsparc64g1230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.objcsparc64g1230.semver=12.3.0
+compiler.objcsparc64g1230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.objcsparc64g1230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 compiler.objcsparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
 compiler.objcsparc64g1310.semver=13.1.0
 compiler.objcsparc64g1310.objdumper=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
@@ -95,7 +105,7 @@ compiler.objcsparc64g1310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/sp
 group.objcsparcleon.compilers=&objcgccsparcleon
 
 # GCC for SPARC-LEON
-group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1:objcsparcleong1310
+group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1:objcsparcleong1230:objcsparcleong1310
 group.objcgccsparcleon.supportsBinary=true
 group.objcgccsparcleon.supportsExecute=false
 group.objcgccsparcleon.baseName=SPARC LEON gcc
@@ -108,6 +118,11 @@ compiler.objcsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/spa
 compiler.objcsparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
 compiler.objcsparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.objcsparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.objcsparcleong1230.exe=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.objcsparcleong1230.semver=12.3.0
+compiler.objcsparcleong1230.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.objcsparcleong1230.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.objcsparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.objcsparcleong1310.semver=13.1.0
@@ -124,7 +139,7 @@ compiler.objcsparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12
 group.objcloongarch64.compilers=&objcgccloongarch64
 
 # GCC for loongarch64
-group.objcgccloongarch64.compilers=objcloongarch64g1220:objcloongarch64g1310
+group.objcgccloongarch64.compilers=objcloongarch64g1220:objcloongarch64g1230:objcloongarch64g1310
 group.objcgccloongarch64.supportsBinary=true
 group.objcgccloongarch64.supportsExecute=false
 group.objcgccloongarch64.baseName=loongarch64 gcc
@@ -135,6 +150,11 @@ compiler.objcloongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/
 compiler.objcloongarch64g1220.semver=12.2.0
 compiler.objcloongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.objcloongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.objcloongarch64g1230.exe=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.objcloongarch64g1230.semver=12.3.0
+compiler.objcloongarch64g1230.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.objcloongarch64g1230.demangler=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.objcloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
 compiler.objcloongarch64g1310.semver=13.1.0
@@ -147,7 +167,7 @@ compiler.objcloongarch64g1310.demangler=/opt/compiler-explorer/loongarch64/gcc-1
 group.objcs390x.compilers=&objcgccs390x
 
 # GCC for s390x
-group.objcgccs390x.compilers=objcs390xg1220:objcs390xg1310
+group.objcgccs390x.compilers=objcs390xg1220:objcs390xg1230:objcs390xg1310
 group.objcgccs390x.supportsBinary=true
 group.objcgccs390x.supportsExecute=false
 group.objcgccs390x.baseName=s390x gcc
@@ -158,6 +178,11 @@ compiler.objcs390xg1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-li
 compiler.objcs390xg1220.semver=12.2.0
 compiler.objcs390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.objcs390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.objcs390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.objcs390xg1230.semver=12.3.0
+compiler.objcs390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.objcs390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.objcs390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
 compiler.objcs390xg1310.semver=13.1.0
@@ -171,7 +196,7 @@ group.objcppcs.isSemVer=true
 group.objcppcs.supportsBinary=true
 group.objcppcs.supportsExecute=false
 
-group.objcppc.compilers=objcppcg1220:objcppcg1310
+group.objcppc.compilers=objcppcg1220:objcppcg1230:objcppcg1310
 group.objcppc.groupName=POWER
 group.objcppc.baseName=POWER GCC
 
@@ -180,12 +205,17 @@ compiler.objcppcg1220.semver=12.2.0
 compiler.objcppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.objcppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.objcppcg1230.semver=12.3.0
+compiler.objcppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.objcppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 compiler.objcppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.objcppcg1310.semver=13.1.0
 compiler.objcppcg1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppcg1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.objcppc64.compilers=objcppc64g1220:objcppc64g1310
+group.objcppc64.compilers=objcppc64g1220:objcppc64g1230:objcppc64g1310
 group.objcppc64.groupName=POWER64
 group.objcppc64.baseName=POWER64 GCC
 
@@ -194,12 +224,17 @@ compiler.objcppc64g1220.semver=12.2.0
 compiler.objcppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.objcppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.objcppc64g1230.semver=12.3.0
+compiler.objcppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.objcppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.objcppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.objcppc64g1310.semver=13.1.0
 compiler.objcppc64g1310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppc64g1310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
-group.objcppc64le.compilers=objcppc64leg1220:objcppc64leg1310
+group.objcppc64le.compilers=objcppc64leg1220:objcppc64leg1230:objcppc64leg1310
 group.objcppc64le.groupName=POWER64LE
 group.objcppc64le.baseName=POWER64LE GCC
 
@@ -207,6 +242,11 @@ compiler.objcppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powe
 compiler.objcppc64leg1220.semver=12.2.0
 compiler.objcppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.objcppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.objcppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.objcppc64leg1230.semver=12.3.0
+compiler.objcppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.objcppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.objcppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.objcppc64leg1310.semver=13.1.0
@@ -224,7 +264,7 @@ group.objcgccarm.includeFlag=-I
 
 # 32 bit
 group.objcgcc32arm.groupName=Arm 32-bit GCC
-group.objcgcc32arm.compilers=objcarmg1220:objcarmgtrunk:objcarmg1310
+group.objcgcc32arm.compilers=objcarmgtrunk:objcarmg1220:objcarmg1230:objcarmg1310
 group.objcgcc32arm.isSemVer=true
 group.objcgcc32arm.instructionSet=arm32
 group.objcgcc32arm.baseName=ARM gcc
@@ -233,6 +273,11 @@ compiler.objcarmg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linu
 compiler.objcarmg1220.semver=12.2.0
 compiler.objcarmg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.objcarmg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.objcarmg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.objcarmg1230.semver=12.3.0
+compiler.objcarmg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.objcarmg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.objcarmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.objcarmg1310.semver=13.1.0
@@ -247,7 +292,7 @@ compiler.objcarmgtrunk.semver=trunk
 # 64 bit
 group.objcgcc64arm.groupName=Arm 64-bit GCC
 group.objcgcc64arm.baseName=ARM64 GCC
-group.objcgcc64arm.compilers=objcarm64gtrunk:objcarm64g1220:objcarm64g1310
+group.objcgcc64arm.compilers=objcarm64gtrunk:objcarm64g1220:objcarm64g1230:objcarm64g1310
 group.objcgcc64arm.isSemVer=true
 group.objcgcc64arm.instructionSet=aarch64
 
@@ -255,6 +300,11 @@ compiler.objcarm64g1220.exe=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unkn
 compiler.objcarm64g1220.semver=12.2.0
 compiler.objcarm64g1220.objdumper=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.objcarm64g1220.demangler=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.objcarm64g1230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.objcarm64g1230.semver=12.3.0
+compiler.objcarm64g1230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.objcarm64g1230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.objcarm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.objcarm64g1310.semver=13.1.0
@@ -275,7 +325,7 @@ group.objcmipss.supportsBinary=true
 group.objcmipss.supportsExecute=false
 
 ## MIPS
-group.objcmips.compilers=objcmipsg1220:objcmipsg1310
+group.objcmips.compilers=objcmipsg1220:objcmipsg1230:objcmipsg1310
 group.objcmips.groupName=MIPS GCC
 group.objcmips.baseName=mips gcc
 
@@ -284,6 +334,11 @@ compiler.objcmipsg1220.semver=12.2.0
 compiler.objcmipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.objcmipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.objcmipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.objcmipsg1230.semver=12.3.0
+compiler.objcmipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.objcmipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.objcmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.objcmipsg1310.semver=13.1.0
 compiler.objcmipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -291,13 +346,18 @@ compiler.objcmipsg1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unk
 
 ## MIPS64
 group.objcmips64.groupName=MIPS64 GCC
-group.objcmips64.compilers=objcmips64g1220:objcmips64g1310
+group.objcmips64.compilers=objcmips64g1220:objcmips64g1230:objcmips64g1310
 group.objcmips64.baseName=MIPS64 gcc
 
 compiler.objcmips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.objcmips64g1220.semver=12.2.0
 compiler.objcmips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.objcmips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.objcmips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.objcmips64g1230.semver=12.3.0
+compiler.objcmips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.objcmips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.objcmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.objcmips64g1310.semver=13.1.0
@@ -306,13 +366,18 @@ compiler.objcmips64g1310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips
 
 ## MIPS EL
 group.objcmipsel.groupName=MIPSEL GCC
-group.objcmipsel.compilers=objcmipselg1220:objcmipselg1310
+group.objcmipsel.compilers=objcmipselg1220:objcmipselg1230:objcmipselg1310
 group.objcmipsel.baseName=mips (el) gcc
 
 compiler.objcmipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.objcmipselg1220.semver=12.2.0
 compiler.objcmipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.objcmipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.objcmipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.objcmipselg1230.semver=12.3.0
+compiler.objcmipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.objcmipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.objcmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.objcmipselg1310.semver=13.1.0
@@ -321,13 +386,18 @@ compiler.objcmipselg1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mips
 
 ## MIPS64 EL
 group.objcmips64el.groupName=MIPS64EL GCC
-group.objcmips64el.compilers=objcmips64elg1220:objcmips64elg1310
+group.objcmips64el.compilers=objcmips64elg1220:objcmips64elg1230:objcmips64elg1310
 group.objcmips64el.baseName=mips64 (el) gcc
 
 compiler.objcmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.objcmips64elg1220.semver=12.2.0
 compiler.objcmips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.objcmips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.objcmips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.objcmips64elg1230.semver=12.3.0
+compiler.objcmips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.objcmips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.objcmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.objcmips64elg1310.semver=13.1.0
@@ -347,12 +417,17 @@ group.objcrv.supportsBinaryObject=true
 ## Subgroup for riscv32
 group.objcrv32.groupName=RISC-V 32-bits
 group.objcrv32.baseName=RISC-V 32 GCC
-group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220:objcrv32g1310
+group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220:objcrv32g1230:objcrv32g1310
 
 compiler.objcrv32g1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32g1220.semver=12.2.0
 compiler.objcrv32g1220.demangler=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 compiler.objcrv32g1220.objdumper=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.objcrv32g1230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.objcrv32g1230.semver=12.3.0
+compiler.objcrv32g1230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.objcrv32g1230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.objcrv32g1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32g1310.semver=13.1.0


### PR DESCRIPTION
Adds 12.3.0 for 20 cross targets.
Adds 11.4.0 for 4 targets.

Not listing all languages as it depends on the targets, but the goal is
always to enable as much as possible.

fixes #5088
fixes #5087

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>