### PR TITLE
Add HPC SDK 23.3 and 23.5 to c++.amazon.properties

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2270,7 +2270,7 @@ compiler.gcc6502_1110.notification=This uses AVR-GCC 11.1.0 to compile C++ and u
 #################################
 # NVHPC nvc++
 
-group.nvcxx_x86_cxx.compilers=nvcxx_x86_cxx22_7:nvcxx_x86_cxx22_9:nvcxx_x86_cxx22_11:nvcxx_x86_cxx23_1
+group.nvcxx_x86_cxx.compilers=nvcxx_x86_cxx22_7:nvcxx_x86_cxx22_9:nvcxx_x86_cxx22_11:nvcxx_x86_cxx23_1:nvcxx_x86_cxx23_3:nvcxx_x86_cxx23_5
 group.nvcxx_x86_cxx.options=
 group.nvcxx_x86_cxx.binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*|_dl_relocate_static_pie)$
 group.nvcxx_x86_cxx.needsMulti=false
@@ -2301,7 +2301,15 @@ compiler.nvcxx_x86_cxx23_1.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64
 compiler.nvcxx_x86_cxx23_1.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/23.1/compilers/bin/nvc++
 compiler.nvcxx_x86_cxx23_1.semver=23.1
 
-group.nvcxx_arm_cxx.compilers=nvcxx_arm_cxx22_7:nvcxx_arm_cxx22_9
+compiler.nvcxx_x86_cxx23_3.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/23.3/compilers/bin/nvdecode
+compiler.nvcxx_x86_cxx23_3.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/23.3/compilers/bin/nvc++
+compiler.nvcxx_x86_cxx23_3.semver=23.3
+
+compiler.nvcxx_x86_cxx23_5.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/23.5/compilers/bin/nvdecode
+compiler.nvcxx_x86_cxx23_5.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/23.5/compilers/bin/nvc++
+compiler.nvcxx_x86_cxx23_5.semver=23.5
+
+group.nvcxx_arm_cxx.compilers=nvcxx_arm_cxx22_7:nvcxx_arm_cxx22_9:nvcxx_arm_cxx22_11:nvcxx_arm_cxx23_1:nvcxx_arm_cxx23_3:nvcxx_arm_cxx23_5
 group.nvcxx_arm_cxx.options=
 group.nvcxx_arm_cxx.supportsBinary=true
 group.nvcxx_arm_cxx.binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*|_dl_relocate_static_pie)$
@@ -2324,6 +2332,22 @@ compiler.nvcxx_arm_cxx22_7.semver=22.7
 compiler.nvcxx_arm_cxx22_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.9/compilers/bin/nvdecode
 compiler.nvcxx_arm_cxx22_9.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.9/compilers/bin/nvc++
 compiler.nvcxx_arm_cxx22_9.semver=22.9
+
+compiler.nvcxx_arm_cxx22_11.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.11/compilers/bin/nvdecode
+compiler.nvcxx_arm_cxx22_11.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/22.11/compilers/bin/nvc++
+compiler.nvcxx_arm_cxx22_11.semver=22.11
+
+compiler.nvcxx_arm_cxx23_1.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/23.1/compilers/bin/nvdecode
+compiler.nvcxx_arm_cxx23_1.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/23.1/compilers/bin/nvc++
+compiler.nvcxx_arm_cxx23_1.semver=23.1
+
+compiler.nvcxx_arm_cxx23_3.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/23.3/compilers/bin/nvdecode
+compiler.nvcxx_arm_cxx23_3.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/23.3/compilers/bin/nvc++
+compiler.nvcxx_arm_cxx23_3.semver=23.3
+
+compiler.nvcxx_arm_cxx23_5.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/23.5/compilers/bin/nvdecode
+compiler.nvcxx_arm_cxx23_5.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/23.5/compilers/bin/nvc++
+compiler.nvcxx_arm_cxx23_5.semver=23.5
 
 #################################
 #################################


### PR DESCRIPTION
See also: https://github.com/compiler-explorer/infra/pull/1032

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
