### PR TITLE
Update AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,7 +7,7 @@ Explorer are:
 - [Austin Morton](https://github.com/apmorton)
 - [Marc Poulhiès](https://poulhies.fr)
 - [Jeremy Rifkin](https://github.com/jeremy-rifkin)
-- [Mats Larsen](https://supergrecko.dev)
+- [Mats Larsen]()
 
 ---
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,7 +7,7 @@ Explorer are:
 - [Austin Morton](https://github.com/apmorton)
 - [Marc Poulhiès](https://poulhies.fr)
 - [Jeremy Rifkin](https://github.com/jeremy-rifkin)
-- [Mats Larsen]()
+- [Mats Larsen](https://www.jun.codes/)
 
 ---
 


### PR DESCRIPTION
The domain "https://supergrecko.dev" has been expired and available to claim which can be used maliciously for Impersonation attacks.

