### PR TITLE
add open source icx

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod
+compilers=&gcc86:&icc:&icx:&icx_os:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -822,6 +822,26 @@ compiler.icc202171.ldPath=/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compil
 compiler.icc202171.libPath=/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.icc202171.semver=2021.7.1
 compiler.icc202171.options=-gxx-name=/opt/compiler-explorer/gcc-12.2.0/bin/g++
+
+################################
+# icx open source
+group.icx_os.compilers=icx_os_20230618
+group.icx_os.intelAsm=-masm=intel
+group.icx_os.options=
+group.icx_os.groupName=ICX Open Source
+group.icx_os.baseName=icx os
+group.icx_os.isSemVer=true
+group.icx_os.compilerType=clang-intel
+group.icx_os.licenseName=LLVM Apache 2
+group.icx_os.licenseLink=https://github.com/intel/llvm/blob/sycl/LICENSE.TXT
+group.icx_os.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.icx_os.compilerCategories=icc
+group.icx_os.instructionSet=amd64
+
+compiler.icx_os_20230618.exe=/opt/compiler-explorer/intel-os-cpp-2023.0618/bin/clang++
+compiler.icx_os_20230618.libPath=opt/compiler-explorer/intel-os-cpp-2023.0618/lib
+compiler.icx_os_20230618.semver=2023.0618
+compiler.icx_os_20230618.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
 ################################
 # icx for x86


### PR DESCRIPTION
Depends on installing: https://github.com/compiler-explorer/infra/pull/1039

icx has an open source counterpart. It is the sycl branch at https://github.com/intel/llvm
This PR makes a daily build available. I can occasionally publish a new daily here.

Most features start in open source and are not available in the product build for many months. Also, this compiler supports LLVM IR viewer in CE, but icx does not.


