### PR TITLE
hotfix libraries

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -932,7 +932,7 @@ export class BaseCompiler implements ICompiler {
 
             const paths = foundVersion.path.map(path => includeFlag + path);
             if (foundVersion.packagedheaders) {
-                paths.push(includeFlag + `./${selectedLib.id}/include`);
+                paths.push(includeFlag + `/app/${selectedLib.id}/include`);
             }
             return paths;
         });

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -869,7 +869,7 @@ export class BaseCompiler implements ICompiler {
 
                 const paths = [...foundVersion.libpath];
                 if (!this.buildenvsetup.extractAllToRoot) {
-                    paths.push(`./${selectedLib.id}/lib`);
+                    paths.push(`/app/${selectedLib.id}/lib`);
                 }
                 return paths;
             }),


### PR DESCRIPTION
Could not be found when using cmake, because that uses a different cwd

Issue found here: https://github.com/compiler-explorer/compiler-explorer/discussions/2763#discussioncomment-6281688 by @DESX

Obviously doesn't work in situations where someone setup a local CE with a working conan link but not using nsjail... Should save and check whether nsjail is used, and if not used then the temporary directory should be used (will required some passing of extra arguments) - nor Windows. But will make different issue for that.
