### PR TITLE
Support control flow graphs for more compilers

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2843,7 +2843,12 @@ export class BaseCompiler implements ICompiler {
     }
 
     isCfgCompiler(compilerVersion: string) {
-        return compilerVersion.includes('clang') || compilerVersion.match(/^([\w-]*-)?g((\+\+)|(cc)|(dc))/g) !== null;
+        return (
+            compilerVersion.includes('clang') ||
+            compilerVersion.includes('icc (ICC)') ||
+            ['amd64', 'arm32', 'aarch64', 'llvm'].includes(this.compiler.instructionSet ?? '') ||
+            compilerVersion.match(/^([\w-]*-)?g((\+\+)|(cc)|(dc))/g) !== null
+        );
     }
 
     async processGccDumpOutput(opts, result, removeEmptyPasses, outputFilename) {

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -70,6 +70,10 @@ export class ClangCompiler extends BaseCompiler {
         }
     }
 
+    override isCfgCompiler() {
+        return true;
+    }
+
     async addTimeTraceToResult(result: CompilationResult, dirPath: string, outputFilename: string) {
         let timeTraceJson = '';
         const outputExt = path.extname(outputFilename);

--- a/test/base-compiler-tests.ts
+++ b/test/base-compiler-tests.ts
@@ -66,41 +66,6 @@ describe('Basic compiler invariants', function () {
         compiler.optOutputRequested(['please', 'recognize', '-fsave-optimization-record']).should.equal(true);
         compiler.optOutputRequested(['please', "don't", 'recognize']).should.equal(false);
     });
-    // Overkill test, but now we're safer!
-    it('should recognize cfg compilers', () => {
-        compiler
-            .isCfgCompiler(
-                'clang version 5.0.0 (https://github.com/asutton/clang.git 449c8c3e91355a3b2b6761e11d9fb5d3c125b791) (https://github.com/llvm-mirror/llvm.git 40b1e969f9cb2a0c697e247435193fb006ef1311)',
-            )
-            .should.equal(true);
-        compiler.isCfgCompiler('clang version 4.0.0 (tags/RELEASE_400/final 299826)').should.equal(true);
-        compiler.isCfgCompiler('clang version 7.0.0 (trunk 325868)').should.equal(true);
-        compiler.isCfgCompiler('clang version 3.3 (tags/RELEASE_33/final)').should.equal(true);
-        compiler
-            .isCfgCompiler('clang version 6.0.0 (tags/RELEASE_600/final 327031) (llvm/tags/RELEASE_600/final 327028)')
-            .should.equal(true);
-
-        compiler.isCfgCompiler('g++ (GCC-Explorer-Build) 4.9.4').should.equal(true);
-        compiler.isCfgCompiler('g++ (GCC-Explorer-Build) 8.0.1 20180223 (experimental)').should.equal(true);
-        compiler.isCfgCompiler('g++ (GCC-Explorer-Build) 8.0.1 20180223 (experimental)').should.equal(true);
-        compiler.isCfgCompiler('g++ (GCC) 4.1.2').should.equal(true);
-
-        compiler.isCfgCompiler('foo-bar-g++ (GCC-Explorer-Build) 4.9.4').should.equal(true);
-        compiler.isCfgCompiler('foo-bar-gcc (GCC-Explorer-Build) 4.9.4').should.equal(true);
-        compiler.isCfgCompiler('foo-bar-gdc (GCC-Explorer-Build) 4.9.4').should.equal(true);
-
-        compiler.isCfgCompiler('fake-for-test (Based on g++)').should.equal(false);
-
-        compiler.isCfgCompiler('gdc (crosstool-NG 203be35 - 20160205-2.066.1-e95a735b97) 5.2.0').should.equal(true);
-        compiler
-            .isCfgCompiler('gdc (crosstool-NG hg+unknown-20131212.080758 - 20140430-2.064.2-404a037d26) 4.8.2')
-            .should.equal(true);
-        compiler
-            .isCfgCompiler('gdc (crosstool-NG crosstool-ng-1.20.0-232-gc746732 - 20150830-2.066.1-d0dd4a83de) 4.9.3')
-            .should.equal(true);
-
-        compiler.isCfgCompiler('fake-for-test (Based on gdc)').should.equal(false);
-    });
     it('should allow comments next to includes (Bug #874)', () => {
         should.equal(compiler.checkSource('#include <cmath> // std::(sin, cos, ...)'), null);
         const badSource = compiler.checkSource('#include </dev/null..> //Muehehehe');


### PR DESCRIPTION
This PR should make cfg generation available for all clang compilers, icc, and any compiler whose instructionSet property is x86, arm, or llvm.