### PR TITLE
ada: add stack-usage support for GNAT

### DIFF
--- a/lib/compilers/ada.ts
+++ b/lib/compilers/ada.ts
@@ -24,6 +24,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import path from 'path';
+import {unwrap} from '../assert.js';
 
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
@@ -38,8 +39,16 @@ export class AdaCompiler extends BaseCompiler {
 
     constructor(info: PreliminaryCompilerInfo, env) {
         super(info, env);
+
+        this.outputFilebase = 'example';
+
         this.compiler.supportsGccDump = true;
         this.compiler.removeEmptyGccDump = true;
+
+        // this is not showing-up in the --help, so argument parser doesn't
+        // automatically detect the support.
+        this.compiler.stackUsageArg = '-fstack-usage';
+        this.compiler.supportsStackUsageOutput = true;
 
         // used for all GNAT related panes (Expanded code, Tree)
         this.compiler.supportsGnatDebugViews = true;
@@ -99,6 +108,10 @@ export class AdaCompiler extends BaseCompiler {
 
         if (this.compiler.adarts) {
             gnatmake_opts.push(`--RTS=${this.compiler.adarts}`);
+        }
+
+        if (this.compiler.supportsStackUsageOutput && backendOptions.produceStackUsageInfo) {
+            gnatmake_opts.push(unwrap(this.compiler.stackUsageArg));
         }
 
         if (!filters.execute && backendOptions.produceGnatDebug && this.compiler.supportsGnatDebugViews)


### PR DESCRIPTION
GNAT is gcc based, but its --help doesn't show all of gcc's option and
the base compiler doesn't detect its support for -fstack-usage.

Force the support (currently we only GNAT as an Ada compiler).

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>