### PR TITLE
Mark older clang versions as debugpatched

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -326,29 +326,36 @@ compiler.clang1101.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.2.0
 compiler.clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang++
 compiler.clang1200.semver=12.0.0
 compiler.clang1200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.3.0
+compiler.clang1200.debugPatched=true
 compiler.clang1201.exe=/opt/compiler-explorer/clang-12.0.1/bin/clang++
 compiler.clang1201.semver=12.0.1
 compiler.clang1201.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.1.0
+compiler.clang1201.debugPatched=true
 compiler.clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.clang1300.semver=13.0.0
 compiler.clang1300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.clang1300.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang1300.debugPatched=true
 compiler.clang1301.exe=/opt/compiler-explorer/clang-13.0.1/bin/clang++
 compiler.clang1301.semver=13.0.1
 compiler.clang1301.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.clang1301.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang1301.debugPatched=true
 compiler.clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
 compiler.clang1400.semver=14.0.0
 compiler.clang1400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.clang1400.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang1400.debugPatched=true
 compiler.clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
 compiler.clang1500.semver=15.0.0
 compiler.clang1500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 compiler.clang1500.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang1500.debugPatched=true
 compiler.clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
 compiler.clang1600.semver=16.0.0
 compiler.clang1600.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 compiler.clang1600.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang1600.debugPatched=true
 
 group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_widberg:clang_resugar
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel


### PR DESCRIPTION
Following https://github.com/compiler-explorer/infra/issues/1045

Mark the reinstalled compilers as `debugPatched` so we'll send the right flag


Originates from https://github.com/compiler-explorer/compiler-explorer/pull/4416
