### PR TITLE
AsmParser update for dotnet

### DIFF
--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -118,8 +118,6 @@ export class DotNetAsmParser implements IAsmParser {
             }
 
             if (line.startsWith('Emitting R2R PE file')) continue;
-            if (line.startsWith(';') && !line.startsWith('; Emitting')) continue;
-
             cleanedAsm.push(line);
         }
 

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -47,7 +47,11 @@ export class DotNetAsmParser implements IAsmParser {
             if (!trimmedLine || trimmedLine.startsWith(';')) continue;
             if (trimmedLine.endsWith(':')) {
                 if (trimmedLine.includes('(')) {
-                    methodDef[line] = trimmedLine.substring(0, trimmedLine.length - 1);
+                    let methodSignature = trimmedLine.substring(0, trimmedLine.length - 1);
+                    if ((methodSignature.match(/\(/g) || []).length > 1) {
+                        methodSignature = methodSignature.substring(0, methodSignature.lastIndexOf('(')).trimEnd();
+                    }
+                    methodDef[line] = methodSignature;
                     allAvailable.push(methodDef[line]);
                 } else {
                     labelDef[line] = {


### PR DESCRIPTION
Adapt changes from https://github.com/dotnet/runtime/pull/88033.

- Filter tier name while recognizing method names
- Keeps comments from asm output 

Without this fix, the code navigation is broken in dotnet languages.