### PR TITLE
Fix the comment test regex for dotnet

### DIFF
--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -138,7 +138,7 @@ export class DotNetAsmParser implements IAsmParser {
         const startingLineCount = asmLines.length;
 
         if (filters.commentOnly) {
-            const commentRe = /^\s*(;.*)$/g;
+            const commentRe = /^\s*(;.*)$/;
             asmLines = asmLines.flatMap(l => (commentRe.test(l) ? [] : [l]));
         }
 


### PR DESCRIPTION
Remove the unnecessary `/g` in the regex pattern.

Fix the issue where comment filter cannot remove all comment lines from the output.