### PR TITLE
add latest alias for oneapi compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -844,7 +844,7 @@ compiler.icc202190.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icxlatest
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -916,6 +916,12 @@ compiler.icx202310.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compil
 compiler.icx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/2021.6.0/lib/intel64/gcc4.8
 compiler.icx202310.semver=2023.1.0
 compiler.icx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
+
+compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icpx
+compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icxlatest.semver=(latest)
+compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
 ################################
 # zapcc

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -799,7 +799,7 @@ compiler.cicc202190.semver=2021.9.0
 compiler.cicc202190.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
 # icx for x86
-group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310
+group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicxlatest
 group.cicx.intelAsm=-masm=intel
 group.cicx.options=
 group.cicx.groupName=ICX x86-64
@@ -868,6 +868,12 @@ compiler.cicx202310.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compi
 compiler.cicx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.cicx202310.semver=2023.1.0
 compiler.cicx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
+
+compiler.cicxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icx
+compiler.cicxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
+compiler.cicxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicxlatest.semver=(latest)
+compiler.cicxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
 ###############################
 # Cross Compilers (mostly GCC & Clang)

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -149,7 +149,7 @@ compiler.ifort202190.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
 ###############################
 # Intel oneAPI for x86
-group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210:ifx202220:ifx202221:ifx202300:ifx202310
+group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210:ifx202220:ifx202221:ifx202300:ifx202310:ifxlatest
 group.ifx.intelAsm=-masm=intel
 group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
@@ -209,6 +209,12 @@ compiler.ifx202310.ldPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/co
 compiler.ifx202310.libPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifx202310.semver=2023.1.0
 compiler.ifx202310.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
+
+compiler.ifxlatest.exe=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/bin/ifx
+compiler.ifxlatest.ldPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifxlatest.libPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifxlatest.semver=(latest)
+compiler.ifxlatest.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
 ###############################
 # GCC Cross-Compilers


### PR DESCRIPTION
Resolves #4941 

Adds a (latest) compiler for icx/icpx/ifx, which is an alias for the most recent. The oneapi installer creates a symlink called latest, so I used the same name. I didn't do it for icc/icpc/ifort because intel announced that it will not be updating the compiler.
