### PR TITLE
Quick llvm ir cfg parsing patches

### DIFF
--- a/lib/cfg/cfg-parsers/llvm-ir.ts
+++ b/lib/cfg/cfg-parsers/llvm-ir.ts
@@ -44,8 +44,8 @@ export class LlvmIrCfgParser extends BaseCFGParser {
     constructor(instructionSetInfo: BaseInstructionSetInfo) {
         super(instructionSetInfo);
         this.functionDefinition = /^define .+ @(.+)\([^(]+$/;
-        this.labelRe = /^([\w.]+):\s*(;.*)?$/;
-        this.labelReference = /%([\w.]+)/g;
+        this.labelRe = /^([\w.-]+):\s*(;.*)?$/;
+        this.labelReference = /%([\w.-]+)/g;
     }
 
     override filterData(asmArr: AssemblyLine[]) {
@@ -196,7 +196,7 @@ export class LlvmIrCfgParser extends BaseCFGParser {
                             from: bb.nameId,
                             to: label,
                             arrows: 'to',
-                            color: 'green',
+                            color: 'blue',
                         });
                     }
                     break;
@@ -207,7 +207,7 @@ export class LlvmIrCfgParser extends BaseCFGParser {
                             from: bb.nameId,
                             to: label,
                             arrows: 'to',
-                            color: 'green',
+                            color: 'blue',
                         });
                     }
                     break;
@@ -233,12 +233,18 @@ export class LlvmIrCfgParser extends BaseCFGParser {
                             terminatingInstruction.lastIndexOf('to label'),
                         );
                         const callbrLabels = [...callbrLabelsPart.matchAll(this.labelReference)].map(m => m[1]);
+                        edges.push({
+                            from: bb.nameId,
+                            to: callbrLabels[0],
+                            arrows: 'to',
+                            color: 'grey',
+                        });
                         for (const label of callbrLabels) {
                             edges.push({
                                 from: bb.nameId,
                                 to: label,
                                 arrows: 'to',
-                                color: 'green',
+                                color: 'blue',
                             });
                         }
                     }

--- a/lib/cfg/cfg-parsers/llvm-ir.ts
+++ b/lib/cfg/cfg-parsers/llvm-ir.ts
@@ -239,7 +239,7 @@ export class LlvmIrCfgParser extends BaseCFGParser {
                             arrows: 'to',
                             color: 'grey',
                         });
-                        for (const label of callbrLabels) {
+                        for (const label of callbrLabels.slice(1)) {
                             edges.push({
                                 from: bb.nameId,
                                 to: label,


### PR DESCRIPTION
Fixes some issues noticed in https://github.com/compiler-explorer/compiler-explorer/pull/5155#issuecomment-1617709720 - confusing coloring and hyphens not being part of the label regex

CC @OfekShilon 