### PR TITLE
Add LLVMOptPipelineView support for Swift compilers

### DIFF
--- a/lib/compilers/swift.ts
+++ b/lib/compilers/swift.ts
@@ -26,9 +26,19 @@ import {BaseCompiler} from '../base-compiler.js';
 
 import {SwiftParser} from './argument-parsers.js';
 
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+
 export class SwiftCompiler extends BaseCompiler {
     static get key() {
         return 'swift';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env) {
+        super(info, env);
+        this.compiler.supportsLLVMOptPipelineView = true;
+        this.compiler.llvmOptArg = ['-Xllvm', '-print-after-all', '-Xllvm', '-print-before-all'];
+        this.compiler.llvmOptModuleScopeArg = ['-Xllvm', '-print-module-scope'];
+        this.compiler.llvmOptNoDiscardValueNamesArg = [];
     }
 
     override getSharedLibraryPathsAsArguments() {


### PR DESCRIPTION
This PR adds support for the LLVM optimisation pipeline view pane for the Swift family of compilers.
