### PR TITLE
gcc: add cross for 10.5.0 arm/arm64

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1382,73 +1382,76 @@ group.gccarm.includeFlag=-I
 
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
-group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1040:arm1031_07:arm1031_10:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armgtrunk:armg1220:armg1230:armg1310
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1310:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
 
 compiler.armhfg54.exe=/opt/compiler-explorer/arm/gcc-5.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.armhfg54.name=ARM gcc 5.4 (linux)
 compiler.armhfg54.alias=armhfg482
 compiler.armhfg54.semver=5.4
+
 compiler.arm541.exe=/opt/compiler-explorer/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-g++
 compiler.arm541.name=ARM gcc 5.4.1 (none)
 compiler.arm541.semver=5.4.1
 compiler.arm541.supportsBinary=false
+
 compiler.armg454.exe=/opt/compiler-explorer/arm/gcc-4.5.4/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg454.alias=armg453
-compiler.armg454.name=ARM gcc 4.5.4 (linux)
 compiler.armg454.semver=4.5.4
+
 compiler.armg464.exe=/opt/compiler-explorer/arm/gcc-4.6.4/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg464.alias=armg463:/usr/bin/arm-linux-gnueabi-g++-4.6
-compiler.armg464.name=ARM gcc 4.6.4 (linux)
 compiler.armg464.semver=4.6.4
+
 compiler.armg630.exe=/opt/compiler-explorer/arm/gcc-6.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg630.name=ARM gcc 6.3.0 (linux)
 compiler.armg630.semver=6.3.0
+
 compiler.arm710.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-7-2017-q4-major/bin/arm-none-eabi-g++
 compiler.arm710.name=ARM gcc 7.2.1 (none)
 compiler.arm710.semver=7.2.1
 compiler.arm710.supportsBinary=false
+
 compiler.armg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg640.name=ARM gcc 6.4 (linux)
 compiler.armg640.semver=6.4.0
+
 compiler.armg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg730.name=ARM gcc 7.3 (linux)
 compiler.armg730.semver=7.3.0
+
 compiler.armg750.exe=/opt/compiler-explorer/arm/gcc-7.5.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg750.name=ARM gcc 7.5 (linux)
 compiler.armg750.semver=7.5.0
+
 compiler.armg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg820.name=ARM gcc 8.2 (linux)
 compiler.armg820.semver=8.2.0
+
 compiler.armg850.exe=/opt/compiler-explorer/arm/gcc-8.5.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg850.name=ARM gcc 8.5 (linux)
 compiler.armg850.semver=8.5.0
+
+compiler.armg1050.exe=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1050.semver=10.5.0
+compiler.armg1050.objdumper=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1050.demangler=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.armg1140.exe=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1140.semver=11.4.0
 compiler.armg1140.objdumper=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1140.demangler=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
-compiler.armg1140.name=ARM gcc 11.4 (linux)
 
 compiler.armg1220.exe=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1220.semver=12.2.0
 compiler.armg1220.objdumper=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1220.demangler=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
-compiler.armg1220.name=ARM gcc 12.2 (linux)
 
 compiler.armg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1230.semver=12.3.0
 compiler.armg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
-compiler.armg1230.name=ARM gcc 12.3 (linux)
 
 compiler.armg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1310.semver=13.1.0
 compiler.armg1310.objdumper=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1310.demangler=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
-compiler.armg1310.name=ARM gcc 13.1 (linux)
+
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)
 compiler.armce820.semver=8.2.0
@@ -1477,44 +1480,44 @@ compiler.arm1121.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-11.2-2022.02/b
 compiler.arm1121.name=ARM gcc 11.2.1 (none)
 compiler.arm1121.semver=11.2.1
 compiler.arm1121.supportsBinary=false
+
 compiler.arm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm930.name=ARM gcc 9.3 (linux)
 compiler.arm930.semver=9.3.0
+
 compiler.arm940.exe=/opt/compiler-explorer/arm/gcc-9.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm940.name=ARM gcc 9.4 (linux)
 compiler.arm940.semver=9.4.0
+
 compiler.arm950.exe=/opt/compiler-explorer/arm/gcc-9.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm950.name=ARM gcc 9.5 (linux)
 compiler.arm950.semver=9.5.0
+
 compiler.arm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm1020.name=ARM gcc 10.2 (linux)
 compiler.arm1020.semver=10.2.0
+
 compiler.arm1030.exe=/opt/compiler-explorer/arm/gcc-10.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm1030.name=ARM gcc 10.3 (linux)
 compiler.arm1030.semver=10.3.0
+
 compiler.arm1040.exe=/opt/compiler-explorer/arm/gcc-10.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm1040.name=ARM gcc 10.4 (linux)
 compiler.arm1040.semver=10.4.0
+
 compiler.arm1100.exe=/opt/compiler-explorer/arm/gcc-11.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm1100.name=ARM gcc 11.1 (linux)
 compiler.arm1100.semver=11.1.0
+
 compiler.arm1120.exe=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm1120.name=ARM gcc 11.2 (linux)
 compiler.arm1120.semver=11.2.0
+
 compiler.arm1130.exe=/opt/compiler-explorer/arm/gcc-11.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.arm1130.name=ARM gcc 11.3 (linux)
 compiler.arm1130.semver=11.3.0
+
 compiler.arm1210.exe=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm1210.objdumper=/opt/compiler-explorer/arm/gcc-12.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
-compiler.arm1210.name=ARM gcc 12.1 (linux)
 compiler.arm1210.semver=12.1.0
+
 compiler.armgtrunk.exe=/opt/compiler-explorer/arm/gcc-trunk/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
-compiler.armgtrunk.name=ARM gcc trunk (linux)
 compiler.armgtrunk.semver=trunk
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310
+group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -1547,6 +1550,11 @@ compiler.arm64g1030.exe=/opt/compiler-explorer/arm64/gcc-10.3.0/aarch64-unknown-
 compiler.arm64g1030.semver=10.3
 compiler.arm64g1040.exe=/opt/compiler-explorer/arm64/gcc-10.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1040.semver=10.4
+
+compiler.arm64g1050.exe=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1050.semver=10.5.0
+compiler.arm64g1050.objdumper=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1050.demangler=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 compiler.arm64g1100.exe=/opt/compiler-explorer/arm64/gcc-11.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1100.semver=11.1
 compiler.arm64g1120.exe=/opt/compiler-explorer/arm64/gcc-11.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1314,7 +1314,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg750:carmg820:carmg850:carmce820:carm831:carm921:carm930:carm1020:carm1030:carm1031_07:carm1031_10:carm1021:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmgtrunk:carmg1220:carmg1230:carmg1310
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1310:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -1345,6 +1345,11 @@ compiler.carmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnu
 compiler.carmg820.semver=8.2.0 (linux)
 compiler.carmg850.exe=/opt/compiler-explorer/arm/gcc-8.5.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gcc
 compiler.carmg850.semver=8.5.0 (linux)
+
+compiler.carmg1050.exe=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1050.semver=10.5.0
+compiler.carmg1050.objdumper=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1050.demangler=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.carmg1140.exe=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carmg1140.semver=11.4.0
@@ -1411,7 +1416,7 @@ compiler.carmgtrunk.semver=trunk (linux)
 # 64 bit
 group.cgcc64arm.groupName=ARM64 gcc
 group.cgcc64arm.baseName=ARM64 GCC
-group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310
+group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -1442,6 +1447,11 @@ compiler.carm64g1030.exe=/opt/compiler-explorer/arm64/gcc-10.3.0/aarch64-unknown
 compiler.carm64g1030.semver=10.3.0
 compiler.carm64g1040.exe=/opt/compiler-explorer/arm64/gcc-10.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1040.semver=10.4.0
+
+compiler.carm64g1050.exe=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1050.semver=10.5.0
+compiler.carm64g1050.objdumper=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1050.demangler=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 compiler.carm64g1100.exe=/opt/compiler-explorer/arm64/gcc-11.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1100.semver=11.1.0
 compiler.carm64g1120.exe=/opt/compiler-explorer/arm64/gcc-11.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -370,7 +370,7 @@ compiler.friscvg1310.demangler=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1210:farmg1220:farmg1230:farmg1310:farmg1140
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1310
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
 
@@ -382,6 +382,11 @@ compiler.farmg730.semver=7.3
 
 compiler.farmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
 compiler.farmg820.semver=8.2
+
+compiler.farmg1050.exe=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1050.semver=10.5.0
+compiler.farmg1050.objdumper=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1050.demangler=/opt/compiler-explorer/arm/gcc-10.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.farmg1140.exe=/opt/compiler-explorer/arm/gcc-11.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
 compiler.farmg1140.semver=11.4.0
@@ -450,7 +455,7 @@ compiler.flangtrunknew.supportsBinary=false
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140
+group.gccaarch64.compilers=farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 group.gccaarch64.baseName=AARCH64 gfortran
 compiler.farm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
@@ -459,6 +464,11 @@ compiler.farm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-l
 compiler.farm64g730.semver=7.3
 compiler.farm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g820.semver=8.2
+
+compiler.farm64g1050.exe=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1050.semver=10.5.0
+compiler.farm64g1050.objdumper=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1050.demangler=/opt/compiler-explorer/arm64/gcc-10.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.farm64g1140.exe=/opt/compiler-explorer/arm64/gcc-11.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g1140.semver=11.4.0


### PR DESCRIPTION
fixes #5223

+ minor cleanup in compiler names.
+ minor reordering caused by the gcc-cross-builder script used to update
the config.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>