### PR TITLE
propcheck: applies to local config

### DIFF
--- a/etc/config/ada.defaults.properties
+++ b/etc/config/ada.defaults.properties
@@ -9,7 +9,6 @@ group.gnat.compilers=gnatdefault
 group.gnat.intelAsm=-masm=intel
 group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
-group.gnat.supportsBinaryObject=true
 group.gnat.objdumper=objdump
 
 compiler.gnatdefault.exe=/usr/bin/gnatmake

--- a/etc/config/analysis.defaults.properties
+++ b/etc/config/analysis.defaults.properties
@@ -16,7 +16,7 @@ compiler.llvm-mcatrunkdef.name=llvm-mca (trunk)
 compiler.llvm-mcatrunkdef.exe=/usr/bin/llvm-mca
 compiler.llvm-mcatrunkdef.alias=mcatrunk
 # Sets both input and output to Intel variant
-compiler.llvm-mcatrunk.intelAsm=--x86-asm-syntax=intel -output-asm-variant=1
+compiler.llvm-mcatrunkdef.intelAsm=--x86-asm-syntax=intel -output-asm-variant=1
 
 group.osaca.compilers=osacatrunkdef
 group.osaca.groupName=Open Source Architecture Code Analyzer

--- a/etc/config/c.defaults.properties
+++ b/etc/config/c.defaults.properties
@@ -1,6 +1,6 @@
 # Default settings for C
-compilers=:&gcc:&clang
-defaultCompiler=gdefault
+compilers=&gcc:&clang
+defaultCompiler=cgdefault
 demangler=c++filt
 objdumper=objdump
 postProcess=

--- a/etc/config/hlsl.defaults.properties
+++ b/etc/config/hlsl.defaults.properties
@@ -1,5 +1,9 @@
 compilers=&dxc:&rga:&clang
 
+defaultCompiler=dxc_default
+supportsBinary=false
+compilerType=hlsl
+
 group.dxc.compilers=dxc_default
 compiler.dxc_default.exe=/usr/dxc-artifacts/bin/dxc
 compiler.dxc_default.name=DXC
@@ -15,6 +19,3 @@ group.clang.compilerType=clang
 compiler.hlsl_clang_default.exe=/usr/bin/clang-trunk
 compiler.hlsl_clang_default.options=-emit-llvm
 
-defaultCompiler=dxc
-supportsBinary=false
-compilerType=hlsl

--- a/etc/config/modula2.defaults.properties
+++ b/etc/config/modula2.defaults.properties
@@ -1,6 +1,6 @@
 # Default settings for modula2
-compilers=:&gcc
-defaultCompiler=gdefault
+compilers=&gcc
+defaultCompiler=m2gdefault
 demangler=c++filt
 objdumper=objdump
 postProcess=

--- a/etc/config/objc.defaults.properties
+++ b/etc/config/objc.defaults.properties
@@ -1,6 +1,6 @@
 # Default settings for Objective-C
-compilers=:&gcc
-defaultCompiler=gdefault
+compilers=&gcc
+defaultCompiler=objcgdefault
 objdumper=objdump
 postProcess=
 supportsBinary=true

--- a/etc/config/openclc.defaults.properties
+++ b/etc/config/openclc.defaults.properties
@@ -18,7 +18,6 @@ compiler.openclcclang8.name=clang 8
 compiler.openclcclang8.options=-Xclang -finclude-default-header
 compiler.openclcclang9.exe=/usr/bin/clang-9
 compiler.openclcclang9.name=clang 9
-compiler.openclcclang8.options=-Xclang -finclude-default-header
 compiler.openclcclang10.exe=/usr/bin/clang-10
 compiler.openclcclang10.name=clang 10
 compiler.openclcclang10.options=-Xclang -finclude-default-header

--- a/etc/config/toit.defaults.properties
+++ b/etc/config/toit.defaults.properties
@@ -6,4 +6,4 @@ interpreted=true
 compilerType=toit
 versionFlag=version
 disasmScript=
-group.toit.intelAsm=-mllvm -x86-asm-syntax=intel
+intelAsm=-mllvm -x86-asm-syntax=intel

--- a/etc/scripts/util/propscheck.py
+++ b/etc/scripts/util/propscheck.py
@@ -26,6 +26,12 @@ import sys
 from os import listdir
 from os.path import isfile, join
 import re
+import argparse
+
+parser = argparse.ArgumentParser(description='Checks for incorrect/suspicious properties.')
+parser.add_argument ('--check-suspicious-in-local-prop', required=False, action="store_true")
+parser.add_argument ('--config-dir', required=False, default="./etc/config")
+
 
 PROP_RE = re.compile(r'([^# ]*)=(.*)#*')
 COMPILERS_LIST_RE = re.compile(r'compilers=(.*)')
@@ -95,7 +101,7 @@ def check_suspicious_path_and_add(line: Line, m, s):
         s.add(Line(line.number, m.group(2)))
 
 
-def process_file(file: str):
+def process_file(file: str, args):
     default_compiler = set()
 
     listed_groups = set()
@@ -127,6 +133,7 @@ def process_file(file: str):
     duplicated_compiler_references = set()
     duplicated_group_references = set()
 
+    suspicious_check = args.check_suspicious_in_local_prop or not (file.endswith('.defaults.properties') or file.endswith('.local.properties'))
     suspicious_path = set()
 
     seen_typo_compilers = set()
@@ -187,13 +194,16 @@ def process_file(file: str):
             match_and_add(line, GROUP_NAME_RE, seen_groups)
 
             match_compiler_exe = match_and_add(line, COMPILER_EXE_RE, seen_compilers_exe)
-            check_suspicious_path_and_add(line, match_compiler_exe, suspicious_path)
+            if suspicious_check:
+                check_suspicious_path_and_add(line, match_compiler_exe, suspicious_path)
 
             match_formatter_exe = match_and_add(line, FORMATTER_EXE_RE, seen_formatters_exe)
-            check_suspicious_path_and_add(line, match_formatter_exe, suspicious_path)
+            if suspicious_check:
+                check_suspicious_path_and_add(line, match_formatter_exe, suspicious_path)
 
             match_tool_exe = match_and_add(line, TOOL_EXE_RE, seen_tools_exe)
-            check_suspicious_path_and_add(line, match_tool_exe, suspicious_path)
+            if suspicious_check:
+                check_suspicious_path_and_add(line, match_tool_exe, suspicious_path)
 
             match_and_add(line, COMPILER_ID_RE, seen_compilers_id)
             match_and_add(line, TOOL_ID_RE, seen_tools_id)
@@ -241,21 +251,17 @@ def process_file(file: str):
         "duplicated_compiler_references": duplicated_compiler_references,
         "duplicated_group_references": duplicated_group_references,
         "suspicious_path": suspicious_path - disabled,
-        "typo_compilers": seen_typo_compilers - disabled
+        "typo_compilers": seen_typo_compilers - disabled,
     }
 
-
-def process_folder(folder: str):
-    return [(f, process_file(join(folder, f)))
+def process_folder(folder: str, args):
+    return [(f, process_file(join(folder, f), args))
             for f in listdir(folder)
             if isfile(join(folder, f))
-            and not (f.endswith('.defaults.properties') or f.endswith('.local.properties'))
             and f.endswith('.properties')]
-
 
 def problems_found(file_result):
     return any(len(file_result[r]) > 0 for r in file_result if r != "filename")
-
 
 def print_issue(name, result):
     if len(result) > 0:
@@ -263,8 +269,9 @@ def print_issue(name, result):
         print(f"{name}:\n  {sep.join(sorted([str(issue) for issue in result]))}")
 
 
-def find_orphans(folder: str):
-    result = sorted([(f, r) for (f, r) in process_folder(folder) if problems_found(r)], key=lambda x: x[0])
+def find_orphans(args: dict):
+    folder = args.config_dir
+    result = sorted([(f, r) for (f, r) in process_folder(folder, args) if problems_found(r)], key=lambda x: x[0])
     if result:
         print(f"Found {len(result)} property file(s) with issues:")
         for (filename, issues) in result:
@@ -282,5 +289,6 @@ def find_orphans(folder: str):
 
 
 if __name__ == '__main__':
-    if find_orphans('./etc/config/'):
+    args = parser.parse_args()
+    if find_orphans(args):
         sys.exit(1)


### PR DESCRIPTION
Applies to local config and fix existing issues.

By defaults, local and defaults are not checked for suspicious path (exe
not starting with /opt/compiler-explorer). This can be forced with the
--check-suspicious-in-local-prop.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>