### PR TITLE
README: Fix link to tinyurl URL shortener implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ parts of the configuration that are pulled from `www.godbolt.ms@443`.
 When running in a corporate setting the URL shortening service can be replaced by an internal one if the default storage
 driver isn't appropriate for your environment. To do this, add a new module in `lib/shortener/myservice.js` and set the
 `urlShortenService` variable in configuration. This module should export a single function, see the
-[tinyurl module](lib/shortener/tinyurl.js) for an example.
+[tinyurl module](lib/shortener/tinyurl.ts) for an example.
 
 ### RESTful API
 


### PR DESCRIPTION
The file has been converted to a TypeScript module in #4504 and the link to it
in README.md has not been updated then. Fix that.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
