### PR TITLE
Use period-correct GCC toolchains for old Clang releases (3.1-4.0)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -223,59 +223,63 @@ group.clang.compilerCategories=clang
 compiler.clang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-11_10/bin/clang++
 compiler.clang30.alias=/usr/bin/clang++
 compiler.clang30.semver=3.0.0
+compiler.clang30.options=-I/opt/compiler-explorer/gcc-4.6.4/lib/gcc/x86_64-linux-gnu/4.6.4/include -I/opt/compiler-explorer/gcc-4.6.4/include/c++/4.6.4 -I/opt/compiler-explorer/gcc-4.6.4/include/c++/4.6.4/x86_64-linux-gnu/
 compiler.clang30.options=
 compiler.clang30.supportsBinary=false
-# Older clangs don't support anything newer than GCC's 6.3
+# Clang 3.1 and above: let's try the latest stable GCC as of the time of build
 compiler.clang31.exe=/opt/compiler-explorer/clang+llvm-3.1-x86_64-linux-ubuntu_12.04/bin/clang++
 compiler.clang31.semver=3.1
-compiler.clang31.options=-gcc-toolchain /opt/compiler-explorer/gcc-6.3.0
+compiler.clang31.options=-gcc-toolchain /opt/compiler-explorer/gcc-4.7.4
 compiler.clang31.supportsBinary=false
 compiler.clang32.exe=/opt/compiler-explorer/clang-3.2/bin/clang++
 compiler.clang32.alias=/opt/clang-3.2/bin/clang++
 compiler.clang32.semver=3.2
-compiler.clang32.options=-gcc-toolchain /opt/compiler-explorer/gcc-6.3.0
+compiler.clang32.options=-gcc-toolchain /opt/compiler-explorer/gcc-4.7.4
 compiler.clang32.supportsBinary=false
 compiler.clang33.exe=/opt/compiler-explorer/clang-3.3/bin/clang++
 compiler.clang33.alias=/opt/clang-3.3/bin/clang++
 compiler.clang33.semver=3.3
-compiler.clang33.options=-gcc-toolchain /opt/compiler-explorer/gcc-6.3.0
+compiler.clang33.options=-gcc-toolchain /opt/compiler-explorer/gcc-4.8.5
 compiler.clang341.exe=/opt/compiler-explorer/clang+llvm-3.4.1-x86_64-unknown-ubuntu12.04/bin/clang++
 compiler.clang341.alias=/opt/clang+llvm-3.4.1-x86_64-unknown-ubuntu12.04/bin/clang++
 compiler.clang341.semver=3.4.1
-compiler.clang341.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang341.options=--gcc-toolchain=/opt/compiler-explorer/gcc-4.8.5
 compiler.clang350.exe=/opt/compiler-explorer/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang++
 compiler.clang350.semver=3.5
-compiler.clang350.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang350.options=--gcc-toolchain=/opt/compiler-explorer/gcc-4.9.4
 compiler.clang351.exe=/opt/compiler-explorer/clang+llvm-3.5.1-x86_64-linux-gnu/bin/clang++
 compiler.clang351.semver=3.5.1
-compiler.clang351.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang351.options=--gcc-toolchain=/opt/compiler-explorer/gcc-4.9.4
 compiler.clang352.exe=/opt/compiler-explorer/clang+llvm-3.5.2-x86_64-linux-gnu/bin/clang++
 compiler.clang352.semver=3.5.2
-compiler.clang352.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang352.options=--gcc-toolchain=/opt/compiler-explorer/gcc-4.9.4
 compiler.clang36x.exe=/opt/compiler-explorer/clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04/bin/clang++
 compiler.clang36x.semver=3.6
-compiler.clang36x.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang36x.options=--gcc-toolchain=/opt/compiler-explorer/gcc-4.9.4
 compiler.clang37x.exe=/opt/compiler-explorer/clang+llvm-3.7.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang++
 compiler.clang37x.semver=3.7
-compiler.clang37x.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang37x.options=--gcc-toolchain=/opt/compiler-explorer/gcc-5.5.0
 compiler.clang371.exe=/opt/compiler-explorer/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04/bin/clang++
 compiler.clang371.semver=3.7.1
-compiler.clang371.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang371.options=--gcc-toolchain=/opt/compiler-explorer/gcc-5.5.0
 compiler.clang380.exe=/opt/compiler-explorer/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang++
 compiler.clang380.semver=3.8
-compiler.clang380.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
+compiler.clang380.options=--gcc-toolchain=/opt/compiler-explorer/gcc-5.5.0
 compiler.clang381.exe=/opt/compiler-explorer/clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-14.04/bin/clang++
 compiler.clang381.semver=3.8.1
-compiler.clang381.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
-# Clang 3.9 onwards support the newer toolchains
+compiler.clang381.options=--gcc-toolchain=/opt/compiler-explorer/gcc-5.5.0
 compiler.clang390.exe=/opt/compiler-explorer/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang++
 compiler.clang390.semver=3.9.0
+compiler.clang390.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
 compiler.clang391.exe=/opt/compiler-explorer/clang-3.9.1/bin/clang++
 compiler.clang391.semver=3.9.1
+compiler.clang391.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
 compiler.clang400.exe=/opt/compiler-explorer/clang-4.0.0/bin/clang++
 compiler.clang400.semver=4.0.0
+compiler.clang400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
 compiler.clang401.exe=/opt/compiler-explorer/clang-4.0.1/bin/clang++
 compiler.clang401.semver=4.0.1
+compiler.clang401.options=--gcc-toolchain=/opt/compiler-explorer/gcc-6.3.0
 compiler.clang500.exe=/opt/compiler-explorer/clang-5.0.0/bin/clang++
 compiler.clang500.semver=5.0.0
 compiler.clang500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
@@ -291,7 +295,6 @@ compiler.clang600.semver=6.0.0
 compiler.clang601.exe=/opt/compiler-explorer/clang-6.0.1/bin/clang++
 compiler.clang601.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
 compiler.clang601.semver=6.0.1
-# Clang 7 and above: let's try the latest stable GCC as of the time of build
 compiler.clang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
 compiler.clang700.semver=7.0.0
 compiler.clang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -224,7 +224,6 @@ compiler.clang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-1
 compiler.clang30.alias=/usr/bin/clang++
 compiler.clang30.semver=3.0.0
 compiler.clang30.options=-I/opt/compiler-explorer/gcc-4.6.4/lib/gcc/x86_64-linux-gnu/4.6.4/include -I/opt/compiler-explorer/gcc-4.6.4/include/c++/4.6.4 -I/opt/compiler-explorer/gcc-4.6.4/include/c++/4.6.4/x86_64-linux-gnu/
-compiler.clang30.options=
 compiler.clang30.supportsBinary=false
 # Clang 3.1 and above: let's try the latest stable GCC as of the time of build
 compiler.clang31.exe=/opt/compiler-explorer/clang+llvm-3.1-x86_64-linux-ubuntu_12.04/bin/clang++


### PR DESCRIPTION
To make it consistent with newer Clang releases, all Clang assertion builds, and user expectations.

The problem
========
Release Clang builds 3.1 through 4.0.1 are using newer GCC 6.3.0 toolchain by default. Major GCC 6.1 release happened 2.5 years after Clang 3.1 release, which makes Clang 3.1 on CE non-period-correct experience. We at LLVM were bitten by that while trying to triage old Clang bugs, so I claim that current experience is off from user expectations.

Starting with release builds of Clang 5, CE defaults to latest GCC release for toolchain, providing period-correct experience. That makes old Clang builds inconsistent with your current policy regarding newer release Clang builds.

Recently introduced Clang builds with assertions enabled use period-correct GCC toolchains in all versions, because period-correct Clang experience is paramount for triaging old bugs. Old release builds are not consistent with that either, which by default leads to a difference in compiler output that doesn't come from _just_ enabling assertions.

The solution
========
I think the best long-term solution is to fix this inconsistency, using the same period-correct GCC toolchains as assertion builds.

This would change output in the links that rely on the difference between old and new GCC standard library. I'd estimate that number of such links is not high. I'd argue that if something worked there, it shouldn't have in the first place.