### PR TITLE
Use session _then_ local storage for saved state

### DIFF
--- a/static/history.ts
+++ b/static/history.ts
@@ -22,9 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import * as local from './local.js';
 import _ from 'underscore';
 import {Sharing} from './sharing.js';
+import {localStorage} from './local.js';
 
 const maxHistoryEntries = 30;
 type Source = {dt: number; source: string};
@@ -50,7 +50,7 @@ function extractEditorSources(content: any[]): EditorSource[] {
 }
 
 function list(): HistoryEntry[] {
-    return JSON.parse(local.get('history', '[]'));
+    return JSON.parse(localStorage.get('history', '[]'));
 }
 
 function getArrayWithJustTheCode(editorSources: Record<string, any>[]): string[] {
@@ -92,7 +92,7 @@ function push(stringifiedConfig: string) {
             completeHistory[duplicateIdx].dt = Date.now();
         }
 
-        local.set('history', JSON.stringify(completeHistory));
+        localStorage.set('history', JSON.stringify(completeHistory));
     }
 }
 

--- a/static/presentation.ts
+++ b/static/presentation.ts
@@ -22,26 +22,26 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import * as local from './local.js';
+import {localStorage} from './local.js';
 
 const CURRENT_SLIDE_KEY = 'presentationCurrentSlide';
 
 export class Presentation {
-    public currentSlide = parseInt(local.get(CURRENT_SLIDE_KEY, '0'));
+    public currentSlide = parseInt(localStorage.get(CURRENT_SLIDE_KEY, '0'));
     public originalLocation = window.location.href;
 
     public constructor(public maxSlides: number) {}
 
     public first() {
         this.currentSlide = 0;
-        local.set(CURRENT_SLIDE_KEY, this.currentSlide.toString(10));
+        localStorage.set(CURRENT_SLIDE_KEY, this.currentSlide.toString(10));
         this.show();
     }
 
     public next() {
         if (this.currentSlide < this.maxSlides - 1) {
             this.currentSlide++;
-            local.set(CURRENT_SLIDE_KEY, this.currentSlide.toString(10));
+            localStorage.set(CURRENT_SLIDE_KEY, this.currentSlide.toString(10));
             this.show();
         }
     }
@@ -49,7 +49,7 @@ export class Presentation {
     public previous() {
         if (this.currentSlide > 0) {
             this.currentSlide--;
-            local.set(CURRENT_SLIDE_KEY, this.currentSlide.toString(10));
+            localStorage.set(CURRENT_SLIDE_KEY, this.currentSlide.toString(10));
             this.show();
         }
     }

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -25,7 +25,6 @@
 import $ from 'jquery';
 import {options} from './options.js';
 import * as colour from './colour.js';
-import * as local from './local.js';
 import {themes, Themes} from './themes.js';
 import {AppTheme, ColourScheme, ColourSchemeInfo} from './colour.js';
 import {Hub} from './hub.js';
@@ -34,6 +33,7 @@ import {keys, isString} from '../shared/common-utils.js';
 import {assert, unwrapString} from './assert.js';
 
 import {LanguageKey} from '../types/languages.interfaces.js';
+import {localStorage} from './local.js';
 
 export type FormatBase = 'Google' | 'LLVM' | 'Mozilla' | 'Chromium' | 'WebKit' | 'Microsoft' | 'GNU';
 
@@ -232,7 +232,7 @@ export class Settings {
     }
 
     public static getStoredSettings(): SiteSettings {
-        return JSON.parse(local.get('settings', '{}'));
+        return JSON.parse(localStorage.get('settings', '{}'));
     }
 
     public setSettings(newSettings: SiteSettings) {

--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -26,7 +26,7 @@ import $ from 'jquery';
 import GoldenLayout from 'golden-layout';
 import _ from 'underscore';
 import ClipboardJS from 'clipboard';
-import {set as localStorageSet} from './local.js';
+import {sessionThenLocalStorage} from './local.js';
 import {ga} from './analytics.js';
 import * as url from './url.js';
 import {options} from './options.js';
@@ -122,7 +122,7 @@ export class Sharing {
         });
 
         $(window).on('blur', async () => {
-            localStorageSet('gl', JSON.stringify(this.layout.toConfig()));
+            sessionThenLocalStorage.set('gl', JSON.stringify(this.layout.toConfig()));
             if (this.settings.keepMultipleTabs) {
                 try {
                     const link = await this.getLinkOfType(LinkType.Full);

--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -31,8 +31,8 @@ import {
 } from '../../types/compilation/compiler-overrides.interfaces.js';
 import {options} from '../options.js';
 import {CompilerInfo} from '../compiler.interfaces.js';
-import * as local from '../local.js';
 import {assert, unwrap} from '../assert.js';
+import {localStorage} from '../local.js';
 
 const FAV_OVERRIDES_STORE_KEY = 'favoverrides';
 
@@ -339,11 +339,11 @@ export class CompilerOverridesWidget {
     }
 
     private getFavorites(): FavOverrides {
-        return JSON.parse(local.get(FAV_OVERRIDES_STORE_KEY, '[]'));
+        return JSON.parse(localStorage.get(FAV_OVERRIDES_STORE_KEY, '[]'));
     }
 
     private setFavorites(faves: FavOverrides) {
-        local.set(FAV_OVERRIDES_STORE_KEY, JSON.stringify(faves));
+        localStorage.set(FAV_OVERRIDES_STORE_KEY, JSON.stringify(faves));
     }
 
     private updateButton() {

--- a/static/widgets/compiler-picker.ts
+++ b/static/widgets/compiler-picker.ts
@@ -26,13 +26,13 @@ import $ from 'jquery';
 import TomSelect from 'tom-select';
 
 import {ga} from '../analytics.js';
-import * as local from '../local.js';
 import {EventHub} from '../event-hub.js';
 import {Hub} from '../hub.js';
 import {CompilerService} from '../compiler-service.js';
 import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import {unwrap} from '../assert.js';
 import {CompilerPickerPopup} from './compiler-picker-popup.js';
+import {localStorage} from '../local.js';
 
 type Favourites = {
     [compilerId: string]: boolean;
@@ -250,11 +250,11 @@ export class CompilerPicker {
     }
 
     getFavorites(): Favourites {
-        return JSON.parse(local.get(CompilerPicker.favoriteStoreKey, '{}'));
+        return JSON.parse(localStorage.get(CompilerPicker.favoriteStoreKey, '{}'));
     }
 
     setFavorites(faves: Favourites) {
-        local.set(CompilerPicker.favoriteStoreKey, JSON.stringify(faves));
+        localStorage.set(CompilerPicker.favoriteStoreKey, JSON.stringify(faves));
     }
 
     isAFavorite(compilerId: string) {

--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -24,10 +24,10 @@
 
 import $ from 'jquery';
 import {options} from '../options.js';
-import * as local from '../local.js';
 import {Library, LibraryVersion} from '../options.interfaces.js';
 import {Lib, WidgetState} from './libs-widget.interfaces.js';
 import {unwrapString} from '../assert.js';
+import {localStorage} from '../local.js';
 
 const FAV_LIBS_STORE_KEY = 'favlibs';
 
@@ -138,11 +138,11 @@ export class LibsWidget {
     }
 
     getFavorites(): FavLibraries {
-        return JSON.parse(local.get(FAV_LIBS_STORE_KEY, '{}'));
+        return JSON.parse(localStorage.get(FAV_LIBS_STORE_KEY, '{}'));
     }
 
     setFavorites(faves: FavLibraries) {
-        local.set(FAV_LIBS_STORE_KEY, JSON.stringify(faves));
+        localStorage.set(FAV_LIBS_STORE_KEY, JSON.stringify(faves));
     }
 
     isAFavorite(libId: string, versionId: string): boolean {

--- a/static/widgets/load-save.ts
+++ b/static/widgets/load-save.ts
@@ -27,10 +27,10 @@ import _ from 'underscore';
 import {saveAs} from 'file-saver';
 import {Alert} from './alert.js';
 import {ga} from '../analytics.js';
-import * as local from '../local.js';
 import {Language} from '../../types/languages.interfaces.js';
 import {unwrap, unwrapString} from '../assert.js';
 import {escapeHTML} from '../../shared/common-utils.js';
+import {localStorage} from '../local.js';
 
 const history = require('../history');
 
@@ -55,13 +55,13 @@ export class LoadSave {
     }
 
     public static getLocalFiles(): Record<string, string> {
-        return JSON.parse(local.get('files', '{}'));
+        return JSON.parse(localStorage.get('files', '{}'));
     }
 
     public static setLocalFile(name: string, file: string) {
         const files = LoadSave.getLocalFiles();
         files[name] = file;
-        local.set('files', JSON.stringify(files));
+        localStorage.set('files', JSON.stringify(files));
     }
 
     public static removeLocalFile(name: string) {
@@ -69,7 +69,7 @@ export class LoadSave {
         if (name in files) {
             delete files[name];
         }
-        local.set('files', JSON.stringify(files));
+        localStorage.set('files', JSON.stringify(files));
     }
 
     private async fetchBuiltins(): Promise<Record<string, any>[]> {

--- a/static/widgets/site-templates-widget.ts
+++ b/static/widgets/site-templates-widget.ts
@@ -27,11 +27,11 @@ import $ from 'jquery';
 import {SiteTemplatesType, UserSiteTemplate} from '../../types/features/site-templates.interfaces.js';
 import {assert, unwrap, unwrapString} from '../assert.js';
 import {Settings} from '../settings.js';
-import * as local from '../local.js';
 import * as url from '../url.js';
 import GoldenLayout from 'golden-layout';
 import {Alert} from './alert.js';
 import {escapeHTML} from '../../shared/common-utils.js';
+import {localStorage} from '../local.js';
 
 class SiteTemplatesWidget {
     private readonly modal: JQuery;
@@ -62,7 +62,7 @@ class SiteTemplatesWidget {
         this.alertSystem.enterSomething('Template Name', '', '', {
             yes: name => {
                 const userTemplates: Record<string, UserSiteTemplate> = JSON.parse(
-                    local.get('userSiteTemplates', '{}'),
+                    localStorage.get('userSiteTemplates', '{}'),
                 );
                 let timestamp = Date.now();
                 while (`t${timestamp}` in userTemplates) timestamp++;
@@ -70,7 +70,7 @@ class SiteTemplatesWidget {
                     title: unwrapString(name),
                     data,
                 };
-                local.set('userSiteTemplates', JSON.stringify(userTemplates));
+                localStorage.set('userSiteTemplates', JSON.stringify(userTemplates));
                 this.populateUserTemplates();
             },
         });
@@ -107,7 +107,7 @@ class SiteTemplatesWidget {
         this.img.src = this.getAsset(first.replace(/[^a-z]/gi, ''));
     }
     populateUserTemplates() {
-        const userTemplates: Record<string, UserSiteTemplate> = JSON.parse(local.get('userSiteTemplates', '{}'));
+        const userTemplates: Record<string, UserSiteTemplate> = JSON.parse(localStorage.get('userSiteTemplates', '{}'));
         const userTemplatesList = $('#site-user-templates-list');
         userTemplatesList.empty();
         if (Object.entries(userTemplates).length === 0) {
@@ -123,10 +123,10 @@ class SiteTemplatesWidget {
             }
             userTemplatesList.find('li .delete').on('click', e => {
                 const userTemplates: Record<string, UserSiteTemplate> = JSON.parse(
-                    local.get('userSiteTemplates', '{}'),
+                    localStorage.get('userSiteTemplates', '{}'),
                 );
                 delete userTemplates[unwrap($(e.target).parent('.delete').attr('data-id'))];
-                local.set('userSiteTemplates', JSON.stringify(userTemplates));
+                localStorage.set('userSiteTemplates', JSON.stringify(userTemplates));
                 this.populate();
             });
         }


### PR DESCRIPTION
In conversation with @mknejp he pointed out that it can be frustating when having a browser loaded up with many tabs of CE links, then reloading the browser (e.g. a reboot, or open/closing the tabs), that upon reload all the tabs will have the same, shared state (corresponding to whichever saved to local storage last).

This change:
- stores state in _both_ session and local storage
- removes from both on UI reset
- loads first from session storage and then falls back to local storage

The net result is:
- tabs reopened with "ctrl-shift T" will regain their prior state, as do any other tabs for which the browser thinks are part of the same session (like on a "reopen tabs" plugins etc)
- newly-opened tabs still have the prior behaviour of using whatever the most recently opened tab had as its starting state

Some more info on session vs local storage [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
