### PR TITLE
Add GCC 13.2.0 native

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,20 +1,20 @@
 # Default settings for Ada
 compilers=&gnat:&gnatcross
-defaultCompiler=gnat131
+defaultCompiler=gnat132
 versionFlag=--version
 compilerType=ada
 
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat131:gnatsnapshot
+group.gnat.compilers=gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat131:gnat132:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=X86-64 GNAT
 group.gnat.baseName=x86-64 gnat
 group.gnat.supportsBinary=true
 group.gnat.supportsExecute=true
-group.gnat.objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
-group.gnat.demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
+group.gnat.objdumper=/opt/compiler-explorer/gcc-13.2.0/bin/objdump
+group.gnat.demangler=/opt/compiler-explorer/gcc-13.2.0/bin/c++filt
 group.gnat.isSemVer=true
 group.gnat.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.gnat.licenseName=GNU General Public License
@@ -49,6 +49,8 @@ compiler.gnat123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gnatmake
 compiler.gnat123.semver=12.3
 compiler.gnat131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gnatmake
 compiler.gnat131.semver=13.1
+compiler.gnat132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gnatmake
+compiler.gnat132.semver=13.2
 compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnatmake
 compiler.gnatsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rv
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
-defaultCompiler=g131
+defaultCompiler=g132
 demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 needsMulti=false
@@ -17,7 +17,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g131:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g131:g132:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -153,6 +153,8 @@ compiler.g123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/g++
 compiler.g123.semver=12.3
 compiler.g131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 compiler.g131.semver=13.1
+compiler.g132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+compiler.g132.semver=13.2
 
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:www.godbolt.ms@443:godbolt.org@443/winprod:&movfuscator
-defaultCompiler=cg131
+defaultCompiler=cg132
 demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 needsMulti=false
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cg132:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -131,6 +131,8 @@ compiler.cg123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gcc
 compiler.cg123.semver=12.3
 compiler.cg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gcc
 compiler.cg131.semver=13.1
+compiler.cg132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gcc
+compiler.cg132.semver=13.2
 
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gdc:&ldc:&dmd:&gdccross
 defaultCompiler=ldc1_32
 
-group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc131:gdctrunk
+group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc131:gdc132:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
@@ -46,6 +46,9 @@ compiler.gdc123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gdc
 compiler.gdc123.semver=12.3
 compiler.gdc131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gdc
 compiler.gdc131.semver=13.1
+compiler.gdc132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gdc
+compiler.gdc132.semver=13.2
+
 compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gdctrunk.semver=(trunk)

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&gfortran_86:&ifort:&ifx:&cross:&clang_llvmflang
-defaultCompiler=gfortran131
-demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
+defaultCompiler=gfortran132
+demangler=/opt/compiler-explorer/gcc-13.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-13.2.0/bin/objdump
 compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran131:gfortransnapshot
+group.gfortran_86.compilers=gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran131:gfortran132:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -66,6 +66,8 @@ compiler.gfortran123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gfortran
 compiler.gfortran123.semver=12.3
 compiler.gfortran131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gfortran
 compiler.gfortran131.semver=13.1
+compiler.gfortran132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gfortran
+compiler.gfortran132.semver=13.2
 
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gccgo:&gl:&cross
 defaultCompiler=gl1200
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 
-group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo131
+group.gccgo.compilers=gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo131:gccgo132
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -39,6 +39,8 @@ compiler.gccgo123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gccgo
 compiler.gccgo123.semver=12.3.0
 compiler.gccgo131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gccgo
 compiler.gccgo131.semver=13.1
+compiler.gccgo132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gccgo
+compiler.gccgo132.semver=13.2
 
 group.gl.compilers=&x86gl:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl
 group.gl.versionFlag=version

--- a/etc/config/modula2.amazon.properties
+++ b/etc/config/modula2.amazon.properties
@@ -1,6 +1,6 @@
 # Default settings for modula2
 compilers=&gm2
-defaultCompiler=gm2131
+defaultCompiler=gm2132
 
 demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -15,13 +15,15 @@ needsMulti=false
 externalparser=CEAsmParser
 externalparser.exe=/usr/local/bin/asm-parser
 
-group.gm2.compilers=gm2131:gm2snapshot
+group.gm2.compilers=gm2131:gm2132:gm2snapshot
 group.gm2.instructionSet=amd64
 group.gm2.isSemVer=true
 group.gm2.baseName=x86-64 gcc gm2
 
 compiler.gm2131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gm2
 compiler.gm2131.semver=13.1
+compiler.gm2132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gm2
+compiler.gm2132.semver=13.2
 
 compiler.gm2snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gm2
 compiler.gm2snapshot.semver=(snapshot)

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&objcppgcc86:&objcppcross
-defaultCompiler=objcppg131
-demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
+defaultCompiler=objcppg132
+demangler=/opt/compiler-explorer/gcc-13.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-13.2.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.objcppgcc86.compilers=objcppg105:objcppg114:objcppg122:objcppg123:objcppg131:objcppgsnapshot
+group.objcppgcc86.compilers=objcppg105:objcppg114:objcppg122:objcppg123:objcppg131:objcppg132:objcppgsnapshot
 group.objcppgcc86.groupName=GCC x86-64
 group.objcppgcc86.instructionSet=amd64
 group.objcppgcc86.baseName=x86-64 gcc
@@ -40,6 +40,9 @@ compiler.objcppg123.semver=12.3
 
 compiler.objcppg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 compiler.objcppg131.semver=13.1
+
+compiler.objcppg132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+compiler.objcppg132.semver=13.2
 
 compiler.objcppgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.objcppgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&objcgcc86:&objccross
-defaultCompiler=objcg131
-demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
+defaultCompiler=objcg132
+demangler=/opt/compiler-explorer/gcc-13.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-13.2.0/bin/objdump
 needsMulti=false
 
 externalparser=CEAsmParser
@@ -9,7 +9,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.objcgcc86.compilers=objcg105:objcg114:objcg122:objcg123:objcg131:objcgsnapshot
+group.objcgcc86.compilers=objcg105:objcg114:objcg122:objcg123:objcg131:objcg132:objcgsnapshot
 group.objcgcc86.groupName=GCC x86-64
 group.objcgcc86.instructionSet=amd64
 group.objcgcc86.isSemVer=true
@@ -33,6 +33,9 @@ compiler.objcg123.semver=12.3
 
 compiler.objcg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gcc
 compiler.objcg131.semver=13.1
+
+compiler.objcg132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gcc
+compiler.objcg132.semver=13.2
 
 compiler.objcgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.objcgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt


### PR DESCRIPTION
Following 13.2.0 release: https://inbox.sourceware.org/gcc/nycvar.YFH.7.77.849.2307270924461.12935@jbgna.fhfr.qr/T/#u

refs https://github.com/compiler-explorer/compiler-explorer/issues/5283