### PR TITLE
C/C++ Add support for libbpf

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2627,7 +2627,7 @@ compiler.nvcxx_arm_cxx23_5.semver=23.5
 #################################
 #################################
 # Installed libs
-libs=abseil:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt
+libs=abseil:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -3389,6 +3389,16 @@ libs.libassert.versions.10.version=1.0
 libs.libassert.versions.10.path=/opt/compiler-explorer/libs/libassert/v1.0/include
 libs.libassert.versions.11.version=1.1
 libs.libassert.versions.11.path=/opt/compiler-explorer/libs/libassert/v1.1/include
+
+libs.libbpf.name=libbpf
+libs.libbpf.versions=100:122
+libs.libbpf.liblink=bpf:dl:m
+libs.libbpf.description=Libbpf supports building BPF CO-RE-enabled applications
+libs.libbpf.url=https://github.com/libbpf/libbpf
+libs.libbpf.versions.100.version=1.0.0
+libs.libbpf.versions.100.path=/opt/compiler-explorer/libs/libbpf/v1.0.0/include
+libs.libbpf.versions.122.version=1.2.2
+libs.libbpf.versions.122.path=/opt/compiler-explorer/libs/libbpf/v1.2.2/include
 
 libs.libguarded.name=CsLibGuarded
 libs.libguarded.versions=trunk:110

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2497,7 +2497,7 @@ compiler.movfuscatortrunk.name=movfuscator (trunk)
 #################################
 #################################
 # Libraries
-libs=cs50:hedley:libuv:lua:nsimd:openssl:python:simde:curl:sqlite
+libs=cs50:hedley:libbpf:libuv:lua:nsimd:openssl:python:simde:curl:sqlite
 
 libs.cs50.name=cs50
 libs.cs50.versions=910
@@ -2512,6 +2512,16 @@ libs.hedley.versions=v12
 libs.hedley.url=https://github.com/nemequ/hedley
 libs.hedley.versions.v12.version=12.0.0
 libs.hedley.versions.v12.path=/opt/compiler-explorer/libs/hedley/v12/
+
+libs.libbpf.name=libbpf
+libs.libbpf.versions=100:122
+libs.libbpf.liblink=bpf:dl:m
+libs.libbpf.description=Libbpf supports building BPF CO-RE-enabled applications
+libs.libbpf.url=https://github.com/libbpf/libbpf
+libs.libbpf.versions.100.version=1.0.0
+libs.libbpf.versions.100.path=/opt/compiler-explorer/libs/libbpf/v1.0.0/include
+libs.libbpf.versions.122.version=1.2.2
+libs.libbpf.versions.122.path=/opt/compiler-explorer/libs/libbpf/v1.2.2/include
 
 libs.lua.name=Lua
 libs.lua.versions=535:540


### PR DESCRIPTION
This change adds support for [libbpf](https://github.com/libbpf/libbpf). libbpf can be used as either a C/C++ library, so please correct if the configuration is incorrect. I tested locally by copying the config to the local config.
![2023-07-28-20:56:04](https://github.com/compiler-explorer/compiler-explorer/assets/2632746/1a9b539c-a139-477e-9961-c7d87b7a3215)
