### PR TITLE
Sort settings language keys before presenting in ui

### DIFF
--- a/static/settings.ts
+++ b/static/settings.ts
@@ -338,6 +338,7 @@ export class Settings {
         const defaultLanguageData = Object.keys(langs).map(lang => {
             return {label: langs[lang].id, desc: langs[lang].name};
         });
+        defaultLanguageData.sort((a, b) => a.desc.localeCompare(b.desc));
         addSelector('.defaultLanguage', 'defaultLanguage', defaultLanguageData, defLang as LanguageKey);
 
         if (this.subLangId) {


### PR DESCRIPTION
Fixes #5007

I tried to investigate a bit further into why the keys aren't sorted when returned from server, but concluded that it probably depends on what order the config files were loaded.

It's probably not worth changing anything on the server, and we already do this sorting for the language dropdown https://github.com/compiler-explorer/compiler-explorer/blob/4260313e13aa3ec057806979dfac3fe6fd856b19/static/panes/editor.ts#L555-L556

