### PR TITLE
Fix execution with library selection in different languages

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -870,7 +870,7 @@ export class BaseCompiler implements ICompiler {
                 if (!foundVersion) return false;
 
                 const paths = [...foundVersion.libpath];
-                if (!this.buildenvsetup.extractAllToRoot) {
+                if (this.buildenvsetup && !this.buildenvsetup.extractAllToRoot) {
                     paths.push(`/app/${selectedLib.id}/lib`);
                 }
                 return paths;


### PR DESCRIPTION
Should fix issues when libraries are selected in other languages than c/c++/circle/rust

Example that gave an error https://godbolt.org/z/hTe6EoGez
