### PR TITLE
New Compiler: Hexagon-clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -849,6 +849,17 @@ compiler.wasm32clang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.wasm32clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.wasm32clang.name=WebAssembly clang (trunk)
 compiler.wasm32clang.options=-target wasm32
+
+################################
+# Clang for Hexagon
+group.hexagon-clang.groupName=Hexagon clang
+group.hexagon-clang.baseName=hexagon-clang
+group.hexagon-clang.compilers=hexagonclang1605
+compiler.hexagonclang1605.semver=16.0.5
+compiler.hexagonclang1605.name=hexagon-clang 16.0.5
+compiler.hexagonclang1605.exe=/opt/compiler-explorer/clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl/x86_64-linux-gnu/bin/clang++
+compiler.hexagonclang1605.compilerType=clang-hexagon
+compiler.hexagonclang1605.compilerCategories=clang-hexagon
 
 ################################
 # icc for x86

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -38,6 +38,7 @@ export {ClangCLCompiler} from './clangcl.js';
 export {ClangCudaCompiler} from './clang.js';
 export {ClangHipCompiler} from './clang.js';
 export {ClangIntelCompiler} from './clang.js';
+export {ClangHexagonCompiler} from './clang.js';
 export {CleanCompiler} from './clean.js';
 export {CompCertCompiler} from './compcert.js';
 export {CppFrontCompiler} from './cppfront.js';

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -34,6 +34,7 @@ import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.in
 import {BaseCompiler} from '../base-compiler.js';
 import {AmdgpuAsmParser} from '../parsers/asm-parser-amdgpu.js';
 import {SassAsmParser} from '../parsers/asm-parser-sass.js';
+import {HexagonAsmParser} from '../parsers/asm-parser-hexagon.js';
 import * as utils from '../utils.js';
 import {ArtifactType} from '../../types/tool.interfaces.js';
 
@@ -328,5 +329,17 @@ export class ClangIntelCompiler extends ClangCompiler {
             ...executeParameters.env,
         };
         return super.runExecutable(executable, executeParameters, homeDir);
+    }
+}
+
+export class ClangHexagonCompiler extends ClangCompiler {
+    static override get key() {
+        return 'clang-hexagon';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env) {
+        super(info, env);
+
+        this.asm = new HexagonAsmParser();
     }
 }

--- a/lib/parsers/asm-parser-hexagon.ts
+++ b/lib/parsers/asm-parser-hexagon.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {PropertyGetter} from '../properties.interfaces.js';
+import {AsmParser} from './asm-parser.js';
+
+export class HexagonAsmParser extends AsmParser {
+    vliwPacketBegin: RegExp;
+    vliwPacketEnd: RegExp;
+
+    constructor(compilerProps?: PropertyGetter) {
+        super(compilerProps);
+
+        this.vliwPacketBegin = /^\s*{\s*$/;
+        this.vliwPacketEnd = /^\s*}\s*(?::\w+)?\s*$/;
+    }
+
+    override checkVLIWpacket(line, inVLIWpacket) {
+        if (this.vliwPacketBegin.test(line)) {
+            return true;
+        } else if (this.vliwPacketEnd.test(line)) {
+            return false;
+        }
+
+        return inVLIWpacket;
+    }
+
+    override hasOpcode(line, inNvccCode, inVLIWpacket?) {
+        // Remove any leading label definition...
+        const match = line.match(this.labelDef);
+        if (match) {
+            line = line.substr(match[0].length);
+        }
+        // Strip any comments
+        line = line.split(this.commentRe, 1)[0];
+        // .inst generates an opcode, so also counts
+        if (this.instOpcodeRe.test(line)) return true;
+        if (inVLIWpacket) {
+            return !(this.vliwPacketBegin.test(line) || this.vliwPacketEnd.test(line));
+        }
+        // Detect assignment, that's not an opcode...
+        if (this.assignmentDef.test(line)) return false;
+        return !!this.hasOpcodeRe.test(line);
+    }
+}


### PR DESCRIPTION
**Related to:** compiler-explorer/infra#1061

**Goal:-**
To enable back-end support for hexagon clang compiler so that it can be used on the Compiler Explorer's website ([https://godbolt.org/.](https://godbolt.org/)) This will be particularly useful to people working on Hexagon Digital Signal Processor (DSP) developed by Qualcomm Technologies.

**Information about Hexagon DSP:-**
[https://developer.qualcomm.com/software/hexagon-dsp-sdk/dsp-processor](https://developer.qualcomm.com/software/hexagon-dsp-sdk/dsp-processor)