### PR TITLE
Add YOMM2 1.4.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2755,7 +2755,7 @@ compiler.nvcxx_arm_cxx23_5.semver=23.5
 #################################
 #################################
 # Installed libs
-libs=abseil:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt
+libs=abseil:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -4166,6 +4166,13 @@ libs.xtl.versions.053.version=0.5.3
 libs.xtl.versions.053.path=/opt/compiler-explorer/libs/xtl/0.5.3/include
 libs.xtl.versions.0416.version=0.4.16
 libs.xtl.versions.0416.path=/opt/compiler-explorer/libs/xtl/0.4.16/include
+
+libs.yomm2.name=YOMM2
+libs.yomm2.description=Fast Open Multi-Methods
+libs.yomm2.versions=trunk
+libs.yomm2.url=https://github.com/jll63/yomm2
+libs.yomm2.versions.trunk.version=trunk
+libs.yomm2.versions.trunk.path=/opt/compiler-explorer/libs/yomm2/trunk/include
 
 libs.ztdcuneicode.name=ztd.cuneicode
 libs.ztdcuneicode.url=https://github.com/soasis/cuneicode


### PR DESCRIPTION
A while ago, I opened https://github.com/compiler-explorer/compiler-explorer/issues/3818. Work started on it, but it stalled. In the meantime, I learned how to add a library to CE, and tested my changes on a local instance.

### Library name

YOMM2

### Library description

YOMM2 implements fast, open multi-methods that closely follow the proposal by Peter Pirkelbauer, Yuriy Solodkyy and Bjarne Stroustrup [in this paper](https://www.stroustrup.com/multimethods.pdf)

### Library repository

https://github.com/jll63/yomm2

