### PR TITLE
fix: correct some compiler categories

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2191,7 +2191,7 @@ compiler.rv32-cgcc1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unk
 compiler.rv32-cgcc1020.semver=10.2.0
 compiler.rv32-cgcc1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 
-compiler.rv32-cgcc1030.exe=/opt/compiler-explorer/riscv64/gcc-10.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1030.exe=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gcc
 compiler.rv32-cgcc1030.semver=10.3.0
 compiler.rv32-cgcc1030.objdumper=/opt/compiler-explorer/riscv32/gcc-10.3.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -49,10 +49,10 @@ export class InstructionSets {
             },
             c6x: {
                 target: ['c6x'],
-                path: ['/c6x-'],
+                path: ['/tic6x-'],
             },
             ebpf: {
-                target: ['ebpf'],
+                target: ['bpf'],
                 path: ['/bpf-'],
             },
             kvx: {
@@ -63,9 +63,13 @@ export class InstructionSets {
                 target: ['loongarch'],
                 path: ['/loongarch64-'],
             },
+            m68k: {
+                target: ['m68k'],
+                path: ['/m68k-'],
+            },
             mips: {
                 target: ['mips'],
-                path: ['/mips', '/mipsel-', '/mips64el-', '/mips64-'],
+                path: ['/mips', '/mipsel-', '/mips64el-', '/mips64-', '/nanomips-'],
             },
             mrisc32: {
                 target: ['mrisc32'],

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -37,6 +37,7 @@ export const InstructionSetsList = [
     'kvx',
     'llvm',
     'loongarch',
+    'm68k',
     'mips',
     'mos6502',
     'mrisc32',


### PR DESCRIPTION
Some compilers were badly assigned the default ISA (amd64).

Also fix rv32 GCC 10.3.0 that was pointing to the rv64 toolchain.

fix #5328

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>