### PR TITLE
Fix for old links where language is not set in the editor

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -117,10 +117,9 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         if ((state.lang as any) === undefined && Object.keys(languages).length > 0) {
             if (!this.currentLanguage) {
                 // Primarily a diagnostic for urls created outside CE. Addresses #4817.
-                this.alertSystem.alert('State Error', 'No language specified for editor', {isError: true});
+                this.alertSystem.notify('No language specified for editor', {});
             } else {
-                // eslint-disable-next-line no-console
-                console.error('No language specified for editor, using ' + this.currentLanguage.id);
+                this.alertSystem.notify('No language specified for editor, using ' + this.currentLanguage.id, {});
             }
         } else if (!(state.lang in languages) && Object.keys(languages).length > 0) {
             this.alertSystem.alert('State Error', 'Unknown language specified for editor', {isError: true});

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -119,6 +119,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                 // Primarily a diagnostic for urls created outside CE. Addresses #4817.
                 this.alertSystem.alert('State Error', 'No language specified for editor', {isError: true});
             } else {
+                // eslint-disable-next-line no-console
                 console.error('No language specified for editor, using ' + this.currentLanguage.id);
             }
         } else if (!(state.lang in languages) && Object.keys(languages).length > 0) {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -323,6 +323,10 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.waitingForLanguage = Boolean(state.source && !state.lang);
         if (this.settings.defaultLanguage && this.settings.defaultLanguage in languages) {
             newLanguage = languages[this.settings.defaultLanguage];
+        } else if (this.hub.defaultLangId && this.hub.defaultLangId in languages) {
+            // the first time the user visits the site (or particular domain), this.settings might not be set yet
+            //  use the hub's default lang if possible
+            newLanguage = languages[this.hub.defaultLangId];
         }
 
         if (state.lang && state.lang in languages) {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -115,8 +115,12 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.alertSystem.prefixMessage = 'Editor #' + this.id;
 
         if ((state.lang as any) === undefined && Object.keys(languages).length > 0) {
-            // Primarily a diagnostic for urls created outside CE. Addresses #4817.
-            this.alertSystem.alert('State Error', 'No language specified for editor', {isError: true});
+            if (!this.currentLanguage) {
+                // Primarily a diagnostic for urls created outside CE. Addresses #4817.
+                this.alertSystem.alert('State Error', 'No language specified for editor', {isError: true});
+            } else {
+                console.error('No language specified for editor, using ' + this.currentLanguage.id);
+            }
         } else if (!(state.lang in languages) && Object.keys(languages).length > 0) {
             this.alertSystem.alert('State Error', 'Unknown language specified for editor', {isError: true});
         }


### PR DESCRIPTION
Prefer unobtrusive error messaging + fix bug when it's the user's 1st visit of the website when SiteSettings have not been initialized yet.

I don't think the order of SiteSettings creation can be fixed (it's done in a function After the layout config has been loaded), or not easily anyway, but the defaultLanguage set to the hub should be correct and that's all we need here.
