### PR TITLE
Fix V `.vmodules` path

### DIFF
--- a/lib/compilers/v.ts
+++ b/lib/compilers/v.ts
@@ -94,7 +94,8 @@ export class VCompiler extends BaseCompiler {
 
     override getDefaultExecOptions(): ExecutionOptions & {env: Record<string, string>} {
         const options = super.getDefaultExecOptions();
-        options.env['VMODULES'] = path.join(path.dirname(this.compiler.exe), '.vmodules');
+        if (process.env.tmpDir === undefined) options.env['VMODULES'] = path.join('/tmp', '.vmodules');
+        else options.env['VMODULES'] = path.join(process.env.tmpDir, '.vmodules');
         return options;
     }
 

--- a/lib/compilers/v.ts
+++ b/lib/compilers/v.ts
@@ -101,10 +101,13 @@ export class VCompiler extends BaseCompiler {
         if (!execOptions) {
             execOptions = super.getDefaultExecOptions();
         }
-        execOptions.env['VMODULES'] = path.join(path.dirname(inputFilename), '.vmodules');
+
+        const tmpDir = path.dirname(inputFilename);
+        execOptions.env['VMODULES'] = path.join(tmpDir, '.vmodules');
+        execOptions.env['VTMP'] = tmpDir;
 
         if (!execOptions.customCwd) {
-            execOptions.customCwd = path.dirname(inputFilename);
+            execOptions.customCwd = tmpDir;
         }
 
         const result = await this.exec(compiler, options, execOptions);

--- a/lib/compilers/v.ts
+++ b/lib/compilers/v.ts
@@ -101,7 +101,7 @@ export class VCompiler extends BaseCompiler {
         if (!execOptions) {
             execOptions = super.getDefaultExecOptions();
         }
-        execOptions.env['VMODULES'] = path.join(this.getOutputDirFromOptions(options), '.vmodules');
+        execOptions.env['VMODULES'] = path.join(path.dirname(inputFilename), '.vmodules');
 
         if (!execOptions.customCwd) {
             execOptions.customCwd = path.dirname(inputFilename);
@@ -112,11 +112,6 @@ export class VCompiler extends BaseCompiler {
             ...this.transformToCompilationResult(result, inputFilename),
             languageId: this.getCompilerResultLanguageId(),
         };
-    }
-
-    getOutputDirFromOptions(options: string[]): string {
-        const outputOpt = options.indexOf('-o') + 1;
-        return path.dirname(options[outputOpt]);
     }
 
     getBackendFromOptions(options: string[]): string {


### PR DESCRIPTION
Currently, the `.vmodules` path is not writable. This PR changes the path to a writable (temporary) directory.

Putting `.vmodules` into the compilation folder seems to be not that simple since the env vars are created before a compilation folder is assigned.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
