### PR TITLE
Introduce ClangDxcCompiler for HLSL

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -46,8 +46,7 @@ group.clang.compilers=hlsl_clang_trunk
 group.clang.groupName=Clang
 group.clang.baseName=Clang
 group.clang.isSemVer=true
-group.clang.compilerType=clang
-group.clang.options=-emit-llvm
+group.clang.compilerType=clang-dxc
 
 compiler.hlsl_clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.hlsl_clang_trunk.semver=(trunk)

--- a/etc/config/hlsl.defaults.properties
+++ b/etc/config/hlsl.defaults.properties
@@ -15,7 +15,6 @@ compiler.rga_default.exe=/usr/rga/rga
 compiler.rga_default.dxcPath=/usr/dxc-artifacts/bin/dxc
 
 group.clang.compilers=hlsl_clang_default
-group.clang.compilerType=clang
+group.clang.compilerType=clang-dxc
 compiler.hlsl_clang_default.exe=/usr/bin/clang-trunk
-compiler.hlsl_clang_default.options=-emit-llvm
-
+compiler.hlsl_clang_default.name=Clang

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -39,6 +39,7 @@ export {ClangCudaCompiler} from './clang.js';
 export {ClangHipCompiler} from './clang.js';
 export {ClangIntelCompiler} from './clang.js';
 export {ClangHexagonCompiler} from './clang.js';
+export {ClangDxcCompiler} from './clang.js';
 export {CleanCompiler} from './clean.js';
 export {CompCertCompiler} from './compcert.js';
 export {CppFrontCompiler} from './cppfront.js';

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -343,3 +343,27 @@ export class ClangHexagonCompiler extends ClangCompiler {
         this.asm = new HexagonAsmParser();
     }
 }
+
+export class ClangDxcCompiler extends ClangCompiler {
+    static override get key() {
+        return 'clang-dxc';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env) {
+        super(info, env);
+
+        this.compiler.supportsIntel = false;
+        this.compiler.irArg = ['-Xclang', '-emit-llvm'];
+        // dxc mode doesn't have -fsave-optimization-record or -fstack-usage
+        this.compiler.supportsOptOutput = false;
+        this.compiler.supportsStackUsageOutput = false;
+    }
+
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
+        return ['--driver-mode=dxc', '-Zi', '-Qembed_debug', '-Fc', this.filename(outputFilename)];
+    }
+}


### PR DESCRIPTION
This uses clang's dxc driver mode so that the flags are compatible with dxc and rga, making it much simpler to switch between compilers for HLSL.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
