### PR TITLE
rename the std::execution library to "stdexec (std::execution)"

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3935,7 +3935,7 @@ libs.sqlite.url=https://sqlite.org
 libs.sqlite.versions.3400.version=3.40.0
 libs.sqlite.versions.3400.path=/opt/compiler-explorer/libs/sqlite/3.40.0
 
-libs.stdexec.name=std::execution
+libs.stdexec.name=stdexec (std::execution)
 libs.stdexec.description=The proposed C++ framework for asynchronous and parallel programming
 libs.stdexec.versions=trunk
 libs.stdexec.url=https://github.com/NVIDIA/stdexec

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1481,7 +1481,7 @@ libs.sqlite.url=https://sqlite.org
 libs.sqlite.versions.3400.version=3.40.0
 libs.sqlite.versions.3400.path=/opt/compiler-explorer/libs/sqlite/3.40.0
 
-libs.stdexec.name=std::execution
+libs.stdexec.name=stdexec (std::execution)
 libs.stdexec.description=The proposed C++ framework for asynchronous and parallel programming
 libs.stdexec.versions=trunk
 libs.stdexec.url=https://github.com/NVIDIA/stdexec


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
