### PR TITLE
dotnet: show the actual error when compilation fails

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -261,6 +261,8 @@ class DotNetCompiler extends BaseCompiler {
         const compilerResult = await super.runCompiler(compiler, publishOptions, inputFilename, execOptions);
         if (compilerResult.code === 0) {
             await fs.createFile(this.getOutputFilename(programDir, this.outputFilebase));
+        } else {
+            return compilerResult;
         }
 
         const version = '// ilc ' + toolVersion;

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -259,11 +259,11 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.maxOutput = 1024 * 1024 * 1024;
 
         const compilerResult = await super.runCompiler(compiler, publishOptions, inputFilename, execOptions);
-        if (compilerResult.code === 0) {
-            await fs.createFile(this.getOutputFilename(programDir, this.outputFilebase));
-        } else {
+        if (compilerResult.code !== 0) {
             return compilerResult;
         }
+
+        await fs.createFile(this.getOutputFilename(programDir, this.outputFilebase));
 
         const version = '// ilc ' + toolVersion;
         const output = await fs.readFile(jitOutFile);


### PR DESCRIPTION
instead of ENOENT from the next line (fs.readFile), return the failed compilation result.