### PR TITLE
oneapi 2023.2.1 release + fix sycl execution

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -867,7 +867,7 @@ compiler.hexagonclang1605.compilerCategories=clang-hexagon
 
 ################################
 # icc for x86
-group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120:icc202130:icc202140:icc202150:icc202160:icc202170:icc202171:icc202180:icc202190
+group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191:icc202112:icc202120:icc202130:icc202140:icc202150:icc202160:icc202170:icc202171:icc202180:icc202190:icc2021100
 group.icc.intelAsm=-masm=intel
 group.icc.options=-gxx-name=/opt/compiler-explorer/gcc-4.7.1/bin/g++
 group.icc.groupName=ICC x86-64
@@ -963,9 +963,15 @@ compiler.icc202190.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compi
 compiler.icc202190.semver=2021.9.0
 compiler.icc202190.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
+compiler.icc2021100.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/intel64/icc
+compiler.icc2021100.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.icc2021100.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.icc2021100.semver=2021.10.0
+compiler.icc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icxlatest
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icxlatest
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -1010,39 +1016,45 @@ compiler.icx202200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 compiler.icx202210.exe=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/bin/icpx
 compiler.icx202210.ldPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/lib
-compiler.icx202210.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.1.0.137/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icx202210.libPath=/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.1.0.137/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.1.0.137/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202210.semver=2022.1.0
 compiler.icx202210.options=--gcc-toolchain=/opt/compiler-explorer/gcc-10.1.0
 
 compiler.icx202220.exe=/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/bin/icpx
 compiler.icx202220.ldPath=/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/lib
-compiler.icx202220.libPath=/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icx202220.libPath=/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.2.0.8772/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202220.semver=2022.2.0
 compiler.icx202220.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 
 compiler.icx202221.exe=/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/bin/icpx
 compiler.icx202221.ldPath=/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/lib
-compiler.icx202221.libPath=/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icx202221.libPath=/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2022.2.1.16991/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202221.semver=2022.2.1
 compiler.icx202221.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 
 compiler.icx202300.exe=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/bin/icpx
 compiler.icx202300.ldPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib
-compiler.icx202300.libPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icx202300.libPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202300.semver=2023.0.0
 compiler.icx202300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
 compiler.icx202310.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icpx
 compiler.icx202310.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
-compiler.icx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202310.semver=2023.1.0
 compiler.icx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
-compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icpx
-compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
-compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/2021.6.0/lib/intel64/gcc4.8
+compiler.icx202321.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icpx
+compiler.icx202321.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
+compiler.icx202321.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.2.1.8/tbb/latest/lib/intel64/gcc4.8
+compiler.icx202321.semver=2023.2.1
+compiler.icx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+
+compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icpx
+compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.2.1.8/tbb/latest/lib/intel64/gcc4.8
 compiler.icxlatest.semver=(latest)
-compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
+compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 
 ################################
 # zapcc

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -713,7 +713,7 @@ compiler.ppci055.semver=0.5.5
 compiler.ppci055.exe=/opt/compiler-explorer/ppci-0.5.5/ppci/cli/cc.py
 
 # icc for x86
-group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112:cicc202120:cicc202130:cicc202140:cicc202150:cicc202160:cicc202170:cicc202171:cicc202180:cicc202190
+group.cicc.compilers=cicc1301:cicc16:cicc17:cicc18:cicc19:cicc191:cicc202112:cicc202120:cicc202130:cicc202140:cicc202150:cicc202160:cicc202170:cicc202171:cicc202180:cicc202190:cicc2021100
 group.cicc.intelAsm=-masm=intel
 group.cicc.options=-x c -gcc-name=/opt/compiler-explorer/gcc-4.7.1/bin/gcc
 group.cicc.groupName=ICC x86-64
@@ -802,8 +802,14 @@ compiler.cicc202190.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/comp
 compiler.cicc202190.semver=2021.9.0
 compiler.cicc202190.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
+compiler.cicc2021100.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/intel64/icc
+compiler.cicc2021100.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.cicc2021100.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicc2021100.semver=2021.10.0
+compiler.cicc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
 # icx for x86
-group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicxlatest
+group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicx202321:cicxlatest
 group.cicx.intelAsm=-masm=intel
 group.cicx.options=
 group.cicx.groupName=ICX x86-64
@@ -873,11 +879,17 @@ compiler.cicx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/comp
 compiler.cicx202310.semver=2023.1.0
 compiler.cicx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
-compiler.cicxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icx
-compiler.cicxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
-compiler.cicxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202321.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icx
+compiler.cicx202321.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
+compiler.cicx202321.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicx202321.semver=2023.2.1
+compiler.cicx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+
+compiler.cicxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icx
+compiler.cicxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
+compiler.cicxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.cicxlatest.semver=(latest)
-compiler.cicxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
+compiler.cicxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 
 ###############################
 # Cross Compilers (mostly GCC & Clang)

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -76,7 +76,7 @@ compiler.gfortransnapshot.semver=(trunk)
 
 ###############################
 # Intel Parallel Studio XE for x86
-group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150:ifort202160:ifort202170:ifort202171:ifort202180:ifort202190
+group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150:ifort202160:ifort202170:ifort202171:ifort202180:ifort202190:ifort2021100
 group.ifort.intelAsm=-masm=intel
 group.ifort.groupName=IFORT x86-64
 group.ifort.isSemVer=true
@@ -151,9 +151,15 @@ compiler.ifort202190.libPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348
 compiler.ifort202190.semver=2021.9.0
 compiler.ifort202190.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
+compiler.ifort2021100.exe=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/bin/intel64/ifort
+compiler.ifort2021100.ldPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifort2021100.libPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifort2021100.semver=2021.10.0
+compiler.ifort2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
 ###############################
 # Intel oneAPI for x86
-group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210:ifx202220:ifx202221:ifx202300:ifx202310:ifxlatest
+group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210:ifx202220:ifx202221:ifx202300:ifx202310:ifx202321:ifxlatest
 group.ifx.intelAsm=-masm=intel
 group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
@@ -214,11 +220,17 @@ compiler.ifx202310.libPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/c
 compiler.ifx202310.semver=2023.1.0
 compiler.ifx202310.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 
-compiler.ifxlatest.exe=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/bin/ifx
-compiler.ifxlatest.ldPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/intel64_lin
-compiler.ifxlatest.libPath=/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.1.0.46348/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202321.exe=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/bin/ifx
+compiler.ifx202321.ldPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifx202321.libPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202321.semver=2023.2.1
+compiler.ifx202321.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
+compiler.ifxlatest.exe=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/bin/ifx
+compiler.ifxlatest.ldPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin
+compiler.ifxlatest.libPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
 compiler.ifxlatest.semver=(latest)
-compiler.ifxlatest.options=-gxx-name=/opt/compiler-explorer/gcc-13.1.0/bin/g++
+compiler.ifxlatest.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 
 ###############################
 # GCC Cross-Compilers


### PR DESCRIPTION
Depends on: https://github.com/compiler-explorer/infra/pull/1080

oneapi 2023.2.1 release. It is the same compiler as 2023.2.0.

Resolves #5408 
The TBB path was wrong. TBB is used by opencl for CPU, and SYCL execution for CE target the CPU opencl device
Note that I tested the new configuration on my local setup but did not reproduce the original problem so it is possible there are other problems.