### PR TITLE
Bring back crossgen2

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -51,6 +51,8 @@ class DotNetCompiler extends BaseCompiler {
     private readonly langVersion: string;
     private readonly corerunPath: string;
     private readonly disassemblyLoaderPath: string;
+    private readonly crossgen2Path: string;
+    private readonly sdkMajorVersion: number;
 
     private versionString: string;
 
@@ -62,12 +64,14 @@ class DotNetCompiler extends BaseCompiler {
 
         const parts = this.sdkVersion.split('.');
         this.targetFramework = `net${parts[0]}.${parts[1]}`;
+        this.sdkMajorVersion = Number(parts[0]);
 
         this.buildConfig = this.compilerProps<string>(`compiler.${this.compiler.id}.buildConfig`);
         this.clrBuildDir = this.compilerProps<string>(`compiler.${this.compiler.id}.clrDir`);
         this.langVersion = this.compilerProps<string>(`compiler.${this.compiler.id}.langVersion`);
 
         this.corerunPath = path.join(this.clrBuildDir, 'corerun');
+        this.crossgen2Path = path.join(this.clrBuildDir, 'crossgen2', 'crossgen2');
         this.asm = new DotNetAsmParser();
         this.versionString = '';
         this.disassemblyLoaderPath = path.join(this.clrBuildDir, 'DisassemblyLoader', 'DisassemblyLoader.dll');
@@ -102,6 +106,7 @@ class DotNetCompiler extends BaseCompiler {
             '--Ot',
             '--optimize-time',
             '--aot',
+            '--crossgen2',
         ];
     }
 
@@ -286,15 +291,15 @@ class DotNetCompiler extends BaseCompiler {
         execOptions: ExecutionOptions & {env: Record<string, string>},
     ): Promise<CompilationResult> {
         const corerunArgs: string[] = [];
-        const ilcOptions: string[] = [
+        // prettier-ignore
+        const toolOptions: string[] = [
             '--codegenopt',
-            'JitDisasm=*',
+            this.sdkMajorVersion === 6 ? 'NgenDisasm=*' : 'JitDisasm=*',
             '--codegenopt',
-            'JitDisasmDiffable=1',
-            '--parallelism',
-            '1',
+            this.sdkMajorVersion < 8 ? 'JitDiffableDasm=1' : 'JitDisasmDiffable=1',
+            '--parallelism', '1',
         ];
-        const ilcSwitches: string[] = [];
+        const toolSwitches: string[] = [];
         const programDir = path.dirname(inputFilename);
         const programOutputPath = path.join(programDir, 'bin', this.buildConfig, this.targetFramework);
         const programDllPath = path.join(programOutputPath, 'CompilerExplorer.dll');
@@ -305,6 +310,7 @@ class DotNetCompiler extends BaseCompiler {
             'DOTNET_TieredCompilation=0',
         ];
         let isAot = false;
+        let isCrossgen2 = this.sdkMajorVersion === 6;
 
         while (options.length > 0) {
             const currentOption = options.shift();
@@ -331,16 +337,18 @@ class DotNetCompiler extends BaseCompiler {
                 if (property) {
                     corerunArgs.push('-p', property);
                 }
-            } else if (this.configurableSwitches.indexOf(currentOption)) {
+            } else if (this.configurableSwitches.indexOf(currentOption) !== -1) {
                 if (currentOption === '--aot') {
                     isAot = true;
+                } else if (currentOption === '--crossgen2') {
+                    isCrossgen2 = true;
                 } else {
-                    ilcSwitches.push(currentOption);
+                    toolSwitches.push(currentOption);
                 }
-            } else if (this.configurableOptions.indexOf(currentOption)) {
+            } else if (this.configurableOptions.indexOf(currentOption) !== -1) {
                 const value = options.shift();
                 if (value) {
-                    ilcOptions.push(currentOption, value);
+                    toolOptions.push(currentOption, value);
                 }
             }
         }
@@ -359,27 +367,42 @@ class DotNetCompiler extends BaseCompiler {
                 };
             }
 
-            compilerResult = await this.publishAot(compiler, ilcOptions, ilcSwitches, inputFilename, execOptions);
+            compilerResult = await this.publishAot(compiler, toolOptions, toolSwitches, inputFilename, execOptions);
         } else {
             compilerResult = await this.buildToDll(compiler, inputFilename, execOptions);
             if (compilerResult.code !== 0) {
                 return compilerResult;
             }
 
-            const envVarFilePath = path.join(programDir, '.env');
-            await fs.writeFile(envVarFilePath, envVarFileContents.join('\n'));
+            if (isCrossgen2) {
+                const crossgen2Result = await this.runCrossgen2(
+                    execOptions,
+                    this.clrBuildDir,
+                    programDllPath,
+                    toolOptions,
+                    toolSwitches,
+                    this.getOutputFilename(programDir, this.outputFilebase),
+                );
 
-            const corerunResult = await this.runCorerunForDisasm(
-                execOptions,
-                this.clrBuildDir,
-                envVarFilePath,
-                programDllPath,
-                corerunArgs,
-                this.getOutputFilename(programDir, this.outputFilebase),
-            );
+                if (crossgen2Result.code !== 0) {
+                    return crossgen2Result;
+                }
+            } else {
+                const envVarFilePath = path.join(programDir, '.env');
+                await fs.writeFile(envVarFilePath, envVarFileContents.join('\n'));
 
-            if (corerunResult.code !== 0) {
-                return corerunResult;
+                const corerunResult = await this.runCorerunForDisasm(
+                    execOptions,
+                    this.clrBuildDir,
+                    envVarFilePath,
+                    programDllPath,
+                    corerunArgs,
+                    this.getOutputFilename(programDir, this.outputFilebase),
+                );
+
+                if (corerunResult.code !== 0) {
+                    return corerunResult;
+                }
             }
         }
 
@@ -428,16 +451,14 @@ class DotNetCompiler extends BaseCompiler {
         }
     }
 
-    async checkRuntimeVersion(execOptions: ExecutionOptions) {
+    async checkCompilerVersion() {
         if (!this.versionString) {
-            this.versionString = '// dotnet runtime ';
-
             const versionFilePath = `${this.clrBuildDir}/version.txt`;
             if (fs.existsSync(versionFilePath)) {
                 const versionString = await fs.readFile(versionFilePath);
-                this.versionString += versionString;
+                this.versionString = versionString.toString();
             } else {
-                this.versionString += '<unknown version>';
+                this.versionString = '<unknown version>';
             }
         }
     }
@@ -450,7 +471,7 @@ class DotNetCompiler extends BaseCompiler {
         options: string[],
         outputPath: string,
     ) {
-        await this.checkRuntimeVersion(execOptions);
+        await this.checkCompilerVersion();
 
         const corerunOptions = ['--clr-path', coreRoot, '--env', envPath].concat([
             ...options,
@@ -462,7 +483,40 @@ class DotNetCompiler extends BaseCompiler {
 
         await fs.writeFile(
             outputPath,
-            `${this.versionString}\n\n${result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`, '')}`,
+            `// runtime ${this.versionString}\n\n${result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`, '')}`,
+        );
+
+        return result;
+    }
+
+    async runCrossgen2(
+        execOptions: ExecutionOptions,
+        bclPath: string,
+        dllPath: string,
+        toolOptions: string[],
+        toolSwitches: string[],
+        outputPath: string,
+    ) {
+        await this.checkCompilerVersion();
+
+        // prettier-ignore
+        const crossgen2Options = [
+            '-r', path.join(bclPath, '/'),
+            '-r', this.disassemblyLoaderPath,
+            dllPath,
+            '-o', `${AssemblyName}.r2r.dll`,
+            '--inputbubble',
+            '--compilebubblegenerics',
+        ].concat(toolOptions).concat(toolSwitches);
+
+        const compilerExecResult = await this.exec(this.crossgen2Path, crossgen2Options, execOptions);
+        const result = this.transformToCompilationResult(compilerExecResult, dllPath);
+
+        await fs.writeFile(
+            outputPath,
+            `// crossgen2 ${this.versionString}\n\n${result.stdout
+                .map(o => o.text)
+                .reduce((a, n) => `${a}\n${n}`, '')}`,
         );
 
         return result;

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -457,7 +457,7 @@ class DotNetCompiler extends BaseCompiler {
         }
     }
 
-    async checkCompilerVersion() {
+    async checkRuntimeVersion() {
         if (!this.versionString) {
             const versionFilePath = `${this.clrBuildDir}/version.txt`;
             if (fs.existsSync(versionFilePath)) {
@@ -477,7 +477,7 @@ class DotNetCompiler extends BaseCompiler {
         options: string[],
         outputPath: string,
     ) {
-        await this.checkCompilerVersion();
+        await this.checkRuntimeVersion();
 
         const corerunOptions = ['--clr-path', coreRoot, '--env', envPath].concat([
             ...options,
@@ -503,7 +503,7 @@ class DotNetCompiler extends BaseCompiler {
         toolSwitches: string[],
         outputPath: string,
     ) {
-        await this.checkCompilerVersion();
+        await this.checkRuntimeVersion();
 
         // prettier-ignore
         const crossgen2Options = [

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -92,6 +92,9 @@ class DotNetCompiler extends BaseCompiler {
             '--singlemethodgenericarg',
             '--codegenopt',
             '--codegen-options',
+            '--maxgenericcycle',
+            '--maxgenericcyclebreadth',
+            '--max-vectort-bitwidth',
         ];
     }
 
@@ -105,6 +108,9 @@ class DotNetCompiler extends BaseCompiler {
             '--optimize-space',
             '--Ot',
             '--optimize-time',
+            '--enable-generic-cycle-detection',
+            '--inputbubble',
+            '--compilebubblegenerics',
             '--aot',
             '--crossgen2',
         ];
@@ -505,8 +511,6 @@ class DotNetCompiler extends BaseCompiler {
             '-r', this.disassemblyLoaderPath,
             dllPath,
             '-o', `${AssemblyName}.r2r.dll`,
-            '--inputbubble',
-            '--compilebubblegenerics',
         ].concat(toolOptions).concat(toolSwitches);
 
         const compilerExecResult = await this.exec(this.crossgen2Path, crossgen2Options, execOptions);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -489,7 +489,7 @@ class DotNetCompiler extends BaseCompiler {
 
         await fs.writeFile(
             outputPath,
-            `// runtime ${this.versionString}\n\n${result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`, '')}`,
+            `// coreclr ${this.versionString}\n\n${result.stdout.map(o => o.text).reduce((a, n) => `${a}\n${n}`, '')}`,
         );
 
         return result;

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -117,6 +117,7 @@ export class DotNetAsmParser implements IAsmParser {
                 continue;
             }
 
+            if (line.startsWith('Emitting R2R PE file')) continue;
             cleanedAsm.push(line);
         }
 


### PR DESCRIPTION
It turns out we still need crossgen2 for net6.0.
So bring crossgen2 back for net6.0 only.

Also fix some bugs around `indexOf`.

No image rebuilding is required.