### PR TITLE
Use the SPIR-V parser for DXC SPIR-V output

### DIFF
--- a/lib/compilers/hlsl.ts
+++ b/lib/compilers/hlsl.ts
@@ -84,6 +84,6 @@ export class HLSLCompiler extends BaseCompiler {
     }
 
     isSpirv(code) {
-        return code.includes('OpMemoryModel') && code.includes('OpEntryPoint');
+        return code.startsWith('; SPIR-V');
     }
 }

--- a/lib/compilers/hlsl.ts
+++ b/lib/compilers/hlsl.ts
@@ -26,8 +26,10 @@ import path from 'path';
 
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
+import {SPIRVAsmParser} from '../parsers/asm-parser-spirv.js';
 
 export class HLSLCompiler extends BaseCompiler {
+    protected spirvAsm: SPIRVAsmParser;
     static get key() {
         return 'hlsl';
     }
@@ -36,6 +38,7 @@ export class HLSLCompiler extends BaseCompiler {
         super(info, env);
 
         this.compiler.supportsIntel = false;
+        this.spirvAsm = new SPIRVAsmParser(this.compilerProps);
     }
 
     /* eslint-disable no-unused-vars */
@@ -70,5 +73,17 @@ export class HLSLCompiler extends BaseCompiler {
 
     override getIrOutputFilename(inputFilename: string) {
         return this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase).replace('.s', '.dxil');
+    }
+
+    override async processAsm(result, filters, options) {
+        if (this.isSpirv(result.asm)) {
+            return this.spirvAsm.processAsm(result.asm, filters);
+        }
+
+        return super.processAsm(result, filters, options);
+    }
+
+    isSpirv(code) {
+        return code.includes('OpMemoryModel') && code.includes('OpEntryPoint');
     }
 }

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -98,6 +98,7 @@ export class SPIRVAsmParser extends AsmParser {
         const endTime = process.hrtime.bigint();
         return {
             asm: asm,
+            languageId: 'spirv',
             labelDefinitions: {},
             parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
             filteredCount: startingLineCount - asm.length,


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
My main motivation for this change is that SPIR-V output currently isn't highlighting source lines (for example, see https://godbolt.org/z/4vYb3PbM7 - there's `OpLine` instructions, but they aren't being parsed).

It looks like there's an existing SPIR-V parser, so I'm just updating the HLSL compiler to detect SPIR-V output and use the parser if so.

There's probably a couple of other ergonomic improvements that could be made - for example, treating `OpSource` and `OpName` as directives for filtering. I might make a followup PR with some of these.