### PR TITLE
Improve the disassembly format for dotnet

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -309,11 +309,13 @@ class DotNetCompiler extends BaseCompiler {
         const programDir = path.dirname(inputFilename);
         const programOutputPath = path.join(programDir, 'bin', this.buildConfig, this.targetFramework);
         const programDllPath = path.join(programOutputPath, 'CompilerExplorer.dll');
+        // prettier-ignore
         const envVarFileContents = [
             'DOTNET_EnableWriteXorExecute=0',
             'DOTNET_JitDisasm=*',
             'DOTNET_JitDisasmAssemblies=CompilerExplorer',
             'DOTNET_TieredCompilation=0',
+            this.sdkMajorVersion < 8 ? 'DOTNET_JitDiffableDasm=1' : 'DOTNET_JitDisasmDiffable=1',
         ];
         let isAot = false;
         let isCrossgen2 = this.sdkMajorVersion === 6;


### PR DESCRIPTION
This is an improvement that can improve the disassembly format to make it more friendly to a diff checker.

All versions tested:

net6.0:
![image](https://github.com/compiler-explorer/compiler-explorer/assets/14960345/1ae4fda5-db73-4703-88f9-abd640b4e5e1)

net7.0:
![image](https://github.com/compiler-explorer/compiler-explorer/assets/14960345/6dfe1a74-a09a-40c4-b586-425b8ee84b12)

trunk:
![image](https://github.com/compiler-explorer/compiler-explorer/assets/14960345/36247f19-1e26-4bb8-ab1d-040d7145854f)
