### PR TITLE
Fix clientstate.ts link

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -270,7 +270,7 @@ If JSON is present in the request's `Accept` header, the compilation results are
 ### `POST /api/shortener` - saves given state _forever_ to a shortlink and returns the unique id for the link
 
 The body of this post should be in the format of a
-[ClientState](https://github.com/compiler-explorer/compiler-explorer/blob/main/lib/clientstate.js) Be sure that the
+[ClientState](../lib/clientstate.ts) Be sure that the
 Content-Type of your post is application/json
 
 An example of one the easiest forms of a clientstate:


### PR DESCRIPTION
The link to the "clientstate" was linking to ".js", and with a full path. Changed it to the correct ".ts" and to a relative path

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
