### PR TITLE
Fix link to formatter section

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -173,7 +173,7 @@ structure:
 
 The name property corresponds to the `<formatter>` when requesting `POST /api/format/<formatter>`. The `type` key in the
 JSON request corresponds to one of the `formatters.<key>.type` found in
-https://github.com/compiler-explorer/compiler-explorer/blob/main/etc/config/compiler-explorer.amazon.properties#L43
+[compiler-explorer.amazon.properties:43](../etc/config/compiler-explorer.amazon.properties#L43)
 
 ### `POST /api/format/<formatter>` - perform a formatter run
 


### PR DESCRIPTION
Changed Link "https://github.com/compiler-explorer/compiler-explorer/blob/main/etc/config/compiler-explorer.amazon.properties#L43" to a relative link and fixed the display to be less huge.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
