### PR TITLE
Add Qt version 6.5.2

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3846,8 +3846,9 @@ libs.qt.url=https://www.qt.io
 libs.qt.packagedheaders=true
 libs.qt.liblink=Qt6Core
 libs.qt.options=-DQT_NO_VERSION_TAGGING
-libs.qt.versions=642
+libs.qt.versions=642:652
 libs.qt.versions.642.version=6.4.2
+libs.qt.versions.652.version=6.5.2
 
 libs.rangesv3.name=range-v3
 libs.rangesv3.versions=trunk:030:035:036:091:0100:0110:0120


### PR DESCRIPTION
This is the counterpart to https://github.com/compiler-explorer/infra/pull/1086 adding Qt 6.5.2 to Compiler Explorer.