### PR TITLE
fix: Do not add default libraries to state if previous state exists

### DIFF
--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -70,7 +70,7 @@ export class LibsWidget {
         this.initButtons();
         this.onChangeCallback = onChangeCallback;
         this.availableLibs = {};
-        this.updateAvailableLibs(possibleLibs);
+        this.updateAvailableLibs(possibleLibs, true);
         this.loadState(state);
 
         this.fullRefresh();
@@ -102,6 +102,14 @@ export class LibsWidget {
     }
 
     loadState(state: WidgetState) {
+        // If state exists, clear previously selected libraries.
+        if (state.libs !== undefined) {
+            const libsInUse = this.listUsedLibs();
+            for (const libId in libsInUse) {
+                this.markLibrary(libId, libsInUse[libId], false);
+            }
+        }
+
         for (const lib of state.libs ?? []) {
             if (lib.name && lib.ver) {
                 this.markLibrary(lib.name, lib.ver, true);
@@ -438,7 +446,7 @@ export class LibsWidget {
         }
     }
 
-    updateAvailableLibs(possibleLibs: CompilerLibs) {
+    updateAvailableLibs(possibleLibs: CompilerLibs, isLangChanged: boolean) {
         if (!(this.currentLangId in this.availableLibs)) {
             this.availableLibs[this.currentLangId] = {};
         }
@@ -455,11 +463,15 @@ export class LibsWidget {
             }
         }
 
-        this.initLangDefaultLibs();
+        if (isLangChanged) {
+            this.initLangDefaultLibs();
+        }
     }
 
     setNewLangId(langId: string, compilerId: string, possibleLibs: CompilerLibs) {
         const libsInUse = this.listUsedLibs();
+
+        const isLangChanged = this.currentLangId !== langId;
 
         this.currentLangId = langId;
 
@@ -470,7 +482,7 @@ export class LibsWidget {
         }
 
         // Clear the dom Root so it gets rebuilt with the new language libraries
-        this.updateAvailableLibs(possibleLibs);
+        this.updateAvailableLibs(possibleLibs, isLangChanged);
 
         for (const libId in libsInUse) {
             this.markLibrary(libId, libsInUse[libId], true);


### PR DESCRIPTION
Closes #5439

As covered in linked issue, currently default libraries are added unconditionally to loaded state. Even if state was created by removing the default libraries.

The fix makes following changes in libs-widget:
* `updateAvailableLibraries` will only add default libraries to state if the langugage has changed.
* `loadState` will check if `libs` exists in the loading state and if they do clear currently used libraries.
* `setNewLangId` will check if langauges is changed (or just the compiler) and pass this into `updateAvailableLibraries`.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
