### PR TITLE
Improve SPIR-V parser

### DIFF
--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -99,7 +99,7 @@ export class SPIRVAsmParser extends AsmParser {
 
         const sourceTag = /^\s*OpLine\s+%(\d+)\s+(\d+)\s+(\d*)$/;
         const endBlock = /OpFunctionEnd/;
-        const comment = /;/;
+        const comment = /^;/;
         const opLine = /OpLine/;
         const opNoLine = /OpNoLine/;
         const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -58,9 +58,25 @@ export class SPIRVAsmParser extends AsmParser {
         const opLine = /OpLine/;
         const opNoLine = /OpNoLine/;
         const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;
+        const opString = /OpString/;
+        const opSource = /OpSource/;
+        const opName = /OpName/;
+
+        const unclosedString = /^[^"]+"(?:[^\\"]|\\.)*$/;
+        const closeQuote = /^(?:[^\\"]|\\.)*"/;
+        let inString = false;
+
         let source: any = null;
 
         for (let line of asmLines) {
+            if (inString) {
+                if (closeQuote.test(line)) {
+                    inString = false;
+                }
+
+                continue;
+            }
+
             const match = line.match(sourceTag);
             if (match) {
                 source = {
@@ -82,7 +98,17 @@ export class SPIRVAsmParser extends AsmParser {
                 continue;
             }
             if (filters.directives) {
-                if (opLine.test(line) || opExtDbg.test(line) || opNoLine.test(line)) {
+                if (
+                    opLine.test(line) ||
+                    opExtDbg.test(line) ||
+                    opNoLine.test(line) ||
+                    opString.test(line) ||
+                    opSource.test(line) ||
+                    opName.test(line)
+                ) {
+                    if (unclosedString.test(line)) {
+                        inString = true;
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
This is following up on #5418 by adding a couple of improvements to the parser.

First, `OpString`, `OpSource`, and `OpName` are added to the directives filter, since they only provide debug information. (And `OpSource` provides the entire source of the input file, which is redundant when viewing the output in Compiler Explorer)

Secondly, label definitions and uses are now parsed.