### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -8,7 +8,8 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Update browerslist
         run: |
           git config user.name 'Compiler Explorer Bot'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/deploy-win.yml
+++ b/.github/workflows/deploy-win.yml
@@ -16,7 +16,8 @@ jobs:
       branch: ${{ steps.build_dist.outputs.branch }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.buildnumber }}
@@ -39,7 +40,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 18.x

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 18.x
@@ -35,7 +36,8 @@ jobs:
       branch: ${{ steps.build_dist.outputs.branch }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 18.x
@@ -58,7 +60,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 18.x

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -9,8 +9,8 @@ jobs:
       matrix:
         browser: ['chrome']
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install prerequisites
         run: make prereqs
       - name: Setup Firefox

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -11,7 +11,8 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 18.x

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -135,3 +135,4 @@ From oldest to newest contributor, we would like to thank:
 - [Jorge López](https://github.com/jolopezl)
 - [Spydr06](https://github.com/spydr06)
 - [Simon Sobisch](https://github.com/GitMensch)
+- [Marc Auberer](https://github.com/marcauberer)


### PR DESCRIPTION
Upgrade checkout action to v4 to make use of Node 20.
Node 16, which v3 is using, reaches end of life on 2023-09-11.