### PR TITLE
Fix WSL for systems that don't have windows paths

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -156,10 +156,14 @@ if (opts.tmpDir) {
 } else if (process.env.wsl) {
     // Dec 2017 preview builds of WSL include /bin/wslpath; do the parsing work for now.
     // Parsing example %TEMP% is C:\Users\apardoe\AppData\Local\Temp
-    const windowsTemp = child_process.execSync('cmd.exe /c echo %TEMP%').toString().replaceAll('\\', '/');
-    const driveLetter = windowsTemp.substring(0, 1).toLowerCase();
-    const directoryPath = windowsTemp.substring(2).trim();
-    process.env.winTmp = path.join('/mnt', driveLetter, directoryPath);
+    try {
+        const windowsTemp = child_process.execSync('cmd.exe /c echo %TEMP%').toString().replaceAll('\\', '/');
+        const driveLetter = windowsTemp.substring(0, 1).toLowerCase();
+        const directoryPath = windowsTemp.substring(2).trim();
+        process.env.winTmp = path.join('/mnt', driveLetter, directoryPath);
+    } catch (e) {
+        logger.warn('Unable to invoke cmd.exe to get windows %TEMP% path.');
+    }
 }
 
 const distPath = utils.resolvePathFromAppRoot('.');

--- a/docs/WindowsSubsystemForLinux.md
+++ b/docs/WindowsSubsystemForLinux.md
@@ -69,7 +69,8 @@ CE only required a few changes in order to run properly under WSL. Those changes
     WSL distros as they all run on the base Microsoft Linux kernel.
   - If the `-tmpDir` option is specified on the command line, both `process.env.tmpDir` and `process.env.winTmp` are set
     to the specified value Note that if this is specified as a non-Windows volume, Windows executables will fail to run
-    properly. Otherwise, `process.env.winTmp` is set to the value of the Windows `%TEMP%` directory.
+    properly. Otherwise, `process.env.winTmp` is set to the value of the Windows `%TEMP%` directory if CE can get the
+    temp path from invoking `cmd.exe` from WSL.
 - `lib/exec.js`: Execute the compiler in the temporary directory. If the compiler's binary is located on a mounted
   volume (`startsWith("/mnt"`)) and CE is running under WSL, run the compiler in the `winTmp` directory. Otherwise, use
   the Linux temp directory.

--- a/lib/compilers/wsl-vc.ts
+++ b/lib/compilers/wsl-vc.ts
@@ -60,7 +60,7 @@ export class WslVcCompiler extends Win32VcCompiler {
     // NPM temp package: https://www.npmjs.com/package/temp, see Affixes
     override newTempDir() {
         return new Promise<string>((resolve, reject) => {
-            temp.mkdir({prefix: 'compiler-explorer-compiler', dir: process.env.winTmp}, (err, dirPath) => {
+            temp.mkdir({prefix: 'compiler-explorer-compiler', dir: unwrap(process.env.winTmp)}, (err, dirPath) => {
                 if (err) reject(`Unable to open temp file: ${err}`);
                 else resolve(dirPath);
             });

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -78,7 +78,8 @@ export function executeDirect(
     let okToCache = true;
     let timedOut = false;
     const cwd =
-        options.customCwd || (command.startsWith('/mnt') && process.env.wsl ? process.env.winTmp : process.env.tmpDir);
+        options.customCwd ||
+        (command.startsWith('/mnt') && process.env.wsl && process.env.winTmp ? process.env.winTmp : process.env.tmpDir);
     logger.debug('Execution', {type: 'executing', command: command, args: args, env: env, cwd: cwd});
     const startTime = process.hrtime.bigint();
 


### PR DESCRIPTION
Attempt to fix #5476. As far as I can tell `process.env.winTmp` is needed just for windows executables and WslVcCompiler. It should be possible to just ignore the exec error and continue. If for some reason the user doesn't have windows paths in their WSL but does want to run windows executables they can pass `-tmpDir`.