### PR TITLE
Add autodetect for staticlib `stdc++exp`

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2792,7 +2792,7 @@ compiler.edg-6_5-gcc-13.name=EDG 6.5 (GNU mode gcc 13)
 #################################
 #################################
 # Installed libs
-libs=abseil:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
+libs=abseil:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -3384,6 +3384,11 @@ libs.gnulibbacktrace.name=backtrace support (GNU)
 libs.gnulibbacktrace.versions=autodetect
 libs.gnulibbacktrace.versions.autodetect.version=autodetect
 libs.gnulibbacktrace.versions.autodetect.staticliblink=stdc++_libbacktrace
+
+libs.gnuexp.name=experimental libstdc++ features support (GNU)
+libs.gnuexp.versions=autodetect
+libs.gnuexp.versions.autodetect.version=autodetect
+libs.gnuexp.versions.autodetect.staticliblink=stdc++exp
 
 libs.googletest.name=Google Test
 libs.googletest.versions=trunk:110

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -369,7 +369,7 @@ compiler.objcppgccrv64trunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/r
 #################################
 #################################
 # Installed libs
-libs=abseil:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:seqan3:simde:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite
+libs=abseil:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cmcstl2:cnl:cppcoro:cppitertools:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:scnlib:seastar:seqan3:simde:sol2:spdlog:spy:stdexec:strong_type:taojson:tbb:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:vcl:xercesc:xsimd:xtensor:xtl:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -930,6 +930,11 @@ libs.gnulibbacktrace.name=backtrace support (GNU)
 libs.gnulibbacktrace.versions=autodetect
 libs.gnulibbacktrace.versions.autodetect.version=autodetect
 libs.gnulibbacktrace.versions.autodetect.staticliblink=stdc++_libbacktrace
+
+libs.gnuexp.name=experimental libstdc++ features support (GNU)
+libs.gnuexp.versions=autodetect
+libs.gnuexp.versions.autodetect.version=autodetect
+libs.gnuexp.versions.autodetect.staticliblink=stdc++exp
 
 libs.googletest.name=Google Test
 libs.googletest.versions=trunk:110


### PR DESCRIPTION
Similar to #3612, starting with GCC 14, using `<stacktrace>` now requires linking to `libstdc++exp.a`.

I added the autodetect to ObjC++ as well because `stdc++_libbacktrace` is also present in that file.

Ref: https://gcc.gnu.org/onlinedocs/libstdc++/manual/using.html