### PR TITLE
GnuCOBOL: always pass -g to the C compiler

### DIFF
--- a/lib/compilers/gnucobol.ts
+++ b/lib/compilers/gnucobol.ts
@@ -50,7 +50,7 @@ export class GnuCobolCompiler extends BaseCompiler {
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
-        let options = ['-o', this.filename(outputFilename), '-I', this.includeDir, '-L', this.libDir];
+        let options = ['-o', this.filename(outputFilename), '-I', this.includeDir, '-L', this.libDir, '-A', '-g'];
         if (this.compiler.intelAsm && filters.intel && !filters.binary && !filters.binaryObject) {
             options = options.concat(this.compiler.intelAsm.split(' '));
         }


### PR DESCRIPTION
As this is done with other compilers like C/C++ and doesn't add extra code (like plain `-g` would).

(this supersedes the broken #5503)