### PR TITLE
jakt: Fix signature of default example's main

### DIFF
--- a/examples/jakt/default.jakt
+++ b/examples/jakt/default.jakt
@@ -1,7 +1,7 @@
-function square(num: i32) -> i32 {
+fn square(num: i32) -> i32 {
     return num * num
 }
 
-function main() throws -> c_int {
+fn main() throws -> c_int {
     return square(num: 3) as! c_int
 }

--- a/static/modes/jakt-mode.ts
+++ b/static/modes/jakt-mode.ts
@@ -43,6 +43,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             'continue',
             'throw',
             'yield',
+            'fn',
             'function',
             'extern',
             'import',


### PR DESCRIPTION
In a precious version of the language, functions were defined with the `function` keyword. They are now defined with `fn`.

Currently, the default example doen't compile.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
