### PR TITLE
fix(config): Add gcc 7.5 to C config

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cg132:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cg132:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -85,6 +85,8 @@ compiler.cg73.exe=/opt/compiler-explorer/gcc-7.3.0/bin/gcc
 compiler.cg73.semver=7.3
 compiler.cg74.exe=/opt/compiler-explorer/gcc-7.4.0/bin/gcc
 compiler.cg74.semver=7.4
+compiler.cg75.exe=/opt/compiler-explorer/gcc-7.5.0/bin/gcc
+compiler.cg75.semver=7.5
 compiler.cg81.exe=/opt/compiler-explorer/gcc-8.1.0/bin/gcc
 compiler.cg81.semver=8.1
 compiler.cg82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gcc


### PR DESCRIPTION
The compiler was installed but missing its config in site's config.

fix #5523

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>