### PR TITLE
Add NASM 2.16.01

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -4,9 +4,9 @@ objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 supportsBinary=true
 supportsExecute=true
 demangler=
-defaultCompiler=nasm21402
+defaultCompiler=nasm21601
 
-group.nasm.compilers=nasm21202:nasm21302:nasm21303:nasm21402
+group.nasm.compilers=nasm21202:nasm21302:nasm21303:nasm21402:nasm21601
 group.nasm.versionFlag=-v
 group.nasm.options=
 group.nasm.isSemVer=true
@@ -21,6 +21,8 @@ compiler.nasm21303.semver=2.13.03
 compiler.nasm21303.exe=/opt/compiler-explorer/nasm-2.13.03/nasm
 compiler.nasm21402.semver=2.14.02
 compiler.nasm21402.exe=/opt/compiler-explorer/nasm-2.14.02/nasm
+compiler.nasm21601.semver=2.16.01
+compiler.nasm21601.exe=/opt/compiler-explorer/nasm-2.16.01/nasm
 
 
 group.gnuas.compilers=gnuas72:gnuas73:gnuas92:gnuas103:gnuas112:gnuas121:gnuassnapshot

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&fpc
 defaultCompiler=fpc322
 
-nasmpath=/opt/compiler-explorer/nasm-2.14.02
+nasmpath=/opt/compiler-explorer/nasm-2.16.01
 
 group.fpc.compilers=fpc260:fpc262:fpc264:fpc302:fpc304:fpc320:fpc322
 group.fpc.options=@/opt/compiler-explorer/fpc/fpc.cfg


### PR DESCRIPTION
Closes #5506 

See PR in infra: [Update NASM version to 2.16.01](https://github.com/compiler-explorer/infra/pull/1101)

Decided to have a go at adding latest NASM release. Let me know if there is anything I missed.