### PR TITLE
add name to `CONTRIBUTORS.md`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -137,3 +137,4 @@ From oldest to newest contributor, we would like to thank:
 - [Simon Sobisch](https://github.com/GitMensch)
 - [Marc Auberer](https://github.com/marcauberer)
 - [Seyed Ali Ghasemi](https://github.com/gha3mi)
+- [Guo Ci](https://github.com/guoci)


### PR DESCRIPTION
Can I add my name to `CONTRIBUTORS.md`?
I have contributed to the stack usage viewer, CUDA PTX/SASS documentations, and a few other issues.
https://github.com/compiler-explorer/compiler-explorer/pulls?q=is%3Apr+author%3Aguoci
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
