### PR TITLE
add arm.com gcc 11.3, 12.2, 12.3

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1595,7 +1595,7 @@ group.gccarm.includeFlag=-I
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
 group.gcc32arm.baseName=ARM GCC
-group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1310:armg1320:armgtrunk
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1310:armg1320:armgtrunk:arm1130_a32bm:arm1220_a32bm:arm1230_a32bm
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -1698,6 +1698,19 @@ compiler.arm1121.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-11.2-2022.02/b
 compiler.arm1121.name=ARM gcc 11.2.1 (none)
 compiler.arm1121.semver=11.2.1
 compiler.arm1121.supportsBinary=false
+
+compiler.arm1130_a32bm.exe=/opt/compiler-explorer/arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++
+compiler.arm1130_a32bm.name=ARM gcc 11.3.0 (none)
+compiler.arm1130_a32bm.semver=11.3.0
+compiler.arm1130_a32bm.supportsBinary=false
+compiler.arm1220_a32bm.exe=/opt/compiler-explorer/arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++
+compiler.arm1220_a32bm.name=ARM gcc 12.2.0 (none)
+compiler.arm1220_a32bm.semver=12.2.0
+compiler.arm1220_a32bm.supportsBinary=false
+compiler.arm1230_a32bm.exe=/opt/compiler-explorer/arm/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++
+compiler.arm1230_a32bm.name=ARM gcc 12.3.0 (none)
+compiler.arm1230_a32bm.semver=12.3.0
+compiler.arm1230_a32bm.supportsBinary=false
 
 compiler.arm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.arm930.semver=9.3.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1416,7 +1416,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1310:carmg1320:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1310:carmg1320:carmgtrunk:carm1130_a32bm:carm1220_a32bm:carm1230_a32bm
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -1501,7 +1501,21 @@ compiler.carm1031_10.supportsBinary=false
 compiler.carm1121.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-11.2-2022.02/bin/arm-none-eabi-gcc
 compiler.carm1121.semver=11.2.1 (none)
 compiler.carm1121.supportsBinary=false
-compiler.carm1021.supportsBinaryObject=true
+compiler.carm1121.supportsBinaryObject=true
+
+compiler.carm1130_a32bm.exe=/opt/compiler-explorer/arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++
+compiler.carm1130_a32bm.name=ARM gcc 11.3.0 (none)
+compiler.carm1130_a32bm.semver=11.3.0
+compiler.carm1130_a32bm.supportsBinary=false
+compiler.carm1220_a32bm.exe=/opt/compiler-explorer/arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++
+compiler.carm1220_a32bm.name=ARM gcc 12.2.0 (none)
+compiler.carm1220_a32bm.semver=12.2.0
+compiler.carm1220_a32bm.supportsBinary=false
+compiler.carm1230_a32bm.exe=/opt/compiler-explorer/arm/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++
+compiler.carm1230_a32bm.name=ARM gcc 12.3.0 (none)
+compiler.carm1230_a32bm.semver=12.3.0
+compiler.carm1230_a32bm.supportsBinary=false
+
 compiler.carm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carm930.semver=9.3.0 (linux)
 compiler.carm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc


### PR DESCRIPTION

* [x] AArch32 bare-metal target (arm-none-eabi)
* [ ] AArch32 GNU/Linux target with hard float (arm-none-linux-gnueabihf) <- this looks to be already available
* [ ] AArch64 bare-metal target (aarch64-none-elf)
* [ ] AArch64 GNU/Linux target (aarch64-none-linux-gnu) <- this looks to be already available
* [ ] AArch64 GNU/Linux big-endian target (aarch64_be-none-linux-gnu)
