### PR TITLE
add arm-unknown-eabi GCC 13.2

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1595,7 +1595,7 @@ group.gccarm.includeFlag=-I
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
 group.gcc32arm.baseName=ARM GCC
-group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1310:armg1320:armgtrunk
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1310:armg1320:armug1320:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -1669,6 +1669,12 @@ compiler.armg1320.exe=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gn
 compiler.armg1320.semver=13.2.0
 compiler.armg1320.objdumper=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1320.demangler=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.armug1320.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
+compiler.armug1320.name=ARM GCC 13.2.0 (unknown-eabi)
+compiler.armug1320.semver=13.2.0
+compiler.armug1320.objdumper=/opt/compiler-explorer/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.armug1320.demangler=/opt/compiler-explorer/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
 
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1416,7 +1416,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1310:carmg1320:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1310:carmg1320:carmug1320:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -1477,6 +1477,13 @@ compiler.carmg1320.exe=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-g
 compiler.carmg1320.semver=13.2.0
 compiler.carmg1320.objdumper=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.carmg1320.demangler=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.carmug1320.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.carmug1320.name=ARM GCC 13.2.0 (unknown-eabi)
+compiler.carmug1320.semver=13.2.0
+compiler.carmug1320.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.carmug1320.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+
 compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc
 compiler.carmce820.semver=8.2.0 (WinCE)
 compiler.carmce820.supportsBinary=false


### PR DESCRIPTION
Add an arm-unknown-eabi GCC 13.2 as asked by GBA community.

fix #5545

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>