### PR TITLE
Update `.js` to `.ts` in documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,21 +16,21 @@ lang-c:
   - lib/compilers/cc65.ts
   - lib/compilers/ellcc.ts
   - lib/compilers/ewarm.ts
-  - lib/compilers/awavr.ts
+  - lib/compilers/ewavr.ts
   - lib/compilers/ppci.ts
   - lib/compilers/sdcc.ts
   - lib/compilers/tendra.ts
   - etc/config/c.*.properties
 lang-c++:
   - lib/compilers/ewarm.ts
-  - lib/compilers/awavr.ts
+  - lib/compilers/ewavr.ts
   - etc/config/c++.*.properties
   - static/modes/cppp-mode.ts
 lang-c++-opencl:
   - etc/config/cpp_for_opencl.*.properties
   - static/modes/cpp-for-opencl-mode.ts
 lang-c3:
-  - lib/compilers/c3.ts
+  - lib/compilers/c3c.ts
   - etc/config/c3.*.properties
   - static/modes/c3-mode.ts
 lang-circle:
@@ -67,7 +67,7 @@ lang-d:
   - static/modes/d-mode.ts
 lang-dotnet:
   - lib/compilers/dotnet.ts
-  - lib/asm-parser-dotnet.ts
+  - lib/parsers/asm-parser-dotnet.ts
   - etc/config/csharp.*.properties
   - etc/config/fsharp.*.properties
   - etc/config/vb.*.properties
@@ -179,7 +179,7 @@ lang-toit:
   - etc/config/toit.*.properties
   - static/modes/toit-mode.ts
 lang-typescript:
-  - lib/compilers/typescript.ts
+  - lib/compilers/typescript-native.ts
   - etc/config/typescript.*.properties
 lang-v:
   - lib/compilers/v.ts

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,28 +2,28 @@ ui:
   - static/**/*
   - views/**/*
 lang-ada:
-  - lib/compilers/ada.js
+  - lib/compilers/ada.ts
   - etc/config/ada.*.properties
   - static/modes/ada-mode.ts
 lang-asm:
-  - lib/compilers/assembly.js
-  - lib/compilers/nasm.js
-  - lib/compilers/ptxas.js
+  - lib/compilers/assembly.ts
+  - lib/compilers/nasm.ts
+  - lib/compilers/ptxas.ts
   - etc/config/assembly.*.properties
   - static/modes/asm-mode.ts
   - static/modes/asm6502-mode.ts
 lang-c:
-  - lib/compilers/cc65.js
-  - lib/compilers/ellcc.js
-  - lib/compilers/ewarm.js
-  - lib/compilers/awavr.js
-  - lib/compilers/ppci.js
-  - lib/compilers/sdcc.js
-  - lib/compilers/tendra.js
+  - lib/compilers/cc65.ts
+  - lib/compilers/ellcc.ts
+  - lib/compilers/ewarm.ts
+  - lib/compilers/awavr.ts
+  - lib/compilers/ppci.ts
+  - lib/compilers/sdcc.ts
+  - lib/compilers/tendra.ts
   - etc/config/c.*.properties
 lang-c++:
-  - lib/compilers/ewarm.js
-  - lib/compilers/awavr.js
+  - lib/compilers/ewarm.ts
+  - lib/compilers/awavr.ts
   - etc/config/c++.*.properties
   - static/modes/cppp-mode.ts
 lang-c++-opencl:
@@ -34,18 +34,18 @@ lang-c3:
   - etc/config/c3.*.properties
   - static/modes/c3-mode.ts
 lang-circle:
-  - lib/compilers/circle.js
+  - lib/compilers/circle.ts
   - etc/config/circle.*.properties
   - static/modes/cppcircle-mode.ts
 lang-circt:
   - lib/compilers/circt.ts
   - etc/config/circt.*.properties
 lang-clean:
-  - lib/compilers/clean.js
+  - lib/compilers/clean.ts
   - etc/config/clean.*.properties
   - static/modes/clean-mode.ts
 lang-cobol:
-  - lib/compilers/gnucobol.js
+  - lib/compilers/gnucobol.ts
   - etc/config/cobol.*.properties
   - static/modes/cobol-mode.ts
 lang-cppx:
@@ -53,16 +53,16 @@ lang-cppx:
   - static/modes/cppx-blue-mode.ts
   - static/modes/cppx-gold-mode.ts
 lang-crystal:
-  - lib/compilers/crystal.js
+  - lib/compilers/crystal.ts
   - etc/config/crystal.*.properties
   - static/modes/crystal-mode.ts
 lang-cuda:
-  - lib/compilers/nvcc.js
+  - lib/compilers/nvcc.ts
   - etc/config/cuda.*.properties
   - static/modes/cuda-mode.ts
 lang-d:
-  - lib/compilers/dmd.js
-  - lib/compilers/ldc.js
+  - lib/compilers/dmd.ts
+  - lib/compilers/ldc.ts
   - etc/config/d.*.properties
   - static/modes/d-mode.ts
 lang-dotnet:
@@ -72,15 +72,15 @@ lang-dotnet:
   - etc/config/fsharp.*.properties
   - etc/config/vb.*.properties
 lang-dart:
-  - lib/compilers/dart.js
+  - lib/compilers/dart.ts
   - etc/config/dart.*.properties
 lang-fortran:
   - lib/compilers/flang.ts
-  - lib/compilers/fortran.js
+  - lib/compilers/fortran.ts
   - etc/config/fortran.*.properties
   - static/modes/fortran-mode.ts
 lang-hlsl:
-  - lib/compilers/hlsl.js
+  - lib/compilers/hlsl.ts
   - etc/config/hlsl.*.properties
   - static/modes/hlsl-mode.ts
 lang-hook:
@@ -92,14 +92,14 @@ lang-jakt:
   - etc/config/jakt.*.properties
   - static/modes/jakt-mode.ts
 lang-go:
-  - lib/compilers/golang.js
+  - lib/compilers/golang.ts
   - etc/config/go.*.properties
 lang-haskell:
-  - lib/compilers/haskell.js
+  - lib/compilers/haskell.ts
   - etc/config/haskell.*.properties
   - static/modes/haskell-mode.ts
 lang-ispc:
-  - lib/compilers/ispc.js
+  - lib/compilers/ispc.ts
   - etc/config/ispc.*.properties
   - static/modes/ispc-mode.ts
 lang-mlir:
@@ -107,30 +107,30 @@ lang-mlir:
   - etc/config/mlir.*.properties
   - static/modes/mlir-mode.ts
 lang-java:
-  - lib/compilers/java.js
+  - lib/compilers/java.ts
   - etc/config/java.*.properties
 lang-julia:
-  - lib/compilers/julia.js
+  - lib/compilers/julia.ts
   - etc/config/julia.*.properties
 lang-kotlin:
-  - lib/compilers/kotlin.js
+  - lib/compilers/kotlin.ts
   - etc/config/kotlin.*.properties
 lang-llvm:
-  - lib/llvm-ast.js
-  - lib/llvm-ir.js
+  - lib/llvm-ast.ts
+  - lib/llvm-ir.ts
   - lib/llvm-opt-transformer.ts
-  - lib/compilers/llc.js
-  - lib/compilers/llvm-mca.js
-  - lib/objdumper/llvm.js
-  - lib/tooling/llvm-mca-tool.js
+  - lib/compilers/llc.ts
+  - lib/compilers/llvm-mca.ts
+  - lib/objdumper/llvm.ts
+  - lib/tooling/llvm-mca-tool.ts
   - etc/config/llvm.*.properties
   - static/modes/llvm-ir-mode.ts
 lang-modula2:
-  - lib/compilers/gm2.js
+  - lib/compilers/gm2.ts
   - etc/config/modula2.*.properties
   - static/modes/modula2-mode.ts
 lang-nim:
-  - lib/compilers/nim.js
+  - lib/compilers/nim.ts
   - etc/config/nim.*.properties
   - static/modes/nim-mode.ts
 lang-objc:
@@ -138,38 +138,38 @@ lang-objc:
 lang-objc++:
   - etc/config/objc++.*.properties
 lang-ocaml:
-  - lib/compilers/ocaml.js
+  - lib/compilers/ocaml.ts
   - etc/config/ocaml.*.properties
   - static/modes/ocaml-mode.ts
 lang-opencl-c:
   - etc/config/openclc.*.properties
   - static/modes/openclc-mode.ts
 lang-pascal:
-  - lib/compilers/pascal.js
+  - lib/compilers/pascal.ts
   - etc/config/pascal.*.properties
 lang-pony:
   - lib/compilers/pony.ts
   - etc/config/pony.*.properties
 lang-python:
-  - lib/compilers/python.js
+  - lib/compilers/python.ts
   - etc/config/python.*.properties
 lang-racket:
   - lib/compilers/racket.ts
   - etc/config/racket.*.properties
 lang-ruby:
-  - lib/compilers/ruby.js
+  - lib/compilers/ruby.ts
   - etc/config/ruby.*.properties
 lang-rust:
-  - lib/compilers/rust.js
+  - lib/compilers/rust.ts
   - etc/config/rust.*.properties
 lang-scala:
-  - lib/compilers/scala.js
+  - lib/compilers/scala.ts
   - etc/config/scala.*.properties
 lang-solidity:
-  - lib/compilers/solidity.js
+  - lib/compilers/solidity.ts
   - etc/config/solidity.*.properties
 lang-swift:
-  - lib/compilers/swift.js
+  - lib/compilers/swift.ts
   - etc/config/swift.*.properties
 lang-snowball:
   - lib/compilers/snowball.ts
@@ -179,7 +179,7 @@ lang-toit:
   - etc/config/toit.*.properties
   - static/modes/toit-mode.ts
 lang-typescript:
-  - lib/compilers/typescript.js
+  - lib/compilers/typescript.ts
   - etc/config/typescript.*.properties
 lang-v:
   - lib/compilers/v.ts
@@ -190,7 +190,7 @@ lang-vala:
   - etc/config/vala.*.properties
   - static/modes/vala-mode.ts
 lang-zig:
-  - lib/compilers/zig.js
+  - lib/compilers/zig.ts
   - etc/config/zig.*.properties
   - static/modes/zig-mode.ts
 documentation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,16 +42,16 @@ when testing your changes locally.
 ## Basic code layout
 
 Code is separated into server-side code and client-side code. All dependencies (server and client side) are installed
-via `package.json`. _Server code_ is in `app.js` and in the `lib` directory. _Client code_ is all in the `static`
+via `package.json`. _Server code_ is in `app.ts` and in the `lib` directory. _Client code_ is all in the `static`
 directory.
 
-In the server code, the `app.js` sets up a basic `express` middleware-driven web server, delegating to the various
-compiler backends in `lib/compilers/`. All of them inherit from `lib/base-compiler.js` which does most of the work of
+In the server code, the `app.ts` sets up a basic `express` middleware-driven web server, delegating to the various
+compiler backends in `lib/compilers/`. All of them inherit from `lib/base-compiler.ts` which does most of the work of
 running compilers, then parsing the output and forming a JSON object to send to the client. Any assembly parsing is done
-in the `lib/asm-parser.js`, and similar, files.
+in the `lib/parsers/asm-parser.ts`, and similar, files.
 
 In the client code, [GoldenLayout](https://www.golden-layout.com/) is used as the container. If you look at some
-components like the `static/compiler.js`, you'll see the general flow. Any state stored makes it into the URL, so be
+components like the `static/panes/compiler.ts`, you'll see the general flow. Any state stored makes it into the URL, so be
 careful not to stash anything too big in there.
 
 The client code follows GoldenLayout's message-based system: no component has a reference to any other and everything is

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -138,3 +138,4 @@ From oldest to newest contributor, we would like to thank:
 - [Marc Auberer](https://github.com/marcauberer)
 - [Seyed Ali Ghasemi](https://github.com/gha3mi)
 - [Guo Ci](https://github.com/guoci)
+- [Rupert Tombs](https://github.com/Rupt)

--- a/docs/AddingACompiler.md
+++ b/docs/AddingACompiler.md
@@ -106,7 +106,7 @@ once the site runs on the Amazon environment, the `&clang` group **will not** ha
 | objdumper            | String     | Path to the object dump tool                                                                                     |
 | objdumperArgs        | String     | List of arguments passed to the object dump tool (separated by `\|` character)                                   |
 
-The `compilerType` option is special: it refers to the Javascript class in `lib/compilers/*.js` which handles running
+The `compilerType` option is special: it refers to the Javascript class in `lib/compilers/*.ts` which handles running
 and handling output for this compiler type.
 
 ## Adding a new compiler locally

--- a/docs/AddingALanguage.md
+++ b/docs/AddingALanguage.md
@@ -20,14 +20,14 @@ If you want to add a new language to the site, you should follow this steps:
   - If the language is supported by Monaco Editor (You can find the list
     [here](https://github.com/microsoft/monaco-editor/tree/main/src/basic-languages)), you should add it to the list of
     languages inside the `MonacoEditorWebpackPlugin` config in `webpack.config.esm.ts`
-  - If not, you should implement your own language mode; see `static/modes/asm-mode.js` as an example. Don't forget to
+  - If not, you should implement your own language mode; see `static/modes/asm-mode.ts` as an example. Don't forget to
     _require_ your mode file in `static/modes/_all.ts`, in alphabetical order
   - `language-key` is how your language will be referred internally by the code. In the rest of this document, replace
     `{language-key}` by the corresponding value in the real files.
   - Add a logo file to the `views/resources/logos/` folder and add its path to the `logoUrl{Dark}` key(s) in the
     language object
 
-- Add a `lib/compilers/{language-key}.js` file using the template below:
+- Add a `lib/compilers/{language-key}.ts` file using the template below:
 
   ```js
   import {BaseCompiler} from '../base-compiler';
@@ -43,7 +43,7 @@ If you want to add a new language to the site, you should follow this steps:
     `etc/config/{language-key}.defaults.properties` (Explained below). This is usually `{language-key}`, but you can use
     whatever fits best
   - Override the `OptionsForFilter` method from the base class
-  - Comment out the line saying `fs.remove(result.dirPath);` in base-compiler.js, so the latest CE compile attempt
+  - Comment out the line saying `fs.remove(result.dirPath);` in `base-compiler.ts`, so the latest CE compile attempt
     remains on disk for you to review
     - Remember to undo this change before opening a PR!
   - For reference, the basic behaviour of BaseCompiler is:
@@ -58,7 +58,7 @@ If you want to add a new language to the site, you should follow this steps:
     - set `execOptions.env` parameter if the compiler requires special environment variables
     - manipulate `options`, but make sure the user can still add their own arguments in CE
 
-- Add your `LanguageCompiler` to `lib/compilers/_all.js`, in alphabetical order
+- Add your `LanguageCompiler` to `lib/compilers/_all.ts`, in alphabetical order
 
 - Add a `etc/config/{language-key}.local.properties` file:
 
@@ -81,5 +81,5 @@ If you want to add a new language to the site, you should follow this steps:
 
 - Make an installer in the [infra](https://github.com/compiler-explorer/infra) repository
 
-- Add your language files (`{language-key}.*.properties` and `lib/compilers/{language-key}.js`) to the list in
+- Add your language files (`{language-key}.*.properties` and `lib/compilers/{language-key}.ts`) to the list in
   `.github/labeler.yml`

--- a/docs/AddingAssemblyDocumentation.md
+++ b/docs/AddingAssemblyDocumentation.md
@@ -21,9 +21,9 @@ developer.arm.com website and the JVM bytecode handler uses Oracle's documentati
 ## 2. Create a tool for collecting the data
 
 Since we want to go through the automated route, you should write a script or a piece of code to automatically gather
-the data for us and store it in a nice format that CE expects. The output of the script should be a generated .js file
+the data for us and store it in a nice format that CE expects. The output of the script should be a generated .ts file
 with a single exported function containing a gigantic switch for the instruction opcode. Examples of this generated file
-can be found in `/lib/asm-docs/generated/asm-docs-amd64.js`.
+can be found in `/lib/asm-docs/generated/asm-docs-amd64.ts`.
 
 How you generate this file is completely up to you, just make sure it's easy for others to run the script if needed as
 well. If you need inspiration on how to write this tool, you can look at the `docenizer-*` scripts found in

--- a/docs/AddingCustomCompilersOverview.md
+++ b/docs/AddingCustomCompilersOverview.md
@@ -15,7 +15,7 @@ that the process is similar for all other types of compilers.
 - If we need to customise the way we execute the compiler and/or display the results, then we can change the
   "[driver](https://github.com/compiler-explorer/compiler-explorer/tree/main/lib/compilers)" for the compiler. Usually
   we can just override a few aspects of the driver, relying on the defaults from the
-  [base driver](https://github.com/compiler-explorer/compiler-explorer/blob/main/lib/base-compiler.js).
+  [base driver](https://github.com/compiler-explorer/compiler-explorer/blob/main/lib/base-compiler.ts).
 - Any UI changes are a bit more work.
 
 More info still in

--- a/docs/SystemdSocketActivation.md
+++ b/docs/SystemdSocketActivation.md
@@ -21,7 +21,7 @@ compiler-explorer.service:
 [Service]
 Type=simple
 WorkingDirectory={{path_to_installation_directory}}/compiler-explorer
-ExecStart=/usr/bin/node {{path_to_installation_directory}}/compiler-explorer/app.js
+ExecStart=/usr/bin/node {{path_to_installation_directory}}/compiler-explorer/out/dist/app.js
 TimeoutStartSec=60
 TimeoutStopSec=60
 User={{run_as_this_user}}

--- a/docs/WindowsSubsystemForLinux.md
+++ b/docs/WindowsSubsystemForLinux.md
@@ -64,23 +64,23 @@ Now you can point your favorite web browser at http://localhost:10240 and see yo
 
 CE only required a few changes in order to run properly under WSL. Those changes are listed here:
 
-- `app.js`:
+- `app.ts`:
   - `process.env.wsl` is set if CE if the string "Microsoft" in found in the output of `uname -a`. This works for all
     WSL distros as they all run on the base Microsoft Linux kernel.
   - If the `-tmpDir` option is specified on the command line, both `process.env.tmpDir` and `process.env.winTmp` are set
     to the specified value Note that if this is specified as a non-Windows volume, Windows executables will fail to run
     properly. Otherwise, `process.env.winTmp` is set to the value of the Windows `%TEMP%` directory if CE can get the
     temp path from invoking `cmd.exe` from WSL.
-- `lib/exec.js`: Execute the compiler in the temporary directory. If the compiler's binary is located on a mounted
+- `lib/exec.ts`: Execute the compiler in the temporary directory. If the compiler's binary is located on a mounted
   volume (`startsWith("/mnt"`)) and CE is running under WSL, run the compiler in the `winTmp` directory. Otherwise, use
   the Linux temp directory.
-- `lib/compilers/wsl-vc.js`: See also `wine-vc.js`, the Wine version of this compiler-specific file. These files provide
+- `lib/compilers/wsl-vc.ts`: See also `wine-vc.ts`, the Wine version of this compiler-specific file. These files provide
   custom behaviors for a compiler. This file does two interesting things:
   - The `CompileCl` function translates from Linux-style directories to Windows-style directories (`/mnt/c/tmp` to
     `c:/tmp`) so that `CL.exe` can find its input files.
   - The `newTempDir` function creates a temporary directory in `winTmp`. CEs creates directories under the temp
     directory that start with `compiler-explorer-compiler` where the compiler and compiler output lives. This is similar
-    to the function in `lib/base-compiler.js`.
+    to the function in `lib/base-compiler.ts`.
 - `etc/config/c++.defaults.properties`: Add a configuration (`&cl19`) for MSVC compilers. This edits in here are
   currently wrong in two ways, but it doesn't affect the main CE instance as it uses `amazon` properties files, and it
   doesn't affect anyone running a local copy of CE because CE will just fail silently when it can't find a compiler.

--- a/docs/internal/FrontendTesting.md
+++ b/docs/internal/FrontendTesting.md
@@ -19,8 +19,8 @@ Steps to add a test:
 
 - Create a new file in `static/tests` (copy paste from `static/tests/hello-world.ts`)
 - Make sure to change the `description` as well as the test
-- Add the file to the imports of `static/tests/_all.js`
-- Add a `runFrontendTest()` call with the new test description to `cypress/integration/frontend-testing.js`
+- Add the file to the imports of `static/tests/_all.ts`
+- Add a `runFrontendTest()` call with the new test description to `cypress/integration/frontend-testing.ts`
 
 ## Starting tests locally
 

--- a/docs/internal/FrontendTesting.md
+++ b/docs/internal/FrontendTesting.md
@@ -20,7 +20,7 @@ Steps to add a test:
 - Create a new file in `static/tests` (copy paste from `static/tests/hello-world.ts`)
 - Make sure to change the `description` as well as the test
 - Add the file to the imports of `static/tests/_all.ts`
-- Add a `runFrontendTest()` call with the new test description to `cypress/integration/frontend-testing.ts`
+- Add a test file with a `runFrontendTest()` call in `cypress/e2e`
 
 ## Starting tests locally
 


### PR DESCRIPTION
While reading the (excellent) documentation here, I noticed a few stale references to `.js` files that are now implemented in TypeScript.

* Update `*.js` to `*.ts` in Markdown documentation.

* Update `app.js` to `out/dist/app.js` in `docs/SystemdSocketActivation.md`.
  _I managed to follow these instructions and locally run Compiler Explorer through socket activation after that change._

* Update `*.js` to `*.ts` in the GitHub labeller config `.github/labeler.yml`.
  _Also correct some misnamed files here. I have checked the new version with `ls $(grep -E "^  - " .github/labeler.yml | sed "s/  - //g")`. If I were more familiar here, I would have liked to add a similar check to the automated tests._

- Sheepishly add myself to the contributors list, despite this being a tiny find-and-replace change.
