### PR TITLE
fix month

### DIFF
--- a/static/utils.ts
+++ b/static/utils.ts
@@ -62,7 +62,7 @@ export function formatDateTimeWithSpaces(d: Date) {
 }
 
 export function formatISODate(dt: Date, full = false) {
-    const month = '' + dt.getUTCMonth();
+    const month = '' + (dt.getUTCMonth() + 1);
     const day = '' + dt.getUTCDate();
     const hrs = '' + dt.getUTCHours();
     const min = '' + dt.getUTCMinutes();


### PR DESCRIPTION
Function `formatISODate()` calls `Date.prototype.getUTCMonth()` whose results is off by one (Jan = 0, ..., Dec = 11). Hence, we add one to align to common practice.
