### PR TITLE
Add support for RISC-V GNU as

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&nasm:&gnuas:&llvmas:&ptxas:&gnuasarm:&gnuasarm64:&beebasm
+compilers=&nasm:&gnuas:&llvmas:&ptxas:&gnuasarm:&gnuasarm64:&gnuasriscv:&beebasm
 compilerType=assembly
 objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 supportsBinary=true
@@ -99,6 +99,63 @@ compiler.gnuasarm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unk
 compiler.gnuasarm64g1020.name=AArch64 binutils 2.35.1
 compiler.gnuasarm64g1020.semver=2.35.1
 
+# GNU as for RISC-V
+group.gnuasriscv.compilers=&gnuasriscv64:&gnuasriscv32
+group.gnuasriscv.groupName=RISC-V binutils
+group.gnuasriscv.isSemVer=true
+group.gnuasriscv.options=-g
+group.gnuasriscv.supportsExecute=false
+group.gnuasriscv.versionFlag=--version
+
+## GNU as for RISC-V 64-bits
+group.gnuasriscv64.compilers=gnuasriscv64g820:gnuasriscv64g1020:gnuasriscv64g1140:gnuasriscv64g1320
+group.gnuasriscv64.groupName=RISC-V (64-bits) binutils
+group.gnuasriscv64.baseName=RISC-V (64-bits) binutils
+
+compiler.gnuasriscv64g820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
+compiler.gnuasriscv64g820.name=RISC-V binutils 2.31.1
+compiler.gnuasriscv64g820.semver=2.31.1
+compiler.gnuasriscv64g820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv64g1020.exe=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
+compiler.gnuasriscv64g1020.name=RISC-V binutils 2.35.1
+compiler.gnuasriscv64g1020.semver=2.35.1
+compiler.gnuasriscv64g1020.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv64g1140.exe=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
+compiler.gnuasriscv64g1140.name=RISC-V binutils 2.37.0
+compiler.gnuasriscv64g1140.semver=2.37.0
+compiler.gnuasriscv64g1140.objdumper=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv64g1320.exe=/opt/compiler-explorer/riscv64/gcc-13.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
+compiler.gnuasriscv64g1320.name=RISC-V binutils 2.38.0
+compiler.gnuasriscv64g1320.semver=2.38.0
+compiler.gnuasriscv64g1320.objdumper=/opt/compiler-explorer/riscv64/gcc-13.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
+## GNU as for RISC-V 32-bits
+group.gnuasriscv32.compilers=gnuasriscv32g820:gnuasriscv32g1020:gnuasriscv32g1140:gnuasriscv32g1320
+group.gnuasriscv32.groupName=RISC-V (32-bits) binutils
+group.gnuasriscv32.baseName=RISC-V (32-bits) binutils
+
+compiler.gnuasriscv32g820.exe=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
+compiler.gnuasriscv32g820.name=RISC-V binutils 2.31.1
+compiler.gnuasriscv32g820.semver=2.31.1
+compiler.gnuasriscv32g820.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv32g1020.exe=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
+compiler.gnuasriscv32g1020.name=RISC-V binutils 2.35.1
+compiler.gnuasriscv32g1020.semver=2.35.1
+compiler.gnuasriscv32g1020.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv32g1140.exe=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
+compiler.gnuasriscv32g1140.name=RISC-V binutils 2.37.0
+compiler.gnuasriscv32g1140.semver=2.37.0
+compiler.gnuasriscv32g1140.objdumper=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv32g1320.exe=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
+compiler.gnuasriscv32g1320.name=RISC-V binutils 2.38.0
+compiler.gnuasriscv32g1320.semver=2.38.0
+compiler.gnuasriscv32g1320.objdumper=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version


### PR DESCRIPTION
Add the 4 versions of RISC-V binutils (2.31.1, 2.35.1, 2.37.0, 2.38.0) bundled with gcc versions used by compiler explorer as assembly targets.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
