### PR TITLE
feat: update grammar of Cpp2

### DIFF
--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -96,7 +96,12 @@ function definition(): monaco.languages.IMonarchLanguage {
         cppfront.at_cpp2_balanced_parentheses = balancedParenthesesRegex(5);
 
         cppfront.at_cpp2_interpolation = /@at_cpp2_balanced_parentheses\$/;
-        cppfront.tokenizer.parse_cpp2_interpolation = [[/./, {token: '@rematch', switchTo: 'parse_cpp2_expression'}]];
+        cppfront.tokenizer.parse_cpp2_interpolation = [
+            [/(\()(.)/, ['delimiter.parenthesis', {token: '@rematch', next: 'parse_cpp2_expression'}]],
+            [/:[^)]*/, 'string'],
+            [/\)/, 'delimiter.parenthesis'],
+            [/\$/, 'delimiter.interpolation', '@pop'],
+        ];
 
         cppfront.at_cpp2_string_literal = /@encoding?(?:\$?R)?"/;
         cppfront.tokenizer.parse_cpp2_string_literal = [
@@ -195,12 +200,27 @@ function definition(): monaco.languages.IMonarchLanguage {
                 /@at_cpp2_non_operator_identifier/,
                 {
                     cases: {
-                        '$S2~definition|parameter': {token: 'identifier.definition', next: '@pop'},
+                        '$S2~definition|parameter': {
+                            token: 'identifier.definition',
+                            switchTo: 'parse_cpp2_parameter_ellipsis.$S2',
+                        },
                         '$S2==type': {token: 'type.contextual', next: '@pop'},
                         '@': {token: 'identifier.use', next: '@pop'},
                     },
                 },
             ],
+        ];
+        cppfront.tokenizer.parse_cpp2_parameter_ellipsis = [
+            [
+                /\.\.\./,
+                {
+                    cases: {
+                        '$S2==parameter': {token: 'delimiter.ellipsis', next: '@pop'},
+                        '@': {token: '@rematch', next: '@pop'},
+                    },
+                },
+            ],
+            [/./, '@rematch', '@pop'],
         ];
 
         cppfront.at_cpp2_type_qualifier = /const\b|\*/;
@@ -228,6 +248,7 @@ function definition(): monaco.languages.IMonarchLanguage {
         cppfront.at_cpp2_template_argument = /@at_cpp2_expression|@at_cpp2_type_id/;
         cppfront.tokenizer.parse_cpp2_template_argument = [
             [/@at_cpp2_keyword_type/, 'keyword.type', '@pop'],
+            [/@at_cpp2_type_qualifier/, {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],
             [/@at_cpp2_expression/, {token: '@rematch', switchTo: 'parse_cpp2_expression.template_argument'}],
             [/@at_cpp2_type_id/, {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],
         ];
@@ -251,6 +272,7 @@ function definition(): monaco.languages.IMonarchLanguage {
         cppfront.tokenizer.parse_cpp2_id_expression = [
             {include: '@whitespace'},
             [/::/, ''],
+            [/\.\.\./, '@rematch', '@pop'],
             [/\./, 'delimiter'],
             [/@at_cpp2_identifier</, {token: '@rematch', switchTo: 'parse_cpp2_template_id.$S2'}],
             [/@at_cpp2_non_operator_identifier(?=\s*(?:\.|::))/, '@rematch', 'parse_cpp2_identifier.use'],
@@ -277,15 +299,28 @@ function definition(): monaco.languages.IMonarchLanguage {
         ];
 
         cppfront.at_cpp2_primary_expression =
-            /@at_cpp2_literal|@at_cpp2_id_expression|\(|@at_cpp2_unnamed_declaration_head/;
+            /@at_cpp2_literal|@at_cpp2_id_expression|\.\.\.|\(|@at_cpp2_unnamed_declaration_head/;
         // Can't ensure sequential parsing.
         cppfront.tokenizer.parse_cpp2_primary_expression = [
             [/inspect\b/, '@rematch', 'parse_cpp2_inspect_expression'],
             // These two happen to parse UDLs:
-            [/@at_cpp2_literal/, '@rematch', 'parse_cpp2_literal'],
-            [/@at_cpp2_id_expression/, '@rematch', 'parse_cpp2_primary_expression_id_expression'],
+            [/@at_cpp2_literal/, {token: '@rematch', switchTo: 'parse_cpp2_primary_expression_literal_.$S2.$S3'}],
+            [
+                /@at_cpp2_id_expression/,
+                {token: '@rematch', switchTo: 'parse_cpp2_primary_expression_id_expression_.$S2.$S3'},
+            ],
+            [/\.\.\./, 'delimiter.ellipsis'],
             // Handle `(` later to workaround `(0)is` being parsed as two adjacent primary expressions.
             [/@at_cpp2_unnamed_declaration_head/, '@rematch', 'parse_cpp2_declaration.expression'],
+            [/./, {token: '@rematch', switchTo: 'parse_cpp2_postfix_expression.$S2.$S3'}],
+        ];
+        cppfront.tokenizer.parse_cpp2_primary_expression_id_expression_ = [
+            [/@at_cpp2_id_expression/, '@rematch', 'parse_cpp2_primary_expression_id_expression'],
+            [/\.\.\./, 'delimiter.ellipsis'],
+            [/./, {token: '@rematch', switchTo: 'parse_cpp2_postfix_expression.$S2.$S3'}],
+        ];
+        cppfront.tokenizer.parse_cpp2_primary_expression_literal_ = [
+            [/@at_cpp2_literal/, '@rematch', 'parse_cpp2_literal'],
             [/./, {token: '@rematch', switchTo: 'parse_cpp2_postfix_expression.$S2.$S3'}],
         ];
 
@@ -645,13 +680,22 @@ function definition(): monaco.languages.IMonarchLanguage {
             [/./, '@rematch', '@pop'],
         ];
 
-        cppfront.tokenizer.parse_cpp2_function_type = [
+        cppfront.tokenizer.parse_cpp2_full_function_type = [
             {include: '@whitespace'},
-            [/\(/, '@rematch', 'parse_cpp2_parameter_declaration_list'],
             [/throws\b/, 'keyword'],
             [/->/, '@rematch', 'parse_cpp2_return_list'],
             [/\[/, '@rematch', 'parse_cpp2_contract_seq'],
             [/./, '@rematch', '@pop'],
+        ];
+        cppfront.tokenizer.parse_cpp2_terse_function = [
+            {include: '@whitespace'},
+            [/\(/, '@rematch', 'parse_cpp2_parameter_declaration_list'],
+            [/throws\b|->|\[/, {token: '@rematch', switchTo: 'parse_cpp2_full_function_type'}],
+            [/requires\b|==?|;/, '@rematch', '@pop'],
+            [/@at_cpp2_expression/, {token: '@rematch', switchTo: 'parse_cpp2_expression'}],
+        ];
+        cppfront.tokenizer.parse_cpp2_function_type = [
+            [/./, {token: '@rematch', switchTo: 'parse_cpp2_terse_function'}],
         ];
 
         cppfront.tokenizer.parse_cpp2_declaration_initializer = [
@@ -684,7 +728,8 @@ function definition(): monaco.languages.IMonarchLanguage {
         ];
 
         cppfront.at_cpp2_unnamed_declaration_head = /:(?!:)/;
-        cppfront.at_cpp2_identifier_definition = /@at_cpp2_identifier\s*@at_cpp2_unnamed_declaration_head/;
+        cppfront.at_cpp2_identifier_definition =
+            /@at_cpp2_identifier\s*(?:\.\.\.)?\s*@at_cpp2_unnamed_declaration_head/;
         cppfront.at_cpp2_top_level_declaration_head =
             /(?:@at_cpp2_access_specifier\s+)?(?!@at_cpp2_access_specifier)@at_cpp2_identifier_definition/;
         cppfront.at_cpp2_declaration_head = /(?:@at_cpp2_access_specifier\s+)?@at_cpp2_identifier_definition/;
@@ -693,6 +738,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             {include: '@whitespace'},
             [/@at_cpp2_access_specifier/, 'keyword'],
             [/@at_cpp2_identifier/, '@rematch', 'parse_cpp2_identifier.$S2'],
+            [/\.\.\./, 'delimiter.ellipsis'],
             [
                 /@at_cpp2_unnamed_declaration_head/,
                 {token: 'identifier.definition', switchTo: 'parse_cpp2_declaration_signature.$S2'},

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -336,7 +336,9 @@ function definition(): monaco.languages.IMonarchLanguage {
                 /./,
                 {
                     token: '@rematch',
-                    switchTo: 'parse_cpp2_is_as_expression_target.parse_cpp2_binary_expression_tail.$S2.$S3',
+                    switchTo:
+                        'parse_cpp2_is_as_expression_target.parse_cpp2_expression.' +
+                        'parse_cpp2_binary_expression_tail.$S2.$S3',
                 },
             ],
         ];
@@ -356,17 +358,15 @@ function definition(): monaco.languages.IMonarchLanguage {
         ];
 
         cppfront.tokenizer.parse_cpp2_is_as_expression_target = [
-            // `@$S2` is the continuation parser.
+            // `@$S2` is the expression parser.
+            // `@$S3.$S4.$S5` is the continuation parser.
             {include: '@whitespace'},
             [
                 /(@at_cpp2_is_as_operator)(\s+)(@at_cpp2_type_id)/,
                 ['keyword', '', {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],
             ],
-            [
-                /(is\b)(\s*)(@at_cpp2_expression)/,
-                ['keyword', '', {token: '@rematch', switchTo: 'parse_cpp2_expression'}],
-            ],
-            [/./, {token: '@rematch', switchTo: '@$S2.$S3.$S4'}],
+            [/(is\b)(\s*)(@at_cpp2_expression)/, ['keyword', '', {token: '@rematch', switchTo: '@$S2'}]],
+            [/./, {token: '@rematch', switchTo: '@$S3.$S4.$S5'}],
         ];
 
         cppfront.at_cpp2_logical_or_operator = /\*|\/|%|\+|-|<<|>>|<=>|<|>|<=|>=|==|!=|&|\^|\||&&|\|\|/;
@@ -434,7 +434,11 @@ function definition(): monaco.languages.IMonarchLanguage {
 
         cppfront.tokenizer.parse_cpp2_alternative = [
             {include: '@whitespace'},
-            [/@at_cpp2_is_as_operator/, '@rematch', 'parse_cpp2_is_as_expression_target.pop'],
+            [
+                /@at_cpp2_is_as_operator/,
+                '@rematch',
+                'parse_cpp2_is_as_expression_target.parse_cpp2_logical_or_expression.pop',
+            ],
             [/@at_cpp2_non_operator_identifier/, '@rematch', 'parse_cpp2_identifier.definition'],
             [/@at_cpp2_unnamed_declaration_head/, 'identifier.definition'],
             [/=/, {token: 'delimiter', switchTo: 'parse_cpp2_statement'}],

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -245,7 +245,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             [/\(/, {token: '@rematch', switchTo: 'parse_cpp2_function_type'}],
         ];
 
-        cppfront.at_cpp2_template_argument = /@at_cpp2_expression|@at_cpp2_type_id/;
+        cppfront.at_cpp2_template_argument = /@at_cpp2_string_literal|@at_cpp2_expression|@at_cpp2_type_id/;
         cppfront.tokenizer.parse_cpp2_template_argument = [
             [/@at_cpp2_keyword_type/, 'keyword.type', '@pop'],
             [/@at_cpp2_type_qualifier/, {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],


### PR DESCRIPTION
This is an update to #5061.
The test cases: <https://highlight-cpp2.godbolt.org/z/o685vYdv9>.

<details><summary>Preview</summary>

![1697424211](https://github.com/compiler-explorer/compiler-explorer/assets/21071787/39fd82d9-6668-43a0-9eb3-053b278f35cb)

</details>