### PR TITLE
Use verbose version flag to get `rustc` version

### DIFF
--- a/etc/config/rust.defaults.properties
+++ b/etc/config/rust.defaults.properties
@@ -7,6 +7,9 @@ stubRe=\bmain\b
 stubText=pub fn main() {/*stub provided by Compiler Explorer*/}
 binaryHideFuncRe=^(_.*|call_gmon_start|(de)?register_tm_clones|frame_dummy|.*@plt.*)$
 
+# short form of `--version --verbose`
+versionFlag=-vV
+
 
 #################################
 #################################


### PR DESCRIPTION
`rustc` by default only gives a short version output like this
```console
$ rustc --version
rustc 1.75.0-nightly (42b1224e9 2023-10-15)
```

There is, however, a more verbose version info that also includes the LLVM version used:
```console
$ rustc --version --verbose
rustc 1.75.0-nightly (42b1224e9 2023-10-15)
binary: rustc
commit-hash: 42b1224e9eb37177f608d3f6a6f2be2ee13902e4
commit-date: 2023-10-15
host: x86_64-unknown-linux-gnu
release: 1.75.0-nightly
LLVM version: 17.0.2
```

This is useful information, so it should be accessible.

---

I’d normally have used `--version --verbose`, but it seems that the `versionFlag` property is passed as one single argument to `rustc` and not split on spaces, so I used the short form `-vV` instead.