### PR TITLE
Add the LLVM TableGen language

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -174,6 +174,10 @@ lang-swift:
 lang-snowball:
   - lib/compilers/snowball.ts
   - etc/config/snowball.*.properties
+lang-tablegen:
+  - lib/compilers/tablegen.ts
+  - etc/config/tablegen.*.properties
+  - static/modes/tablegen-mode.ts
 lang-toit:
   - lib/compilers/toit.ts
   - etc/config/toit.*.properties

--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -1,0 +1,20 @@
+compilers=&llvmtblgen
+defaultCompiler=llvmtblgen1701
+compilerType=tablegen
+supportsBinary=false
+supportsExecute=false
+
+group.llvmtblgen.compilers=llvmtblgen1701
+group.llvmtblgen.groupName=LLVM TableGen
+group.llvmtblgen.baseName=LLVM TableGen
+group.llvmtblgen.isSemVer=true
+group.llvmtblgen.compilerType=tablegen
+group.llvmtblgen.licenseName=LLVM Apache 2
+group.llvmtblgen.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.llvmtblgen.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.llvmtblgen.supportsBinaryObject=false
+group.llvmtblgen.supportsBinary=false
+group.llvmtblgen.compilerCategories=tablegen
+
+compiler.llvmtblgen1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-tblgen
+compiler.llvmtblgen1701.semver=17.0.1

--- a/etc/config/tablegen.defaults.properties
+++ b/etc/config/tablegen.defaults.properties
@@ -1,0 +1,8 @@
+compilerType=tablegen
+compilers=llvmtblgen
+defaultCompiler=llvmtblgen
+supportsBinary=false
+supportsExecute=false
+
+compiler.llvmtblgen.exe=/usr/bin/llvm-tblgen
+compiler.llvmtblgen.name=llvm-tblgen

--- a/examples/tablegen/default.td
+++ b/examples/tablegen/default.td
@@ -1,0 +1,8 @@
+class Register<int _size, string _alias=""> {
+    int size = _size;
+    string alias = _alias;
+}
+
+def X0: Register<8> {}
+
+def X29: Register<8, "frame pointer"> {}

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -106,6 +106,7 @@ export {SdccCompiler} from './sdcc.js';
 export {SolidityCompiler} from './solidity.js';
 export {SPIRVCompiler} from './spirv.js';
 export {SwiftCompiler} from './swift.js';
+export {TableGenCompiler} from './tablegen.js';
 export {TenDRACompiler} from './tendra.js';
 export {TIC2000} from './tic2000.js';
 export {TinyCCompiler} from './tinyc.js';

--- a/lib/compilers/tablegen.ts
+++ b/lib/compilers/tablegen.ts
@@ -1,0 +1,12 @@
+import {BaseCompiler} from '../base-compiler.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+
+export class TableGenCompiler extends BaseCompiler {
+    static get key() {
+        return 'tablegen';
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
+        return ['-o', outputFilename];
+    }
+}

--- a/lib/compilers/tablegen.ts
+++ b/lib/compilers/tablegen.ts
@@ -9,4 +9,8 @@ export class TableGenCompiler extends BaseCompiler {
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
         return ['-o', outputFilename];
     }
+
+    override isCfgCompiler() {
+        return false;
+    }
 }

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -637,6 +637,17 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
     },
+    tablegen: {
+        name: 'TableGen',
+        monaco: 'tablegen',
+        extensions: ['.td'],
+        alias: [],
+        logoUrl: 'llvm.png',
+        logoUrlDark: null,
+        formatter: null,
+        previewFilter: null,
+        monacoDisassembly: null,
+    },
     toit: {
         name: 'Toit',
         monaco: 'toit',

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -638,7 +638,7 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         monacoDisassembly: null,
     },
     tablegen: {
-        name: 'TableGen',
+        name: 'LLVM TableGen',
         monaco: 'tablegen',
         extensions: ['.td'],
         alias: [],

--- a/static/modes/_all.ts
+++ b/static/modes/_all.ts
@@ -59,6 +59,7 @@ import './ocaml-mode';
 import './openclc-mode';
 import './ptx-mode';
 import './spirv-mode';
+import './tablegen-mode';
 import './v-mode';
 import './vala-mode';
 import './zig-mode';

--- a/static/modes/tablegen-mode.ts
+++ b/static/modes/tablegen-mode.ts
@@ -1,0 +1,201 @@
+// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as monaco from 'monaco-editor';
+
+export function definition(): monaco.languages.IMonarchLanguage {
+    return {
+        keywords: [
+            'assert',
+            'class',
+            'code',
+            'def',
+            'dump',
+            'else',
+            'false',
+            'foreach',
+            'defm',
+            'defset',
+            'defvar',
+            'field',
+            'if',
+            'in',
+            'include',
+            'let',
+            'multiclass',
+            'then',
+            'true',
+        ],
+        standardTypes: [
+            'bit',
+            'int',
+            'string',
+            'dag',
+            'bits',
+            'list',
+        ],
+        operators: [
+            '!add',
+            '!and',
+            '!cast',
+            '!con',
+            '!cond',
+            '!dag',
+            '!div',
+            '!empty',
+            '!eq',
+            '!exists',
+            '!filter',
+            '!find',
+            '!foldl',
+            '!foreach',
+            '!ge',
+            '!getdagarg',
+            '!getdagname',
+            '!getdagop',
+            '!gt',
+            '!head',
+            '!if',
+            '!interleave',
+            '!isa',
+            '!le',
+            '!listconcat',
+            '!listremove',
+            '!listsplat',
+            '!logtwo',
+            '!lt',
+            '!mul',
+            '!ne',
+            '!not',
+            '!or',
+            '!range',
+            '!repr',
+            '!setdagarg',
+            '!setdagname',
+            '!setdagop',
+            '!shl',
+            '!size',
+            '!sra',
+            '!srl',
+            '!strconcat',
+            '!sub',
+            '!subst',
+            '!substr',
+            '!tail',
+            '!tolower',
+            '!toupper',
+            '!xor',
+        ],
+        brackets: [
+            {
+                open: '(',
+                close: ')',
+                token: 'delimiter.parenthesis',
+            },
+            {
+                open: '[',
+                close: ']',
+                token: 'delimiter.square',
+            },
+            {
+                open: '<',
+                close: '>',
+                token: 'delimiter.angle',
+            },
+        ],
+        symbols: /[=><!~&|+\-*/^]+/,
+        delimiters: /[;=.:,`]/,
+        escapes: /\\(?:[abfnrtv\\'\n\r]|x[0-9A-Fa-f]{2}|[0-7]{3}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|N\{\w+\})/,
+
+        tokenizer: {
+            root: [
+                [
+                    /[a-zA-Z_][a-zA-Z0-9_]*/,
+                    {
+                        cases: {
+                            '@standardTypes': 'type',
+                            '@keywords': 'keyword',
+                            '@default': 'identifier',
+                        },
+                    },
+                ],
+                {include: '@whitespace'},
+
+                [/[()[\]<>]/, '@brackets'],
+
+                // Numbers
+                [/0x([abcdef]|[ABCDEF]|\d)+/, 'number.hex'],
+                [/0b[01]+1/, 'number.binary'],
+                // Decimal may have + or - in front.
+                [/[-+]?\d+/, 'number'],
+
+                // Strings
+                [/"([^"\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+                [/"/, 'string', '@string'],
+
+                [
+                    /@delimiters/,
+                    {
+                        cases: {
+                            '@keywords': 'keyword',
+                            '@default': 'delimiter',
+                        },
+                    },
+                ],
+            ],
+
+            whitespace: [
+                [/[ \t\r\n]+/, 'white'],
+                [/\/\*/, 'comment', '@comment'],
+                [/\/\+/, 'comment', '@nestingcomment'],
+                [/\/\/.*$/, 'comment'],
+            ],
+
+            comment: [
+                [/[^/*]+/, 'comment'],
+                [/\*\//, 'comment', '@pop'],
+                [/[/*]/, 'comment'],
+            ],
+
+            nestingcomment: [
+                [/[^/+]+/, 'comment'],
+                [/\/\+/, 'comment', '@push'],
+                [/\/\+/, 'comment.invalid'],
+                [/\+\//, 'comment', '@pop'],
+                [/[/+]/, 'comment'],
+            ],
+
+            string: [
+                [/[^\\"]+/, 'string'],
+                [/@escapes/, 'string.escape'],
+                [/\\./, 'string.escape.invalid'],
+                [/"/, 'string', '@pop'],
+            ],
+        },
+    };
+}
+monaco.languages.register({id: 'tablegen'});
+monaco.languages.setMonarchTokensProvider('tablegen', definition());
+
+export {};

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -78,6 +78,7 @@ export type LanguageKey =
     | 'scala'
     | 'solidity'
     | 'swift'
+    | 'tablegen'
     | 'toit'
     | 'typescript'
     | 'v'


### PR DESCRIPTION
LLVM TableGen is used to generate complex output files in the llvm project. A generic description of classes and definitions produces "records" that can then be walked by a TableGen backend to produce things like C++ code, configuration files, etc.

The biggest examples are LLVM's assembler and disassembler where all the targets' instructions are defined in TableGen.

https://llvm.org/docs/TableGen/ProgRef.html

An example:
```
class Register<int _size, string _alias=""> {
    int size = _size;
    string alias = _alias;
}
def X0: Register<8> {}
def X29: Register<8, "frame pointer"> {}
```
```
------------- Classes -----------------
class Register<int Register:_size = ?, string Register:_alias = ""> {
  int size = Register:_size;
  string alias = Register:_alias;
}
------------- Defs -----------------
def X0 {        // Register
  int size = 8;
  string alias = "";
}
def X29 {       // Register
  int size = 8;
  string alias = "frame pointer";
}
```

It's often a pain point for people new to LLVM so having a quick way to experiment would be a great benefit for the community (we have a Jupyter kernel which is good but not as simple as Compiler Explorer).

The compiler for TableGen is `llvm-tblgen`. This comes with most release builds of LLVM in /bin along with clang and the others. Its default is to output a text dump of the records defined so that's what I've used here. This is not executable code so I've disabled the features related to that.

A user could pass options to `llvm-tblgen` to produce text in a format other than this, C++ code or JSON for example. However this text dump is the main use case.

I've re-used an existing clang install, since that includes `llvm-tblgen` in `bin/`. I just added the 17.01 version for this first change.

Syntax highlighting is a mix of the Fortran and Ada configuration, following the language spec I linked above. Though I am very new to that so it is likely incomplete.