### PR TITLE
feat(devcontainers): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG NODE_MAJOR_VERSION
+
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
+
+ENV EDITOR="code -w" VISUAL="code -w"
+
+# install system dependencies for cypress (https://docs.cypress.io/guides/continuous-integration/introduction)
+RUN apt update && apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+# uncomment to install additional npm packages
+# RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "compiler-explorer",
+  "dockerFile": "Dockerfile",
+  "build": {
+    "args": {"NODE_MAJOR_VERSION": "20"}
+  },
+  "postCreateCommand": [".devcontainer/post-create.sh"],
+  "portsAttributes": {
+    "10240": {"label": "Compiler Explorer"}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "EditorConfig.EditorConfig", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# when in a VS Code or GitHub Codespaces devcontainer
+if [ -n "${REMOTE_CONTAINERS}" ]; then
+    this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+    workspace_root=$(realpath ${this_dir}/..)
+
+    # perform additional one-time setup just after
+    # the devcontainer is created
+    npm install --prefix "${workspace_root}" # install node dependencies
+
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ in the right direction.
 when testing your changes locally.
 
 > Note that this repository is compatible with `GitHub Codespaces` as well as `VS Code Dev Containers`. Opening your
-> cloned project with either of these options will ensure that your development envrionment is already set up and
+> cloned project with either of these options will ensure that your development environment is already set up and
 > configured correctly!
 
 ## In brief

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ in the right direction.
 **Compiler Explorer** currently targets [Node.js](https://nodejs.org/) version 20, so it's better if you do so as well
 when testing your changes locally.
 
+> Note that this repository is compatible with `GitHub Codespaces` as well as `VS Code Dev Containers`. Opening your
+> cloned project with either of these options will ensure that your development envrionment is already set up and
+> configured correctly!
+
 ## In brief
 
 - Make your changes, trying to stick to the style and format where possible.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -139,3 +139,4 @@ From oldest to newest contributor, we would like to thank:
 - [Seyed Ali Ghasemi](https://github.com/gha3mi)
 - [Guo Ci](https://github.com/guoci)
 - [Rupert Tombs](https://github.com/Rupt)
+- [Andrew Brey](https://github.com/andrewbrey)


### PR DESCRIPTION
For `Hacktoberfest`, I have been adding `GitHub Codespaces` / `VS Code Remote Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via `GH Codespaces`, or inside of fully, and correctly configured containers on their own computer with `VS Code Remote Containers` (both of these use the same configuration, as `GH Codespaces` leverages the `Remote Containers` features under the hood).

For the `compiler-explorer` project, this configuration includes the following:
- Preinstalled `Node 20`
- Preinstalled `ESLint`,  `Prettier`, and `EditorConfig` extensions
- Preinstalled `cypress` dependencies
- Automation of the `npm install` when the devcontainer is first created

Basically everything needed for a contributor to open the project after a fresh clone and be immediately productive, either locally with `VS Code` or remotely with `GitHub Codespaces`!

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36
- https://github.com/date-fns/date-fns/pull/3551
- https://github.com/floating-ui/floating-ui/pull/2606
- https://github.com/EveryBoard/EveryBoard/pull/155
- https://github.com/melt-ui/melt-ui/pull/658
- https://github.com/JamesLMilner/terra-draw/pull/108
