### PR TITLE
fix(devcontainer): ensure post-create runs in GitHub Codespaces

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # when in a VS Code or GitHub Codespaces devcontainer
-if [ -n "${REMOTE_CONTAINERS}" ]; then
+if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
     this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
     workspace_root=$(realpath ${this_dir}/..)
 


### PR DESCRIPTION
This is a quick follow up to https://github.com/compiler-explorer/compiler-explorer/pull/5631 to add a missing environment check that would prevent the `devcontainer` _post-create.sh_ from running when using `GitHub Codespaces`. Sorry I missed this in the first PR, but now with this the experience in Codespaces is the same as locally in VS Code :+1: 