### PR TITLE
Fix #5621

### DIFF
--- a/lib/cfg/cfg-parsers/base.ts
+++ b/lib/cfg/cfg-parsers/base.ts
@@ -130,7 +130,7 @@ export class BaseCFGParser {
     }
 
     protected isFunctionName(line: AssemblyLine) {
-        return line.text.trim().indexOf('.') !== 0;
+        return line.text.trim().indexOf('.') !== 0 || line.text.startsWith('.omp_outlined.');
     }
 
     protected getAsmDirective(txt: string) {
@@ -167,7 +167,7 @@ export class BaseCFGParser {
     }
 
     protected isFunctionEnd(x: string) {
-        return x[0] !== ' ' && x[0] !== '.' && x.includes(':');
+        return x[0] !== ' ' && (x[0] !== '.' || x.startsWith('.omp_outlined.')) && x.includes(':');
     }
 
     protected isBasicBlockEnd(inst: string, prevInst: string) {

--- a/lib/cfg/cfg-parsers/base.ts
+++ b/lib/cfg/cfg-parsers/base.ts
@@ -130,7 +130,7 @@ export class BaseCFGParser {
     }
 
     protected isFunctionName(line: AssemblyLine) {
-        return line.text.trim().indexOf('.') !== 0 || line.text.startsWith('.omp_outlined.');
+        return line.text.trim().indexOf('.') !== 0 || line.text.startsWith('.omp_');
     }
 
     protected getAsmDirective(txt: string) {
@@ -167,7 +167,7 @@ export class BaseCFGParser {
     }
 
     protected isFunctionEnd(x: string) {
-        return x[0] !== ' ' && (x[0] !== '.' || x.startsWith('.omp_outlined.')) && x.includes(':');
+        return x[0] !== ' ' && (x[0] !== '.' || x.startsWith('.omp_')) && x.includes(':');
     }
 
     protected isBasicBlockEnd(inst: string, prevInst: string) {


### PR DESCRIPTION
I'm not sure about this PR, feedback and ideas are very welcome.

When `-fopenmp` is involved, the compiler generates functions that in assembly dump are hard to distinguish from labels. In particular: 
```
f(int*, int*, int):                              # @f(int*, int*, int)     <--- an obvious function
        sub     rsp, 24
        mov     qword ptr [rsp + 16], rdi
        mov     qword ptr [rsp + 8], rsi
        mov     dword ptr [rsp + 4], edx
        lea     rdi, [rip + .L__unnamed_1]
        lea     rdx, [rip + .omp_outlined.]
        lea     rcx, [rsp + 4]
        lea     r8, [rsp + 16]
        lea     r9, [rsp + 8]
        mov     esi, 3
        xor     eax, eax
        call    __kmpc_fork_call@PLT
        add     rsp, 24
        ret
.omp_outlined.:                         # @.omp_outlined.        <--- function too!
        cmp     dword ptr [rdx], 0
        jle     .LBB1_3
        mov     rax, qword ptr [r8]
        mov     rcx, qword ptr [rcx]
        xor     esi, esi
.LBB1_2:                                # =>This Inner Loop Header: Depth=1       <---- label
        mov     edi, dword ptr [rax + 4*rsi]
        add     edi, 19
        mov     dword ptr [rcx + 4*rsi], edi
        add     rsi, 1
        movsxd  rdi, dword ptr [rdx]
        cmp     rsi, rdi
        jl      .LBB1_2
.LBB1_3:                                           <---- label
        ret
.L__unnamed_2:                                     <---- label
        .asciz  ";/tmp/compiler-explorer-compiler2023922-55033-8svfoq.hy3cf/example.cpp;f;2;5;;"
...
```

It *seems* like one way to distinguish labels from functions would have been to search the line for `# @<repeat the beginning of the line until ':'>`, but CE currently takes a naive approach like:
```ts
    protected isFunctionName(line: AssemblyLine) {
        return line.text.trim().indexOf('.') !== 0;
    }
```


I opted to suggest as minor a change as possible, and just special-cased these `.omp_outlined.` functions (their name can contain an index) in two places. This is enough to solve the confusing IR/ASM cfg diff, and have asm separate functions properly.