### PR TITLE
Another fix on the way to resolving #5617

### DIFF
--- a/lib/cfg/instruction-sets/arm.ts
+++ b/lib/cfg/instruction-sets/arm.ts
@@ -96,8 +96,8 @@ export class ArmInstructionSetInfo extends BaseInstructionSetInfo {
 
     override getInstructionType(instruction: string) {
         const opcode = instruction.trim().split(' ')[0].toLowerCase();
-        if (opcode.match(ArmInstructionSetInfo.unconditionalJumps)) return InstructionType.jmp;
-        else if (opcode.match(ArmInstructionSetInfo.conditionalJumps)) return InstructionType.conditionalJmpInst;
+        if (opcode.match(ArmInstructionSetInfo.conditionalJumps)) return InstructionType.conditionalJmpInst;
+        else if (opcode.match(ArmInstructionSetInfo.unconditionalJumps)) return InstructionType.jmp;
         else if (instruction.trim().toLocaleLowerCase().match(ArmInstructionSetInfo.returnInstruction)) {
             return InstructionType.retInst;
         } else {


### PR DESCRIPTION
Turns out `ArmInstructionSetInfo.unconditionalJumps` and `ArmInstructionSetInfo.conditionalJumps` are not disjoint, and the order in which they are tested matters. Specifically an opcode like `b.lt` provides a match for `ArmInstructionSetInfo.unconditionalJumps` in the single char `b` and so erroneously returned `InstructionType.jmp`.

One can imagine a better solution in modifying the regexes to make them properly disjoint, but AFAICT this is good enough, at least to un-break the ARM CFG.
