### PR TITLE
Fix libbpf includes

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3685,9 +3685,9 @@ libs.libbpf.liblink=bpf:dl:m
 libs.libbpf.description=Libbpf supports building BPF CO-RE-enabled applications
 libs.libbpf.url=https://github.com/libbpf/libbpf
 libs.libbpf.versions.100.version=1.0.0
-libs.libbpf.versions.100.path=/opt/compiler-explorer/libs/libbpf/v1.0.0/include
+libs.libbpf.versions.100.path=/opt/compiler-explorer/libs/libbpf/v1.0.0/include:/opt/compiler-explorer/libs/libbpf/v1.0.0/src
 libs.libbpf.versions.122.version=1.2.2
-libs.libbpf.versions.122.path=/opt/compiler-explorer/libs/libbpf/v1.2.2/include
+libs.libbpf.versions.122.path=/opt/compiler-explorer/libs/libbpf/v1.2.2/include:/opt/compiler-explorer/libs/libbpf/v1.2.2/src
 
 libs.libguarded.name=CsLibGuarded
 libs.libguarded.versions=trunk:110

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2722,9 +2722,9 @@ libs.libbpf.liblink=bpf:dl:m
 libs.libbpf.description=Libbpf supports building BPF CO-RE-enabled applications
 libs.libbpf.url=https://github.com/libbpf/libbpf
 libs.libbpf.versions.100.version=1.0.0
-libs.libbpf.versions.100.path=/opt/compiler-explorer/libs/libbpf/v1.0.0/include
+libs.libbpf.versions.100.path=/opt/compiler-explorer/libs/libbpf/v1.0.0/include:/opt/compiler-explorer/libs/libbpf/v1.0.0/src
 libs.libbpf.versions.122.version=1.2.2
-libs.libbpf.versions.122.path=/opt/compiler-explorer/libs/libbpf/v1.2.2/include
+libs.libbpf.versions.122.path=/opt/compiler-explorer/libs/libbpf/v1.2.2/include:/opt/compiler-explorer/libs/libbpf/v1.2.2/src
 
 libs.lua.name=Lua
 libs.lua.versions=535:540


### PR DESCRIPTION
This change fixes the include paths for libbpf.

Tested on a local install. I think in the original PR I had libbpf headers on the system and were being picked up.
![2023-10-24-20:15:31](https://github.com/compiler-explorer/compiler-explorer/assets/2632746/b541cd85-087b-4187-b363-b0a4ca499769)

The same code fails in the current version:
```
// Type your code here, or load an example.
#include <lib/libbpf.h>

int square(int num) {
    return libbpf_major_version();
}
```
Error:
```
<source>:2:10: fatal error: 'lib/libbpf.h' file not found
#include <lib/libbpf.h>
         ^~~~~~~~~~~~~~
1 error generated.
ASM generation compiler returned: 1
<source>:2:10: fatal error: 'lib/libbpf.h' file not found
#include <lib/libbpf.h>
         ^~~~~~~~~~~~~~
1 error generated.
Execution build compiler returned: 1
```

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
