### PR TITLE
LLVM TableGen: Add trunk compiler and default include path

### DIFF
--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -4,7 +4,7 @@ compilerType=tablegen
 supportsBinary=false
 supportsExecute=false
 
-group.llvmtblgen.compilers=llvmtblgen1701
+group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701
 group.llvmtblgen.groupName=LLVM TableGen
 group.llvmtblgen.baseName=LLVM TableGen
 group.llvmtblgen.isSemVer=true
@@ -16,5 +16,7 @@ group.llvmtblgen.supportsBinaryObject=false
 group.llvmtblgen.supportsBinary=false
 group.llvmtblgen.compilerCategories=tablegen
 
+compiler.llvmtblgen_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-tblgen
+compiler.llvmtblgen_trunk.semver=(trunk)
 compiler.llvmtblgen1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-tblgen
 compiler.llvmtblgen1701.semver=17.0.1

--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -18,7 +18,9 @@ group.llvmtblgen.compilerCategories=tablegen
 
 compiler.llvmtblgen_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-tblgen
 compiler.llvmtblgen_trunk.semver=(trunk)
+compiler.llvmtblgen_trunk.isNightly=true
 compiler.llvmtblgen_trunk.includePath=/opt/compiler-explorer/clang-trunk/include/
+
 compiler.llvmtblgen1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-tblgen
 compiler.llvmtblgen1701.semver=17.0.1
 compiler.llvmtblgen1701.includePath=/opt/compiler-explorer/clang-17.0.1/include/

--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -18,5 +18,7 @@ group.llvmtblgen.compilerCategories=tablegen
 
 compiler.llvmtblgen_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-tblgen
 compiler.llvmtblgen_trunk.semver=(trunk)
+compiler.llvmtblgen_trunk.includePath=/opt/compiler-explorer/clang-trunk/include/
 compiler.llvmtblgen1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-tblgen
 compiler.llvmtblgen1701.semver=17.0.1
+compiler.llvmtblgen1701.includePath=/opt/compiler-explorer/clang-17.0.1/include/

--- a/lib/compilers/tablegen.ts
+++ b/lib/compilers/tablegen.ts
@@ -7,7 +7,11 @@ export class TableGenCompiler extends BaseCompiler {
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
-        return ['-o', outputFilename];
+        const options: string[] = ['-o', outputFilename];
+        if (this.compiler.includePath) {
+            options.push(`-I${this.compiler.includePath}`);
+        }
+        return options;
     }
 
     override isCfgCompiler() {


### PR DESCRIPTION
Since trunk will be a moving target, I've left the default compiler as 17.01.

The standard include path will allow for examples that include files like `include "llvm/TableGen/SearchableTable.td"`, without extra options. This is useful if you want to create a minimal example of the records that an existing backend expects to see.