### PR TITLE
Support LLVM-MCA for armv8-a clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4509,7 +4509,7 @@ tools.llvm-mcatrunk.name=llvm-mca (trunk)
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
-tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
+tools.llvm-mcatrunk.exclude=avr:rv32:arm:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
 tools.osacatrunk.name=OSACA (0.5.2)


### PR DESCRIPTION
LLVM-MCA is supported for X86-64 clang compilers, but not for armv8-a clang.  This enables LLVM-MCA support for AArch64 because it is supported for many AArch64 cores.

Fixes request #5649.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
