### PR TITLE
Dont attempt to demangle (llvm-ir) if we cant

### DIFF
--- a/lib/demangler/base.ts
+++ b/lib/demangler/base.ts
@@ -79,6 +79,10 @@ export class BaseDemangler extends AsmRegex {
         this.compiler = compiler;
     }
 
+    public canDemangle() {
+        return !!this.demanglerExe;
+    }
+
     // Iterates over the labels, demangle the label names and updates the start and
     // end position of the label.
     protected demangleLabels(labels, tree: PrefixTree) {

--- a/lib/llvm-ir.ts
+++ b/lib/llvm-ir.ts
@@ -242,7 +242,7 @@ export class LlvmIrParser {
             };
         }
 
-        if (options.demangle) {
+        if (options.demangle && this.irDemangler.canDemangle()) {
             return {
                 asm: (await this.irDemangler.process({asm: result})).asm,
                 languageId: 'llvm-ir',


### PR DESCRIPTION
Fixes #5655

The llvm-ir demangling stage doesn't check supportsDemangle, and we can't really check correctly here. So just slapped on a canDemangle() function that checks if the exe is set.
