### PR TITLE
Add seastar trunk and 2211 versions to CE

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4038,10 +4038,14 @@ libs.scnlib.versions.04.path=/opt/compiler-explorer/libs/scnlib/refs/tags/v0.4/i
 
 libs.seastar.name=Seastar
 libs.seastar.description=SeaStar is an event-driven framework allowing you to write non-blocking, asynchronous code in a relatively straightforward manner.
-libs.seastar.versions=180
+libs.seastar.versions=trunk:180:2211
 libs.seastar.url=http://seastar.io
 libs.seastar.versions.180.version=18.08.0
 libs.seastar.versions.180.path=/opt/compiler-explorer/libs/seastar/seastar-18.08.0
+libs.seastar.versions.2211.version=22.11.0
+libs.seastar.versions.2211.path=/opt/compiler-explorer/libs/seastar/seastar-22.11.0/include
+libs.seastar.versions.trunk.version=trunk
+libs.seastar.versions.trunk.path=/opt/compiler-explorer/libs/seastar/trunk/include
 
 libs.seqan3.name=SeqAn3
 libs.seqan3.description=A modern C++ library for sequence analysis.


### PR DESCRIPTION
The existing seastar version 1808 is more than five years old and lots of exciting changes have occurred since then. This patch adds seastar 2211 from last last year as well as trunk.

The 2211 version of seastar requires PR compiler-explorer/infra#1134 to be accepted first to add it on the infra side.

`make check` passes.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
