### PR TITLE
Sort Armv8 all architectural features clang below trunk version

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -720,7 +720,7 @@ compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/op
 compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-full-clang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-full-clang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
-compiler.armv8-full-clang-trunk.semver=(trunk, all architectural features)
+compiler.armv8-full-clang-trunk.semver=(all architectural features, trunk)
 compiler.armv8-full-clang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features
 compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -545,7 +545,7 @@ compiler.armv8-cclang-trunk.isNightly=true
 # Arm v8-a
 compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
-compiler.armv8-full-cclang-trunk.name=armv8-a clang (trunk, all architectural features)
+compiler.armv8-full-cclang-trunk.name=armv8-a clang (all architectural features, trunk)
 compiler.armv8-full-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-full-cclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -171,7 +171,7 @@ compiler.armv8-cpp4oclclang-trunk-assertions.isNightly=true
 # Arm v8-a
 compiler.armv8-cpp4oclclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
-compiler.armv8-full-cpp4oclclang-trunk.name=armv8-a clang (trunk, all architectural features)
+compiler.armv8-full-cpp4oclclang-trunk.name=armv8-a clang (all architectural features, trunk)
 compiler.armv8-full-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-full-cpp4oclclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -192,7 +192,7 @@ compiler.armv8-oclcclang-trunk-assertions.semver=(assertions trunk)
 # Arm v8-a
 compiler.armv8-oclcclang-trunk-assertions.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
-compiler.armv8-full-oclcclang-trunk.name=armv8-a clang (trunk, all architectural features)
+compiler.armv8-full-oclcclang-trunk.name=armv8-a clang (all architectural features, trunk)
 compiler.armv8-full-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-full-oclcclang-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
Fixes #5641

The "all architectural features" compiler is trunk, plus a whole bunch of `-march` flags to enable the kitchen sink for AArch64. Which is useful for some, but as pointed out in the issue, not representative of what the average clang on the average system will produce. So plain trunk is a better first entry for this category.

To fix this, I've changed the semver value so that we will have this order:
```
(trunk)
(all architectural features, trunk)
17.0.1
<more versions...>
```

`(trunk)` is not treated as a valid semver so it's sorted by the string value. So the shorter `(trunk)` was shown before the longer `(trunk, all...`.

This is why the other special compiler versions sort as they do, because they are `(` then something < `t` (and I didn't find any special workarounds either).

Putting `trunk` at the end fixes this issue and will not break existing URLs since the name of the compiler settings file entry (e.g. `armv8-full-clang-trunk` for C++) has not changed.