### PR TITLE
Fix #5683

### DIFF
--- a/lib/cfg/cfg-parsers/base.ts
+++ b/lib/cfg/cfg-parsers/base.ts
@@ -86,14 +86,14 @@ export class BaseCFGParser {
         while (first !== last) {
             if (this.isFunctionEnd(asmArr[first].text)) {
                 fnRange.end = first;
-                result.push(_.clone(fnRange));
+                if (fnRange.end > fnRange.start + 1) result.push(_.clone(fnRange));
                 fnRange.start = first;
             }
             ++first;
         }
 
         fnRange.end = last;
-        result.push(_.clone(fnRange));
+        if (fnRange.end > fnRange.start + 1) result.push(_.clone(fnRange));
         return result;
     }
 


### PR DESCRIPTION
The filtering of directive lines (those starting with dot) is already performed at `parser.filterData`. All that was missing is dropping empty "functions".
