### PR TITLE
Handle errors in the LLVM transform

### DIFF
--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -86,9 +86,14 @@ export class LLVMOptTransformer extends Transform {
     }
 
     override _transform(chunk: any, encoding: string, done: TransformCallback) {
-        this._buffer += chunk.toString();
-        //buffer until we have a start and end if at any time i care about improving performance stash the offset
-        this.processBuffer();
+        // See https://stackoverflow.com/a/40928431/390318 - we have to catch all exceptions here
+        try {
+            this._buffer += chunk.toString();
+            this.processBuffer();
+        } catch (exception) {
+            done(exception as Error);
+            return;
+        }
         done();
     }
 


### PR DESCRIPTION
Previously an error in e.g. YAML parsing would take down the whole process.

Part of #5686 but doesn't fix the underlying issue.
