### PR TITLE
Fix #5672

### DIFF
--- a/lib/cfg/instruction-sets/arm.ts
+++ b/lib/cfg/instruction-sets/arm.ts
@@ -77,9 +77,9 @@ export class ArmInstructionSetInfo extends BaseInstructionSetInfo {
     static returnInstruction = new RegExp(
         '(?:' +
             [`bx`, `ret`].map(re => `(?:${re})`).join('|') +
-            ')\\b.+' +
-            `|pop\\s*\\{(?:r(?:\\d{2,}|[4-9]),\\s*)*pc\\}.+` +
-            `|mov\\s*pc\\s*,.+`,
+            ')\\b.*' +
+            `|pop\\s*\\{(?:r(?:\\d{2,}|[4-9]),\\s*)*pc\\}.*` +
+            `|mov\\s*pc\\s*,.*`,
     );
 
     static override get key(): InstructionSet[] {


### PR DESCRIPTION
The existing `returnInstruction` regex failed both `ret` (with no arguments) and `pop {r4, pc}`. This small fix solves these.