### PR TITLE
LLVM TableGen: Add actions to Overrides menu

### DIFF
--- a/lib/compilers/tablegen.ts
+++ b/lib/compilers/tablegen.ts
@@ -1,5 +1,7 @@
 import {BaseCompiler} from '../base-compiler.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {TableGenParser} from './argument-parsers.js';
+import {CompilerOverrideType} from '../../types/compilation/compiler-overrides.interfaces.js';
 
 export class TableGenCompiler extends BaseCompiler {
     static get key() {
@@ -16,5 +18,27 @@ export class TableGenCompiler extends BaseCompiler {
 
     override isCfgCompiler() {
         return false;
+    }
+
+    override getArgumentParser() {
+        return TableGenParser;
+    }
+
+    override async populatePossibleOverrides() {
+        const possibleActions = await TableGenParser.getPossibleActions(this);
+        if (possibleActions.length > 0) {
+            this.compiler.possibleOverrides?.push({
+                name: CompilerOverrideType.action,
+                display_title: 'Action',
+                description:
+                    'The action to perform, which is the backend you wish to ' +
+                    'run. By default, the records are just printed as text.',
+                flags: ['<value>'],
+                values: possibleActions,
+                default: '--print-records',
+            });
+        }
+
+        await super.populatePossibleOverrides();
     }
 }

--- a/test/compilers/argument-parsers-tests.js
+++ b/test/compilers/argument-parsers-tests.js
@@ -29,6 +29,7 @@ import {
     GCCParser,
     ICCParser,
     PascalParser,
+    TableGenParser,
     VCParser,
 } from '../../lib/compilers/argument-parsers.js';
 import {FakeCompiler} from '../../lib/compilers/fake-for-test.js';
@@ -269,6 +270,31 @@ describe('ICC argument parser', () => {
                 name: 'gnu++98: conforms to 1998 ISO C++ standard plus GNU extensions',
                 value: 'gnu++98',
             },
+        ]);
+    });
+});
+
+describe('TableGen argument parser', () => {
+    it('Should extract actions', () => {
+        const lines = [
+            'USAGE: llvm-tblgen [options] <input file>',
+            '',
+            'OPTIONS:',
+            '',
+            'General options:',
+            '',
+            '  -D <macro name>                     - Name of the macro...',
+            '  Action to perform:',
+            '      --gen-attrs                        - Generate attributes',
+            '      --print-detailed-records           - Print full details...',
+            '      --gen-x86-mnemonic-tables          - Generate X86...',
+            '  --no-warn-on-unused-template-args   - Disable...',
+        ];
+        const actions = TableGenParser.extractPossibleActions(lines);
+        actions.should.deep.equal([
+            {name: 'gen-attrs: Generate attributes', value: '--gen-attrs'},
+            {name: 'print-detailed-records: Print full details...', value: '--print-detailed-records'},
+            {name: 'gen-x86-mnemonic-tables: Generate X86...', value: '--gen-x86-mnemonic-tables'},
         ]);
     });
 });

--- a/types/compilation/compiler-overrides.interfaces.ts
+++ b/types/compilation/compiler-overrides.interfaces.ts
@@ -30,6 +30,7 @@ export enum CompilerOverrideType {
     env = 'env',
     edition = 'edition',
     stdver = 'stdver',
+    action = 'action',
 }
 
 export type CompilerOverrideTypes = Set<CompilerOverrideType>;


### PR DESCRIPTION
"actions" are TableGen's version of the target for a compiler like clang. Where clang might target "Arm" TableGen will target a backend that produces some format like `gen-searchable-tables` which generates C++ code.

Actions are gathered from `--help` and appear in the UI as:
```
<option without -->: <description>
```
For example:
```
gen-searchable-tables: Generate generic binary-searchable table
```

The option name means if you are trying replicate an example from inside llvm, you can match it to the options passed in the build system. The long description is there if you are just browsing the options and want to know what it does. When passed to the compiler I add back the `--` to create the right option.

The default action is `--print-records` which is the same as passing no action, which is what I did until now.

With this feature it is possible to make examples like https://godbolt.org/z/ohK178eMf in a cleaner way than adding the action option to the compiler options box.

I considered just calling this the "target" as for other compilers, but decided against it because:
* `llvm-tblgen --help` refers to it as an action, and I want to be consistent with that.
* I saw Rust had already added Editions as an override, so adding a new type here seems acceptable.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
