### PR TITLE
Fix #5255

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -633,7 +633,7 @@ export class BaseCompiler implements ICompiler {
     }
 
     getGccDumpFileName(outputFilename: string) {
-        return outputFilename.replace(path.extname(outputFilename), '.dump');
+        return outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.dump';
     }
 
     getGccDumpOptions(gccDumpOptions, outputFilename: string) {
@@ -1402,27 +1402,27 @@ export class BaseCompiler implements ICompiler {
     }
 
     getRustMacroExpansionOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.expanded.rs');
+        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.expanded.rs';
     }
 
     getRustHirOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.hir');
+        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.hir';
     }
 
     getRustMirOutputFilename(outputFilename) {
-        return outputFilename.replace(path.extname(outputFilename), '.mir');
+        return outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.mir';
     }
 
     getHaskellCoreOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.dump-simpl');
+        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.dump-simpl';
     }
 
     getHaskellStgOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.dump-stg-final');
+        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.dump-stg-final';
     }
 
     getHaskellCmmOutputFilename(inputFilename) {
-        return inputFilename.replace(path.extname(inputFilename), '.dump-cmm');
+        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.dump-cmm';
     }
 
     // Currently called for getting macro expansion and HIR.
@@ -1495,7 +1495,7 @@ export class BaseCompiler implements ICompiler {
 
     getIrOutputFilename(inputFilename: string, filters: ParseFiltersAndOutputOptions): string {
         // filters are passed because rust needs to know whether a binary is being produced or not
-        return inputFilename.replace(path.extname(inputFilename), '.ll');
+        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.ll';
     }
 
     getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -633,7 +633,7 @@ export class BaseCompiler implements ICompiler {
     }
 
     getGccDumpFileName(outputFilename: string) {
-        return outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.dump';
+        return utils.changeExtension(outputFilename, '.dump');
     }
 
     getGccDumpOptions(gccDumpOptions, outputFilename: string) {
@@ -1402,27 +1402,27 @@ export class BaseCompiler implements ICompiler {
     }
 
     getRustMacroExpansionOutputFilename(inputFilename) {
-        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.expanded.rs';
+        return utils.changeExtension(inputFilename, '.expanded.rs');
     }
 
     getRustHirOutputFilename(inputFilename) {
-        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.hir';
+        return utils.changeExtension(inputFilename, '.hir');
     }
 
     getRustMirOutputFilename(outputFilename) {
-        return outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.mir';
+        return utils.changeExtension(outputFilename, '.mir');
     }
 
     getHaskellCoreOutputFilename(inputFilename) {
-        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.dump-simpl';
+        return utils.changeExtension(inputFilename, '.dump-simpl');
     }
 
     getHaskellStgOutputFilename(inputFilename) {
-        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.dump-stg-final';
+        return utils.changeExtension(inputFilename, '.dump-stg-final');
     }
 
     getHaskellCmmOutputFilename(inputFilename) {
-        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.dump-cmm';
+        return utils.changeExtension(inputFilename, '.dump-cmm');
     }
 
     // Currently called for getting macro expansion and HIR.
@@ -1495,7 +1495,7 @@ export class BaseCompiler implements ICompiler {
 
     getIrOutputFilename(inputFilename: string, filters: ParseFiltersAndOutputOptions): string {
         // filters are passed because rust needs to know whether a binary is being produced or not
-        return inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.ll';
+        return utils.changeExtension(inputFilename, '.ll');
     }
 
     getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {

--- a/lib/compilers/cl430.ts
+++ b/lib/compilers/cl430.ts
@@ -25,6 +25,7 @@
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
+import {changeExtension} from '../utils.js';
 
 export class CL430Compiler extends BaseCompiler {
     static get key() {
@@ -52,7 +53,7 @@ export class CL430Compiler extends BaseCompiler {
             '--keep_asm',
             '--asm_extension=.s',
             '--output_file',
-            this.filename(outputFilename.substring(0, outputFilename.lastIndexOf('.'))),
+            this.filename(changeExtension(outputFilename, '')),
         ];
     }
 }

--- a/lib/compilers/cl430.ts
+++ b/lib/compilers/cl430.ts
@@ -52,7 +52,7 @@ export class CL430Compiler extends BaseCompiler {
             '--keep_asm',
             '--asm_extension=.s',
             '--output_file',
-            this.filename(outputFilename.replace('.s', '')),
+            this.filename(outputFilename.substring(0, outputFilename.lastIndexOf('.'))),
         ];
     }
 }

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -79,7 +79,7 @@ export class ClangCompiler extends BaseCompiler {
         let timeTraceJson = '';
         const outputExt = path.extname(outputFilename);
         if (outputExt) {
-            timeTraceJson = outputFilename.replace(outputExt, '.json');
+            timeTraceJson = outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.json';
         } else {
             timeTraceJson += '.json';
         }

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -77,12 +77,7 @@ export class ClangCompiler extends BaseCompiler {
 
     async addTimeTraceToResult(result: CompilationResult, dirPath: string, outputFilename: string) {
         let timeTraceJson = '';
-        const outputExt = path.extname(outputFilename);
-        if (outputExt) {
-            timeTraceJson = outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.json';
-        } else {
-            timeTraceJson += '.json';
-        }
+        timeTraceJson = utils.changeExtension(outputFilename, '.json');
         const jsonFilepath = path.join(dirPath, timeTraceJson);
         if (await utils.fileExists(jsonFilepath)) {
             this.addArtifactToResult(

--- a/lib/compilers/spirv.ts
+++ b/lib/compilers/spirv.ts
@@ -185,7 +185,7 @@ export class SPIRVCompiler extends BaseCompiler {
 
         const index = newOptions.indexOf(outputFile);
         if (index !== -1) {
-            newOptions[index] = inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.ll';
+            newOptions[index] = utils.changeExtension(inputFilename, '.ll');
         }
 
         return super.runCompiler(compiler, newOptions, inputFilename, execOptions);

--- a/lib/compilers/spirv.ts
+++ b/lib/compilers/spirv.ts
@@ -185,7 +185,7 @@ export class SPIRVCompiler extends BaseCompiler {
 
         const index = newOptions.indexOf(outputFile);
         if (index !== -1) {
-            newOptions[index] = inputFilename.replace(path.extname(inputFilename), '.ll');
+            newOptions[index] = inputFilename.substring(0, inputFilename.lastIndexOf('.')) + '.ll';
         }
 
         return super.runCompiler(compiler, newOptions, inputFilename, execOptions);

--- a/lib/compilers/typescript-native.ts
+++ b/lib/compilers/typescript-native.ts
@@ -89,7 +89,7 @@ export class TypeScriptNativeCompiler extends BaseCompiler {
         const outputFilename = this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase);
         // As per #4054, if we are asked for binary mode, the output will be in the .s file, no .ll will be emited
         if (!filters.binary) {
-            return outputFilename.replace('.s', '.ll');
+            return outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.ll';
         }
         return outputFilename;
     }

--- a/lib/compilers/typescript-native.ts
+++ b/lib/compilers/typescript-native.ts
@@ -29,7 +29,7 @@ import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {LLVMIrBackendOptions} from '../../types/compilation/ir.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
-import {asSafeVer} from '../utils.js';
+import {asSafeVer, changeExtension} from '../utils.js';
 
 import {TypeScriptNativeParser} from './argument-parsers.js';
 import {ExecutableExecutionOptions} from '../../types/execution/execution.interfaces.js';
@@ -89,7 +89,7 @@ export class TypeScriptNativeCompiler extends BaseCompiler {
         const outputFilename = this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase);
         // As per #4054, if we are asked for binary mode, the output will be in the .s file, no .ll will be emited
         if (!filters.binary) {
-            return outputFilename.substring(0, outputFilename.lastIndexOf('.')) + '.ll';
+            return changeExtension(outputFilename, '.ll');
         }
         return outputFilename;
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -74,6 +74,12 @@ export function maskRootdir(filepath: string): string {
     }
 }
 
+export function changeExtension(filename: string, newExtension: string): string {
+    const lastDot = filename.lastIndexOf('.');
+    if (lastDot === -1) return filename + newExtension;
+    return filename.substring(0, lastDot) + newExtension;
+}
+
 const ansiColoursRe = /\x1B\[[\d;]*[Km]/g;
 
 function _parseOutputLine(line: string, inputFilename?: string, pathPrefix?: string) {


### PR DESCRIPTION
The idiom - 
```js
outputFilename.replace(path.extname(outputFilename), '.mir')
```
is risky because it works as intended only when `extname` appears in `outputFilename` only at the end. However, random file name generation is done in temp.js by 
```js
var generateName = function(rawAffixes, defaultPrefix) {
  var affixes = parseAffixes(rawAffixes, defaultPrefix);
  var now = new Date();
  var name = [affixes.prefix,
              now.getFullYear(), now.getMonth(), now.getDate(),
              '-',
              process.pid,
              '-',
              (Math.random() * 0x100000000 + 1).toString(36),    // <----
              affixes.suffix].join('');
  return path.join(affixes.dir || dir, name);
};
```
Which includes a dot followed by essentially any string. e.g -
```js
(12341234.34563456).toString(36)
'7cik2.cfxxc3'
```

So this idiom occasionally breaks (when replacing `.c` extensions or any other single-letter ext, it breaks on average once every 36 invocations).

This is an attempt to hunt and replace all risky `.*Filename.replace` usage.