### PR TITLE
Fix #5694

### DIFF
--- a/lib/cfg/cfg-parsers/llvm-ir.ts
+++ b/lib/cfg/cfg-parsers/llvm-ir.ts
@@ -155,13 +155,12 @@ export class LlvmIrCfgParser extends BaseCFGParser {
                 } else if (
                     lastInst >= 1 &&
                     asmArr[lastInst].text.includes('unwind label') &&
-                    asmArr[lastInst - 1].text.trim().startsWith('invoke')
+                    asmArr[lastInst - 1].text.trim().includes('invoke ')
                 ) {
                     // Handle multi-line `invoke` like:
                     // invoke void @__cxa_throw(ptr nonnull %exception, ptr nonnull @typeinfo for int, ptr null) #3
                     //          to label %unreachable unwind label %lpad
-                    lastInst--;
-                    return this.concatInstructions(asmArr, lastInst, lastInst + 1);
+                    return this.concatInstructions(asmArr, lastInst - 1, lastInst + 1);
                 } else if (
                     lastInst >= 1 &&
                     asmArr[lastInst - 1].text.includes('landingpad') &&
@@ -170,13 +169,14 @@ export class LlvmIrCfgParser extends BaseCFGParser {
                     // Handle multi-line `landingpad` like:
                     // %0 = landingpad { ptr, i32 }
                     //         catch ptr null
-                    lastInst--;
-                    return this.concatInstructions(asmArr, lastInst, lastInst + 1);
+                    return this.concatInstructions(asmArr, lastInst - 1, lastInst + 1);
                 } else {
                     return asmArr[lastInst].text;
                 }
             })();
-            const terminator = terminatingInstruction.trim().split(' ')[0];
+            const terminator = terminatingInstruction.includes('invoke ')
+                ? 'invoke'
+                : terminatingInstruction.trim().split(' ')[0];
             const labels = [...terminatingInstruction.matchAll(this.labelReference)].map(m => m[1]);
             switch (terminator) {
                 case 'ret':

--- a/test/cfg-cases/cfg-llvmir.invoke.json
+++ b/test/cfg-cases/cfg-llvmir.invoke.json
@@ -1,0 +1,365 @@
+{
+    "asm": [
+        {
+            "text": "define dso_local noundef i32 @f(int)(i32 noundef %n) personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {",
+            "scope": "!10",
+            "source": {
+                "file": null,
+                "line": 3
+            }
+        },
+        {
+            "text": "entry:"
+        },
+        {
+            "text": "  %retval = alloca i32, align 4"
+        },
+        {
+            "text": "  %n.addr = alloca i32, align 4"
+        },
+        {
+            "text": "  %a = alloca i32, align 4"
+        },
+        {
+            "text": "  %exn.slot = alloca i8*, align 8"
+        },
+        {
+            "text": "  %ehselector.slot = alloca i32, align 4"
+        },
+        {
+            "text": "  store i32 %n, i32* %n.addr, align 4"
+        },
+        {
+            "text": "  %0 = load i32, i32* %n.addr, align 4",
+            "scope": "!21",
+            "source": {
+                "file": null,
+                "line": 6,
+                "column": 19
+            }
+        },
+        {
+            "text": "  %call = invoke noundef i32 @g(int)(i32 noundef %0)"
+        },
+        {
+            "text": "          to label %invoke.cont unwind label %lpad",
+            "scope": "!22",
+            "source": {
+                "file": null,
+                "line": 6,
+                "column": 17
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "invoke.cont:"
+        },
+        {
+            "text": "  store i32 %call, i32* %a, align 4",
+            "scope": "!20",
+            "source": {
+                "file": null,
+                "line": 6,
+                "column": 13
+            }
+        },
+        {
+            "text": "  %1 = load i32, i32* %a, align 4",
+            "scope": "!23",
+            "source": {
+                "file": null,
+                "line": 7,
+                "column": 16
+            }
+        },
+        {
+            "text": "  store i32 %1, i32* %retval, align 4",
+            "scope": "!24",
+            "source": {
+                "file": null,
+                "line": 7,
+                "column": 9
+            }
+        },
+        {
+            "text": "  br label %return",
+            "scope": "!24",
+            "source": {
+                "file": null,
+                "line": 7,
+                "column": 9
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "lpad:"
+        },
+        {
+            "text": "  %2 = landingpad { i8*, i32 }"
+        },
+        {
+            "text": "          catch i8* null",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "  %3 = extractvalue { i8*, i32 } %2, 0",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "  store i8* %3, i8** %exn.slot, align 8",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "  %4 = extractvalue { i8*, i32 } %2, 1",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "  store i32 %4, i32* %ehselector.slot, align 4",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "  br label %catch",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "catch:"
+        },
+        {
+            "text": "  %exn = load i8*, i8** %exn.slot, align 8",
+            "scope": "!26",
+            "source": {
+                "file": null,
+                "line": 8,
+                "column": 5
+            }
+        },
+        {
+            "text": "  %5 = call i8* @__cxa_begin_catch(i8* %exn) #4",
+            "scope": "!26",
+            "source": {
+                "file": null,
+                "line": 8,
+                "column": 5
+            }
+        },
+        {
+            "text": "  %6 = load i32, i32* %n.addr, align 4",
+            "scope": "!27",
+            "source": {
+                "file": null,
+                "line": 11,
+                "column": 16
+            }
+        },
+        {
+            "text": "  store i32 %6, i32* %retval, align 4",
+            "scope": "!29",
+            "source": {
+                "file": null,
+                "line": 11,
+                "column": 9
+            }
+        },
+        {
+            "text": "  call void @__cxa_end_catch()",
+            "scope": "!30",
+            "source": {
+                "file": null,
+                "line": 12,
+                "column": 5
+            }
+        },
+        {
+            "text": "  br label %return"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "try.cont:"
+        },
+        {
+            "text": "  call void @llvm.trap()",
+            "scope": "!30",
+            "source": {
+                "file": null,
+                "line": 12,
+                "column": 5
+            }
+        },
+        {
+            "text": "  unreachable",
+            "scope": "!30",
+            "source": {
+                "file": null,
+                "line": 12,
+                "column": 5
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "return:"
+        },
+        {
+            "text": "  %7 = load i32, i32* %retval, align 4",
+            "scope": "!31",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "  ret i32 %7",
+            "scope": "!31",
+            "source": {
+                "file": null,
+                "line": 13,
+                "column": 1
+            }
+        },
+        {
+            "text": "}"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare void @llvm.dbg.declare(metadata, metadata, metadata) #1"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare noundef i32 @g(int)(i32 noundef) #2"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare i32 @__gxx_personality_v0(...)"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare i8* @__cxa_begin_catch(i8*)"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare void @__cxa_end_catch()"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare void @llvm.trap() #3"
+        },
+        {
+            "text": ""
+        }
+    ],
+    "cfg": {
+        "f(int)(i32 noundef %n) personality i8* bitcast (i32 ": {
+            "nodes": [
+                {
+                    "id": "f(int)(i32 noundef %n) personality i8* bitcast (i32 ",
+                    "label": "f(int)(i32 noundef %n) personality i8* bitcast (i32 :\n  %retval = alloca i32, align 4\n  %n.addr = alloca i32, align 4\n  %a = alloca i32, align 4\n  %exn.slot = alloca i8*, align 8\n  %ehselector.slot = alloca i32, align 4\n  store i32 %n, i32* %n.addr, align 4\n  %0 = load i32, i32* %n.addr, align 4\n  %call = invoke noundef i32 @g(int)(i32 noundef %0)\n          to label %invoke.cont unwind label %lpad"
+                },
+                {
+                    "id": "invoke.cont",
+                    "label": "invoke.cont:\n  store i32 %call, i32* %a, align 4\n  %1 = load i32, i32* %a, align 4\n  store i32 %1, i32* %retval, align 4\n  br label %return"
+                },
+                {
+                    "id": "lpad",
+                    "label": "lpad:\n  %2 = landingpad { i8*, i32 }\n          catch i8* null\n  %3 = extractvalue { i8*, i32 } %2, 0\n  store i8* %3, i8** %exn.slot, align 8\n  %4 = extractvalue { i8*, i32 } %2, 1\n  store i32 %4, i32* %ehselector.slot, align 4\n  br label %catch"
+                },
+                {
+                    "id": "catch",
+                    "label": "catch:\n  %exn = load i8*, i8** %exn.slot, align 8\n  %5 = call i8* @__cxa_begin_catch(i8* %exn) #4\n  %6 = load i32, i32* %n.addr, align 4\n  store i32 %6, i32* %retval, align 4\n  call void @__cxa_end_catch()\n  br label %return"
+                },
+                {
+                    "id": "try.cont",
+                    "label": "try.cont:\n  call void @llvm.trap()\n  unreachable"
+                },
+                {
+                    "id": "return",
+                    "label": "return:\n  %7 = load i32, i32* %retval, align 4\n  ret i32 %7"
+                }
+            ],
+            "edges": [
+                {
+                    "from": "f(int)(i32 noundef %n) personality i8* bitcast (i32 ",
+                    "to": "invoke.cont",
+                    "arrows": "to",
+                    "color": "green"
+                },
+                {
+                    "from": "f(int)(i32 noundef %n) personality i8* bitcast (i32 ",
+                    "to": "lpad",
+                    "arrows": "to",
+                    "color": "grey"
+                },
+                {
+                    "from": "invoke.cont",
+                    "to": "return",
+                    "arrows": "to",
+                    "color": "blue"
+                },
+                {
+                    "from": "lpad",
+                    "to": "catch",
+                    "arrows": "to",
+                    "color": "blue"
+                },
+                {
+                    "from": "catch",
+                    "to": "return",
+                    "arrows": "to",
+                    "color": "blue"
+                }
+            ]
+        }
+    }
+}

--- a/test/cfg-cases/cfg-llvmir.loop.json
+++ b/test/cfg-cases/cfg-llvmir.loop.json
@@ -1,0 +1,352 @@
+{
+    "asm": [
+        {
+            "text": "define dso_local noundef i32 @foo(int*, int*, int)(i32* noundef %a, i32* noundef %b, i32 noundef %size) {",
+            "scope": "!10",
+            "source": {
+                "file": null,
+                "line": 2
+            }
+        },
+        {
+            "text": "entry:"
+        },
+        {
+            "text": "  %a.addr = alloca i32*, align 8"
+        },
+        {
+            "text": "  %b.addr = alloca i32*, align 8"
+        },
+        {
+            "text": "  %size.addr = alloca i32, align 4"
+        },
+        {
+            "text": "  %i = alloca i32, align 4"
+        },
+        {
+            "text": "  store i32* %a, i32** %a.addr, align 8"
+        },
+        {
+            "text": "  store i32* %b, i32** %b.addr, align 8"
+        },
+        {
+            "text": "  store i32 %size, i32* %size.addr, align 4"
+        },
+        {
+            "text": "  store i32 0, i32* %i, align 4",
+            "scope": "!25",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 13
+            }
+        },
+        {
+            "text": "  br label %for.cond",
+            "scope": "!26",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 9
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "for.cond:"
+        },
+        {
+            "text": "  %0 = load i32, i32* %i, align 4",
+            "scope": "!27",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 18
+            }
+        },
+        {
+            "text": "  %1 = load i32, i32* %size.addr, align 4",
+            "scope": "!29",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 20
+            }
+        },
+        {
+            "text": "  %cmp = icmp slt i32 %0, %1",
+            "scope": "!30",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 19
+            }
+        },
+        {
+            "text": "  br i1 %cmp, label %for.body, label %for.end",
+            "scope": "!31",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 5
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "for.body:"
+        },
+        {
+            "text": "  %2 = load i32*, i32** %b.addr, align 8",
+            "scope": "!32",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 16
+            }
+        },
+        {
+            "text": "  %3 = load i32, i32* %i, align 4",
+            "scope": "!33",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 18
+            }
+        },
+        {
+            "text": "  %idxprom = sext i32 %3 to i64",
+            "scope": "!32",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 16
+            }
+        },
+        {
+            "text": "  %arrayidx = getelementptr inbounds i32, i32* %2, i64 %idxprom",
+            "scope": "!32",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 16
+            }
+        },
+        {
+            "text": "  %4 = load i32, i32* %arrayidx, align 4",
+            "scope": "!32",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 16
+            }
+        },
+        {
+            "text": "  %add = add nsw i32 %4, 12",
+            "scope": "!34",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 21
+            }
+        },
+        {
+            "text": "  %5 = load i32*, i32** %a.addr, align 8",
+            "scope": "!35",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 9
+            }
+        },
+        {
+            "text": "  %6 = load i32, i32* %i, align 4",
+            "scope": "!36",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 11
+            }
+        },
+        {
+            "text": "  %idxprom1 = sext i32 %6 to i64",
+            "scope": "!35",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 9
+            }
+        },
+        {
+            "text": "  %arrayidx2 = getelementptr inbounds i32, i32* %5, i64 %idxprom1",
+            "scope": "!35",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 9
+            }
+        },
+        {
+            "text": "  store i32 %add, i32* %arrayidx2, align 4",
+            "scope": "!37",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 14
+            }
+        },
+        {
+            "text": "  br label %for.inc",
+            "scope": "!35",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 9
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "for.inc:"
+        },
+        {
+            "text": "  %7 = load i32, i32* %i, align 4",
+            "scope": "!38",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 26
+            }
+        },
+        {
+            "text": "  %inc = add nsw i32 %7, 1",
+            "scope": "!38",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 26
+            }
+        },
+        {
+            "text": "  store i32 %inc, i32* %i, align 4",
+            "scope": "!38",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 26
+            }
+        },
+        {
+            "text": "  br label %for.cond",
+            "scope": "!39",
+            "source": {
+                "file": null,
+                "line": 3,
+                "column": 5
+            }
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "for.end:"
+        },
+        {
+            "text": "  call void @llvm.trap()",
+            "scope": "!41",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 23
+            }
+        },
+        {
+            "text": "  unreachable",
+            "scope": "!41",
+            "source": {
+                "file": null,
+                "line": 4,
+                "column": 23
+            }
+        },
+        {
+            "text": "}"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare void @llvm.dbg.declare(metadata, metadata, metadata) #1"
+        },
+        {
+            "text": ""
+        },
+        {
+            "text": "declare void @llvm.trap() #2"
+        },
+        {
+            "text": ""
+        }
+    ],
+    "cfg": {
+        "foo(int*, int*, int)": {
+            "nodes": [
+                {
+                    "id": "foo(int*, int*, int)",
+                    "label": "foo(int*, int*, int):\n  %a.addr = alloca i32*, align 8\n  %b.addr = alloca i32*, align 8\n  %size.addr = alloca i32, align 4\n  %i = alloca i32, align 4\n  store i32* %a, i32** %a.addr, align 8\n  store i32* %b, i32** %b.addr, align 8\n  store i32 %size, i32* %size.addr, align 4\n  store i32 0, i32* %i, align 4\n  br label %for.cond"
+                },
+                {
+                    "id": "for.cond",
+                    "label": "for.cond:\n  %0 = load i32, i32* %i, align 4\n  %1 = load i32, i32* %size.addr, align 4\n  %cmp = icmp slt i32 %0, %1\n  br i1 %cmp, label %for.body, label %for.end"
+                },
+                {
+                    "id": "for.body",
+                    "label": "for.body:\n  %2 = load i32*, i32** %b.addr, align 8\n  %3 = load i32, i32* %i, align 4\n  %idxprom = sext i32 %3 to i64\n  %arrayidx = getelementptr inbounds i32, i32* %2, i64 %idxprom\n  %4 = load i32, i32* %arrayidx, align 4\n  %add = add nsw i32 %4, 12\n  %5 = load i32*, i32** %a.addr, align 8\n  %6 = load i32, i32* %i, align 4\n  %idxprom1 = sext i32 %6 to i64\n  %arrayidx2 = getelementptr inbounds i32, i32* %5, i64 %idxprom1\n  store i32 %add, i32* %arrayidx2, align 4\n  br label %for.inc"
+                },
+                {
+                    "id": "for.inc",
+                    "label": "for.inc:\n  %7 = load i32, i32* %i, align 4\n  %inc = add nsw i32 %7, 1\n  store i32 %inc, i32* %i, align 4\n  br label %for.cond"
+                },
+                {
+                    "id": "for.end",
+                    "label": "for.end:\n  call void @llvm.trap()\n  unreachable"
+                }
+            ],
+            "edges": [
+                {
+                    "from": "foo(int*, int*, int)",
+                    "to": "for.cond",
+                    "arrows": "to",
+                    "color": "blue"
+                },
+                {
+                    "from": "for.cond",
+                    "to": "for.body",
+                    "arrows": "to",
+                    "color": "green"
+                },
+                {
+                    "from": "for.cond",
+                    "to": "for.end",
+                    "arrows": "to",
+                    "color": "red"
+                },
+                {
+                    "from": "for.body",
+                    "to": "for.inc",
+                    "arrows": "to",
+                    "color": "blue"
+                },
+                {
+                    "from": "for.inc",
+                    "to": "for.cond",
+                    "arrows": "to",
+                    "color": "blue"
+                }
+            ]
+        }
+    }
+}

--- a/test/cfg-tests.ts
+++ b/test/cfg-tests.ts
@@ -26,7 +26,7 @@ import * as cfg from '../lib/cfg/cfg.js';
 
 import {fs, makeFakeCompilerInfo, path, resolvePathFromTestRoot} from './utils.js';
 
-async function DoCfgTest(cfgArg, filename) {
+async function DoCfgTest(cfgArg, filename, isLlvmIr = false) {
     const contents = await fs.readJson(filename, 'utf8');
     const structure = cfg.generateStructure(
         makeFakeCompilerInfo({
@@ -34,7 +34,7 @@ async function DoCfgTest(cfgArg, filename) {
             version: cfgArg,
         }),
         contents.asm,
-        false,
+        isLlvmIr,
     );
     structure.should.deep.equal(contents.cfg);
 }
@@ -66,6 +66,14 @@ describe('Cfg test cases', () => {
         for (const filename of files.filter(x => x.includes('clang'))) {
             it(filename, async () => {
                 await DoCfgTest('clang', path.join(testcasespath, filename));
+            });
+        }
+    });
+
+    describe('llvmir', () => {
+        for (const filename of files.filter(x => x.includes('llvmir'))) {
+            it(filename, async () => {
+                await DoCfgTest('clang', path.join(testcasespath, filename), true);
             });
         }
     });


### PR DESCRIPTION
This fixes the "Internal Compiler Explorer error" you can still see in https://godbolt.org/z/xY5sGbT96, but also adds test per [Matt's request](https://github.com/compiler-explorer/compiler-explorer/pull/5654#pullrequestreview-1705306059) and now `invoke` is even properly linked to the call and landing pad:
![image](https://github.com/compiler-explorer/compiler-explorer/assets/73080/7d2c1e8d-bd0b-4360-8941-3edbcf5576ba)
