### PR TITLE
LLVM TableGen: Improve docstring for Actions Override and add example

### DIFF
--- a/examples/tablegen/searchable_tables.td
+++ b/examples/tablegen/searchable_tables.td
@@ -1,0 +1,20 @@
+// This example uses the Searchable Tables backend, aka --gen-searchable-tables.
+// To choose the backend, select it as the "Action" in the "Overrides" menu,
+// or add "--gen-searchable-tables" to the compiler options.
+// For more details:
+// https://llvm.org/docs/TableGen/BackEnds.html#searchabletables-reference
+
+include "llvm/TableGen/SearchableTable.td"
+
+class Pair<string name, int value> : SearchableTable {
+  let SearchableFields = ["Name", "Value"];
+  let EnumValueField = "Value";
+
+  string Name = name;
+  bits<2> Value = value;
+}
+
+def : Pair<"Example 0", 0b00>;
+def : Pair<"Example 1", 0b01>;
+def : Pair<"Example 2", 0b10>;
+def : Pair<"Example 3", 0b11>;

--- a/lib/compilers/tablegen.ts
+++ b/lib/compilers/tablegen.ts
@@ -32,7 +32,13 @@ export class TableGenCompiler extends BaseCompiler {
                 display_title: 'Action',
                 description:
                     'The action to perform, which is the backend you wish to ' +
-                    'run. By default, the records are just printed as text.',
+                    'run. By default, the records are just printed as text. ' +
+                    'Many backends expect to find certain classes and defnitions ' +
+                    'in your source code. You may find details of those in the ' +
+                    '<a href="https://llvm.org/docs/TableGen/BackEnds.html" target="_blank">documentation</a>, ' +
+                    'but if not, refer to use of the backend in the ' +
+                    '<a href="https://github.com/llvm/llvm-project" target="_blank">LLVM Project</a> ' +
+                    'by searching for the command line name e.g. "gen-attrs".',
                 flags: ['<value>'],
                 values: possibleActions,
                 default: '--print-records',


### PR DESCRIPTION
A majority of the actions/backends expect to find certain classes and definitions in the source code. There's no canonical reference for this so it's a combination of incomplete docs and the actual uses in llvm-project.

(most of the time I expect people will come from llvm-project to experiment, rather than the other way around)

I've added an example that uses the Searchable Tables backend.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
