### PR TITLE
Fix z-index of toasts in Boostreap 4

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -371,6 +371,8 @@ pre.content.wrap * {
 
 .toast {
     max-width: 100% !important;
+    // Not set in Bootstrap 4, remove once we upgrade
+    z-index: 1090;
 }
 
 .toast-header .close {


### PR DESCRIPTION
Closes #5707

Boostrap 4 [does not define a zindex for toasts](https://github.com/twbs/bootstrap/blob/e5643aaa89eb67327a5b4abe7db976f0ea276b70/scss/_variables.scss#L692), but Boostrap 5 [does](https://github.com/twbs/bootstrap/blob/a4d2f597029cb36169bb2e20252317198cdd988d/scss/_variables.scss#L1142) - This gets toast in line with 5's priorities, where it has greater index than everything else (There's a comment saying that the order is like that on pourpose)