### PR TITLE
Add llvm-dwarfdump tool for C/C++ languages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -123,6 +123,7 @@ lang-llvm:
   - lib/compilers/llvm-mca.ts
   - lib/objdumper/llvm.ts
   - lib/tooling/llvm-mca-tool.ts
+  - lib/tooling/llvm-dwarfdump-tool.ts
   - etc/config/llvm.*.properties
   - static/modes/llvm-ir-mode.ts
 lang-modula2:

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4467,7 +4467,7 @@ libs.copperspice.versions.180.libpath=/opt/compiler-explorer/libs/copperspice/1.
 #################################
 #################################
 # Installed tools
-tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:iwyu:ldd:llvm-covtrunk:llvm-mcatrunk:osacatrunk:pahole:readelf:nm:Sonar:strings:x86to6502
+tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:iwyu:ldd:llvm-covtrunk:llvm-mcatrunk:osacatrunk:pahole:readelf:nm:Sonar:strings:x86to6502:llvmdwarfdumptrunk
 
 tools.PVS-Studio.name=PVS-Studio
 tools.PVS-Studio.exe=/opt/compiler-explorer/pvs-studio-latest/bin/pvs-studio-analyzer
@@ -4576,3 +4576,11 @@ tools.x86to6502.class=x86to6502-tool
 tools.x86to6502.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new_arm32:djggp:riscv:wasm:frc2019:raspbian:arduino
 tools.x86to6502.stdinHint=disabled
 tools.x86to6502.languageId=asm6502
+
+tools.llvmdwarfdumptrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-dwarfdump
+tools.llvmdwarfdumptrunk.name=llvm-dwarfdump (trunk)
+tools.llvmdwarfdumptrunk.type=postcompilation
+tools.llvmdwarfdumptrunk.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumptrunk.stdinHint=disabled
+# MSVC does not produce DWARF debug information.
+tools.llvmdwarfdumptrunk.exclude=cl19:cl_new

--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -50,7 +50,7 @@ compiler.clang12.name=clang 12
 compiler.clangdefault.exe=/usr/bin/clang++
 compiler.clangdefault.name=clang default
 
-tools=clangquerydefault:clangtidydefault:clangquery7:clangquery8:clangquery9:clangquery10:clangquery11:clangquery12:strings:ldd:readelf:nm
+tools=clangquerydefault:clangtidydefault:clangquery7:clangquery8:clangquery9:clangquery10:clangquery11:clangquery12:strings:ldd:readelf:nm:llvmdwarfdumpdefault
 
 tools.clangquerydefault.exe=/usr/bin/clang-query
 tools.clangquerydefault.name=clang-query (default)
@@ -128,6 +128,12 @@ tools.strings.type=postcompilation
 tools.strings.class=strings-tool
 tools.strings.exclude=djggp
 tools.strings.stdinHint=disabled
+
+tools.llvmdwarfdumpdefault.exe=/usr/bin/llvm-dwarfdump
+tools.llvmdwarfdumpdefault.name=llvm-dwarfdump (default)
+tools.llvmdwarfdumpdefault.type=postcompilation
+tools.llvmdwarfdumpdefault.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumpdefault.stdinHint=disabled
 
 defaultCompiler=gdefault
 postProcess=

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2819,7 +2819,7 @@ libs.sqlite.versions.3400.path=/opt/compiler-explorer/libs/sqlite/3.40.0
 #################################
 #################################
 # Installed tools
-tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:ldd:llvm-mcatrunk:osacatrunk:pahole:readelf:nm:Sonar:strings
+tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:ldd:llvm-mcatrunk:osacatrunk:pahole:readelf:nm:Sonar:strings:llvmdwarfdumptrunk
 
 tools.PVS-Studio.name=PVS-Studio
 tools.PVS-Studio.exe=/opt/compiler-explorer/pvs-studio-latest/bin/pvs-studio-analyzer
@@ -2905,3 +2905,11 @@ tools.strings.type=postcompilation
 tools.strings.class=strings-tool
 tools.strings.exclude=
 tools.strings.stdinHint=disabled
+
+tools.llvmdwarfdumptrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-dwarfdump
+tools.llvmdwarfdumptrunk.name=llvm-dwarfdump (trunk)
+tools.llvmdwarfdumptrunk.type=postcompilation
+tools.llvmdwarfdumptrunk.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumptrunk.stdinHint=disabled
+# MSVC does not produce DWARF debug information.
+tools.llvmdwarfdumptrunk.exclude=ccl19:ccl_new

--- a/etc/config/c.defaults.properties
+++ b/etc/config/c.defaults.properties
@@ -59,7 +59,7 @@ compiler.cclangdefault.name=clang default
 compiler.cclangccdefault.exe=/usr/bin/clangcc
 compiler.cclangccdefault.name=clang default
 
-tools=clangquerydefault:clangtidydefault:readelf:nm
+tools=clangquerydefault:clangtidydefault:readelf:nm:llvmdwarfdumpdefault
 
 tools.clangquerydefault.exe=/usr/bin/clang-query
 tools.clangquerydefault.name=clang-query (default)
@@ -87,3 +87,9 @@ tools.nm.type=postcompilation
 tools.nm.class=nm-tool
 tools.nm.exclude=djggp
 tools.nm.stdinHint=disabled
+
+tools.llvmdwarfdumpdefault.exe=/usr/bin/llvm-dwarfdump
+tools.llvmdwarfdumpdefault.name=llvm-dwarfdump (default)
+tools.llvmdwarfdumpdefault.type=postcompilation
+tools.llvmdwarfdumpdefault.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumpdefault.stdinHint=disabled

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1816,7 +1816,7 @@ libs.copperspice.versions.180.libpath=/opt/compiler-explorer/libs/copperspice/1.
 #################################
 #################################
 # Installed tools
-tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:iwyu:ldd:llvm-covtrunk:llvm-mcatrunk:osacatrunk:pahole:readelf:strings:x86to6502
+tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:iwyu:ldd:llvm-covtrunk:llvm-mcatrunk:osacatrunk:pahole:readelf:strings:x86to6502:llvmdwarfdumptrunk
 
 tools.PVS-Studio.name=PVS-Studio
 tools.PVS-Studio.exe=/opt/compiler-explorer/pvs-studio-latest/bin/pvs-studio-analyzer
@@ -1909,3 +1909,9 @@ tools.x86to6502.class=x86to6502-tool
 tools.x86to6502.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new_arm32:djggp:riscv:wasm:frc2019:raspbian:arduino
 tools.x86to6502.stdinHint=disabled
 tools.x86to6502.languageId=asm6502
+
+tools.llvmdwarfdumptrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-dwarfdump
+tools.llvmdwarfdumptrunk.name=llvm-dwarfdump (trunk)
+tools.llvmdwarfdumptrunk.type=postcompilation
+tools.llvmdwarfdumptrunk.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumptrunk.stdinHint=disabled

--- a/etc/config/objc++.defaults.properties
+++ b/etc/config/objc++.defaults.properties
@@ -46,7 +46,7 @@ compiler.objcxxg11.name=g++ 11.x
 compiler.objcxxgdefault.exe=/usr/bin/g++
 compiler.objcxxgdefault.name=g++ default
 
-tools=strings:ldd
+tools=strings:ldd:llvmdwarfdumpdefault
 
 tools.ldd.name=ldd
 tools.ldd.exe=/usr/bin/ldd
@@ -62,6 +62,11 @@ tools.strings.class=strings-tool
 tools.strings.exclude=djggp
 tools.strings.stdinHint=disabled
 
+tools.llvmdwarfdumpdefault.exe=/usr/bin/llvm-dwarfdump
+tools.llvmdwarfdumpdefault.name=llvm-dwarfdump (default)
+tools.llvmdwarfdumpdefault.type=postcompilation
+tools.llvmdwarfdumpdefault.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumpdefault.stdinHint=disabled
 
 #################################
 #################################

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -663,7 +663,7 @@ libs.curl.versions.7831.path=/opt/compiler-explorer/libs/curl/7.83.1/include
 #################################
 #################################
 # Installed tools
-tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:ldd:llvm-mcatrunk:osacatrunk:pahole:readelf:strings
+tools=PVS-Studio:clangformattrunk:clangquerytrunk:clangtidytrunk:ldd:llvm-mcatrunk:osacatrunk:pahole:readelf:strings:llvmdwarfdumptrunk
 
 tools.PVS-Studio.name=PVS-Studio
 tools.PVS-Studio.exe=/opt/compiler-explorer/pvs-studio-latest/bin/pvs-studio-analyzer
@@ -733,3 +733,9 @@ tools.strings.type=postcompilation
 tools.strings.class=strings-tool
 tools.strings.exclude=
 tools.strings.stdinHint=disabled
+
+tools.llvmdwarfdumptrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-dwarfdump
+tools.llvmdwarfdumptrunk.name=llvm-dwarfdump (trunk)
+tools.llvmdwarfdumptrunk.type=postcompilation
+tools.llvmdwarfdumptrunk.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumptrunk.stdinHint=disabled

--- a/etc/config/objc.defaults.properties
+++ b/etc/config/objc.defaults.properties
@@ -37,3 +37,11 @@ compiler.objcg11.exe=/usr/bin/gcc-11
 compiler.objcg11.name=gcc 11.x
 compiler.objcgdefault.exe=/usr/bin/gcc
 compiler.objcgdefault.name=gcc default
+
+tools=llvmdwarfdumpdefault
+
+tools.llvmdwarfdumpdefault.exe=/usr/bin/llvm-dwarfdump
+tools.llvmdwarfdumpdefault.name=llvm-dwarfdump (default)
+tools.llvmdwarfdumpdefault.type=postcompilation
+tools.llvmdwarfdumpdefault.class=llvm-dwarfdump-tool
+tools.llvmdwarfdumpdefault.stdinHint=disabled

--- a/lib/tooling/llvm-dwarfdump-tool.ts
+++ b/lib/tooling/llvm-dwarfdump-tool.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Compiler Explorer Authors
+// Copyright (c) 2023, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -22,21 +22,26 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-export {ClangFormatTool} from './clang-format-tool.js';
-export {ClangQueryTool} from './clang-query-tool.js';
-export {ClangTidyTool} from './clang-tidy-tool.js';
-export {CompilerDropinTool} from './compiler-dropin-tool.js';
-export {LLVMMcaTool} from './llvm-mca-tool.js';
-export {LLVMCovTool} from './llvm-cov-tool.js';
-export {LLVMDWARFDumpTool} from './llvm-dwarfdump-tool.js';
-export {MicrosoftAnalysisTool} from './microsoft-analysis-tool.js';
-export {NmTool} from './nm-tool.js';
-export {OSACATool} from './osaca-tool.js';
-export {PaholeTool} from './pahole-tool.js';
-export {PvsStudioTool} from './pvs-studio-tool.js';
-export {ReadElfTool} from './readelf-tool.js';
-export {RustFmtTool} from './rustfmt-tool.js';
-export {SonarTool} from './sonar-tool.js';
-export {StringsTool} from './strings-tool.js';
-export {x86to6502Tool} from './x86to6502-tool.js';
-export {TestingTool} from './testing-tool.js';
+import {fileExists} from '../utils.js';
+
+import {BaseTool} from './base-tool.js';
+
+export class LLVMDWARFDumpTool extends BaseTool {
+    static get key() {
+        return 'llvm-dwarfdump-tool';
+    }
+
+    override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
+        if (!compilationInfo.filters.binary && !compilationInfo.filters.binaryObject) {
+            return this.createErrorResponse(
+                `${this.tool.name ?? 'llvm-dwarfdump'} requires an executable or binary object`,
+            );
+        }
+
+        if (await fileExists(compilationInfo.executableFilename)) {
+            return super.runTool(compilationInfo, compilationInfo.executableFilename, args);
+        } else {
+            return super.runTool(compilationInfo, compilationInfo.outputFilename, args);
+        }
+    }
+}


### PR DESCRIPTION
https://llvm.org/docs/CommandGuide/llvm-dwarfdump.html

This dumps the DWARF debugging information in a human readable form:
```
<source>: file format ELF64-x86-64

.debug_info contents:
0x00000000: Compile Unit: length = 0x00000063 version = 0x0004 abbr_offset = ... 

0x0000000b: DW_TAG_compile_unit
              DW_AT_producer  ("GNU C17 9.4.0 ...)
```

This tool would be useful to have when comparing the debug output of two 
compiler versions or compiler targets. For instance I wanted to find out 
recently how AArch64 and X86 targets represent TLS variables.

The tool runs on the compiled binary, so is post compilation. If the binary
has no debug information the tool does not crash, it just tells you that
there is no information.

To fit the other llvm/clang tools, I've just added an "llvm-dwarfdump (trunk)"
like llvm-mca has done. Added it to c/c++/objc/objc++ (open CL can't compile
to binary so skipped those). MSVC is excluded because it produces PDB files
instead.

The tool works for at least ELF and XCOFF files, I haven't been able to test
any others.