### PR TITLE
Fix #5463

### DIFF
--- a/static/panes/compiler.interfaces.ts
+++ b/static/panes/compiler.interfaces.ts
@@ -32,6 +32,8 @@ export type CompilerState = WidgetState & {
     source?: number;
     compiler: string;
     options?: string;
+    flagsViewOpen?: boolean;
+    deviceViewOpen?: boolean;
     wantOptInfo?: boolean;
     lang?: string;
     overrides?: ConfiguredOverrides;

--- a/static/panes/compiler.interfaces.ts
+++ b/static/panes/compiler.interfaces.ts
@@ -32,8 +32,6 @@ export type CompilerState = WidgetState & {
     source?: number;
     compiler: string;
     options?: string;
-    flagsViewOpen?: boolean;
-    deviceViewOpen?: boolean;
     wantOptInfo?: boolean;
     lang?: string;
     overrides?: ConfiguredOverrides;

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -372,6 +372,8 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         }
         this.options = state.options || (options.compileOptions[this.currentLangId ?? ''] ?? '');
 
+        this.deviceViewOpen = !!state.deviceViewOpen;
+        this.flagsViewOpen = state.flagsViewOpen || false;
         this.wantOptInfo = state.wantOptInfo;
         this.originalCompilerId = state.compiler;
         this.selection = state.selection;
@@ -467,6 +469,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             const currentState: CompilerCurrentState = this.getCurrentState();
             // Delete the saved id to force a new one
             delete currentState.id;
+            // [flags|device]ViewOpen flags are a part of the state to prevent opening twice,
+            // but do not pertain to the cloned compiler
+            delete currentState.flagsViewOpen;
+            delete currentState.deviceViewOpen;
             return {
                 type: 'component',
                 componentName: 'compiler',
@@ -3231,6 +3237,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             libs: this.libsWidget?.get(),
             lang: this.currentLangId ?? undefined,
             selection: this.selection,
+            flagsViewOpen: this.flagsViewOpen,
             overrides: this.compilerShared.getOverrides(),
             runtimeTools: this.compilerShared.getRuntimeTools(),
         };

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3233,7 +3233,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             libs: this.libsWidget?.get(),
             lang: this.currentLangId ?? undefined,
             selection: this.selection,
-            flagsViewOpen: this.flagsViewOpen,
             deviceViewOpen: this.deviceViewOpen,
             overrides: this.compilerShared.getOverrides(),
             runtimeTools: this.compilerShared.getRuntimeTools(),

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -372,8 +372,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         }
         this.options = state.options || (options.compileOptions[this.currentLangId ?? ''] ?? '');
 
-        this.deviceViewOpen = !!state.deviceViewOpen;
-        this.flagsViewOpen = state.flagsViewOpen || false;
         this.wantOptInfo = state.wantOptInfo;
         this.originalCompilerId = state.compiler;
         this.selection = state.selection;
@@ -3233,7 +3231,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             libs: this.libsWidget?.get(),
             lang: this.currentLangId ?? undefined,
             selection: this.selection,
-            deviceViewOpen: this.deviceViewOpen,
             overrides: this.compilerShared.getOverrides(),
             runtimeTools: this.compilerShared.getRuntimeTools(),
         };


### PR DESCRIPTION
`cloneComponent` calls `getCurrentState`:
https://github.com/compiler-explorer/compiler-explorer/blob/286e83530d9a333137093008c17e46f3f690b636/static/panes/compiler.ts#L469

And for some reason `getCurrentState` included `flagsViewOpen`:
https://github.com/compiler-explorer/compiler-explorer/blob/286e83530d9a333137093008c17e46f3f690b636/static/panes/compiler.ts#L3236

So if it was open in the original compiler it would be *considered* as open in the new clone. 

Perhaps `deviceViewOpen` should be removed from `getCurrentState` too? Not sure what a device view is and how to check it, so leaving it alone for now :(

Anyway all the other dozens of `.*ViewOpen` members are not included in getCurrentState, pretty sure `flagsViewOpen` doesn't belong there either.