### PR TITLE
Disable diffable asm for dotnet 8.0+ by default

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -326,7 +326,6 @@ class DotNetCompiler extends BaseCompiler {
                     const normalizedName = name.trim().toUpperCase();
                     if (
                         normalizedName === 'DOTNET_JITDISASM' ||
-                        normalizedName === 'DOTNET_JITDUMP' ||
                         normalizedName === 'DOTNET_JITDISASMASSEMBILES'
                     ) {
                         continue;
@@ -366,10 +365,10 @@ class DotNetCompiler extends BaseCompiler {
         }
 
         if (!overrideDiffable) {
-            toolOptions.push('--codegenopt', this.sdkMajorVersion < 8 ? 'JitDiffableDasm=1' : 'JitDisasmDiffable=1');
-            envVarFileContents.push(
-                this.sdkMajorVersion < 8 ? 'DOTNET_JitDiffableDasm=1' : 'DOTNET_JitDisasmDiffable=1',
-            );
+            if (this.sdkMajorVersion < 8) {
+                toolOptions.push('--codegenopt', 'JitDiffableDasm=1');
+                envVarFileContents.push('DOTNET_JitDiffableDasm=1');
+            }
         }
 
         this.setCompilerExecOptions(execOptions, programDir);


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Since .NET 8.0, the JIT disasm no longer prints encoded bytes of instructions by default, so we can disable diffable asm by default.