### PR TITLE
Put Overrides button in success state only when overrides are actually used

### DIFF
--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -347,8 +347,20 @@ export class CompilerOverridesWidget {
     }
 
     private updateButton() {
-        const selected = this.get();
-        if (selected && selected.length > 0) {
+        // Filter out overrides that are set but will not be used by the current
+        // compiler.
+        const selected = (this.get() ?? []).filter(override => {
+            // Env vars are always used.
+            if (override.name === CompilerOverrideType.env) {
+                return true;
+            }
+            if (!override.value) {
+                return false;
+            }
+            return this.compiler?.possibleOverrides?.find(ov => ov.name === override.name);
+        });
+
+        if (selected.length > 0) {
             this.dropdownButton
                 .addClass('btn-success')
                 .removeClass('btn-light')


### PR DESCRIPTION
Currently the button is in the success state (green in the default colours) if there are any overrides set, regardless of whether the current compiler will use them.

This is unlike the libraries button which is only active when at least one enabled library will actually be used by the current compiler. Meaning the list of libraries you have enabled can include things the current compiler doesn't support.

For example if you select a library with clang then switch to MSVC. We still know you enabled that library, but because it isn't wired up for MSVC, the button is not put into the success state because MSVC isn't going to use it.

This change makes the Overrides button have the same behaviour as the Libraries button.

For Example:
* You are on gcc which supports a "target" override.
* You set this to some target.
* Overrides button is now in the success state.
* You switch to a clang that does not support this "target" override.
* Overrides button is now not in the success state.
* As long as you don't open the Overrides menu, the "target" override is still saved, just not used.
* Switch back to gcc, the "target" override is used again.
* Overrides button is put into the success state again.

The same works between languages. Like if the gcc above was a C compiler and the clang a C++ compiler.

At time of writing, https://godbolt.org/z/5eqx3b96r demonstrates the old behaviour. MSVC is selected but the previous "target" override for gcc is still causing the button to be in the success state when MSVC isn't using it.
