### PR TITLE
Remove unsupported overrides when the compiler changes

### DIFF
--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -305,7 +305,14 @@ export class CompilerOverridesWidget {
     }
 
     set(configured: ConfiguredOverrides) {
-        this.configured = configured;
+        // Remove overrides that are not supported by the current compiler.
+        this.configured = configured.filter(override => {
+            // Env vars are always compatible.
+            if (override.name === CompilerOverrideType.env) {
+                return true;
+            }
+            return this.compiler?.possibleOverrides?.find(ov => ov.name === override.name);
+        });
         this.updateButton();
     }
 


### PR DESCRIPTION
Prior to this, unsupported overrides were kept around as long as you didn't open the overrides menu. They weren't added to the compiler's command line, because it would filter them out behind the scenes, but you could switch back to the old compiler and it'd be used again.

This changes that so when the compiler changes, overrides that aren't possible for the new compiler are removed completely. This means that the Overrides button status and its tooltip correctly reflect what it's actually using.

For example:
* You are on a gcc that supports the "target" override.
* You set that override to some value.
* You switch to a clang that does not support "target", it gets removed from the overrides.
* When you switch back to gcc, "target" will not be set