### PR TITLE
vax: add built 10.5.0 gcc-vax cross compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1945,13 +1945,20 @@ compiler.k1cg750.hidden=true
 ###############################
 # GCC for VAX
 #
-group.vax.compilers=vaxg1040
+group.vax.compilers=vaxg1050:vaxg1040
 group.vax.groupName=VAX GCC
 group.vax.baseName=vax gcc
 group.vax.isSemVer=true
 group.vax.supportsBinary=true
 group.vax.supportsBinaryObject=true
 group.vax.supportsExecute=false
+
+compiler.vaxg1050.exe=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-g++
+compiler.vaxg1050.options=--sysroot /opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/vax--netbsdelf-sysroot/
+compiler.vaxg1050.objdumper=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-objdump
+compiler.vaxg1050.demangler=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-c++filt
+compiler.vaxg1050.name=VAX gcc NetBSDELF 10.5.0 (Nov 15 03:50:22 2023)
+compiler.vaxg1050.semver=10.5.0
 
 compiler.vaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-g++
 compiler.vaxg1040.options=--sysroot /opt/compiler-explorer/vax/gcc-10.4.0/vax--netbsdelf-sysroot/

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1713,13 +1713,20 @@ compiler.ck1cg750.objdumper=/opt/compiler-explorer/k1/gcc-7.5.0/k1-unknown-elf/b
 ###############################
 # GCC for VAX
 #
-group.cvax.compilers=cvaxg1040
+group.cvax.compilers=cvaxg1050:cvaxg1040
 group.cvax.groupName=VAX GCC
 group.cvax.baseName=vax gcc
 group.cvax.isSemVer=true
 group.cvax.supportsBinary=true
 group.cvax.supportsBinaryObject=true
 group.cvax.supportsExecute=false
+
+compiler.cvaxg1050.exe=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-gcc
+compiler.cvaxg1050.options=--sysroot /opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/vax--netbsdelf-sysroot/
+compiler.cvaxg1050.objdumper=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-objdump
+compiler.cvaxg1050.demangler=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-c++filt
+compiler.cvaxg1050.name=VAX gcc NetBSDELF 10.5.0 (Nov 15 03:50:22 2023)
+compiler.cvaxg1050.semver=10.5.0
 
 compiler.cvaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-gcc
 compiler.cvaxg1040.options=--sysroot /opt/compiler-explorer/vax/gcc-10.4.0/vax--netbsdelf-sysroot/

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -543,13 +543,20 @@ compiler.objcrv64gtrunk.isNightly=true
 ###############################
 # GCC for VAX
 #
-group.objcvax.compilers=objcvaxg1040
+group.objcvax.compilers=objcvaxg1050:objcvaxg1040
 group.objcvax.groupName=VAX GCC
 group.objcvax.baseName=vax gcc
 group.objcvax.isSemVer=true
 group.objcvax.supportsExecute=false
 group.objcvax.supportsBinary=true
 group.objcvax.supportsBinaryObject=true
+
+compiler.objcvaxg1050.exe=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-gcc
+compiler.objcvaxg1050.options=--sysroot /opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/vax--netbsdelf-sysroot/
+compiler.objcvaxg1050.objdumper=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-objdump
+compiler.objcvaxg1050.demangler=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-c++filt
+compiler.objcvaxg1050.name=VAX gcc NetBSDELF 10.5.0 (Nov 15 03:50:22 2023)
+compiler.objcvaxg1050.semver=10.5.0
 
 compiler.objcvaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-gcc
 compiler.objcvaxg1040.options=--sysroot /opt/compiler-explorer/vax/gcc-10.4.0/vax--netbsdelf-sysroot/


### PR DESCRIPTION
The compiler has an explicit reference to a timestamp corresponding to
the NetBSD commit used to build the compiler.

It corresponds to (using https://github.com/NetBSD/src/commit/cd217f2d265f3f9781aa873c348052ee05002ce6):

```
   commit cd217f2d265f3f9781aa873c348052ee05002ce6
   Author: msaitoh <msaitoh@NetBSD.org>
   Date:   Wed Nov 15 03:50:22 2023 +0000

       ixgbe: Clear the WTHRESH bit field before writing it.
```

fixes https://github.com/compiler-explorer/compiler-explorer/issues/5708

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>