### PR TITLE
Add Racket nightly snapshot

### DIFF
--- a/etc/config/racket.amazon.properties
+++ b/etc/config/racket.amazon.properties
@@ -1,12 +1,18 @@
 compilers=&racket
-defaultCompiler=racket86
+defaultCompiler=racketnightly
 
 group.racket.groupName=Racket
-group.racket.compilers=racket86
+group.racket.compilers=racketnightly:racket86
 group.racket.isSemVer=true
 group.racket.baseName=Racket
 group.racket.licenseName=MIT and Apache 2
 group.racket.licenseLink=https://docs.racket-lang.org/license/
+
 compiler.racket86.semver=8.6
 compiler.racket86.exe=/opt/compiler-explorer/racket/racket-8.6/bin/racket
 compiler.racket86.raco=/opt/compiler-explorer/racket/racket-8.6/bin/raco
+
+compiler.racketnightly.semver=(nightly snapshot)
+compiler.racketnightly.isNightly=true
+compiler.racketnightly.exe=/opt/compiler-explorer/racket/racket-nightly/bin/racket
+compiler.racketnightly.raco=/opt/compiler-explorer/racket/racket-nightly/bin/raco


### PR DESCRIPTION
This extends existing Racket support (https://github.com/compiler-explorer/compiler-explorer/pull/4098) by adding a nightly snapshot version.

Depends on https://github.com/compiler-explorer/infra/pull/1173