### PR TITLE
Add gimple front-end syntax option for gcc tree/rtl viewer

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -730,6 +730,9 @@ export class BaseCompiler implements ICompiler {
         // GCC accepts these options as a list of '-' separated names that may
         // appear in any order.
         let flags = '';
+        if (gccDumpOptions.dumpFlags.gimpleFe !== false) {
+            flags += '-gimple';
+        }
         if (gccDumpOptions.dumpFlags.address !== false) {
             flags += '-address';
         }

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -63,6 +63,7 @@ import {
     CompilationRequest,
     CompilationRequestOptions,
     CompilationResult,
+    GccDumpFlags,
     FiledataPair,
 } from '../../types/compilation/compilation.interfaces.js';
 import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
@@ -142,19 +143,6 @@ type Assembly = {
     opcodes?: string[];
     text?: string;
     fake?: boolean;
-};
-
-type DumpFlags = {
-    address: boolean;
-    slim: boolean;
-    raw: boolean;
-    details: boolean;
-    stats: boolean;
-    blocks: boolean;
-    vops: boolean;
-    lineno: boolean;
-    uid: boolean;
-    all: boolean;
 };
 
 // Disable max line count only for the constructor. Turns out, it needs to do quite a lot of things
@@ -272,7 +260,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     private treeDumpEnabled?: boolean;
     private rtlDumpEnabled?: boolean;
     private ipaDumpEnabled?: boolean;
-    private dumpFlags?: DumpFlags;
+    private dumpFlags?: GccDumpFlags;
     private gnatDebugTreeViewOpen: boolean;
     private gnatDebugViewOpen: boolean;
     private rustMirViewOpen: boolean;
@@ -2352,6 +2340,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             this.rtlDumpEnabled = dumpOpts.rtlDump;
             this.ipaDumpEnabled = dumpOpts.ipaDump;
             this.dumpFlags = {
+                gimpleFe: dumpOpts.gimpleFeOption,
                 address: dumpOpts.addressOption,
                 slim: dumpOpts.slimOption,
                 raw: dumpOpts.rawOption,

--- a/static/panes/gccdump-view.interfaces.ts
+++ b/static/panes/gccdump-view.interfaces.ts
@@ -45,6 +45,7 @@ export type GccDumpFiltersState = {
     slimOption: boolean;
     allOption: boolean;
 
+    gimpleFeOption: boolean;
     addressOption: boolean;
     blocksOption: boolean;
     linenoOption: boolean;

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -55,6 +55,8 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
     dumpRtlTitle: string;
     dumpIpaButton: JQuery<HTMLElement>;
     dumpIpaTitle: string;
+    optionGimpleFeButton: JQuery<HTMLElement>;
+    optionGimpleFeTitle: string;
     optionAddressButton: JQuery<HTMLElement>;
     optionAddressTitle: string;
     optionSlimButton: JQuery<HTMLElement>;
@@ -196,6 +198,9 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         this.dumpIpaButton = this.domRoot.find("[data-bind='ipaDump']");
         this.dumpIpaTitle = this.dumpIpaButton.prop('title');
 
+        this.optionGimpleFeButton = this.domRoot.find("[data-bind='gimpleFe']");
+        this.optionGimpleFeTitle = this.optionGimpleFeButton.prop('title');
+
         this.optionAddressButton = this.domRoot.find("[data-bind='addressOption']");
         this.optionAddressTitle = this.optionAddressButton.prop('title');
 
@@ -249,6 +254,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         formatButtonTitle(this.dumpTreesButton, this.dumpTreesTitle);
         formatButtonTitle(this.dumpRtlButton, this.dumpRtlTitle);
         formatButtonTitle(this.dumpIpaButton, this.dumpIpaTitle);
+        formatButtonTitle(this.optionGimpleFeButton, this.optionGimpleFeTitle);
         formatButtonTitle(this.optionAddressButton, this.optionAddressTitle);
         formatButtonTitle(this.optionSlimButton, this.optionSlimTitle);
         formatButtonTitle(this.optionRawButton, this.optionRawTitle);

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -56,6 +56,20 @@ export type CompileChildLibraries = {
     version: string;
 };
 
+export type GccDumpFlags = {
+    gimpleFe: boolean;
+    address: boolean;
+    slim: boolean;
+    raw: boolean;
+    details: boolean;
+    stats: boolean;
+    blocks: boolean;
+    vops: boolean;
+    lineno: boolean;
+    uid: boolean;
+    all: boolean;
+};
+
 export type CompilationRequestOptions = {
     userArguments: string;
     compilerOptions: {
@@ -69,7 +83,7 @@ export type CompilationRequestOptions = {
             treeDump?: boolean;
             rtlDump?: boolean;
             ipaDump?: boolean;
-            dumpFlags: any;
+            dumpFlags?: GccDumpFlags;
         };
         produceStackUsageInfo?: boolean;
         produceOptInfo?: boolean;

--- a/views/templates/panes/gccdump.pug
+++ b/views/templates/panes/gccdump.pug
@@ -27,7 +27,7 @@ mixin optionButton(bind, isActive, text, title)
         div.dropdown-divider
         +optionButton("allOption", false, "All Options", "Turn on all options (except raw, slim and lineno)")
         // This addresses one was marked as aria-pressed=true, but not checked. What should its default state be then? Set to false for now
-        +optionButton("gimpleFeOption", false, "Gimple Frontend Syntax", "Dump syntax that the gimple frontend can accept")
+        +optionButton("gimpleFeOption", false, "GIMPLE Frontend Syntax", "Dump syntax that the GIMPLE frontend can accept")
         +optionButton("addressOption", false, "Addresses", "Print the address of each tree node")
         +optionButton("blocksOption", false, "Basic Blocks", "Show the basic block boundaries (disabled in raw dumps)")
         +optionButton("linenoOption", false, "Line Numbers", "Show line numbers")

--- a/views/templates/panes/gccdump.pug
+++ b/views/templates/panes/gccdump.pug
@@ -27,6 +27,7 @@ mixin optionButton(bind, isActive, text, title)
         div.dropdown-divider
         +optionButton("allOption", false, "All Options", "Turn on all options (except raw, slim and lineno)")
         // This addresses one was marked as aria-pressed=true, but not checked. What should its default state be then? Set to false for now
+        +optionButton("gimpleFeOption", false, "Gimple Frontend Syntax", "Dump syntax that the gimple frontend can accept")
         +optionButton("addressOption", false, "Addresses", "Print the address of each tree node")
         +optionButton("blocksOption", false, "Basic Blocks", "Show the basic block boundaries (disabled in raw dumps)")
         +optionButton("linenoOption", false, "Line Numbers", "Show line numbers")


### PR DESCRIPTION
This PR adds an option to the gcc tree/rtl dump viewer to dump syntax that the gimple frontend can accept

![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/4a5ff503-9420-4fc3-ba6f-6b1dc196e938)
