### PR TITLE
Add LanguageConfiguration for llvm ir

### DIFF
--- a/etc/config/llvm.defaults.properties
+++ b/etc/config/llvm.defaults.properties
@@ -2,14 +2,20 @@ binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_sta
 objdumper=objdump
 demangler=c++filt
 
-compilers=irclang:llc:opt
+compilers=irclang:irclang17:llc:opt
 defaultCompiler=irclang
 
 compiler.irclang.intelAsm=-masm=intel
 compiler.irclang.groupName=Clang x86-64
 compiler.irclang.options=-x ir
 compiler.irclang.exe=/usr/bin/clang++
-compiler.irclang.name=clang 3.9.1
+compiler.irclang.name=clang default
+
+compiler.irclang17.intelAsm=-masm=intel
+compiler.irclang17.groupName=Clang x86-64
+compiler.irclang17.options=-x ir
+compiler.irclang17.exe=/usr/bin/clang++-17
+compiler.irclang17.name=clang 17
 
 compiler.llc.compilerType=llc
 compiler.llc.supportsExecute=false

--- a/static/modes/llvm-ir-mode.ts
+++ b/static/modes/llvm-ir-mode.ts
@@ -347,7 +347,33 @@ export function definition(): monaco.languages.IMonarchLanguage {
     };
 }
 
+const config: monaco.languages.LanguageConfiguration = {
+    comments: {
+        lineComment: ';',
+    },
+    brackets: [
+        ['{', '}'],
+        ['[', ']'],
+        ['(', ')'],
+    ],
+    autoClosingPairs: [
+        {open: '[', close: ']'},
+        {open: '{', close: '}'},
+        {open: '(', close: ')'},
+        {open: "'", close: "'", notIn: ['string', 'comment']},
+        {open: '"', close: '"', notIn: ['string']},
+    ],
+    surroundingPairs: [
+        {open: '{', close: '}'},
+        {open: '[', close: ']'},
+        {open: '(', close: ')'},
+        {open: '"', close: '"'},
+        {open: "'", close: "'"},
+    ],
+};
+
 monaco.languages.register({id: 'llvm-ir'});
 monaco.languages.setMonarchTokensProvider('llvm-ir', definition());
+monaco.languages.setLanguageConfiguration('llvm-ir', config);
 
 export {};


### PR DESCRIPTION
The main point of this is to make ctrl+/ work, also added an entry to llvm.defaults.properties