### PR TITLE
fix typo in the name of the tl::expected library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4223,7 +4223,7 @@ libs.thinkcell.versions=trunk
 libs.thinkcell.versions.trunk.version=trunk
 libs.thinkcell.versions.trunk.path=/opt/compiler-explorer/libs/thinkcell/trunk
 
-libs.tlexpected.name=tl::exected
+libs.tlexpected.name=tl::expected
 libs.tlexpected.versions=trunk:100
 libs.tlexpected.description=Single header implementation of std::expected with functional-style extensions.
 libs.tlexpected.url=https://github.com/TartanLlama/expected

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1559,7 +1559,7 @@ libs.tbb.versions.20214.version=2021.4.0
 libs.tbb.versions.20214.path=/opt/compiler-explorer/libs/tbb/2021.4.0/include
 libs.tbb.versions.20214.liblink=tbb_debug:tbbmalloc_debug:tbbmalloc_proxy_debug
 
-libs.tlexpected.name=tl::exected
+libs.tlexpected.name=tl::expected
 libs.tlexpected.versions=trunk:100
 libs.tlexpected.description=Single header implementation of std::expected with functional-style extensions.
 libs.tlexpected.url=https://github.com/TartanLlama/expected


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
