### PR TITLE
Update cmake to 3.28.0

### DIFF
--- a/etc/config/cmakescript.amazon.properties
+++ b/etc/config/cmakescript.amazon.properties
@@ -1,7 +1,7 @@
-compilers=cmake-3_26_1:cmake-3_27_9:cmake-3_28_0-rc5
+compilers=cmake-3_26_1:cmake-3_27_9:cmake-3_28_0
 isSemVer=true
 baseName=cmake
-defaultCompiler=cmake-3_27_9
+defaultCompiler=cmake-3_28_0
 
 compiler.cmake-3_26_1.exe=/opt/compiler-explorer/cmake-v3.26.1/bin/cmake
 compiler.cmake-3_26_1.semver=3.26.1
@@ -9,5 +9,5 @@ compiler.cmake-3_26_1.semver=3.26.1
 compiler.cmake-3_27_9.exe=/opt/compiler-explorer/cmake-v3.27.9/bin/cmake
 compiler.cmake-3_27_9.semver=3.27.9
 
-compiler.cmake-3_28_0-rc5.exe=/opt/compiler-explorer/cmake-v3.28.0-rc5/bin/cmake
-compiler.cmake-3_28_0-rc5.semver=3.28.0 rc5
+compiler.cmake-3_28_0.exe=/opt/compiler-explorer/cmake-v3.28.0/bin/cmake
+compiler.cmake-3_28_0.semver=3.28.0

--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -36,7 +36,7 @@ sentrySlowRequestMs=30000
 alwaysResetLdPath=true
 plogConverter=/opt/compiler-explorer/pvs-studio-latest/bin/plog-converter
 
-cmake=/opt/compiler-explorer/cmake/bin/cmake
+cmake=/opt/compiler-explorer/cmake-v3.28.0/bin/cmake
 useninja=false
 ld=/usr/bin/ld
 readelf=/usr/bin/readelf

--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -36,7 +36,7 @@ sentrySlowRequestMs=30000
 alwaysResetLdPath=true
 plogConverter=/opt/compiler-explorer/pvs-studio-latest/bin/plog-converter
 
-cmake=/opt/compiler-explorer/cmake-v3.28.0/bin/cmake
+cmake=/opt/compiler-explorer/cmake/bin/cmake
 useninja=false
 ld=/usr/bin/ld
 readelf=/usr/bin/readelf


### PR DESCRIPTION
CMake 3.28.0 has just been released. This PR replaces the cmake v3.28.0.rc5 to cmake v3.28.0

I believe that we need changes to the images using by the amazon instance (as I can infer).

In addition to it, it sets cmake 3.28.0 as the cmake version to be used when building projects with cmake (IDE mode). This is important since 3.28 brings key features such as the support of non-experimental C++ modules.

Let me now if I need to add anything else.

New cmake release: https://github.com/Kitware/CMake/releases/tag/v3.28.0

Thanks!

X-ref: #5815 