### PR TITLE
gimple: add all missing cross gcc

### DIFF
--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gimplegcc86:&gimplegccarm:&gimpleavr:&rvgimplegcc
+compilers=&gimplegcc86:&gimplecross
 defaultCompiler=gimpleg132
 demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
@@ -75,6 +75,743 @@ compiler.gimplegstatic-analysis.objdumper=/opt/compiler-explorer/gcc-snapshot/bi
 compiler.gimplegstatic-analysis.semver=(static analysis)
 compiler.gimplegstatic-analysis.options=-fanalyzer -fdiagnostics-urls=never -fdiagnostics-color=always
 compiler.gimplegstatic-analysis.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+
+################################
+# GCC for AVR
+group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1310:gimpleavrg1320
+group.gimpleavr.groupName=AVR GCC
+group.gimpleavr.baseName=AVR gcc
+group.gimpleavr.isSemVer=true
+
+compiler.gimpleavrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-gcc
+compiler.gimpleavrg920.semver=9.2.0
+compiler.gimpleavrg920.objdumper=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-objdump
+
+compiler.gimpleavrg930.exe=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-gcc
+compiler.gimpleavrg930.semver=9.3.0
+compiler.gimpleavrg930.objdumper=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-objdump
+
+compiler.gimpleavrg1030.exe=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-gcc
+compiler.gimpleavrg1030.semver=10.3.0
+compiler.gimpleavrg1030.objdumper=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-objdump
+
+compiler.gimpleavrg1100.exe=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-gcc
+compiler.gimpleavrg1100.semver=11.1.0
+compiler.gimpleavrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdump
+
+compiler.gimpleavrg1210.exe=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-gcc
+compiler.gimpleavrg1210.semver=12.1.0
+compiler.gimpleavrg1210.objdumper=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-objdump
+
+compiler.gimpleavrg1220.exe=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-gcc
+compiler.gimpleavrg1220.semver=12.2.0
+compiler.gimpleavrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-objdump
+compiler.gimpleavrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
+
+compiler.gimpleavrg1230.exe=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-gcc
+compiler.gimpleavrg1230.semver=12.3.0
+compiler.gimpleavrg1230.objdumper=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-objdump
+compiler.gimpleavrg1230.demangler=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-c++filt
+
+compiler.gimpleavrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-gcc
+compiler.gimpleavrg1310.semver=13.1.0
+compiler.gimpleavrg1310.objdumper=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-objdump
+compiler.gimpleavrg1310.demangler=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-c++filt
+
+compiler.gimpleavrg1320.exe=/opt/compiler-explorer/avr/gcc-13.2.0/avr/bin/avr-gcc
+compiler.gimpleavrg1320.semver=13.2.0
+compiler.gimpleavrg1320.objdumper=/opt/compiler-explorer/avr/gcc-13.2.0/avr/bin/avr-objdump
+compiler.gimpleavrg1320.demangler=/opt/compiler-explorer/avr/gcc-13.2.0/avr/bin/avr-c++filt
+
+################################
+# GCC for Xtensa ESP32
+group.gimplextensaesp32.compilers=gimpleesp32g2022r1:gimpleesp32g20230208
+group.gimplextensaesp32.groupName=Xtensa ESP32 GCC
+group.gimplextensaesp32.supportsBinary=false
+group.gimplextensaesp32.instructionSet=xtensa
+group.gimplextensaesp32.supportsAsmDocs=false
+group.gimplextensaesp32.supportsBinaryObject=true
+
+compiler.gimpleesp32g2022r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc11_2_0-esp-2022r1/bin/xtensa-esp32-elf-gcc
+compiler.gimpleesp32g2022r1.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc11_2_0-esp-2022r1/bin/xtensa-esp32-elf-objdump
+compiler.gimpleesp32g2022r1.name=Xtensa ESP32 gcc 11.2.0 (2022r1)
+compiler.gimpleesp32g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-gcc
+compiler.gimpleesp32g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-objdump
+compiler.gimpleesp32g20230208.name=Xtensa ESP32 gcc 12.2.0 (20230208)
+
+################################
+# GCC for Xtensa ESP32-S2
+group.gimplextensaesp32s2.compilers=gimpleesp32s2g2022r1:gimpleesp32s2g20230208
+group.gimplextensaesp32s2.groupName=Xtensa ESP32-S2 GCC
+group.gimplextensaesp32s2.supportsBinary=false
+group.gimplextensaesp32s2.instructionSet=xtensa
+group.gimplextensaesp32s2.supportsAsmDocs=false
+group.gimplextensaesp32s2.supportsBinaryObject=true
+
+compiler.gimpleesp32s2g2022r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc11_2_0-esp-2022r1/bin/xtensa-esp32s2-elf-gcc
+compiler.gimpleesp32s2g2022r1.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc11_2_0-esp-2022r1/bin/xtensa-esp32s2-elf-objdump
+compiler.gimpleesp32s2g2022r1.name=Xtensa ESP32-S2 gcc 11.2.0 (2022r1)
+compiler.gimpleesp32s2g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-gcc
+compiler.gimpleesp32s2g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-objdump
+compiler.gimpleesp32s2g20230208.name=Xtensa ESP32-S2 gcc 12.2.0 (20230208)
+
+################################
+# GCC for Xtensa ESP32-S3
+group.gimplextensaesp32s3.compilers=gimpleesp32s3g2022r1:gimpleesp32s3g20230208
+group.gimplextensaesp32s3.groupName=Xtensa ESP32-S3 GCC
+group.gimplextensaesp32s3.supportsBinary=false
+group.gimplextensaesp32s3.instructionSet=xtensa
+group.gimplextensaesp32s3.supportsAsmDocs=false
+group.gimplextensaesp32s3.supportsBinaryObject=true
+
+compiler.gimpleesp32s3g2022r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc11_2_0-esp-2022r1/bin/xtensa-esp32s3-elf-gcc
+compiler.gimpleesp32s3g2022r1.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc11_2_0-esp-2022r1/bin/xtensa-esp32s3-elf-objdump
+compiler.gimpleesp32s3g2022r1.name=Xtensa ESP32-S3 gcc 11.2.0 (2022r1)
+compiler.gimpleesp32s3g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-gcc
+compiler.gimpleesp32s3g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-objdump
+compiler.gimpleesp32s3g20230208.name=Xtensa ESP32-S3 gcc 12.2.0 (20230208)
+
+###############################
+# GCC for Kalray
+group.gimplekalray.compilers=gimplekvxg1130_v4120:gimplekvxg1031_v4111:gimplekvxg1031_v4100:gimplekvxg941_v490:gimplekvxg941_v480:gimplekvxg941_v460
+group.gimplekalray.groupName=Kalray MPPA GCC
+group.gimplekalray.isSemVer=true
+# kvx versions are different from the GCC they wrap
+
+compiler.gimplekvxg1130_v4120.exe=/opt/compiler-explorer/kvx/acb-4.12.0/bin/kvx-elf-gcc
+compiler.gimplekvxg1130_v4120.name=KVX ACB 4.12.0 (GCC 11.3.0)
+compiler.gimplekvxg1130_v4120.semver=4.12.0
+compiler.gimplekvxg1130_v4120.objdumper=/opt/compiler-explorer/kvx/acb-4.12.0/bin/kvx-elf-objdump
+
+compiler.gimplekvxg1031_v4111.exe=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-gcc
+compiler.gimplekvxg1031_v4111.name=KVX ACB 4.11.1 (GCC 10.3.1)
+compiler.gimplekvxg1031_v4111.semver=4.11.1
+compiler.gimplekvxg1031_v4111.objdumper=/opt/compiler-explorer/kvx/acb-4.11.1/bin/kvx-elf-objdump
+compiler.gimplekvxg1031_v4111.alias=ckvxg1031_v4110
+
+compiler.gimplekvxg1031_v4100.exe=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-gcc
+compiler.gimplekvxg1031_v4100.name=KVX ACB 4.10.0 (GCC 10.3.1)
+compiler.gimplekvxg1031_v4100.semver=4.10.0
+compiler.gimplekvxg1031_v4100.objdumper=/opt/compiler-explorer/kvx/acb-4.10.0/bin/kvx-elf-objdump
+
+compiler.gimplekvxg941_v490.exe=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-gcc
+compiler.gimplekvxg941_v490.name=KVX ACB 4.9.0 (GCC 9.4.1)
+compiler.gimplekvxg941_v490.semver=4.9.0
+compiler.gimplekvxg941_v490.objdumper=/opt/compiler-explorer/kvx/acb-4.9.0/bin/kvx-elf-objdump
+
+compiler.gimplekvxg941_v480.exe=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-gcc
+compiler.gimplekvxg941_v480.name=KVX ACB 4.8.0 (GCC 9.4.1)
+compiler.gimplekvxg941_v480.semver=4.8.0
+compiler.gimplekvxg941_v480.objdumper=/opt/compiler-explorer/kvx/acb-4.8.0/bin/kvx-elf-objdump
+
+compiler.gimplekvxg941_v460.exe=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-gcc
+compiler.gimplekvxg941_v460.name=KVX ACB 4.6.0 (GCC 9.4.1)
+compiler.gimplekvxg941_v460.semver=4.6.0
+compiler.gimplekvxg941_v460.objdumper=/opt/compiler-explorer/kvx/acb-4.6.0/bin/kvx-elf-objdump
+
+###############################
+# GCC for VAX
+#
+group.gimplevax.compilers=gimplevaxg1050:gimplevaxg1040
+group.gimplevax.groupName=VAX GCC
+group.gimplevax.baseName=vax gcc
+group.gimplevax.isSemVer=true
+group.gimplevax.supportsBinary=true
+group.gimplevax.supportsBinaryObject=true
+group.gimplevax.supportsExecute=false
+
+compiler.gimplevaxg1050.exe=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-gcc
+compiler.gimplevaxg1050.options=--sysroot /opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/vax--netbsdelf-sysroot/
+compiler.gimplevaxg1050.objdumper=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-objdump
+compiler.gimplevaxg1050.demangler=/opt/compiler-explorer/vax/gcc-10.5.0-2023-11-16/bin/vax--netbsdelf-c++filt
+compiler.gimplevaxg1050.name=VAX gcc NetBSDELF 10.5.0 (Nov 15 03:50:22 2023)
+compiler.gimplevaxg1050.semver=10.5.0
+
+compiler.gimplevaxg1040.exe=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-gcc
+compiler.gimplevaxg1040.options=--sysroot /opt/compiler-explorer/vax/gcc-10.4.0/vax--netbsdelf-sysroot/
+compiler.gimplevaxg1040.objdumper=/opt/compiler-explorer/vax/gcc-10.4.0/bin/vax--netbsdelf-objdump
+compiler.gimplevaxg1040.name=VAX gcc NetBSDELF 10.4.0
+compiler.gimplevaxg1040.semver=10.4.0
+
+
+###############################
+# Cross compilers for MIPS
+group.gimplemipss.compilers=&gimplemips:&gimplemipsel:&gimplemips64:&gimplemips64el
+group.gimplemipss.isSemVer=true
+group.gimplemipss.supportsBinary=true
+group.gimplemipss.supportsExecute=false
+
+# GCC for all MIPS
+## MIPS
+group.gimplemips.compilers=gimplemips930:gimplemips1120:gimplemipsg1210:gimplemipsg1220:gimplemipsg1230:gimplemipsg1310:gimplemipsg1320
+group.gimplemips.groupName=MIPS GCC
+group.gimplemips.baseName=mips gcc
+
+compiler.gimplemips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
+compiler.gimplemips930.name=mips gcc 9.3.0 (codescape)
+compiler.gimplemips930.semver=9.3.0
+compiler.gimplemips930.objdumper=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-objdump
+
+compiler.gimplemips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemips1120.semver=11.2.0
+compiler.gimplemips1120.objdumper=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+compiler.gimplemipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1210.semver=12.1.0
+compiler.gimplemipsg1210.objdumper=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+compiler.gimplemipsg1220.exe=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1220.semver=12.2.0
+compiler.gimplemipsg1220.objdumper=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gimplemipsg1220.demangler=/opt/compiler-explorer/mips/gcc-12.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gimplemipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1230.semver=12.3.0
+compiler.gimplemipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gimplemipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gimplemipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1310.semver=13.1.0
+compiler.gimplemipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gimplemipsg1310.demangler=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gimplemipsg1320.exe=/opt/compiler-explorer/mips/gcc-13.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1320.semver=13.2.0
+compiler.gimplemipsg1320.objdumper=/opt/compiler-explorer/mips/gcc-13.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gimplemipsg1320.demangler=/opt/compiler-explorer/mips/gcc-13.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+## MIPS64
+group.gimplemips64.groupName=MIPS64 GCC
+group.gimplemips64.compilers=gimplemips64g1210:gimplemips64g1220:gimplemips64g1230:gimplemips64g1310:gimplemips64g1320:gimplemips112064
+group.gimplemips64.baseName=mips64 gcc
+
+
+compiler.gimplemips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips112064.semver=11.2.0
+compiler.gimplemips112064.objdumper=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+compiler.gimplemips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1210.semver=12.1.0
+compiler.gimplemips64g1210.objdumper=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+compiler.gimplemips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1220.semver=12.2.0
+compiler.gimplemips64g1220.objdumper=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gimplemips64g1220.demangler=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gimplemips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1230.semver=12.3.0
+compiler.gimplemips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gimplemips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gimplemips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1310.semver=13.1.0
+compiler.gimplemips64g1310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gimplemips64g1310.demangler=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gimplemips64g1320.exe=/opt/compiler-explorer/mips64/gcc-13.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1320.semver=13.2.0
+compiler.gimplemips64g1320.objdumper=/opt/compiler-explorer/mips64/gcc-13.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gimplemips64g1320.demangler=/opt/compiler-explorer/mips64/gcc-13.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+## MIPS EL
+group.gimplemipsel.groupName=MIPSEL GCC
+group.gimplemipsel.compilers=gimplemipselg1210:gimplemipselg1220:gimplemipselg1230:gimplemipselg1310:gimplemipselg1320
+group.gimplemipsel.baseName=mips (el) gcc
+
+compiler.gimplemipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1210.semver=12.1.0
+compiler.gimplemipselg1210.objdumper=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+
+compiler.gimplemipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1220.semver=12.2.0
+compiler.gimplemipselg1220.objdumper=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gimplemipselg1220.demangler=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gimplemipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1230.semver=12.3.0
+compiler.gimplemipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gimplemipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gimplemipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1310.semver=13.1.0
+compiler.gimplemipselg1310.objdumper=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gimplemipselg1310.demangler=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gimplemipselg1320.exe=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1320.semver=13.2.0
+compiler.gimplemipselg1320.objdumper=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gimplemipselg1320.demangler=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+## MIPS64 EL
+group.gimplemips64el.groupName=MIPS64EL GCC
+group.gimplemips64el.compilers=gimplemips64elg1210:gimplemips64elg1220:gimplemips64elg1230:gimplemips64elg1310:gimplemips64elg1320
+group.gimplemips64el.baseName=mips64 (el) gcc
+
+compiler.gimplemips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1210.semver=12.1.0
+compiler.gimplemips64elg1210.objdumper=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+
+compiler.gimplemips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1220.semver=12.2.0
+compiler.gimplemips64elg1220.objdumper=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gimplemips64elg1220.demangler=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.gimplemips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1230.semver=12.3.0
+compiler.gimplemips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gimplemips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.gimplemips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1310.semver=13.1.0
+compiler.gimplemips64elg1310.objdumper=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gimplemips64elg1310.demangler=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.gimplemips64elg1320.exe=/opt/compiler-explorer/mips64el/gcc-13.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1320.semver=13.2.0
+compiler.gimplemips64elg1320.objdumper=/opt/compiler-explorer/mips64el/gcc-13.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gimplemips64elg1320.demangler=/opt/compiler-explorer/mips64el/gcc-13.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+###############################
+# Cross Compilers
+group.gimplecross.compilers=&gimpleppcs:&gimplemipss:&gimplemsp:&gimplegccarm:&gimpleavr:&gimplervgcc:&gimplextensaesp32:&gimplextensaesp32s2:&gimplextensaesp32s3:&gimplekalray:&gimples390x:&gimplesh:&gimpleloongarch64:&gimplec6x:&gimplesparc:&gimplesparc64:&gimplesparcleon:&gimplebpf:&gimplevax:&gimplem68k
+group.gimplecross.supportsBinary=false
+group.gimplecross.supportsBinaryObject=true
+group.gimplecross.groupName=Cross GCC
+group.gimplecross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
+group.gimplecross.licenseName=GNU General Public License
+group.gimplecross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+group.gimplecross.compilerCategories=gcc
+
+###############################
+# Cross for BPF
+group.gimplebpf.compilers=&gimplegccbpf
+group.gimplebpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
+# GCC for BPF
+group.gimplegccbpf.compilers=gimplebpfg1310:gimplebpfg1320:gimplebpfgtrunk
+group.gimplegccbpf.supportsBinary=true
+group.gimplegccbpf.supportsExecute=false
+group.gimplegccbpf.baseName=BPF gcc
+group.gimplegccbpf.groupName=BPF GCC
+group.gimplegccbpf.isSemVer=true
+group.gimplegccbpf.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
+
+compiler.gimplebpfg1310.exe=/opt/compiler-explorer/bpf/gcc-13.1.0/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.gimplebpfg1310.semver=13.1.0
+compiler.gimplebpfg1310.objdumper=/opt/compiler-explorer/bpf/gcc-13.1.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.gimplebpfg1310.demangler=/opt/compiler-explorer/bpf/gcc-13.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
+compiler.gimplebpfg1320.exe=/opt/compiler-explorer/bpf/gcc-13.2.0/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.gimplebpfg1320.semver=13.2.0
+compiler.gimplebpfg1320.objdumper=/opt/compiler-explorer/bpf/gcc-13.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.gimplebpfg1320.demangler=/opt/compiler-explorer/bpf/gcc-13.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
+compiler.gimplebpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.gimplebpfgtrunk.semver=trunk
+compiler.gimplebpfgtrunk.isNightly=true
+compiler.gimplebpfgtrunk.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.gimplebpfgtrunk.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
+
+###############################
+# Cross for m68k
+group.gimplem68k.compilers=&gimplegccm68k
+group.gimplem68k.demangler=/opt/compiler-explorer/m68k/gcc-13.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
+# GCC for m68k
+group.gimplegccm68k.compilers=gimplem68kg1310:gimplem68kg1320
+group.gimplegccm68k.supportsBinary=true
+group.gimplegccm68k.supportsExecute=false
+group.gimplegccm68k.baseName=M68K gcc
+group.gimplegccm68k.groupName=M68K GCC
+group.gimplegccm68k.isSemVer=true
+group.gimplegccm68k.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
+
+compiler.gimplem68kg1310.exe=/opt/compiler-explorer/m68k/gcc-13.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-gcc
+compiler.gimplem68kg1310.semver=13.1.0
+compiler.gimplem68kg1310.objdumper=/opt/compiler-explorer/m68k/gcc-13.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
+compiler.gimplem68kg1310.demangler=/opt/compiler-explorer/m68k/gcc-13.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
+compiler.gimplem68kg1320.exe=/opt/compiler-explorer/m68k/gcc-13.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-gcc
+compiler.gimplem68kg1320.semver=13.2.0
+compiler.gimplem68kg1320.objdumper=/opt/compiler-explorer/m68k/gcc-13.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
+compiler.gimplem68kg1320.demangler=/opt/compiler-explorer/m68k/gcc-13.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
+###############################
+# Cross for SPARC
+group.gimplesparc.compilers=&gimplegccsparc
+
+# GCC for SPARC
+group.gimplegccsparc.compilers=gimplesparcg1220:gimplesparcg1230:gimplesparcg1310:gimplesparcg1320
+group.gimplegccsparc.baseName=SPARC gcc
+group.gimplegccsparc.groupName=SPARC GCC
+group.gimplegccsparc.isSemVer=true
+
+compiler.gimplesparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.gimplesparcg1220.semver=12.2.0
+compiler.gimplesparcg1220.objdumper=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gimplesparcg1220.demangler=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gimplesparcg1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.gimplesparcg1230.semver=12.3.0
+compiler.gimplesparcg1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gimplesparcg1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gimplesparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.gimplesparcg1310.semver=13.1.0
+compiler.gimplesparcg1310.objdumper=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gimplesparcg1310.demangler=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gimplesparcg1320.exe=/opt/compiler-explorer/sparc/gcc-13.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.gimplesparcg1320.semver=13.2.0
+compiler.gimplesparcg1320.objdumper=/opt/compiler-explorer/sparc/gcc-13.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gimplesparcg1320.demangler=/opt/compiler-explorer/sparc/gcc-13.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+###############################
+# Cross for SPARC64
+group.gimplesparc64.compilers=&gimplegccsparc64
+
+# GCC for SPARC64
+group.gimplegccsparc64.compilers=gimplesparc64g1220:gimplesparc64g1230:gimplesparc64g1310:gimplesparc64g1320
+group.gimplegccsparc64.baseName=SPARC64 gcc
+group.gimplegccsparc64.groupName=SPARC64 GCC
+group.gimplegccsparc64.isSemVer=true
+
+compiler.gimplesparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.gimplesparc64g1220.semver=12.2.0
+compiler.gimplesparc64g1220.objdumper=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gimplesparc64g1220.demangler=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gimplesparc64g1230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.gimplesparc64g1230.semver=12.3.0
+compiler.gimplesparc64g1230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gimplesparc64g1230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gimplesparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.gimplesparc64g1310.semver=13.1.0
+compiler.gimplesparc64g1310.objdumper=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gimplesparc64g1310.demangler=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gimplesparc64g1320.exe=/opt/compiler-explorer/sparc64/gcc-13.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.gimplesparc64g1320.semver=13.2.0
+compiler.gimplesparc64g1320.objdumper=/opt/compiler-explorer/sparc64/gcc-13.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gimplesparc64g1320.demangler=/opt/compiler-explorer/sparc64/gcc-13.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+###############################
+# Cross for SPARC-LEON
+group.gimplesparcleon.compilers=&gimplegccsparcleon
+
+# GCC for SPARC-LEON
+group.gimplegccsparcleon.compilers=gimplesparcleong1220:gimplesparcleong1220-1:gimplesparcleong1230:gimplesparcleong1310:gimplesparcleong1320
+group.gimplegccsparcleon.baseName=SPARC LEON gcc
+group.gimplegccsparcleon.groupName=SPARC LEON GCC
+group.gimplegccsparcleon.isSemVer=true
+
+# this one was wrongly built using 'master', not 12.2.0 release.
+compiler.gimplesparcleong1220.hidden=true
+compiler.gimplesparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1220.name=SPARC LEON gcc 13.x (incorrectly named 12.2.0 in the past)
+compiler.gimplesparcleong1220.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1220.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.gimplesparcleong1230.exe=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1230.semver=12.3.0
+compiler.gimplesparcleong1230.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1230.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.gimplesparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1310.semver=13.1.0
+compiler.gimplesparcleong1310.objdumper=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1310.demangler=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.gimplesparcleong1320.exe=/opt/compiler-explorer/sparc-leon/gcc-13.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1320.semver=13.2.0
+compiler.gimplesparcleong1320.objdumper=/opt/compiler-explorer/sparc-leon/gcc-13.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1320.demangler=/opt/compiler-explorer/sparc-leon/gcc-13.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.gimplesparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1220-1.semver=12.2.0
+compiler.gimplesparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+###############################
+# Cross for TI C6x
+group.gimplec6x.compilers=&gimplegccc6x
+
+# GCC for TI C6x
+group.gimplegccc6x.compilers=gimplec6xg1220:gimplec6xg1230:gimplec6xg1310:gimplec6xg1320
+group.gimplegccc6x.baseName=TI C6x gcc
+group.gimplegccc6x.groupName=TI C6x GCC
+group.gimplegccc6x.isSemVer=true
+
+compiler.gimplec6xg1220.exe=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.gimplec6xg1220.semver=12.2.0
+compiler.gimplec6xg1220.objdumper=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.gimplec6xg1220.demangler=/opt/compiler-explorer/c6x/gcc-12.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.gimplec6xg1230.exe=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.gimplec6xg1230.semver=12.3.0
+compiler.gimplec6xg1230.objdumper=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.gimplec6xg1230.demangler=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.gimplec6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.gimplec6xg1310.semver=13.1.0
+compiler.gimplec6xg1310.objdumper=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.gimplec6xg1310.demangler=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.gimplec6xg1320.exe=/opt/compiler-explorer/c6x/gcc-13.2.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.gimplec6xg1320.semver=13.2.0
+compiler.gimplec6xg1320.objdumper=/opt/compiler-explorer/c6x/gcc-13.2.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.gimplec6xg1320.demangler=/opt/compiler-explorer/c6x/gcc-13.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+###############################
+# Cross for loongarch64
+group.gimpleloongarch64.compilers=&gimplegccloongarch64
+
+# GCC for loongarch64
+group.gimplegccloongarch64.compilers=gimpleloongarch64g1220:gimpleloongarch64g1230:gimpleloongarch64g1310:gimpleloongarch64g1320
+group.gimplegccloongarch64.baseName=loongarch64 gcc
+group.gimplegccloongarch64.groupName=loongarch64 GCC
+group.gimplegccloongarch64.isSemVer=true
+
+compiler.gimpleloongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.gimpleloongarch64g1220.semver=12.2.0
+compiler.gimpleloongarch64g1220.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gimpleloongarch64g1220.demangler=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.gimpleloongarch64g1230.exe=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.gimpleloongarch64g1230.semver=12.3.0
+compiler.gimpleloongarch64g1230.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gimpleloongarch64g1230.demangler=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.gimpleloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.gimpleloongarch64g1310.semver=13.1.0
+compiler.gimpleloongarch64g1310.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gimpleloongarch64g1310.demangler=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.gimpleloongarch64g1320.exe=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.gimpleloongarch64g1320.semver=13.2.0
+compiler.gimpleloongarch64g1320.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gimpleloongarch64g1320.demangler=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+###############################
+# Cross for sh
+group.gimplesh.compilers=&gimplegccsh
+
+# GCC for sh
+group.gimplegccsh.compilers=gimpleshg950:gimpleshg1220:gimpleshg1230:gimpleshg1310:gimpleshg1320
+group.gimplegccsh.baseName=sh gcc
+group.gimplegccsh.groupName=sh GCC
+group.gimplegccsh.isSemVer=true
+
+compiler.gimpleshg950.exe=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg950.semver=9.5.0
+compiler.gimpleshg950.objdumper=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg950.demangler=/opt/compiler-explorer/sh/gcc-9.5.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.gimpleshg1220.exe=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg1220.semver=12.2.0
+compiler.gimpleshg1220.objdumper=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg1220.demangler=/opt/compiler-explorer/sh/gcc-12.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.gimpleshg1230.exe=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg1230.semver=12.3.0
+compiler.gimpleshg1230.objdumper=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg1230.demangler=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.gimpleshg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg1310.semver=13.1.0
+compiler.gimpleshg1310.objdumper=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg1310.demangler=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.gimpleshg1320.exe=/opt/compiler-explorer/sh/gcc-13.2.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg1320.semver=13.2.0
+compiler.gimpleshg1320.objdumper=/opt/compiler-explorer/sh/gcc-13.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg1320.demangler=/opt/compiler-explorer/sh/gcc-13.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+###############################
+# Cross for s390x
+group.gimples390x.compilers=&gimplegccs390x
+
+# GCC for s390x
+group.gimplegccs390x.compilers=gimplegccs390x112:gimples390xg1210:gimples390xg1220:gimples390xg1230:gimples390xg1310:gimples390xg1320
+group.gimplegccs390x.baseName=s390x gcc
+group.gimplegccs390x.groupName=s390x GCC
+group.gimplegccs390x.isSemVer=true
+
+compiler.gimplegccs390x112.exe=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimplegccs390x112.semver=11.2.0
+compiler.gimplegccs390x112.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+compiler.gimples390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1210.semver=12.1.0
+compiler.gimples390xg1210.objdumper=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+
+compiler.gimples390xg1220.exe=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1220.semver=12.2.0
+compiler.gimples390xg1220.objdumper=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gimples390xg1220.demangler=/opt/compiler-explorer/s390x/gcc-12.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gimples390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1230.semver=12.3.0
+compiler.gimples390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gimples390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gimples390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1310.semver=13.1.0
+compiler.gimples390xg1310.objdumper=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gimples390xg1310.demangler=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gimples390xg1320.exe=/opt/compiler-explorer/s390x/gcc-13.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1320.semver=13.2.0
+compiler.gimples390xg1320.objdumper=/opt/compiler-explorer/s390x/gcc-13.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gimples390xg1320.demangler=/opt/compiler-explorer/s390x/gcc-13.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+###############################
+# Cross compilers for PPC
+group.gimpleppcs.compilers=&gimpleppc:&gimpleppc64:&gimpleppc64le
+group.gimpleppcs.isSemVer=true
+
+group.gimpleppc.compilers=gimpleppcg1120:gimpleppcg1210:gimpleppcg1220:gimpleppcg1230:gimpleppcg1310:gimpleppcg1320
+group.gimpleppc.groupName=POWER
+group.gimpleppc.baseName=power gcc
+
+compiler.gimpleppcg1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1120.objdumper=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1120.semver=11.2.0
+
+compiler.gimpleppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1210.objdumper=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1210.semver=12.1.0
+
+compiler.gimpleppcg1220.exe=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1220.semver=12.2.0
+compiler.gimpleppcg1220.objdumper=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1220.demangler=/opt/compiler-explorer/powerpc/gcc-12.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gimpleppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1230.semver=12.3.0
+compiler.gimpleppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gimpleppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1310.semver=13.1.0
+compiler.gimpleppcg1310.objdumper=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1310.demangler=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gimpleppcg1320.exe=/opt/compiler-explorer/powerpc/gcc-13.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1320.semver=13.2.0
+compiler.gimpleppcg1320.objdumper=/opt/compiler-explorer/powerpc/gcc-13.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1320.demangler=/opt/compiler-explorer/powerpc/gcc-13.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+group.gimpleppc64.compilers=gimpleppc64g9:gimpleppc64g1120:gimpleppc64g1210:gimpleppc64g1220:gimpleppc64g1230:gimpleppc64g1310:gimpleppc64g1320
+group.gimpleppc64.groupName=POWER64
+group.gimpleppc64.baseName=POWER64 gcc
+
+compiler.gimpleppc64g9.exe=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g9.objdumper=/opt/compiler-explorer/powerpc64/gcc-at13/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g9.name=power64 AT13.0 (gcc9)
+compiler.gimpleppc64g9.semver=(snapshot)
+
+compiler.gimpleppc64g1120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1120.objdumper=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1120.semver=11.2.0
+
+compiler.gimpleppc64g1210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1210.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1210.semver=12.1.0
+
+compiler.gimpleppc64g1220.exe=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1220.semver=12.2.0
+compiler.gimpleppc64g1220.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1220.demangler=/opt/compiler-explorer/powerpc64/gcc-12.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1230.semver=12.3.0
+compiler.gimpleppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1310.semver=13.1.0
+compiler.gimpleppc64g1310.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1310.demangler=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64g1320.exe=/opt/compiler-explorer/powerpc64/gcc-13.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1320.semver=13.2.0
+compiler.gimpleppc64g1320.objdumper=/opt/compiler-explorer/powerpc64/gcc-13.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1320.demangler=/opt/compiler-explorer/powerpc64/gcc-13.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+group.gimpleppc64le.compilers=gimpleppc64leg9:gimpleppc64leg1120:gimpleppc64leg1210:gimpleppc64leg1220:gimpleppc64leg1230:gimpleppc64leg1310:gimpleppc64leg1320
+group.gimpleppc64le.groupName=POWER64LE GCC
+group.gimpleppc64le.baseName=power64le gcc
+
+compiler.gimpleppc64leg9.exe=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg9.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at13/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg9.name=power64le AT13.0 (gcc9)
+compiler.gimpleppc64leg9.semver=(snapshot)
+
+compiler.gimpleppc64leg1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1120.objdumper=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1120.semver=11.2.0
+
+compiler.gimpleppc64leg1210.exe=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1210.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1210.semver=12.1.0
+
+compiler.gimpleppc64leg1220.exe=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1220.semver=12.2.0
+compiler.gimpleppc64leg1220.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1220.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1230.semver=12.3.0
+compiler.gimpleppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1310.semver=13.1.0
+compiler.gimpleppc64leg1310.objdumper=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1310.demangler=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64leg1320.exe=/opt/compiler-explorer/powerpc64le/gcc-13.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1320.semver=13.2.0
+compiler.gimpleppc64leg1320.objdumper=/opt/compiler-explorer/powerpc64le/gcc-13.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1320.demangler=/opt/compiler-explorer/powerpc64le/gcc-13.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+
+################################
+# GCC for MSP
+group.gimplemsp.compilers=gimplemsp430g1210:gimplemsp430g1220:gimplemsp430g1230:gimplemsp430g1310:gimplemsp430g1320
+group.gimplemsp.groupName=MSP GCC
+group.gimplemsp.baseName=MSP430 gcc
+group.gimplemsp.isSemVer=true
+
+compiler.gimplemsp430g1210.exe=/opt/compiler-explorer/msp430/gcc-12.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1210.semver=12.1.0
+compiler.gimplemsp430g1210.objdumper=/opt/compiler-explorer/msp430/gcc-12.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1210.demangler=/opt/compiler-explorer/msp430/gcc-12.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.gimplemsp430g1220.exe=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1220.semver=12.2.0
+compiler.gimplemsp430g1220.objdumper=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1220.demangler=/opt/compiler-explorer/msp430/gcc-12.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.gimplemsp430g1230.exe=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1230.semver=12.3.0
+compiler.gimplemsp430g1230.objdumper=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1230.demangler=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.gimplemsp430g1310.exe=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1310.semver=13.1.0
+compiler.gimplemsp430g1310.objdumper=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1310.demangler=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.gimplemsp430g1320.exe=/opt/compiler-explorer/msp430/gcc-13.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1320.semver=13.2.0
+compiler.gimplemsp430g1320.objdumper=/opt/compiler-explorer/msp430/gcc-13.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1320.demangler=/opt/compiler-explorer/msp430/gcc-13.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
 
 ###############################
 # GCC for ARM
@@ -247,63 +984,15 @@ compiler.gimplearm64gm101a1.semver=10.1.0 Alpha 1
 compiler.gimplearm64gm101a2.exe=/opt/compiler-explorer/arm64morello/gcc-aarch64-none-elf-10.1.morello-alp2-x86_64/bin/aarch64-none-elf-gcc
 compiler.gimplearm64gm101a2.semver=10.1.2 Alpha 2
 
-################################
-# GCC for AVR
-group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1310:gimpleavrg1320
-group.gimpleavr.groupName=AVR GCC
-group.gimpleavr.baseName=AVR gcc
-group.gimpleavr.isSemVer=true
-group.gimpleavr.compilerType=gimple
-
-compiler.gimpleavrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-gcc
-compiler.gimpleavrg920.semver=9.2.0
-compiler.gimpleavrg920.objdumper=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-objdump
-
-compiler.gimpleavrg930.exe=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-gcc
-compiler.gimpleavrg930.semver=9.3.0
-compiler.gimpleavrg930.objdumper=/opt/compiler-explorer/avr/gcc-9.3.0/bin/avr-objdump
-
-compiler.gimpleavrg1030.exe=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-gcc
-compiler.gimpleavrg1030.semver=10.3.0
-compiler.gimpleavrg1030.objdumper=/opt/compiler-explorer/avr/gcc-10.3.0/bin/avr-objdump
-
-compiler.gimpleavrg1100.exe=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-gcc
-compiler.gimpleavrg1100.semver=11.1.0
-compiler.gimpleavrg1100.objdumper=/opt/compiler-explorer/avr/gcc-11.1.0/bin/avr-objdump
-
-compiler.gimpleavrg1210.exe=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-gcc
-compiler.gimpleavrg1210.semver=12.1.0
-compiler.gimpleavrg1210.objdumper=/opt/compiler-explorer/avr/gcc-12.1.0/avr/bin/avr-objdump
-
-compiler.gimpleavrg1220.exe=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-gcc
-compiler.gimpleavrg1220.semver=12.2.0
-compiler.gimpleavrg1220.objdumper=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-objdump
-compiler.gimpleavrg1220.demangler=/opt/compiler-explorer/avr/gcc-12.2.0/avr/bin/avr-c++filt
-
-compiler.gimpleavrg1230.exe=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-gcc
-compiler.gimpleavrg1230.semver=12.3.0
-compiler.gimpleavrg1230.objdumper=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-objdump
-compiler.gimpleavrg1230.demangler=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-c++filt
-
-compiler.gimpleavrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-gcc
-compiler.gimpleavrg1310.semver=13.1.0
-compiler.gimpleavrg1310.objdumper=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-objdump
-compiler.gimpleavrg1310.demangler=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-c++filt
-
-compiler.gimpleavrg1320.exe=/opt/compiler-explorer/avr/gcc-13.2.0/avr/bin/avr-gcc
-compiler.gimpleavrg1320.semver=13.2.0
-compiler.gimpleavrg1320.objdumper=/opt/compiler-explorer/avr/gcc-13.2.0/avr/bin/avr-objdump
-compiler.gimpleavrg1320.demangler=/opt/compiler-explorer/avr/gcc-13.2.0/avr/bin/avr-c++filt
-
 ###############################
 # GCC for RISC-V
-group.rvgimplegcc.compilers=&rv64-gimplegccs:&rv32-gimplegccs
-group.rvgimplegcc.groupName=RISC-V GCC
-group.rvgimplegcc.isSemVer=true
-group.rvgimplegcc.supportsExecute=false
-group.rvgimplegcc.supportsBinary=true
-group.rvgimplegcc.supportsBinaryObject=true
-group.rvgimplegcc.compilerType=gimple
+group.gimplervgcc.compilers=&rv64-gimplegccs:&rv32-gimplegccs
+group.gimplervgcc.groupName=RISC-V GCC
+group.gimplervgcc.isSemVer=true
+group.gimplervgcc.supportsExecute=false
+group.gimplervgcc.supportsBinary=true
+group.gimplervgcc.supportsBinaryObject=true
+group.gimplervgcc.compilerType=gimple
 
 ## GCC for RISC-V 64-bits
 group.rv64-gimplegccs.compilers=rv64-gimplegcctrunk:rv64-gimplegcc1230:rv64-gimplegcc1210:rv64-gimplegcc1140:rv64-gimplegcc1130:rv64-gimplegcc1220:rv64-gimplegcc1120:rv64-gimplegcc1030:rv64-gimplegcc1020:rv64-gimplegcc940:rv64-gimplegcc1310:rv64-gimplegcc1320


### PR DESCRIPTION
After the initial support of GIMPLE, many cross-gcc were missing.

fixes #5837

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>