### PR TITLE
Compilers for exectuable Cerberus CHERI C and ISO C semantics

### DIFF
--- a/docs/Cerberus.md
+++ b/docs/Cerberus.md
@@ -1,0 +1,39 @@
+# Cerberus
+
+[Cerberus](https://www.cl.cam.ac.uk/~pes20/cerberus/) offers executable semantics for a substantial fragment of C and
+CHERI-C languages. It is implemented via an elaboration into a simpler Core language, which is displayed as the compiler
+output in the Compiler Explorer. Evaluation of C programs (execution) is also supported.
+
+## Prerequisites
+
+The easiest way to install both the Cerberus and Cerberus-CHERI compilers is by using Docker:
+
+`docker pull vzaliva/cerberus-cheri`
+
+Then, for example, you can print the _Core_ elaboration for `test.c` using ISO C semantics:
+
+`docker run -v $HOME/tmp:/mnt -it vzaliva/cerberus-cheri cerberus --pp=core --exec /mnt/test.c`
+
+## Configuration
+
+The file `etc/config/c.defaults.properties` defines a group of two compilers: 'cerberus' for ISO C and 'cerberus-cheri'
+for CHERI-C. It assumes that the corresponding executables are in the path.
+
+## Limitations and Future Improvement
+
+Presently, only simple Core output is shown. It is not syntactically highlighted nor linked to C source code locations.
+Some potential future improvements include:
+
+1. Error location handling in warning and error messages
+2. Specifying execution flags
+3. Core syntax highlighting
+4. Display of AST
+5. Display of other intermediate languages (Cabs, Ail)
+6. Tooltips/links to the ISO C document from Core annotations
+
+## See also:
+
+- [Cerberus (project page)](https://www.cl.cam.ac.uk/~pes20/cerberus/)
+- [Cerberus (GitHub repository)](https://github.com/rems-project/cerberus)
+- ["Formal Mechanised Semantics of CHERI C: Capabilities, Undefined Behaviour, and Provenance" (paper, preprint)](https://zaliva.org/cheric-asplos24.pdf)
+- ["CHERI C semantics as an extension of the ISO C17 standard" (tech report)](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-988.html)

--- a/docs/Cerberus.md
+++ b/docs/Cerberus.md
@@ -1,13 +1,13 @@
 # Cerberus
 
-[Cerberus](https://www.cl.cam.ac.uk/~pes20/cerberus/) offers executable semantics for a substantial fragment of C and
-CHERI-C languages. It is implemented via an elaboration into a simpler Core language, which is displayed as the compiler
-output in the Compiler Explorer. Evaluation of C programs (execution) is also supported.
+[Cerberus](https://www.cl.cam.ac.uk/~pes20/cerberus/) offers executable semantics for a substantial fragment of the C
+and CHERI-C languages. It is implemented via an elaboration into a simpler Core language, which is displayed as the
+compiler output in the Compiler Explorer. Evaluation of C programs (execution) is also supported.
 
 ## Prerequisites
 
-To build Cerberus, you need **opam** package manager (>= 2.0.0, see [here](https://opam.ocaml.org/doc/Install.html) to
-install) and OCaml (>= 4.12.0).
+To build Cerberus, you need the **opam** package manager (>= 2.0.0, see [here](https://opam.ocaml.org/doc/Install.html)
+for installation) and OCaml (>= 4.12.0).
 
 Then, the following commands will set up the required opam repositories and download and install the required packages:
 
@@ -23,25 +23,51 @@ opam pin add -n --yes cerberus-cheri https://github.com/rems-project/cerberus.gi
 opam install --yes cerberus cerberus-cheri
 ```
 
-Now you can execute `cerberus-cheri` and `cerberus` commands using `opam exec -- cerberus-cheri` or
+Now you can execute the `cerberus-cheri` and `cerberus` commands using `opam exec -- cerberus-cheri` or
 `opam exec -- cerberus` respectively.
 
 ## Configuration
 
-The file `etc/config/c.defaults.properties` defines a group of two compilers: 'cerberus' for ISO C and 'cerberus-cheri'
-for CHERI-C. It assumes that the corresponding executables are in the path.
+Once you have Cerberus installed, as described in the previous section, you can enable it by modifying the file
+`etc/config/c.defaults.properties` as shown below. This change defines a group of two compilers: 'cerberus' for ISO C
+and 'cerberus-cheri' for CHERI-C.
 
-## Limitations and Future Improvement
+```
+compilers=&gcc:&clang:&cerberus
+
+group.cerberus.compilers=cerberus:cerberus-cheri
+group.cerberus.compilerType=cerberus
+group.cerberus.instructionSet=core
+group.cerberus.demangler=
+group.cerberus.postProcess=
+group.cerberus.options=
+group.cerberus.supportsBinary=false
+group.cerberus.needsMulti=false
+group.cerberus.supportsExecute=true
+group.cerberus.interpreted=true
+group.cerberus.versionFlag=--version
+
+compiler.cerberus.name=Cerberus
+compiler.cerberus.exe=opam exec -- cerberus
+compiler.cerberus.objdumper=opam exec -- cerberus
+
+compiler.cerberus-cheri.name=Cerberus-CHERI
+compiler.cerberus-cheri.exe=opam exec -- cerberus-cheri
+compiler.cerberus-cheri.objdumper=opam exec -- cerberus-cheri
+
+```
+
+## Limitations and Future Improvements
 
 Presently, only simple Core output is shown. It is not syntactically highlighted nor linked to C source code locations.
 Some potential future improvements include:
 
-1. Error location handling in warning and error messages
-2. Specifying execution flags
-3. Core syntax highlighting
-4. Display of AST
-5. Display of other intermediate languages (Cabs, Ail)
-6. Tooltips/links to the ISO C document from Core annotations
+1. Error location handling in warning and error messages.
+2. Specifying execution flags.
+3. Core syntax highlighting.
+4. Display of AST.
+5. Display of other intermediate languages (Cabs, Ail).
+6. Tooltips/links to the ISO C document from Core annotations.
 
 ## See also:
 

--- a/docs/Cerberus.md
+++ b/docs/Cerberus.md
@@ -48,12 +48,12 @@ group.cerberus.interpreted=true
 group.cerberus.versionFlag=--version
 
 compiler.cerberus.name=Cerberus
-compiler.cerberus.exe=opam exec -- cerberus
-compiler.cerberus.objdumper=opam exec -- cerberus
+compiler.cerberus.exe=cerberus
+compiler.cerberus.objdumper=cerberus
 
 compiler.cerberus-cheri.name=Cerberus-CHERI
-compiler.cerberus-cheri.exe=opam exec -- cerberus-cheri
-compiler.cerberus-cheri.objdumper=opam exec -- cerberus-cheri
+compiler.cerberus-cheri.exe=cerberus-cheri
+compiler.cerberus-cheri.objdumper=cerberus-cheri
 
 ```
 

--- a/docs/Cerberus.md
+++ b/docs/Cerberus.md
@@ -6,13 +6,25 @@ output in the Compiler Explorer. Evaluation of C programs (execution) is also su
 
 ## Prerequisites
 
-The easiest way to install both the Cerberus and Cerberus-CHERI compilers is by using Docker:
+To build Cerberus, you need **opam** package manager (>= 2.0.0, see [here](https://opam.ocaml.org/doc/Install.html) to
+install) and OCaml (>= 4.12.0).
 
-`docker pull vzaliva/cerberus-cheri`
+Then, the following commands will set up the required opam repositories and download and install the required packages:
 
-Then, for example, you can print the _Core_ elaboration for `test.c` using ISO C semantics:
+```sh
+opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
+opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
+opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
+opam pin --yes -n coq-sail https://github.com/rems-project/coq-sail.git
+opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
+opam pin add -n --yes cerberus-lib https://github.com/rems-project/cerberus.git
+opam pin add -n --yes cerberus https://github.com/rems-project/cerberus.git
+opam pin add -n --yes cerberus-cheri https://github.com/rems-project/cerberus.git
+opam install --yes cerberus cerberus-cheri
+```
 
-`docker run -v $HOME/tmp:/mnt -it vzaliva/cerberus-cheri cerberus --pp=core --exec /mnt/test.c`
+Now you can execute `cerberus-cheri` and `cerberus` commands using `opam exec -- cerberus-cheri` or
+`opam exec -- cerberus` respectively.
 
 ## Configuration
 

--- a/etc/config/c.defaults.properties
+++ b/etc/config/c.defaults.properties
@@ -1,5 +1,5 @@
 # Default settings for C
-compilers=&gcc:&clang:&cerberus
+compilers=&gcc:&clang
 defaultCompiler=cgdefault
 demangler=c++filt
 objdumper=objdump
@@ -10,36 +10,6 @@ binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_sta
 stubRe=\bmain\b
 stubText=int main(void){return 0;/*stub provided by Compiler Explorer*/}
 supportsLibraryCodeFilter=true
-
-group.cerberus.compilers=cerberus:cerberus-cheri
-
-compiler.cerberus.name=Cerberus
-compiler.cerberus.exe=cerberus
-compiler.cerberus.compilerType=cerberus
-compiler.cerberus.versionFlag=--version
-compiler.cerberus.objdumper=cerberus
-compiler.cerberus.instructionSet=core
-compiler.cerberus.demangler=
-compiler.cerberus.postProcess=
-compiler.cerberus.options=
-compiler.cerberus.supportsBinary=false
-compiler.cerberus.needsMulti=false
-compiler.cerberus.supportsExecute=true
-compiler.cerberus.interpreted=true
-
-compiler.cerberus-cheri.name=Cerberus-CHERI
-compiler.cerberus-cheri.exe=cerberus-cheri
-compiler.cerberus-cheri.compilerType=cerberus
-compiler.cerberus-cheri.versionFlag=--version
-compiler.cerberus-cheri.objdumper=cerberus-cheri
-compiler.cerberus-cheri.instructionSet=core
-compiler.cerberus-cheri.demangler=
-compiler.cerberus-cheri.postProcess=
-compiler.cerberus-cheri.options=
-compiler.cerberus-cheri.supportsBinary=false
-compiler.cerberus-cheri.needsMulti=false
-compiler.cerberus-cheri.supportsExecute=true
-compiler.cerberus-cheri.interpreted=true
 
 group.gcc.compilers=cg44:cg45:cg46:cg47:cg48:cg5:cg6x:cg7:cg8:cg9:cg10:cg11:cgdefault
 compiler.cg44.exe=/usr/bin/gcc-4.4

--- a/etc/config/c.defaults.properties
+++ b/etc/config/c.defaults.properties
@@ -1,5 +1,5 @@
 # Default settings for C
-compilers=&gcc:&clang
+compilers=&gcc:&clang:&cerberus
 defaultCompiler=cgdefault
 demangler=c++filt
 objdumper=objdump
@@ -10,6 +10,36 @@ binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_sta
 stubRe=\bmain\b
 stubText=int main(void){return 0;/*stub provided by Compiler Explorer*/}
 supportsLibraryCodeFilter=true
+
+group.cerberus.compilers=cerberus:cerberus-cheri
+
+compiler.cerberus.name=Cerberus
+compiler.cerberus.exe=cerberus
+compiler.cerberus.compilerType=cerberus
+compiler.cerberus.versionFlag=--version
+compiler.cerberus.objdumper=cerberus
+compiler.cerberus.instructionSet=core
+compiler.cerberus.demangler=
+compiler.cerberus.postProcess=
+compiler.cerberus.options=
+compiler.cerberus.supportsBinary=false
+compiler.cerberus.needsMulti=false
+compiler.cerberus.supportsExecute=true
+compiler.cerberus.interpreted=true
+
+compiler.cerberus-cheri.name=Cerberus-CHERI
+compiler.cerberus-cheri.exe=cerberus-cheri
+compiler.cerberus-cheri.compilerType=cerberus
+compiler.cerberus-cheri.versionFlag=--version
+compiler.cerberus-cheri.objdumper=cerberus-cheri
+compiler.cerberus-cheri.instructionSet=core
+compiler.cerberus-cheri.demangler=
+compiler.cerberus-cheri.postProcess=
+compiler.cerberus-cheri.options=
+compiler.cerberus-cheri.supportsBinary=false
+compiler.cerberus-cheri.needsMulti=false
+compiler.cerberus-cheri.supportsExecute=true
+compiler.cerberus-cheri.interpreted=true
 
 group.gcc.compilers=cg44:cg45:cg46:cg47:cg48:cg5:cg6x:cg7:cg8:cg9:cg10:cg11:cgdefault
 compiler.cg44.exe=/usr/bin/gcc-4.4

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -29,6 +29,7 @@ export {AvrGcc6502Compiler} from './avrgcc6502.js';
 export {BeebAsmCompiler} from './beebasm.js';
 export {C3Compiler} from './c3c.js';
 export {CarbonCompiler} from './carbon.js';
+export {CerberusCompiler} from './cerberus.js';
 export {Cc65Compiler} from './cc65.js';
 export {CircleCompiler} from './circle.js';
 export {CIRCTCompiler} from './circt.js';

--- a/lib/compilers/cerberus.ts
+++ b/lib/compilers/cerberus.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2016, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+import * as utils from '../utils.js';
+
+import {ExecutableExecutionOptions} from '../../types/execution/execution.interfaces.js';
+
+import {BypassCache, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {logger} from '../logger.js';
+
+export class CerberusCompiler extends BaseCompiler {
+    static get key() {
+        return 'cerberus';
+    }
+
+    constructor(compilerInfo: PreliminaryCompilerInfo, env) {
+        super(
+            {
+                // Default is to disable all "cosmetic" filters
+                disabledFilters: ['labels', 'directives', 'commentOnly', 'trim', 'debugCalls'],
+                ...compilerInfo,
+            },
+            env,
+        );
+    }
+
+    override getSharedLibraryPathsAsArguments() {
+        return [];
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFileName: string) {
+        filters.binary = true;
+        return ['-c', '-o', outputFileName];
+    }
+
+    override getOutputFilename(dirPath: string) {
+        return path.join(dirPath, `${path.basename(this.compileFilename, this.lang.extensions[0])}.co`);
+    }
+
+    override async objdump(outputFilename, result: any, maxSize: number) {
+        if (!(await utils.fileExists(outputFilename))) {
+            result.asm = '<No output file ' + outputFilename + '>';
+            return result;
+        }
+
+        const execOptions: ExecutionOptions = {
+            maxOutput: maxSize,
+            customCwd: (result.dirPath as string) || path.dirname(outputFilename),
+        };
+
+        const args = ['--pp=core', outputFilename];
+
+        const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
+        if (objResult.code === 0) {
+            result.objdumpTime = objResult.execTime;
+            result.asm = this.postProcessObjdumpOutput(objResult.stdout);
+        } else {
+            logger.error(`Error executing objdump ${this.compiler.objdumper}`, objResult);
+            result.asm = `<No output: objdump returned ${objResult.code}>`;
+        }
+
+        return result;
+    }
+
+    override async handleInterpreting(key, executeParameters: ExecutableExecutionOptions) {
+        const compileResult = await this.getOrBuildExecutable(key, BypassCache.None);
+        if (compileResult.code === 0) {
+            executeParameters.args = [
+                '--exec',
+                this.getOutputFilename(compileResult.dirPath),
+                '--',
+                ...executeParameters.args,
+            ];
+            const result = await this.runExecutable(this.compiler.exe, executeParameters, compileResult.dirPath);
+            return {
+                ...result,
+                didExecute: true,
+                buildResult: compileResult,
+            };
+        } else {
+            return {
+                stdout: compileResult.stdout,
+                stderr: compileResult.stderr,
+                code: compileResult.code,
+                didExecute: false,
+                buildResult: compileResult,
+                timedOut: false,
+            };
+        }
+    }
+
+    override async processAsm(result) {
+        // Handle "error" documents.
+        if (!result.asm.includes('\n') && result.asm[0] === '<') {
+            return [{text: result.asm, source: null}];
+        }
+
+        const lines = result.asm.split('\n');
+        const plines = lines.map(l => ({text: l}));
+        return {
+            asm: plines,
+            languageId: 'core',
+        };
+    }
+}

--- a/lib/compilers/cerberus.ts
+++ b/lib/compilers/cerberus.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Compiler Explorer Authors
+// Copyright (c) 2023, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -127,6 +127,10 @@ export class InstructionSets {
                 target: [],
                 path: [],
             },
+            core: {
+                target: [],
+                path: [],
+            },
             java: {
                 target: [],
                 path: [],

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -33,6 +33,7 @@ export const InstructionSetsList = [
     'ebpf',
     'evm',
     'hook',
+    'core',
     'java',
     'kvx',
     'llvm',


### PR DESCRIPTION
# Cerberus

[Cerberus](https://www.cl.cam.ac.uk/~pes20/cerberus/) offers executable semantics for a substantial fragment of C and
CHERI-C languages. It is implemented via an elaboration into a simpler Core language, which is displayed as the compiler
output in the Compiler Explorer. Evaluation of C programs (execution) is also supported.

## Prerequisites

The easiest way to install both the Cerberus and Cerberus-CHERI compilers is by using Docker:

`docker pull vzaliva/cerberus-cheri`

Then, for example, you can print the _Core_ elaboration for `test.c` using ISO C semantics:

`docker run -v $HOME/tmp:/mnt -it vzaliva/cerberus-cheri cerberus --pp=core --exec /mnt/test.c`

## Configuration

The file `etc/config/c.defaults.properties` defines a group of two compilers: 'cerberus' for ISO C and 'cerberus-cheri'
for CHERI-C. It assumes that the corresponding executables are in the path.

## Limitations and Future Improvement

Presently, only simple Core output is shown. It is not syntactically highlighted nor linked to C source code locations.
Some potential future improvements include:

1. Error location handling in warning and error messages
2. Specifying execution flags
3. Core syntax highlighting
4. Display of AST
5. Display of other intermediate languages (Cabs, Ail)
6. Tooltips/links to the ISO C document from Core annotations

## See also:

- [Cerberus (project page)](https://www.cl.cam.ac.uk/~pes20/cerberus/)
- [Cerberus (GitHub repository)](https://github.com/rems-project/cerberus)
- ["Formal Mechanised Semantics of CHERI C: Capabilities, Undefined Behaviour, and Provenance" (paper, preprint)](https://zaliva.org/cheric-asplos24.pdf)
- ["CHERI C semantics as an extension of the ISO C17 standard" (tech report)](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-988.html)
