### PR TITLE
oneapi 2024.0.0 release

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1017,7 +1017,7 @@ compiler.icc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icxlatest
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icxlatest
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -1096,9 +1096,15 @@ compiler.icx202321.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/
 compiler.icx202321.semver=2023.2.1
 compiler.icx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 
-compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icpx
-compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
-compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.2.1.8/tbb/latest/lib/intel64/gcc4.8
+compiler.icx202400.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icpx
+compiler.icx202400.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
+compiler.icx202400.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
+compiler.icx202400.semver=2024.0.0
+compiler.icx202400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+
+compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icpx
+compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
 compiler.icxlatest.semver=(latest)
 compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -843,7 +843,7 @@ compiler.cicc2021100.semver=2021.10.0
 compiler.cicc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 
 # icx for x86
-group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicx202321:cicx202400:cicxlatest
+group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicx202400:cicxlatest
 group.cicx.intelAsm=-masm=intel
 group.cicx.options=
 group.cicx.groupName=ICX x86-64

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -843,7 +843,7 @@ compiler.cicc2021100.semver=2021.10.0
 compiler.cicc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 
 # icx for x86
-group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicx202321:cicxlatest
+group.cicx.compilers=cicx202112:cicx202120:cicx202130:cicx202140:cicx202200:cicx202210:cicx202220:cicx202221:cicx202300:cicx202310:cicx202321:cicx202400:cicxlatest
 group.cicx.intelAsm=-masm=intel
 group.cicx.options=
 group.cicx.groupName=ICX x86-64
@@ -913,15 +913,15 @@ compiler.cicx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/comp
 compiler.cicx202310.semver=2023.1.0
 compiler.cicx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
 
-compiler.cicx202321.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icx
-compiler.cicx202321.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
-compiler.cicx202321.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
-compiler.cicx202321.semver=2023.2.1
-compiler.cicx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+compiler.cicx202400.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icx
+compiler.cicx202400.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
+compiler.cicx202400.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
+compiler.cicx202400.semver=2024.0.0
+compiler.cicx202400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 
-compiler.cicxlatest.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icx
-compiler.cicxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
-compiler.cicxlatest.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.cicxlatest.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icx
+compiler.cicxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
+compiler.cicxlatest.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
 compiler.cicxlatest.semver=(latest)
 compiler.cicxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -77,7 +77,7 @@ compiler.gfortransnapshot.isNightly=true
 
 ###############################
 # Intel Parallel Studio XE for x86
-group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150:ifort202160:ifort202170:ifort202171:ifort202180:ifort202190:ifort2021100
+group.ifort.compilers=ifort19:ifort202112:ifort202120:ifort202130:ifort202140:ifort202150:ifort202160:ifort202170:ifort202171:ifort202180:ifort202190:ifort2021100:ifort2021110
 group.ifort.intelAsm=-masm=intel
 group.ifort.groupName=IFORT x86-64
 group.ifort.isSemVer=true
@@ -158,9 +158,15 @@ compiler.ifort2021100.libPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/co
 compiler.ifort2021100.semver=2021.10.0
 compiler.ifort2021100.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 
+compiler.ifort2021110.exe=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/bin/ifort
+compiler.ifort2021110.ldPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
+compiler.ifort2021110.libPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
+compiler.ifort2021110.semver=2021.11.0
+compiler.ifort2021110.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
 ###############################
 # Intel oneAPI for x86
-group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210:ifx202220:ifx202221:ifx202300:ifx202310:ifx202321:ifxlatest
+group.ifx.compilers=ifx202112:ifx202120:ifx202130:ifx202140:ifx202200:ifx202210:ifx202220:ifx202221:ifx202300:ifx202310:ifx202321:ifx202400:ifxlatest
 group.ifx.intelAsm=-masm=intel
 group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
@@ -227,9 +233,15 @@ compiler.ifx202321.libPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compi
 compiler.ifx202321.semver=2023.2.1
 compiler.ifx202321.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 
-compiler.ifxlatest.exe=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/bin/ifx
-compiler.ifxlatest.ldPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin
-compiler.ifxlatest.libPath=/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-fortran-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin
+compiler.ifx202400.exe=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/bin/ifx
+compiler.ifx202400.ldPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
+compiler.ifx202400.libPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
+compiler.ifx202400.semver=2024.0.0
+compiler.ifx202400.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
+compiler.ifxlatest.exe=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/bin/ifx
+compiler.ifxlatest.ldPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
+compiler.ifxlatest.libPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
 compiler.ifxlatest.semver=(latest)
 compiler.ifxlatest.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
 

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -320,8 +320,11 @@ export class ClangIntelCompiler extends ClangCompiler {
     }
 
     override runExecutable(executable, executeParameters: ExecutableExecutionOptions, homeDir) {
+        const base = path.dirname(this.compiler.exe);
+        const ocl_pre2024 = path.resolve(`${base}/../lib/x64/libintelocl.so`);
+        const ocl_2024 = path.resolve(`${base}/../lib/libintelocl.so`);
         executeParameters.env = {
-            OCL_ICD_FILENAMES: path.resolve(path.dirname(this.compiler.exe) + '/../lib/x64/libintelocl.so'),
+            OCL_ICD_FILENAMES: `${ocl_2024}:${ocl_pre2024}`,
             ...executeParameters.env,
         };
         return super.runExecutable(executable, executeParameters, homeDir);


### PR DESCRIPTION
* directory structure has changed
* no more releases of icc

Depends on deployment of https://github.com/compiler-explorer/infra/pull/1188