### PR TITLE
Fix #5883: the default maxOptions=50 isn't enough

### DIFF
--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -116,6 +116,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
             dropdownParent: 'body',
             plugins: ['input_autogrow'],
             sortField: 'title',
+            maxOptions: 1000,
             onChange: e => this.selectGroup(e as string),
         });
         this.groupSelector.on('dropdown_close', () => {

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -137,6 +137,7 @@ export class Tree {
             items: [this.multifileService.getLanguageId()],
             dropdownParent: 'body',
             plugins: ['input_autogrow'],
+            maxOptions: 1000,
             onChange: (val: any) => this.onLanguageChange(val),
         });
         this.selectize.on('dropdown_close', () => {


### PR DESCRIPTION
`CompilerPicker` already set the language dropdown `maxOptions` to 1000 (the default is 50 and currently there are 66 languages). This does the same for `Tree` and similarly for the passes in `OptPipeline`