### PR TITLE
Fix #5854: just filter out `-E` when generating IR

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1346,7 +1346,8 @@ export class BaseCompiler implements ICompiler {
     ) {
         // These options make Clang produce an IR
         const newOptions = options
-            .filter(option => option !== '-fcolor-diagnostics')
+            // `-E` causes some mayhem. See #5854
+            .filter(option => option !== '-fcolor-diagnostics' && option !== '-E')
             .concat(unwrap(this.compiler.irArg));
 
         if (irOptions.noDiscardValueNames && this.compiler.optPipeline?.noDiscardValueNamesArg) {


### PR DESCRIPTION
Fixing the root issues is too risky at this point. 
If more unwanted side-effects of other switches arise, or other cases of compilation tasks messing with each other's output - maybe reconsider.