### PR TITLE
Limit exec streams to max string length

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1434,6 +1434,14 @@ export class BaseCompiler implements ICompiler {
             };
         }
 
+        if (output.truncated) {
+            return {
+                error: 'Clang exceeded max output limit',
+                results: {},
+                compileTime: output.execTime || compileEnd - compileStart,
+            };
+        }
+
         if (output.code !== 0) {
             return;
         }

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1428,7 +1428,7 @@ export class BaseCompiler implements ICompiler {
 
         if (output.timedOut) {
             return {
-                error: 'Clang invocation timed out',
+                error: 'Invocation timed out',
                 results: {},
                 compileTime: output.execTime || compileEnd - compileStart,
             };
@@ -1436,7 +1436,7 @@ export class BaseCompiler implements ICompiler {
 
         if (output.truncated) {
             return {
-                error: 'Clang exceeded max output limit',
+                error: 'Exceeded max output limit',
                 results: {},
                 compileTime: output.execTime || compileEnd - compileStart,
             };

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -203,7 +203,7 @@ export class RacketCompiler extends BaseCompiler {
 
         if (output.timedOut) {
             return {
-                error: 'Racket invocation timed out',
+                error: 'Invocation timed out',
                 results: {},
                 compileTime: output.execTime || compileEnd - compileStart,
             };
@@ -211,7 +211,7 @@ export class RacketCompiler extends BaseCompiler {
 
         if (output.truncated) {
             return {
-                error: 'Racket exceeded max output limit',
+                error: 'Exceeded max output limit',
                 results: {},
                 compileTime: output.execTime || compileEnd - compileStart,
             };

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -209,6 +209,14 @@ export class RacketCompiler extends BaseCompiler {
             };
         }
 
+        if (output.truncated) {
+            return {
+                error: 'Racket exceeded max output limit',
+                results: {},
+                compileTime: output.execTime || compileEnd - compileStart,
+            };
+        }
+
         if (output.code !== 0) {
             return;
         }

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -165,9 +165,11 @@ export function executeDirect(
                 truncated: streams.truncated,
                 execTime: ((endTime - startTime) / BigInt(1000000)).toString(),
             };
-            // It's not safe to log the entire `result` here, as one or more
-            // streams may be at the string limit.
-            logger.debug('Execution', {type: 'executed', command: command, args: args});
+            // Check debug level explicitly as result may be a very large string
+            // which we'd prefer to avoid preparing if it won't be used
+            if (logger.isDebugEnabled()) {
+                logger.debug('Execution', {type: 'executed', command: command, args: args, result: result});
+            }
             resolve(result);
         });
         if (child.stdin) {

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -127,7 +127,7 @@ export function executeDirect(
                 const truncatedMsg = '\n[Truncated]';
                 const spaceLeft = Math.max(maxOutput - streams[name].length - truncatedMsg.length, 0);
                 streams[name] = streams[name] + data.slice(0, spaceLeft);
-                streams[name] += truncatedMsg;
+                streams[name] += truncatedMsg.slice(0, maxOutput - streams[name].length);
                 streams.truncated = true;
                 kill();
                 return;

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -24,6 +24,7 @@
 
 import child_process from 'child_process';
 import path from 'path';
+import buffer from 'buffer';
 
 import fs from 'fs-extra';
 import treeKill from 'tree-kill';
@@ -59,7 +60,7 @@ export function executeDirect(
     filenameTransform?: FilenameTransformFunc,
 ): Promise<UnprocessedExecResult> {
     options = options || {};
-    const maxOutput = options.maxOutput || 1024 * 1024;
+    const maxOutput = Math.min(options.maxOutput || 1024 * 1024, buffer.constants.MAX_STRING_LENGTH);
     const timeoutMs = options.timeoutMs || 0;
     const env = {...process.env, ...options.env};
 
@@ -123,8 +124,10 @@ export function executeDirect(
             if (streams.truncated) return;
             const newLength = streams[name].length + data.length;
             if (maxOutput > 0 && newLength > maxOutput) {
-                streams[name] = streams[name] + data.slice(0, maxOutput - streams[name].length);
-                streams[name] += '\n[Truncated]';
+                const truncatedMsg = '\n[Truncated]';
+                const spaceLeft = Math.max(maxOutput - streams[name].length - truncatedMsg.length, 0);
+                streams[name] = streams[name] + data.slice(0, spaceLeft);
+                streams[name] += truncatedMsg;
                 streams.truncated = true;
                 kill();
                 return;
@@ -162,7 +165,9 @@ export function executeDirect(
                 truncated: streams.truncated,
                 execTime: ((endTime - startTime) / BigInt(1000000)).toString(),
             };
-            logger.debug('Execution', {type: 'executed', command: command, args: args, result: result});
+            // It's not safe to log the entire `result` here, as one or more
+            // streams may be at the string limit.
+            logger.debug('Execution', {type: 'executed', command: command, args: args});
             resolve(result);
         });
         if (child.stdin) {

--- a/test/exec-tests.ts
+++ b/test/exec-tests.ts
@@ -118,7 +118,7 @@ describe('Execution tests', () => {
             });
             it('limits output', () => {
                 return exec
-                    .execute('echo', ['A very very very very very long string'], {maxOutput: 10})
+                    .execute('echo', ['A very very very very very long string'], {maxOutput: 22})
                     .then(testExecOutput)
                     .should.eventually.deep.equals({
                         code: 0,

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -146,6 +146,7 @@ export type CompilationResult = {
     devices?: Record<string, CompilationResult>;
     stdout: ResultLine[];
     stderr: ResultLine[];
+    truncated?: boolean;
     didExecute?: boolean;
     execResult?: {
         stdout?: ResultLine[];

--- a/types/execution/execution.interfaces.ts
+++ b/types/execution/execution.interfaces.ts
@@ -29,6 +29,8 @@ export type BasicExecutionResult = {
     execTime: string;
     processExecutionResultTime?: number;
     timedOut: boolean;
+    languageId?: string;
+    truncated?: boolean;
 };
 
 export enum RuntimeToolType {


### PR DESCRIPTION
Some operations set `exec`'s `maxOutput` to a value larger than the max string length. This change ensures we always cap output to the engine's string limit (currently 512 MB in recent Node versions).

This also tweaks handling when reaching the string limit to ensure adding the "truncated" message itself does not send us beyond the limit.
