### PR TITLE
Handle ir and machine functions separately in OptPipeline

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -141,3 +141,4 @@ From oldest to newest contributor, we would like to thank:
 - [Rupert Tombs](https://github.com/Rupt)
 - [Andrew Brey](https://github.com/andrewbrey)
 - [Weile Wei](https://github.com/weilewei)
+- [Anirudh Sundar Subramaniam](https://github.com/quic-sanirudh)


### PR DESCRIPTION
This patch makes a small change in how functions are handled while parsing LLVM opt pipeline output. Specifically, it differentiates between IR function and machine function, and while checking for the close of function, it only checks if the corresponding function is open.

This was needed because in some targets like hexagon, the machine functions could contain `BUNDLE`s as part of the dump and `BUNDLE`s are also represented with opening and closing braces ({}). This was causing assertion because the close brace for a BUNDLE was considered to be a IR function close statement.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
