### PR TITLE
rust: update objdumper, linker and defaultCompiler

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&rust:&rustgcc:&mrustc:&rustccggcc
-objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
-linker=/opt/compiler-explorer/gcc-11.1.0/bin/gcc
-defaultCompiler=r1730
+objdumper=/opt/compiler-explorer/gcc-13.2.0/bin/objdump
+linker=/opt/compiler-explorer/gcc-13.2.0/bin/gcc
+defaultCompiler=r1740
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
 
 buildenvsetup=ceconan-rust


### PR DESCRIPTION
I noticed the default Rust version was outdated, and we didn't have an upgrade of the `objdumper` and `linker` for a while, so I decided to send this in advance of tomorrow's Rust version upgrade.

I don't know what is the policy to update `objdumper` and `linker` though. We have 13.2, 13.1, 12.1, 11.2 and 11.1 around, so I went with the latest. Hopefully that is OK, please let me know if there is some kind of rule about it.