### PR TITLE
fix android-d8 compiler ids

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -1,15 +1,15 @@
 compilers=&android-d8
 
-group.android-d8.compilers=d8-8156
+group.android-d8.compilers=java-d8-8156
 group.android-d8.compilerType=android-d8
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 
-compiler.d8-8156.name=d8 8.1.56
-compiler.d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
-compiler.d8-8156.javaId=java1601
-compiler.d8-8156.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
-compiler.d8-8156.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
-compiler.d8-8156.kotlinId=kotlinc1920
-compiler.d8-8156.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
+compiler.java-d8-8156.name=d8 8.1.56
+compiler.java-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
+compiler.java-d8-8156.javaId=java1601
+compiler.java-d8-8156.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
+compiler.java-d8-8156.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
+compiler.java-d8-8156.kotlinId=kotlinc1920
+compiler.java-d8-8156.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
 
-defaultCompiler=d8-8156
+defaultCompiler=java-d8-8156

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -2,16 +2,16 @@ compilers=&android-d8
 compilerType=android-d8
 objdumper=/usr/local/bin/baksmali.jar
 
-group.android-d8.compilers=android-d8-default
-compiler.android-d8-default.name=android d8 default
-compiler.android-d8-default.exe=/usr/local/bin/r8.jar
+group.android-d8.compilers=android-java-d8-default
+compiler.android-java-d8-default.name=android d8 default
+compiler.android-java-d8-default.exe=/usr/local/bin/r8.jar
 
 # When testing locally, these paths must be valid and should
 # reflect the paths in the java and kotlin default config.
-compiler.android-d8-default.javaId=javacdefault
-compiler.android-d8-default.javaPath=/usr/bin/java
-compiler.android-d8-default.javacPath=/usr/bin/javac
-compiler.android-d8-default.kotlinId=kotlincdefault
-compiler.android-d8-default.kotlincPath=/usr/bin/kotlinc-jvm
+compiler.android-java-d8-default.javaId=javacdefault
+compiler.android-java-d8-default.javaPath=/usr/bin/java
+compiler.android-java-d8-default.javacPath=/usr/bin/javac
+compiler.android-java-d8-default.kotlinId=kotlincdefault
+compiler.android-java-d8-default.kotlincPath=/usr/bin/kotlinc-jvm
 
-defaultCompiler=android-d8-default
+defaultCompiler=android-java-d8-default

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -1,15 +1,15 @@
 compilers=&android-d8
 
-group.android-d8.compilers=d8-8156
+group.android-d8.compilers=kotlin-d8-8156
 group.android-d8.compilerType=android-d8
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 
-compiler.d8-8156.name=d8 8.1.56
-compiler.d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
-compiler.d8-8156.javaId=java1601
-compiler.d8-8156.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
-compiler.d8-8156.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
-compiler.d8-8156.kotlinId=kotlinc1920
-compiler.d8-8156.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
+compiler.kotlin-d8-8156.name=d8 8.1.56
+compiler.kotlin-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
+compiler.kotlin-d8-8156.javaId=java1601
+compiler.kotlin-d8-8156.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
+compiler.kotlin-d8-8156.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
+compiler.kotlin-d8-8156.kotlinId=kotlinc1920
+compiler.kotlin-d8-8156.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
 
-defaultCompiler=d8-8156
+defaultCompiler=kotlin-d8-8156

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -2,16 +2,16 @@ compilers=&android-d8
 compilerType=android-d8
 objdumper=/usr/local/bin/baksmali.jar
 
-group.android-d8.compilers=android-d8-default
-compiler.android-d8-default.name=android d8 default
-compiler.android-d8-default.exe=/usr/local/bin/r8.jar
+group.android-d8.compilers=android-kotlin-d8-default
+compiler.android-kotlin-d8-default.name=android d8 default
+compiler.android-kotlin-d8-default.exe=/usr/local/bin/r8.jar
 
 # When testing locally, these paths must be valid and should
 # reflect the paths in the java and kotlin default config.
-compiler.android-d8-default.javaId=javacdefault
-compiler.android-d8-default.javaPath=/usr/bin/java
-compiler.android-d8-default.javacPath=/usr/bin/javac
-compiler.android-d8-default.kotlinId=kotlincdefault
-compiler.android-d8-default.kotlincPath=/usr/bin/kotlinc-jvm
+compiler.android-kotlin-d8-default.javaId=javacdefault
+compiler.android-kotlin-d8-default.javaPath=/usr/bin/java
+compiler.android-kotlin-d8-default.javacPath=/usr/bin/javac
+compiler.android-kotlin-d8-default.kotlinId=kotlincdefault
+compiler.android-kotlin-d8-default.kotlincPath=/usr/bin/kotlinc-jvm
 
-defaultCompiler=android-d8-default
+defaultCompiler=android-kotlin-d8-default


### PR DESCRIPTION
Fixes #5897

Not only causes issues on Windows (that are non-crashing on Linux???)
On the main site it uses the same id for both kotlin and java, this is Ok in the current situation where the kotlin settings are duplicated with java, but if kotlin started to deviate from java this would result in unexpected situations.
