### PR TITLE
Add pybind11 library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2915,7 +2915,7 @@ compiler.edg-6_5-default-13.name=EDG 6.5
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
+libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:fmt:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -4038,6 +4038,14 @@ libs.pugixml.url=https://pugixml.org/
 libs.pugixml.staticliblink=pugixml
 libs.pugixml.versions.1114.version=1.11.4
 libs.pugixml.versions.1114.path=/opt/compiler-explorer/libs/pugixml/v1.11.4/src/
+
+libs.pybind11.name=Pybind11
+libs.pybind11.url=https://github.com/pybind/pybind11
+libs.pybind11.versions=trunk:2_11_1
+libs.pybind11.versions.trunk.version=trunk
+libs.pybind11.versions.trunk.path=/opt/compiler-explorer/libs/pybind11/trunk/include
+libs.pybind11.versions.2_11_1.version=v2.11.1
+libs.pybind11.versions.2_11_1.path=/opt/compiler-explorer/libs/pybind11/v2.11.1/include
 
 libs.python.name=Python
 libs.python.url=https://python.org


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

First, thanks for maintaining compiler explorer. It is a wonderful tool.

I have been playing with EDG/reflections on godbolt.org and decided to make a proof of concept library for python bindings that relies on reflections. To make my life easier, I wanted to depend on pybind11, instead of re-learning CPython API.
That brings me to this pull request. I would appreciate having pybind11 available in godbolt.

I am not sure if I am missing anything regarding this. Pybind11 is header-only and the path specified is the one that should be passed to `-isystem`.
Also, the issue template mentions tests, but I am not sure how or even if tests are needed for this change.

I will also understand if you would rather not add more libraries to the compiler explorer image for the sake of its size.