### PR TITLE
Fix #5941: mark mrustc compilation result with languageId='c'

### DIFF
--- a/lib/compilers/mrustc.ts
+++ b/lib/compilers/mrustc.ts
@@ -76,4 +76,8 @@ export class MrustcCompiler extends BaseCompiler {
     override getArgumentParser() {
         return MrustcParser;
     }
+
+    override getCompilerResultLanguageId() {
+        return 'c';
+    }
 }


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
