### PR TITLE
Fix #5945: tiny change to regexes parsing 

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -103,8 +103,8 @@ function parseSeverity(message: string): number {
 }
 
 const SOURCE_RE = /^\s*<source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
-const SOURCE_WITH_FILENAME = /^\s*([\w.]*)[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
-const ATFILELINE_RE = /\s*at ([\w-/.]*):(\d+)/;
+const SOURCE_WITH_FILENAME = /^\s*([\w.]+)[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+const ATFILELINE_RE = /\s*at ([\w-/.]+):(\d+)/;
 
 export enum LineParseOption {
     SourceMasking,


### PR DESCRIPTION
Tiny change to regexes parsing compiler stdout lines, to make them stop classifying lines like "(0.00 s) Setup: DONE" as errors.

One could imagine other, more thorough, fixes to [this code](https://github.com/compiler-explorer/compiler-explorer/blob/ec8f8e5d50f81f4fb65b37bc5337f1ad93784f38/lib/utils.ts#L195-L202) - it currently attempts to capture errors from all compilers, *not* differentiating by compiler but instead by some general output formats (`<source>`:line:col , or "file.ext":line, etc.).  I settled for a 1-char fix that seems to makes sense by itself.

