### PR TITLE
Fix semver ordering for libraries

### DIFF
--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -362,11 +362,7 @@ export class ClientOptionsHandler {
         for (const langGroup of Object.values(libraries)) {
             for (const libGroup of Object.values(langGroup)) {
                 const versions = Object.values(libGroup.versions);
-                // TODO: A and B don't contain any property called semver here. It's probably leftover from old code
-                // and should be removed in the future.
-                versions.sort((a, b) =>
-                    semverParser.compare(asSafeVer((a as any).semver), asSafeVer((b as any).semver), true),
-                );
+                versions.sort((a, b) => semverParser.compare(asSafeVer(a.version), asSafeVer(b.version), true));
                 let order = 0;
                 // Set $order to index on array. As group is an array, iteration order is guaranteed.
                 for (const lib of versions) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -516,6 +516,10 @@ export function asSafeVer(semver: string | number | null | undefined) {
                 return validated;
             }
         }
+
+        if (semver.includes('trunk') || semver.includes('main')) {
+            return '99999999.99999.999';
+        }
     }
-    return '9999999.99999.999';
+    return '99999998.99999.999';
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -499,7 +499,12 @@ export function countOccurrences<T>(collection: Iterable<T>, item: T): number {
     return result;
 }
 
-export function asSafeVer(semver: string | number | null | undefined) {
+export enum magic_semver {
+    trunk = '99999999.99999.999',
+    non_trunk = '99999998.99999.999',
+}
+
+export function asSafeVer(semver: string | number | null | undefined): string {
     if (semver != null) {
         if (typeof semver === 'number') {
             semver = `${semver}`;
@@ -518,8 +523,8 @@ export function asSafeVer(semver: string | number | null | undefined) {
         }
 
         if (semver.includes('trunk') || semver.includes('main')) {
-            return '99999999.99999.999';
+            return magic_semver.trunk;
         }
     }
-    return '99999998.99999.999';
+    return magic_semver.non_trunk;
 }

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -566,19 +566,16 @@ describe('safe semver', () => {
         utils.asSafeVer('1.1.0').should.equal('1.1.0');
         utils.asSafeVer('1.1.1').should.equal('1.1.1');
 
-        const MAGIC_TRUNK_VERSION = '99999999.99999.999';
-        const MAGIC_NONTRUNK_VERSION = '99999998.99999.999';
+        utils.asSafeVer('trunk').should.equal(utils.magic_semver.trunk);
+        utils.asSafeVer('(trunk)').should.equal(utils.magic_semver.trunk);
+        utils.asSafeVer('(123.456.789 test)').should.equal(utils.magic_semver.non_trunk);
 
-        utils.asSafeVer('trunk').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('(trunk)').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('(123.456.789 test)').should.equal(MAGIC_NONTRUNK_VERSION);
-
-        utils.asSafeVer('0..0').should.equal(MAGIC_NONTRUNK_VERSION);
-        utils.asSafeVer('0.0.').should.equal(MAGIC_NONTRUNK_VERSION);
-        utils.asSafeVer('0.').should.equal(MAGIC_NONTRUNK_VERSION);
-        utils.asSafeVer('.0.0').should.equal(MAGIC_NONTRUNK_VERSION);
-        utils.asSafeVer('.0..').should.equal(MAGIC_NONTRUNK_VERSION);
-        utils.asSafeVer('0..').should.equal(MAGIC_NONTRUNK_VERSION);
+        utils.asSafeVer('0..0').should.equal(utils.magic_semver.non_trunk);
+        utils.asSafeVer('0.0.').should.equal(utils.magic_semver.non_trunk);
+        utils.asSafeVer('0.').should.equal(utils.magic_semver.non_trunk);
+        utils.asSafeVer('.0.0').should.equal(utils.magic_semver.non_trunk);
+        utils.asSafeVer('.0..').should.equal(utils.magic_semver.non_trunk);
+        utils.asSafeVer('0..').should.equal(utils.magic_semver.non_trunk);
 
         utils.asSafeVer('123 TEXT').should.equal('123.0.0');
         utils.asSafeVer('123.456 TEXT').should.equal('123.456.0');

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -566,17 +566,19 @@ describe('safe semver', () => {
         utils.asSafeVer('1.1.0').should.equal('1.1.0');
         utils.asSafeVer('1.1.1').should.equal('1.1.1');
 
-        const MAGIC_TRUNK_VERSION = '9999999.99999.999';
+        const MAGIC_TRUNK_VERSION = '99999999.99999.999';
+        const MAGIC_NONTRUNK_VERSION = '99999998.99999.999';
+
         utils.asSafeVer('trunk').should.equal(MAGIC_TRUNK_VERSION);
         utils.asSafeVer('(trunk)').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('(123.456.789 test)').should.equal(MAGIC_TRUNK_VERSION);
+        utils.asSafeVer('(123.456.789 test)').should.equal(MAGIC_NONTRUNK_VERSION);
 
-        utils.asSafeVer('0..0').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('0.0.').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('0.').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('.0.0').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('.0..').should.equal(MAGIC_TRUNK_VERSION);
-        utils.asSafeVer('0..').should.equal(MAGIC_TRUNK_VERSION);
+        utils.asSafeVer('0..0').should.equal(MAGIC_NONTRUNK_VERSION);
+        utils.asSafeVer('0.0.').should.equal(MAGIC_NONTRUNK_VERSION);
+        utils.asSafeVer('0.').should.equal(MAGIC_NONTRUNK_VERSION);
+        utils.asSafeVer('.0.0').should.equal(MAGIC_NONTRUNK_VERSION);
+        utils.asSafeVer('.0..').should.equal(MAGIC_NONTRUNK_VERSION);
+        utils.asSafeVer('0..').should.equal(MAGIC_NONTRUNK_VERSION);
 
         utils.asSafeVer('123 TEXT').should.equal('123.0.0');
         utils.asSafeVer('123.456 TEXT').should.equal('123.456.0');


### PR DESCRIPTION
Fix #5951
Fix #5085

Extended the fictitious version number for non-numbers, so that trunk can be listed higher than a `yyyymmdd` as a version (EVE uses this)
