### PR TITLE
Fixing paths for Glaze and adding latest version

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3512,12 +3512,14 @@ libs.gemmlowp.versions.trunk.path=/opt/compiler-explorer/libs/gemmlowp/trunk
 
 libs.glaze.name=glaze
 libs.glaze.description=JSON, reflection, and interface library
-libs.glaze.versions=trunk:198
+libs.glaze.versions=trunk:198:203
 libs.glaze.url=https://github.com/stephenberry/glaze
 libs.glaze.versions.trunk.version=trunk
-libs.glaze.versions.trunk.path=/opt/compiler-explorer/libs/glaze/trunk
+libs.glaze.versions.trunk.path=/opt/compiler-explorer/libs/glaze/trunk/include
 libs.glaze.versions.198.version=1.9.8
-libs.glaze.versions.198.path=/opt/compiler-explorer/libs/glaze/v1.9.8
+libs.glaze.versions.198.path=/opt/compiler-explorer/libs/glaze/v1.9.8/include
+libs.glaze.versions.203.version=2.0.3
+libs.glaze.versions.203.path=/opt/compiler-explorer/libs/glaze/v2.0.3/include
 
 libs.glm.name=GLM
 libs.glm.description=OpenGL Mathematics


### PR DESCRIPTION
This adds the latest version of Glaze, as well as adding `/include` to the paths per a request from #5901. Thanks!
