### PR TITLE
Fix #5832: cuda 11.3.1 is incompatible with gcc 10+

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -268,7 +268,7 @@ compiler.cltrunk.semver=trunk
 compiler.cltrunk.name=trunk sm_86 CUDA-11.3
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
+compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0 --cuda-path=/opt/compiler-explorer/cuda/11.3.1 --cuda-gpu-arch=sm_86 --cuda-device-only -Wno-unknown-cuda-version
 group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang


### PR DESCRIPTION
According to the [CUDA 11.3 installation guide](https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html) only `gcc 9.*` are supported for it:

![image](https://github.com/compiler-explorer/compiler-explorer/assets/73080/f5c77f25-7595-40b4-a3d9-d8d23f8a12e1)

This PR pins the gcc used to 9.3.
I have no way to test locally but I think it is safe - these compilations currently don't work anyway, and I can't see any way this would mess up any other compilations.

