### PR TITLE
Fix a leftover case of bad file-extension replacement in rust

### DIFF
--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -32,7 +32,7 @@ import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.in
 import {unwrap} from '../assert.js';
 import {BaseCompiler} from '../base-compiler.js';
 import type {BuildEnvDownloadInfo} from '../buildenvsetup/buildenv.interfaces.js';
-import {parseRustOutput} from '../utils.js';
+import {parseRustOutput, changeExtension} from '../utils.js';
 
 import {RustParser} from './argument-parsers.js';
 import {CompilerOverrideType} from '../../types/compilation/compiler-overrides.interfaces.js';
@@ -201,7 +201,7 @@ export class RustCompiler extends BaseCompiler {
         const outputFilename = this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase);
         // As per #4054, if we are asked for binary mode, the output will be in the .s file, no .ll will be emited
         if (!filters.binary) {
-            return outputFilename.replace('.s', '.ll');
+            return changeExtension(outputFilename, '.ll');
         }
         return outputFilename;
     }

--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -110,11 +110,11 @@ export class CompilerOverridesWidget {
         return envVars
             .split('\n')
             .map(env => {
-                const arr = env.split('=');
-                if (arr[0]) {
+                const firstEqPos = env.indexOf('=');
+                if (firstEqPos !== -1) {
                     return {
-                        name: arr[0],
-                        value: arr[1],
+                        name: env.substring(0, firstEqPos),
+                        value: env.substring(firstEqPos + 1),
                     };
                 } else {
                     return false;


### PR DESCRIPTION
Seems I missed this one when doing PR #5700. This caused *some* of the grief mentioned in the discussion of issue #5667, but certainly not all of it.
