### PR TITLE
icc: workaround bug in libstdc++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1082,31 +1082,36 @@ compiler.icx202300.exe=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/
 compiler.icx202300.ldPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib
 compiler.icx202300.libPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202300.semver=2023.0.0
-compiler.icx202300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
+# switch back to gcc-13.3 when released. See #5943
+compiler.icx202300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
 
 compiler.icx202310.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icpx
 compiler.icx202310.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
 compiler.icx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202310.semver=2023.1.0
-compiler.icx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.1.0
+# switch back to gcc-13.3 when released. See #5943
+compiler.icx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
 
 compiler.icx202321.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icpx
 compiler.icx202321.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
 compiler.icx202321.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.2.1.8/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202321.semver=2023.2.1
-compiler.icx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+# switch back to gcc-13.3 when released. See #5943
+compiler.icx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
 
 compiler.icx202400.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icpx
 compiler.icx202400.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
 compiler.icx202400.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
 compiler.icx202400.semver=2024.0.0
-compiler.icx202400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+# switch back to gcc-13.3 when released. See #5943
+compiler.icx202400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
 
 compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icpx
 compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
 compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
 compiler.icxlatest.semver=(latest)
-compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+# switch back to gcc-13.3 when released. See #5943
+compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
 
 ################################
 # zapcc


### PR DESCRIPTION
Use gcc-12.3 until gcc-13.3 is released (includes a fix for a bug in
current 13.2).

Should be switch back to gcc-13.3 when it is released.

fixes #5943

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>