### PR TITLE
Add Zig 0.11.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2718,7 +2718,7 @@ compiler.djggp494.semver=4.9.4
 
 #################################
 # Zig c++
-group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxxtrunk
+group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxxtrunk
 group.zigcxx.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcxx.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcxx.options=
@@ -2744,6 +2744,8 @@ compiler.zcxx090.exe=/opt/compiler-explorer/zig-0.9.0/zig
 compiler.zcxx090.semver=0.9.0
 compiler.zcxx0100.exe=/opt/compiler-explorer/zig-0.10.0/zig
 compiler.zcxx0100.semver=0.10.0
+compiler.zcxx0110.exe=/opt/compiler-explorer/zig-0.11.0/zig
+compiler.zcxx0110.semver=0.11.0
 compiler.zcxxtrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcxxtrunk.semver=trunk
 compiler.zcxxtrunk.isNightly=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2586,7 +2586,7 @@ compiler.tinycc0927.semver=0.9.27
 
 #################################
 # Zig cc
-group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcctrunk
+group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcctrunk
 group.zigcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcc.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcc.options=
@@ -2611,6 +2611,8 @@ compiler.zcc090.exe=/opt/compiler-explorer/zig-0.9.0/zig
 compiler.zcc090.semver=0.9.0
 compiler.zcc0100.exe=/opt/compiler-explorer/zig-0.10.0/zig
 compiler.zcc0100.semver=0.10.0
+compiler.zcc0110.exe=/opt/compiler-explorer/zig-0.11.0/zig
+compiler.zcc0110.semver=0.11.0
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 compiler.zcctrunk.isNightly=true

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -1,8 +1,8 @@
 compilers=&zig
-defaultCompiler=z0100
+defaultCompiler=z0110
 
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
-group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100
+group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
@@ -36,6 +36,8 @@ compiler.z090.exe=/opt/compiler-explorer/zig-0.9.0/zig
 compiler.z090.semver=0.9.0
 compiler.z0100.exe=/opt/compiler-explorer/zig-0.10.0/zig
 compiler.z0100.semver=0.10.0
+compiler.z0110.exe=/opt/compiler-explorer/zig-0.11.0/zig
+compiler.z0110.semver=0.11.0
 
 #################################
 #################################


### PR DESCRIPTION
Fixes #5351

I just copied the changes in #4358 and checked that it works locally with

```sh
make debug EXTRA_ARGS='--language zig'
```

although I had to make the following changes to get it to work locally:

```diff
diff --git a/etc/config/zig.defaults.properties b/etc/config/zig.defaults.properties
index 008aa215..f4db084c 100644
--- a/etc/config/zig.defaults.properties
+++ b/etc/config/zig.defaults.properties
@@ -1,4 +1,4 @@
-compilers=/usr/bin/zig
+compilers=/opt/homebrew/bin/zig
 supportsBinary=true
 compilerType=zig
 objdumper=objdump
diff --git a/lib/compilers/zig.ts b/lib/compilers/zig.ts
index b0d55432..8e33767f 100644
--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -44,6 +44,7 @@ export class ZigCompiler extends BaseCompiler {
         super(info, env);
         this.compiler.supportsIntel = true;
         this.compiler.supportsIrView = true;
+        this.compiler.semver = '0.11.0';
 
         this.self_hosted_cli =
             this.compiler.semver === 'trunk' ||
```