### PR TITLE
Since ES6 there's no reason to use `underscore`s map and filter

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -253,7 +253,7 @@ function getFaviconFilename() {
 const propHierarchy = [
     'defaults',
     defArgs.env,
-    _.map(defArgs.env, e => `${e}.${process.platform}`),
+    defArgs.env.map(e => `${e}.${process.platform}`),
     process.platform,
     os.hostname(),
 ].flat();
@@ -583,7 +583,7 @@ async function main() {
         if (JSON.stringify(prevCompilers) === JSON.stringify(compilers)) {
             return;
         }
-        logger.info(`Compiler scan count: ${_.size(compilers)}`);
+        logger.info(`Compiler scan count: ${compilers.length}`);
         logger.debug('Compilers:', compilers);
         prevCompilers = compilers;
         await clientOptionsHandler.setCompilers(compilers);

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1227,11 +1227,9 @@ export class BaseCompiler implements ICompiler {
 
     async generateAST(inputFilename, options): Promise<ResultLine[]> {
         // These options make Clang produce an AST dump
-        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics').concat([
-            '-Xclang',
-            '-ast-dump',
-            '-fsyntax-only',
-        ]);
+        const newOptions = options
+            .filter(option => option !== '-fcolor-diagnostics')
+            .concat(['-Xclang', '-ast-dump', '-fsyntax-only']);
 
         const execOptions = this.getDefaultExecOptions();
         // A higher max output is needed for when the user includes headers
@@ -2160,7 +2158,7 @@ export class BaseCompiler implements ICompiler {
         });
 
         if (detectedLibs.length > 0) {
-            libsAndOptions.options = _.filter(libsAndOptions.options, option => !foundlibOptions.includes(option));
+            libsAndOptions.options = libsAndOptions.options.filter(option => !foundlibOptions.includes(option));
             libsAndOptions.libraries = _.union(libsAndOptions.libraries, detectedLibs);
 
             return true;

--- a/lib/buildenvsetup/cliconan.ts
+++ b/lib/buildenvsetup/cliconan.ts
@@ -53,7 +53,7 @@ export class BuildEnvSetupCliConan extends BuildEnvSetupBase {
     override async setup(key, dirPath, libraryDetails, binary): Promise<BuildEnvDownloadInfo[]> {
         if (this.onlyonstaticliblink && !binary) return [];
 
-        const librariesToDownload = _.filter(libraryDetails, details => this.shouldDownloadPackage(details));
+        const librariesToDownload = libraryDetails.filter(details => this.shouldDownloadPackage(details));
 
         await this.prepareConanRequest(librariesToDownload, dirPath);
         return this.installLibrariesViaConan(key, dirPath);

--- a/lib/compilation-env.ts
+++ b/lib/compilation-env.ts
@@ -172,6 +172,6 @@ export class CompilationEnvironment {
     }
 
     findBadOptions(options: string[]) {
-        return _.filter(options, option => !this.okOptions.test(option) || this.badOptions.test(option));
+        return options.filter(option => !this.okOptions.test(option) || this.badOptions.test(option));
     }
 }

--- a/lib/compilers/hlsl.ts
+++ b/lib/compilers/hlsl.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import _ from 'underscore';
-
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {SPIRVAsmParser} from '../parsers/asm-parser-spirv.js';
@@ -50,9 +48,9 @@ export class HLSLCompiler extends BaseCompiler {
 
     override async generateAST(inputFilename, options): Promise<ResultLine[]> {
         // These options make DXC produce an AST dump
-        const newOptions = _.filter(options, option => option !== '-Zi' && option !== '-Qembed_debug').concat([
-            '-ast-dump',
-        ]);
+        const newOptions = options
+            .filter(option => option !== '-Zi' && option !== '-Qembed_debug')
+            .concat(['-ast-dump']);
 
         const execOptions = this.getDefaultExecOptions();
         // A higher max output is needed for when the user includes headers

--- a/lib/compilers/ispc.ts
+++ b/lib/compilers/ispc.ts
@@ -23,7 +23,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import Semver from 'semver';
-import _ from 'underscore';
 
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
@@ -80,7 +79,7 @@ export class ISPCCompiler extends BaseCompiler {
 
     override async generateAST(inputFilename, options): Promise<ResultLine[]> {
         // These options make Clang produce an AST dump
-        const newOptions = _.filter(options, option => option !== '--colored-output').concat(['--ast-dump']);
+        const newOptions = options.filter(option => option !== '--colored-output').concat(['--ast-dump']);
 
         const execOptions = this.getDefaultExecOptions();
         // A higher max output is needed for when the user includes headers

--- a/lib/compilers/pony.ts
+++ b/lib/compilers/pony.ts
@@ -24,8 +24,6 @@
 
 import path from 'path';
 
-import _ from 'underscore';
-
 import type {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
@@ -70,7 +68,8 @@ export class PonyCompiler extends BaseCompiler {
         produceCfg: boolean,
         filters: ParseFiltersAndOutputOptions,
     ) {
-        const newOptions = _.filter(options, option => !['--pass', 'asm', '-b', this.outputFilebase].includes(option))
+        const newOptions = options
+            .filter(option => !['--pass', 'asm', '-b', this.outputFilebase].includes(option))
             .concat(unwrap(this.compiler.irArg))
             .concat(['-b', path.parse(inputFilename).name]);
 
@@ -106,7 +105,7 @@ export class PonyCompiler extends BaseCompiler {
 
         // Pony operates upon the directory as a whole, not files it seems
         // So we must set the input to the directory rather than a file.
-        options = _.map(options, arg => (arg.includes(inputFilename) ? path.dirname(arg) : arg));
+        options = options.map(arg => (arg.includes(inputFilename) ? path.dirname(arg) : arg));
 
         const compilerExecResult = await this.exec(compiler, options, execOptions);
         return this.transformToCompilationResult(compilerExecResult, inputFilename);

--- a/lib/compilers/spirv.ts
+++ b/lib/compilers/spirv.ts
@@ -24,8 +24,6 @@
 
 import path from 'path';
 
-import _ from 'underscore';
-
 import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
@@ -68,10 +66,9 @@ export class SPIRVCompiler extends BaseCompiler {
         backendOptions = backendOptions || {};
 
         if (this.compiler.options) {
-            const compilerOptions = _.filter(
-                utils.splitArguments(this.compiler.options),
-                option => option !== '-fno-crash-diagnostics',
-            );
+            const compilerOptions = utils
+                .splitArguments(this.compiler.options)
+                .filter(option => option !== '-fno-crash-diagnostics');
 
             options = options.concat(compilerOptions);
         }
@@ -193,7 +190,7 @@ export class SPIRVCompiler extends BaseCompiler {
     }
 
     override async generateAST(inputFilename, options): Promise<ResultLine[]> {
-        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics').concat(['-ast-dump']);
+        const newOptions = options.filter(option => option !== '-fcolor-diagnostics').concat(['-ast-dump']);
 
         const execOptions = this.getDefaultExecOptions();
         execOptions.maxOutput = 1024 * 1024 * 1024;
@@ -210,7 +207,7 @@ export class SPIRVCompiler extends BaseCompiler {
         produceCfg: boolean,
         filters: ParseFiltersAndOutputOptions,
     ) {
-        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics').concat('-emit-llvm');
+        const newOptions = options.filter(option => option !== '-fcolor-diagnostics').concat('-emit-llvm');
 
         const execOptions = this.getDefaultExecOptions();
         execOptions.maxOutput = 1024 * 1024 * 1024;

--- a/lib/compilers/tinyc.ts
+++ b/lib/compilers/tinyc.ts
@@ -45,6 +45,6 @@ export class TinyCCompiler extends BaseCompiler {
     }
 
     override filterUserOptions(userOptions) {
-        return _.filter(userOptions, opt => opt !== '-run');
+        return userOptions.filter(opt => opt !== '-run');
     }
 }

--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -91,7 +91,7 @@ export class Win32Compiler extends BaseCompiler {
     }
 
     override getStaticLibraryLinks(libraries) {
-        return _.map(super.getSortedStaticLibraries(libraries), lib => {
+        return super.getSortedStaticLibraries(libraries).map(lib => {
             return '"' + lib + '.lib"';
         });
     }

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -175,7 +175,7 @@ export class ZigCompiler extends BaseCompiler {
 
     override filterUserOptions(userOptions: string[]): string[] {
         const forbiddenOptions = /^(((--(cache-dir|name|output|verbose))|(-(mllvm|f(no-)?emit-))).*)$/;
-        return _.filter(userOptions, option => !forbiddenOptions.test(option));
+        return userOptions.filter(option => !forbiddenOptions.test(option));
     }
 
     override isCfgCompiler(/*compilerVersion*/): boolean {

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -392,7 +392,7 @@ export class CompileHandler {
             // If specified exactly, we'll take that with ?filters=a,b,c
             if (query.filters) {
                 filters = _.object(
-                    _.map(query.filters.split(','), filter => [filter, true]),
+                    query.filters.split(',').map(filter => [filter, true]),
                 ) as any as ParseFiltersAndOutputOptions;
             }
             // Add a filter. ?addFilters=binary

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -97,7 +97,7 @@ export function parseProperties(blob: string, name) {
 
 export function initialize(directory: string, hier) {
     if (hier === null) throw new Error('Must supply a hierarchy array');
-    hierarchy = _.map(hier, x => x.toLowerCase());
+    hierarchy = hier.map(x => x.toLowerCase());
     logger.info(`Reading properties from ${directory} with hierarchy ${hierarchy}`);
     const endsWith = /\.properties$/;
     const propertyFiles = fs.readdirSync(directory).filter(filename => filename.match(endsWith));

--- a/lib/tooling/compiler-dropin-tool.ts
+++ b/lib/tooling/compiler-dropin-tool.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import _ from 'underscore';
-
 import {Library} from '../../types/libraries/libraries.interfaces.js';
 import {ToolResult} from '../../types/tool.interfaces.js';
 import {getToolchainPath} from '../toolchain-utils.js';
@@ -67,7 +65,7 @@ export class CompilerDropinTool extends BaseTool {
             compileFlags = compileFlags.concat(['--gcc-toolchain=' + toolchainPath]);
             compileFlags = compileFlags.concat(['--gcc-toolchain=' + toolchainPath]);
 
-            compilerOptions = _.filter(compilerOptions, option => {
+            compilerOptions = compilerOptions.filter(option => {
                 return !(option.indexOf('--gcc-toolchain=') === 0 || option.indexOf('--gxx-name=') === 0);
             });
         } else {
@@ -86,7 +84,7 @@ export class CompilerDropinTool extends BaseTool {
         compileFlags = compileFlags.concat(libOptions);
         compileFlags = compileFlags.concat(args || []);
 
-        const pathFilteredFlags: (string | false)[] = _.map(compileFlags, option => {
+        const pathFilteredFlags: (string | false)[] = compileFlags.map(option => {
             if (option && option.length > 1) {
                 if (option[0] === '/') {
                     return false;
@@ -96,7 +94,7 @@ export class CompilerDropinTool extends BaseTool {
             return option;
         });
 
-        return _.filter(pathFilteredFlags) as string[];
+        return pathFilteredFlags.filter(Boolean) as string[];
     }
 
     override async runTool(

--- a/lib/tooling/x86to6502-tool.ts
+++ b/lib/tooling/x86to6502-tool.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import _ from 'underscore';
-
 import {ToolResult} from '../../types/tool.interfaces.js';
 import {AsmParser} from '../parsers/asm-parser.js';
 
@@ -52,15 +50,17 @@ export class x86to6502Tool extends BaseTool {
 
         const result = parser.process(compilationInfo.asm, filters);
 
-        const asm = _.map(result.asm, obj => {
-            if (typeof obj.text !== 'string' || obj.text.trim() === '') {
-                return '';
-            } else if (/.*:/.test(obj.text)) {
-                return obj.text.replace(/^\s*/, '');
-            } else {
-                return obj.text.replace(/^\s*/, '\t');
-            }
-        }).join('\n');
+        const asm = result.asm
+            .map(obj => {
+                if (typeof obj.text !== 'string' || obj.text.trim() === '') {
+                    return '';
+                } else if (/.*:/.test(obj.text)) {
+                    return obj.text.replace(/^\s*/, '');
+                } else {
+                    return obj.text.replace(/^\s*/, '\t');
+                }
+            })
+            .join('\n');
 
         return super.runTool(compilationInfo, undefined, args, asm);
     }

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -107,7 +107,7 @@ export class MultifileService {
     private getLanguageIdFromFilename(filename: string): string {
         const filenameExt = path.extname(filename);
 
-        const possibleLang = _.filter(languages, lang => {
+        const possibleLang = languages.filter(lang => {
             return lang.extensions.includes(filenameExt);
         });
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3404,7 +3404,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 this.pushRevealJump();
                 this.editor.revealLineInCenter(lineNums[0]);
             }
-            this.decorations.linkedCode = _.map(lineNums, line => {
+            this.decorations.linkedCode = lineNums.map(line => {
                 return {
                     range: new monaco.Range(line, 1, line, 1),
                     options: {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1591,19 +1591,15 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         const editorModel = this.editor.getModel();
         if (editorModel) monaco.editor.setModelMarkers(editorModel, ownerId, widgets);
 
-        this.decorations.tags = _.map(
-            widgets,
-            function (tag) {
-                return {
-                    range: new monaco.Range(tag.startLineNumber, tag.startColumn, tag.startLineNumber + 1, 1),
-                    options: {
-                        isWholeLine: false,
-                        inlineClassName: 'error-code',
-                    },
-                };
-            },
-            this,
-        );
+        this.decorations.tags = widgets.map(function (tag) {
+            return {
+                range: new monaco.Range(tag.startLineNumber, tag.startColumn, tag.startLineNumber + 1, 1),
+                options: {
+                    isWholeLine: false,
+                    inlineClassName: 'error-code',
+                },
+            };
+        }, this);
 
         this.updateDecorations();
     }


### PR DESCRIPTION
Mindless replacements of the form 
`_.filter(options, option =>...`  --> `options.filter(option =>...`.

One not *entirely* mindless replacement at the bottom of compiler-dropin-tool.ts :
```
-        return _.filter(pathFilteredFlags) as string[];
+        return pathFilteredFlags.filter(Boolean) as string[];
```
6 files can now stop importing underscore.

