### PR TITLE
rust: display unwise option warning for `-C target-cpu=native`

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -10,6 +10,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 group.rust.compilers=r1750:r1740:r1730:r1720:r1710:r1700:r1690:r1680:r1670:r1660:r1650:r1640:r1630:r1620:r1610:r1600:r1590:r1580:r1570:r1560:r1550:r1540:r1530:r1520:r1510:r1500:r1490:r1480:r1470:r1460:r1452:r1450:r1440:r1430:r1420:r1410:r1400:r1390:r1380:r1370:r1360:r1350:r1340:r1330:r1320:r1310:r1300:r1290:r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190:r180:r170:r160:r150:r140:r130:r120:r110:r100:nightly:beta
 group.rust.compilerType=rust
 group.rust.isSemVer=true
+group.rust.unwiseOptions=-Ctarget-cpu=native|target-cpu=native
 group.rust.baseName=rustc
 group.rust.licenseLink=https://github.com/rust-lang/rust/blob/master/COPYRIGHT
 group.rust.licenseName=Dual-licensed under Apache 2.0 and MIT terms
@@ -187,6 +188,7 @@ group.rustgcc.supportsBinary=true
 group.rustgcc.supportsBinaryObject=true
 group.rustgcc.compilerType=gccrs
 group.rustgcc.isSemVer=true
+group.rustgcc.unwiseOptions=-march=native
 ## needed, until its support is on-par with rustc (at some arbitrary version).
 group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
 group.rustgcc.notification=Rust GCC Frontend - Very early snapshot
@@ -195,6 +197,7 @@ group.rustgcc.notification=Rust GCC Frontend - Very early snapshot
 group.gcc86.compilers=gccrs-snapshot:gcc-snapshot
 group.gcc86.groupName=x86-64 GCCRS
 group.gcc86.baseName=x86-64 GCCRS
+group.gcc86.unwiseOptions=-march=native
 
 compiler.gcc-snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gccrs
 compiler.gcc-snapshot.semver=(GCC master)
@@ -224,6 +227,7 @@ group.rustccggcc.compilerType=rustc-cg-gcc
 group.rustccggcc.supportsExecute=false
 group.rustccggcc.supportsBinary=false
 group.rustccggcc.supportsBinaryObject=false
+group.rustccggcc.unwiseOptions=-Ctarget-cpu=native|target-cpu=native
 compiler.rustccggcc-master.exe=/opt/compiler-explorer/rustc-cg-gcc-master/bin/rustc
 compiler.rustccggcc-master.name=rustc-cg-gcc (master)
 compiler.rustccggcc-master.isNightly=true


### PR DESCRIPTION
Resolves #5983.

This is not 100% accurate as it matches `target-cpu=native` without a preceding `-C`, but there isn’t an obvious case where this would occur in an otherwise valid compiler invocation, so it’s probably good enough?