### PR TITLE
Fix #5630: filter out `--emit mir=..` in RustCompiler.buildExecutable

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1737,7 +1737,12 @@ export class BaseCompiler implements ICompiler {
         return tooling;
     }
 
-    buildExecutable(compiler, options, inputFilename, execOptions) {
+    buildExecutable(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptions & {env: Record<string, string>},
+    ) {
         // default implementation, but should be overridden by compilers
         return this.runCompiler(compiler, options, inputFilename, execOptions);
     }

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -36,6 +36,7 @@ import {parseRustOutput, changeExtension} from '../utils.js';
 
 import {RustParser} from './argument-parsers.js';
 import {CompilerOverrideType} from '../../types/compilation/compiler-overrides.interfaces.js';
+import {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import {SemVer} from 'semver';
 
 export class RustCompiler extends BaseCompiler {
@@ -220,5 +221,19 @@ export class RustCompiler extends BaseCompiler {
             stdout: parseRustOutput(input.stdout, inputFilename),
             stderr: parseRustOutput(input.stderr, inputFilename),
         };
+    }
+
+    override buildExecutable(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptions & {env: Record<string, string>},
+    ) {
+        // bug #5630: in presence of `--emit mir=..` rustc does not produce an executable.
+        const newOptions = options.filter(
+            (opt, idx, allOpts) =>
+                !(opt === '--emit' && allOpts[idx + 1].startsWith('mir=')) && !opt.startsWith('mir='),
+        );
+        return super.runCompiler(compiler, newOptions, inputFilename, execOptions);
     }
 }


### PR DESCRIPTION
With a small added ts'ification in base-compiler.
