### PR TITLE
Add PyPy 3.9 and 3.10

### DIFF
--- a/etc/config/python.amazon.properties
+++ b/etc/config/python.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&python3
+compilers=&python3:&pypy
 defaultCompiler=python311
 
 group.python3.compilers=python35:python36:python37:python38:python39:python310:python311
@@ -21,3 +21,14 @@ compiler.python310.exe=/opt/compiler-explorer/python-3.10.0/bin/python3.10
 compiler.python310.semver=3.10
 compiler.python311.exe=/opt/compiler-explorer/python-3.11.0/bin/python3.11
 compiler.python311.semver=3.11
+
+group.pypy.compilers=pypy39:pypy310
+group.pypy.isSemVer=true
+group.pypy.baseName=PyPy
+group.pypy.licenseLink=https://github.com/pypy/pypy/blob/main/LICENSE
+group.pypy.licenseName=The MIT License
+
+compiler.pypy39.exe=/opt/compiler-explorer/pypy3.9-v7.3.14/bin/pypy
+compiler.pypy39.semver=3.9
+compiler.pypy310.exe=/opt/compiler-explorer/pypy3.10-v7.3.14/bin/pypy
+compiler.pypy310.semver=3.10


### PR DESCRIPTION
Resolves #5761.

I originally also wanted to include PyPy2.7 (which is still supported and would be the only Python2 on Compiler Explorer), but it doesn’t support `-I` which CE uses: https://github.com/compiler-explorer/compiler-explorer/blob/37f68bfa4ac97f1ae0dd710744c76532748e7315/lib/compilers/python.ts#L79

infra PR: https://github.com/compiler-explorer/infra/pull/1212