### PR TITLE
Add latest GNU assembler for Arm64

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -77,13 +77,13 @@ compiler.gnuasarm1020.name=ARM gcc 10.2 (linux)
 compiler.gnuasarm1020.semver=ARM binutils 2.35.1
 
 
-group.gnuasarm64.compilers=gnuasarm64g630:gnuasarm64g820:gnuasarm64g930:gnuasarm64g1020
+group.gnuasarm64.compilers=gnuasarm64g630:gnuasarm64g820:gnuasarm64g930:gnuasarm64g1020:gnuasarm64g1320
 group.gnuasarm64.versionFlag=--version
 group.gnuasarm64.options=-g
 group.gnuasarm64.isSemVer=true
 group.gnuasarm64.baseName=AArch64 binutils
 group.gnuasarm64.supportsExecute=false
-group.gnuasarm64.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
+group.gnuasarm64.objdumper=/opt/compiler-explorer/arm64/gcc-13.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gnuasarm64.instructionSet=aarch64
 
 compiler.gnuasarm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-as
@@ -98,6 +98,9 @@ compiler.gnuasarm64g930.semver=2.33.1
 compiler.gnuasarm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
 compiler.gnuasarm64g1020.name=AArch64 binutils 2.35.1
 compiler.gnuasarm64g1020.semver=2.35.1
+compiler.gnuasarm64g1320.exe=/opt/compiler-explorer/arm64/gcc-13.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g1320.name=AArch64 binutils 2.38
+compiler.gnuasarm64g1320.semver=2.38
 
 # GNU as for RISC-V
 group.gnuasriscv.compilers=&gnuasriscv64:&gnuasriscv32


### PR DESCRIPTION
The previous highest version was 2.35.1 and between then and 2.38, support for many new extensions has been added.

This includes the Scalable Vector Extension (SVE), it's own extension SVE2, memcopy acceleration (MOPS) and many more.

I checked the version number by installing locally:
```
/opt/compiler-explorer/arm64/gcc-13.2.0/aarch64-unknown-linux-gnu/bin$ ./aarch64-unknown-linux-gnu-as --version
GNU assembler (GNU Binutils) 2.38
```

So that we can handle the new encodings, the objdumper for this category is also updated to the same version.