### PR TITLE
Update LLVM Flang file names

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -511,8 +511,8 @@ group.clang_llvmflang.compilers=flangtrunk:flangtrunknew
 group.clang_llvmflang.groupName=LLVM-FLANG x86-64
 group.clang_llvmflang.compilerType=flang
 
-compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
-compiler.flangtrunk.name=flang-trunk (old)
+compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-to-external-fc
+compiler.flangtrunk.name=flang-trunk (flang-to-external-fc)
 compiler.flangtrunk.gfortranPath=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.flangtrunk.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
 compiler.flangtrunk.isNightly=true


### PR DESCRIPTION
The latest builds contain:
```
$ ./bin/flang-
flang-new             flang-to-external-fc
```

The script that was `flang` is now `flang-to-external-fc`.

I've renamed "(old)" to be more specific. I don't think anyone who knew what "old" meant will be confused by "flang-to-external-fc", and anyone who didn't know what it meant can at least Google that name and find out that it's a script.
