### PR TITLE
Add artArtifactDir to Android config files

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -17,6 +17,7 @@ group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 
 compiler.java-dex2oat-latest.name=ART dex2oat latest
+compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
 compiler.java-dex2oat-latest.d8Id=java-d8-8156

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -17,6 +17,7 @@ group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 
 compiler.kotlin-dex2oat-latest.name=ART dex2oat latest
+compiler.kotlin-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.kotlin-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.kotlin-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
 compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8156


### PR DESCRIPTION
This was present in the default properties files for android-java and android-kotlin but missing for the amazon properties files.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
