### PR TITLE
Add gcem library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2942,7 +2942,7 @@ compiler.vast-trunk.isNightly=true
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
+libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -3537,6 +3537,15 @@ libs.fmt.versions.1011.version=10.1.1
 libs.fmt.versions.1011.path=/opt/compiler-explorer/libs/fmt/10.1.1/include
 libs.fmt.versions.1021.version=10.2.1
 libs.fmt.versions.1021.path=/opt/compiler-explorer/libs/fmt/10.2.1/include
+
+libs.gcem.name=GCEM
+libs.gcem.description=Generalized Constant Expression Math: a C++ compile-time math library using generalized constant expressions
+libs.gcem.versions=trunk:1_17_0
+libs.gcem.url=https://github.com/kthohr/gcem
+libs.gcem.versions.trunk.version=trunk
+libs.gcem.versions.trunk.path=/opt/compiler-explorer/libs/gcem/trunk/include
+libs.gcem.versions.1_17_0.version=1.17.0
+libs.gcem.versions.1_17_0.path=/opt/compiler-explorer/libs/gcem/v1.17.0/include
 
 libs.gemmlowp.name=gemmlowp
 libs.gemmlowp.url=https://github.com/google/gemmlowp


### PR DESCRIPTION
Resolves #4977.

[GCEM](https://github.com/kthohr/gcem/) is a header-only library for C++11 that provides `constexpr` implementations of various math functions.

Infra PR: https://github.com/compiler-explorer/infra/pull/1215