### PR TITLE
Add note to Rust example explaining why functions are missing in the output

### DIFF
--- a/examples/rust/default.rs
+++ b/examples/rust/default.rs
@@ -1,4 +1,12 @@
 // Type your code here, or load an example.
+
+// As of Rust 1.75, small functions are automatically
+// marked as `#[inline]` so they will not show up in
+// the output when compiling with optimisations. Use
+// `#[no_mangle]` or `#[inline(never)]` to work around
+// this issue.
+// See https://github.com/compiler-explorer/compiler-explorer/issues/5939
+#[no_mangle]
 pub fn square(num: i32) -> i32 {
     num * num
 }


### PR DESCRIPTION
Resolves #5939.

Rust issue about this problem: https://github.com/rust-lang/rust/issues/119850

Hopefully this can be reverted again when there is a fix on the Rust side.