### PR TITLE
Add prepare hint to javascript example

### DIFF
--- a/examples/javascript/default.mjs
+++ b/examples/javascript/default.mjs
@@ -3,6 +3,9 @@ function square(a) {
 	return result;
 }
 
+// Collect type information on next call of function
+%PrepareFunctionForOptimization(square)
+
 // Call function once to fill type information
 square(23);
 


### PR DESCRIPTION
Without this additional line, v8 trunk produces no output, and v8 11.3 produces a bunch of assembly with no `imull` instruction.

I don't actually know much about v8 or javascript, but based on [this mailing list post](https://groups.google.com/g/v8-users/c/xlx22gScRNs/m/yE2-boWsBQAJ) and testing on godbolt.org, this works.