### PR TITLE
add some cross gcc mips

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2225,12 +2225,27 @@ compiler.mips64el-clang1300.semver=13.0.0
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mips930:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1310:mipsg1320
+group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1310:mipsg1320
 group.mips.baseName=mips gcc
+
+compiler.mipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg494.semver=4.9.4
+compiler.mipsg494.objdumper=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg494.demangler=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mips5.semver=5.4
 compiler.mips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+compiler.mipsg550.exe=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg550.semver=5.5.0
+compiler.mipsg550.objdumper=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg550.demangler=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.mipsg950.exe=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg950.semver=9.5.0
+compiler.mipsg950.objdumper=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg950.demangler=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.mips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-g++
 compiler.mips930.name=mips gcc 9.3.0 (codescape)
@@ -2267,12 +2282,27 @@ compiler.mipsg1320.demangler=/opt/compiler-explorer/mips/gcc-13.2.0/mips-unknown
 
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips564:mips112064
+group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips564:mips112064
 group.mips64.baseName=mips64 gcc
 
+compiler.mips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g494.semver=4.9.4
+compiler.mips64g494.objdumper=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g494.demangler=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.mips64g550.exe=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g550.semver=5.5.0
+compiler.mips64g550.objdumper=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g550.demangler=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
-compiler.mips564.semver=5.4
+compiler.mips564.semver=5.4.0
 compiler.mips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+
+compiler.mips64g950.exe=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g950.semver=9.5.0
+compiler.mips64g950.objdumper=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g950.demangler=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.mips112064.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips112064.semver=11.2.0
@@ -2304,12 +2334,27 @@ compiler.mips64g1320.demangler=/opt/compiler-explorer/mips64/gcc-13.2.0/mips64-u
 
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el:mipselg1210:mipselg1220:mipselg1230:mipselg1310:mipselg1320
+group.mipsel.compilers=mipselg494:mipselg550:mips5el:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1310:mipselg1320
 group.mipsel.baseName=mipsel gcc
 
+compiler.mipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
+compiler.mipselg494.semver=4.9.4
+compiler.mipselg494.objdumper=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.mipselg494.demangler=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
+
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
-compiler.mips5el.semver=5.4
+compiler.mips5el.semver=5.4.0
 compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
+
+compiler.mipselg550.exe=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
+compiler.mipselg550.semver=5.5.0
+compiler.mipselg550.objdumper=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.mipselg550.demangler=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
+
+compiler.mipselg950.exe=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
+compiler.mipselg950.semver=9.5.0
+compiler.mipselg950.objdumper=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.mipselg950.demangler=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
 
 compiler.mipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
 compiler.mipselg1210.semver=12.1.0
@@ -2337,13 +2382,28 @@ compiler.mipselg1320.demangler=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-m
 
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips564el
+group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips564el
 group.mips64el.baseName=mips64 (el) gcc
 group.mips64el.compilerCategories=gcc
 
+compiler.mips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
+compiler.mips64elg494.semver=4.9.4
+compiler.mips64elg494.objdumper=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.mips64elg494.demangler=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
+
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
-compiler.mips564el.semver=5.4
+compiler.mips564el.semver=5.4.0
 compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+
+compiler.mips64elg550.exe=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
+compiler.mips64elg550.semver=5.5.0
+compiler.mips64elg550.objdumper=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.mips64elg550.demangler=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
+
+compiler.mips64elg950.exe=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
+compiler.mips64elg950.semver=9.5.0
+compiler.mips64elg950.objdumper=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.mips64elg950.demangler=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
 
 compiler.mips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
 compiler.mips64elg1210.semver=12.1.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2006,13 +2006,28 @@ compiler.mips64el-cclang1300.semver=13.0.0
 
 # GCC for all MIPS
 ## MIPS
-group.cmips.compilers=cmips5:cmips930:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1310:cmipsg1320
+group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1310:cmipsg1320
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
+
+compiler.cmipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg494.semver=4.9.4
+compiler.cmipsg494.objdumper=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg494.demangler=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.cmips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmips5.semver=5.4
 compiler.cmips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+
+compiler.cmipsg550.exe=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg550.semver=5.5.0
+compiler.cmipsg550.objdumper=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg550.demangler=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.cmipsg950.exe=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg950.semver=9.5.0
+compiler.cmipsg950.objdumper=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg950.demangler=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.cmips930.exe=/opt/compiler-explorer/mips/mips-mti-elf/2020.06-01/bin/mips-mti-elf-gcc
 compiler.cmips930.name=mips gcc 9.3.0 (codescape)
@@ -2049,8 +2064,23 @@ compiler.cmipsg1320.demangler=/opt/compiler-explorer/mips/gcc-13.2.0/mips-unknow
 
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips564:cmips112064
+group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips564:cmips112064
 group.cmips64.baseName=mips64 gcc
+
+compiler.cmips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g494.semver=4.9.4
+compiler.cmips64g494.objdumper=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g494.demangler=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.cmips64g550.exe=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g550.semver=5.5.0
+compiler.cmips64g550.objdumper=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g550.demangler=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.cmips64g950.exe=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g950.semver=9.5.0
+compiler.cmips64g950.objdumper=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g950.demangler=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.cmips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.cmips564.semver=5.4
@@ -2086,8 +2116,23 @@ compiler.cmips64g1320.demangler=/opt/compiler-explorer/mips64/gcc-13.2.0/mips64-
 
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1310:cmipselg1320
+group.cmipsel.compilers=cmipselg494:cmips5el:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1310:cmipselg1320
 group.cmipsel.baseName=mips (el) gcc
+
+compiler.cmipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
+compiler.cmipselg494.semver=4.9.4
+compiler.cmipselg494.objdumper=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.cmipselg494.demangler=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
+
+compiler.cmipselg550.exe=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
+compiler.cmipselg550.semver=5.5.0
+compiler.cmipselg550.objdumper=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.cmipselg550.demangler=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
+
+compiler.cmipselg950.exe=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
+compiler.cmipselg950.semver=9.5.0
+compiler.cmipselg950.objdumper=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.cmipselg950.demangler=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
 
 compiler.cmips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
 compiler.cmips5el.semver=5.4
@@ -2119,13 +2164,27 @@ compiler.cmipselg1320.demangler=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-
 
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips564el
+group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips564el:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320
 group.cmips64el.baseName=mips64 (el) gcc
 
+compiler.cmips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
+compiler.cmips64elg494.semver=4.9.4
+compiler.cmips64elg494.objdumper=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.cmips64elg494.demangler=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
+
+compiler.cmips64elg550.exe=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
+compiler.cmips64elg550.semver=5.5.0
+compiler.cmips64elg550.objdumper=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.cmips64elg550.demangler=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
+
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
-compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
-compiler.cmips564el.semver=5.4
+compiler.cmips564el.semver=5.4.0
 compiler.cmips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+
+compiler.cmips64elg950.exe=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
+compiler.cmips64elg950.semver=9.5.0
+compiler.cmips64elg950.objdumper=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.cmips64elg950.demangler=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
 
 compiler.cmips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.cmips64elg1210.semver=12.1.0

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -718,9 +718,24 @@ compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-
 
 ################################
 # GCC for MIPS
-group.gccmips.compilers=fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1310:fmipsg1320
+group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1310:fmipsg1320
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
+
+compiler.fmipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg494.semver=4.9.4
+compiler.fmipsg494.objdumper=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg494.demangler=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.fmipsg550.exe=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg550.semver=5.5.0
+compiler.fmipsg550.objdumper=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg550.demangler=/opt/compiler-explorer/mips/gcc-5.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.fmipsg950.exe=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg950.semver=9.5.0
+compiler.fmipsg950.objdumper=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg950.demangler=/opt/compiler-explorer/mips/gcc-9.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.fmipsg1210.exe=/opt/compiler-explorer/mips/gcc-12.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
 compiler.fmipsg1210.semver=12.1.0
@@ -748,9 +763,24 @@ compiler.fmipsg1320.demangler=/opt/compiler-explorer/mips/gcc-13.2.0/mips-unknow
 
 ################################
 # GCC for MIPS64
-group.gccmips64.compilers=fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320
+group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
+
+compiler.fmips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g494.semver=4.9.4
+compiler.fmips64g494.objdumper=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g494.demangler=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.fmips64g550.exe=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g550.semver=5.5.0
+compiler.fmips64g550.objdumper=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g550.demangler=/opt/compiler-explorer/mips64/gcc-5.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.fmips64g950.exe=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g950.semver=9.5.0
+compiler.fmips64g950.objdumper=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g950.demangler=/opt/compiler-explorer/mips64/gcc-9.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.fmips64g1210.exe=/opt/compiler-explorer/mips64/gcc-12.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
 compiler.fmips64g1210.semver=12.1.0
@@ -778,9 +808,24 @@ compiler.fmips64g1320.demangler=/opt/compiler-explorer/mips64/gcc-13.2.0/mips64-
 
 ################################
 # GCC for MIPSEL
-group.gccmipsel.compilers=fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1310:fmipselg1320
+group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1310:fmipselg1320
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
+
+compiler.fmipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gfortran
+compiler.fmipselg494.semver=4.9.4
+compiler.fmipselg494.objdumper=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.fmipselg494.demangler=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
+
+compiler.fmipselg550.exe=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gfortran
+compiler.fmipselg550.semver=5.5.0
+compiler.fmipselg550.objdumper=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.fmipselg550.demangler=/opt/compiler-explorer/mipsel/gcc-5.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
+
+compiler.fmipselg950.exe=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gfortran
+compiler.fmipselg950.semver=9.5.0
+compiler.fmipselg950.objdumper=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-objdump
+compiler.fmipselg950.demangler=/opt/compiler-explorer/mipsel/gcc-9.5.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-c++filt
 
 compiler.fmipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
 compiler.fmipselg1210.semver=12.1.0
@@ -808,9 +853,24 @@ compiler.fmipselg1320.demangler=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-
 
 ################################
 # GCC for MIPS64el
-group.gccmips64el.compilers=fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320
+group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
+
+compiler.fmips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gfortran
+compiler.fmips64elg494.semver=4.9.4
+compiler.fmips64elg494.objdumper=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.fmips64elg494.demangler=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
+
+compiler.fmips64elg550.exe=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gfortran
+compiler.fmips64elg550.semver=5.5.0
+compiler.fmips64elg550.objdumper=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.fmips64elg550.demangler=/opt/compiler-explorer/mips64el/gcc-5.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
+
+compiler.fmips64elg950.exe=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gfortran
+compiler.fmips64elg950.semver=9.5.0
+compiler.fmips64elg950.objdumper=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
+compiler.fmips64elg950.demangler=/opt/compiler-explorer/mips64el/gcc-9.5.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-c++filt
 
 compiler.fmips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
 compiler.fmips64elg1210.semver=12.1.0


### PR DESCRIPTION
Add missing 4.9.4, 5.5.0 and 9.5.0 for some mips variant.

goes with https://github.com/compiler-explorer/compiler-explorer/pull/5723