### PR TITLE
[julia_wrapper] Slightly improve performance

### DIFF
--- a/etc/scripts/julia_wrapper.jl
+++ b/etc/scripts/julia_wrapper.jl
@@ -1,4 +1,4 @@
-doc = """Julia wrapper.
+const doc = """Julia wrapper.
 
 Usage:
   julia_wrapper.jl <input_code> <output_path> [--format=<fmt>] [--debuginfo=<info>] [--optimize=<opt>] [--verbose]
@@ -14,138 +14,137 @@ Options:
 
 using InteractiveUtils
 
-if first(ARGS) == "--"
-    popfirst!(ARGS)
-end
+function main()
 
-format = "native"
-debuginfo = :default
-optimize = true
-verbose = false
-show_help = false
-arg_parser_error = false
-positional_ARGS = String[]
-
-for x in ARGS
-    if startswith(x, "--format=")
-        global format = x[10:end]
-    elseif startswith(x, "--debuginfo=")
-        if x[13:end] == "none"
-            global debuginfo = :none
-        end
-    elseif startswith(x, "--optimize=")
-        # Do not error out if we can't parse the option
-        global optimize = something(tryparse(Bool, x[12:end]), true)
-    elseif x == "--verbose"
-        global verbose = true
-    elseif x == "--help" || x == "-h"
-        global show_help = true
-    elseif !startswith(x, "-")
-        push!(positional_ARGS, x)
-    else
-        global arg_parser_error = true
-        println("Unknown argument ", x)
+    if first(ARGS) == "--"
+        popfirst!(ARGS)
     end
-end
 
-if show_help
-    println(doc)
-    exit(Int(arg_parser_error)) # exit(1) if failed to parse
-end
+    format = "native"
+    debuginfo = :default
+    optimize = true
+    verbose = false
+    show_help = false
+    arg_parser_error = false
+    positional_ARGS = String[]
 
-if length(positional_ARGS) != 2
-    arg_parser_error = true
-    println("Expected two position args", positional_ARGS)
-end
-
-if arg_parser_error
-    println(doc)
-    exit(1)
-end
-
-input_file = popfirst!(positional_ARGS)
-output_path = popfirst!(positional_ARGS)
-
-# Include user code into module
-m = Module(:Godbolt)
-Base.include(m, input_file)
-
-# Find functions and method specializations
-m_methods = Any[]
-for name in names(m, all=true, imported=true)
-    local fun = getfield(m, name)
-    if fun isa Function
-        if verbose
-            println("Function: ", fun)
-        end
-        # only show methods found in input module
-        for me in methods(fun, m)
-            # In julia v1.7-1.9 `me.specializations` is always a `Core.SimpleVector`, but in
-            # Julia v1.10+ it can also be a single instance of `Core.MethodInstance`, which
-            # isn't iterable, so we put it in a tuple to be able to do the for loop below.
-            specs = if me.specializations isa Core.SimpleVector
-                me.specializations
-            elseif me.specializations isa Core.MethodInstance
-                (me.specializations,)
-            else
-                error("Cannot handle specializations of type $(typeof(me.specializations))")
+    for x in ARGS
+        if startswith(x, "--format=")
+            format = x[10:end]
+        elseif startswith(x, "--debuginfo=")
+            if x[13:end] == "none"
+                debuginfo = :none
             end
-            for s in specs
-                if s != nothing
-                    spec_types = s.specTypes
-                    # In case of a parametric type, see https://docs.julialang.org/en/v1/devdocs/types/#UnionAll-types
-                    while typeof(spec_types) == UnionAll
-                        spec_types = spec_types.body
-                    end
-                    me_types = getindex(spec_types.parameters, 2:length(spec_types.parameters))
-                    push!(m_methods, (fun, me_types, me))
-                    if verbose
-                        println("    Method types: ", me_types)
+        elseif startswith(x, "--optimize=")
+            # Do not error out if we can't parse the option
+            optimize = something(tryparse(Bool, x[12:end]), true)
+        elseif x == "--verbose"
+            verbose = true
+        elseif x == "--help" || x == "-h"
+            show_help = true
+        elseif !startswith(x, "-")
+            push!(positional_ARGS, x)
+        else
+            arg_parser_error = true
+            println("Unknown argument ", x)
+        end
+    end
+
+    if show_help
+        println(doc)
+        exit(Int(arg_parser_error)) # exit(1) if failed to parse
+    end
+
+    if length(positional_ARGS) != 2
+        arg_parser_error = true
+        println("Expected two position args", positional_ARGS)
+    end
+
+    if arg_parser_error
+        println(doc)
+        exit(1)
+    end
+
+    input_file = popfirst!(positional_ARGS)
+    output_path = popfirst!(positional_ARGS)
+
+    # Include user code into module
+    m = Module(:Godbolt)
+    Base.include(m, input_file)
+
+    # Find functions and method specializations
+    m_methods = Any[]
+    for name in names(m, all=true, imported=true)
+        local fun = getfield(m, name)
+        if fun isa Function
+            if verbose
+                println("Function: ", fun)
+            end
+            # only show methods found in input module
+            for me in methods(fun, m)
+                # In julia v1.7-1.9 `me.specializations` is always a `Core.SimpleVector`, but in
+                # Julia v1.10+ it can also be a single instance of `Core.MethodInstance`, which
+                # isn't iterable, so we put it in a tuple to be able to do the for loop below.
+                specs = if me.specializations isa Core.SimpleVector
+                    me.specializations
+                elseif me.specializations isa Core.MethodInstance
+                    (me.specializations,)
+                else
+                    error("Cannot handle specializations of type $(typeof(me.specializations))")
+                end
+                for s in specs
+                    if s != nothing
+                        spec_types = s.specTypes
+                        # In case of a parametric type, see https://docs.julialang.org/en/v1/devdocs/types/#UnionAll-types
+                        while typeof(spec_types) == UnionAll
+                            spec_types = spec_types.body
+                        end
+                        me_types = getindex(spec_types.parameters, 2:length(spec_types.parameters))
+                        push!(m_methods, (fun, me_types, me))
+                        if verbose
+                            println("    Method types: ", me_types)
+                        end
                     end
                 end
             end
         end
     end
+
+    # open output file
+    open(output_path, "w") do io
+        # For all found methods
+        for (me_fun, me_types, me) in m_methods
+            io_buf = IOBuffer() # string buffer
+            if format == "typed"
+                ir, retval = InteractiveUtils.code_typed(me_fun, me_types; optimize, debuginfo)[1]
+                Base.IRShow.show_ir(io_buf, ir)
+            elseif format == "lowered"
+                cl = Base.code_lowered(me_fun, me_types; debuginfo)
+                print(io_buf, cl)
+            elseif format == "llvm"
+                InteractiveUtils.code_llvm(io_buf, me_fun, me_types; optimize, debuginfo)
+            elseif format == "native"
+                InteractiveUtils.code_native(io_buf, me_fun, me_types; debuginfo)
+            elseif format == "warntype"
+                InteractiveUtils.code_warntype(io_buf, me_fun, me_types; debuginfo)
+            end
+            code = String(take!(io_buf))
+            line_num = count("\n",code)
+            # Print first line: <[source code line] [number of output lines] [function name] [method types]>
+            print(io, "<")
+            print(io, me.line)
+            print(io, " ")
+            print(io, line_num)
+            print(io, " ")
+            print(io, me_fun)
+            print(io, " ")
+            print(io, join(me_types, ", "))
+            println(io, ">")
+            # Print code for this method
+            println(io, code)
+        end
+    end
+    exit(0)
 end
 
-# Open output file
-open(output_path, "w") do io
-    # For all found methods
-    for (me_fun, me_types, me) in m_methods
-        io_buf = IOBuffer() # string buffer
-        if format == "typed"
-            ir, retval = InteractiveUtils.code_typed(me_fun, me_types; optimize, debuginfo)[1]
-            Base.IRShow.show_ir(io_buf, ir)
-        elseif format == "lowered"
-            cl = Base.code_lowered(me_fun, me_types; debuginfo)
-            print(io_buf, cl)
-        elseif format == "llvm"
-            InteractiveUtils.code_llvm(io_buf, me_fun, me_types; optimize, debuginfo)
-        elseif format == "native"
-            InteractiveUtils.code_native(io_buf, me_fun, me_types; debuginfo)
-        elseif format == "warntype"
-            InteractiveUtils.code_warntype(io_buf, me_fun, me_types; debuginfo)
-        end
-        code = String(take!(io_buf))
-        line_num = count("\n",code)
-        # Print first line: <[source code line] [number of output lines] [function name] [method types]>
-        write(io, "<")
-        print(io, me.line)
-        print(io, " ")
-        print(io, line_num)
-        print(io, " ")
-        print(io, me_fun)
-        write(io, " ")
-        for i in 1:length(me_types)
-            print(io, me_types[i])
-            if i < length(me_types)
-                write(io, ", ")
-            end
-        end
-        write(io, ">\n")
-        # Print code for this method
-        write(io, code)
-        write(io, "\n")
-    end
-end
-exit(0)
+main()


### PR DESCRIPTION
This PR slightly improves compilation time with Julia by moving the code to a function, and marking the help text as a constant, which are the very basic [performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/) recommended when writing Julia code.  Note that most of the changes involve indentation, so the diff is easier to read by ignoring whitespace changes.

With this change, on my machine (Intel i7-4870HQ CPU) I get a runtime improvement in the range 10%-40%, depending on the julia version used.  It isn't a huge saving, but I guess shaving off a few hundreds milliseconds isn't too bad :slightly_smiling_face: 

<details><summary>Details of benchmarks</summary>
<p>

`input.jl` file:
```julia
function axpy(a, x, y)
    @simd for idx in eachindex(x, y)
        @inbounds y[idx] = muladd(a, x[idx], y[idx])
    end
    return nothing
end

precompile(axpy, (Float32, Vector{Float32}, Vector{Float32}))
```

Benchmark (`julia_wrapper.jl` is the script in this PR, `julia_wrapper_main.jl` is [the script currently in the `main` branch](https://github.com/compiler-explorer/compiler-explorer/blob/0be4fbf9c55c77c18babacfce4dcc86a1dee844f/etc/scripts/julia_wrapper.jl), I used [juliaup](https://github.com/JuliaLang/juliaup) to launch the different julia versions)

```console
% for version in 1.7 1.8 1.9 1.10; do hyperfine --warmup=1 "julia +${version} --startup-file=no julia_wrapper.jl input.jl output.ll --format=llvm" "julia +${version} --startup-file=no julia_wrapper_main.jl input.jl output.ll --format=llvm"; done
Benchmark 1: julia +1.7 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.364 s ±  0.035 s    [User: 1.512 s, System: 0.511 s]
  Range (min … max):    1.299 s …  1.399 s    10 runs
 
Benchmark 2: julia +1.7 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.899 s ±  0.010 s    [User: 2.072 s, System: 0.541 s]
  Range (min … max):    1.878 s …  1.914 s    10 runs
 
Summary
  julia +1.7 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm ran
    1.39 ± 0.04 times faster than julia +1.7 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
Benchmark 1: julia +1.8 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.702 s ±  0.048 s    [User: 1.848 s, System: 0.535 s]
  Range (min … max):    1.642 s …  1.784 s    10 runs
 
Benchmark 2: julia +1.8 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.858 s ±  0.053 s    [User: 1.995 s, System: 0.558 s]
  Range (min … max):    1.792 s …  1.956 s    10 runs
 
Summary
  julia +1.8 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm ran
    1.09 ± 0.04 times faster than julia +1.8 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
Benchmark 1: julia +1.9 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.693 s ±  0.059 s    [User: 1.750 s, System: 0.256 s]
  Range (min … max):    1.616 s …  1.776 s    10 runs
 
Benchmark 2: julia +1.9 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      2.338 s ±  0.035 s    [User: 2.391 s, System: 0.253 s]
  Range (min … max):    2.284 s …  2.389 s    10 runs
 
Summary
  julia +1.9 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm ran
    1.38 ± 0.05 times faster than julia +1.9 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
Benchmark 1: julia +1.10 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.541 s ±  0.024 s    [User: 1.596 s, System: 0.256 s]
  Range (min … max):    1.501 s …  1.580 s    10 runs
 
Benchmark 2: julia +1.10 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
  Time (mean ± σ):      1.752 s ±  0.029 s    [User: 1.808 s, System: 0.255 s]
  Range (min … max):    1.707 s …  1.791 s    10 runs
 
Summary
  julia +1.10 --startup-file=no --project=. julia_wrapper.jl input.jl output.ll --format=llvm ran
    1.14 ± 0.03 times faster than julia +1.10 --startup-file=no --project=. julia_wrapper_main.jl input.jl output.ll --format=llvm
```

</p>
</details> 