### PR TITLE
Fix issue with compiler picker group sorting

### DIFF
--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -140,7 +140,10 @@ export class CompilerService {
                 return {value: compiler.group, label: compiler.groupName || compiler.group};
             })
             .sort((a, b) => {
-                return a.label.localeCompare(b.label, undefined /* Ignore language */, {sensitivity: 'base'}) === 0;
+                // I'm pretty sure the @types are wrong and _Chain.sort is just Array.prototype.sort
+                return a.label.localeCompare(b.label, undefined /* Ignore language */, {
+                    sensitivity: 'base',
+                }) as unknown as boolean;
             })
             .value();
     }

--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -133,19 +133,15 @@ export class CompilerService {
     }
 
     public getGroupsInUse(langId: string): {value: string; label: string}[] {
-        return _.chain(this.getCompilersForLang(langId))
-            .map((compiler: CompilerInfo) => compiler)
-            .uniq(false, compiler => compiler.group)
+        return _.uniq(Object.values(this.getCompilersForLang(langId) ?? {}), false, compiler => compiler.group)
             .map(compiler => {
                 return {value: compiler.group, label: compiler.groupName || compiler.group};
             })
-            .sort((a, b) => {
-                // I'm pretty sure the @types are wrong and _Chain.sort is just Array.prototype.sort
-                return a.label.localeCompare(b.label, undefined /* Ignore language */, {
+            .sort((a, b) =>
+                a.label.localeCompare(b.label, undefined /* Ignore language */, {
                     sensitivity: 'base',
-                }) as unknown as boolean;
-            })
-            .value();
+                }),
+            );
     }
 
     getCompilersForLang(langId: string): Record<string, CompilerInfo> | undefined {


### PR DESCRIPTION
This restores the sorting behavior for the compiler picker to about two years ago before the ts conversion. I'm not sure what the effect of `.localeCompare() === 0` on .sort is, since that's only giving equality information. The `@types` for underscorejs says `_._Chain.sort`'s compare function should return a boolean but I can't actually find the definition of any `sort` function in underscorejs nor are there docs about what its compare function should return, but I think it's really calling `Array.prototype.sort` which expects a negative/0/positive.