### PR TITLE
Fix #5126:  fix event_hub.mediateDependentCalls

### DIFF
--- a/static/event-hub.ts
+++ b/static/event-hub.ts
@@ -101,15 +101,13 @@ export class EventHub {
             hasDependencyExecuted = true;
             if (lastDependentArguments) {
                 dependent.apply(this, lastDependentArguments);
-                lastDependentArguments = null;
             }
         };
         const dependentProxy = function (this: unknown, ...args: unknown[]) {
             if (hasDependencyExecuted) {
                 dependent.apply(this, args);
-            } else {
-                lastDependentArguments = args;
             }
+            lastDependentArguments = args;
         };
         return {dependencyProxy, dependentProxy};
     }


### PR DESCRIPTION
Pane contents are populated by `<pane>.onCompileResult`, triggered by `eventHub.emit('compileResult'..)` in `compiler.ts`.
The contents' colors are updated by `<pane>.onColours`, triggered mainly by `eventHub.emit('colours'...)`  invoked indirectly by `editor.onCompileResult`.  (colors are an editor property).
The order of invocations is governed by the order of registration and is hard to control, and so a mechanism was devised to cache `onColours` arguments and invoke it only after `onCompileResult`: `mediateDependentCalls`:
https://github.com/compiler-explorer/compiler-explorer/blob/ab937c5d151807eeff8d0735ca999ae36ff10392/static/event-hub.ts#L93-L116

It is coded as a generic mechanism but used only for this color->compileResult dependency in ir-view and ast-view. 

I imagine this worked for a while, but somewhere along the line triggering of events got messier - there are now multiple compilation runs that generate different contents, and the `mediateDependentCalls` logic breaks for some triggering orders, eg:  dependent -> dependency -> dependency. (note how 
https://github.com/compiler-explorer/compiler-explorer/blob/ab937c5d151807eeff8d0735ca999ae36ff10392/static/event-hub.ts#L104
prevents `dependent` from being called after the last `dependency` call).

This PR fixes `mediateDependentCalls` to make it call `dependent` with its _latest_ arguments after _every_ `dependency` call.  

This brings color back to IR and to AST. Until a few days ago I wasn't aware they were already colored in the past, and I suspects others weren't aware either: https://github.com/compiler-explorer/compiler-explorer/issues/5475#issuecomment-1714699031


