### PR TITLE
Fortran: Add LLVM Flang to default compiler config

### DIFF
--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -1,5 +1,5 @@
 # Default settings for Fortran
-compilers=&gfortran_86
+compilers=&gfortran_86:&clang_llvmflang
 defaultCompiler=gfortran
 demangler=c++filt
 objdumper=objdump
@@ -94,3 +94,19 @@ compiler.gfortran11.exe=/usr/bin/gfortran-11
 compiler.gfortran11.name=gfortran 11.x
 compiler.gfortran.exe=/usr/bin/gfortran
 compiler.gfortran.name=gfortran
+
+###############################
+# LLVM Flang
+group.clang_llvmflang.compilers=flangtrunk:flangtrunknew
+group.clang_llvmflang.groupName=LLVM-FLANG
+group.clang_llvmflang.compilerType=flang
+
+compiler.flangtrunk.exe=/usr/local/bin/flang-to-external-fc
+compiler.flangtrunk.name=flang-trunk (flang-to-external-fc)
+compiler.flangtrunk.gfortranPath=/usr/bin/
+compiler.flangtrunk.isNightly=true
+
+compiler.flangtrunknew.exe=/usr/local/bin/flang-new
+compiler.flangtrunknew.name=flang-trunk (flang-new)
+compiler.flangtrunknew.gfortranPath=/usr/bin/
+compiler.flangtrunknew.isNightly=true


### PR DESCRIPTION
And enable exectution for flang-new.

This assumes that LLVM flang is installed from `ninja install` rather
than a package manager, since I'm not sure any have it yet. So
it's `/usr/local/bin` instead of `/usr/bin`.

gfortran I've assumed is in `/usr/bin` to match the existing
settings in the file.

I removed the `ldPath` settings that the `amazon` config has because:
* Most of them refer to /opt/compiler-explorer.
* Removing the rest didn't prevent me from linking/running binaries.

flang-new used to require a seperate libpgmath library to produce
exectuables but this requirement has been removed so I've enabled
execution.