### PR TITLE
flang: Enable llvm-ir viewer for flang-new

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1013,6 +1013,19 @@ export class FlangParser extends ClangParser {
         return 'fortran/default.f90';
     }
 
+    static override setCompilerSettingsFromOptions(compiler, options) {
+        super.setCompilerSettingsFromOptions(compiler, options);
+
+        // flang does not allow -emit-llvm to be used as it is with clang
+        // as -Xflang -emit-llvm. Instead you just give -emit-llvm to flang
+        // directly.
+        if (this.hasSupport(options, '-emit-llvm')) {
+            compiler.compiler.supportsIrView = true;
+            compiler.compiler.irArg = ['-emit-llvm'];
+            compiler.compiler.minIrArgs = ['-emit-llvm'];
+        }
+    }
+
     static override hasSupport(options, param) {
         // param is available but we get a warning, so lets not use it
         if (param === '-fcolor-diagnostics') return undefined;


### PR DESCRIPTION
flang supports the -emit-llvm option but the difference from clang is that while clang allows `-Xclang -emit-llvm`, flang does not allow `-Xflang -emit-llvm`. Instead we need to use `-emit-llvm` alone.

This is a deliberate choice by the flang driver to make sure the user isn't asking the compiler to do 2 things at once. In this case assemble and emit llvm IR.

The way compiler explorer calls clang, the IR ends up not in the `-o` file path but in a file named after the input file but with the extension `.ll`. For flang we will get the IR in the file specified by `-o`.

To handle this I've copied code from ISPCCompiler which does the same thing. We could dedupe this, but I'm not sure whether it's worth it while we have only 2 compilers doing this.

(clang supports `clang ... -emit-llvm` as well, so perhaps the flang style could become the majority mode eventually)

Final note, flang-to-external-fc could support this with changes but users are better off just using flang-new, the result is the same (as flang-to-external-fc doesn't advertise -emit-llvm, it won't be selectable anyway).