### PR TITLE
fortran: Enable running binaries with flang-new

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -521,7 +521,6 @@ compiler.flangtrunknew.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flan
 compiler.flangtrunknew.name=flang-trunk (flang-new)
 compiler.flangtrunknew.gfortranPath=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.flangtrunknew.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
-compiler.flangtrunknew.supportsBinary=false
 compiler.flangtrunknew.isNightly=true
 
 ###############################


### PR DESCRIPTION
Flang used to require that libpgmath be installed
(https://github.com/flang-compiler/flang/blob/master/docs/libpgmath.rst).

This is no longer the case (https://reviews.llvm.org/D140236), so we should be able to build executable binaries without it.
