### PR TITLE
Fix #5350 and #4910: make BaseCompiler.preProcess able to modify `filters`

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2811,7 +2811,7 @@ export class BaseCompiler implements ICompiler {
                 const start = performance.now();
                 compilationQueueTimeHistogram.observe((start - queueTime) / 1000);
                 const res = await (async () => {
-                    source = this.preProcess(source, filters);
+                    [source, filters] = this.preProcess(source, filters);
 
                     if (backendOptions.executorRequest) {
                         const execResult = await this.handleExecution(key, executeOptions, bypassCache);
@@ -3175,11 +3175,11 @@ but nothing was dumped. Possible causes are:
         return this.handlePostProcessResult(result, await this.exec('bash', ['-c', postCommand], {maxOutput: maxSize}));
     }
 
-    preProcess(source: string, filters: CompilerOutputOptions): string {
+    preProcess(source: string, filters: CompilerOutputOptions): [string, CompilerOutputOptions] {
         if (filters.binary && !this.stubRe.test(source)) {
             source += `\n${this.stubText}\n`;
         }
-        return source;
+        return [source, filters];
     }
 
     async postProcess(result, outputFilename: string, filters: ParseFiltersAndOutputOptions) {

--- a/lib/compilers/pony.ts
+++ b/lib/compilers/pony.ts
@@ -25,7 +25,7 @@
 import path from 'path';
 
 import type {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
-import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import type {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {unwrap} from '../assert.js';
 import {LLVMIrBackendOptions} from '../../types/compilation/ir.interfaces.js';
@@ -52,13 +52,13 @@ export class PonyCompiler extends BaseCompiler {
         return options;
     }
 
-    override preProcess(source: string, filters: any) {
+    override preProcess(source: string, filters: CompilerOutputOptions): [string, CompilerOutputOptions] {
         // I do not think you can make a Pony "library", so you must always have a main.
         // Looking at the stdlib, the main is used as a test harness.
         if (!this.stubRe.test(source)) {
             source += `\n${this.stubText}\n`;
         }
-        return source;
+        return [source, filters];
     }
 
     override async generateIR(

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -28,7 +28,7 @@ import Semver from 'semver';
 import _ from 'underscore';
 
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
-import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import type {CompilerOutputOptions, ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import type {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {asSafeVer} from '../utils.js';
@@ -61,7 +61,7 @@ export class ZigCompiler extends BaseCompiler {
         return [];
     }
 
-    override preProcess(source: string): string {
+    override preProcess(source: string, filters: CompilerOutputOptions): [string, CompilerOutputOptions] {
         if (Semver.eq(asSafeVer(this.compiler.semver), '0.2.0', true)) {
             source += '\n';
             source += 'extern fn zig_panic() noreturn;\n';
@@ -103,7 +103,7 @@ export class ZigCompiler extends BaseCompiler {
             source += '}\n';
         }
 
-        return source;
+        return [source, filters];
     }
 
     override optionsForFilter(

--- a/lib/compilers/zigcc.ts
+++ b/lib/compilers/zigcc.ts
@@ -43,7 +43,7 @@ export class ZigCC extends ClangCompiler {
             Semver.lt(asSafeVer(this.compiler.semver), '0.9.0', true);
     }
 
-    override preProcess(source: string, filters: CompilerOutputOptions): string {
+    override preProcess(source: string, filters: CompilerOutputOptions): [string, CompilerOutputOptions] {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;

--- a/lib/compilers/zigcxx.ts
+++ b/lib/compilers/zigcxx.ts
@@ -48,7 +48,7 @@ export class ZigCXX extends ClangCompiler {
         return ZigCxxParser;
     }
 
-    override preProcess(source: string, filters: CompilerOutputOptions): string {
+    override preProcess(source: string, filters: CompilerOutputOptions): [string, CompilerOutputOptions] {
         if (this.needsForcedBinary) {
             // note: zig versions > 0.6 don't emit asm, only binary works - https://github.com/ziglang/zig/issues/8153
             filters.binary = true;


### PR DESCRIPTION
The additional logic requested for rust is "if the source contains 'fn main()' don't build as `--crate-type lib`", since it would trigger `warning: function `main` is never used`.

Some potential hooks for intervention are:

1. `fixIncompatibleOptions` - which would have required reading the source from disk,
2. A new hook with no-op BaseCompiler implementation, somewhere in `BaseCompiler.compile`
3. `preProcess`.

I opted for `preProcess` since it is already used and does sort-of-similar things in other places, eg https://github.com/compiler-explorer/compiler-explorer/blob/9705843bb78f6e89adc4b05140db92b8815206fd/lib/compilers/zigcc.ts#L46-L53

This did require a change of return type (now _returns_ filters too) and some adaptations around. 

Would appreciate another opinion on this choice.

