### PR TITLE
Minor improvements to noscript for mobile users 

### DIFF
--- a/views/noscript/compiler.pug
+++ b/views/noscript/compiler.pug
@@ -34,10 +34,10 @@ block content
                 option(value=compiler.id )= compiler.name
       .form-pair-inlined
         label(for='compileroptions') Options
-        input#compileroptions(name='userArguments' type="text" placeholder='Compiler options...' autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" value=(session.compilers.length > 0) ? session.compilers[0].options : '')
+        input#compileroptions(name='userArguments' type="text" placeholder='Compiler options...' autocorrect="off" autocapitalize="off" spellcheck="false" value=(session.compilers.length > 0) ? session.compilers[0].options : '')
       .form-pair-block
         label(for='source') Source code
-        textarea#source(name='source' cols='70' rows='10' placeholder='Type your code here')
+        textarea#source(name='source' cols='70' rows='10' placeholder='Type your code here' autocorrect="off" autocapitalize="off" spellcheck="false")
           =session.source
       .form-pair-inlined
         input(type='submit' value='Compile')


### PR DESCRIPTION
The `input` field for compiler arguments in noscript has `autocomplete` set to off, which results in the field being cleared between each compilation on Safari & Samsung Internet. 

Also, autocorrect and auto capitalization are enabled in the source code `textarea`, which makes it incredibly tedious to type anything on mobile. This PR addresses both of these issues. 