### PR TITLE
use the right source folder inside nsjail

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -26,7 +26,7 @@ import path from 'path';
 
 import fs from 'fs-extra';
 import * as PromClient from 'prom-client';
-import temp from 'temp';
+import * as temputils from './temp-utils.js';
 import _ from 'underscore';
 
 import {
@@ -115,7 +115,6 @@ import {HeaptrackWrapper} from './runtime-tools/heaptrack-wrapper.js';
 import {propsFor} from './properties.js';
 import stream from 'node:stream';
 import {SentryCapture} from './sentry.js';
-import os from 'os';
 
 const compilationTimeHistogram = new PromClient.Histogram({
     name: 'ce_base_compiler_compilation_duration_seconds',
@@ -383,9 +382,7 @@ export class BaseCompiler implements ICompiler {
     }
 
     async newTempDir(): Promise<string> {
-        // `temp` caches the os tmp dir on import (which we may change), so here we ensure we use the current os.tmpdir
-        // each time.
-        return await temp.mkdir({prefix: 'compiler-explorer-compiler', dir: os.tmpdir()});
+        return await temputils.newTempDir();
     }
 
     optOutputRequested(options: string[]) {

--- a/lib/compilers/clean.ts
+++ b/lib/compilers/clean.ts
@@ -30,6 +30,7 @@ import type {ExecutionOptions} from '../../types/compilation/compilation.interfa
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import * as utils from '../utils.js';
+import {mapTempDirToJailDir} from '../temp-utils.js';
 
 export class CleanCompiler extends BaseCompiler {
     static get key() {
@@ -118,10 +119,8 @@ export class CleanCompiler extends BaseCompiler {
         await fs.mkdir(execOptions.env.CLEANABCPATH);
         await fs.mkdir(execOptions.env.CLEANOPATH);
 
-        if (this.executionType === 'nsjail') {
-            execOptions.env.CLEANABCPATH = '/app/Clean System Files';
-            execOptions.env.CLEANOPATH = '/app/obj';
-        }
+        execOptions.env.CLEANABCPATH = mapTempDirToJailDir(execOptions.env.CLEANABCPATH, this.executionType);
+        execOptions.env.CLEANOPATH = mapTempDirToJailDir(execOptions.env.CLEANOPATH, this.executionType);
 
         const rawResult = await this.exec(compiler, options, execOptions);
         const result = {

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -150,7 +150,7 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.env.DOTNET_CLI_TELEMETRY_OPTOUT = 'true';
         // Some versions of .NET complain if they can't work out what the user's directory is. We force it to the output
         // directory here.
-        execOptions.env.DOTNET_CLI_HOME = programDir;
+        execOptions.env.DOTNET_CLI_HOME = utils.fixRootDirIfNeeded(programDir, this.executionType);
         execOptions.env.DOTNET_ROOT = path.join(this.clrBuildDir, '.dotnet');
         // Try to be less chatty
         execOptions.env.DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true';
@@ -160,7 +160,10 @@ class DotNetCompiler extends BaseCompiler {
 
         if (!skipNuget) {
             // Place nuget packages in the output directory.
-            execOptions.env.NUGET_PACKAGES = path.join(programDir, '.nuget');
+            execOptions.env.NUGET_PACKAGES = path.join(
+                utils.fixRootDirIfNeeded(programDir, this.executionType),
+                '.nuget',
+            );
         }
     }
 

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -37,6 +37,7 @@ import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.in
 import {BaseCompiler} from '../base-compiler.js';
 import {DotNetAsmParser} from '../parsers/asm-parser-dotnet.js';
 import * as utils from '../utils.js';
+import {fixRootDirIfNeeded} from '../temp-utils.js';
 
 const AssemblyName = 'CompilerExplorer';
 
@@ -150,7 +151,7 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.env.DOTNET_CLI_TELEMETRY_OPTOUT = 'true';
         // Some versions of .NET complain if they can't work out what the user's directory is. We force it to the output
         // directory here.
-        execOptions.env.DOTNET_CLI_HOME = utils.fixRootDirIfNeeded(programDir, this.executionType);
+        execOptions.env.DOTNET_CLI_HOME = fixRootDirIfNeeded(programDir, this.executionType);
         execOptions.env.DOTNET_ROOT = path.join(this.clrBuildDir, '.dotnet');
         // Try to be less chatty
         execOptions.env.DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true';
@@ -160,10 +161,7 @@ class DotNetCompiler extends BaseCompiler {
 
         if (!skipNuget) {
             // Place nuget packages in the output directory.
-            execOptions.env.NUGET_PACKAGES = path.join(
-                utils.fixRootDirIfNeeded(programDir, this.executionType),
-                '.nuget',
-            );
+            execOptions.env.NUGET_PACKAGES = path.join(fixRootDirIfNeeded(programDir, this.executionType), '.nuget');
         }
     }
 

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -447,7 +447,7 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.appHome = homeDir;
         execOptions.env = executeParameters.env;
         execOptions.env.DOTNET_EnableWriteXorExecute = '0';
-        execOptions.env.DOTNET_CLI_HOME = programDir;
+        execOptions.env.DOTNET_CLI_HOME = mapTempDirToJailDir(programDir, this.sandboxType);
         execOptions.env.CORE_ROOT = this.clrBuildDir;
         execOptions.input = executeParameters.stdin;
         const execArgs = ['-p', 'System.Runtime.TieredCompilation=false', programDllPath, ...executeParameters.args];

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -37,7 +37,7 @@ import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.in
 import {BaseCompiler} from '../base-compiler.js';
 import {DotNetAsmParser} from '../parsers/asm-parser-dotnet.js';
 import * as utils from '../utils.js';
-import {fixRootDirIfNeeded} from '../temp-utils.js';
+import {mapTempDirToJailDir} from '../temp-utils.js';
 
 const AssemblyName = 'CompilerExplorer';
 
@@ -151,7 +151,7 @@ class DotNetCompiler extends BaseCompiler {
         execOptions.env.DOTNET_CLI_TELEMETRY_OPTOUT = 'true';
         // Some versions of .NET complain if they can't work out what the user's directory is. We force it to the output
         // directory here.
-        execOptions.env.DOTNET_CLI_HOME = fixRootDirIfNeeded(programDir, this.executionType);
+        execOptions.env.DOTNET_CLI_HOME = mapTempDirToJailDir(programDir, this.executionType);
         execOptions.env.DOTNET_ROOT = path.join(this.clrBuildDir, '.dotnet');
         // Try to be less chatty
         execOptions.env.DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true';
@@ -161,7 +161,7 @@ class DotNetCompiler extends BaseCompiler {
 
         if (!skipNuget) {
             // Place nuget packages in the output directory.
-            execOptions.env.NUGET_PACKAGES = path.join(fixRootDirIfNeeded(programDir, this.executionType), '.nuget');
+            execOptions.env.NUGET_PACKAGES = path.join(mapTempDirToJailDir(programDir, this.executionType), '.nuget');
         }
     }
 

--- a/lib/external-parsers/base.ts
+++ b/lib/external-parsers/base.ts
@@ -5,9 +5,9 @@ import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.j
 import type {TypicalExecutionFunc, UnprocessedExecResult} from '../../types/execution/execution.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {logger} from '../logger.js';
-import {maskRootdir} from '../utils.js';
 
 import {IExternalParser} from './external-parser.interface.js';
+import {maskRootdir} from '../temp-utils.js';
 
 const starterScriptName = 'dump-and-parse.sh';
 

--- a/lib/parsers/asm-parser-dart.ts
+++ b/lib/parsers/asm-parser-dart.ts
@@ -30,7 +30,7 @@ import {
 } from '../../types/asmresult/asmresult.interfaces.js';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {assert} from '../assert.js';
-import * as utils from '../utils.js';
+import {maskRootdir} from '../temp-utils.js';
 
 import {AsmParser} from './asm-parser.js';
 import {AsmRegex} from './asmregex.js';
@@ -92,7 +92,7 @@ export class DartAsmParser extends AsmParser {
                 assert(match.groups);
                 if (dontMaskFilenames) {
                     source = {
-                        file: utils.maskRootdir(match[1]),
+                        file: maskRootdir(match[1]),
                         line: parseInt(match.groups.line),
                         mainsource: true,
                     };

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {AsmResultLabel, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
+import {maskRootdir} from '../temp-utils.js';
 import * as utils from '../utils.js';
 
 import {AsmParser} from './asm-parser.js';
@@ -127,7 +128,7 @@ export class SPIRVAsmParser extends AsmParser {
             const match = line.match(sourceTag);
             if (match) {
                 source = {
-                    file: utils.maskRootdir(opStrings[parseInt(match[1])]),
+                    file: maskRootdir(opStrings[parseInt(match[1])]),
                     line: parseInt(match[2]),
                     mainsource: true,
                 };

--- a/lib/parsers/asm-parser-z88dk.ts
+++ b/lib/parsers/asm-parser-z88dk.ts
@@ -7,6 +7,7 @@ import {
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {assert} from '../assert.js';
 import {PropertyGetter} from '../properties.interfaces.js';
+import {maskRootdir} from '../temp-utils.js';
 import * as utils from '../utils.js';
 
 import {AsmParser} from './asm-parser.js';
@@ -62,7 +63,7 @@ export class AsmParserZ88dk extends AsmParser {
             const match = line.match(this.sourceTag);
             if (match) {
                 const sourceLine = parseInt(match[1]);
-                const file = utils.maskRootdir(match[2]);
+                const file = maskRootdir(match[2]);
                 if (file) {
                     if (dontMaskFilenames) {
                         source = {

--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -38,6 +38,7 @@ import * as utils from '../utils.js';
 
 import {IAsmParser} from './asm-parser.interfaces.js';
 import {AsmRegex} from './asmregex.js';
+import {maskRootdir} from '../temp-utils.js';
 
 export type ParsingContext = {
     files: Record<number, string>;
@@ -384,7 +385,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
     protected handleSource(context: ParsingContext, line: string) {
         let match = line.match(this.sourceTag);
         if (match) {
-            const file = utils.maskRootdir(context.files[parseInt(match[1])]);
+            const file = maskRootdir(context.files[parseInt(match[1])]);
             const sourceLine = parseInt(match[2]);
             if (file) {
                 if (context.dontMaskFilenames) {
@@ -419,7 +420,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 if (match) {
                     // cv_loc reports: function file line column
                     const sourceLine = parseInt(match[3]);
-                    const file = utils.maskRootdir(context.files[parseInt(match[2])]);
+                    const file = maskRootdir(context.files[parseInt(match[2])]);
                     if (context.dontMaskFilenames) {
                         context.source = {
                             file: file,
@@ -462,7 +463,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
     protected handle6502(context: ParsingContext, line: string) {
         const match = line.match(this.source6502Dbg);
         if (match) {
-            const file = utils.maskRootdir(match[1]);
+            const file = maskRootdir(match[1]);
             const sourceLine = parseInt(match[2]);
             if (context.dontMaskFilenames) {
                 context.source = {
@@ -724,7 +725,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 assert(match.groups);
                 if (dontMaskFilenames) {
                     source = {
-                        file: utils.maskRootdir(match[1]),
+                        file: maskRootdir(match[1]),
                         line: parseInt(match.groups.line),
                         mainsource: true,
                     };

--- a/lib/temp-utils.ts
+++ b/lib/temp-utils.ts
@@ -65,7 +65,7 @@ export function maskRootdir(filepath: string): string {
  * @param jailtype - the type of jail can be: 'nsjail', 'firejail', 'cewrapper', or ''/'none'
  * @returns
  */
-export function fixRootDirIfNeeded(filepath: string, jailtype: string): string {
+export function mapTempDirToJailDir(filepath: string, jailtype: string): string {
     if (filepath && jailtype === 'nsjail') {
         const hasTrailingSlash = filepath.endsWith('/');
         const re = getRegexForTempdir();

--- a/lib/temp-utils.ts
+++ b/lib/temp-utils.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import temp from 'temp';
+import os from 'os';
+
+const temp_prefix = 'compiler-explorer-compiler';
+
+export async function newTempDir(): Promise<string> {
+    // `temp` caches the os tmp dir on import (which we may change), so here we ensure we use the current os.tmpdir
+    // each time.
+    return await temp.mkdir({prefix: temp_prefix, dir: os.tmpdir()});
+}
+
+function getRegexForTempdir(): RegExp {
+    const tmp = os.tmpdir();
+    return new RegExp(tmp.replaceAll('/', '\\/') + '\\/' + temp_prefix + '[\\w\\d-.]*\\/');
+}
+
+export function maskRootdir(filepath: string): string {
+    if (filepath) {
+        // todo: make this compatible with local installations etc
+        if (process.platform === 'win32') {
+            return filepath
+                .replace(/^C:\/Users\/[\w\d-.]*\/AppData\/Local\/Temp\/compiler-explorer-compiler[\w\d-.]*\//, '/app/')
+                .replace(/^\/app\//, '');
+        } else {
+            const re = getRegexForTempdir();
+            return filepath.replace(re, '/app/').replace(/^\/app\//, '');
+        }
+    } else {
+        return filepath;
+    }
+}
+
+export function fixRootDirIfNeeded(filepath: string, jailtype: string): string {
+    if (filepath && jailtype === 'nsjail') {
+        const hasTrailingSlash = filepath.endsWith('/');
+        const re = getRegexForTempdir();
+        if (hasTrailingSlash) {
+            return filepath.replace(re, '/app/');
+        } else {
+            return (filepath + '/').replace(re, '/app/').replace(/\/$/, '');
+        }
+    } else {
+        return filepath;
+    }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -31,10 +31,10 @@ import {ComponentConfig, ItemConfigType} from 'golden-layout';
 import semverParser from 'semver';
 import {parse as quoteParse} from 'shell-quote';
 import _ from 'underscore';
-import os from 'os';
 
 import type {CacheableValue} from '../types/cache.interfaces.js';
 import type {ResultLine} from '../types/resultline/resultline.interfaces.js';
+import {maskRootdir} from './temp-utils.js';
 
 const tabsRe = /\t/g;
 const lineRe = /\r?\n/;
@@ -58,38 +58,6 @@ export function expandTabs(line: string): string {
         extraChars += spacesNeeded - 1;
         return '        '.substr(spacesNeeded);
     });
-}
-
-export function maskRootdir(filepath: string): string {
-    if (filepath) {
-        // todo: make this compatible with local installations etc
-        if (process.platform === 'win32') {
-            return filepath
-                .replace(/^C:\/Users\/[\w\d-.]*\/AppData\/Local\/Temp\/compiler-explorer-compiler[\w\d-.]*\//, '/app/')
-                .replace(/^\/app\//, '');
-        } else {
-            const tmp = os.tmpdir();
-            const re = new RegExp(tmp.replaceAll('/', '\\/') + '\\/compiler-explorer-compiler[\\w\\d-.]*\\/');
-            return filepath.replace(re, '/app/').replace(/^\/app\//, '');
-        }
-    } else {
-        return filepath;
-    }
-}
-
-export function fixRootDirIfNeeded(filepath: string, jailtype: string): string {
-    if (filepath && jailtype === 'nsjail') {
-        const hasTrailingSlash = filepath.endsWith('/');
-        const tmp = os.tmpdir();
-        const re = new RegExp(tmp.replaceAll('/', '\\/') + '\\/compiler-explorer-compiler[\\w\\d-.]*\\/');
-        if (hasTrailingSlash) {
-            return filepath.replace(re, '/app/');
-        } else {
-            return (filepath + '/').replace(re, '/app/').replace(/\/$/, '');
-        }
-    } else {
-        return filepath;
-    }
 }
 
 export function changeExtension(filename: string, newExtension: string): string {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -31,6 +31,7 @@ import {ComponentConfig, ItemConfigType} from 'golden-layout';
 import semverParser from 'semver';
 import {parse as quoteParse} from 'shell-quote';
 import _ from 'underscore';
+import os from 'os';
 
 import type {CacheableValue} from '../types/cache.interfaces.js';
 import type {ResultLine} from '../types/resultline/resultline.interfaces.js';
@@ -67,7 +68,24 @@ export function maskRootdir(filepath: string): string {
                 .replace(/^C:\/Users\/[\w\d-.]*\/AppData\/Local\/Temp\/compiler-explorer-compiler[\w\d-.]*\//, '/app/')
                 .replace(/^\/app\//, '');
         } else {
-            return filepath.replace(/^\/tmp\/compiler-explorer-compiler[\w\d-.]*\//, '/app/').replace(/^\/app\//, '');
+            const tmp = os.tmpdir();
+            const re = new RegExp(tmp.replaceAll('/', '\\/') + '\\/compiler-explorer-compiler[\\w\\d-.]*\\/');
+            return filepath.replace(re, '/app/').replace(/^\/app\//, '');
+        }
+    } else {
+        return filepath;
+    }
+}
+
+export function fixRootDirIfNeeded(filepath: string, jailtype: string): string {
+    if (filepath && jailtype === 'nsjail') {
+        const hasTrailingSlash = filepath.endsWith('/');
+        const tmp = os.tmpdir();
+        const re = new RegExp(tmp.replaceAll('/', '\\/') + '\\/compiler-explorer-compiler[\\w\\d-.]*\\/');
+        if (hasTrailingSlash) {
+            return filepath.replace(re, '/app/');
+        } else {
+            return (filepath + '/').replace(re, '/app/').replace(/\/$/, '');
         }
     } else {
         return filepath;

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -29,6 +29,7 @@ import {fileURLToPath} from 'url';
 import winston from 'winston';
 
 import {makeLogStream} from '../lib/logger.js';
+import * as temputils from '../lib/temp-utils.js';
 import * as utils from '../lib/utils.js';
 
 import {fs} from './utils.js';
@@ -619,13 +620,13 @@ describe('argument splitting', () => {
 describe('tmp dir fixing (depends on jailtype)', () => {
     it('should replace when used with sourcefile', () => {
         if (process.platform !== 'win32') {
-            utils
+            temputils
                 .fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail')
                 .should.equal('/app/example.cpp');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            utils
+            temputils
                 .fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail')
                 .should.equal('/app/example.cpp');
             process.env.TMP = oldTmp;
@@ -633,13 +634,13 @@ describe('tmp dir fixing (depends on jailtype)', () => {
     });
     it('should replace when used with subdir', () => {
         if (process.platform !== 'win32') {
-            utils
+            temputils
                 .fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail')
                 .should.equal('/app/.nuget');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            utils
+            temputils
                 .fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail')
                 .should.equal('/app/.nuget');
             process.env.TMP = oldTmp;
@@ -647,11 +648,11 @@ describe('tmp dir fixing (depends on jailtype)', () => {
     });
     it('should replace when used without suffix', () => {
         if (process.platform !== 'win32') {
-            utils.fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
+            temputils.fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            utils.fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
+            temputils.fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
             process.env.TMP = oldTmp;
         }
     });
@@ -660,15 +661,17 @@ describe('tmp dir fixing (depends on jailtype)', () => {
 describe('tmp dir masking (for source annotations)', () => {
     it('should replace when used with sourcefile', () => {
         if (process.platform !== 'win32') {
-            utils.maskRootdir('/tmp/compiler-explorer-compiler-123abc/example.cpp').should.equal('example.cpp');
-            utils
+            temputils.maskRootdir('/tmp/compiler-explorer-compiler-123abc/example.cpp').should.equal('example.cpp');
+            temputils
                 .maskRootdir('/tmp/compiler-explorer-compiler-123abc/subdir/myheader.h')
                 .should.equal('subdir/myheader.h');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            utils.maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp').should.equal('example.cpp');
-            utils
+            temputils
+                .maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp')
+                .should.equal('example.cpp');
+            temputils
                 .maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/subdir/myheader.h')
                 .should.equal('subdir/myheader.h');
             process.env.TMP = oldTmp;

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -29,7 +29,7 @@ import {fileURLToPath} from 'url';
 import winston from 'winston';
 
 import {makeLogStream} from '../lib/logger.js';
-import {fixRootDirIfNeeded, maskRootdir} from '../lib/temp-utils.js';
+import {mapTempDirToJailDir, maskRootdir} from '../lib/temp-utils.js';
 import * as utils from '../lib/utils.js';
 
 import {fs} from './utils.js';
@@ -620,13 +620,13 @@ describe('argument splitting', () => {
 describe('tmp dir fixing (depends on jailtype)', () => {
     it('should replace when used with sourcefile', () => {
         if (process.platform !== 'win32') {
-            fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail').should.equal(
+            mapTempDirToJailDir('/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail').should.equal(
                 '/app/example.cpp',
             );
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail').should.equal(
+            mapTempDirToJailDir('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail').should.equal(
                 '/app/example.cpp',
             );
             process.env.TMP = oldTmp;
@@ -634,11 +634,11 @@ describe('tmp dir fixing (depends on jailtype)', () => {
     });
     it('should replace when used with subdir', () => {
         if (process.platform !== 'win32') {
-            fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail').should.equal('/app/.nuget');
+            mapTempDirToJailDir('/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail').should.equal('/app/.nuget');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail').should.equal(
+            mapTempDirToJailDir('/nosym/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail').should.equal(
                 '/app/.nuget',
             );
             process.env.TMP = oldTmp;
@@ -646,11 +646,11 @@ describe('tmp dir fixing (depends on jailtype)', () => {
     });
     it('should replace when used without suffix', () => {
         if (process.platform !== 'win32') {
-            fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
+            mapTempDirToJailDir('/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
+            mapTempDirToJailDir('/nosym/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
             process.env.TMP = oldTmp;
         }
     });

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -29,7 +29,7 @@ import {fileURLToPath} from 'url';
 import winston from 'winston';
 
 import {makeLogStream} from '../lib/logger.js';
-import * as temputils from '../lib/temp-utils.js';
+import {fixRootDirIfNeeded, maskRootdir} from '../lib/temp-utils.js';
 import * as utils from '../lib/utils.js';
 
 import {fs} from './utils.js';
@@ -620,39 +620,37 @@ describe('argument splitting', () => {
 describe('tmp dir fixing (depends on jailtype)', () => {
     it('should replace when used with sourcefile', () => {
         if (process.platform !== 'win32') {
-            temputils
-                .fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail')
-                .should.equal('/app/example.cpp');
+            fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail').should.equal(
+                '/app/example.cpp',
+            );
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            temputils
-                .fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail')
-                .should.equal('/app/example.cpp');
+            fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp', 'nsjail').should.equal(
+                '/app/example.cpp',
+            );
             process.env.TMP = oldTmp;
         }
     });
     it('should replace when used with subdir', () => {
         if (process.platform !== 'win32') {
-            temputils
-                .fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail')
-                .should.equal('/app/.nuget');
+            fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail').should.equal('/app/.nuget');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            temputils
-                .fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail')
-                .should.equal('/app/.nuget');
+            fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc/.nuget', 'nsjail').should.equal(
+                '/app/.nuget',
+            );
             process.env.TMP = oldTmp;
         }
     });
     it('should replace when used without suffix', () => {
         if (process.platform !== 'win32') {
-            temputils.fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
+            fixRootDirIfNeeded('/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            temputils.fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
+            fixRootDirIfNeeded('/nosym/tmp/compiler-explorer-compiler-123abc', 'nsjail').should.equal('/app');
             process.env.TMP = oldTmp;
         }
     });
@@ -661,19 +659,15 @@ describe('tmp dir fixing (depends on jailtype)', () => {
 describe('tmp dir masking (for source annotations)', () => {
     it('should replace when used with sourcefile', () => {
         if (process.platform !== 'win32') {
-            temputils.maskRootdir('/tmp/compiler-explorer-compiler-123abc/example.cpp').should.equal('example.cpp');
-            temputils
-                .maskRootdir('/tmp/compiler-explorer-compiler-123abc/subdir/myheader.h')
-                .should.equal('subdir/myheader.h');
+            maskRootdir('/tmp/compiler-explorer-compiler-123abc/example.cpp').should.equal('example.cpp');
+            maskRootdir('/tmp/compiler-explorer-compiler-123abc/subdir/myheader.h').should.equal('subdir/myheader.h');
 
             const oldTmp = os.tmpdir();
             process.env.TMP = '/nosym/tmp';
-            temputils
-                .maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp')
-                .should.equal('example.cpp');
-            temputils
-                .maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/subdir/myheader.h')
-                .should.equal('subdir/myheader.h');
+            maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/example.cpp').should.equal('example.cpp');
+            maskRootdir('/nosym/tmp/compiler-explorer-compiler-123abc/subdir/myheader.h').should.equal(
+                'subdir/myheader.h',
+            );
             process.env.TMP = oldTmp;
         }
     });


### PR DESCRIPTION
Fixes #6069

Utils function taken from https://github.com/compiler-explorer/compiler-explorer/pull/5533 but altered to reflect changes `os.tmpdir()`

Probably needs a better name
