### PR TITLE
Replace the deprecated `monaco.editor.ICodeEditor.deltaDecorations` 

### DIFF
--- a/static/colour.ts
+++ b/static/colour.ts
@@ -72,12 +72,12 @@ export const schemes: ColourSchemeInfo[] = [
     },
 ];
 
+// In every MonacoPane-child that needs to use this, make sure `createEditor` calls `this.initDecorations()`
 export function applyColours(
-    editor: monaco.editor.ICodeEditor,
     colours: Record<number, number>,
     schemeName: string,
-    previousDecorations: string[],
-): string[] {
+    editorDecorations: monaco.editor.IEditorDecorationsCollection,
+): void {
     const scheme = schemes.find(scheme => scheme.name === schemeName) ?? schemes[0];
     const newDecorations: monaco.editor.IModelDeltaDecoration[] = Object.entries(colours).map(([line, index]) => {
         const realLineNumber = parseInt(line) + 1;
@@ -90,5 +90,5 @@ export function applyColours(
         };
     });
 
-    return editor.deltaDecorations(previousDecorations, newDecorations);
+    editorDecorations.set(newDecorations);
 }

--- a/static/modes/no-highlight-mode.ts
+++ b/static/modes/no-highlight-mode.ts
@@ -25,7 +25,9 @@ import * as monaco from 'monaco-editor';
 
 function definition(): monaco.languages.IMonarchLanguage {
     return {
-        tokenizer: {},
+        tokenizer: {
+            root: [[/.*/, 'token']],
+        },
     };
 }
 

--- a/static/panes/ast-view.ts
+++ b/static/panes/ast-view.ts
@@ -109,8 +109,8 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
         this.editor.onDidChangeCursorSelection(e => cursorSelectionThrottledFunction(e));
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig({
                 language: 'plaintext',
@@ -119,6 +119,7 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
                 lineNumbersMinChars: 3,
             }),
         );
+        this.initDecorations();
     }
 
     override getPrintName() {
@@ -248,7 +249,7 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
                     }
                 }
             }
-            this.colours = colour.applyColours(this.editor, astColours, scheme, this.colours);
+            colour.applyColours(astColours, scheme, this.editorDecorations);
         }
     }
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3681,12 +3681,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         const model = this.editor.getModel();
         if (!model || line > model.getLineCount()) return [];
         const flavour = model.getLanguageId();
-        let tokens;
-        try {
-            tokens = monaco.editor.tokenize(model.getLineContent(line), flavour);
-        } catch (err) {
-            SentryCapture(err, `Error tokenizing line: ${line}, language: ${flavour}`);
-        }
+        const tokens = monaco.editor.tokenize(model.getLineContent(line), flavour);
         return tokens.length > 0 ? tokens[0] : [];
     }
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -160,7 +160,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     private options: string;
     private source: string;
     private assembly: Assembly[];
-    private colours: string[];
     private lastResult: CompilationResult | null;
     private lastTimeTaken: number;
     private pendingRequestSentAt: number;
@@ -291,7 +290,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
         this.source = '';
         this.assembly = [];
-        this.colours = [];
         this.lastResult = null;
 
         this.lastTimeTaken = 0;
@@ -372,7 +370,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     }
 
     override createEditor(editorRoot: HTMLElement) {
-        return monaco.editor.create(
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig(
                 {
@@ -391,6 +389,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 this.settings,
             ),
         );
+        this.initDecorations();
     }
 
     override getPrintName() {
@@ -3256,13 +3255,13 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         });
 
         Object.values(asmColours).forEach(col => {
-            this.colours = colour.applyColours(this.editor, col, scheme, this.colours);
+            colour.applyColours(col, scheme, this.editorDecorations);
         });
     }
 
     onColoursForCompiler(compilerId: number, colours: Record<number, number>, scheme: string): void {
         if (this.id === compilerId) {
-            this.colours = colour.applyColours(this.editor, colours, scheme, this.colours);
+            colour.applyColours(colours, scheme, this.editorDecorations);
         }
     }
 
@@ -3682,7 +3681,12 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         const model = this.editor.getModel();
         if (!model || line > model.getLineCount()) return [];
         const flavour = model.getLanguageId();
-        const tokens = monaco.editor.tokenize(model.getLineContent(line), flavour);
+        let tokens;
+        try {
+            tokens = monaco.editor.tokenize(model.getLineContent(line), flavour);
+        } catch (err) {
+            SentryCapture(err, `Error tokenizing line: ${line}, language: ${flavour}`);
+        }
         return tokens.length > 0 ? tokens[0] : [];
     }
 

--- a/static/panes/device-view.ts
+++ b/static/panes/device-view.ts
@@ -47,7 +47,6 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
     private prevDecorations: string[];
     private selectedDevice: string;
     private devices: Record<string, CompilationResult> | null;
-    private colours: string[];
     private deviceCode: ResultLine[];
     private lastColours: Record<number, number>;
     private lastColourScheme: string;
@@ -67,7 +66,6 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
         this.selectedDevice = state.device || '';
         this.devices = null;
 
-        this.colours = [];
         this.deviceCode = [];
         this.lastColours = [];
         this.lastColourScheme = '';
@@ -88,8 +86,8 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
         return $('#device').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig({
                 language: 'asm',
@@ -98,6 +96,7 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
                 lineNumbersMinChars: 3,
             }),
         );
+        this.initDecorations();
     }
 
     override getPrintName() {
@@ -383,7 +382,7 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
                     irColours[index] = colours[x.source.line - 1];
                 }
             });
-            this.colours = colour.applyColours(this.editor, irColours, scheme, this.colours);
+            colour.applyColours(irColours, scheme, this.editorDecorations);
         }
     }
 

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -72,7 +72,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     private asmByCompiler: Record<string, ResultLine[] | undefined>;
     private defaultFileByCompiler: Record<number, string>;
     private busyCompilers: Record<number, boolean>;
-    private colours: string[];
     private treeCompilers: Record<number, Record<number, boolean> | undefined>;
     private decorations: Record<string, IModelDeltaDecoration[] | undefined>;
     private prevDecorations: string[];
@@ -180,7 +179,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.asmByCompiler = {};
         this.defaultFileByCompiler = {};
         this.busyCompilers = {};
-        this.colours = [];
         this.treeCompilers = {};
 
         this.decorations = {};
@@ -213,8 +211,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         return $('#codeEditor').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): editor.IStandaloneCodeEditor {
-        const editor = monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig(
                 {
@@ -229,9 +227,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             ),
         );
 
-        editor.getModel()?.setEOL(monaco.editor.EndOfLineSequence.LF);
-
-        return editor;
+        this.editor.getModel()?.setEOL(monaco.editor.EndOfLineSequence.LF);
+        this.initDecorations();
     }
 
     override getPrintName() {
@@ -1355,7 +1352,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     }
 
     updateColours(colours) {
-        this.colours = colour.applyColours(this.editor, colours, this.settings.colourScheme, this.colours);
+        colour.applyColours(colours, this.settings.colourScheme, this.editorDecorations);
         this.eventHub.emit('colours', this.id, colours, this.settings.colourScheme);
     }
 
@@ -1408,7 +1405,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
 
     onColoursForEditor(editorId: number, colours: Record<number, number>, scheme: string): void {
         if (this.id === editorId) {
-            this.colours = colour.applyColours(this.editor, colours, scheme, this.colours);
+            colour.applyColours(colours, scheme, this.editorDecorations);
         }
     }
 

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -138,8 +138,8 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         return $('#gccdump').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig({
                 readOnly: true,

--- a/static/panes/gnatdebug-view.ts
+++ b/static/panes/gnatdebug-view.ts
@@ -50,8 +50,8 @@ export class GnatDebug extends MonacoPane<monaco.editor.IStandaloneCodeEditor, G
         return $('#gnatdebug').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'ada',

--- a/static/panes/gnatdebugtree-view.ts
+++ b/static/panes/gnatdebugtree-view.ts
@@ -50,8 +50,8 @@ export class GnatDebugTree extends MonacoPane<monaco.editor.IStandaloneCodeEdito
         return $('#gnatdebugtree').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'plainText',

--- a/static/panes/haskellcmm-view.ts
+++ b/static/panes/haskellcmm-view.ts
@@ -49,8 +49,8 @@ export class HaskellCmm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
         return $('#haskellCmm').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'haskell',

--- a/static/panes/haskellcore-view.ts
+++ b/static/panes/haskellcore-view.ts
@@ -49,8 +49,8 @@ export class HaskellCore extends MonacoPane<monaco.editor.IStandaloneCodeEditor,
         return $('#haskellCore').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'haskell',

--- a/static/panes/haskellstg-view.ts
+++ b/static/panes/haskellstg-view.ts
@@ -49,8 +49,8 @@ export class HaskellStg extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
         return $('#haskellStg').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'haskell',

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -76,8 +76,8 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
         return $('#ir').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'llvm-ir',
@@ -86,6 +86,7 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
                 lineNumbersMinChars: 3,
             }),
         );
+        this.initDecorations();
     }
 
     override getPrintName() {
@@ -260,7 +261,7 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
                 irColours[index] = colours[code.source.line - 1];
             }
         }
-        this.colours = applyColours(this.editor, irColours, scheme, this.colours);
+        applyColours(irColours, scheme, this.editorDecorations);
     }
 
     onMouseMove(e: monaco.editor.IEditorMouseEvent): void {

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -168,9 +168,9 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         return monacoLanguage;
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneDiffEditor {
+    override createEditor(editorRoot: HTMLElement): void {
         const monacoLanguage = this.getMonacoLanguage();
-        const editor = monaco.editor.createDiffEditor(
+        this.editor = monaco.editor.createDiffEditor(
             editorRoot,
             extendConfig({
                 language: monacoLanguage,
@@ -181,8 +181,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         );
         this.originalModel = monaco.editor.createModel('', monacoLanguage);
         this.modifiedModel = monaco.editor.createModel('', monacoLanguage);
-        editor.setModel({original: this.originalModel, modified: this.modifiedModel});
-        return editor;
+        this.editor.setModel({original: this.originalModel, modified: this.modifiedModel});
     }
 
     updateEditor() {

--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -55,8 +55,8 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
         return $('#opt').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'plaintext',

--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -280,6 +280,7 @@ export abstract class Pane<S> {
  */
 export abstract class MonacoPane<E extends monaco.editor.IEditor, S> extends Pane<S> {
     editor: E;
+    editorDecorations: monaco.editor.IEditorDecorationsCollection;
     selection: monaco.Selection | undefined = undefined;
     fontScale: FontScale;
 
@@ -292,7 +293,7 @@ export abstract class MonacoPane<E extends monaco.editor.IEditor, S> extends Pan
 
     override registerButtons(state: S): void {
         const editorRoot = this.domRoot.find('.monaco-placeholder')[0];
-        this.editor = this.createEditor(editorRoot);
+        this.createEditor(editorRoot);
         this.fontScale = new FontScale(this.domRoot, state, this.editor);
     }
 
@@ -326,7 +327,11 @@ export abstract class MonacoPane<E extends monaco.editor.IEditor, S> extends Pan
      * }));
      * ```
      */
-    abstract createEditor(editorRoot: HTMLElement): E;
+    abstract createEditor(editorRoot: HTMLElement): void;
+
+    initDecorations(): void {
+        this.editorDecorations = this.editor.createDecorationsCollection();
+    }
 
     protected override onSettingsChange(settings: SiteSettings) {
         super.onSettingsChange(settings);

--- a/static/panes/pp-view.ts
+++ b/static/panes/pp-view.ts
@@ -56,8 +56,8 @@ export class PP extends MonacoPane<monaco.editor.IStandaloneCodeEditor, PPViewSt
         return $('#pp').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig({
                 language: 'plaintext',

--- a/static/panes/rusthir-view.ts
+++ b/static/panes/rusthir-view.ts
@@ -49,8 +49,8 @@ export class RustHir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Rus
         return $('#rusthir').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'plainText',

--- a/static/panes/rustmacroexp-view.ts
+++ b/static/panes/rustmacroexp-view.ts
@@ -49,8 +49,8 @@ export class RustMacroExp extends MonacoPane<monaco.editor.IStandaloneCodeEditor
         return $('#rustmacroexp').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'rust',

--- a/static/panes/rustmir-view.ts
+++ b/static/panes/rustmir-view.ts
@@ -49,8 +49,8 @@ export class RustMir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Rus
         return $('#rustmir').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'rust',

--- a/static/panes/stack-usage-view.ts
+++ b/static/panes/stack-usage-view.ts
@@ -55,8 +55,8 @@ export class StackUsage extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
         return $('#stackusage').html();
     }
 
-    override createEditor(editorRoot: HTMLElement): monaco.editor.IStandaloneCodeEditor {
-        return monaco.editor.create(
+    override createEditor(editorRoot: HTMLElement): void {
+        this.editor = monaco.editor.create(
             editorRoot,
             extendConfig({
                 language: 'plaintext',

--- a/static/panes/tool-input-view.ts
+++ b/static/panes/tool-input-view.ts
@@ -60,7 +60,7 @@ export class ToolInputView extends MonacoPane<monaco.editor.IStandaloneCodeEdito
     }
 
     override createEditor(editorRoot: HTMLElement) {
-        return monaco.editor.create(
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig({
                 value: '',

--- a/static/panes/tool.ts
+++ b/static/panes/tool.ts
@@ -126,7 +126,7 @@ export class Tool extends MonacoPane<monaco.editor.IStandaloneCodeEditor, ToolSt
     }
 
     override createEditor(editorRoot: HTMLElement) {
-        return monaco.editor.create(
+        this.editor = monaco.editor.create(
             editorRoot,
             monacoConfig.extendConfig({
                 readOnly: true,


### PR DESCRIPTION
…with `monaco.editor.IEditorDecorationsCollection`

Seems that today the official way of colouring monaco editors is having them `createDecorationsCollection`, keep the resulting decorations-collection and call `set` on it with new decorations whenever needed. 
There are many possible design choices on where to put it, I opted to put `editorDecorations` in `MonacoPane`, and have `MonacoPane.createEditor` initialize it only in panes where decorations are actually used. 
Also some signatures changed which had a broad (but non-interesting) impact.




