### PR TITLE
Fix nsjail environment variables that need mapping to destination paths

### DIFF
--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -247,7 +247,8 @@ export function getNsJailOptions(
     }
 
     for (const [key, value] of Object.entries(env)) {
-        if (value !== undefined) jailingOptions.push(`--env=${key}=${value}`);
+        const transform = filenameTransform || (x => x);
+        if (value !== undefined) jailingOptions.push(`--env=${key}=${transform(value)}`);
     }
     delete options.env;
 

--- a/test/exec-tests.ts
+++ b/test/exec-tests.ts
@@ -329,6 +329,26 @@ describe('Execution tests', () => {
                 './output.s',
             ]);
         });
+        it('Should remap env vars', () => {
+            const {args, options} = exec.getSandboxNsjailOptions('/tmp/hellow/output.s', [], {
+                customCwd: '/tmp/hellow',
+                env: {SOME_DOTNET_THING: '/tmp/hellow/dotnet'},
+            });
+
+            options.should.deep.equals({});
+            args.should.deep.equals([
+                '--config',
+                'etc/nsjail/sandbox.cfg',
+                '--cwd',
+                '/app',
+                '--bindmount',
+                '/tmp/hellow:/app',
+                '--env=SOME_DOTNET_THING=/app/dotnet',
+                '--env=HOME=/app',
+                '--',
+                './output.s',
+            ]);
+        });
 
         it('Subdirectory', () => {
             const {args, options} = exec.getSandboxNsjailOptions('/tmp/hellow/subdir/output.s', [], {


### PR DESCRIPTION
Maps env vars just like we map everything else, to catch all cases where "app dir" is an input to jailed processes, the jailed process only sees the "right" path (`/app/something`).

Tested locally and fixes the dot net "read only `/nosym`" thing while keeping the `/nosym` behaviour etc