### PR TITLE
fix: clang trunk should use gcc trunk

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -296,13 +296,13 @@ compiler.cclang_trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_trunk.semver=(trunk)
 compiler.cclang_trunk.isNightly=true
-compiler.cclang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 compiler.cclang_assertions_trunk.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
 compiler.cclang_assertions_trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_assertions_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_assertions_trunk.semver=(assertions trunk)
 compiler.cclang_assertions_trunk.isNightly=true
-compiler.cclang_assertions_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang_assertions_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 compiler.cclang_dang.exe=/opt/compiler-explorer/clang-dang-main/bin/clang
 compiler.cclang_dang.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cclang_dang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
clang trunk for C was using gcc-9, which caused mismatch between compiler and actual binutils supports:

 /opt/compiler-explorer/gcc-9.2.0/lib/gcc/x86_64-linux-gnu/9.2.0/../../../../x86_64-linux-gnu/bin/ld:
 warning: /lib/x86_64-linux-gnu/libc.so.6: unsupported
 GNU_PROPERTY_TYPE (5) type: 0xc0008002

This is not the case in the C++ config where we correctly use nightly gcc.