### PR TITLE
Add LDC 1.36.0 and make it the default

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,14 +1,14 @@
 compilers=&gdc:&ldc:&dmd:&gdccross
-defaultCompiler=ldc1_35
+defaultCompiler=ldc1_36
 
 group.gdc.compilers=gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc131:gdc132:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
 group.gdc.baseName=gdc
-group.gdc.demangler=/opt/compiler-explorer/ldc1.31.0/ldc2-1.31.0-linux-x86_64/bin/ddemangle
+group.gdc.demangler=/opt/compiler-explorer/ldc1.36.0/ldc2-1.36.0-linux-x86_64/bin/ddemangle
 group.gdc.objdumper=/opt/compiler-explorer/gcc-12.2.0/bin/objdump
-group.gdc.llvmSymbolizer=/opt/compiler-explorer/clang-14.0.0/bin/llvm-symbolizer
+group.gdc.llvmSymbolizer=/opt/compiler-explorer/clang-17.0.1/bin/llvm-symbolizer
 
 compiler.gdc49.exe=/opt/compiler-explorer/gdc4.9.3/x86_64-pc-linux-gnu/bin/gdc
 compiler.gdc49.alias=/opt/x86_64-gdcproject-linux-gnu/bin/gdc
@@ -396,13 +396,13 @@ compiler.gdcmipsel1320.semver=13.2.0
 compiler.gdcmipsel1320.objdumper=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gdcmipsel1320.demangler=/opt/compiler-explorer/mipsel/gcc-13.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
-group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldc1_28:ldc1_29:ldc1_30:ldc1_31:ldc1_32:ldc1_33:ldc1_34:ldc1_35:ldcbeta:ldclatestci
+group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldc1_28:ldc1_29:ldc1_30:ldc1_31:ldc1_32:ldc1_33:ldc1_34:ldc1_35:ldc1_36:ldcbeta:ldclatestci
 group.ldc.compilerType=ldc
 group.ldc.isSemVer=true
 group.ldc.baseName=ldc
-group.ldc.demangler=/opt/compiler-explorer/ldc1.35.0/ldc2-1.35.0-linux-x86_64/bin/ddemangle
+group.ldc.demangler=/opt/compiler-explorer/ldc1.36.0/ldc2-1.36.0-linux-x86_64/bin/ddemangle
 group.ldc.objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
-group.ldc.llvmSymbolizer=/opt/compiler-explorer/clang-14.0.0/bin/llvm-symbolizer
+group.ldc.llvmSymbolizer=/opt/compiler-explorer/clang-17.0.1/bin/llvm-symbolizer
 
 compiler.ldc017.exe=/opt/compiler-explorer/ldc0.17.2/ldc2-0.17.2-linux-x86_64/bin/ldc2
 compiler.ldc017.semver=0.17.2
@@ -495,6 +495,9 @@ compiler.ldc1_34.options=-gcc=gcc
 compiler.ldc1_35.exe=/opt/compiler-explorer/ldc1.35.0/ldc2-1.35.0-linux-x86_64/bin/ldc2
 compiler.ldc1_35.semver=1.35.0
 compiler.ldc1_35.options=-gcc=gcc
+compiler.ldc1_36.exe=/opt/compiler-explorer/ldc1.36.0/ldc2-1.36.0-linux-x86_64/bin/ldc2
+compiler.ldc1_36.semver=1.36.0
+compiler.ldc1_36.options=-gcc=gcc
 compiler.ldcbeta.exe=/opt/compiler-explorer/ldcbeta/bin/ldc2
 compiler.ldcbeta.semver=beta
 compiler.ldcbeta.options=-gcc=gcc


### PR DESCRIPTION
Also update llvm-symbolizer to LLVM 17 (I hope the clang 17 package contains llvm-symbolizer like before ;-)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
