### PR TITLE
[CI] Fix labeler configuration vor labler@v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,217 +1,383 @@
 ui:
-  - static/**/*
-  - views/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'static/**/*'
+          - 'views/**/*'
+
 lang-ada:
-  - lib/compilers/ada.ts
-  - etc/config/ada.*.properties
-  - static/modes/ada-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/ada.ts'
+          - 'etc/config/ada.*.properties'
+          - 'static/modes/ada-mode.ts'
+
 lang-android-java:
-  - lib/compilers/d8.ts
-  - etc/config/android-java.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/d8.ts'
+          - 'etc/config/android-java.*.properties'
+
 lang-android-kotlin:
-  - lib/compilers/d8.ts
-  - etc/config/android-kotlin.*.properties
+  - changed-files:
+      - 'lib/compilers/d8.ts'
+      - 'etc/config/android-kotlin.*.properties'
+
 lang-asm:
-  - lib/compilers/assembly.ts
-  - lib/compilers/nasm.ts
-  - lib/compilers/ptxas.ts
-  - etc/config/assembly.*.properties
-  - static/modes/asm-mode.ts
-  - static/modes/asm6502-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/assembly.ts'
+          - 'lib/compilers/nasm.ts'
+          - 'lib/compilers/ptxas.ts'
+          - 'etc/config/assembly.*.properties'
+          - 'static/modes/asm-mode.ts'
+          - 'static/modes/asm6502-mode.ts'
+
 lang-c:
-  - lib/compilers/cc65.ts
-  - lib/compilers/ellcc.ts
-  - lib/compilers/ewarm.ts
-  - lib/compilers/ewavr.ts
-  - lib/compilers/ppci.ts
-  - lib/compilers/sdcc.ts
-  - lib/compilers/tendra.ts
-  - etc/config/c.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/cc65.ts'
+          - 'lib/compilers/ellcc.ts'
+          - 'lib/compilers/ewarm.ts'
+          - 'lib/compilers/ewavr.ts'
+          - 'lib/compilers/ppci.ts'
+          - 'lib/compilers/sdcc.ts'
+          - 'lib/compilers/tendra.ts'
+          - 'etc/config/c.*.properties'
+
 lang-c++:
-  - lib/compilers/ewarm.ts
-  - lib/compilers/ewavr.ts
-  - etc/config/c++.*.properties
-  - static/modes/cppp-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/ewarm.ts'
+          - 'lib/compilers/ewavr.ts'
+          - 'etc/config/c++.*.properties'
+          - 'static/modes/cppp-mode.ts'
+
 lang-c++-opencl:
-  - etc/config/cpp_for_opencl.*.properties
-  - static/modes/cpp-for-opencl-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'etc/config/cpp_for_opencl.*.properties'
+          - 'static/modes/cpp-for-opencl-mode.ts'
+
 lang-c3:
-  - lib/compilers/c3c.ts
-  - etc/config/c3.*.properties
-  - static/modes/c3-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/c3c.ts'
+          - 'etc/config/c3.*.properties'
+          - 'static/modes/c3-mode.ts'
+
 lang-cmakescript:
-  - lib/compilers/cmakescript.ts
-  - etc/config/cmakescript.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/cmakescript.ts'
+          - 'etc/config/cmakescript.*.properties'
+
 lang-circle:
-  - lib/compilers/circle.ts
-  - etc/config/circle.*.properties
-  - static/modes/cppcircle-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/circle.ts'
+          - 'etc/config/circle.*.properties'
+          - 'static/modes/cppcircle-mode.ts'
+
 lang-circt:
-  - lib/compilers/circt.ts
-  - etc/config/circt.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/circt.ts'
+          - 'etc/config/circt.*.properties'
+
 lang-clean:
-  - lib/compilers/clean.ts
-  - etc/config/clean.*.properties
-  - static/modes/clean-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/clean.ts'
+          - 'etc/config/clean.*.properties'
+          - 'static/modes/clean-mode.ts'
+
 lang-cobol:
-  - lib/compilers/gnucobol.ts
-  - etc/config/cobol.*.properties
-  - static/modes/cobol-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/gnucobol.ts'
+          - 'etc/config/cobol.*.properties'
+          - 'static/modes/cobol-mode.ts'
+
 lang-cppx:
-  - etc/config/cppx?(_blue|_gold).*.properties
-  - static/modes/cppx-blue-mode.ts
-  - static/modes/cppx-gold-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'etc/config/cppx?(_blue|_gold).*.properties'
+          - 'static/modes/cppx-blue-mode.ts'
+          - 'static/modes/cppx-gold-mode.ts'
+
 lang-crystal:
-  - lib/compilers/crystal.ts
-  - etc/config/crystal.*.properties
-  - static/modes/crystal-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/crystal.ts'
+          - 'etc/config/crystal.*.properties'
+          - 'static/modes/crystal-mode.ts'
+
 lang-cuda:
-  - lib/compilers/nvcc.ts
-  - etc/config/cuda.*.properties
-  - static/modes/cuda-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - lib/compilers/nvcc.ts
+          - etc/config/cuda.*.properties
+          - static/modes/cuda-mode.ts
+
 lang-d:
-  - lib/compilers/dmd.ts
-  - lib/compilers/ldc.ts
-  - etc/config/d.*.properties
-  - static/modes/d-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/dmd.ts'
+          - 'lib/compilers/ldc.ts'
+          - 'etc/config/d.*.properties'
+          - 'static/modes/d-mode.ts'
+
 lang-dotnet:
-  - lib/compilers/dotnet.ts
-  - lib/parsers/asm-parser-dotnet.ts
-  - etc/config/csharp.*.properties
-  - etc/config/fsharp.*.properties
-  - etc/config/vb.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/dotnet.ts'
+          - 'lib/parsers/asm-parser-dotnet.ts'
+          - 'etc/config/csharp.*.properties'
+          - 'etc/config/fsharp.*.properties'
+          - 'etc/config/vb.*.properties'
+
 lang-dart:
-  - lib/compilers/dart.ts
-  - etc/config/dart.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/dart.ts'
+          - 'etc/config/dart.*.properties'
+
 lang-fortran:
-  - lib/compilers/flang.ts
-  - lib/compilers/fortran.ts
-  - etc/config/fortran.*.properties
-  - static/modes/fortran-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/flang.ts'
+          - 'lib/compilers/fortran.ts'
+          - 'etc/config/fortran.*.properties'
+          - 'static/modes/fortran-mode.ts'
+
 lang-gimple:
-  - lib/compilers/gimple.ts
-  - etc/config/gimple.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/gimple.ts'
+          - 'etc/config/gimple.*.properties'
+
 lang-hlsl:
-  - lib/compilers/hlsl.ts
-  - etc/config/hlsl.*.properties
-  - static/modes/hlsl-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/hlsl.ts'
+          - 'etc/config/hlsl.*.properties'
+          - 'static/modes/hlsl-mode.ts'
+
 lang-hook:
-  - lib/compilers/hook.ts
-  - etc/config/hook.*.properties
-  - static/modes/hook-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/hook.ts'
+          - 'etc/config/hook.*.properties'
+          - 'static/modes/hook-mode.ts'
+
 lang-jakt:
-  - lib/compilers/jakt.ts
-  - etc/config/jakt.*.properties
-  - static/modes/jakt-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/jakt.ts'
+          - 'etc/config/jakt.*.properties'
+          - 'static/modes/jakt-mode.ts'
+
 lang-go:
-  - lib/compilers/golang.ts
-  - etc/config/go.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/golang.ts'
+          - 'etc/config/go.*.properties'
+
 lang-haskell:
-  - lib/compilers/haskell.ts
-  - etc/config/haskell.*.properties
-  - static/modes/haskell-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/haskell.ts'
+          - 'etc/config/haskell.*.properties'
+          - 'static/modes/haskell-mode.ts'
+
 lang-ispc:
-  - lib/compilers/ispc.ts
-  - etc/config/ispc.*.properties
-  - static/modes/ispc-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/ispc.ts'
+          - 'etc/config/ispc.*.properties'
+          - 'static/modes/ispc-mode.ts'
+
 lang-mlir:
-  - lib/compilers/mlir.ts
-  - etc/config/mlir.*.properties
-  - static/modes/mlir-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/mlir.ts'
+          - 'etc/config/mlir.*.properties'
+          - 'static/modes/mlir-mode.ts'
+
 lang-java:
-  - lib/compilers/java.ts
-  - etc/config/java.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/java.ts'
+          - 'etc/config/java.*.properties'
+
 lang-julia:
-  - lib/compilers/julia.ts
-  - etc/config/julia.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/julia.ts'
+          - 'etc/config/julia.*.properties'
+
 lang-kotlin:
-  - lib/compilers/kotlin.ts
-  - etc/config/kotlin.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/kotlin.ts'
+          - 'etc/config/kotlin.*.properties'
+
 lang-llvm:
-  - lib/llvm-ast.ts
-  - lib/llvm-ir.ts
-  - lib/llvm-opt-transformer.ts
-  - lib/compilers/llc.ts
-  - lib/compilers/llvm-mca.ts
-  - lib/objdumper/llvm.ts
-  - lib/tooling/llvm-mca-tool.ts
-  - lib/tooling/llvm-dwarfdump-tool.ts
-  - etc/config/llvm.*.properties
-  - static/modes/llvm-ir-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/llvm-ast.ts'
+          - 'lib/llvm-ir.ts'
+          - 'lib/llvm-opt-transformer.ts'
+          - 'lib/compilers/llc.ts'
+          - 'lib/compilers/llvm-mca.ts'
+          - 'lib/objdumper/llvm.ts'
+          - 'lib/tooling/llvm-mca-tool.ts'
+          - 'lib/tooling/llvm-dwarfdump-tool.ts'
+          - 'etc/config/llvm.*.properties'
+          - 'static/modes/llvm-ir-mode.ts'
+
 lang-modula2:
-  - lib/compilers/gm2.ts
-  - etc/config/modula2.*.properties
-  - static/modes/modula2-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/gm2.ts'
+          - 'etc/config/modula2.*.properties'
+          - 'static/modes/modula2-mode.ts'
+
 lang-nim:
-  - lib/compilers/nim.ts
-  - etc/config/nim.*.properties
-  - static/modes/nim-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/nim.ts'
+          - 'etc/config/nim.*.properties'
+          - 'static/modes/nim-mode.ts'
+
 lang-objc:
-  - etc/config/objc.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'etc/config/objc.*.properties'
+
 lang-objc++:
-  - etc/config/objc++.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'etc/config/objc++.*.properties'
+
 lang-ocaml:
-  - lib/compilers/ocaml.ts
-  - etc/config/ocaml.*.properties
-  - static/modes/ocaml-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/ocaml.ts'
+          - 'etc/config/ocaml.*.properties'
+          - 'static/modes/ocaml-mode.ts'
+
 lang-opencl-c:
-  - etc/config/openclc.*.properties
-  - static/modes/openclc-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'etc/config/openclc.*.properties'
+          - 'static/modes/openclc-mode.ts'
+
 lang-pascal:
-  - lib/compilers/pascal.ts
-  - etc/config/pascal.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/pascal.ts'
+          - 'etc/config/pascal.*.properties'
+
 lang-pony:
-  - lib/compilers/pony.ts
-  - etc/config/pony.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/pony.ts'
+          - 'etc/config/pony.*.properties'
+
 lang-python:
-  - lib/compilers/python.ts
-  - etc/config/python.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/python.ts'
+          - 'etc/config/python.*.properties'
+
 lang-racket:
-  - lib/compilers/racket.ts
-  - etc/config/racket.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/racket.ts'
+          - 'etc/config/racket.*.properties'
+
 lang-ruby:
-  - lib/compilers/ruby.ts
-  - etc/config/ruby.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/ruby.ts'
+          - 'etc/config/ruby.*.properties'
+
 lang-rust:
-  - lib/compilers/rust.ts
-  - etc/config/rust.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/rust.ts'
+          - 'etc/config/rust.*.properties'
+
 lang-scala:
-  - lib/compilers/scala.ts
-  - etc/config/scala.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/scala.ts'
+          - 'etc/config/scala.*.properties'
+
 lang-solidity:
-  - lib/compilers/solidity.ts
-  - etc/config/solidity.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/solidity.ts'
+          - 'etc/config/solidity.*.properties'
+
 lang-swift:
-  - lib/compilers/swift.ts
-  - etc/config/swift.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/swift.ts'
+          - 'etc/config/swift.*.properties'
+
 lang-snowball:
-  - lib/compilers/snowball.ts
-  - etc/config/snowball.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/snowball.ts'
+          - 'etc/config/snowball.*.properties'
+
 lang-tablegen:
-  - lib/compilers/tablegen.ts
-  - etc/config/tablegen.*.properties
-  - static/modes/tablegen-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/tablegen.ts'
+          - 'etc/config/tablegen.*.properties'
+          - 'static/modes/tablegen-mode.ts'
+
 lang-toit:
-  - lib/compilers/toit.ts
-  - etc/config/toit.*.properties
-  - static/modes/toit-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/toit.ts'
+          - 'etc/config/toit.*.properties'
+          - 'static/modes/toit-mode.ts'
+
 lang-typescript:
-  - lib/compilers/typescript-native.ts
-  - etc/config/typescript.*.properties
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/typescript-native.ts'
+          - 'etc/config/typescript.*.properties'
+
 lang-v:
-  - lib/compilers/v.ts
-  - etc/config/v.*.properties
-  - static/modes/v-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/v.ts'
+          - 'etc/config/v.*.properties'
+          - 'static/modes/v-mode.ts'
+
 lang-vala:
-  - lib/compilers/vala.ts
-  - etc/config/vala.*.properties
-  - static/modes/vala-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/vala.ts'
+          - 'etc/config/vala.*.properties'
+          - 'static/modes/vala-mode.ts'
+
 lang-zig:
-  - lib/compilers/zig.ts
-  - etc/config/zig.*.properties
-  - static/modes/zig-mode.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/zig.ts'
+          - 'etc/config/zig.*.properties'
+          - 'static/modes/zig-mode.ts'
+
 documentation:
-  - docs/**/*
-  - README.md
-  - CONTRIBUTING.md
-  - SECURITY.md
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**/*'
+          - 'README.md'
+          - 'CONTRIBUTING.md'
+          - 'SECURITY.md'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,6 +11,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This pr fixes the failing labeler action labeling pull requests, which was probably broken by renovate when upgrading the action from v4 to v5.
I wasn't able to test the configuration, but let's hope it works.