### PR TITLE
fix clang-format formatter name

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -44,7 +44,7 @@ mkfifo=/usr/bin/mkfifo
 heaptrackPath=/opt/compiler-explorer/heaptrack-v1.3.0
 
 formatters=clangformat:rustfmt:gofmt:dartformat:vfmt
-formatter.clangformat.name=clang-format
+formatter.clangformat.name=clangformat
 formatter.clangformat.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit:Microsoft:GNU
 formatter.clangformat.type=clangformat


### PR DESCRIPTION
Should fix https://github.com/compiler-explorer/compiler-explorer/issues/6074

Tested the regular formatting, Preprocessor and clang-format tool. Don't think this should break anything.
