### PR TITLE
Enable the llvm-dwarfdump tool for Rust.

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -915,13 +915,19 @@ libs.winapi.versions.039.path=libwinapi.rlib
 #################################
 # Installed tools
 
-tools=llvm-mcatrunk:osacatrunk:rustfmt1436
+tools=llvm-mcatrunk:llvm-dwarfdumptrunk:osacatrunk:rustfmt1436
 
 tools.llvm-mcatrunk.name=llvm-mca (trunk)
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
+
+tools.llvm-dwarfdumptrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-dwarfdump
+tools.llvm-dwarfdumptrunk.name=llvm-dwarfdump (trunk)
+tools.llvm-dwarfdumptrunk.type=postcompilation
+tools.llvm-dwarfdumptrunk.class=llvm-dwarfdump-tool
+tools.llvm-dwarfdumptrunk.stdinHint=disabled
 
 tools.osacatrunk.name=OSACA (0.5.2)
 tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca


### PR DESCRIPTION
This PR enables the llvm-dwarfdump tool for Rust (inspired by https://github.com/compiler-explorer/compiler-explorer/pull/5726). The default backend for the Rust compiler is LLVM and being able to inspect the debuginfo it generates would be really useful.
