### PR TITLE
flang: Enable the Intel asm syntax option

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1031,6 +1031,13 @@ export class FlangParser extends ClangParser {
             compiler.compiler.irArg = ['-emit-llvm'];
             compiler.compiler.minIrArgs = ['-emit-llvm'];
         }
+
+        // flang-new supports -mllvm, flang-to-external-fc does not.
+        if (this.hasSupport(options, '-mllvm')) {
+            // flang doesn't support -masm, but the llvm equivalent does work.
+            compiler.compiler.supportsIntel = true;
+            compiler.compiler.intelAsm = '-mllvm -x86-asm-syntax=intel';
+        }
     }
 
     static override hasSupport(options, param) {


### PR DESCRIPTION
flang-new doesn't support `-masm=intel` (though it seems likely it eventually will), so this uses `-mllvm ...` to achieve the same thing.

flang-to-external-fc is a wrapper script that will be removed once flang-new becomes flang, so it is not being updated and won't support -masm or -mllvm ever.

(and you'll get the same output by choosing a gfortran compiler, since that's what the script uses for codegen)