### PR TITLE
[Spice] Make clang and lld available to compiler executable

### DIFF
--- a/etc/config/spice.amazon.properties
+++ b/etc/config/spice.amazon.properties
@@ -12,6 +12,9 @@ group.spice.licenseLink=https://github.com/spicelang/spice/blob/main/LICENSE
 group.spice.licenseName=The MIT License
 group.spice.licensePreamble=Copyright (c) 2021-2024 Marc Auberer
 
+# spice needs to be able to find clang for linking
+group.spice.extraPath=/opt/compiler-explorer/clang-17.0.1/bin
+
 compiler.spice01902.exe=/opt/compiler-explorer/spice-0.19.2/spice
 compiler.spice01902.semver=0.19.2
 


### PR DESCRIPTION
Previously the compiler has thrown an error like:
```
terminate called after throwing an instance of 'spice::compiler::LinkerError'
  what():  [Error|Linker] Linker not found: Please check if you have installed clang and added it to the PATH variable
Program terminated with signal: SIGSEGV
Compiler returned: 139
```

This fix makes clang and lld available to compiler executable.