### PR TITLE
Update D8 versions (up to 8.2.42)

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -1,16 +1,25 @@
 compilers=&android-d8:&dex2oat
 
-group.android-d8.compilers=java-d8-8156
+group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242
 group.android-d8.compilerType=android-d8
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
+group.android-d8.javaId=java1601
+group.android-d8.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
+group.android-d8.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
+group.android-d8.kotlinId=kotlinc1920
+group.android-d8.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
+
+compiler.java-d8-8242.name=d8 8.2.42
+compiler.java-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
+
+compiler.java-d8-8233.name=d8 8.2.33
+compiler.java-d8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
+
+compiler.java-d8-8172.name=d8 8.1.72
+compiler.java-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 
 compiler.java-d8-8156.name=d8 8.1.56
 compiler.java-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
-compiler.java-d8-8156.javaId=java1601
-compiler.java-d8-8156.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
-compiler.java-d8-8156.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
-compiler.java-d8-8156.kotlinId=kotlinc1920
-compiler.java-d8-8156.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
 
 group.dex2oat.compilers=java-dex2oat-latest
 group.dex2oat.groupName=ART

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -1,18 +1,19 @@
 compilers=&android-d8:&dex2oat
 
 group.android-d8.compilers=android-java-d8-default
+# When testing locally, these paths must be valid and should
+# reflect the paths in the java and kotlin default config.
+group.android-d8.javaId=javacdefault
+group.android-d8.javaPath=/usr/bin/java
+group.android-d8.javacPath=/usr/bin/javac
+group.android-d8.kotlinId=kotlincdefault
+group.android-d8.kotlincPath=/usr/bin/kotlinc-jvm
+
 compiler.android-java-d8-default.name=android d8 default
 compiler.android-java-d8-default.compilerType=android-d8
 compiler.android-java-d8-default.objdumper=/usr/local/bin/baksmali.jar
 compiler.android-java-d8-default.exe=/usr/local/bin/r8.jar
 
-# When testing locally, these paths must be valid and should
-# reflect the paths in the java and kotlin default config.
-compiler.android-java-d8-default.javaId=javacdefault
-compiler.android-java-d8-default.javaPath=/usr/bin/java
-compiler.android-java-d8-default.javacPath=/usr/bin/javac
-compiler.android-java-d8-default.kotlinId=kotlincdefault
-compiler.android-java-d8-default.kotlincPath=/usr/bin/kotlinc-jvm
 
 group.dex2oat.compilers=android-java-dex2oat-default
 group.dex2oat.groupName=ART

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -1,16 +1,25 @@
 compilers=&android-d8:&dex2oat
 
-group.android-d8.compilers=kotlin-d8-8156
+group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242
 group.android-d8.compilerType=android-d8
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
+group.android-d8.javaId=java1601
+group.android-d8.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
+group.android-d8.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
+group.android-d8.kotlinId=kotlinc1920
+group.android-d8.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
+
+compiler.kotlin-d8-8242.name=d8 8.2.42
+compiler.kotlin-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
+
+compiler.kotlin-d8-8233.name=d8 8.2.33
+compiler.kotlin-d8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
+
+compiler.kotlin-d8-8172.name=d8 8.1.72
+compiler.kotlin-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 
 compiler.kotlin-d8-8156.name=d8 8.1.56
 compiler.kotlin-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
-compiler.kotlin-d8-8156.javaId=java1601
-compiler.kotlin-d8-8156.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
-compiler.kotlin-d8-8156.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
-compiler.kotlin-d8-8156.kotlinId=kotlinc1920
-compiler.kotlin-d8-8156.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
 
 group.dex2oat.compilers=kotlin-dex2oat-latest
 group.dex2oat.groupName=ART

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -1,18 +1,19 @@
 compilers=&android-d8:&dex2oat
 
 group.android-d8.compilers=android-kotlin-d8-default
+# When testing locally, these paths must be valid and should
+# reflect the paths in the java and kotlin default config.
+group.android-d8.javaId=javacdefault
+group.android-d8.javaPath=/usr/bin/java
+group.android-d8.javacPath=/usr/bin/javac
+group.android-d8.kotlinId=kotlincdefault
+group.android-d8.kotlincPath=/usr/bin/kotlinc-jvm
+
 compiler.android-kotlin-d8-default.name=android d8 default
 compiler.android-kotlin-d8-default.compilerType=android-d8
 compiler.android-kotlin-d8-default.objdumper=/usr/local/bin/baksmali.jar
 compiler.android-kotlin-d8-default.exe=/usr/local/bin/r8.jar
 
-# When testing locally, these paths must be valid and should
-# reflect the paths in the java and kotlin default config.
-compiler.android-kotlin-d8-default.javaId=javacdefault
-compiler.android-kotlin-d8-default.javaPath=/usr/bin/java
-compiler.android-kotlin-d8-default.javacPath=/usr/bin/javac
-compiler.android-kotlin-d8-default.kotlinId=kotlincdefault
-compiler.android-kotlin-d8-default.kotlincPath=/usr/bin/kotlinc-jvm
 
 group.dex2oat.compilers=android-kotlin-dex2oat-default
 group.dex2oat.groupName=ART

--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -60,12 +60,12 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         this.lineNumberRegex = /^\s+\.line\s+(\d+).*$/;
         this.methodEndRegex = /^\s*\.end\smethod.*$/;
 
-        this.javaId = this.compilerProps<string>(`compiler.${this.compiler.id}.javaId`);
-        this.kotlinId = this.compilerProps<string>(`compiler.${this.compiler.id}.kotlinId`);
+        this.javaId = this.compilerProps<string>(`group.${this.compiler.group}.javaId`);
+        this.kotlinId = this.compilerProps<string>(`group.${this.compiler.group}.kotlinId`);
 
-        this.javaPath = this.compilerProps<string>(`compiler.${this.compiler.id}.javaPath`);
-        this.javacPath = this.compilerProps<string>(`compiler.${this.compiler.id}.javacPath`);
-        this.kotlincPath = this.compilerProps<string>(`compiler.${this.compiler.id}.kotlincPath`);
+        this.javaPath = this.compilerProps<string>(`group.${this.compiler.group}.javaPath`);
+        this.javacPath = this.compilerProps<string>(`group.${this.compiler.group}.javacPath`);
+        this.kotlincPath = this.compilerProps<string>(`group.${this.compiler.group}.kotlincPath`);
     }
 
     override getOutputFilename(dirPath: string) {


### PR DESCRIPTION
This change adds recent D8 versions (8.1.72, 8.2.33, 8.2.42). Properties for D8 have been reformatted to use groups in order to avoid duplication of java/kotlin references.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
