### PR TITLE
Clang time trace support in execution pane

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1751,10 +1751,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
         this.checkForHints(result);
 
-        this.offerEmulationIfPossible(result);
+        this.offerFilesIfPossible(result);
     }
 
-    offerEmulationIfPossible(result: CompilationResult) {
+    offerFilesIfPossible(result: CompilationResult) {
         if (result.artifacts) {
             for (const artifact of result.artifacts) {
                 if (artifact.type === ArtifactType.nesrom) {

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -698,6 +698,8 @@ export class Executor extends Pane<ExecutorState> {
             for (const artifact of result.artifacts) {
                 if (artifact.type === ArtifactType.heaptracktxt) {
                     this.offerViewInSpeedscope(artifact);
+                } else if (artifact.type === ArtifactType.timetrace) {
+                    this.offerViewInSpeedscope(artifact);
                 }
             }
         }


### PR DESCRIPTION
Fixes #6120 

Problems were:
* filename of the time trace json is actually different with a build
* the execution pane didn't read the trace artifact
* builds are done separately where you don't know what the "compilationresult" object is yet

The bad:
* the artifact only shows up in the api if its the first time or you recompile, not when you only fetch the cached build and execute the executable, but it's better than nothing for the moment