### PR TITLE
flang: Use -masm to enable Intel syntax

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1032,11 +1032,11 @@ export class FlangParser extends ClangParser {
             compiler.compiler.minIrArgs = ['-emit-llvm'];
         }
 
-        // flang-new supports -mllvm, flang-to-external-fc does not.
+        // We're not going to use -mllvm, this just tells us whether we are flang
+        // or flang-to-external-fc. The latter does not support -masm.
         if (this.hasSupport(options, '-mllvm')) {
-            // flang doesn't support -masm, but the llvm equivalent does work.
             compiler.compiler.supportsIntel = true;
-            compiler.compiler.intelAsm = '-mllvm -x86-asm-syntax=intel';
+            compiler.compiler.intelAsm = '-masm=intel';
         }
     }
 


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/commit/9ca1a1575a337931d0e49859f83a0d5b70916abd, flang supports the use of `-masm` without having to use `-mllvm`. flang converts this into `-mllvm...` so the result is the same.

The check still looks for `-mllvm`, as this is the best way to tell flang and flang-to-external-fc apart. As `-masm` doesn't appear in the --help output of flang.
