### PR TITLE
Add VAST as a C compiler and fix paths to resources & toolchain.

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3018,6 +3018,7 @@ group.vast.supportsBinaryObject=true
 compiler.vast-trunk.semver=(trunk)
 compiler.vast-trunk.exe=/opt/compiler-explorer/vast-trunk/bin/vast-front
 compiler.vast-trunk.isNightly=true
+compiler.vast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/lib/clang/17/ --gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 
 #################################
 #################################

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3003,7 +3003,7 @@ compiler.edg-6_5-default-13.name=EDG 6.5
 group.vast.groupName=VAST x86-64
 group.vast.compilers=vast-trunk
 group.vast.isSemVer=true
-group.vast.notification=<a href="https://trailofbits.github.io/vast/" target="_blank">VAST</a> is an experimental compiler pipeline designed for program analysis of C and C++. It provides a tower of IRs as MLIR dialects to choose the best fit representations for a program analysis or further program abstraction.
+group.vast.notification=<a href="https://trailofbits.github.io/vast/" target="_blank">VAST</a> is a C and C++ program analysis-focused compiler offering various program representations via MLIR. Use `-vast-emit-mlir=hl` to emit high-level dialect. Check <a href="https://trailofbits.github.io/vast/Tools/vast-front/" target="_blank">documentation</a> for other dialect options.
 
 group.vast.licenseLink=https://github.com/trailofbits/vast/blob/master/LICENSE
 group.vast.licenseName=Apache 2.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:www.godbolt.ms@443:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:www.godbolt.ms@443:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast
 defaultCompiler=cg132
 demangler=/opt/compiler-explorer/gcc-13.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
@@ -2785,6 +2785,28 @@ group.upmem-clang.compilers=upmem-clang-2023-2
 group.upmem-clang.groupName=UPMEM DPU Clang
 compiler.upmem-clang-2023-2.exe=/opt/compiler-explorer/upmem-dpu/upmem-2023.2.0-Linux-x86_64/bin/dpu-upmem-dpurte-clang
 compiler.upmem-clang-2023-2.name=clang 12 for DPU (rel 2023.2.0)
+
+################################
+# VAST for x86
+group.cvast.groupName=VAST x86-64
+group.cvast.compilers=cvast-trunk
+group.cvast.isSemVer=true
+group.cvast.notification=<a href="https://trailofbits.github.io/vast/" target="_blank">VAST</a> is a C and C++ program analysis-focused compiler offering various program representations via MLIR. Use `-vast-emit-mlir=hl` to emit high-level dialect. Check <a href="https://trailofbits.github.io/vast/Tools/vast-front/" target="_blank">documentation</a> for other dialect options.
+
+group.cvast.licenseLink=https://github.com/trailofbits/vast/blob/master/LICENSE
+group.cvast.licenseName=Apache 2.0
+group.cvast.licensePreamble=The VAST Project is licensed under the Apache License, Version 2.0
+
+group.cvast.baseName=vast
+group.cvast.instructionSet=amd64
+group.cvast.intelAsm=-mllvm -x86-asm-syntax=intel
+
+group.cvast.supportsBinaryObject=true
+
+compiler.cvast-trunk.semver=(trunk)
+compiler.cvast-trunk.exe=/opt/compiler-explorer/vast-trunk/bin/vast-front
+compiler.cvast-trunk.isNightly=true
+compiler.cvast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/lib/clang/17/ --gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 
 #################################
 #################################


### PR DESCRIPTION
- Updates VAST to appear in the C compilers dropdown.
- Corrects paths to resources so that VAST can locate C standard library.
- Adds clarification to the pop-up, recommending the use of the -vast-emit-mlir option.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
