### PR TITLE
Change getCompilerResultLanguageId prototype

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -467,7 +467,7 @@ export class BaseCompiler implements ICompiler {
         };
     }
 
-    getCompilerResultLanguageId(): string | undefined {
+    getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return undefined;
     }
 
@@ -476,6 +476,7 @@ export class BaseCompiler implements ICompiler {
         options: string[],
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
+        filters?: ParseFiltersAndOutputOptions,
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
@@ -488,7 +489,7 @@ export class BaseCompiler implements ICompiler {
         const result = await this.exec(compiler, options, execOptions);
         return {
             ...this.transformToCompilationResult(result, inputFilename),
-            languageId: this.getCompilerResultLanguageId(),
+            languageId: this.getCompilerResultLanguageId(filters),
         };
     }
 
@@ -2294,7 +2295,7 @@ export class BaseCompiler implements ICompiler {
             rustMacroExpResult,
             toolsResult,
         ] = await Promise.all([
-            this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
+            this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions, filters),
             makeAst ? this.generateAST(inputFilename, options) : null,
             makePp ? this.generatePP(inputFilename, options, backendOptions.producePp) : null,
             makeIr

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -282,7 +282,7 @@ export class ClangCudaCompiler extends ClangCompiler {
         this.asm = new SassAsmParser();
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'ptx';
     }
 

--- a/lib/compilers/cppfront.ts
+++ b/lib/compilers/cppfront.ts
@@ -41,7 +41,7 @@ export class CppFrontCompiler extends BaseCompiler {
         this.outputFilebase = 'example';
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'cppp';
     }
 

--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -77,6 +77,7 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         options: string[],
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
+        filters?: ParseFiltersAndOutputOptions,
     ): Promise<CompilationResult> {
         const preliminaryCompilePath = path.dirname(inputFilename);
         let outputFilename = '';
@@ -154,7 +155,7 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         const result = await this.exec(this.javaPath, d8Options, execOptions);
         return {
             ...this.transformToCompilationResult(result, outputFilename),
-            languageId: this.getCompilerResultLanguageId(),
+            languageId: this.getCompilerResultLanguageId(filters),
         };
     }
 

--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -113,6 +113,7 @@ export class Dex2OatCompiler extends BaseCompiler {
         options: string[],
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
+        filters?: ParseFiltersAndOutputOptions,
     ): Promise<CompilationResult> {
         // Make sure --full-output from previous invocations doesn't persist.
         this.fullOutput = false;
@@ -225,7 +226,7 @@ export class Dex2OatCompiler extends BaseCompiler {
         const result = await this.exec(this.compiler.exe, dex2oatOptions, execOptions);
         return {
             ...this.transformToCompilationResult(result, d8OutputFilename),
-            languageId: this.getCompilerResultLanguageId(),
+            languageId: this.getCompilerResultLanguageId(filters),
         };
     }
 

--- a/lib/compilers/gnucobol.ts
+++ b/lib/compilers/gnucobol.ts
@@ -61,7 +61,7 @@ export class GnuCobolCompiler extends BaseCompiler {
         return options;
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'asm';
     }
 

--- a/lib/compilers/jakt.ts
+++ b/lib/compilers/jakt.ts
@@ -39,7 +39,7 @@ export class JaktCompiler extends BaseCompiler {
         this.outputFilebase = 'example';
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'cppp';
     }
 

--- a/lib/compilers/mlir.ts
+++ b/lib/compilers/mlir.ts
@@ -56,7 +56,7 @@ export class MLIRCompiler extends BaseCompiler {
         );
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'mlir';
     }
 

--- a/lib/compilers/mrustc.ts
+++ b/lib/compilers/mrustc.ts
@@ -77,7 +77,7 @@ export class MrustcCompiler extends BaseCompiler {
         return MrustcParser;
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'c';
     }
 }

--- a/lib/compilers/opt.ts
+++ b/lib/compilers/opt.ts
@@ -42,7 +42,7 @@ export class OptCompiler extends BaseCompiler {
         };
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'llvm-ir';
     }
 

--- a/lib/compilers/ruby.ts
+++ b/lib/compilers/ruby.ts
@@ -44,7 +44,7 @@ export class RubyCompiler extends BaseCompiler {
             this.compilerProps('disasmScript') || resolvePathFromAppRoot('etc', 'scripts', 'disasms', 'disasm.rb');
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'asmruby';
     }
 

--- a/lib/compilers/v.ts
+++ b/lib/compilers/v.ts
@@ -97,6 +97,7 @@ export class VCompiler extends BaseCompiler {
         options: string[],
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
+        filters?: ParseFiltersAndOutputOptions,
     ): Promise<CompilationResult> {
         if (!execOptions) {
             execOptions = super.getDefaultExecOptions();
@@ -113,7 +114,7 @@ export class VCompiler extends BaseCompiler {
         const result = await this.exec(compiler, options, execOptions);
         return {
             ...this.transformToCompilationResult(result, inputFilename),
-            languageId: this.getCompilerResultLanguageId(),
+            languageId: this.getCompilerResultLanguageId(filters),
         };
     }
 

--- a/lib/compilers/vala.ts
+++ b/lib/compilers/vala.ts
@@ -42,7 +42,7 @@ export class ValaCompiler extends BaseCompiler {
         this.pkgconfigPath = this.compilerProps<string>(`compiler.${this.compiler.id}.pkgconfigpath`);
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'c';
     }
 

--- a/lib/compilers/wyrm.ts
+++ b/lib/compilers/wyrm.ts
@@ -29,6 +29,7 @@ import {BaseCompiler} from '../base-compiler.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 import {unwrap} from '../assert.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 
 export class WyrmCompiler extends BaseCompiler {
     static get key() {
@@ -56,6 +57,7 @@ export class WyrmCompiler extends BaseCompiler {
         options: string[],
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
+        filters?: ParseFiltersAndOutputOptions,
     ) {
         const gcc = this.getGcc();
         const result = await gcc.runCompiler(
@@ -68,7 +70,7 @@ export class WyrmCompiler extends BaseCompiler {
         await fs.rename(`${path.dirname(oPath)}/x.ll`, oPath);
         return {
             ...result,
-            languageId: this.getCompilerResultLanguageId(),
+            languageId: this.getCompilerResultLanguageId(filters),
         };
     }
 
@@ -79,7 +81,7 @@ export class WyrmCompiler extends BaseCompiler {
         };
     }
 
-    override getCompilerResultLanguageId() {
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'llvm-ir';
     }
 }


### PR DESCRIPTION
The getCompilerResultLanguageId() method can be overridden by compiler
classes to report what mode the monaco editor should be using to display
what the compiler is emitting. The method was not provided with the
"filters" (badly named...) object that contains the user selected options
for "link to binary", "compile to object", etc. Some compilers may need
different monaco settings depending on how they are called.

refs #6079