### PR TITLE
Fix executor pane url inclusion

### DIFF
--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -373,11 +373,11 @@ export class Executor extends Pane<ExecutorState> {
                 }),
             );
         }
-        request.files.push(...moreFiles);
 
         Promise.all(fetches).then(() => {
             const treeState = tree.currentState();
             const cmakeProject = tree.multifileService.isACMakeProject();
+            request.files.push(...moreFiles);
 
             if (bypassCache) request.bypassCache = bypassCache;
             if (!this.compiler) {


### PR DESCRIPTION
Fixes #4801

Similar to https://github.com/compiler-explorer/compiler-explorer/commit/d9030cf41e744f93672afdb40a4eeed8674d4212

The push was done too early when the files hadn't been populated yet