### PR TITLE
Fix json that is forwarded to remote when in noscript

### DIFF
--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -149,19 +149,24 @@ export class CompileHandler {
                     lang: body.lang,
                     compiler: body.compiler,
                     source: body.source,
-                    options: body.userArguments,
-                    filters: Object.fromEntries(
-                        [
-                            'commentOnly',
-                            'directives',
-                            'libraryCode',
-                            'labels',
-                            'demangle',
-                            'intel',
-                            'execute',
-                            'debugCalls',
-                        ].map(key => [key, body[key] === 'true']),
-                    ),
+                    options: {
+                        userArguments: body.userArguments,
+                        filters: Object.fromEntries(
+                            [
+                                'commentOnly',
+                                'directives',
+                                'libraryCode',
+                                'labels',
+                                'demangle',
+                                'intel',
+                                'execute',
+                                'debugCalls',
+                                'binary',
+                                'binaryObject',
+                                'trim',
+                            ].map(key => [key, body[key] === 'true']),
+                        ),
+                    },
                 });
             } else {
                 SentryCapture(


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/6179

Noscript forwarding was partially fixed with https://github.com/compiler-explorer/compiler-explorer/pull/4524 but it was incomplete.

This fixes the json object and adds some extra filters