### PR TITLE
Fix mis-coloured IR panes

### DIFF
--- a/static/panes/ast-view.ts
+++ b/static/panes/ast-view.ts
@@ -260,7 +260,7 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
     }
 
     onColours(id: number, srcColours: Record<number, number>, colourScheme: string): void {
-        if (id !== this.compilerInfo.compilerId) return;
+        if (id !== this.compilerInfo.editorId) return;
 
         this.srcColours = srcColours;
         this.colourScheme = colourScheme;

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -271,8 +271,8 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
         applyColours(irColours, this.colourScheme, this.editorDecorations);
     }
 
-    onColours(compilerId: number, srcColours: Record<number, number>, scheme: string): void {
-        if (compilerId !== this.compilerInfo.compilerId) return;
+    onColours(editorId: number, srcColours: Record<number, number>, scheme: string): void {
+        if (editorId !== this.compilerInfo.editorId) return;
         this.colourScheme = scheme;
         this.srcColours = srcColours;
 


### PR DESCRIPTION
'colours' event is emitted with editor-id and not compiler-id, needs to be handled as such too.
