### PR TITLE
pythran: initial support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -291,6 +291,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'lib/compilers/python.ts'
+          - 'lib/compilers/pythran.ts'
           - 'etc/config/python.*.properties'
 
 'lang-racket':

--- a/etc/config/python.amazon.properties
+++ b/etc/config/python.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&python3:&pypy
+compilers=&python3:&pypy:&pythran
 defaultCompiler=python312
 
 group.python3.compilers=python35:python36:python37:python38:python39:python310:python311:python312
@@ -34,3 +34,23 @@ compiler.pypy39.exe=/opt/compiler-explorer/pypy3.9-v7.3.14/bin/pypy
 compiler.pypy39.semver=3.9
 compiler.pypy310.exe=/opt/compiler-explorer/pypy3.10-v7.3.14/bin/pypy
 compiler.pypy310.semver=3.10
+
+##  Pythran
+group.pythran.compilers=pythran015
+group.pythran.instructionSet=amd64
+group.pythran.interpreted=false
+group.pythran.compilerType=pythran
+group.pythran.licenseLink=https://raw.githubusercontent.com/serge-sans-paille/pythran/master/LICENSE
+group.pythran.licenseName=BSD-3-Clause
+
+group.pythran.supportsBinary=true
+group.pythran.supportsBinaryObject=false
+group.pythran.supportsExecute=false
+group.pythran.demangler=/opt/compiler-explorer/gcc-13.2.0/bin/c++filt
+group.pythran.objdumper=/opt/compiler-explorer/gcc-13.2.0/bin/objdump
+group.pythran.isSemVer=true
+group.pythran.baseName=Pythran
+
+compiler.pythran015.exe=/opt/compiler-explorer/pythran/pythran-0.15/bin/pythran
+compiler.pythran015.semver=0.15
+compiler.pythran015.cpp_compiler_root=/opt/compiler-explorer/gcc-13.2.0/

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -103,6 +103,7 @@ export {PonyCompiler} from './pony.js';
 export {PPCICompiler} from './ppci.js';
 export {PtxAssembler} from './ptxas.js';
 export {PythonCompiler} from './python.js';
+export {PythranCompiler} from './pythran.js';
 export {RacketCompiler} from './racket.js';
 export {RGACompiler} from './rga.js';
 export {RubyCompiler} from './ruby.js';

--- a/lib/compilers/pythran.ts
+++ b/lib/compilers/pythran.ts
@@ -19,7 +19,7 @@ export class PythranCompiler extends BaseCompiler {
         const execOptions = super.getDefaultExecOptions();
         if (this.cpp_compiler_root) {
             execOptions.env.PATH = path.join(this.cpp_compiler_root, 'bin');
-            let ld_library_path = [
+            const ld_library_path = [
                 path.join(this.cpp_compiler_root, 'lib'),
                 path.join(this.cpp_compiler_root, 'lib64'),
             ];

--- a/lib/compilers/pythran.ts
+++ b/lib/compilers/pythran.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+import {BaseCompiler} from '../base-compiler.js';
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+
+export class PythranCompiler extends BaseCompiler {
+    static get key() {
+        return 'pythran';
+    }
+
+    cpp_compiler_root: string;
+
+    constructor(info: PreliminaryCompilerInfo, env) {
+        super(info, env);
+        this.cpp_compiler_root = this.compilerProps<string>(`compiler.${this.compiler.id}.cpp_compiler_root`);
+    }
+
+    override getDefaultExecOptions() {
+        const execOptions = super.getDefaultExecOptions();
+        if (this.cpp_compiler_root) {
+            execOptions.env.PATH = path.join(this.cpp_compiler_root, 'bin');
+            execOptions.env.LD_LIBRARY_PATH = path.join(this.cpp_compiler_root, 'lib');
+        }
+
+        return execOptions;
+    }
+
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
+        let options = ['-o', this.filename(outputFilename)];
+        if (!filters.binary && !filters.binaryObject) options = options.concat('-E');
+        return options;
+    }
+
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
+        if (typeof filters !== 'undefined' && filters.binary) return 'asm';
+        else return 'cppp';
+    }
+}

--- a/lib/compilers/pythran.ts
+++ b/lib/compilers/pythran.ts
@@ -19,7 +19,11 @@ export class PythranCompiler extends BaseCompiler {
         const execOptions = super.getDefaultExecOptions();
         if (this.cpp_compiler_root) {
             execOptions.env.PATH = path.join(this.cpp_compiler_root, 'bin');
-            execOptions.env.LD_LIBRARY_PATH = path.join(this.cpp_compiler_root, 'lib');
+            let ld_library_path = [
+                path.join(this.cpp_compiler_root, 'lib'),
+                path.join(this.cpp_compiler_root, 'lib64'),
+            ];
+            execOptions.env.LD_LIBRARY_PATH = ld_library_path.join(':');
         }
 
         return execOptions;


### PR DESCRIPTION
Pythran is a python to c++ transpiler.
Our supports both the C++ and the full link to a share library (a python module).

See https://pypi.org/project/pythran/ for more information.

fixes #6079