### PR TITLE
[Spice] Also apply abort-after-dump option to assembly output

### DIFF
--- a/lib/compilers/spice.ts
+++ b/lib/compilers/spice.ts
@@ -71,7 +71,7 @@ export class SpiceCompiler extends BaseCompiler {
         outputFilename: string,
         userOptions: string[],
     ): string[] {
-        const options = ['build', '-g', '-o', outputFilename, '--dump-to-files', '-asm'];
+        const options = ['build', '-g', '-o', outputFilename, '--dump-to-files', '-asm', '--abort-after-dump'];
 
         if (filters.intel) {
             options.push('-llvm', '--x86-asm-syntax=intel');
@@ -124,7 +124,7 @@ export class SpiceCompiler extends BaseCompiler {
     }
 
     override filterUserOptions(userOptions: string[]): string[] {
-        const forbiddenOptions = /^(((--(output|target))|(-o)|install|uninstall).*)$/;
+        const forbiddenOptions = /^(((--(output|target))|(-o)|install|uninstall|test).*)$/;
         return _.filter(userOptions, option => !forbiddenOptions.test(option));
     }
 


### PR DESCRIPTION
- Use the `--abort-after-dump` flag not only for IR, but also for assembly
- Add `test` subcommand to forbidden options