### PR TITLE
Add assembly dump to erlang amazon configuration

### DIFF
--- a/etc/config/erlang.amazon.properties
+++ b/etc/config/erlang.amazon.properties
@@ -1,8 +1,16 @@
-compilers=&erlang
+compilers=&erlang:&erlangasm
 
 group.erlang.compilers=erl2416:erl2622
 group.erlang.isSemVer=true
 group.erlang.baseName=Erlang
+group.erlang.compilerType=erlang
+group.erlang.instructionSet=beam
+
+group.erlangasm.compilers=erl2622asm
+group.erlangasm.isSemVer=true
+group.erlangasm.baseName=Erlang Asm
+group.erlangasm.compilerType=erlangasm
+group.erlangasm.instructionSet=amd64
 
 compiler.erl2416.exe=/opt/compiler-explorer/erlang-24.1.6/bin/erl
 compiler.erl2416.runtime=/opt/compiler-explorer/erlang-24.1.6/bin/erl
@@ -11,3 +19,9 @@ compiler.erl2416.semver=24.1.6
 compiler.erl2622.exe=/opt/compiler-explorer/erlang-26.2.2/bin/erl
 compiler.erl2622.runtime=/opt/compiler-explorer/erlang-26.2.2/bin/erl
 compiler.erl2622.semver=26.2.2
+
+compiler.erl2622asm.exe=/opt/compiler-explorer/erlang-26.2.2/bin/erl
+compiler.erl2622asm.runtime=/opt/compiler-explorer/erlang-26.2.2/bin/erl
+compiler.erl2622asm.semver=26.2.2
+
+


### PR DESCRIPTION
Hi,
in this PR I port the jitted decimpiled view to the amazon properties, as we already have in the default properties ([here](https://github.com/compiler-explorer/compiler-explorer/blob/main/etc/config/erlang.defaults.properties))

