### PR TITLE
Disable sharing clipboard button when link generation fails

### DIFF
--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -176,6 +176,7 @@ export class Sharing {
         const socialSharingElements = modal.find('.socialsharing');
         const permalink = modal.find('.permalink');
         const embedsettings = modal.find('#embedsettings');
+        const clipboardButton = modal.find('.clippy');
 
         const updatePermaLink = () => {
             socialSharingElements.empty();
@@ -183,13 +184,14 @@ export class Sharing {
             Sharing.getLinks(config, currentBind, (error: any, newUrl: string, extra: string, updateState: boolean) => {
                 permalink.off('click');
                 if (error || !newUrl) {
-                    permalink.prop('disabled', true);
+                    clipboardButton.prop('disabled', true);
                     permalink.val(error || 'Error providing URL');
                     SentryCapture(error, 'Error providing url');
                 } else {
                     if (updateState) {
                         Sharing.storeCurrentConfig(config, extra);
                     }
+                    clipboardButton.prop('disabled', false);
                     permalink.val(newUrl);
                     permalink.on('click', () => {
                         permalink.trigger('focus').trigger('select');


### PR DESCRIPTION
Fixes #2545

The text box containing the link was already read only. So I think the intention was always to set the clipboard button to disabled, but the author used the wrong object by mistake.

I've changed it so that it finds the clipboard button and disables it on error, and enables it on success.

The modal is constructed once and updated if re-opened, so we need to set the state each time in case the result has changed.

I tested this locally by making the code always take the error path.
