### PR TITLE
fix llvm-cov

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -228,6 +228,7 @@ group.clang.compilerType=clang
 group.clang.unwiseOptions=-march=native
 group.clang.supportsPVS-Studio=true
 group.clang.supportsSonar=true
+group.clang.supportsLlvmCov=true
 group.clang.licenseName=LLVM Apache 2
 group.clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
@@ -395,6 +396,7 @@ group.clangx86trunk.compilerType=clang
 group.clangx86trunk.unwiseOptions=-march=native
 group.clangx86trunk.supportsPVS-Studio=true
 group.clangx86trunk.supportsSonar=true
+group.clangx86trunk.supportsLlvmCov=true
 group.clangx86trunk.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 group.clangx86trunk.compilerCategories=clang
 
@@ -575,6 +577,7 @@ group.clang-rocm.compilerType=clang
 group.clang-rocm.unwiseOptions=-march=native
 group.clang-rocm.supportsPVS-Studio=true
 group.clang-rocm.supportsSonar=true
+group.clang-rocm.supportsLlvmCov=true
 group.clang-rocm.licenseName=LLVM Apache 2 and NCSA
 group.clang-rocm.licenseLink=https://github.com/RadeonOpenCompute/llvm-project/blob/amd-stg-open/LICENSE.TXT
 # and https://github.com/RadeonOpenCompute/ROCm-Device-Libs/blob/amd-stg-open/LICENSE.TXT
@@ -4739,10 +4742,11 @@ tools.ldd.class=readelf-tool
 tools.ldd.exclude=djggp
 tools.ldd.stdinHint=disabled
 
-tools.llvm-covtrunk.name=llvm-cov (trunk)
+tools.llvm-covtrunk.name=llvm-cov (clang-only)
 tools.llvm-covtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-cov
 tools.llvm-covtrunk.type=postcompilation
 tools.llvm-covtrunk.class=llvm-cov-tool
+tools.llvm-covtrunk.includeKey=supportsLlvmCov
 
 tools.llvm-mcatrunk.name=llvm-mca (trunk)
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca

--- a/lib/tooling/llvm-cov-tool.ts
+++ b/lib/tooling/llvm-cov-tool.ts
@@ -24,7 +24,7 @@
 
 import path from 'path';
 
-import {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import {CompilationInfo, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 
 import {BaseTool} from './base-tool.js';
 
@@ -33,14 +33,32 @@ export class LLVMCovTool extends BaseTool {
         return 'llvm-cov-tool';
     }
 
-    override async runTool(compilationInfo, inputFilepath, args: string[], stdin) {
+    override async runTool(compilationInfo: CompilationInfo, inputFilepath, args: string[], stdin) {
         const compilationExecOptions = this.getDefaultExecOptions();
         compilationExecOptions.customCwd = path.dirname(inputFilepath);
         compilationExecOptions.input = stdin;
         try {
             const generatedExecutableName = this.getUniqueFilePrefix() + '-coverage.a';
-            // Remove inputs
-            const options = compilationInfo.compilationOptions.slice().splice(0, 4);
+
+            let skipNext = false;
+            const options: string[] = [];
+            const withoutInputFile = (compilationInfo.compilationOptions || []).filter(
+                v => !v.includes(inputFilepath) && v !== '-S' && !v.startsWith('-O'),
+            );
+            for (const v of withoutInputFile) {
+                if (v === '-o') {
+                    skipNext = true;
+                    continue;
+                }
+
+                if (skipNext) {
+                    skipNext = false;
+                    continue;
+                }
+
+                options.push(v);
+            }
+
             const compilationArgs = [
                 ...options,
                 '-fprofile-instr-generate',
@@ -51,6 +69,8 @@ export class LLVMCovTool extends BaseTool {
                 '-o',
                 generatedExecutableName,
             ];
+
+            const compilerPath = path.dirname(compilationInfo.compiler.exe);
 
             const compilationResult = await this.exec(
                 compilationInfo.compiler.exe,
@@ -72,8 +92,7 @@ export class LLVMCovTool extends BaseTool {
                 input: stdin,
             });
 
-            const folder = path.dirname(this.tool.exe);
-            const profdataPath = path.join(folder, 'llvm-profdata');
+            const profdataPath = path.join(compilerPath, 'llvm-profdata');
 
             const generatedProfdataName = this.getUniqueFilePrefix() + '.profdata';
             const profdataResult = await this.exec(
@@ -88,7 +107,7 @@ export class LLVMCovTool extends BaseTool {
             }
 
             const covResult = await this.exec(
-                this.tool.exe,
+                path.join(compilerPath, 'llvm-cov'),
                 [
                     'show',
                     './' + generatedExecutableName,

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -257,7 +257,25 @@ export type BuildStep = BasicExecutionResult & {
     step: string;
 };
 
-export type CompilationInfo = {
+export type CompilationInfo = CompilationResult & {
+    mtime: Date | null;
+    compiler: CompilerInfo & Record<string, unknown>;
+    args: string[];
+    options: ExecutionOptions;
+    outputFilename: string;
+    executableFilename: string;
+    asmParser: IAsmParser;
+    inputFilename?: string;
+    dirPath?: string;
+};
+
+export type CustomInputForTool = {
+    inputFilename: string;
+    dirPath: string;
+    outputFilename: string;
+};
+
+export type CompilationInfo2 = CustomInputForTool & {
     mtime: Date | null;
     compiler: CompilerInfo & Record<string, unknown>;
     args: string[];
@@ -276,10 +294,21 @@ export type CompilationCacheKey = {
     options: ExecutionOptions;
 };
 
-export type CustomInputForTool = {
-    inputFilename: string;
-    dirPath: string;
-    outputFilename: string;
+export type CacheKey = {
+    compiler: any;
+    source: string;
+    options: string[];
+    backendOptions: any;
+    filters?: any;
+    tools: any[];
+    libraries: any[];
+    files: any[];
+};
+
+export type CmakeCacheKey = CacheKey & {
+    compiler: CompilerInfo;
+    files: [];
+    api: string;
 };
 
 export type FiledataPair = {


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/4796

This PR solves a couple of problems:
1. Bad types, I've done something about it, but it still has bad names etc. But at least they're more correct.
2. Arguments were spliced at a fixed position, since the original implementation things have changed on the compiler argument front, I've replaced the code with removing and adding some instead but keeping the rest intact
3. Once the arguments were fixed, the problem arose that clang-trunk (which is setup in the tool exe) requires a newer format of the profiling file than the clang that it tried to compile with used. I have aligned the versions to use the clang compiler that is selected by the user and disabled the tool for everything non-clang-x86.
