### PR TITLE
Decode UTF-8 encoded strings in numeric tooltip

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -33,7 +33,6 @@ import {LRUCache} from 'lru-cache';
 import {options} from '../options.js';
 import * as monaco from 'monaco-editor';
 import {Alert} from '../widgets/alert.js';
-import bigInt from 'big-integer';
 import {LibsWidget} from '../widgets/libs-widget.js';
 import * as codeLensHandler from '../codelens-handler.js';
 import * as monacoConfig from '../monaco-config.js';
@@ -80,7 +79,7 @@ import {CompilerShared} from '../compiler-shared.js';
 import {SentryCapture} from '../sentry.js';
 import {LLVMIrBackendOptions} from '../compilation/ir.interfaces.js';
 import {InstructionSet} from '../instructionsets.js';
-import {addDigitSeparator, escapeHTML} from '../../shared/common-utils.js';
+import {escapeHTML} from '../../shared/common-utils.js';
 import {CompilerVersionInfo, setCompilerVersionPopoverForPane} from '../widgets/compiler-version-info.js';
 
 const toolIcons = require.context('../../views/resources/logos', false, /\.(png|svg)$/);
@@ -3477,75 +3476,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         });
     }
 
-    private static readonly hexLike = /^(#?[$]|0x)([0-9a-fA-F]+)$/;
-    private static readonly hexLike2 = /^(#?)([0-9a-fA-F]+)H$/;
-    private static readonly decimalLike = /^(#?)(-?[0-9]+)$/;
-    private static readonly ptxFloat32 = /^0[fF]([0-9a-fA-F]{8})$/;
-    private static readonly ptxFloat64 = /^0[dD]([0-9a-fA-F]{16})$/;
-
-    private static parseNumericValue(value: string): bigInt.BigInteger | null {
-        const hexMatch = this.hexLike.exec(value) || this.hexLike2.exec(value);
-        if (hexMatch) return bigInt(hexMatch[2], 16);
-
-        const hexMatchPTX = this.ptxFloat32.exec(value) ?? this.ptxFloat64.exec(value);
-        if (hexMatchPTX) return bigInt(hexMatchPTX[1], 16);
-
-        const decMatch = this.decimalLike.exec(value);
-        if (decMatch) return bigInt(decMatch[2]);
-
-        return null;
-    }
-
-    public static getNumericToolTip(value: string, digitSeparator?: string): string | null {
-        const formatNumber = (number, base, chunkSize) => {
-            const numberString = number.toString(base).toUpperCase();
-            if (digitSeparator !== undefined) {
-                return addDigitSeparator(numberString, digitSeparator, chunkSize);
-            } else {
-                return numberString;
-            }
-        };
-        const numericValue = this.parseNumericValue(value);
-        if (numericValue === null) return null;
-
-        // PTX floats
-        const view = new DataView(new ArrayBuffer(8));
-        view.setBigUint64(0, BigInt(numericValue.toString()), true);
-        if (this.ptxFloat32.test(value)) return view.getFloat32(0, true).toPrecision(9) + 'f';
-        if (this.ptxFloat64.test(value)) return view.getFloat64(0, true).toPrecision(17);
-
-        // Decimal representation.
-        let result = formatNumber(numericValue, 10, 3);
-        const masked = bigInt('ffffffffffffffff', 16).and(numericValue);
-
-        // Hexadecimal representation.
-        if (numericValue.isNegative()) {
-            result += ' = 0x' + formatNumber(masked, 16, 4);
-        } else {
-            result += ' = 0x' + formatNumber(numericValue, 16, 4);
-        }
-
-        // Float32/64 representation.
-        view.setBigUint64(0, BigInt(numericValue.toString()), true);
-        if (numericValue.bitLength().lesserOrEquals(32))
-            result += ' = ' + view.getFloat32(0, true).toPrecision(9) + 'f';
-        // only subnormal doubles and zero may have upper 32 bits all 0, assume unlikely to be double
-        else result += ' = ' + view.getFloat64(0, true).toPrecision(17);
-
-        // Printable UTF-8 characters.
-        const bytes = (numericValue.isNegative() ? masked : numericValue).toArray(256).value;
-        // This assumes that `numericValue` is encoded as little-endian.
-        bytes.reverse();
-        const decoder = new TextDecoder('utf-8', {fatal: true});
-        try {
-            result += ' = ' + JSON.stringify(decoder.decode(Uint8Array.from(bytes)));
-        } catch (e) {
-            // ignore `TypeError` when the number is not valid UTF-8
-        }
-
-        return result;
-    }
-
     public static async getAsmInfo(
         opcode: string,
         instructionSet: InstructionSet,
@@ -3642,7 +3572,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             );
             const lang = this.compiler?.lang;
             const language = lang === undefined ? undefined : languages[lang];
-            const numericToolTip = Compiler.getNumericToolTip(word, language?.digitSeparator);
+            const numericToolTip = utils.getNumericToolTip(word, language?.digitSeparator);
             if (numericToolTip) {
                 this.decorations.numericToolTip = [
                     {

--- a/static/panes/device-view.ts
+++ b/static/panes/device-view.ts
@@ -41,6 +41,7 @@ import {assert} from '../assert.js';
 import {Alert} from '../widgets/alert';
 import {Compiler} from './compiler';
 import {InstructionSet} from '../instructionsets.js';
+import * as utils from '../utils.js';
 
 export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, DeviceAsmState> {
     private decorations: Record<string, monaco.editor.IModelDeltaDecoration[]>;
@@ -420,7 +421,7 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
                 e.target.position.lineNumber,
                 currentWord.endColumn,
             );
-            const numericToolTip = Compiler.getNumericToolTip(word);
+            const numericToolTip = utils.getNumericToolTip(word);
             if (numericToolTip) {
                 this.decorations.numericToolTip = [
                     {

--- a/static/utils.ts
+++ b/static/utils.ts
@@ -22,6 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import bigInt from 'big-integer';
+import {addDigitSeparator} from '../shared/common-utils.js';
+
 export function updateAndCalcTopBarHeight(domRoot: JQuery, topBar: JQuery, hideable: JQuery): number {
     let topBarHeight = 0;
     if (!topBar.hasClass('d-none')) {
@@ -82,4 +85,72 @@ export function formatISODate(dt: Date, full = false) {
     } else {
         return dt.getUTCFullYear() + '-' + month.padStart(2, '0') + '-' + day.padStart(2, '0');
     }
+}
+
+const hexLike = /^(#?[$]|0x)([0-9a-fA-F]+)$/;
+const hexLike2 = /^(#?)([0-9a-fA-F]+)H$/;
+const decimalLike = /^(#?)(-?[0-9]+)$/;
+const ptxFloat32 = /^0[fF]([0-9a-fA-F]{8})$/;
+const ptxFloat64 = /^0[dD]([0-9a-fA-F]{16})$/;
+
+function parseNumericValue(value: string): bigInt.BigInteger | null {
+    const hexMatch = hexLike.exec(value) || hexLike2.exec(value);
+    if (hexMatch) return bigInt(hexMatch[2], 16);
+
+    const hexMatchPTX = ptxFloat32.exec(value) ?? ptxFloat64.exec(value);
+    if (hexMatchPTX) return bigInt(hexMatchPTX[1], 16);
+
+    const decMatch = decimalLike.exec(value);
+    if (decMatch) return bigInt(decMatch[2]);
+
+    return null;
+}
+
+export function getNumericToolTip(value: string, digitSeparator?: string): string | null {
+    const formatNumber = (number, base, chunkSize) => {
+        const numberString = number.toString(base).toUpperCase();
+        if (digitSeparator !== undefined) {
+            return addDigitSeparator(numberString, digitSeparator, chunkSize);
+        } else {
+            return numberString;
+        }
+    };
+    const numericValue = parseNumericValue(value);
+    if (numericValue === null) return null;
+
+    // PTX floats
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigUint64(0, BigInt(numericValue.toString()), true);
+    if (ptxFloat32.test(value)) return view.getFloat32(0, true).toPrecision(9) + 'f';
+    if (ptxFloat64.test(value)) return view.getFloat64(0, true).toPrecision(17);
+
+    // Decimal representation.
+    let result = formatNumber(numericValue, 10, 3);
+    const masked = bigInt('ffffffffffffffff', 16).and(numericValue);
+
+    // Hexadecimal representation.
+    if (numericValue.isNegative()) {
+        result += ' = 0x' + formatNumber(masked, 16, 4);
+    } else {
+        result += ' = 0x' + formatNumber(numericValue, 16, 4);
+    }
+
+    // Float32/64 representation.
+    view.setBigUint64(0, BigInt(numericValue.toString()), true);
+    if (numericValue.bitLength().lesserOrEquals(32)) result += ' = ' + view.getFloat32(0, true).toPrecision(9) + 'f';
+    // only subnormal doubles and zero may have upper 32 bits all 0, assume unlikely to be double
+    else result += ' = ' + view.getFloat64(0, true).toPrecision(17);
+
+    // Printable UTF-8 characters.
+    const bytes = (numericValue.isNegative() ? masked : numericValue).toArray(256).value;
+    // This assumes that `numericValue` is encoded as little-endian.
+    bytes.reverse();
+    const decoder = new TextDecoder('utf-8', {fatal: true});
+    try {
+        result += ' = ' + JSON.stringify(decoder.decode(Uint8Array.from(bytes)));
+    } catch (e) {
+        // ignore `TypeError` when the number is not valid UTF-8
+    }
+
+    return result;
 }

--- a/test/static/utils-tests.ts
+++ b/test/static/utils-tests.ts
@@ -20,6 +20,10 @@ describe('numeric tooltip', () => {
         expect(utils.getNumericToolTip('-6934491452449512253')).toEqual(
             '-6934491452449512253 = 0x9FC3BCC3B6C3A4C3 = -1.1500622354593239e-155 = "äöüß"',
         );
+        expect(utils.getNumericToolTip('-1530699166')).toEqual(
+            '-1530699166 = 0xFFFFFFFFA4C36262 = -8.47344364e-17f = "bbä"',
+        );
+        expect(utils.getNumericToolTip('-23357')).toEqual('-23357 = 0xFFFFFFFFFFFFA4C3 = NaNf = "ä"');
     });
     it('inserts digit separators', () => {
         expect(utils.getNumericToolTip('1234', '_')).toEqual('1_234 = 0x4D2 = 1.72920230e-42f');

--- a/test/static/utils-tests.ts
+++ b/test/static/utils-tests.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+
+import * as utils from '../../static/utils.js';
+
+describe('numeric tooltip', () => {
+    it('handles ASCII characters', () => {
+        expect(utils.getNumericToolTip('42')).toEqual('42 = 0x2A = 5.88545355e-44f = "*"');
+        expect(utils.getNumericToolTip('97')).toEqual('97 = 0x61 = 1.35925951e-43f = "a"');
+        expect(utils.getNumericToolTip('10')).toEqual('10 = 0xA = 1.40129846e-44f = "\\n"');
+        expect(utils.getNumericToolTip('92')).toEqual('92 = 0x5C = 1.28919459e-43f = "\\\\"');
+        expect(utils.getNumericToolTip('1')).toEqual('1 = 0x1 = 1.40129846e-45f = "\\u0001"');
+    });
+    it('handles ASCII strings', () => {
+        expect(utils.getNumericToolTip('0x61626364')).toEqual('1633837924 = 0x61626364 = 2.61007876e+20f = "dcba"');
+        expect(utils.getNumericToolTip('8583909746840200552')).toEqual(
+            '8583909746840200552 = 0x77202C6F6C6C6568 = 6.5188685003648344e+265 = "hello, w"',
+        );
+    });
+    it('handles UTF-8 strings', () => {
+        expect(utils.getNumericToolTip('-6934491452449512253')).toEqual(
+            '-6934491452449512253 = 0x9FC3BCC3B6C3A4C3 = -1.1500622354593239e-155 = "äöüß"',
+        );
+    });
+    it('inserts digit separators', () => {
+        expect(utils.getNumericToolTip('1234', '_')).toEqual('1_234 = 0x4D2 = 1.72920230e-42f');
+        expect(utils.getNumericToolTip('1234567', "'")).toEqual("1'234'567 = 0x12'D687 = 1.72999684e-39f");
+        expect(utils.getNumericToolTip('-6934491452449512253', '_')).toEqual(
+            '-6_934_491_452_449_512_253 = 0x9FC3_BCC3_B6C3_A4C3 = -1.1500622354593239e-155 = "äöüß"',
+        );
+    });
+});

--- a/test/static/utils-tests.ts
+++ b/test/static/utils-tests.ts
@@ -28,4 +28,9 @@ describe('numeric tooltip', () => {
             '-6_934_491_452_449_512_253 = 0x9FC3_BCC3_B6C3_A4C3 = -1.1500622354593239e-155 = "äöüß"',
         );
     });
+    it('does nothing for strings that are not numbers', () => {
+        expect(utils.getNumericToolTip('word')).toEqual(null);
+        expect(utils.getNumericToolTip('NaN')).toEqual(null);
+        expect(utils.getNumericToolTip('1.5')).toEqual(null);
+    });
 });


### PR DESCRIPTION
Compilers like to encode short-ish strings into immediate arguments to various assembly instructions. This makes it hard to read the assembly.

To improve readability, show a string representation of a number’s bytes when they’re valid UTF-8.

This now also shows a string representation for *unprintable* ASCII characters, such as `10` being shown as `"\n"` or `1` as `"\u0001"`.

Resolves #6220.

## Examples

([link](https://godbolt.org/z/7hzn6b8YG))

* 8583909746840200552: `8'583'909'746'840'200'552 = 0x7720'2C6F'6C6C'6568 = 6.5188685003648344e+265 = "hello, w"`
* 1684828783: `1'684'828'783 = 0x646C'726F = 1.74467096e+22f = "orld"`
* -6934491452449512253: `-6'934'491'452'449'512'253 = 0x9FC3'BCC3'B6C3'A4C3 = -1.1500622354593239e-155 = "äöüß"`
* 1633837924: `1'633'837'924 = 0x6162'6364 = 2.61007876e+20f = "dcba"`
* 97: `97 = 0x61 = 1.35925951e-43f = "a"`
* 10: `10 = 0xA = 1.40129846e-44f = "\n"`
* 92: `92 = 0x5C = 1.28919459e-43f = "\\"`

## Open questions

* The code assumes little-endian encoding, so the string representation is reversed compared to the numeric representation (see `integer` example). Should this be configurable or should the bytes not be reversed?
* Negative numbers are masked to 64-bit unsigned ints (same as in the hex representation), so if the number is shorter than 8 bytes, it has some leading `ff` bytes and is not valid UTF-8 (see `small_negative_number` in the example link). Is this an acceptable limitation?
* I'd like to add some tests for `getNumericToolTip`, but I’m not really familiar with TypeScript. I tried to importing `static/panes/compiler.ts` in a test file, but ([after](https://github.com/vitest-dev/vitest/discussions/1806#discussioncomment-3570047) some [struggling](https://vitest.dev/config/#environment)) it seems that that file needs a [specific DOM element](https://github.com/compiler-explorer/compiler-explorer/blob/3c26c64ca320853cb383b3751d3e08a86b581639/static/options.ts#L27) that is not present during testing. The simplest solution I could come up with is moving `getNumericToolTip` into another file (such as `static/utils.ts`). Is that okay or is is it possible test `static/panes/compiler.ts` some other way?