### PR TITLE
builtin.ts: treat EXAMPLES_PATH as relative to app root.

### DIFF
--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -26,11 +26,12 @@ import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
 
+import * as utils from '../utils.js';
 import * as props from '../properties.js';
 
 import type {Source, SourceEntry} from './index.js';
 
-const EXAMPLES_PATH = props.get('builtin', 'sourcePath', './examples/');
+const EXAMPLES_PATH = utils.resolvePathFromAppRoot(props.get('builtin', 'sourcePath', './examples/'));
 const NAME_SUBSTUTION_PATTERN = new RegExp('_', 'g');
 const ALL_EXAMPLES: SourceEntry[] = fs.readdirSync(EXAMPLES_PATH).flatMap(folder => {
     // Recurse through the language folders


### PR DESCRIPTION
I feel this is the least surprising behaviour most of the time. This will help when packaging and distributing the application.

It may also make sense to base this at rootDir, but examples/ sits outside etc/ at the moment and I didn't want to disturb that too much.

Thanks!