### PR TITLE
more paths resolved relative to app root.

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -622,6 +622,7 @@ async function main() {
     webServer
         .set('trust proxy', true)
         .set('view engine', 'pug')
+        .set('views', utils.resolvePathFromAppRoot('./views'))
         .on('error', err => logger.error('Caught error in web handler; continuing:', err))
         // sentry request handler must be the first middleware on the app
         .use(

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -45,7 +45,7 @@ export class BaseParser {
     }
 
     static getExamplesRoot(): string {
-        return props.get('builtin', 'sourcePath', './examples/');
+        return utils.resolvePathFromAppRoot(props.get('builtin', 'sourcePath', './examples/'));
     }
 
     static getDefaultExampleFilename() {

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -26,6 +26,8 @@ import path from 'path';
 
 import fs from 'fs-extra';
 
+import * as utils from './utils.js';
+
 import type {Language, LanguageKey} from '../types/languages.interfaces.js';
 
 type DefKeys =
@@ -824,7 +826,7 @@ export const languages = Object.fromEntries(
     Object.entries(definitions).map(([key, lang]) => {
         let example: string;
         try {
-            example = fs.readFileSync(path.join('examples', key, 'default' + lang.extensions[0]), 'utf8');
+            example = fs.readFileSync(utils.resolvePathFromAppRoot('examples', key, 'default' + lang.extensions[0]), 'utf8');
         } catch (error) {
             example = 'Oops, something went wrong and we could not get the default code for this language.';
         }

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import path from 'path';
-
 import fs from 'fs-extra';
 
 import * as utils from './utils.js';
@@ -824,9 +822,10 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
 
 export const languages = Object.fromEntries(
     Object.entries(definitions).map(([key, lang]) => {
+        const exampleFile = utils.resolvePathFromAppRoot('examples', key, 'default' + lang.extensions[0]);
         let example: string;
         try {
-            example = fs.readFileSync(utils.resolvePathFromAppRoot('examples', key, 'default' + lang.extensions[0]), 'utf8');
+            example = fs.readFileSync(exampleFile, 'utf8');
         } catch (error) {
             example = 'Oops, something went wrong and we could not get the default code for this language.';
         }

--- a/webpack.config.esm.ts
+++ b/webpack.config.esm.ts
@@ -94,7 +94,11 @@ const plugins: Webpack.WebpackPluginInstance[] = [
         'window.PRODUCTION': JSON.stringify(!isDev),
     }),
     new CopyWebpackPlugin({
-        patterns: [{from: './static/favicons', to: path.resolve(distPath, 'static', 'favicons')}],
+        patterns: [
+            {from: './static/favicons', to: path.resolve(distPath, 'static', 'favicons')},
+            {from: './views', to: path.resolve(distPath, 'views')},
+            {from: './examples', to: path.resolve(distPath, 'examples')},
+        ],
     }),
 ];
 


### PR DESCRIPTION
This fixes paths in the express views, and language examples and defaults.

There is some duplication between getExamplesRoot() and the earlier changes at https://github.com/compiler-explorer/compiler-explorer/pull/6237, but I leave this for now.