### PR TITLE
Revert "builtin.ts: treat EXAMPLES_PATH as relative to app root."

### DIFF
--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -26,12 +26,11 @@ import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
 
-import * as utils from '../utils.js';
 import * as props from '../properties.js';
 
 import type {Source, SourceEntry} from './index.js';
 
-const EXAMPLES_PATH = utils.resolvePathFromAppRoot(props.get('builtin', 'sourcePath', './examples/'));
+const EXAMPLES_PATH = props.get('builtin', 'sourcePath', './examples/');
 const NAME_SUBSTUTION_PATTERN = new RegExp('_', 'g');
 const ALL_EXAMPLES: SourceEntry[] = fs.readdirSync(EXAMPLES_PATH).flatMap(folder => {
     // Recurse through the language folders


### PR DESCRIPTION
Reverts compiler-explorer/compiler-explorer#6237.

This PR broke the recommended `make run` workflow. When using `make run`, the dist folder does not contain the needed resources.