### PR TITLE
For clang cross-compiles with libc++, explicitly add `-I../include/x86_64…

### DIFF
--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -158,10 +158,10 @@ export class ClangCompiler extends BaseCompiler {
     // Clang cross-compile with -stdlib=libc++ is currently (up to at least 18.1.0) broken:
     // https://github.com/llvm/llvm-project/issues/57104
     //
-    // To smoke-test future versions, check if this succeeds: https://godbolt.org/z/7dKrad7Wc
-    //
     // Below is a workaround discussed in CE issue #5293. If the llvm issue is ever resolved it would be best
     // to apply this only for clang versions up to the official resolution.
+    // To smoke-test such future versions, check locally *without* this filterUserOptions overload whether
+    // compiling `#include <string>` with flag `-stdlib=libc++` succeeds: https://godbolt.org/z/7dKrad7Wc
 
     override filterUserOptions(userOptions: string[]): string[] {
         if (

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -155,10 +155,14 @@ export class ClangCompiler extends BaseCompiler {
         return this.forceDwarf4UnlessOverridden(options);
     }
 
-    // Cross-compiling for clang with -stdlib=libc++ is currently (at least up to 18.1.0) broken:
+    // Clang cross-compile with -stdlib=libc++ is currently (up to at least 18.1.0) broken:
     // https://github.com/llvm/llvm-project/issues/57104
+    //
+    // To smoke-test future versions, check if this succeeds: https://godbolt.org/z/7dKrad7Wc
+    //
     // Below is a workaround discussed in CE issue #5293. If the llvm issue is ever resolved it would be best
     // to apply this only for clang versions up to the official resolution.
+
     override filterUserOptions(userOptions: string[]): string[] {
         if (
             this.lang.id === 'c++' &&

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -155,6 +155,30 @@ export class ClangCompiler extends BaseCompiler {
         return this.forceDwarf4UnlessOverridden(options);
     }
 
+    // Cross-compiling for clang with -stdlib=libc++ is currently (at least up to 18.1.0) broken:
+    // https://github.com/llvm/llvm-project/issues/57104
+    // Below is a workaround discussed in CE issue #5293. If the llvm issue is ever resolved it would be best
+    // to apply this only for clang versions up to the official resolution.
+    override filterUserOptions(userOptions: string[]): string[] {
+        if (
+            this.lang.id === 'c++' &&
+            !this.buildenvsetup.compilerSupportsX86 && // cross-compilation
+            _.any(userOptions, option => {
+                return option === '-stdlib=libc++';
+            })
+        ) {
+            const addedIncludePath =
+                '-I' + path.join(path.dirname(this.compiler.exe), '../include/x86_64-unknown-linux-gnu/c++/v1/');
+            if (
+                !_.any(userOptions, option => {
+                    return option === addedIncludePath;
+                })
+            )
+                userOptions = userOptions.concat(addedIncludePath);
+        }
+        return userOptions;
+    }
+
     override async afterCompilation(
         result,
         doExecute,


### PR DESCRIPTION
…-unknown-linux-gnu/c++/v1/`

This hopefully fixes #5293 and #5143. 
But must be tested in staging first - the workaround depends indirectly on `/usr/include` contents and so I can't test locally.
