### PR TITLE
[julia] Do not modify in-place `options` in `runCompiler`

### DIFF
--- a/lib/compilers/julia.ts
+++ b/lib/compilers/julia.ts
@@ -121,8 +121,8 @@ export class JuliaCompiler extends BaseCompiler {
         }
 
         const juliaOptions = [this.compilerWrapperPath, '--'];
-        options.push(this.getOutputFilename(dirPath, this.outputFilebase));
         juliaOptions.push(...options);
+        juliaOptions.push(this.getOutputFilename(dirPath, this.outputFilebase));
 
         const execResult = await this.exec(compiler, juliaOptions, execOptions);
         return {


### PR DESCRIPTION
I was looking together with @vchuravy into adding the LLVM IR tool to the Julia compiler, and I was having some troubles because the `runCompiler` function overridden in `julia.ts` modifies in-place the input argument `options`, and then when it's called at https://github.com/compiler-explorer/compiler-explorer/blob/5bcc3bf74f2c7fe0f9076930faa3110672ea38f9/lib/base-compiler.ts#L1372 the arguments are `<input file> <output file> compiler.irArg <output file>`, with the duplicate argument `<output file>` coming from https://github.com/compiler-explorer/compiler-explorer/blob/5bcc3bf74f2c7fe0f9076930faa3110672ea38f9/lib/compilers/julia.ts#L124 I hope this makes sense :slightly_smiling_face: 