### PR TITLE
Add DXC 1.8.2403 releases

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&dxc:&rga:&clang
 
-group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1
 group.dxc.groupName=DXC
 group.dxc.isSemVer=true
 group.dxc.baseName=DXC
@@ -18,6 +18,10 @@ compiler.dxc_1_7_2308.exe=/opt/compiler-explorer/dxc-1.7.2308/bin/dxc
 compiler.dxc_1_7_2308.semver=1.7.2308
 compiler.dxc_1_8_2306.exe=/opt/compiler-explorer/dxc-1.8.2306-preview/bin/dxc
 compiler.dxc_1_8_2306.semver=1.8.2306-preview
+compiler.dxc_1_8_2403.exe=/opt/compiler-explorer/dxc-1.8.2403/bin/dxc
+compiler.dxc_1_8_2403.semver=1.8.2403
+compiler.dxc_1_8_2403_1.exe=/opt/compiler-explorer/dxc-1.8.2403.1/bin/dxc
+compiler.dxc_1_8_2403_1.semver=1.8.2403.1
 
 group.rga.compilers=rga262_dxctrunk:rga262_dxc172207:rga262_dxc162112:rga261_dxc172207:rga261_dxc162112
 group.rga.groupName=RGA


### PR DESCRIPTION
DXC has come out with a couple new releases!

This depends on the new tags added in https://github.com/compiler-explorer/infra/pull/1262, which also need to be built.
