### PR TITLE
[julia] Add LLVM IrView

### DIFF
--- a/etc/scripts/julia_wrapper.jl
+++ b/etc/scripts/julia_wrapper.jl
@@ -127,9 +127,9 @@ function main()
                 @static if VERSION >= v"1.11.0-"
                     # Hide safepoint on entry.  Only in Julia v1.11+ `code_llvm` exposes
                     # codegen parameters.
-                    InteractiveUtils.code_llvm(io_buf, me_fun, me_types; optimize, debuginfo, raw=true, dump_module=true, params=Base.CodegenParams(; safepoint_on_entry=false))
+                    InteractiveUtils.code_llvm(io_buf, me_fun, me_types; optimize, debuginfo=:source, raw=true, dump_module=true, params=Base.CodegenParams(; debug_info_kind=Cint(1), safepoint_on_entry=false, debug_info_level=Cint(2)))
                 else
-                    InteractiveUtils.code_llvm(io_buf, me_fun, me_types; optimize, debuginfo, raw=true, dump_module=true)
+                    InteractiveUtils.code_llvm(io_buf, me_fun, me_types; optimize, debuginfo=:source, raw=true, dump_module=true)
                 end
             elseif format == "native"
                 # In Julia v1.10- `code_native` doesn't expose codegen parameters.
@@ -138,7 +138,7 @@ function main()
                     # <https://github.com/JuliaLang/julia/blob/bf9079afb05829f51e60db888cb29a7c45296ee1/base/reflection.jl#L1393>.
                     # Also hide safepoint on entry.  Codegen parameters only available in
                     # Julia v1.11+.
-                    InteractiveUtils.code_native(io_buf, me_fun, me_types; debuginfo, params=Base.CodegenParams(; debug_info_kind=Cint(1), safepoint_on_entry=false))
+                    InteractiveUtils.code_native(io_buf, me_fun, me_types; debuginfo, params=Base.CodegenParams(; debug_info_kind=Cint(1), safepoint_on_entry=false, debug_info_level=Cint(2)))
                 else
                     InteractiveUtils.code_native(io_buf, me_fun, me_types; debuginfo)
                 end

--- a/etc/scripts/julia_wrapper.jl
+++ b/etc/scripts/julia_wrapper.jl
@@ -1,13 +1,12 @@
 const doc = """Julia wrapper.
 
 Usage:
-  julia_wrapper.jl <input_code> <output_path> [--format=<fmt>] [--debuginfo=<info>] [--optimize=<opt>] [--verbose]
+  julia_wrapper.jl <input_code> <output_path> [--format=<fmt>] [--optimize=<opt>] [--verbose]
   julia_wrapper.jl --help
 
 Options:
   -h --help                Show this screen.
   --format=<fmt>           Set output format (One of "lowered", "typed", "warntype", "llvm", "native") [default: native]
-  --debuginfo=<info>       Controls amount of generated metadata (One of "default", "none") [default: default]
   --optimize={true*|false} Controls whether "llvm" or "typed" output should be optimized or not [default: true]
   --verbose                Prints some process info
 """
@@ -21,7 +20,7 @@ function main()
     end
 
     format = "native"
-    debuginfo = :default
+    debuginfo = :source
     optimize = true
     verbose = false
     show_help = false
@@ -31,10 +30,6 @@ function main()
     for x in ARGS
         if startswith(x, "--format=")
             format = x[10:end]
-        elseif startswith(x, "--debuginfo=")
-            if x[13:end] == "none"
-                debuginfo = :none
-            end
         elseif startswith(x, "--optimize=")
             # Do not error out if we can't parse the option
             optimize = something(tryparse(Bool, x[12:end]), true)

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1599,7 +1599,7 @@ export class BaseCompiler implements ICompiler {
         return [{text: 'Internal error; unable to open output path'}];
     }
 
-    getIrOutputFilename(inputFilename: string, filters: ParseFiltersAndOutputOptions): string {
+    getIrOutputFilename(inputFilename: string, filters?: ParseFiltersAndOutputOptions): string {
         // filters are passed because rust needs to know whether a binary is being produced or not
         return utils.changeExtension(inputFilename, '.ll');
     }


### PR DESCRIPTION
Julia is based on LLVM like other toolchains supported by Compiler Explorer, and it can emit LLVM IR, but at the moment we only expose it via the flag `--format=llvm` to the compiler wrapper.

With this PR we add a proper LLVM IR viewer, like the other LLVM-based toolchains.  We add a new option for the wrapper to emit the entire LLVM module, which has the benefit of being parsable by Compiler Explorer, so that we can automatically filter out debug information and metadata annotations.

Preview (from https://github.com/compiler-explorer/compiler-explorer/issues/4597#issuecomment-2018956112):

![image](https://github.com/compiler-explorer/compiler-explorer/assets/765740/7c2f80b4-9c92-4761-9f6e-393d0ad26935)

We removed the custom `<[source code line] [number of output lines] [function name] [method types]>` line in the output of the `code_*` functions, together with the custom ASM parsing, because they invalidate the output (it isn't valid ASM nor LLVM), and create more problems than they solve.

This PR was prepared in collaboration with @vchuravy.

This should eventually address #4597, once inlined LLVM functions are handled by the IR parser in Compiler Explorer, I think @vchuravy can comment more on that issue.