### PR TITLE
Add MadPascal

### DIFF
--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -40,9 +40,10 @@ group.madpascal.supportsExecute=false
 group.madpascal.compilerType=madpascal
 
 compiler.mptrunk.exe=/opt/compiler-explorer/madpas-compiler-trunk/bin/mp
+compiler.mptrunk.madsexe=/opt/compiler-explorer/madpas-compiler-trunk/bin/mads
 compiler.mptrunk.semver=trunk
 compiler.mptrunk.options=-ipath:/opt/compiler-explorer/madpas-compiler-trunk/lib
-compiler.mptrunk.supportsBinary=false
+compiler.mptrunk.supportsBinary=true
 compiler.mptrunk.supportsBinaryObject=false
 
 #################################
@@ -61,12 +62,14 @@ tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
+tools.llvm-mcatrunk.exclude=mptrunk
 
 tools.osacatrunk.name=OSACA (0.5.2)
 tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled
+tools.osacatrunk.exclude=mptrunk
 
 tools.pahole.name=pahole
 tools.pahole.exe=/opt/compiler-explorer/pahole/bin/pahole
@@ -74,3 +77,4 @@ tools.pahole.type=postcompilation
 tools.pahole.class=pahole-tool
 tools.pahole.languageId=cppp
 tools.pahole.stdinHint=disabled
+tools.pahole.exclude=mptrunk

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&fpc
+compilers=&fpc:&madpascal
 defaultCompiler=fpc322
 
 nasmpath=/opt/compiler-explorer/nasm-2.16.01
@@ -26,6 +26,24 @@ compiler.fpc320.exe=/opt/compiler-explorer/fpc-3.2.0.x86_64-linux/bin/fpc
 compiler.fpc320.semver=3.2.0
 compiler.fpc322.exe=/opt/compiler-explorer/fpc-3.2.2.x86_64-linux/bin/fpc
 compiler.fpc322.semver=3.2.2
+
+
+group.madpascal.compilers=mptrunk
+group.madpascal.options=
+group.madpascal.demanglerClass=
+group.madpascal.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
+group.madpascal.isSemVer=true
+group.madpascal.baseName=madpascal
+group.madpascal.licenseLink=https://github.com/tebe6502/Mad-Pascal/blob/master/src/LICENSE
+group.madpascal.licenseName=MIT
+group.madpascal.supportsExecute=false
+group.madpascal.compilerType=madpascal
+
+compiler.mptrunk.exe=/opt/compiler-explorer/madpas-compiler-trunk/bin/mp
+compiler.mptrunk.semver=trunk
+compiler.mptrunk.options=-ipath:/opt/compiler-explorer/madpas-compiler-trunk/lib
+compiler.mptrunk.supportsBinary=false
+compiler.mptrunk.supportsBinaryObject=false
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -85,6 +85,7 @@ export {LDCCompiler} from './ldc.js';
 export {LLCCompiler} from './llc.js';
 export {LLVMmcaTool} from './llvm-mca.js';
 export {LLVMMOSCompiler} from './llvm-mos.js';
+export {MadPascalCompiler} from './madpascal.js';
 export {MovfuscatorCompiler} from './movfuscator.js';
 export {MLIRCompiler} from './mlir.js';
 export {GM2Compiler} from './gm2.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1178,3 +1178,28 @@ export class GnuCobolParser extends GCCParser {
         return possible;
     }
 }
+
+export class MadpascalParser extends GCCParser {
+    static override async parse(compiler) {
+        const results = await Promise.all([this.getOptions(compiler, '')]);
+        const options = Object.assign({}, ...results);
+        await this.setCompilerSettingsFromOptions(compiler, options);
+        return compiler;
+    }
+
+    static override async getOptions(compiler, helpArg) {
+        const optionFinder = /^(-[\w<>:]*) *(.*)/i;
+        const result = await compiler.execCompilerCached(compiler.compiler.exe, helpArg.split(' '));
+        const options = this.parseLines(result.stdout + result.stderr, optionFinder);
+        compiler.possibleArguments.populateOptions(options);
+        return options;
+    }
+
+    static override async getPossibleStdvers(compiler): Promise<CompilerOverrideOptions> {
+        return [];
+    }
+
+    static override async getPossibleTargets(compiler): Promise<string[]> {
+        return ['a8', 'c64', 'c4p', 'raw', 'neo'];
+    }
+}

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1189,7 +1189,7 @@ export class MadpascalParser extends GCCParser {
 
     static override async getOptions(compiler, helpArg) {
         const optionFinder = /^(-[\w<>:]*) *(.*)/i;
-        const result = await compiler.execCompilerCached(compiler.compiler.exe, helpArg.split(' '));
+        const result = await compiler.execCompilerCached(compiler.compiler.exe, []);
         const options = this.parseLines(result.stdout + result.stderr, optionFinder);
         compiler.possibleArguments.populateOptions(options);
         return options;

--- a/lib/compilers/madpascal.ts
+++ b/lib/compilers/madpascal.ts
@@ -25,18 +25,24 @@
 import {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler, c_value_placeholder} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
 import {MadpascalParser} from './argument-parsers.js';
 import * as path from 'path';
+import {MadsAsmParser} from '../parsers/asm-parser-mads.js';
 
 export class MadPascalCompiler extends BaseCompiler {
+    protected madsExe: any;
+
     static get key() {
         return 'madpascal';
     }
 
-    constructor(info: PreliminaryCompilerInfo, env) {
+    constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(info, env);
 
         this.compileFilename = 'output.pas';
+        this.madsExe = this.compilerProps<string>(`compiler.${info.id}.madsexe`);
+        this.asm = new MadsAsmParser(this.compilerProps);
     }
 
     override getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {

--- a/lib/compilers/madpascal.ts
+++ b/lib/compilers/madpascal.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler, c_value_placeholder} from '../base-compiler.js';
+import {MadpascalParser} from './argument-parsers.js';
+import * as path from 'path';
+
+export class MadPascalCompiler extends BaseCompiler {
+    static get key() {
+        return 'madpascal';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env) {
+        super(info, env);
+
+        this.compileFilename = 'output.pas';
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string, key?: any): string {
+        let filename;
+        if (key && key.backendOptions && key.backendOptions.customOutputFilename) {
+            filename = key.backendOptions.customOutputFilename;
+        } else {
+            filename = `${outputFilebase}.a65`;
+        }
+
+        if (dirPath) {
+            return path.join(dirPath, filename);
+        } else {
+            return filename;
+        }
+    }
+
+    protected override getArgumentParser(): any {
+        return MadpascalParser;
+    }
+
+    protected override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
+        filters.demangle = false;
+        return [];
+    }
+
+    override getTargetFlags(): string[] {
+        return [`-target:${c_value_placeholder}`];
+    }
+
+    override orderArguments(
+        options: string[],
+        inputFilename: string,
+        libIncludes: string[],
+        libOptions: string[],
+        libPaths: string[],
+        libLinks: string[],
+        userOptions: string[],
+        staticLibLinks: string[],
+    ) {
+        return options.concat(
+            [this.filename(inputFilename)],
+            libIncludes,
+            libOptions,
+            libPaths,
+            libLinks,
+            staticLibLinks,
+            userOptions,
+        );
+    }
+}

--- a/lib/parsers/asm-parser-mads.ts
+++ b/lib/parsers/asm-parser-mads.ts
@@ -22,9 +22,25 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import * as utils from '../utils.js';
+import {assert} from '../assert.js';
+import {
+    AsmResultLabel,
+    AsmResultSource,
+    ParsedAsmResult,
+    ParsedAsmResultLine,
+} from '../../types/asmresult/asmresult.interfaces.js';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {AsmParser} from './asm-parser.js';
+import {AsmRegex} from './asmregex.js';
 
 export class MadsAsmParser extends AsmParser {
+    protected lineWithoutAddress: RegExp;
+    protected standAloneLabel: RegExp;
+    protected asmOpcodeReWithInlineLabel: RegExp;
+    protected varAssignment: RegExp;
+    protected constAssignment: RegExp;
+
     constructor(compilerProps) {
         super(compilerProps);
 
@@ -36,9 +52,190 @@ export class MadsAsmParser extends AsmParser {
         // not really a proper file/line annotation, but it's all we have
         this.source6502Dbg = /^; optimize (?:OK|FAIL) \((.*)\), line = (\d*)/;
         this.source6502DbgEnd = /\s*\.ENDL/;
+
+        this.lineWithoutAddress = /[\d ]{6} (.*)/;
+
+        this.asmOpcodeRe = /^[\d ]{6} (?<address>[\dA-F]+)\s(?<opcodes>([\dA-F]{2} ?)+)\s*(?<disasm>.*)/;
+        this.asmOpcodeReWithInlineLabel =
+            /^[\d ]{6} (?<address>[\dA-F]+) (?<opcodes>([\dA-F]{2} ?)+)\t+(?<label>[A-Z][\w\d]*)\t+(?<disasm>.*)/;
+        this.standAloneLabel = /^[\d ]{6} ([\dA-F]{4})\t+([a-zA-Z@][\w\d_]*)/;
+
+        this.constAssignment = /^[\d ]{6} (= )([\dA-Z]{4})\t+(.*)\t(= .*)/;
+        this.varAssignment = /^[\d ]{6} ([\dA-Z]{4})\t+(\.var )(.*)\t(= .*)/;
+
+        this.commentOnly = /^[\d ]{6} \t*(; .*)/;
+
+        this.lineRe = /^[\d ]{6} (.*)/;
     }
 
     override handleSource(context, line) {}
 
     override handleStabs(context, line) {}
+
+    getAsmLineWithOpcodeReMatch(
+        line: string,
+        source: AsmResultSource | undefined | null,
+        filters: ParseFiltersAndOutputOptions,
+        match,
+    ): ParsedAsmResultLine {
+        const labelsInLine: AsmResultLabel[] = [];
+
+        const address = parseInt(match.groups.address, 16);
+        const opcodes = (match.groups.opcodes || '').split(' ').filter(x => !!x);
+        let text = '';
+        if (match.groups.label) {
+            text = match.groups.label.trim() + ': ';
+        }
+        const disassembly = ' ' + AsmRegex.filterAsmLine(match.groups.disasm, filters);
+        const destMatch = line.match(this.destRe);
+        if (destMatch) {
+            const labelName = destMatch[2];
+            const startCol = disassembly.indexOf(labelName) + 1;
+            labelsInLine.push({
+                name: labelName,
+                range: {
+                    startCol: startCol,
+                    endCol: startCol + labelName.length,
+                },
+            });
+        }
+
+        return {
+            opcodes: opcodes,
+            address: address,
+            text: text + disassembly,
+            source: source,
+            labels: labelsInLine,
+        };
+    }
+
+    override processBinaryAsm(asmResult: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
+        const startTime = process.hrtime.bigint();
+        const asm: ParsedAsmResultLine[] = [];
+        const labelDefinitions: Record<string, number> = {};
+        const dontMaskFilenames = filters.dontMaskFilenames;
+
+        let asmLines = utils.splitLines(asmResult);
+        const startingLineCount = asmLines.length;
+        const source: AsmResultSource | undefined | null = null;
+        const func: string | null = null;
+        const mayRemovePreviousLabel = true;
+
+        // Handle "error" documents.
+        if (asmLines.length === 1 && asmLines[0][0] === '<') {
+            return {
+                asm: [{text: asmLines[0], source: null}],
+            };
+        }
+
+        if (filters.preProcessBinaryAsmLines !== undefined) {
+            asmLines = filters.preProcessBinaryAsmLines(asmLines);
+        }
+
+        const linePrefix = filters.trim ? ' ' : '  ';
+
+        for (const line of asmLines) {
+            const labelsInLine: AsmResultLabel[] = [];
+
+            if (asm.length >= this.maxAsmLines) {
+                if (asm.length === this.maxAsmLines) {
+                    asm.push({
+                        text: '[truncated; too many lines]',
+                        source: null,
+                        labels: labelsInLine,
+                    });
+                }
+                continue;
+            }
+
+            let match = line.match(this.asmOpcodeReWithInlineLabel);
+            if (match) {
+                assert(match.groups);
+
+                labelDefinitions[match.groups.label] = asm.length;
+                asm.push(this.getAsmLineWithOpcodeReMatch(line, source, filters, match));
+
+                continue;
+            }
+
+            match = line.match(this.asmOpcodeRe);
+            if (match) {
+                assert(match.groups);
+
+                const parsedLine = this.getAsmLineWithOpcodeReMatch(line, source, filters, match);
+                parsedLine.text = linePrefix + parsedLine.text;
+                asm.push(parsedLine);
+
+                continue;
+            }
+
+            match = line.match(this.standAloneLabel);
+            if (match) {
+                const address = parseInt(match[1], 16);
+                const label = match[2];
+                labelDefinitions[label] = asm.length;
+                asm.push({
+                    address: address,
+                    text: label + ':',
+                });
+                continue;
+            }
+
+            match = line.match(this.commentOnly);
+            if (match) {
+                if (!filters.commentOnly) {
+                    asm.push({
+                        text: linePrefix + match[1],
+                    });
+                }
+
+                continue;
+            }
+
+            match = line.match(this.constAssignment);
+            if (match) {
+                const value = parseInt(match[1], 16);
+
+                const label = match[3];
+                labelDefinitions[label] = asm.length;
+                asm.push({
+                    text: match[3] + ' ' + match[4],
+                });
+                continue;
+            }
+
+            match = line.match(this.varAssignment);
+            if (match) {
+                const address = parseInt(match[1], 16);
+                const label = match[3];
+                labelDefinitions[label] = asm.length;
+                asm.push({
+                    address: address,
+                    text: match[2] + match[3] + ' ' + match[4],
+                });
+                continue;
+            }
+
+            if (!filters.directives) {
+                match = line.match(this.lineRe);
+                if (match) {
+                    asm.push({
+                        text: linePrefix + match[1],
+                    });
+                }
+            }
+        }
+
+        this.removeLabelsWithoutDefinition(asm, labelDefinitions);
+
+        const endTime = process.hrtime.bigint();
+
+        return {
+            asm: asm,
+            labelDefinitions: labelDefinitions,
+            parsingTime: ((endTime - startTime) / BigInt(1000000)).toString(),
+            filteredCount: startingLineCount - asm.length,
+            languageId: 'asm6502',
+        };
+    }
 }

--- a/lib/parsers/asm-parser-mads.ts
+++ b/lib/parsers/asm-parser-mads.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {AsmParser} from './asm-parser.js';
+
+export class MadsAsmParser extends AsmParser {
+    constructor(compilerProps) {
+        super(compilerProps);
+
+        this.labelDef = /^([l|L]_\d*)$/;
+        this.assignmentDef = /^([A-Z_a-z][\w$.]*)\s*=/;
+
+        this.stdInLooking = /<stdin>|^-$|output\.[^/]+$|<source>/;
+
+        // not really a proper file/line annotation, but it's all we have
+        this.source6502Dbg = /^; optimize (?:OK|FAIL) \((.*)\), line = (\d*)/;
+        this.source6502DbgEnd = /\s*\.ENDL/;
+    }
+
+    override handleSource(context, line) {}
+
+    override handleStabs(context, line) {}
+}


### PR DESCRIPTION
Fixes #6143

MadPascal is a crosscompiler for 6502 targets

Currently only shows assembly (pretty much unparsed)

For the Assembler, we also need to build https://github.com/tebe6502/Mad-Assembler and use that to assemble executables to use in possible vms - this a task for later

Todo:

- [x] For staging/prod we need to wait for a new nightly build
- [x] Argument Parser doesn't work for some reason
