### PR TITLE
[HLSL] Add DXC 1.8.2403.2 release

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&dxc:&rga:&clang
 
-group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2
 group.dxc.groupName=DXC
 group.dxc.isSemVer=true
 group.dxc.baseName=DXC
@@ -22,6 +22,8 @@ compiler.dxc_1_8_2403.exe=/opt/compiler-explorer/dxc-1.8.2403/bin/dxc
 compiler.dxc_1_8_2403.semver=1.8.2403
 compiler.dxc_1_8_2403_1.exe=/opt/compiler-explorer/dxc-1.8.2403.1/bin/dxc
 compiler.dxc_1_8_2403_1.semver=1.8.2403.1
+compiler.dxc_1_8_2403_2.exe=/opt/compiler-explorer/dxc-1.8.2403.2/bin/dxc
+compiler.dxc_1_8_2403_2.semver=1.8.2403.2
 
 group.rga.compilers=rga262_dxctrunk:rga262_dxc172207:rga262_dxc162112:rga261_dxc172207:rga261_dxc162112
 group.rga.groupName=RGA


### PR DESCRIPTION
This change adds the new DXC 1.8.2403.2 release. This PR depends on the infra PR below being merged and compilers built:

https://github.com/compiler-explorer/infra/pull/1266
