### PR TITLE
Implement alert filters for library dialog

### DIFF
--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -61,8 +61,8 @@ export class LibsWidget {
                     content:
                         'Compiler Explorer does not yet support libraries for the rustc nightly/beta compilers.' +
                         'For library support, please use the stable compiler. Please see tracking issue' +
-                        '<a href="https://github.com/compiler-explorer/compiler-explorer/issues/3766">compiler-explorer/' +
-                        'compiler-explorer#3766</a> for more information.',
+                        '<a href="https://github.com/compiler-explorer/compiler-explorer/issues/3766">' +
+                        'compiler-explorer/compiler-explorer#3766</a> for more information.',
                 };
             }
             return null;

--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -59,8 +59,10 @@ export class LibsWidget {
                 return {
                     title: 'Missing library support for rustc nightly/beta',
                     content:
-                        'Compiler Explorer does not yet support libraries for the rustc nightly/beta compilers.　For library support, please use the stable compiler.' +
-                        'Please see tracking issue <a href="https://github.com/compiler-explorer/compiler-explorer/issues/3766">compiler-explorer/compiler-explorer#3766</a> for more information.',
+                        'Compiler Explorer does not yet support libraries for the rustc nightly/beta compilers.' +
+                        'For library support, please use the stable compiler. Please see tracking issue' +
+                        '<a href="https://github.com/compiler-explorer/compiler-explorer/issues/3766">compiler-explorer/' +
+                        'compiler-explorer#3766</a> for more information.',
                 };
             }
             return null;

--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -28,6 +28,7 @@ import {Library, LibraryVersion} from '../options.interfaces.js';
 import {Lib, WidgetState} from './libs-widget.interfaces.js';
 import {unwrapString} from '../assert.js';
 import {localStorage} from '../local.js';
+import {Alert} from './alert';
 
 const FAV_LIBS_STORE_KEY = 'favlibs';
 
@@ -37,6 +38,8 @@ type AvailableLibs = Record<string, LangLibs>;
 type LibInUse = {libId: string; versionId: string} & LibraryVersion;
 
 type FavLibraries = Record<string, string[]>;
+
+type PopupAlertFilter = (compiler: string, langId: string) => {title: string; content: string} | null;
 
 export class LibsWidget {
     private domRoot: JQuery;
@@ -50,6 +53,19 @@ export class LibsWidget {
     private readonly onChangeCallback: () => void;
 
     private readonly availableLibs: AvailableLibs;
+    private readonly filters: PopupAlertFilter[] = [
+        (compilerId, langId) => {
+            if (langId === 'rust' && ['beta', 'nightly'].includes(compilerId)) {
+                return {
+                    title: 'Missing library support for rustc nightly/beta',
+                    content:
+                        'Compiler Explorer does not yet support libraries for the rustc nightly/beta compilers.　For library support, please use the stable compiler.' +
+                        'Please see tracking issue <a href="https://github.com/compiler-explorer/compiler-explorer/issues/3766">compiler-explorer/compiler-explorer#3766</a> for more information.',
+                };
+            }
+            return null;
+        },
+    ];
 
     constructor(
         langId: string,
@@ -83,6 +99,18 @@ export class LibsWidget {
 
         this.domRoot.on('shown.bs.modal', () => {
             searchInput.trigger('focus');
+
+            for (const filter of this.filters) {
+                const filterResult = filter(this.currentCompilerId, this.currentLangId);
+                if (filterResult !== null) {
+                    const alertSystem = new Alert();
+                    alertSystem.notify(`${filterResult.title}: ${filterResult.content}`, {
+                        group: 'libs',
+                        alertClass: 'notification-error',
+                    });
+                    break;
+                }
+            }
         });
 
         searchInput.on('input', this.startSearching.bind(this));


### PR DESCRIPTION
Hey friends, it's been a while since last time :)

There are quite a few conditions/cases where the library alert will pop up, without anything meaningful inside of it. This is particularly the case for Rust where you have the 100 crates on stable, but zero support in beta/nightly. I figured informing the user in cases like this would be nice to have.

This PR adds a rather simple alerting mechanism to alert the user of any conditions that might not be as apparent (such as Rust crates only being on stable)

Below is a small gif of how it works. I'm not sure this is the easiest way to convey this information (especially considering the modal popup overshadows the alert) so please share any other ideas. Maybe it's better to have the content fill the modal instead?

![Peek 2024-04-07 00-43](https://github.com/compiler-explorer/compiler-explorer/assets/42585241/53b8a8ad-3f5a-4500-83ce-af627f2e5655)

Relevant issues: #3766 #6250