### PR TITLE
Add llvm 18 compilers for LLVM IR/MIR, assembly and TableGen

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -160,7 +160,7 @@ compiler.gnuasriscv32g1320.name=RISC-V binutils 2.38.0
 compiler.gnuasriscv32g1320.semver=2.38.0
 compiler.gnuasriscv32g1320.objdumper=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
-group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas_trunk:llvmas_assertions_trunk
+group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version
 group.llvmas.options=-filetype=obj -o example.o
 group.llvmas.versionRe=LLVM version .*
@@ -233,6 +233,8 @@ compiler.llvmas1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/llvm-mc
 compiler.llvmas1600.semver=16.0.0
 compiler.llvmas1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-mc
 compiler.llvmas1701.semver=17.0.1
+compiler.llvmas1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llvm-mc
+compiler.llvmas1810.semver=18.1.0
 compiler.llvmas_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mc
 compiler.llvmas_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llvmas_trunk.semver=(trunk)

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -8,7 +8,7 @@ licenseName=LLVM Apache 2
 licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.irclang.compilers=irclang401:irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclang1001:irclang1100:irclang1101:irclang1200:irclang1201:irclang1300:irclang1400:irclang1500:irclang1600:irclang1701:irclangtrunk:irclang-assertions-trunk
+group.irclang.compilers=irclang401:irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclang1001:irclang1100:irclang1101:irclang1200:irclang1201:irclang1300:irclang1400:irclang1500:irclang1600:irclang1701:irclang1810:irclangtrunk:irclang-assertions-trunk
 group.irclang.intelAsm=-masm=intel
 group.irclang.groupName=Clang x86-64
 group.irclang.options=-x ir
@@ -49,6 +49,8 @@ compiler.irclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
 compiler.irclang1600.semver=16.0.0
 compiler.irclang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang++
 compiler.irclang1701.semver=17.0.1
+compiler.irclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
+compiler.irclang1810.semver=18.1.0
 compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.irclangtrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.irclangtrunk.semver=(trunk)
@@ -56,7 +58,7 @@ compiler.irclang-assertions-trunk.exe=/opt/compiler-explorer/clang-assertions-tr
 compiler.irclang-assertions-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.irclang-assertions-trunk.semver=(assertions trunk)
 
-group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llc1600:llc1701:llctrunk:llc-assertions-trunk
+group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llc1600:llc1701:llc1810:llctrunk:llc-assertions-trunk
 group.llc.compilerType=llc
 group.llc.supportsExecute=false
 group.llc.intelAsm=-masm=intel
@@ -107,6 +109,8 @@ compiler.llc1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/llc
 compiler.llc1600.semver=16.0.0
 compiler.llc1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llc
 compiler.llc1701.semver=17.0.1
+compiler.llc1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llc
+compiler.llc1810.semver=18.1.0
 compiler.llctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.llctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llctrunk.semver=(trunk)
@@ -114,7 +118,7 @@ compiler.llc-assertions-trunk.exe=/opt/compiler-explorer/clang-assertions-trunk/
 compiler.llc-assertions-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llc-assertions-trunk.semver=(assertions trunk)
 
-group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opt1001:opt1100:opt1101:opt1200:opt1201:opt1300:opt1400:opt1500:opt1600:opt1701:opttrunk:opt-assertions-trunk
+group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opt1001:opt1100:opt1101:opt1200:opt1201:opt1300:opt1400:opt1500:opt1600:opt1701:opt1810:opttrunk:opt-assertions-trunk
 group.opt.compilerType=opt
 group.opt.supportsBinary=false
 group.opt.supportsExecute=false
@@ -167,6 +171,8 @@ compiler.opt1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/opt
 compiler.opt1600.semver=16.0.0
 compiler.opt1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/opt
 compiler.opt1701.semver=17.0.1
+compiler.opt1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/opt
+compiler.opt1810.semver=18.1.0
 compiler.opttrunk.exe=/opt/compiler-explorer/clang-trunk/bin/opt
 compiler.opttrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.opttrunk.semver=(trunk)

--- a/etc/config/llvm_mir.amazon.properties
+++ b/etc/config/llvm_mir.amazon.properties
@@ -8,7 +8,7 @@ licenseName=LLVM Apache 2
 licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.mirllc.compilers=mirllc32:mirllc33:mirllc391:mirllc400:mirllc401:mirllc500:mirllc600:mirllc700:mirllc800:mirllc900:mirllc1000:mirllc1001:mirllc1100:mirllc1101:mirllc1200:mirllc1201:mirllc1300:mirllc1400:mirllc1500:mirllctrunk:mirllc-assertions-trunk
+group.mirllc.compilers=mirllc32:mirllc33:mirllc391:mirllc400:mirllc401:mirllc500:mirllc600:mirllc700:mirllc800:mirllc900:mirllc1000:mirllc1001:mirllc1100:mirllc1101:mirllc1200:mirllc1201:mirllc1300:mirllc1400:mirllc1500:mirllc1600:mirllc1701:mirllc1810:mirllctrunk:mirllc-assertions-trunk
 group.mirllc.compilerType=llc
 group.mirllc.supportsExecute=false
 group.mirllc.intelAsm=-masm=intel
@@ -55,6 +55,12 @@ compiler.mirllc1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/llc
 compiler.mirllc1400.semver=14.0.0
 compiler.mirllc1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/llc
 compiler.mirllc1500.semver=15.0.0
+compiler.mirllc1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/llc
+compiler.mirllc1600.semver=16.0.0
+compiler.mirllc1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llc
+compiler.mirllc1701.semver=17.0.1
+compiler.mirllc1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llc
+compiler.mirllc1810.semver=18.1.0
 compiler.mirllctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.mirllctrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.mirllctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&llvmtblgen
-defaultCompiler=llvmtblgen1701
+defaultCompiler=llvmtblgen1810
 compilerType=tablegen
 supportsBinary=false
 supportsExecute=false
 
-group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701
+group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701:llvmtblgen1810
 group.llvmtblgen.groupName=LLVM TableGen
 group.llvmtblgen.baseName=LLVM TableGen
 group.llvmtblgen.isSemVer=true
@@ -24,3 +24,7 @@ compiler.llvmtblgen_trunk.includePath=/opt/compiler-explorer/clang-trunk/include
 compiler.llvmtblgen1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-tblgen
 compiler.llvmtblgen1701.semver=17.0.1
 compiler.llvmtblgen1701.includePath=/opt/compiler-explorer/clang-17.0.1/include/
+
+compiler.llvmtblgen1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llvm-tblgen
+compiler.llvmtblgen1810.semver=18.1.0
+compiler.llvmtblgen1810.includePath=/opt/compiler-explorer/clang-18.1.0/include/


### PR DESCRIPTION
Fixes #6260

This uses the 18.1.0 llvm install that C is already using.

It also updates TableGen's default to 18.1.0 and adds 16 and 17 compilers to MIR where they were missing.