### PR TITLE
Simplify Android compiler properties

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -5,10 +5,8 @@ group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
-group.android-d8.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
-group.android-d8.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
 group.android-d8.kotlinId=kotlinc1920
-group.android-d8.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
+group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.java-d8-8242.name=d8 8.2.42
 compiler.java-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
@@ -32,7 +30,6 @@ compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-lates
 compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
 compiler.java-dex2oat-latest.d8Id=java-d8-8242
-compiler.java-dex2oat-latest.d8Path=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.java-dex2oat-latest.isNightly=true
 
 compiler.java-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
@@ -40,6 +37,5 @@ compiler.java-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11
 compiler.java-dex2oat-3411.exe=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3411.objdumper=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/oatdump
 compiler.java-dex2oat-3411.d8Id=java-d8-8242
-compiler.java-dex2oat-3411.d8Path=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 
 defaultCompiler=java-dex2oat-latest

--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -6,7 +6,6 @@ group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
-group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.java-d8-8242.name=d8 8.2.42
 compiler.java-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -5,9 +5,8 @@ group.android-d8.compilers=android-java-d8-default
 # reflect the paths in the java and kotlin default config.
 group.android-d8.javaId=javacdefault
 group.android-d8.javaPath=/usr/bin/java
-group.android-d8.javacPath=/usr/bin/javac
 group.android-d8.kotlinId=kotlincdefault
-group.android-d8.kotlincPath=/usr/bin/kotlinc-jvm
+group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.android-java-d8-default.name=android d8 default
 compiler.android-java-d8-default.compilerType=android-d8
@@ -27,7 +26,6 @@ compiler.android-java-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatd
 
 # This should reflect the ID and exe for android-java-d8-default.
 compiler.android-java-dex2oat-default.d8Id=android-java-d8-default
-compiler.android-java-dex2oat-default.d8Path=/usr/local/bin/r8.jar
 
 
 defaultCompiler=android-java-dex2oat-default

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -6,7 +6,6 @@ group.android-d8.compilers=android-java-d8-default
 group.android-d8.javaId=javacdefault
 group.android-d8.javaPath=/usr/bin/java
 group.android-d8.kotlinId=kotlincdefault
-group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.android-java-d8-default.name=android d8 default
 compiler.android-java-d8-default.compilerType=android-d8

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -6,7 +6,6 @@ group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
-group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.kotlin-d8-8242.name=d8 8.2.42
 compiler.kotlin-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -5,10 +5,8 @@ group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
-group.android-d8.javaPath=/opt/compiler-explorer/jdk-16.0.1/bin/java
-group.android-d8.javacPath=/opt/compiler-explorer/jdk-16.0.1/bin/javac
 group.android-d8.kotlinId=kotlinc1920
-group.android-d8.kotlincPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/bin/kotlinc
+group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.kotlin-d8-8242.name=d8 8.2.42
 compiler.kotlin-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
@@ -32,7 +30,6 @@ compiler.kotlin-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-lat
 compiler.kotlin-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.kotlin-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
 compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8242
-compiler.kotlin-dex2oat-latest.d8Path=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.kotlin-dex2oat-latest.isNightly=true
 
 compiler.kotlin-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
@@ -40,6 +37,5 @@ compiler.kotlin-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11
 compiler.kotlin-dex2oat-3411.exe=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/dex2oat64
 compiler.kotlin-dex2oat-3411.objdumper=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/oatdump
 compiler.kotlin-dex2oat-3411.d8Id=kotlin-d8-8242
-compiler.kotlin-dex2oat-3411.d8Path=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 
 defaultCompiler=kotlin-dex2oat-latest

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -4,10 +4,8 @@ group.android-d8.compilers=android-kotlin-d8-default
 # When testing locally, these paths must be valid and should
 # reflect the paths in the java and kotlin default config.
 group.android-d8.javaId=javacdefault
-group.android-d8.javaPath=/usr/bin/java
-group.android-d8.javacPath=/usr/bin/javac
 group.android-d8.kotlinId=kotlincdefault
-group.android-d8.kotlincPath=/usr/bin/kotlinc-jvm
+group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.android-kotlin-d8-default.name=android d8 default
 compiler.android-kotlin-d8-default.compilerType=android-d8
@@ -27,7 +25,6 @@ compiler.android-kotlin-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oa
 
 # This should reflect the ID and exe for android-kotlin-d8-default.
 compiler.android-kotlin-dex2oat-default.d8Id=android-kotlin-d8-default
-compiler.android-kotlin-dex2oat-default.d8Path=/usr/local/bin/r8.jar
 
 
 defaultCompiler=android-kotlin-dex2oat-default

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -5,7 +5,6 @@ group.android-d8.compilers=android-kotlin-d8-default
 # reflect the paths in the java and kotlin default config.
 group.android-d8.javaId=javacdefault
 group.android-d8.kotlinId=kotlincdefault
-group.android-d8.d8Class=com.android.tools.r8.D8
 
 compiler.android-kotlin-d8-default.name=android d8 default
 compiler.android-kotlin-d8-default.compilerType=android-d8

--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -49,7 +49,6 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
 
     javaId: string;
     kotlinId: string;
-    d8Class: string;
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env) {
         super({...compilerInfo}, env);
@@ -59,13 +58,6 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
 
         this.javaId = this.compilerProps<string>(`group.${this.compiler.group}.javaId`);
         this.kotlinId = this.compilerProps<string>(`group.${this.compiler.group}.kotlinId`);
-
-        // Points to com.android.tools.r8.D8 by default, but can be overridden
-        // per-compiler if needed.
-        this.d8Class = this.compilerProps<string>(`compiler.${this.compiler.id}.d8Class`);
-        if (!this.d8Class) {
-            this.d8Class = this.compilerProps<string>(`group.${this.compiler.group}.d8Class`);
-        }
     }
 
     override getOutputFilename(dirPath: string) {
@@ -149,7 +141,7 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         const d8Options = [
             '-cp',
             this.compiler.exe, // R8 jar.
-            this.d8Class,
+            'com.android.tools.r8.D8', // Main class name for the D8 compiler.
             ...options.slice(0, sourceFileOptionIndex),
             ...classFiles,
         ];

--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -66,7 +66,6 @@ export class Dex2OatCompiler extends BaseCompiler {
     fullOutput: boolean;
 
     d8Id: string;
-    d8Path: string;
     artArtifactDir: string;
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env) {
@@ -102,7 +101,6 @@ export class Dex2OatCompiler extends BaseCompiler {
 
         // The underlying D8 version+exe.
         this.d8Id = this.compilerProps<string>(`compiler.${this.compiler.id}.d8Id`);
-        this.d8Path = this.compilerProps<string>(`compiler.${this.compiler.id}.d8Path`);
 
         // The directory containing ART artifacts necessary for dex2oat to run.
         this.artArtifactDir = this.compilerProps<string>(`compiler.${this.compiler.id}.artArtifactDir`);
@@ -147,7 +145,7 @@ export class Dex2OatCompiler extends BaseCompiler {
         );
 
         const compileResult = await d8Compiler.runCompiler(
-            this.d8Path,
+            d8Compiler.getInfo().exe,
             d8Options,
             this.filename(inputFilename),
             d8Compiler.getDefaultExecOptions(),


### PR DESCRIPTION
updates intermediate compiler exe input to refer to the compiler's getInfo().exe so that paths don't need to be hardcoded in properties.
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
