### PR TITLE
Update dex2oat input arguments

### DIFF
--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -202,6 +202,7 @@ export class Dex2OatCompiler extends BaseCompiler {
             '--generate-debug-info',
             '--dex-location=/system/framework/classes.dex',
             `--dex-file=${tmpDir}/${dexFile}`,
+            '--copy-dex-files=always',
             '--runtime-arg',
             '-Xbootclasspath:' + bootclassjars.map(f => path.join(this.artArtifactDir, f)).join(':'),
             '--runtime-arg',


### PR DESCRIPTION
Adds '--copy-dex-files=always', as it is needed in newer versions of dex2oat. This doesn't affect older versions.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
