### PR TITLE
Support compilation with boot image for Android

### DIFF
--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -203,12 +203,14 @@ export class Dex2OatCompiler extends BaseCompiler {
             '--dex-location=/system/framework/classes.dex',
             `--dex-file=${tmpDir}/${dexFile}`,
             '--runtime-arg',
+            '-Xgc:CMC',
+            '--runtime-arg',
             '-Xbootclasspath:' + bootclassjars.map(f => path.join(this.artArtifactDir, f)).join(':'),
             '--runtime-arg',
-            '-Xbootclasspath-locations:/apex/com.android.art/core-oj.jar:/apex/com.android.art/core-libart.jar' +
-                ':/apex/com.android.art/okhttp.jar:/apex/com.android.art/bouncycastle.jar' +
-                ':/apex/com.android.art/javalib/apache-xml.jar',
-            '--boot-image=/nonx/boot.art',
+            '-Xbootclasspath-locations:/apex/com.android.art/javalib/core-oj.jar' +
+                ':/apex/com.android.art/javalib/core-libart.jar:/apex/com.android.art/javalib/okhttp.jar' +
+                ':/apex/com.android.art/javalib/bouncycastle.jar:/apex/com.android.art/javalib/apache-xml.jar',
+            `--boot-image=${this.artArtifactDir}/app/system/framework/boot.art`,
             `--oat-file=${tmpDir}/classes.odex`,
             '--force-allow-oj-inlines',
             `--dump-cfg=${tmpDir}/classes.cfg`,


### PR DESCRIPTION
Updates dex2oat to specify a valid boot image for accurate compilations. For example, these two methods should now (correctly) compile to the same native code:
```
static int insertAndReturn(int num) {
    int[] arr = {num};
    return arr[0];
}

static int justReturn(int num) {
    return num;
}
```
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
