### PR TITLE
Add the `phf` crate for Rust

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -146,3 +146,4 @@ From oldest to newest contributor, we would like to thank:
 - [Andrea Tomasi](https://github.com/treere)
 - [Khyber Sen](https://github.com/kkysen)
 - [Matthew Guidry](https://github.com/mguid65)
+- [Adam Thibert](https://github.com/adamaq01)

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -252,7 +252,7 @@ compiler.mrustc-master.isNightly=true
 #################################
 # Installed libs, generated from ce_install generate-rust-crates
 # Don't modify directly
-libs=aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bitflags:block-buffer:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
+libs=aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bitflags:block-buffer:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
 
 libs.aho-corasick.name=aho-corasick
 libs.aho-corasick.url=https://crates.io/crates/aho-corasick
@@ -643,6 +643,12 @@ libs.percent-encoding.url=https://crates.io/crates/percent-encoding
 libs.percent-encoding.versions=210
 libs.percent-encoding.versions.210.version=2.1.0
 libs.percent-encoding.versions.210.path=libpercent_encoding.rlib
+
+libs.phf.name=phf
+libs.phf.url=https://crates.io/crates/phf
+libs.phf.versions=0112
+libs.phf.versions.0112.version=0.11.2
+libs.phf.versions.0112.path=libphf.rlib
 
 libs.pin-project-lite.name=pin-project-lite
 libs.pin-project-lite.url=https://crates.io/crates/pin-project-lite


### PR DESCRIPTION
Hi! Thanks for the amazing tool that is CE.

I would like to have the rust `phf` crate added on the website because I think it would be nice to have an easy way to see how static maps performs compare to non static ones.
Feel free to reject the PR if you think that it is not relevant 🥲

I also opened a PR on the `infra` repository since the crates data is actually generated from it.
See: https://github.com/compiler-explorer/infra/pull/1280