### PR TITLE
Add profile support for dex2oat.

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -30,11 +30,13 @@ compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bi
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
 compiler.java-dex2oat-latest.d8Id=java-d8-8242
 compiler.java-dex2oat-latest.isNightly=true
+compiler.java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
 
 compiler.java-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
 compiler.java-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11
 compiler.java-dex2oat-3411.exe=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3411.objdumper=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/oatdump
 compiler.java-dex2oat-3411.d8Id=java-d8-8242
+compiler.java-dex2oat-3411.profmanPath=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/profman
 
 defaultCompiler=java-dex2oat-latest

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -22,6 +22,7 @@ compiler.android-java-dex2oat-default.compilerType=dex2oat
 compiler.android-java-dex2oat-default.artArtifactDir=/usr/bin/dex2oat
 compiler.android-java-dex2oat-default.exe=/usr/bin/dex2oat/x86_64/bin/dex2oat64
 compiler.android-java-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatdump
+compiler.android-java-dex2oat-default.profmanPath=/usr/bin/dex2oat/x86_64/bin/profman
 
 # This should reflect the ID and exe for android-java-d8-default.
 compiler.android-java-dex2oat-default.d8Id=android-java-d8-default

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -30,11 +30,13 @@ compiler.kotlin-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/
 compiler.kotlin-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
 compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8242
 compiler.kotlin-dex2oat-latest.isNightly=true
+compiler.kotlin-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
 
 compiler.kotlin-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
 compiler.kotlin-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11
 compiler.kotlin-dex2oat-3411.exe=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/dex2oat64
 compiler.kotlin-dex2oat-3411.objdumper=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/oatdump
 compiler.kotlin-dex2oat-3411.d8Id=kotlin-d8-8242
+compiler.kotlin-dex2oat-3411.profmanPath=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/profman
 
 defaultCompiler=kotlin-dex2oat-latest

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -21,6 +21,7 @@ compiler.android-kotlin-dex2oat-default.compilerType=dex2oat
 compiler.android-kotlin-dex2oat-default.artArtifactDir=/usr/bin/dex2oat
 compiler.android-kotlin-dex2oat-default.exe=/usr/bin/dex2oat/x86_64/bin/dex2oat64
 compiler.android-kotlin-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatdump
+compiler.android-kotlin-dex2oat-default.profmanPath=/usr/bin/dex2oat/x86_64/bin/profman
 
 # This should reflect the ID and exe for android-kotlin-d8-default.
 compiler.android-kotlin-dex2oat-default.d8Id=android-kotlin-d8-default

--- a/examples/android-java/default.java
+++ b/examples/android-java/default.java
@@ -5,3 +5,10 @@ class Square {
     }
 }
 
+// Set `enabled` to `true` to enable profile-guided compilation for dex2oat.
+// (For advanced use only!)
+/* ---------- begin profile (enabled=false) ----------
+HSPLSquare;-><init>()V
+HSPLSquare;->square(I)I
+LSquare;
+---------- end profile ---------- */

--- a/examples/android-java/default.java
+++ b/examples/android-java/default.java
@@ -6,6 +6,8 @@ class Square {
 }
 
 // Set `enabled` to `true` to enable profile-guided compilation for dex2oat.
+// For the profile format, see
+// https://developer.android.com/topic/performance/baselineprofiles/manually-create-measure#define-rules-manually
 // (For advanced use only!)
 /* ---------- begin profile (enabled=false) ----------
 HSPLSquare;-><init>()V

--- a/examples/android-kotlin/default.kt
+++ b/examples/android-kotlin/default.kt
@@ -2,6 +2,8 @@
 fun square(num: Int): Int = num * num
 
 // Set `enabled` to `true` to enable profile-guided compilation for dex2oat.
+// For the profile format, see
+// https://developer.android.com/topic/performance/baselineprofiles/manually-create-measure#define-rules-manually
 // (For advanced use only!)
 /* ---------- begin profile (enabled=false) ----------
 HSPLExampleKt;->square(I)I

--- a/examples/android-kotlin/default.kt
+++ b/examples/android-kotlin/default.kt
@@ -1,2 +1,9 @@
 // Type your code here, or load an example.
 fun square(num: Int): Int = num * num
+
+// Set `enabled` to `true` to enable profile-guided compilation for dex2oat.
+// (For advanced use only!)
+/* ---------- begin profile (enabled=false) ----------
+HSPLExampleKt;->square(I)I
+LExampleKt;
+---------- end profile ---------- */


### PR DESCRIPTION
dex2oat supports profile-guided compilation. In addition to taking dex code as an input, it can take a profile as another input, to guide the compilation. The profile determines which methods need to be compiled, how calls can be inlined, and so on.

Because Compiler Explorer doesn't support multiple input files, the profile is added as a comment block in the Java/Kotlin source code. A post-processor extracts the profile from the comment block into a separate file, in order to input it to dex2oat.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
