### PR TITLE
Removed UseDynamicNumberOfCompilerThreads command-line argument when running on java <11

### DIFF
--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -135,7 +135,7 @@ export class JavaCompiler extends BaseCompiler implements SimpleOutputFilenameCo
         if (compileResult.code === 0) {
             const extraXXFlags: string[] = [];
             if (Semver.gte(utils.asSafeVer(this.compiler.semver), '11.0.0', true)) {
-                extraXXFlags.push("-XX:-UseDynamicNumberOfCompilerThreads")
+                extraXXFlags.push('-XX:-UseDynamicNumberOfCompilerThreads');
             }
             executeParameters.args = [
                 '-Xss136K', // Reduce thread stack size

--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -25,6 +25,7 @@
 import path from 'path';
 
 import fs from 'fs-extra';
+import Semver from 'semver';
 
 import type {ParsedAsmResult, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
 import {BypassCache} from '../../types/compilation/compilation.interfaces.js';
@@ -132,17 +133,30 @@ export class JavaCompiler extends BaseCompiler implements SimpleOutputFilenameCo
     override async handleInterpreting(key, executeParameters: ExecutableExecutionOptions) {
         const compileResult = await this.getOrBuildExecutable(key, BypassCache.None);
         if (compileResult.code === 0) {
-            executeParameters.args = [
-                '-Xss136K', // Reduce thread stack size
-                '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
-                '-XX:-UseDynamicNumberOfCompilerThreads',
-                '-XX:-UseDynamicNumberOfGCThreads',
-                '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
-                await this.getMainClassName(compileResult.dirPath),
-                '-cp',
-                compileResult.dirPath,
-                ...executeParameters.args,
-            ];
+            if (Semver.lt(utils.asSafeVer(this.compiler.semver), '11.0.0', true)) {
+                executeParameters.args = [
+                    '-Xss136K', // Reduce thread stack size
+                    '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
+                    '-XX:-UseDynamicNumberOfGCThreads',
+                    '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
+                    await this.getMainClassName(compileResult.dirPath),
+                    '-cp',
+                    compileResult.dirPath,
+                    ...executeParameters.args,
+                ];
+            } else {
+                executeParameters.args = [
+                    '-Xss136K', // Reduce thread stack size
+                    '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
+                    '-XX:-UseDynamicNumberOfCompilerThreads',
+                    '-XX:-UseDynamicNumberOfGCThreads',
+                    '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
+                    await this.getMainClassName(compileResult.dirPath),
+                    '-cp',
+                    compileResult.dirPath,
+                    ...executeParameters.args,
+                ];
+            }
             const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
             return {
                 ...result,


### PR DESCRIPTION
This fixes #6388.