### PR TITLE
Fix inline opt-remarks: toggling a filter off did not remove the remarks from the display.

### DIFF
--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -170,24 +170,26 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
         });
         const groupedRemarks = _(remarksToDisplay).groupBy(x => x.DebugLoc.Line);
 
+        // eslint-disable-next-line prefer-const
+        let resLines = [...this.srcAsOptview];
         for (const [key, value] of Object.entries(groupedRemarks)) {
             const origLineNum = Number(key);
-            const curLineNum = this.srcAsOptview.findIndex(srcLine => srcLine.srcLine === origLineNum);
+            const curLineNum = resLines.findIndex(line => line.srcLine === origLineNum);
             const contents = value.map(rem => ({
                 text: rem.displayString,
                 srcLine: -1,
                 optClass: rem.optType,
             }));
-            this.srcAsOptview.splice(curLineNum, 0, ...contents);
+            resLines.splice(curLineNum, 0, ...contents);
         }
 
-        const newText: string = this.srcAsOptview.reduce((accText, curSrcLine) => {
+        const newText: string = resLines.reduce((accText, curSrcLine) => {
             return accText + (curSrcLine.optClass === 'None' ? curSrcLine.text : '  ') + '\n';
         }, '');
         this.editor.setValue(newText);
 
         const optDecorations: monaco.editor.IModelDeltaDecoration[] = [];
-        this.srcAsOptview.forEach((line, lineNum) => {
+        resLines.forEach((line, lineNum) => {
             if (line.optClass !== 'None') {
                 optDecorations.push({
                     range: new monaco.Range(lineNum + 1, 1, lineNum + 1, Infinity),

--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -170,8 +170,7 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
         });
         const groupedRemarks = _(remarksToDisplay).groupBy(x => x.DebugLoc.Line);
 
-        // eslint-disable-next-line prefer-const
-        let resLines = [...this.srcAsOptview];
+        const resLines = [...this.srcAsOptview];
         for (const [key, value] of Object.entries(groupedRemarks)) {
             const origLineNum = Number(key);
             const curLineNum = resLines.findIndex(line => line.srcLine === origLineNum);


### PR DESCRIPTION
No idea how this worked on my machine prior to submitting...
Anyway, fixed now.
