### PR TITLE
gcc: add old renovated versions

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -17,7 +17,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g131:g132:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g131:g132:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -31,6 +31,10 @@ group.gcc86.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a
 group.gcc86.supportsBinaryObject=true
 group.gcc86.compilerCategories=gcc
 
+compiler.g346.exe=/opt/compiler-explorer/gcc-renovated-3.4.6/bin/g++
+compiler.g346.semver=3.4.6
+compiler.g404.exe=/opt/compiler-explorer/gcc-renovated-4.0.4/bin/g++
+compiler.g404.semver=4.0.4
 compiler.g412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/g++
 compiler.g412.semver=4.1.2
 compiler.g412.supportsBinary=false
@@ -94,9 +98,11 @@ compiler.g6.semver=6.1
 compiler.g62.exe=/opt/compiler-explorer/gcc-6.2.0/bin/g++
 compiler.g62.semver=6.2
 compiler.g63.exe=/opt/compiler-explorer/gcc-6.3.0/bin/g++
-compiler.g64.semver=6.4
-compiler.g64.exe=/opt/compiler-explorer/gcc-6.4.0/bin/g++
 compiler.g63.semver=6.3
+compiler.g64.exe=/opt/compiler-explorer/gcc-6.4.0/bin/g++
+compiler.g64.semver=6.4
+compiler.g65.exe=/opt/compiler-explorer/gcc-renovated-6.5.0/bin/g++
+compiler.g65.semver=6.5
 compiler.g71.exe=/opt/compiler-explorer/gcc-7.1.0/bin/g++
 compiler.g71.semver=7.1
 compiler.g72.exe=/opt/compiler-explorer/gcc-7.2.0/bin/g++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cg132:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg131:cg132:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -26,6 +26,10 @@ group.cgcc86.licenseName=GNU General Public License
 group.cgcc86.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 group.cgcc86.compilerCategories=gcc
 
+compiler.cg346.exe=/opt/compiler-explorer/gcc-renovated-3.4.6/bin/gcc
+compiler.cg346.semver=3.4.6
+compiler.cg404.exe=/opt/compiler-explorer/gcc-renovated-4.0.4/bin/gcc
+compiler.cg404.semver=4.0.4
 compiler.cg412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/gcc
 compiler.cg412.semver=4.1.2
 compiler.cg447.exe=/opt/compiler-explorer/gcc-4.4.7/bin/gcc
@@ -77,6 +81,8 @@ compiler.cg62.exe=/opt/compiler-explorer/gcc-6.2.0/bin/gcc
 compiler.cg62.semver=6.2
 compiler.cg63.exe=/opt/compiler-explorer/gcc-6.3.0/bin/gcc
 compiler.cg63.semver=6.3
+compiler.cg65.exe=/opt/compiler-explorer/gcc-renovated-6.5.0/bin/gcc
+compiler.cg65.semver=6.5
 compiler.cg71.exe=/opt/compiler-explorer/gcc-7.1.0/bin/gcc
 compiler.cg71.semver=7.1
 compiler.cg72.exe=/opt/compiler-explorer/gcc-7.2.0/bin/gcc

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -9,7 +9,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.objcgcc86.compilers=objcg105:objcg114:objcg122:objcg123:objcg131:objcg132:objcgsnapshot
+group.objcgcc86.compilers=objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg131:objcg132:objcgsnapshot
 group.objcgcc86.groupName=GCC x86-64
 group.objcgcc86.instructionSet=amd64
 group.objcgcc86.isSemVer=true
@@ -18,6 +18,15 @@ group.objcgcc86.supportsPVS-Studio=true
 group.objcgcc86.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.objcgcc86.licenseName=GNU General Public License
 group.objcgcc86.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
+compiler.objcg346.exe=/opt/compiler-explorer/gcc-renovated-3.4.6/bin/gcc
+compiler.objcg346.semver=3.4.6
+
+compiler.objcg404.exe=/opt/compiler-explorer/gcc-renovated-4.0.4/bin/gcc
+compiler.objcg404.semver=4.0.4
+
+compiler.objcg650.exe=/opt/compiler-explorer/gcc-renovated-6.5.0/bin/gcc
+compiler.objcg650.semver=6.5.0
 
 compiler.objcg105.exe=/opt/compiler-explorer/gcc-10.5.0/bin/gcc
 compiler.objcg105.semver=10.5


### PR DESCRIPTION
Add 3.4.6, 4.0.4 and 6.5.0.

fixes #6323