### PR TITLE
Add missing clang versions for armv7-a C++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -629,9 +629,9 @@ compiler.clang-rocm-50700.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unkn
 
 ################################
 # Clang for Arm
-# Provides 32- menu items for clang-9, clang-10 and trunk
+# Provides 32-bit menu items for release versions and trunk
 group.armclang32.groupName=Arm 32-bit clang
-group.armclang32.compilers=armv7-clang900:armv7-clang901:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang1101:armv7-clang-trunk
+group.armclang32.compilers=armv7-clang900:armv7-clang901:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang1101:armv7-clang1200:armv7-clang1201:armv7-clang1300:armv7-clang1301:armv7-clang1400:armv7-clang1500:armv7-clang1600:armv7-clang1701:armv7-clang1810:armv7-clang-trunk
 group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
@@ -643,6 +643,33 @@ group.armclang32.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICE
 group.armclang32.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armclang32.compilerCategories=clang
 
+compiler.armv7-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
+compiler.armv7-clang1810.semver=18.1.0
+compiler.armv7-clang1810.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang++
+compiler.armv7-clang1701.semver=17.0.1
+compiler.armv7-clang1701.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang++
+compiler.armv7-clang1600.semver=16.0.0
+compiler.armv7-clang1600.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang++
+compiler.armv7-clang1500.semver=15.0.0
+compiler.armv7-clang1500.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang++
+compiler.armv7-clang1400.semver=14.0.0
+compiler.armv7-clang1400.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1301.exe=/opt/compiler-explorer/clang-13.0.1/bin/clang++
+compiler.armv7-clang1301.semver=13.0.1
+compiler.armv7-clang1301.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
+compiler.armv7-clang1300.semver=13.0.0
+compiler.armv7-clang1300.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-11.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1201.exe=/opt/compiler-explorer/clang-12.0.1/bin/clang++
+compiler.armv7-clang1201.semver=12.0.1
+compiler.armv7-clang1201.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-11.1.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-11.1.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-clang1200.exe=/opt/compiler-explorer/clang-12.0.0/bin/clang++
+compiler.armv7-clang1200.semver=12.0.0
+compiler.armv7-clang1200.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-10.3.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-10.3.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
 compiler.armv7-clang1101.exe=/opt/compiler-explorer/clang-11.0.1/bin/clang++
 compiler.armv7-clang1101.semver=11.0.1
 compiler.armv7-clang1101.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot


### PR DESCRIPTION
These were present for C but not C++.