### PR TITLE
Add Flang frontend driver to Fortran Compilers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -148,6 +148,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'lib/compilers/flang.ts'
+          - 'lib/compilers/flang-fc1.ts'
           - 'lib/compilers/fortran.ts'
           - 'etc/config/fortran.*.properties'
           - 'static/modes/fortran-mode.ts'

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -510,7 +510,7 @@ compiler.fs390xg1320.demangler=/opt/compiler-explorer/s390x/gcc-13.2.0/s390x-ibm
 
 ###############################
 # LLVM Flang for X86
-group.clang_llvmflang.compilers=flangtrunk:flangtrunknew:flangtruncknew-fc
+group.clang_llvmflang.compilers=flangtrunk:flangtrunknew:flangtrunknew-fc
 group.clang_llvmflang.groupName=LLVM-FLANG x86-64
 group.clang_llvmflang.compilerType=flang
 
@@ -526,13 +526,13 @@ compiler.flangtrunknew.gfortranPath=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.flangtrunknew.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
 compiler.flangtrunknew.isNightly=true
 
-compiler.flangtruncknew-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
-compiler.flangtruncknew-fc.name=flang-trunk-fc1 (flang-new)
-compiler.flangtruncknew-fc.compilerType=flang-fc1
-compiler.flangtruncknew-fc.isNightly=true
-compiler.flangtruncknew-fc.supportsBinary=false
-compiler.flangtruncknew-fc.supportsBinaryObject=false
-compiler.flangtruncknew-fc.supportsBinaryExecute=false
+compiler.flangtrunknew-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
+compiler.flangtrunknew-fc.name=flang-trunk-fc1 (flang-new)
+compiler.flangtrunknew-fc.compilerType=flang-fc1
+compiler.flangtrunknew-fc.isNightly=true
+compiler.flangtrunknew-fc.supportsBinary=false
+compiler.flangtrunknew-fc.supportsBinaryObject=false
+compiler.flangtrunknew-fc.supportsBinaryExecute=false
 
 ###############################
 # GCC for ARM 64bit

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -510,7 +510,7 @@ compiler.fs390xg1320.demangler=/opt/compiler-explorer/s390x/gcc-13.2.0/s390x-ibm
 
 ###############################
 # LLVM Flang for X86
-group.clang_llvmflang.compilers=flangtrunk:flangtrunknew
+group.clang_llvmflang.compilers=flangtrunk:flangtrunknew:flangtruncknew-fc
 group.clang_llvmflang.groupName=LLVM-FLANG x86-64
 group.clang_llvmflang.compilerType=flang
 
@@ -525,6 +525,14 @@ compiler.flangtrunknew.name=flang-trunk (flang-new)
 compiler.flangtrunknew.gfortranPath=/opt/compiler-explorer/gcc-snapshot/bin
 compiler.flangtrunknew.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
 compiler.flangtrunknew.isNightly=true
+
+compiler.flangtruncknew-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
+compiler.flangtruncknew-fc.name=flang-trunk-fc1 (flang-new)
+compiler.flangtruncknew-fc.compilerType=flang-fc1
+compiler.flangtruncknew-fc.isNightly=true
+compiler.flangtruncknew-fc.supportsBinary=false
+compiler.flangtruncknew-fc.supportsBinaryObject=false
+compiler.flangtruncknew-fc.supportsBinaryExecute=false
 
 ###############################
 # GCC for ARM 64bit

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -63,6 +63,7 @@ export {EWARMCompiler} from './ewarm.js';
 export {EWAVRCompiler} from './ewavr.js';
 export {FakeCompiler} from './fake-for-test.js';
 export {FlangCompiler} from './flang.js';
+export {FlangFC1Compiler} from './flang-fc1.js';
 export {FortranCompiler} from './fortran.js';
 export {FPCCompiler} from './pascal.js';
 export {FSharpCompiler} from './dotnet.js';

--- a/lib/compilers/flang-fc1.ts
+++ b/lib/compilers/flang-fc1.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {ConfiguredOverrides} from '../../types/compilation/compiler-overrides.interfaces.js';
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+
+export class FlangFC1Compiler extends BaseCompiler {
+    static get key() {
+        return 'flang-fc1';
+    }
+
+    constructor(compilerInfo: PreliminaryCompilerInfo, env) {
+        super(
+            {
+                disabledFilters: [
+                    'binary',
+                    'execute',
+                    'demangle',
+                    'intel',
+                    'labels',
+                    'libraryCode',
+                    'directives',
+                    'commentOnly',
+                    'trim',
+                    'debugCalls',
+                ],
+                ...compilerInfo,
+            },
+            env,
+        );
+    }
+
+    override prepareArguments(
+        userOptions: string[],
+        filters: ParseFiltersAndOutputOptions,
+        backendOptions: Record<string, any>,
+        inputFilename: string,
+        outputFilename: string,
+        libraries,
+        overrides: ConfiguredOverrides,
+    ) {
+        let options = ['-fc1'];
+        userOptions = this.filterUserOptions(userOptions) || [];
+        options = options.concat(userOptions);
+        options = options.concat(['-o', this.filename(outputFilename)]);
+        options = options.concat(inputFilename);
+        return options;
+    }
+}


### PR DESCRIPTION
"This pull request introduces the Flang frontend driver as a new compiler, as discussed in issue #6400. with minimal support. 

With this change, users can now specify LLVM Flang frontend-related options such as _**-emit-hlfir, -fdebug-dump-parse-tree**_, etc.,(no explicit **_-fc1_** needed) by selecting the compiler (**flang-trunk-fc1**)."