### PR TITLE
Hanfle filtering `tail call void @llvm.dbg.*` in LLVM IR

### DIFF
--- a/lib/llvm-ir.ts
+++ b/lib/llvm-ir.ts
@@ -67,7 +67,7 @@ export class LlvmIrParser {
         this.namedMetaDirective = /^(![.A-Z_a-z-]+) = (?:distinct )?!{.*}/;
         this.metaNodeOptionsRe = /(\w+): (!?\d+|\w+|""|"(?:[^"]|\\")*[^\\]")/gi;
 
-        this.llvmDebugLine = /^\s*call void @llvm\.dbg\..*$/;
+        this.llvmDebugLine = /^\s*(tail\s)?call void @llvm\.dbg\..*$/;
         this.llvmDebugAnnotation = /,? !dbg !\d+/;
         this.otherMetadataAnnotation = /,? !(?!dbg)[\w.]+ (!\d+)/;
         this.attributeAnnotation = /,? #\d+(?= )/;

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -99,7 +99,7 @@ export class LlvmPassDumpParser {
 
         // Additional filters conditionally enabled by `filterDebugInfo`
         this.debugInfoFilters = [
-            /^\s+(tail\s)?call void @llvm.dbg.+$/, // dbg calls
+            /^\s+(tail\s)?call void @llvm\.dbg.+$/, // dbg calls
             /^\s+DBG_.+$/, // dbg pseudo-instructions
             /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]+?)\)/, // meta
             /^(!\d+) = (?:distinct )?!{.*}/, // meta


### PR DESCRIPTION
Fixes #6416. Additionally escapes a dot in another copy of an `@llvm.dbg` check.

Didn't find any existing tests for IR filtering to update where this filter applies, but did make sure locally that it does start hiding the instructions for clang-17 and clang-18.