### PR TITLE
Update clangir compiler options

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -473,7 +473,7 @@ compiler.clang_variadic_friends.options=-Xclang -fvariadic-friends
 compiler.clang_variadic_friends.notification=A rough implementation of variadic friends. More information <a href="https://wg21.link/P2893" target="_blank" rel="noopener noreferrer">here<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_clangir.exe=/opt/compiler-explorer/clang-clangir-trunk/bin/clang++
 compiler.clang_clangir.semver=(clangir)
-compiler.clang_clangir.options=-std=c++20 -Xclang -fclangir-enable -Xclang -emit-cir -Xclang -clangir-disable-emit-cxx-default
+compiler.clang_clangir.options=-std=c++20 -Xclang -fclangir -Xclang -emit-cir -Xclang -clangir-disable-emit-cxx-default
 compiler.clang_clangir.notification=ClangIR enabled clang compiler; see <a href="https://clangir.org" target="_blank" rel="noopener noreferrer">clangir.org<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 group.clangx86assert.compilers=clang26assert:clang27assert:clang28assert:clang29assert:clang30assert:clang31assert:clang32assert:clang33assert:clang34assert:clang35assert:clang36assert:clang37assert:clang38assert:clang39assert:clang40assert:clang50assert:clang60assert:clang70assert:clang80assert:clang90assert:clang100assert:clang110assert:clang120assert:clang130assert:clang140assert:clang150assert:clang160assert:clang170assert:clang181assert


### PR DESCRIPTION
The upstream has changed from `-fclangir-enable` to `-fclangir`. Update here as well.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
