### PR TITLE
Fix exception in case of empty IR

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1444,7 +1444,7 @@ export class BaseCompiler implements ICompiler {
             asm: ir.asm,
         };
 
-        if (result.asm[result.asm.length - 1].text === '[truncated; too many lines]') {
+        if (result.asm.length > 0 && result.asm[result.asm.length - 1].text === '[truncated; too many lines]') {
             return result;
         }
 


### PR DESCRIPTION
This fixes #6449 - I carelessly ignored the case of empty IR output.
Repro link for verification: https://godbolt.org/z/4d46dahqq

