### PR TITLE
Suggestion to update llvm-cxxfilt logic

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -242,6 +242,7 @@ group.clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.T
 group.clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.clang.supportsBinaryObject=true
 group.clang.compilerCategories=clang
+group.clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 # Ancient clangs don't support GCC toolchain option
 compiler.clang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-11_10/bin/clang++
@@ -411,6 +412,7 @@ group.clangx86trunk.supportsSonar=true
 group.clangx86trunk.supportsLlvmCov=true
 group.clangx86trunk.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 group.clangx86trunk.compilerCategories=clang
+group.clangx86trunk.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.clang_trunk.semver=(trunk)
@@ -481,6 +483,7 @@ compiler.clang_clangir.notification=ClangIR enabled clang compiler; see <a href=
 group.clangx86assert.compilers=clang26assert:clang27assert:clang28assert:clang29assert:clang30assert:clang31assert:clang32assert:clang33assert:clang34assert:clang35assert:clang36assert:clang37assert:clang38assert:clang39assert:clang40assert:clang50assert:clang60assert:clang70assert:clang80assert:clang90assert:clang100assert:clang110assert:clang120assert:clang130assert:clang140assert:clang150assert:clang160assert:clang170assert:clang181assert
 group.clangx86assert.options=
 group.clangx86assert.groupName=Clang x86-64 (assertions)
+group.clangx86assert.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 # Ancient clangs don't support GCC toolchain option
 compiler.clang26assert.exe=/opt/compiler-explorer/clang-assertions-2.6.0/bin/clang
@@ -602,6 +605,7 @@ group.clang-rocm.licenseName=LLVM Apache 2 and NCSA
 group.clang-rocm.licenseLink=https://github.com/RadeonOpenCompute/llvm-project/blob/amd-stg-open/LICENSE.TXT
 # and https://github.com/RadeonOpenCompute/ROCm-Device-Libs/blob/amd-stg-open/LICENSE.TXT
 group.clang-rocm.compilerCategories=clang
+group.clang-rocm.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.clang-rocm-trunk.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
 compiler.clang-rocm-trunk.semver=(amd-stg-open)
@@ -650,6 +654,7 @@ group.armclang32.licenseName=LLVM Apache 2
 group.armclang32.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armclang32.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armclang32.compilerCategories=clang
+group.armclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.armv7-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.armv7-clang1810.semver=18.1.0
@@ -723,6 +728,7 @@ group.armclang64.licenseName=LLVM Apache 2
 group.armclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armclang64.compilerCategories=clang
+group.armclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.armv8-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.armv8-clang1810.semver=18.1.0
@@ -798,6 +804,7 @@ group.mosclang-trunk.isNightly=true
 group.mosclang-trunk.objdumper=/opt/compiler-explorer/llvm-mos-trunk/bin/llvm-objdump
 group.mosclang-trunk.objdumperType=llvm
 group.mosclang-trunk.compilerCategories=clang
+group.mosclang-trunk.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mos-atari2600-3e-trunk.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/mos-atari2600-3e-clang++
 compiler.mos-atari2600-3e-trunk.semver=atari2600-3e
@@ -921,6 +928,7 @@ group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unkn
 group.rv32clang.baseName=RISC-V rv32gc clang
 group.rv32clang.groupName=RISC-V 32 Clang
 group.rv32clang.compilerCategories=clang
+group.rv32clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.rv32-clang900.semver=9.0.0
@@ -971,6 +979,7 @@ group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unkn
 group.rv64clang.baseName=RISC-V rv64gc clang
 group.rv64clang.groupName=RISC-V 64 Clang
 group.rv64clang.compilerCategories=clang
+group.rv64clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.rv64-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.rv64-clang900.semver=9.0.0
@@ -1024,6 +1033,7 @@ group.wasmclang.licenseName=LLVM Apache 2
 group.wasmclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.wasmclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.wasmclang.compilerCategories=clang
+group.wasmclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.wasm32clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.wasm32clang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -1036,6 +1046,7 @@ compiler.wasm32clang.isNightly=true
 group.hexagon-clang.groupName=Hexagon clang
 group.hexagon-clang.baseName=hexagon-clang
 group.hexagon-clang.compilers=hexagonclang1605
+group.hexagon-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 compiler.hexagonclang1605.semver=16.0.5
 compiler.hexagonclang1605.name=hexagon-clang 16.0.5
 compiler.hexagonclang1605.exe=/opt/compiler-explorer/clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl/x86_64-linux-gnu/bin/clang++
@@ -1285,6 +1296,7 @@ group.clangm68k.options=-target m68k
 group.clangm68k.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.clangm68k.objdumperType=llvm
 group.clangm68k.compilerCategories=clang
+group.clangm68k.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.m68kclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.m68kclangtrunk.semver=(trunk)
@@ -2271,6 +2283,7 @@ group.mips-clang.supportsExecute=false
 group.mips-clang.options=-target mips-elf
 group.mips-clang.compilerCategories=clang
 group.mips-clang.instructionSet=mips
+group.mips-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mips-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.mips-clang1810.semver=18.1.0
@@ -2300,6 +2313,7 @@ group.mipsel-clang.supportsBinaryObject=false
 group.mipsel-clang.supportsExecute=false
 group.mipsel-clang.options=-target mipsel-elf
 group.mipsel-clang.compilerCategories=clang
+group.mipsel-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mipsel-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.mipsel-clang1810.semver=18.1.0
@@ -2329,6 +2343,7 @@ group.mips64-clang.supportsBinaryObject=false
 group.mips64-clang.supportsExecute=false
 group.mips64-clang.options=-target mips64-elf
 group.mips64-clang.compilerCategories=clang
+group.mips64-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mips64-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.mips64-clang1810.semver=18.1.0
@@ -2358,6 +2373,7 @@ group.mips64el-clang.supportsBinaryObject=false
 group.mips64el-clang.supportsExecute=false
 group.mips64el-clang.options=-target mips64el-elf
 group.mips64el-clang.compilerCategories=clang
+group.mips64el-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mips64el-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.mips64el-clang1810.semver=18.1.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -13,7 +13,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 externalparser=CEAsmParser
 externalparser.exe=/usr/local/bin/asm-parser
 
-llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
+llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -10,7 +10,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 externalparser=CEAsmParser
 externalparser.exe=/usr/local/bin/asm-parser
 
-llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
+llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -192,6 +192,7 @@ group.cclang.licenseName=LLVM Apache 2
 group.cclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.cclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.cclang.compilerCategories=clang
+group.cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.cclang30.exe=/opt/compiler-explorer/clang+llvm-3.0-x86_64-linux-Ubuntu-11_10/bin/clang
 compiler.cclang30.semver=3.0.0
@@ -335,6 +336,7 @@ group.armcclang32.licenseName=LLVM Apache 2
 group.armcclang32.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armcclang32.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang32.compilerCategories=clang
+group.armcclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.armcclang64.groupName=Arm 64-bit clang
 group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang1701:armv8-cclang1810:armv8-cclang-trunk:armv8-full-cclang-trunk
@@ -346,6 +348,7 @@ group.armcclang64.licenseName=LLVM Apache 2
 group.armcclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armcclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang64.compilerCategories=clang
+group.armcclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.armv7-cclang1810.name=armv7-a clang 18.1.0
 compiler.armv7-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
@@ -591,6 +594,7 @@ group.cmosclang-trunk.objdumper=/opt/compiler-explorer/llvm-mos-trunk/bin/llvm-o
 group.cmosclang-trunk.objdumperType=llvm
 group.cmosclang-trunk.compilerCategories=clang
 group.cmosclang-trunk.isNightly=true
+group.cmosclang-trunk.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.cmos-nes-cnrom-trunk.exe=/opt/compiler-explorer/llvm-mos-trunk/bin/mos-nes-cnrom-clang
 compiler.cmos-nes-cnrom-trunk.semver=nes-cnrom
@@ -640,6 +644,7 @@ group.rv32cclang.licenseName=LLVM Apache 2
 group.rv32cclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.rv32cclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.rv32cclang.compilerCategories=clang
+group.rv32cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.rv32-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.rv32-cclang900.semver=9.0.0
@@ -690,6 +695,7 @@ group.rv64cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unkn
 group.rv64cclang.baseName=RISC-V rv64gc clang
 group.rv64cclang.groupName=RISC-V 64 Clang
 group.rv64cclang.compilerCategories=clang
+group.rv64cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.rv64-cclang900.semver=9.0.0
 compiler.rv64-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
@@ -744,6 +750,7 @@ group.wasmcclang.licenseName=LLVM Apache 2
 group.wasmcclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.wasmcclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.wasmcclang.compilerCategories=clang
+group.wasmcclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.wasm32cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.wasm32cclang.name=WebAssembly clang (trunk)
@@ -1037,6 +1044,7 @@ group.cclangm68k.isSemVer=true
 group.cclangm68k.options=-target m68k
 group.cclangm68k.objdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.cclangm68k.objdumperType=llvm
+group.cclangm68k.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.cm68kclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cm68kclangtrunk.semver=(trunk)
@@ -1942,6 +1950,7 @@ group.mips-cclang.supportsBinaryObject=false
 group.mips-cclang.supportsExecute=false
 group.mips-cclang.options=-target mips-elf
 group.mips-cclang.compilerCategories=clang
+group.mips-cclang.compilerCategories.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mips-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mips-cclang1810.semver=18.1.0
@@ -1971,6 +1980,7 @@ group.mipsel-cclang.supportsBinaryObject=false
 group.mipsel-cclang.supportsExecute=false
 group.mipsel-cclang.options=-target mipsel-elf
 group.mipsel-cclang.compilerCategories=clang
+group.mipsel-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mipsel-cclang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang
 compiler.mipsel-cclang1701.semver=17.0.1
@@ -2000,6 +2010,7 @@ group.mips64-cclang.supportsBinaryObject=false
 group.mips64-cclang.supportsExecute=false
 group.mips64-cclang.options=-target mips64-elf
 group.mips64-cclang.compilerCategories=clang
+group.mips64-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mips64-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mips64-cclang1810.semver=18.1.0
@@ -2029,6 +2040,7 @@ group.mips64el-cclang.supportsBinaryObject=false
 group.mips64el-cclang.supportsExecute=false
 group.mips64el-cclang.options=-target mips64el-elf
 group.mips64el-cclang.compilerCategories=clang
+group.mips64el-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.mips64el-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mips64el-cclang1810.semver=18.1.0

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -18,6 +18,7 @@ group.armcpp4oclclang32.supportsExecute=false
 group.armcpp4oclclang32.instructionSet=arm32
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
 group.armcpp4oclclang32.baseOptions=-Dkernel= -D__kernel=
+group.armcpp4oclclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.armcpp4oclclang64.groupName=Arm 64-bit clang
 group.armcpp4oclclang64.compilers=armv8-cpp4oclclang1000:armv8-cpp4oclclang1001:armv8-cpp4oclclang1100:armv8-cpp4oclclang1101:armv8-cpp4oclclang1200:armv8-cpp4oclclang1300:armv8-cpp4oclclang1400:armv8-cpp4oclclang1500:armv8-cpp4oclclang-trunk:armv8-cpp4oclclang-trunk-assertions:armv8-full-cpp4oclclang-trunk
@@ -27,6 +28,7 @@ group.armcpp4oclclang64.supportsExecute=false
 group.armcpp4oclclang64.instructionSet=aarch64
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
 group.armcpp4oclclang64.baseOptions=-Dkernel= -D__kernel=
+group.armcpp4oclclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 # Specify each Clang version
 
@@ -184,6 +186,7 @@ group.spirv32cpp4oclclang.supportsExecute=false
 group.spirv32cpp4oclclang.instructionSet=spirv
 # The latest llvm-spirv accepts translation with spirv32 target.
 group.spirv32cpp4oclclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
+group.spirv32cpp4oclclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.spirv64cpp4oclclang.groupName=SPIR-V 64-bit clang (with llvm-spirv)
 group.spirv64cpp4oclclang.compilers=spirv64-cpp4oclclang-trunk:spirv64-cpp4oclclang-trunk-assertions
@@ -193,6 +196,7 @@ group.spirv64cpp4oclclang.supportsExecute=false
 group.spirv64cpp4oclclang.instructionSet=spirv
 # The latest llvm-spirv accepts translation with spirv64 target.
 group.spirv64cpp4oclclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
+group.spirv64cpp4oclclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 # 32 bits
 compiler.spirv32-cpp4oclclang-trunk.alias=armv7-cpp4oclclang-trunk-spir

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -14,6 +14,7 @@ group.irclang.groupName=Clang x86-64
 group.irclang.options=-x ir
 group.irclang.isSemVer=true
 group.irclang.baseName=clang
+group.irclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.irclang401.exe=/opt/compiler-explorer/clang-4.0.1/bin/clang++
 compiler.irclang401.semver=4.0.1

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -10,7 +10,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 externalparser=CEAsmParser
 externalparser.exe=/usr/local/bin/asm-parser
 
-llvmDisassembler=/opt/compiler-explorer/clang-14.0.0/bin/llvm-dis
+llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -18,6 +18,7 @@ group.armoclcclang32.supportsExecute=false
 group.armoclcclang32.instructionSet=arm32
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
 group.armoclcclang32.baseOptions=-Dkernel= -D__kernel=
+group.armoclcclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.armoclcclang64.groupName=Arm 64-bit clang
 group.armoclcclang64.compilers=armv8-oclcclang900:armv8-oclcclang901:armv8-oclcclang1000:armv8-oclcclang1001:armv8-oclcclang1100:armv8-oclcclang1101:armv8-oclcclang1200:armv8-oclcclang1300:armv8-oclcclang1400:armv8-oclcclang1500:armv8-oclcclang-trunk:armv8-full-oclcclang-trunk:armv8-oclcclang-trunk-assertions
@@ -27,6 +28,7 @@ group.armoclcclang64.supportsExecute=false
 group.armoclcclang64.instructionSet=aarch64
 # The -Dkernel= -D__kernel= workaround is required to prevent the Clang crash reported in https://llvm.org/PR50841
 group.armoclcclang64.baseOptions=-Dkernel= -D__kernel=
+group.armoclcclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 #Specify each Clang versions
 
@@ -204,6 +206,7 @@ group.spirv32oclcclang.supportsExecute=false
 group.spirv32oclcclang.instructionSet=spirv
 # The latest llvm-spirv accepts translation with spirv32 target.
 group.spirv32oclcclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir-unknown-unknown
+group.spirv32oclcclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.spirv64oclcclang.groupName=SPIR-V 64-bit clang (with llvm-spirv)
 group.spirv64oclcclang.compilers=spirv64-oclcclang-trunk:spirv64-oclcclang-trunk-assertions
@@ -213,6 +216,7 @@ group.spirv64oclcclang.supportsExecute=false
 group.spirv64oclcclang.instructionSet=spirv
 # The latest llvm-spirv accepts translation with spirv64 target.
 group.spirv64oclcclang.baseOptions=-finclude-default-header -fdeclare-opencl-builtins -triple spir64-unknown-unknown
+group.spirv64oclcclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 # 32 bits
 compiler.spirv32-oclcclang-trunk.alias=armv7-oclcclang-trunk-spir

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -55,9 +55,9 @@ export class ClangCompiler extends BaseCompiler {
     }
 
     constructor(info: PreliminaryCompilerInfo, env) {
-        // By default use the compiler-local llvm demangler, but allow overriding from config
-        // (for bpf)
-        if (info.demangler === undefined) {
+        // Prefer the demangler bundled with this clang version.
+        // Still allows overriding from config (for bpf)
+        if (info.demangler.includes('llvm-cxxfilt')) {
             const demanglerPath = path.join(path.dirname(info.exe), 'llvm-cxxfilt');
             if (fs.existsSync(demanglerPath)) {
                 info.demangler = demanglerPath;

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -38,6 +38,7 @@ import type {ExecutableExecutionOptions, UnprocessedExecResult} from '../../type
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {ArtifactType} from '../../types/tool.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
 import {AmdgpuAsmParser} from '../parsers/asm-parser-amdgpu.js';
 import {HexagonAsmParser} from '../parsers/asm-parser-hexagon.js';
 import {SassAsmParser} from '../parsers/asm-parser-sass.js';
@@ -54,10 +55,10 @@ export class ClangCompiler extends BaseCompiler {
         return 'clang';
     }
 
-    constructor(info: PreliminaryCompilerInfo, env) {
+    constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         // Prefer the demangler bundled with this clang version.
         // Still allows overriding from config (for bpf)
-        if (info.demangler.includes('llvm-cxxfilt')) {
+        if (!info.demangler || info.demangler.includes('llvm-cxxfilt')) {
             const demanglerPath = path.join(path.dirname(info.exe), 'llvm-cxxfilt');
             if (fs.existsSync(demanglerPath)) {
                 info.demangler = demanglerPath;


### PR DESCRIPTION
(1) Restore explicit specification of `group.*.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt` for all clang compiler groups, except bpf and windows.
(2) Make the ClangCompiler` constructor adjust the path of `llvm-cxxfilt`, so that a compiler-local version is preferred, if one exists.
(3) Pass-by update: bump the version of llvmDisassembler from clang-14 to clang-18.1.

Hopefully this addresses all demangling issues known so far.