### PR TITLE
Update NDK toolchain finder

### DIFF
--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -466,17 +466,14 @@ export class CompilerFinder {
         for (const [langId, ndkPath] of Object.entries(ndkPaths)) {
             if (ndkPath) {
                 const toolchains = fs.readdirSync(`${ndkPath}/toolchains`);
-                for (const [version, index] of toolchains) {
-                    const path = `${ndkPath}/toolchains/${version}/prebuilt/linux-x86_64/bin/`;
-                    if (fs.existsSync(path)) {
-                        const cc = fs.readdirSync(path).find(filename => filename.includes('g++'));
-                        toolchains[index] = path + cc;
-                    } else {
-                        toolchains[index] = null;
+                for (const version of toolchains) {
+                    const path = `${ndkPath}/toolchains/${version}/prebuilt/linux-x86_64/bin`;
+                    for (const exe of fs.readdirSync(path)) {
+                        if (exe.endsWith('clang++') || exe.endsWith('g++')) {
+                            langToCompilers[langId].push(`${path}/${exe}`);
+                        }
                     }
                 }
-                // TODO: Something awful is going on with the type of toolchains here
-                langToCompilers[langId].push(toolchains.filter(x => x !== null));
             }
         }
     }


### PR DESCRIPTION
Previous version would only match one g++ toolchain executable.
Iterate over all available versions (different arch/android ABI cross-compilers) and add support for clang/llvm toolchains.

This is a really basic patch for newer NDK versions, as support for Android NDK doesn't seem maintained in CE:
- `androidNdk` property is commented out in c++/objc++ configs (with path to a really old version number)
- No support for it in C config files
- No clear way to add sysroot/tools to each of them