### PR TITLE
Set -fverbose-asm/-fno-verbose-asm from Comment filter

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -224,6 +224,7 @@ export class BaseCompiler implements ICompiler {
         if (!this.compiler.options) this.compiler.options = '';
         if (!this.compiler.optArg) this.compiler.optArg = '';
         if (!this.compiler.supportsOptOutput) this.compiler.supportsOptOutput = false;
+        if (!this.compiler.supportsVerboseAsm) this.compiler.supportsVerboseAsm = false;
 
         if (!compilerInfo.disabledFilters) this.compiler.disabledFilters = [];
         else if (typeof (this.compiler.disabledFilters as any) === 'string') {
@@ -748,6 +749,9 @@ export class BaseCompiler implements ICompiler {
         let options = ['-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary && !filters.binaryObject) {
             options = options.concat(this.compiler.intelAsm.split(' '));
+        }
+        if (this.compiler.supportsVerboseAsm) {
+            options = options.concat(filters.commentOnly ? '-fno-verbose-asm' : '-fverbose-asm');
         }
         if (!filters.binary && !filters.binaryObject) options = options.concat('-S');
         else if (filters.binaryObject) options = options.concat('-c');

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -169,6 +169,9 @@ export class GCCParser extends BaseParser {
             if (compiler.compiler.options) compiler.compiler.options += ' ';
             compiler.compiler.options += '-fdiagnostics-color=always';
         }
+        if (this.hasSupport(options, '-fverbose-asm')) {
+            compiler.compiler.supportsVerboseAsm = true;
+        }
         // This check is not infallible, but takes care of Rust and Swift being picked up :)
         if (_.find(keys, key => key.startsWith('-fdump-'))) {
             compiler.compiler.supportsGccDump = true;
@@ -262,6 +265,9 @@ export class ClangParser extends BaseParser {
         if (this.hasSupport(options, '-fstack-usage')) {
             compiler.compiler.stackUsageArg = '-fstack-usage';
             compiler.compiler.supportsStackUsageOutput = true;
+        }
+        if (this.hasSupport(options, '-fverbose-asm')) {
+            compiler.compiler.supportsVerboseAsm = true;
         }
 
         if (this.hasSupport(options, '-emit-llvm')) {
@@ -495,6 +501,10 @@ export class LDCParser extends BaseParser {
         if (this.hasSupport(options, '--fsave-optimization-record')) {
             compiler.compiler.optArg = '--fsave-optimization-record';
             compiler.compiler.supportsOptOutput = true;
+        }
+
+        if (this.hasSupport(options, '-fverbose-asm')) {
+            compiler.compiler.supportsVerboseAsm = true;
         }
 
         if (this.hasSupport(options, '--print-before-all') && this.hasSupport(options, '--print-after-all')) {

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -71,6 +71,7 @@ export type CompilerInfo = {
     supportsGccDump?: boolean;
     supportsFiltersInBinary?: boolean;
     supportsOptOutput?: boolean;
+    supportsVerboseAsm?: boolean;
     supportsStackUsageOutput?: boolean;
     supportsPpView?: boolean;
     supportsAstView?: boolean;


### PR DESCRIPTION
~~This removes useless comments (namely repeated function/label names, `<n>-byte Folded Spill` and others) from the generated assembly.~~

Fixes #5964