### PR TITLE
Init optRemarks in ctor

### DIFF
--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -58,6 +58,7 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
 
     constructor(hub: Hub, container: Container, state: OptState & MonacoPaneState) {
         super(hub, container, state);
+        this.optRemarks = state.optOutput ?? [];
         this.eventHub.emit('optViewOpened', this.compilerInfo.compilerId);
     }
 


### PR DESCRIPTION
Fix #6460: trying to access an `undefined` this.optRemarks.

The order of opt-view.ts invocations at opt-view pane open is:
1. `constructor`,
2. `registerButtons`,
3. `onCompileResult`

If someone manages to click the filter checkboxes after (2) but before (3), then `showOptRemarks` would be triggered before `this.optRemakrs` is initialized and this exception would ensue. The solution here is to initialize `this.optRemakrs` at the constructor.

Couldn't reproduce, the solution is entirely hypothetical. If it would happen again we'll revisit this.
