### PR TITLE
Fix #6464: defend against empty saved layout

### DIFF
--- a/static/hub.ts
+++ b/static/hub.ts
@@ -394,7 +394,8 @@ export class Hub {
         // Ensure editors are closable: some older versions had 'isClosable' false.
         // NB there doesn't seem to be a better way to do this than reach into the config and rely on the fact nothing
         // has used it yet.
-        container.parent.config.isClosable = true;
+        // Also: prohibit closing the editor if it is the only one
+        container.parent.config.isClosable = this.editors.length > 0;
         const editor = new Editor(this, state, container);
         this.editors.push(editor);
     }

--- a/static/main.ts
+++ b/static/main.ts
@@ -367,8 +367,9 @@ function findConfig(defaultConfig: ConfigType, options: CompilerExplorerOptions,
             }
             if (!config) {
                 const savedState = sessionThenLocalStorage.get('gl', null);
-                config = savedState !== null ? JSON.parse(savedState) : defaultConfig;
+                if (savedState) config = JSON.parse(savedState);
             }
+            if (!config.layout || !config.layout.content || config.layout.content === 0) config = defaultConfig;
         }
     } else {
         config = _.extend(
@@ -668,7 +669,8 @@ function start() {
             // Only preserve state in localStorage in non-embedded mode.
             const shouldSave = !window.hasUIBeenReset && !hasUIBeenReset;
             if (!options.embedded && !isMobileViewer() && shouldSave) {
-                sessionThenLocalStorage.set('gl', JSON.stringify(layout.toConfig()));
+                if (layout.config.content && layout.config.content.length > 0)
+                    sessionThenLocalStorage.set('gl', JSON.stringify(layout.toConfig()));
             }
         });
 


### PR DESCRIPTION
Fix #6464, following the discord discussion.

2 protections are added here:

(1) Make the first code editor non-closable, to avoid an empty layout,
(2) If a loaded config has empty layout - fallback to the default config. 
