### PR TITLE
Detect local label assignments as directives on MIPS (#6392)

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -110,7 +110,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*)/;
         this.definesWeak = /^\s*\.(?:weakext|weak)\s*([.A-Z_a-z][\w$.]*)/;
         this.indentedLabelDef = /^\s*([$.A-Z_a-z][\w$.]*):/;
-        this.assignmentDef = /^\s*([$.A-Z_a-z][\w$.]*)\s*=/;
+        this.assignmentDef = /^\s*([$.A-Z_a-z][\w$.]*)\s*=\s*(.*)/;
         this.directive = /^\s*\..*$/;
         // These four regexes when phrased as /\s*#APP.*/ etc exhibit costly polynomial backtracking
         // Instead use ^$ and test with regex.test(line.trim()), more robust anyway
@@ -619,7 +619,12 @@ export class AsmParser extends AsmRegex implements IAsmParser {
 
                 // g-as shows local labels as eg: "1:  call  mcount". We characterize such a label as
                 // "the label-matching part doesn't equal the whole line" and treat it as used.
-                if (labelsUsed[match[1]] === undefined && match[0] === line) {
+                // As a special case, consider assignments of the form "symbol = ." to be labels.
+                if (
+                    labelsUsed[match[1]] === undefined &&
+                    match[0] === line &&
+                    (match[2] === undefined || match[2].trim() === '.')
+                ) {
                     // It's an unused label.
                     if (filters.labels) {
                         continue;

--- a/test/filters-cases/bug-660.asm.directives.comments.json
+++ b/test/filters-cases/bug-660.asm.directives.comments.json
@@ -457,8 +457,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 2,
-    "$LFB12": 4,
-    "$LVL0": 13,
     "main": 5
   }
 }

--- a/test/filters-cases/bug-660.asm.directives.json
+++ b/test/filters-cases/bug-660.asm.directives.json
@@ -457,8 +457,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 2,
-    "$LFB12": 4,
-    "$LVL0": 13,
     "main": 5
   }
 }

--- a/test/filters-cases/bug-660.asm.directives.labels.comments.json
+++ b/test/filters-cases/bug-660.asm.directives.labels.comments.json
@@ -13,11 +13,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB12 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "main:"
     },
     {
@@ -91,11 +86,6 @@
     },
     {
       "labels": [],
-      "source": null,
-      "text": "$LVL0 = ."
-    },
-    {
-      "labels": [],
       "source": {
         "file": null,
         "line": 4
@@ -142,8 +132,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 1,
-    "$LFB12": 3,
-    "$LVL0": 12,
-    "main": 4
+    "main": 3
   }
 }

--- a/test/filters-cases/bug-660.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/bug-660.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -13,11 +13,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB12 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "main:"
     },
     {
@@ -97,11 +92,6 @@
     },
     {
       "labels": [],
-      "source": null,
-      "text": "$LVL0 = ."
-    },
-    {
-      "labels": [],
       "source": {
         "file": "example.cpp",
         "line": 4,
@@ -153,8 +143,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 1,
-    "$LFB12": 3,
-    "$LVL0": 12,
-    "main": 4
+    "main": 3
   }
 }

--- a/test/filters-cases/bug-660.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/bug-660.asm.directives.labels.comments.library.json
@@ -13,11 +13,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB12 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "main:"
     },
     {
@@ -91,11 +86,6 @@
     },
     {
       "labels": [],
-      "source": null,
-      "text": "$LVL0 = ."
-    },
-    {
-      "labels": [],
       "source": {
         "file": null,
         "line": 4
@@ -142,8 +132,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 1,
-    "$LFB12": 3,
-    "$LVL0": 12,
-    "main": 4
+    "main": 3
   }
 }

--- a/test/filters-cases/bug-660.asm.directives.labels.json
+++ b/test/filters-cases/bug-660.asm.directives.labels.json
@@ -13,11 +13,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB12 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "main:"
     },
     {
@@ -91,11 +86,6 @@
     },
     {
       "labels": [],
-      "source": null,
-      "text": "$LVL0 = ."
-    },
-    {
-      "labels": [],
       "source": {
         "file": null,
         "line": 4
@@ -142,8 +132,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 1,
-    "$LFB12": 3,
-    "$LVL0": 12,
-    "main": 4
+    "main": 3
   }
 }

--- a/test/filters-cases/bug-660.asm.directives.library.json
+++ b/test/filters-cases/bug-660.asm.directives.library.json
@@ -457,8 +457,6 @@
   ],
   "labelDefinitions": {
     "$LC0": 2,
-    "$LFB12": 4,
-    "$LVL0": 13,
     "main": 5
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.comments.json
+++ b/test/filters-cases/mips5-square.asm.directives.comments.json
@@ -163,7 +163,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 2,
     "_Z6squarei": 3
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.json
+++ b/test/filters-cases/mips5-square.asm.directives.json
@@ -163,7 +163,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 2,
     "_Z6squarei": 3
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.labels.comments.json
+++ b/test/filters-cases/mips5-square.asm.directives.labels.comments.json
@@ -3,11 +3,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB0 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "_Z6squarei:"
     },
     {
@@ -113,7 +108,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 1,
-    "_Z6squarei": 2
+    "_Z6squarei": 1
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/mips5-square.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -3,11 +3,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB0 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "_Z6squarei:"
     },
     {
@@ -125,7 +120,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 1,
-    "_Z6squarei": 2
+    "_Z6squarei": 1
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/mips5-square.asm.directives.labels.comments.library.json
@@ -3,11 +3,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB0 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "_Z6squarei:"
     },
     {
@@ -113,7 +108,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 1,
-    "_Z6squarei": 2
+    "_Z6squarei": 1
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.labels.json
+++ b/test/filters-cases/mips5-square.asm.directives.labels.json
@@ -3,11 +3,6 @@
     {
       "labels": [],
       "source": null,
-      "text": "$LFB0 = ."
-    },
-    {
-      "labels": [],
-      "source": null,
       "text": "_Z6squarei:"
     },
     {
@@ -113,7 +108,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 1,
-    "_Z6squarei": 2
+    "_Z6squarei": 1
   }
 }

--- a/test/filters-cases/mips5-square.asm.directives.library.json
+++ b/test/filters-cases/mips5-square.asm.directives.library.json
@@ -163,7 +163,6 @@
     }
   ],
   "labelDefinitions": {
-    "$LFB0": 2,
     "_Z6squarei": 3
   }
 }


### PR DESCRIPTION
For obscure reasons (see [comment here](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/config/mips/mips.h;h=9d965966f2fa9b16f8320b628a6885666aa6cf8a;hb=refs/heads/trunk#l2948)) GCC MIPS inserts DWARF debug labels with the format `$LXX = .` instead of `$LXX:`. So this updates the regexes in that scenario using the existing MIPS detection, to explicitly consider that specific pattern as a directive instead of an assignment. That way they are filtered correctly in the assembly output with the "Directives" option like on all other architectures.

This shouldn't need any additional tests, just updating the existing ones to say those labels should now be filtered. Currently it causes test failures though, I couldn't find any testing docs or if there is an automatic way to regenerate the test files? If there is a recommended way, I can update them.