### PR TITLE
Mark the go compiler `gc` as not supporting cfg

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3181,12 +3181,12 @@ export class BaseCompiler implements ICompiler {
         return false;
     }
 
-    isCfgCompiler(compilerVersion: string) {
+    isCfgCompiler() {
         return (
-            compilerVersion.includes('clang') ||
-            compilerVersion.includes('icc (ICC)') ||
+            this.compiler.version.includes('clang') ||
+            this.compiler.version.includes('icc (ICC)') ||
             ['amd64', 'arm32', 'aarch64', 'llvm'].includes(this.compiler.instructionSet ?? '') ||
-            compilerVersion.match(/^([\w-]*-)?g((\+\+)|(cc)|(dc))/g) !== null
+            /^([\w-]*-)?g((\+\+)|(cc)|(dc))/.test(this.compiler.version) !== null
         );
     }
 
@@ -3586,7 +3586,7 @@ but nothing was dumped. Possible causes are:
             logger.debug(`${compiler} is version '${version}'`);
             this.compiler.version = version;
             this.compiler.fullVersion = fullVersion;
-            this.compiler.supportsCfg = this.isCfgCompiler(version);
+            this.compiler.supportsCfg = this.isCfgCompiler();
             // all C/C++ compilers support -E
             this.compiler.supportsPpView = this.compiler.lang === 'c' || this.compiler.lang === 'c++';
             this.compiler.supportsAstView = this.couldSupportASTDump(version);

--- a/lib/compilers/assembly.ts
+++ b/lib/compilers/assembly.ts
@@ -191,7 +191,7 @@ export class AssemblyCompiler extends BaseCompiler {
         return this.getGeneratedOutputFilename(defaultOutputFilename);
     }
 
-    override isCfgCompiler(/* compilerVersion */) {
+    override isCfgCompiler() {
         return true;
     }
 }

--- a/lib/compilers/beebasm.ts
+++ b/lib/compilers/beebasm.ts
@@ -108,7 +108,7 @@ export class BeebAsmCompiler extends BaseCompiler {
         return result;
     }
 
-    override isCfgCompiler(/*compilerVersion: string*/): boolean {
+    override isCfgCompiler(): boolean {
         return true;
     }
 }

--- a/lib/compilers/golang.ts
+++ b/lib/compilers/golang.ts
@@ -272,4 +272,9 @@ export class GolangCompiler extends BaseCompiler {
     override getArgumentParser(): any {
         return GolangParser;
     }
+
+    override isCfgCompiler() {
+        // #6439: `gccgo` is ok, the default go compiler `gc` isn't
+        return !this.compiler.version.includes('go version');
+    }
 }

--- a/lib/compilers/ispc.ts
+++ b/lib/compilers/ispc.ts
@@ -90,7 +90,7 @@ export class ISPCCompiler extends BaseCompiler {
         );
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return true;
     }
 }

--- a/lib/compilers/movfuscator.ts
+++ b/lib/compilers/movfuscator.ts
@@ -31,7 +31,7 @@ export class MovfuscatorCompiler extends BaseCompiler {
         return 'movfuscator';
     }
 
-    override isCfgCompiler(compilerVersion: string) {
+    override isCfgCompiler() {
         return true;
     }
 

--- a/lib/compilers/nim.ts
+++ b/lib/compilers/nim.ts
@@ -114,7 +114,7 @@ export class NimCompiler extends BaseCompiler {
         return NimParser;
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return true;
     }
 

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -81,7 +81,7 @@ export class RacketCompiler extends BaseCompiler {
         return [];
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return false;
     }
 

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -245,7 +245,7 @@ export class RustCompiler extends BaseCompiler {
         return RustParser;
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return true;
     }
 

--- a/lib/compilers/snowball.ts
+++ b/lib/compilers/snowball.ts
@@ -92,7 +92,7 @@ export class SnowballCompiler extends BaseCompiler {
         return options;
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return true;
     }
 }

--- a/lib/compilers/solidity-eravm.ts
+++ b/lib/compilers/solidity-eravm.ts
@@ -45,7 +45,7 @@ export class SolidityEravmCompiler extends BaseCompiler {
         return ['--combined-json', 'asm', '-o', 'contracts'];
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return false;
     }
 

--- a/lib/compilers/solidity.ts
+++ b/lib/compilers/solidity.ts
@@ -57,7 +57,7 @@ export class SolidityCompiler extends BaseCompiler {
         ];
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return false;
     }
 

--- a/lib/compilers/swift.ts
+++ b/lib/compilers/swift.ts
@@ -49,7 +49,7 @@ export class SwiftCompiler extends BaseCompiler {
         return SwiftParser;
     }
 
-    override isCfgCompiler(/*compilerVersion*/) {
+    override isCfgCompiler() {
         return true;
     }
 }

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -178,7 +178,7 @@ export class ZigCompiler extends BaseCompiler {
         return userOptions.filter(option => !forbiddenOptions.test(option));
     }
 
-    override isCfgCompiler(/*compilerVersion*/): boolean {
+    override isCfgCompiler(): boolean {
         return true;
     }
 }


### PR DESCRIPTION
Following #6439: mark the go compiler `gc` as not supporting cfg.
Also, don't pass argument to `isCfgCompiler` - the base-compiler implementation uses `this.compiler.instructionSet` anyway.


