### PR TITLE
Don't trust `hasStackUsageOutput`/`hasOptOutput`

### DIFF
--- a/static/panes/opt-view.ts
+++ b/static/panes/opt-view.ts
@@ -124,7 +124,8 @@ export class Opt extends MonacoPane<monaco.editor.IStandaloneCodeEditor, OptStat
         }
 
         this.editor.setValue(unwrap(result.source));
-        if (result.hasOptOutput) {
+        if (result.optOutput) {
+            // result.hasOptOutput might be true for failed compilations
             this.optRemarks = result.optOutput;
             this.showOptRemarks();
         }

--- a/static/panes/stack-usage-view.ts
+++ b/static/panes/stack-usage-view.ts
@@ -88,9 +88,11 @@ export class StackUsage extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
     override onCompileResult(id: number, compiler: CompilerInfo, result: CompilationResult) {
         if (this.compilerInfo.compilerId !== id || !this.isCompilerSupported) return;
         this.editor.setValue(unwrap(result.source));
-        if (result.hasStackUsageOutput) {
-            this.showStackUsageResults(unwrap(result.stackUsageOutput));
+        if (result.stackUsageOutput) {
+            // result.hasStackUsageOutput might be true for failed compilations
+            this.showStackUsageResults(result.stackUsageOutput);
         }
+
         // TODO: This is inelegant again. Previously took advantage of fourth argument for the compileResult event.
         const lang = compiler.lang === 'c++' ? 'cpp' : compiler.lang;
         const model = this.editor.getModel();


### PR DESCRIPTION
... they can be true for compilations that failed and really have no `stackUsageOutput`/`optOutput`
This fixes #6468 alright, but I'm not sure about the followup questions:

(1) Is there really a point in keeping the boolean members `hasStackUsageOutput`/`hasOptOutput`?
(2) What about other `has*` members - `hasPpOutput`, `hasAstOutput`, `hasIrOutput` etc?    I didn't give them similar treatment as I couldn't reproduce similar problems. 

I tend to stick with this quick-n-dirty-ish solution but would appreciate opinions.