### PR TITLE
Add the "nix" Rust crate

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -147,3 +147,4 @@ From oldest to newest contributor, we would like to thank:
 - [Khyber Sen](https://github.com/kkysen)
 - [Matthew Guidry](https://github.com/mguid65)
 - [Adam Thibert](https://github.com/adamaq01)
+- [Nazım Can Altınova](https://github.com/canova)

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -258,7 +258,7 @@ compiler.mrustc-master.isNightly=true
 #################################
 # Installed libs, generated from ce_install generate-rust-crates
 # Don't modify directly
-libs=aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
+libs=aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
 
 libs.aho-corasick.name=aho-corasick
 libs.aho-corasick.url=https://crates.io/crates/aho-corasick
@@ -595,6 +595,12 @@ libs.ndarray.url=https://crates.io/crates/ndarray
 libs.ndarray.versions=0154
 libs.ndarray.versions.0154.version=0.15.4
 libs.ndarray.versions.0154.path=libndarray.rlib
+
+libs.nix.name=nix
+libs.nix.url=https://crates.io/crates/nix
+libs.nix.versions=0280
+libs.nix.versions.0280.version=0.28.0
+libs.nix.versions.0280.path=libnix.rlib
 
 libs.num.name=num
 libs.num.url=https://crates.io/crates/num


### PR DESCRIPTION
This PR fixes #6212 and infra PR is here: https://github.com/compiler-explorer/infra/pull/1299

It adds the nix crate that will be useful when users need to access more user friendly *nix APIs.
Thanks!