### PR TITLE
Add widberg-defs C/C++ library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3309,7 +3309,7 @@ compiler.vast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/li
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2
+libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2:widberg-defs
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -4994,6 +4994,13 @@ libs.copperspice.versions=180
 libs.copperspice.versions.180.version=1.8.0
 libs.copperspice.versions.180.path=/opt/compiler-explorer/libs/copperspice/1.8.0/include:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtCore:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXml:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXmlPatterns:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtNetwork:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtScript:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtGui
 libs.copperspice.versions.180.libpath=/opt/compiler-explorer/libs/copperspice/1.8.0/lib
+
+libs.widberg-defs.name=widberg-defs
+libs.widberg-defs.description=An alternative implementation of defs.h from the Hex-Rays decompiler sdk
+libs.widberg-defs.versions=trunk
+libs.widberg-defs.url=https://github.com/widberg/widberg-defs
+libs.widberg-defs.versions.trunk.version=trunk
+libs.widberg-defs.versions.trunk.path=/opt/compiler-explorer/libs/widberg-defs/trunk/include
 
 
 #################################

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2975,7 +2975,7 @@ compiler.cvast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/l
 #################################
 #################################
 # Libraries
-libs=cs50:hedley:libbpf:libuv:lua:nsimd:openssl:python:simde:curl:sqlite
+libs=cs50:hedley:libbpf:libuv:lua:nsimd:openssl:python:simde:curl:sqlite:widberg-defs
 
 libs.cs50.name=cs50
 libs.cs50.versions=910
@@ -3090,6 +3090,14 @@ libs.sqlite.liblink=sqlite3
 libs.sqlite.url=https://sqlite.org
 libs.sqlite.versions.3400.version=3.40.0
 libs.sqlite.versions.3400.path=/opt/compiler-explorer/libs/sqlite/3.40.0
+
+libs.widberg-defs.name=widberg-defs
+libs.widberg-defs.description=An alternative implementation of defs.h from the Hex-Rays decompiler sdk
+libs.widberg-defs.versions=trunk
+libs.widberg-defs.url=https://github.com/widberg/widberg-defs
+libs.widberg-defs.versions.trunk.version=trunk
+libs.widberg-defs.versions.trunk.path=/opt/compiler-explorer/libs/widberg-defs/trunk/include
+
 
 #################################
 #################################


### PR DESCRIPTION
[widberg-defs](https://github.com/widberg/widberg-defs) is a simple single header library with some utilities for recompiling decompiled code. I often find myself prepending this to CE sources when using the [llvm-project-widberg-extensions](https://github.com/widberg/llvm-project-widberg-extensions) compiler. It would be nice to be able to use it like a normal library on CE.

Infra PR: https://github.com/compiler-explorer/infra/pull/1303