### PR TITLE
Update Android compilers (D8, dex2oat)

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -1,11 +1,20 @@
 compilers=&android-d8:&dex2oat
 
-group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242
+group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242:java-d8-8247:java-d8-8336:java-d8-8337
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
+
+compiler.java-d8-8337.name=d8 8.3.37
+compiler.java-d8-8337.exe=/opt/compiler-explorer/r8-8.3.37/r8-8.3.37.jar
+
+compiler.java-d8-8336.name=d8 8.3.36
+compiler.java-d8-8336.exe=/opt/compiler-explorer/r8-8.3.36/r8-8.3.36.jar
+
+compiler.java-d8-8247.name=d8 8.2.47
+compiler.java-d8-8247.exe=/opt/compiler-explorer/r8-8.2.47/r8-8.2.47.jar
 
 compiler.java-d8-8242.name=d8 8.2.42
 compiler.java-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
@@ -19,7 +28,7 @@ compiler.java-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.java-d8-8156.name=d8 8.1.56
 compiler.java-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
-group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3411
+group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3411:java-dex2oat-3413:java-dex2oat-3414:java-dex2oat-3415:java-dex2oat-3416
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
@@ -28,9 +37,37 @@ compiler.java-dex2oat-latest.name=ART dex2oat latest
 compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
-compiler.java-dex2oat-latest.d8Id=java-d8-8242
+compiler.java-dex2oat-latest.d8Id=java-d8-8337
 compiler.java-dex2oat-latest.isNightly=true
 compiler.java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+compiler.java-dex2oat-3416.name=ART dex2oat aml_art_341615020 (Apr 2024)
+compiler.java-dex2oat-3416.artArtifactDir=/opt/compiler-explorer/dex2oat-34.16
+compiler.java-dex2oat-3416.exe=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3416.objdumper=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/oatdump
+compiler.java-dex2oat-3416.d8Id=java-d8-8337
+compiler.java-dex2oat-3416.profmanPath=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/profman
+
+compiler.java-dex2oat-3415.name=ART dex2oat aml_art_341514410 (Mar 2024)
+compiler.java-dex2oat-3415.artArtifactDir=/opt/compiler-explorer/dex2oat-34.15
+compiler.java-dex2oat-3415.exe=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3415.objdumper=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/oatdump
+compiler.java-dex2oat-3415.d8Id=java-d8-8337
+compiler.java-dex2oat-3415.profmanPath=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/profman
+
+compiler.java-dex2oat-3414.name=ART dex2oat aml_art_341411300 (Feb 2024)
+compiler.java-dex2oat-3414.artArtifactDir=/opt/compiler-explorer/dex2oat-34.14
+compiler.java-dex2oat-3414.exe=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3414.objdumper=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/oatdump
+compiler.java-dex2oat-3414.d8Id=java-d8-8337
+compiler.java-dex2oat-3414.profmanPath=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/profman
+
+compiler.java-dex2oat-3413.name=ART dex2oat aml_art_341311100 (Jan 2024)
+compiler.java-dex2oat-3413.artArtifactDir=/opt/compiler-explorer/dex2oat-34.13
+compiler.java-dex2oat-3413.exe=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3413.objdumper=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/oatdump
+compiler.java-dex2oat-3413.d8Id=java-d8-8337
+compiler.java-dex2oat-3413.profmanPath=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/profman
 
 compiler.java-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
 compiler.java-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -1,11 +1,20 @@
 compilers=&android-d8:&dex2oat
 
-group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242
+group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242:kotlin-d8-8247:kotlin-d8-8336:kotlin-d8-8337
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
+
+compiler.kotlin-d8-8337.name=d8 8.3.37
+compiler.kotlin-d8-8337.exe=/opt/compiler-explorer/r8-8.3.37/r8-8.3.37.jar
+
+compiler.kotlin-d8-8336.name=d8 8.3.36
+compiler.kotlin-d8-8336.exe=/opt/compiler-explorer/r8-8.3.36/r8-8.3.36.jar
+
+compiler.kotlin-d8-8247.name=d8 8.2.47
+compiler.kotlin-d8-8247.exe=/opt/compiler-explorer/r8-8.2.47/r8-8.2.47.jar
 
 compiler.kotlin-d8-8242.name=d8 8.2.42
 compiler.kotlin-d8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
@@ -19,7 +28,7 @@ compiler.kotlin-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.kotlin-d8-8156.name=d8 8.1.56
 compiler.kotlin-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
-group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3411
+group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3411:kotlin-dex2oat-3413:kotlin-dex2oat-3414:kotlin-dex2oat-3415:kotlin-dex2oat-3416
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
@@ -28,9 +37,37 @@ compiler.kotlin-dex2oat-latest.name=ART dex2oat latest
 compiler.kotlin-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.kotlin-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.kotlin-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
-compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8242
+compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8337
 compiler.kotlin-dex2oat-latest.isNightly=true
 compiler.kotlin-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3416.name=ART dex2oat aml_art_341615020 (Apr 2024)
+compiler.kotlin-dex2oat-3416.artArtifactDir=/opt/compiler-explorer/dex2oat-34.16
+compiler.kotlin-dex2oat-3416.exe=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3416.objdumper=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3416.d8Id=kotlin-d8-8337
+compiler.kotlin-dex2oat-3416.profmanPath=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3415.name=ART dex2oat aml_art_341514410 (Mar 2024)
+compiler.kotlin-dex2oat-3415.artArtifactDir=/opt/compiler-explorer/dex2oat-34.15
+compiler.kotlin-dex2oat-3415.exe=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3415.objdumper=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3415.d8Id=kotlin-d8-8337
+compiler.kotlin-dex2oat-3415.profmanPath=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3414.name=ART dex2oat aml_art_341411300 (Feb 2024)
+compiler.kotlin-dex2oat-3414.artArtifactDir=/opt/compiler-explorer/dex2oat-34.14
+compiler.kotlin-dex2oat-3414.exe=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3414.objdumper=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3414.d8Id=kotlin-d8-8337
+compiler.kotlin-dex2oat-3414.profmanPath=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3413.name=ART dex2oat aml_art_341311100 (Jan 2024)
+compiler.kotlin-dex2oat-3413.artArtifactDir=/opt/compiler-explorer/dex2oat-34.13
+compiler.kotlin-dex2oat-3413.exe=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3413.objdumper=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3413.d8Id=kotlin-d8-8337
+compiler.kotlin-dex2oat-3413.profmanPath=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/profman
 
 compiler.kotlin-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
 compiler.kotlin-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11


### PR DESCRIPTION
D8: 8.2.47, 8.3.36, 8.3.37
dex2oat: 34.13, 34.14, 34.15, 34.16

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
