### PR TITLE
Support Android API stubs

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -40,3 +40,9 @@ compiler.java-dex2oat-3411.d8Id=java-d8-8242
 compiler.java-dex2oat-3411.profmanPath=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/profman
 
 defaultCompiler=java-dex2oat-latest
+
+libs=android-api-stubs
+libs.android-api-stubs.name=Android API stubs
+libs.android-api-stubs.versions=11662386
+libs.android-api-stubs.versions.11662386.version=11662386
+libs.android-api-stubs.versions.11662386.path=/opt/compiler-explorer/android-api-stubs-11662386/android.jar

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -40,3 +40,9 @@ compiler.kotlin-dex2oat-3411.d8Id=kotlin-d8-8242
 compiler.kotlin-dex2oat-3411.profmanPath=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/profman
 
 defaultCompiler=kotlin-dex2oat-latest
+
+libs=android-api-stubs
+libs.android-api-stubs.name=Android API stubs
+libs.android-api-stubs.versions=11662386
+libs.android-api-stubs.versions.11662386.version=11662386
+libs.android-api-stubs.versions.11662386.path=/opt/compiler-explorer/android-api-stubs-11662386/android.jar


### PR DESCRIPTION
Updates the d8 and dex2oat compiler implementations so that android.jar is included in the classpath for javac/kotlinc.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
