### PR TITLE
Switch back some ICC to use recent gcc 13.3 headers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1229,36 +1229,31 @@ compiler.icx202300.exe=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/
 compiler.icx202300.ldPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib
 compiler.icx202300.libPath=/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.0.0.25393/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202300.semver=2023.0.0
-# switch back to gcc-13.3 when released. See #5943
-compiler.icx202300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
+compiler.icx202300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202310.exe=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/bin/icpx
 compiler.icx202310.ldPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib
 compiler.icx202310.libPath=/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.1.0.46347/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202310.semver=2023.1.0
-# switch back to gcc-13.3 when released. See #5943
-compiler.icx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
+compiler.icx202310.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202321.exe=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/bin/icpx
 compiler.icx202321.ldPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib
 compiler.icx202321.libPath=/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/intel64_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/compiler/lib/ia32_lin:/opt/compiler-explorer/intel-cpp-2023.2.1.8/compiler/latest/linux/lib:/opt/compiler-explorer/intel-cpp-2023.2.1.8/tbb/latest/lib/intel64/gcc4.8
 compiler.icx202321.semver=2023.2.1
-# switch back to gcc-13.3 when released. See #5943
-compiler.icx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
+compiler.icx202321.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202400.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icpx
 compiler.icx202400.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
 compiler.icx202400.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
 compiler.icx202400.semver=2024.0.0
-# switch back to gcc-13.3 when released. See #5943
-compiler.icx202400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
+compiler.icx202400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/bin/icpx
 compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib
 compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2024.0.0.49524/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.0.0.49524/tbb/latest/lib
 compiler.icxlatest.semver=(latest)
-# switch back to gcc-13.3 when released. See #5943
-compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.3.0
+compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 ################################
 # zapcc


### PR DESCRIPTION
ICC was using gcc 12.3 headers as a workaround for a know bug. This bug has been fixed in gcc 13.3, so switching ICC back to using GCC 13.

fixes #6004