### PR TITLE
[HLSL] Add DXC 1.8.2405 release

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&dxc:&rga:&clang
 
-group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405
 group.dxc.groupName=DXC
 group.dxc.isSemVer=true
 group.dxc.baseName=DXC
@@ -24,6 +24,8 @@ compiler.dxc_1_8_2403_1.exe=/opt/compiler-explorer/dxc-1.8.2403.1/bin/dxc
 compiler.dxc_1_8_2403_1.semver=1.8.2403.1
 compiler.dxc_1_8_2403_2.exe=/opt/compiler-explorer/dxc-1.8.2403.2/bin/dxc
 compiler.dxc_1_8_2403_2.semver=1.8.2403.2
+compiler.dxc_1_8_2405.exe=/opt/compiler-explorer/dxc-1.8.2405/bin/dxc
+compiler.dxc_1_8_2405.semver=1.8.2405
 
 group.rga.compilers=rga262_dxctrunk:rga262_dxc172207:rga262_dxc162112:rga261_dxc172207:rga261_dxc162112:rga290_dxctrunk
 group.rga.groupName=RGA


### PR DESCRIPTION
This adds the latest DXC version 1.8.2405, the May 2024 release of DXC

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
