### PR TITLE
Some extra safety, following sentry-caught exceptions

### DIFF
--- a/static/widgets/timing-info-widget.ts
+++ b/static/widgets/timing-info-widget.ts
@@ -81,7 +81,9 @@ function initializeChartDataFromResult(compileResult: CompilationResult, totalTi
     };
 
     if (compileResult.retreivedFromCache) {
-        pushTimingInfo(data, 'Retrieve result from cache', unwrap(compileResult.retreivedFromCacheTime));
+        if (compileResult.packageDownloadAndUnzipTime) {
+            pushTimingInfo(data, 'Retrieve result from cache', unwrap(compileResult.retreivedFromCacheTime));
+        }
 
         if (compileResult.packageDownloadAndUnzipTime) {
             pushTimingInfo(data, 'Download binary from cache', unwrap(compileResult.execTime));


### PR DESCRIPTION
This is the crash:  https://compiler-explorer.sentry.io/issues/5427865018/

Looking at [where these values are populated](https://github.com/compiler-explorer/compiler-explorer/blob/2307e16fa485bf5d92dd28e0d88bfde9cf6d9b99/lib/base-compiler.ts#L2711-L2715) my conjecture is that `BigInt.toString` failed and returned undefined / null, but I see no documented conditions that can trigger this (maybe [just for ridiculous values](https://stackoverflow.com/a/75593358/89706)). 