### PR TITLE
Add a way to filter opt-pipeline passes

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="file://$PROJECT_DIR$" libraries="{Node.js Core}" />
+  </component>
+</project>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{Node.js Core}" />
-  </component>
-</project>

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -135,7 +135,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.eventHub.emit('optPipelineViewOpened', this.compilerInfo.compilerId);
         this.eventHub.emit('requestSettings');
         this.emitOptions(true);
-        this.passesFilter.on('input', _.debounce(this.onFiltersChange.bind(this), 500));
+        this.passesFilter.on('input', _.debounce(this.onFiltersChange.bind(this), 250));
     }
 
     upgradeStateFields() {

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -25,6 +25,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import * as monaco from 'monaco-editor';
+import * as sifter from '@orchidjs/sifter';
 import {Container} from 'golden-layout';
 import TomSelect from 'tom-select';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -44,7 +45,7 @@ import {
     OptPipelineOutput,
     OptPipelineResults,
 } from '../compilation/opt-pipeline-output.interfaces.js';
-import {unwrap} from '../assert.js';
+import {unwrap, unwrapString} from '../assert.js';
 import {CompilationResult} from '../compilation/compilation.interfaces.js';
 import {CompilerInfo} from '../compiler.interfaces.js';
 import {escapeHTML} from '../../shared/common-utils.js';
@@ -91,6 +92,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.passesFilter = this.domRoot.find('.passes-filter');
         this.passesList = this.domRoot.find('.passes-list');
         this.body = this.domRoot.find('.opt-pipeline-body');
+
         if (state.sidebarWidth === 0) {
             _.defer(() => {
                 state.sidebarWidth = parseInt(
@@ -389,11 +391,8 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         const passes = this.results[name];
         this.passesList.empty();
         let isFirstMachinePass = true;
-        const filterValue = this.passesFilter.val() as string;
+        const newPasses: any = [];
         for (const [i, pass] of passes.entries()) {
-            if (filterValue && !pass.name.includes(filterValue)) {
-                continue;
-            }
             if (filterInconsequentialPasses && !pass.irChanged) {
                 continue;
             }
@@ -402,8 +401,12 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
                 className += ' firstMachinePass';
                 isFirstMachinePass = false;
             }
-            this.passesList.append(`<div data-i="${i}" class="pass ${className}">${escapeHTML(pass.name)}</div>`);
+            newPasses.push({
+                name: pass.name,
+                div: `<div data-i="${i}" class="pass ${className}">${escapeHTML(pass.name)}</div>`,
+            });
         }
+        this.filterPasses(newPasses);
         const passDivs = this.passesList.find('.pass');
         passDivs.on('click', e => {
             const target = e.target;
@@ -428,6 +431,25 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
                     scrollMode: 'if-needed',
                     block: 'center',
                 });
+            }
+        }
+    }
+
+    private filterPasses(newPasses: any) {
+        const filterValue = unwrapString(this.passesFilter.val()).trim();
+        if (filterValue === '') {
+            for (const pass of newPasses) {
+                this.passesList.append(pass.div);
+            }
+        } else {
+            const searcher = new sifter.Sifter(newPasses, {diacritics: false});
+            const filteredPasses = searcher.search(filterValue, {
+                fields: ['name'],
+                conjunction: 'and',
+                sort: 'name',
+            });
+            for (const result of filteredPasses.items) {
+                this.passesList.append(newPasses[result.id].div);
             }
         }
     }
@@ -481,7 +503,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         }
     }
 
-    onFiltersChange(e: any): void {
+    onFiltersChange(_: any): void {
         this.selectGroup(this.state.selectedGroup);
     }
 

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -56,6 +56,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
     compiler: CompilerInfo | null;
     groupName: JQuery;
     passesColumn: JQuery;
+    passesFilter: JQuery;
     passesList: JQuery;
     passesColumnResizer: JQuery;
     body: JQuery;
@@ -87,6 +88,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.groupName = this.domRoot.find('.opt-group-name');
         this.updateGroupName();
         this.passesColumn = this.domRoot.find('.passes-column');
+        this.passesFilter = this.domRoot.find('.passes-filter');
         this.passesList = this.domRoot.find('.passes-list');
         this.body = this.domRoot.find('.opt-pipeline-body');
         if (state.sidebarWidth === 0) {
@@ -131,6 +133,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.eventHub.emit('optPipelineViewOpened', this.compilerInfo.compilerId);
         this.eventHub.emit('requestSettings');
         this.emitOptions(true);
+        this.passesFilter.on('input', _.debounce(this.onFiltersChange.bind(this), 500));
     }
 
     upgradeStateFields() {
@@ -386,7 +389,11 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         const passes = this.results[name];
         this.passesList.empty();
         let isFirstMachinePass = true;
+        const filterValue = this.passesFilter.val() as string;
         for (const [i, pass] of passes.entries()) {
+            if (filterValue && !pass.name.includes(filterValue)) {
+                continue;
+            }
             if (filterInconsequentialPasses && !pass.irChanged) {
                 continue;
             }
@@ -472,6 +479,10 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
                 }
             }
         }
+    }
+
+    onFiltersChange(e: any): void {
+        this.selectGroup(this.state.selectedGroup);
     }
 
     override getCurrentState() {

--- a/views/templates/panes/opt-pipeline.pug
+++ b/views/templates/panes/opt-pipeline.pug
@@ -32,6 +32,7 @@ mixin optionButton(bind, isActive, text, title)
         select.opt-group-picker.group-selector(placeholder="Select group")
   div.opt-pipeline-body
     .passes-column(style="width: 250px;") Passes:
+      input.passes-filter(placeholder="Filter passes")
       .passes-list
     .passes-column-resizer
       .passes-column-resizer-handle


### PR DESCRIPTION
Somewhat of a rough sketch in the matching department, I'd like something more like TomSelect does with the fuzzy matching, but need to look into getting that behaviour without using the select iself

Closes #6569 


(Else, we could always just move this to be a multi selector no?)