### PR TITLE
Update ansi dark colors

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -630,6 +630,7 @@ kbd {
 
 .linked-compiler-output-line {
     cursor: pointer;
+    color: var(--terminal-bright-blue) !important;
 }
 
 .lm_content {

--- a/static/styles/themes/ansi-dark.scss
+++ b/static/styles/themes/ansi-dark.scss
@@ -1,18 +1,18 @@
 body {
-    --terminal-black: #555;
-    --terminal-red: #f55;
-    --terminal-green: #5f5;
-    --terminal-yellow: #ff5;
-    --terminal-blue: #008df8;
-    --terminal-magenta: #f5f;
-    --terminal-cyan: #5ff;
-    --terminal-white: #fff;
-    --terminal-bright-black: #555;
-    --terminal-bright-red: #f55;
-    --terminal-bright-green: #5f5;
-    --terminal-bright-yellow: #ff5;
-    --terminal-bright-blue: #008df8;
-    --terminal-bright-magenta: #f5f;
-    --terminal-bright-cyan: #5ff;
-    --terminal-bright-white: #fff;
+    --terminal-black: #4f5666;
+    --terminal-red: #f85757;
+    --terminal-green: #50d750;
+    --terminal-yellow: #f9e131;
+    --terminal-blue: #3396ff;
+    --terminal-magenta: #de73ff;
+    --terminal-cyan: #4cdee0;
+    --terminal-white: #e6e6e6;
+    --terminal-bright-black: #4f5666;
+    --terminal-bright-red: #f85757;
+    --terminal-bright-green: #50d750;
+    --terminal-bright-yellow: #f9e131;
+    --terminal-bright-blue: #3396ff;
+    --terminal-bright-magenta: #de73ff;
+    --terminal-bright-cyan: #4cdee0;
+    --terminal-bright-white: #e6e6e6;
 }

--- a/static/styles/themes/dark-theme.scss
+++ b/static/styles/themes/dark-theme.scss
@@ -298,10 +298,6 @@ textarea.form-control {
     background: #433b4b !important;
 }
 
-.linked-compiler-output-line {
-    color: #007bfd !important;
-}
-
 .lm_controls {
     .lm_maximise {
         background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23fff' d='M0 4.5V0h9v9H0zM8 5V2H1v6h7z'/%3E%3C/svg%3E") !important;

--- a/static/styles/themes/default-theme.scss
+++ b/static/styles/themes/default-theme.scss
@@ -330,10 +330,6 @@ div.argmenuitem span.argdescription {
     color: black;
 }
 
-.linked-compiler-output-line {
-    color: #007bfd;
-}
-
 .logo-pri {
     fill: #67c52a;
 }

--- a/static/styles/themes/one-dark-theme.scss
+++ b/static/styles/themes/one-dark-theme.scss
@@ -349,10 +349,6 @@ textarea.form-control {
     background: $light !important;
 }
 
-.linked-compiler-output-line {
-    color: #007bfd !important;
-}
-
 .linked-code-decoration-column {
     font-weight: 600;
     color: #44ab40 !important;

--- a/static/styles/themes/pink-theme.scss
+++ b/static/styles/themes/pink-theme.scss
@@ -310,10 +310,6 @@ textarea.form-control {
     background: $dark !important;
 }
 
-.linked-compiler-output-line {
-    color: #007bfd !important;
-}
-
 .linked-code-decoration-column {
     font-weight: 600;
     color: #44ab40 !important;


### PR DESCRIPTION
This PR tweaks some of the ansi colors for dark themes. It's fairly subtle overall, I mainly:
- Decreased brightnesses of green/cyan/yellow
- Desaturated purple/blue/red and made them a bit lighter
- Switched white to a slightly off-white

| old | new |
|---|---|
| ![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/edc17a12-fb8f-44e8-8111-f771d3591df0) | ![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/b36e7244-f354-447a-841d-f0f17d99ed93) |

Old:
![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/76e05892-3984-48fb-8e90-2a36f2e71107)

New:
![image](https://github.com/compiler-explorer/compiler-explorer/assets/51220084/d7573514-2307-440a-babf-bed5c646e8fe)
