### PR TITLE
Update llvm-objdump for Webassembly

### DIFF
--- a/etc/config/wasm.amazon.properties
+++ b/etc/config/wasm.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&wasmtime
-objdumper=llvm-objdump
+objdumper=/opt/compiler-explorer/clang-18.1.0/bin/llvm-objdump
 objdumperType=llvm
 binaryHideFuncRe=^.*::(:?native_to_wasm_trampoline|wasm_to_native_trampoline|array_to_wasm_trampoline).*$
 


### PR DESCRIPTION
👋 Hey,

The Webassembly language was recently added (in #6429). I tested it today on the live enviornment, and it appears to not be working (example: https://godbolt.org/z/YP5KdscEM).

I don't really know how to debug this, there is no other output other than `objdump returned 255` which doesn't tell me a whole lot. (If someone can help me investigate this it would be appreciated)

Looking at the configs for the other languages, they always specify a objdump binary in the `/opt` path, so maybe `llvm-objdump` is not available in the system?

This PR attempts to fix it by changing to a fixed version of `llvm-objdump` in the `/opt` install path. (I've also double checked, and that version does work locally)
