### PR TITLE
Add ZKsync solidity compiler 1.4.1 and 1.5.0

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -323,7 +323,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'lib/compilers/solidity.ts'
-          - 'lib/compilers/solidity-eravm.ts'
+          - 'lib/compilers/solidity-zksync.ts'
           - 'etc/config/solidity.*.properties'
 
 'lang-spice':

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -24,14 +24,18 @@ compiler.solc0821.exe=/opt/compiler-explorer/solc-0.8.21/solc
 compiler.solc0821.semver=0.8.21
 compiler.solc0821.name=solc 0.8.21
 
-group.zksolc.compilers=zksolc140
+group.zksolc.compilers=zksolc141:zksolc150
 group.zksolc.compilerType=solidity-eravm
 group.zksolc.supportsBinary=false
 group.zksolc.instructionSet=eravm
-compiler.zksolc140.exe=/opt/compiler-explorer/zksolc-1.4.0/zksolc
-compiler.zksolc140.semver=1.4.0
-compiler.zksolc140.name=zksolc 1.4.0
-compiler.zksolc140.options=--solc /opt/compiler-explorer/solc-0.8.21/solc
+compiler.zksolc141.exe=/opt/compiler-explorer/zksolc-1.4.1/zksolc
+compiler.zksolc141.semver=1.4.1
+compiler.zksolc141.name=zksolc 1.4.1
+compiler.zksolc141.options=--solc /opt/compiler-explorer/zksync-solc-0.8.25-1.0.1/solc
+compiler.zksolc150.exe=/opt/compiler-explorer/zksolc-1.5.0/zksolc
+compiler.zksolc150.semver=1.5.0
+compiler.zksolc150.name=zksolc 1.5.0
+compiler.zksolc150.options=--solc /opt/compiler-explorer/zksync-solc-0.8.26-1.0.1/solc
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -10,8 +10,8 @@ compiler.solc.instructionSet=evm
 compiler.solc.isSemVer=true
 
 compiler.zksolc.exe=/usr/bin/zksolc
-compiler.zksolc.semver=1.4.0
-compiler.zksolc.name=zksolc 1.4.0
+compiler.zksolc.semver=1.5.0
+compiler.zksolc.name=zksolc 1.5.0
 compiler.zksolc.compilerType=solidity-eravm
 compiler.zksolc.instructionSet=eravm
 compiler.zksolc.isSemVer=true

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -114,7 +114,7 @@ export {RustCompiler} from './rust.js';
 export {ScalaCompiler} from './scala.js';
 export {SdccCompiler} from './sdcc.js';
 export {SolidityCompiler} from './solidity.js';
-export {SolidityEravmCompiler} from './solidity-eravm.js';
+export {SolidityZKsyncCompiler} from './solidity-zksync.js';
 export {SpiceCompiler} from './spice.js';
 export {SPIRVCompiler} from './spirv.js';
 export {SwiftCompiler} from './swift.js';

--- a/lib/compilers/solidity-zksync.ts
+++ b/lib/compilers/solidity-zksync.ts
@@ -28,7 +28,7 @@ import {BaseCompiler} from '../base-compiler.js';
 
 import {ZksolcParser} from './argument-parsers.js';
 
-export class SolidityEravmCompiler extends BaseCompiler {
+export class SolidityZKsyncCompiler extends BaseCompiler {
     static get key() {
         return 'solidity-eravm';
     }


### PR DESCRIPTION
## ZKsync solidity compiler

Adds two latest releases of **ZK**sync solidity compiler (`zksolc`) `v1.4.1` and `v1.5.0`.

Related infra change: https://github.com/compiler-explorer/infra/pull/1324

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
