### PR TITLE
Add 'wrap lines' toggle to ir-view

### DIFF
--- a/static/panes/ir-view.interfaces.ts
+++ b/static/panes/ir-view.interfaces.ts
@@ -26,6 +26,7 @@ export interface IrState {
     irOutput: any;
     // options/filters
     // marked as optional so they don't have to be specified in components.ts, just let them default
+    wrap?: boolean;
     'demangle-symbols'?: boolean;
     '-fno-discard-value-names'?: boolean;
     'filter-debug-info'?: boolean;

--- a/views/templates/panes/ir.pug
+++ b/views/templates/panes/ir.pug
@@ -7,6 +7,11 @@ mixin optionButton(bind, isActive, text, title)
 #ir
   .top-bar.btn-toolbar.bg-light(role="toolbar")
     include ../../font-size
+    .btn-group.btn-group-sm.wrap(role="group")
+      .button-checkbox
+        button.btn.btn-sm.btn-light.wrap-lines(type="button" title="Wrap lines" data-bind="wrap" aria-pressed="false" aria-label="Wrap lines")
+          span Wrap lines
+        input.d-none(type="checkbox" checked=false)
     .btn-group.btn-group-sm.options(role="group")
       button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="LLVM Opt Pass Options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Set output options")
         span.fas.fa-anchor


### PR DESCRIPTION
Mostly for rust - IR line length there can be legendary.
![irwrap](https://github.com/compiler-explorer/compiler-explorer/assets/73080/1d584ea2-3911-4592-867b-01793425f3e0)


