### PR TITLE
Add C23 keywords to our C highlighting mode

### DIFF
--- a/static/modes/nc-mode.ts
+++ b/static/modes/nc-mode.ts
@@ -33,11 +33,15 @@ function definition(): monaco.languages.IMonarchLanguage {
     const nc = $.extend(true, {}, cpp.language); // deep copy
     // https://en.cppreference.com/w/c/keyword
     nc.keywords = [
+        'alignas', // (C23)
+        'alignof', // (C23)
         'auto',
+        'bool', // (C23)
         'break',
         'case',
         'char',
         'const',
+        'constexpr', // (C23)
         'continue',
         'default',
         'do',
@@ -45,38 +49,49 @@ function definition(): monaco.languages.IMonarchLanguage {
         'else',
         'enum',
         'extern',
+        'false', // (C23)
         'float',
         'for',
         'goto',
         'if',
-        'inline',
+        'inline', // (C99)
         'int',
         'long',
+        'nullptr', // (C23)
         'register',
-        'restrict',
+        'restrict', // (C99)
         'return',
         'short',
         'signed',
         'sizeof',
         'static',
+        'static_assert', // (C23)
         'struct',
         'switch',
+        'thread_local', // (C23)
+        'true', // (C23)
         'typedef',
+        'typeof', // (C23)
+        'typeof_unqual', // (C23)
         'union',
         'unsigned',
         'void',
         'volatile',
         'while',
-        '_Alignas',
-        '_Alignof',
-        '_Atomic',
-        '_Bool',
-        '_Complex',
-        '_Generic',
-        '_Imaginary',
-        '_Noreturn',
-        '_Static_assert',
-        '_Thread_local',
+        '_Alignas', // (C11)
+        '_Alignof', // (C11)
+        '_Atomic', // (C11)
+        '_BitInt', // (C23)
+        '_Bool', // (C99)
+        '_Complex', // (C99)
+        '_Decimal128', // (C23)
+        '_Decimal32', // (C23)
+        '_Decimal64', // (C23)
+        '_Generic', // (C11)
+        '_Imaginary', // (C99)
+        '_Noreturn', // (C11)
+        '_Static_assert', // (C11)
+        '_Thread_local', // (C11)
     ];
     return nc;
 }


### PR DESCRIPTION
This PR adds new C23 keywords from https://en.cppreference.com/w/c/keyword. I have some FUD about always highlighting things like `bool`, since what most people think of as C is not C23. I think ideally we'd be able to only highlight C23 keywords when `-std=c23` is being used, but that of course makes things a good deal more complex. But also, it probably makes sense to just go ahead and highlight these.

Possibly related to #6568.