### PR TITLE
Fix paneRenaming not affecting source editor

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -291,6 +291,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         );
     }
 
+    // Not using the normal getCurrentState/updateState pattern because the editor does not conform to its own interface
+    // (legacy links!)
     override updateState(): void {
         const state = {
             id: this.id,
@@ -300,8 +302,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             filename: this.filename,
         };
         this.fontScale.addState(state);
+        this.paneRenaming.addState(state);
         this.container.setState(state);
-
         this.updateButtons();
     }
 


### PR DESCRIPTION
Closes https://github.com/compiler-explorer/compiler-explorer/issues/6525

I found that the pane does not use the normal getCurrentState/update state pattern because it does not conform to its own EditorState interface, which I _think_ is due to legacy links being different than expressed there?

Either way, this PR modifies the min code needed to get it working, and maybe we can homeogenize the rest later

Note that even moving the state to a `getCurrentState()` fails because the history panes then don't know how to handle the editor and you get some "missing `componentState`" errors