### PR TITLE
add some msvc compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winstaging:&hexagon-clang:&edg:&vast
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winstaging:&hexagon-clang:&edg:&vast
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -217,11 +217,11 @@ compiler.vcpp_v19_29_VS16_10_arm64.semver=14.29.30040.0
 compiler.vcpp_v19_29_VS16_11_x86.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
 compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
-compiler.vcpp_v19_29_VS16_11_x86.name=x64 msvc v19.29 VS16.11
+compiler.vcpp_v19_29_VS16_11_x86.name=x86 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_x86.semver=14.29.30153.0
 
 compiler.vcpp_v19_29_VS16_11_x64.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/comp621.0/um/x64;ilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
 compiler.vcpp_v19_29_VS16_11_x64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_29_VS16_11_x64.name=x64 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_x64.semver=14.29.30153.0

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -56,7 +56,7 @@ group.vcpp_x86.needsMulti=false
 group.vcpp_x86.includeFlag=/I
 group.vcpp_x86.versionFlag=/?
 group.vcpp_x86.versionRe=^.*Microsoft \(R\).*$
-group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86
+group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86
 group.vcpp_x86.groupName=MSVC x86
 group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
@@ -71,7 +71,7 @@ group.vcpp_x64.needsMulti=false
 group.vcpp_x64.includeFlag=/I
 group.vcpp_x64.versionFlag=/?
 group.vcpp_x64.versionRe=^.*Microsoft \(R\).*$
-group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64
+group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64
 group.vcpp_x64.groupName=MSVC x64
 group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
@@ -86,7 +86,7 @@ group.vcpp_arm64.needsMulti=false
 group.vcpp_arm64.includeFlag=/I
 group.vcpp_arm64.versionFlag=/?
 group.vcpp_arm64.versionRe=^.*Microsoft \(R\).*$
-group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64
+group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64
 group.vcpp_arm64.groupName=MSVC arm64
 group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
@@ -95,142 +95,328 @@ group.vcpp_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx
 group.vcpp_arm64.demanglerType=win32
 group.vcpp_arm64.compilerCategories=msvc
 
+compiler.vcpp_v19_20_VS16_0_x86.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_20_VS16_0_x86.libPath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib;Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/atlmfc/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_20_VS16_0_x86.includePath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_20_VS16_0_x86.name=x86 msvc v19.20 VS16.0
+compiler.vcpp_v19_20_VS16_0_x86.semver=14.20.27525.0
+
+compiler.vcpp_v19_20_VS16_0_x64.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_20_VS16_0_x64.libPath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib;Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib/x64;Z:/compilers/msvc/14.20.27508-14.20.27525.0/atlmfc/lib/x64;Z:/compilers/msvc/14.20.27508-14.20.27525.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_20_VS16_0_x64.includePath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_20_VS16_0_x64.name=x64 msvc v19.20 VS16.0
+compiler.vcpp_v19_20_VS16_0_x64.semver=14.20.27525.0
+
+compiler.vcpp_v19_20_VS16_0_arm64.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_20_VS16_0_arm64.libPath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib;Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib/arm64;Z:/compilers/msvc/14.20.27508-14.20.27525.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.20.27508-14.20.27525.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_20_VS16_0_arm64.includePath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_20_VS16_0_arm64.name=arm64 msvc v19.20 VS16.0
+compiler.vcpp_v19_20_VS16_0_arm64.semver=14.20.27525.0
+
+compiler.vcpp_v19_21_VS16_1_x86.exe=Z:/compilers/msvc/14.21.27702-14.21.27702.2/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_21_VS16_1_x86.libPath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib;Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib/x86;Z:/compilers/msvc/14.21.27702-14.21.27702.2/atlmfc/lib/x86;Z:/compilers/msvc/14.21.27702-14.21.27702.2/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_21_VS16_1_x86.includePath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_21_VS16_1_x86.name=x86 msvc v19.21 VS16.1
+compiler.vcpp_v19_21_VS16_1_x86.semver=14.21.27702.2
+
+compiler.vcpp_v19_21_VS16_1_x64.exe=Z:/compilers/msvc/14.21.27702-14.21.27702.2/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_21_VS16_1_x64.libPath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib;Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib/x64;Z:/compilers/msvc/14.21.27702-14.21.27702.2/atlmfc/lib/x64;Z:/compilers/msvc/14.21.27702-14.21.27702.2/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_21_VS16_1_x64.includePath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_21_VS16_1_x64.name=x64 msvc v19.21 VS16.1
+compiler.vcpp_v19_21_VS16_1_x64.semver=14.21.27702.2
+
+compiler.vcpp_v19_21_VS16_1_arm64.exe=Z:/compilers/msvc/14.21.27702-14.21.27702.2/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_21_VS16_1_arm64.libPath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib;Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib/arm64;Z:/compilers/msvc/14.21.27702-14.21.27702.2/atlmfc/lib/arm64;Z:/compilers/msvc/14.21.27702-14.21.27702.2/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_21_VS16_1_arm64.includePath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_21_VS16_1_arm64.name=arm64 msvc v19.21 VS16.1
+compiler.vcpp_v19_21_VS16_1_arm64.semver=14.21.27702.2
+
+compiler.vcpp_v19_22_VS16_2_x86.exe=Z:/compilers/msvc/14.22.27905-14.22.27905.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_22_VS16_2_x86.libPath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib;Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib/x86;Z:/compilers/msvc/14.22.27905-14.22.27905.0/atlmfc/lib/x86;Z:/compilers/msvc/14.22.27905-14.22.27905.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_22_VS16_2_x86.includePath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_22_VS16_2_x86.name=x86 msvc v19.22 VS16.2
+compiler.vcpp_v19_22_VS16_2_x86.semver=14.22.27905.0
+
+compiler.vcpp_v19_22_VS16_2_x64.exe=Z:/compilers/msvc/14.22.27905-14.22.27905.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_22_VS16_2_x64.libPath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib;Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib/x64;Z:/compilers/msvc/14.22.27905-14.22.27905.0/atlmfc/lib/x64;Z:/compilers/msvc/14.22.27905-14.22.27905.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_22_VS16_2_x64.includePath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_22_VS16_2_x64.name=x64 msvc v19.22 VS16.2
+compiler.vcpp_v19_22_VS16_2_x64.semver=14.22.27905.0
+
+compiler.vcpp_v19_22_VS16_2_arm64.exe=Z:/compilers/msvc/14.22.27905-14.22.27905.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_22_VS16_2_arm64.libPath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib;Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib/arm64;Z:/compilers/msvc/14.22.27905-14.22.27905.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.22.27905-14.22.27905.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_22_VS16_2_arm64.includePath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_22_VS16_2_arm64.name=arm64 msvc v19.22 VS16.2
+compiler.vcpp_v19_22_VS16_2_arm64.semver=14.22.27905.0
+
+compiler.vcpp_v19_23_VS16_3_x86.exe=Z:/compilers/msvc/14.23.28105-14.23.28105.4/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_23_VS16_3_x86.libPath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib;Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib/x86;Z:/compilers/msvc/14.23.28105-14.23.28105.4/atlmfc/lib/x86;Z:/compilers/msvc/14.23.28105-14.23.28105.4/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_23_VS16_3_x86.includePath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_23_VS16_3_x86.name=x86 msvc v19.23 VS16.3
+compiler.vcpp_v19_23_VS16_3_x86.semver=14.23.28105.4
+
+compiler.vcpp_v19_23_VS16_3_x64.exe=Z:/compilers/msvc/14.23.28105-14.23.28105.4/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_23_VS16_3_x64.libPath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib;Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib/x64;Z:/compilers/msvc/14.23.28105-14.23.28105.4/atlmfc/lib/x64;Z:/compilers/msvc/14.23.28105-14.23.28105.4/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_23_VS16_3_x64.includePath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_23_VS16_3_x64.name=x64 msvc v19.23 VS16.3
+compiler.vcpp_v19_23_VS16_3_x64.semver=14.23.28105.4
+
+compiler.vcpp_v19_23_VS16_3_arm64.exe=Z:/compilers/msvc/14.23.28105-14.23.28105.4/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_23_VS16_3_arm64.libPath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib;Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib/arm64;Z:/compilers/msvc/14.23.28105-14.23.28105.4/atlmfc/lib/arm64;Z:/compilers/msvc/14.23.28105-14.23.28105.4/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_23_VS16_3_arm64.includePath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_23_VS16_3_arm64.name=arm64 msvc v19.23 VS16.3
+compiler.vcpp_v19_23_VS16_3_arm64.semver=14.23.28105.4
+
 compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_24_VS16_4_x86.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/atlmfc/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_24_VS16_4_x86.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_24_VS16_4_x86.name=x86 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_x86.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_x86.alias=vcpp_v19_24_x86
 
 compiler.vcpp_v19_24_VS16_4_x64.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_24_VS16_4_x64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_24_VS16_4_x64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_x64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/atlmfc/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_24_VS16_4_x64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_24_VS16_4_x64.name=x64 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_x64.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_x64.alias=vcpp_v19_24_x64
 
 compiler.vcpp_v19_24_VS16_4_arm64.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_24_VS16_4_arm64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.283lmfc/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_24_VS16_4_arm64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_arm64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_24_VS16_4_arm64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_24_VS16_4_arm64.name=arm64 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_arm64.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_arm64.alias=vcpp_v19_24_arm64
 
 compiler.vcpp_v19_25_VS16_5_x86.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_25_VS16_5_x86.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_25_VS16_5_x86.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_x86.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/atlmfc/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_25_VS16_5_x86.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_25_VS16_5_x86.name=x86 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_x86.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_x86.alias=vcpp_v19_25_x86
 
 compiler.vcpp_v19_25_VS16_5_x64.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_25_VS16_5_x64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_25_VS16_5_x64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_x64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/atlmfc/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_25_VS16_5_x64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_25_VS16_5_x64.name=x64 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_x64.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_x64.alias=vcpp_v19_25_x64
 
 compiler.vcpp_v19_25_VS16_5_arm64.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_25_VS16_5_arm64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.286lmfc/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_25_VS16_5_arm64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_arm64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_25_VS16_5_arm64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_25_VS16_5_arm64.name=arm64 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_arm64.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_arm64.alias=vcpp_v19_25_arm64
 
+compiler.vcpp_v19_26_VS16_6_x86.exe=Z:/compilers/msvc/14.26.28801-14.26.28806.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_26_VS16_6_x86.libPath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib;Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib/x86;Z:/compilers/msvc/14.26.28801-14.26.28806.0/atlmfc/lib/x86;Z:/compilers/msvc/14.26.28801-14.26.28806.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_26_VS16_6_x86.includePath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_26_VS16_6_x86.name=x86 msvc v19.26 VS16.6
+compiler.vcpp_v19_26_VS16_6_x86.semver=14.26.28806.0
+
+compiler.vcpp_v19_26_VS16_6_x64.exe=Z:/compilers/msvc/14.26.28801-14.26.28806.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_26_VS16_6_x64.libPath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib;Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib/x64;Z:/compilers/msvc/14.26.28801-14.26.28806.0/atlmfc/lib/x64;Z:/compilers/msvc/14.26.28801-14.26.28806.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_26_VS16_6_x64.includePath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_26_VS16_6_x64.name=x64 msvc v19.26 VS16.6
+compiler.vcpp_v19_26_VS16_6_x64.semver=14.26.28806.0
+
+compiler.vcpp_v19_26_VS16_6_arm64.exe=Z:/compilers/msvc/14.26.28801-14.26.28806.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_26_VS16_6_arm64.libPath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib;Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib/arm64;Z:/compilers/msvc/14.26.28801-14.26.28806.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.26.28801-14.26.28806.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_26_VS16_6_arm64.includePath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_26_VS16_6_arm64.name=arm64 msvc v19.26 VS16.6
+compiler.vcpp_v19_26_VS16_6_arm64.semver=14.26.28806.0
+
 compiler.vcpp_v19_27_VS16_7_x86.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_27_VS16_7_x86.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_27_VS16_7_x86.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_x86.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/atlmfc/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_27_VS16_7_x86.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_27_VS16_7_x86.name=x86 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_x86.semver=14.27.29120.0
 compiler.vcpp_v19_27_VS16_7_x86.alias=vcpp_v19_27_x86
 
 compiler.vcpp_v19_27_VS16_7_x64.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_27_VS16_7_x64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_27_VS16_7_x64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_x64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/atlmfc/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_27_VS16_7_x64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_27_VS16_7_x64.name=x64 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_x64.semver=14.27.29120.0
 compiler.vcpp_v19_27_VS16_7_x64.alias=vcpp_v19_27_x64
 
 compiler.vcpp_v19_27_VS16_7_arm64.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_27_VS16_7_arm64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.291lmfc/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_27_VS16_7_arm64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_arm64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_27_VS16_7_arm64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_27_VS16_7_arm64.name=arm64 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_arm64.semver=14.27.29120.0
 
 compiler.vcpp_v19_28_VS16_8_x86.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_28_VS16_8_x86.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_28_VS16_8_x86.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_x86.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/atlmfc/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_28_VS16_8_x86.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_8_x86.name=x86 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_x86.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_x86.alias=vcpp_v19_28_x86
 
 compiler.vcpp_v19_28_VS16_8_x64.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_28_VS16_8_x64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_28_VS16_8_x64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_x64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/atlmfc/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_28_VS16_8_x64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_8_x64.name=x64 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_x64.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_x64.alias=vcpp_v19_28_x64
 
 compiler.vcpp_v19_28_VS16_8_arm64.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_28_VS16_8_arm64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.293lmfc/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_28_VS16_8_arm64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_arm64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_28_VS16_8_arm64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_8_arm64.name=arm64 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_arm64.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_arm64.alias=vcpp_v19_28_arm64
 
 compiler.vcpp_v19_28_VS16_9_x86.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_28_VS16_9_x86.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_28_VS16_9_x86.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_x86.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/atlmfc/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_28_VS16_9_x86.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_9_x86.name=x86 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_x86.semver=14.28.29921.0
 
 compiler.vcpp_v19_28_VS16_9_x64.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_28_VS16_9_x64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_28_VS16_9_x64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_x64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/atlmfc/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_28_VS16_9_x64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_9_x64.name=x64 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_x64.semver=14.28.29921.0
 
 compiler.vcpp_v19_28_VS16_9_arm64.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_28_VS16_9_arm64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_28_VS16_9_arm64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_arm64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_28_VS16_9_arm64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_9_arm64.name=arm64 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_arm64.semver=14.28.29921.0
 
 compiler.vcpp_v19_29_VS16_10_x86.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_29_VS16_10_x86.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_29_VS16_10_x86.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_x86.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_29_VS16_10_x86.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_10_x86.name=x86 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_x86.semver=14.29.30040.0
 
 compiler.vcpp_v19_29_VS16_10_x64.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_29_VS16_10_x64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_29_VS16_10_x64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_x64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_29_VS16_10_x64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_10_x64.name=x64 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_x64.semver=14.29.30040.0
 
 compiler.vcpp_v19_29_VS16_10_arm64.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_29_VS16_10_arm64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_29_VS16_10_arm64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_arm64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_29_VS16_10_arm64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_10_arm64.name=arm64 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_arm64.semver=14.29.30040.0
 
 compiler.vcpp_v19_29_VS16_11_x86.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_11_x86.name=x86 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_x86.semver=14.29.30153.0
 
 compiler.vcpp_v19_29_VS16_11_x64.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_29_VS16_11_x64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_29_VS16_11_x64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_11_x64.name=x64 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_x64.semver=14.29.30153.0
 
 compiler.vcpp_v19_29_VS16_11_arm64.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_29_VS16_11_arm64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/arm64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_29_VS16_11_arm64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_arm64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/arm64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_29_VS16_11_arm64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_11_arm64.name=arm64 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_arm64.semver=14.29.30153.0
 
+compiler.vcpp_v19_30_VS17_0_x86.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_30_VS17_0_x86.libPath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib;Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib/x86;Z:/compilers/msvc/14.30.30705-14.30.30715.0/atlmfc/lib/x86;Z:/compilers/msvc/14.30.30705-14.30.30715.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_30_VS17_0_x86.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_30_VS17_0_x86.name=x86 msvc v19.30 VS17.0
+compiler.vcpp_v19_30_VS17_0_x86.semver=14.30.30715.0
 
-tools=
+compiler.vcpp_v19_30_VS17_0_x64.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_30_VS17_0_x64.libPath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib;Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib/x64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/atlmfc/lib/x64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_30_VS17_0_x64.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_30_VS17_0_x64.name=x64 msvc v19.30 VS17.0
+compiler.vcpp_v19_30_VS17_0_x64.semver=14.30.30715.0
+
+compiler.vcpp_v19_30_VS17_0_arm64.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_30_VS17_0_arm64.libPath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib;Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib/arm64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_30_VS17_0_arm64.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_30_VS17_0_arm64.name=arm64 msvc v19.30 VS17.0
+compiler.vcpp_v19_30_VS17_0_arm64.semver=14.30.30715.0
+
+compiler.vcpp_v19_31_VS17_1_x86.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_31_VS17_1_x86.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/x86;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/x86;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_31_VS17_1_x86.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_31_VS17_1_x86.name=x86 msvc v19.31 VS17.1
+compiler.vcpp_v19_31_VS17_1_x86.semver=14.31.31107.0
+
+compiler.vcpp_v19_31_VS17_1_x64.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_31_VS17_1_x64.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/x64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/x64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_31_VS17_1_x64.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_31_VS17_1_x64.name=x64 msvc v19.31 VS17.1
+compiler.vcpp_v19_31_VS17_1_x64.semver=14.31.31107.0
+
+compiler.vcpp_v19_31_VS17_1_arm64.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_31_VS17_1_arm64.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/arm64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_31_VS17_1_arm64.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_31_VS17_1_arm64.name=arm64 msvc v19.31 VS17.1
+compiler.vcpp_v19_31_VS17_1_arm64.semver=14.31.31107.0
+
+compiler.vcpp_v19_33_VS17_3_x86.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_33_VS17_3_x86.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/x86;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/x86;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_33_VS17_3_x86.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_33_VS17_3_x86.name=x86 msvc v19.33 VS17.3
+compiler.vcpp_v19_33_VS17_3_x86.semver=14.33.31630.0
+
+compiler.vcpp_v19_33_VS17_3_x64.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_33_VS17_3_x64.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/x64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/x64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_33_VS17_3_x64.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_33_VS17_3_x64.name=x64 msvc v19.33 VS17.3
+compiler.vcpp_v19_33_VS17_3_x64.semver=14.33.31630.0
+
+compiler.vcpp_v19_33_VS17_3_arm64.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_33_VS17_3_arm64.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/arm64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_33_VS17_3_arm64.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_33_VS17_3_arm64.name=arm64 msvc v19.33 VS17.3
+compiler.vcpp_v19_33_VS17_3_arm64.semver=14.33.31630.0
+
+compiler.vcpp_v19_35_VS17_5_x86.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_35_VS17_5_x86.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/x86;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/x86;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_35_VS17_5_x86.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_35_VS17_5_x86.name=x86 msvc v19.35 VS17.5
+compiler.vcpp_v19_35_VS17_5_x86.semver=14.35.32217.1
+
+compiler.vcpp_v19_35_VS17_5_x64.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_35_VS17_5_x64.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/x64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/x64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_35_VS17_5_x64.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_35_VS17_5_x64.name=x64 msvc v19.35 VS17.5
+compiler.vcpp_v19_35_VS17_5_x64.semver=14.35.32217.1
+
+compiler.vcpp_v19_35_VS17_5_arm64.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_35_VS17_5_arm64.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/arm64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/arm64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_35_VS17_5_arm64.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_35_VS17_5_arm64.name=arm64 msvc v19.35 VS17.5
+compiler.vcpp_v19_35_VS17_5_arm64.semver=14.35.32217.1
+
+compiler.vcpp_v19_37_VS17_7_x86.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_37_VS17_7_x86.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/x86;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/x86;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_37_VS17_7_x86.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_37_VS17_7_x86.name=x86 msvc v19.37 VS17.7
+compiler.vcpp_v19_37_VS17_7_x86.semver=14.37.32826.1
+
+compiler.vcpp_v19_37_VS17_7_x64.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_37_VS17_7_x64.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/x64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/x64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_37_VS17_7_x64.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_37_VS17_7_x64.name=x64 msvc v19.37 VS17.7
+compiler.vcpp_v19_37_VS17_7_x64.semver=14.37.32826.1
+
+compiler.vcpp_v19_37_VS17_7_arm64.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_37_VS17_7_arm64.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/arm64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/arm64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_37_VS17_7_arm64.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_37_VS17_7_arm64.name=arm64 msvc v19.37 VS17.7
+compiler.vcpp_v19_37_VS17_7_arm64.semver=14.37.32826.1
+
+
+tools=MicrosoftAnalysisTool
+tools.MicrosoftAnalysisTool.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/x64/cl.exe
+tools.MicrosoftAnalysisTool.exclude=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_30_arm64:vcpp_v19_31_arm64:vcpp_v19_32_arm64:vcpp_v19_33_arm64:vcpp_v19_34_arm64:vcpp_v19_35_arm64:vcpp_v19_36_arm64:vcpp_v19_37_arm64:vcpp_v19_latest_arm64
+tools.MicrosoftAnalysisTool.name=Static Analysis
+tools.MicrosoftAnalysisTool.type=independent
+tools.MicrosoftAnalysisTool.class=microsoft-analysis-tool
+tools.MicrosoftAnalysisTool.stdinHint=disabled

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -508,6 +508,7 @@ compiler.vcpp_v19_38_VS17_8_arm64.includePath=Z:/compilers/msvc/14.38.33130-14.3
 compiler.vcpp_v19_38_VS17_8_arm64.name=arm64 msvc v19.38 VS17.8
 compiler.vcpp_v19_38_VS17_8_arm64.semver=14.38.33133.0
 
+libs=
 
 tools=MicrosoftAnalysisTool
 tools.MicrosoftAnalysisTool.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/x64/cl.exe

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -1,4 +1,4 @@
-compilers=&mingw64
+compilers=&mingw64:&vcpp_x86:&vcpp_x64:&vcpp_arm64
 objdumper=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/objdump.exe
 demangler=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/c++filt.exe
 
@@ -48,5 +48,181 @@ compiler.mingw64_ucrt_clang_1406.semver=14.0.6
 
 compiler.mingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0-ucrt-r3/bin/clang++.exe
 compiler.mingw64_ucrt_clang_1403.semver=14.0.3
+
+
+group.vcpp_x86.options=-EHsc
+group.vcpp_x86.compilerType=win32-vc
+group.vcpp_x86.needsMulti=false
+group.vcpp_x86.includeFlag=/I
+group.vcpp_x86.versionFlag=/?
+group.vcpp_x86.versionRe=^.*Microsoft \(R\).*$
+group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86
+group.vcpp_x86.groupName=MSVC x86
+group.vcpp_x86.isSemVer=true
+group.vcpp_x86.supportsBinary=true
+group.vcpp_x86.supportsExecute=false
+group.vcpp_x86.demangler=C:/data/msvc/14.38.32919-Pre-v1/bin/Hostx64/x64/undname.exe
+
+group.vcpp_x64.options=-EHsc
+group.vcpp_x64.compilerType=win32-vc
+group.vcpp_x64.needsMulti=false
+group.vcpp_x64.includeFlag=/I
+group.vcpp_x64.versionFlag=/?
+group.vcpp_x64.versionRe=^.*Microsoft \(R\).*$
+group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64
+group.vcpp_x64.groupName=MSVC x64
+group.vcpp_x64.isSemVer=true
+group.vcpp_x64.supportsBinary=true
+group.vcpp_x64.supportsExecute=false
+
+group.vcpp_arm64.options=-EHsc
+group.vcpp_arm64.compilerType=win32-vc
+group.vcpp_arm64.needsMulti=false
+group.vcpp_arm64.includeFlag=/I
+group.vcpp_arm64.versionFlag=/?
+group.vcpp_arm64.versionRe=^.*Microsoft \(R\).*$
+group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64
+group.vcpp_arm64.groupName=MSVC arm64
+group.vcpp_arm64.isSemVer=true
+group.vcpp_arm64.supportsBinary=false
+group.vcpp_arm64.supportsExecute=false
+
+compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_24_VS16_4_x86.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_x86.name=x86 msvc v19.24 VS16.4
+compiler.vcpp_v19_24_VS16_4_x86.semver=14.24.28325.0
+compiler.vcpp_v19_24_VS16_4_x86.alias=vcpp_v19_24_x86
+
+compiler.vcpp_v19_24_VS16_4_x64.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_24_VS16_4_x64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_24_VS16_4_x64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_x64.name=x64 msvc v19.24 VS16.4
+compiler.vcpp_v19_24_VS16_4_x64.semver=14.24.28325.0
+compiler.vcpp_v19_24_VS16_4_x64.alias=vcpp_v19_24_x64
+
+compiler.vcpp_v19_24_VS16_4_arm64.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_24_VS16_4_arm64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.283lmfc/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_24_VS16_4_arm64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_arm64.name=arm64 msvc v19.24 VS16.4
+compiler.vcpp_v19_24_VS16_4_arm64.semver=14.24.28325.0
+compiler.vcpp_v19_24_VS16_4_arm64.alias=vcpp_v19_24_arm64
+
+compiler.vcpp_v19_25_VS16_5_x86.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_25_VS16_5_x86.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_25_VS16_5_x86.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_x86.name=x86 msvc v19.25 VS16.5
+compiler.vcpp_v19_25_VS16_5_x86.semver=14.25.28614.0
+compiler.vcpp_v19_25_VS16_5_x86.alias=vcpp_v19_25_x86
+
+compiler.vcpp_v19_25_VS16_5_x64.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_25_VS16_5_x64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_25_VS16_5_x64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_x64.name=x64 msvc v19.25 VS16.5
+compiler.vcpp_v19_25_VS16_5_x64.semver=14.25.28614.0
+compiler.vcpp_v19_25_VS16_5_x64.alias=vcpp_v19_25_x64
+
+compiler.vcpp_v19_25_VS16_5_arm64.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_25_VS16_5_arm64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.286lmfc/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_25_VS16_5_arm64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_arm64.name=arm64 msvc v19.25 VS16.5
+compiler.vcpp_v19_25_VS16_5_arm64.semver=14.25.28614.0
+compiler.vcpp_v19_25_VS16_5_arm64.alias=vcpp_v19_25_arm64
+
+compiler.vcpp_v19_27_VS16_7_x86.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_27_VS16_7_x86.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_27_VS16_7_x86.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_x86.name=x86 msvc v19.27 VS16.7
+compiler.vcpp_v19_27_VS16_7_x86.semver=14.27.29120.0
+compiler.vcpp_v19_27_VS16_7_x86.alias=vcpp_v19_27_x86
+
+compiler.vcpp_v19_27_VS16_7_x64.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_27_VS16_7_x64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_27_VS16_7_x64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_x64.name=x64 msvc v19.27 VS16.7
+compiler.vcpp_v19_27_VS16_7_x64.semver=14.27.29120.0
+compiler.vcpp_v19_27_VS16_7_x64.alias=vcpp_v19_27_x64
+
+compiler.vcpp_v19_27_VS16_7_arm64.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_27_VS16_7_arm64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.291lmfc/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_27_VS16_7_arm64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_arm64.name=arm64 msvc v19.27 VS16.7
+compiler.vcpp_v19_27_VS16_7_arm64.semver=14.27.29120.0
+
+compiler.vcpp_v19_28_VS16_8_x86.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_28_VS16_8_x86.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_28_VS16_8_x86.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_x86.name=x86 msvc v19.28 VS16.8
+compiler.vcpp_v19_28_VS16_8_x86.semver=14.28.29335.0
+compiler.vcpp_v19_28_VS16_8_x86.alias=vcpp_v19_28_x86
+
+compiler.vcpp_v19_28_VS16_8_x64.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_28_VS16_8_x64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_28_VS16_8_x64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_x64.name=x64 msvc v19.28 VS16.8
+compiler.vcpp_v19_28_VS16_8_x64.semver=14.28.29335.0
+compiler.vcpp_v19_28_VS16_8_x64.alias=vcpp_v19_28_x64
+
+compiler.vcpp_v19_28_VS16_8_arm64.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_28_VS16_8_arm64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.293lmfc/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_28_VS16_8_arm64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_arm64.name=arm64 msvc v19.28 VS16.8
+compiler.vcpp_v19_28_VS16_8_arm64.semver=14.28.29335.0
+compiler.vcpp_v19_28_VS16_8_arm64.alias=vcpp_v19_28_arm64
+
+compiler.vcpp_v19_28_VS16_9_x86.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_28_VS16_9_x86.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_28_VS16_9_x86.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_x86.name=x86 msvc v19.28 VS16.9
+compiler.vcpp_v19_28_VS16_9_x86.semver=14.28.29921.0
+
+compiler.vcpp_v19_28_VS16_9_x64.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_28_VS16_9_x64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_28_VS16_9_x64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_x64.name=x64 msvc v19.28 VS16.9
+compiler.vcpp_v19_28_VS16_9_x64.semver=14.28.29921.0
+
+compiler.vcpp_v19_28_VS16_9_arm64.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_28_VS16_9_arm64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.299lmfc/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_28_VS16_9_arm64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_arm64.name=arm64 msvc v19.28 VS16.9
+compiler.vcpp_v19_28_VS16_9_arm64.semver=14.28.29921.0
+
+compiler.vcpp_v19_29_VS16_10_x86.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_29_VS16_10_x86.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.c/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_29_VS16_10_x86.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-1de/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_x86.name=x86 msvc v19.29 VS16.10
+compiler.vcpp_v19_29_VS16_10_x86.semver=14.29.30040.0
+
+compiler.vcpp_v19_29_VS16_10_x64.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_29_VS16_10_x64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.c/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_29_VS16_10_x64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-1de/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_x64.name=x64 msvc v19.29 VS16.10
+compiler.vcpp_v19_29_VS16_10_x64.semver=14.29.30040.0
+
+compiler.vcpp_v19_29_VS16_10_arm64.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_29_VS16_10_arm64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30tlmfc/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64; 
+compiler.vcpp_v19_29_VS16_10_arm64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kitslude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_arm64.name=arm64 msvc v19.29 VS16.10
+compiler.vcpp_v19_29_VS16_10_arm64.semver=14.29.30040.0
+
+compiler.vcpp_v19_29_VS16_11_x86.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.c/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z10/include/10.0.22621.0/wi:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_x86.name=x64 msvc v19.29 VS16.11
+compiler.vcpp_v19_29_VS16_11_x86.semver=14.29.30153.0
+
+compiler.vcpp_v19_29_VS16_11_x64.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.c/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/comp621.0/um/x64;ilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_29_VS16_11_x64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z10/include/10.0.22621.0/wi:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_x64.name=x64 msvc v19.29 VS16.11
+compiler.vcpp_v19_29_VS16_11_x64.semver=14.29.30153.0
+
+compiler.vcpp_v19_29_VS16_11_arm64.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_29_VS16_11_arm64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/arm64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_29_VS16_11_arm64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_arm64.name=arm64 msvc v19.29 VS16.11
+compiler.vcpp_v19_29_VS16_11_arm64.semver=14.29.30153.0
+
 
 tools=

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -56,7 +56,7 @@ group.vcpp_x86.needsMulti=false
 group.vcpp_x86.includeFlag=/I
 group.vcpp_x86.versionFlag=/?
 group.vcpp_x86.versionRe=^.*Microsoft \(R\).*$
-group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86
+group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86:vcpp_v19_32_VS17_2_x86:vcpp_v19_34_VS17_4_x86:vcpp_v19_36_VS17_6_x86:vcpp_v19_38_VS17_8_x86
 group.vcpp_x86.groupName=MSVC x86
 group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
@@ -71,7 +71,7 @@ group.vcpp_x64.needsMulti=false
 group.vcpp_x64.includeFlag=/I
 group.vcpp_x64.versionFlag=/?
 group.vcpp_x64.versionRe=^.*Microsoft \(R\).*$
-group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64
+group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64:vcpp_v19_32_VS17_2_x64:vcpp_v19_34_VS17_4_x64:vcpp_v19_36_VS17_6_x64:vcpp_v19_38_VS17_8_x64
 group.vcpp_x64.groupName=MSVC x64
 group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
@@ -86,7 +86,7 @@ group.vcpp_arm64.needsMulti=false
 group.vcpp_arm64.includeFlag=/I
 group.vcpp_arm64.versionFlag=/?
 group.vcpp_arm64.versionRe=^.*Microsoft \(R\).*$
-group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64
+group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64:vcpp_v19_32_VS17_2_arm64:vcpp_v19_34_VS17_4_arm64:vcpp_v19_36_VS17_6_arm64:vcpp_v19_38_VS17_8_arm64
 group.vcpp_arm64.groupName=MSVC arm64
 group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
@@ -327,90 +327,186 @@ compiler.vcpp_v19_30_VS17_0_x86.libPath=Z:/compilers/msvc/14.30.30705-14.30.3071
 compiler.vcpp_v19_30_VS17_0_x86.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_30_VS17_0_x86.name=x86 msvc v19.30 VS17.0
 compiler.vcpp_v19_30_VS17_0_x86.semver=14.30.30715.0
+compiler.vcpp_v19_30_VS17_0_x86.alias=vcpp_v19_30_x86
 
 compiler.vcpp_v19_30_VS17_0_x64.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_30_VS17_0_x64.libPath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib;Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib/x64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/atlmfc/lib/x64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_30_VS17_0_x64.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_30_VS17_0_x64.name=x64 msvc v19.30 VS17.0
 compiler.vcpp_v19_30_VS17_0_x64.semver=14.30.30715.0
+compiler.vcpp_v19_30_VS17_0_x64.alias=vcpp_v19_30_x64
 
 compiler.vcpp_v19_30_VS17_0_arm64.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_30_VS17_0_arm64.libPath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib;Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib/arm64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.30.30705-14.30.30715.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
 compiler.vcpp_v19_30_VS17_0_arm64.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_30_VS17_0_arm64.name=arm64 msvc v19.30 VS17.0
 compiler.vcpp_v19_30_VS17_0_arm64.semver=14.30.30715.0
+compiler.vcpp_v19_30_VS17_0_arm64.alias=vcpp_v19_30_arm64
 
 compiler.vcpp_v19_31_VS17_1_x86.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_31_VS17_1_x86.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/x86;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/x86;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_31_VS17_1_x86.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_31_VS17_1_x86.name=x86 msvc v19.31 VS17.1
 compiler.vcpp_v19_31_VS17_1_x86.semver=14.31.31107.0
+compiler.vcpp_v19_31_VS17_1_x86.alias=vcpp_v19_31_x86
 
 compiler.vcpp_v19_31_VS17_1_x64.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_31_VS17_1_x64.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/x64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/x64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_31_VS17_1_x64.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_31_VS17_1_x64.name=x64 msvc v19.31 VS17.1
 compiler.vcpp_v19_31_VS17_1_x64.semver=14.31.31107.0
+compiler.vcpp_v19_31_VS17_1_x64.alias=vcpp_v19_31_x64
 
 compiler.vcpp_v19_31_VS17_1_arm64.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_31_VS17_1_arm64.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/arm64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
 compiler.vcpp_v19_31_VS17_1_arm64.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_31_VS17_1_arm64.name=arm64 msvc v19.31 VS17.1
 compiler.vcpp_v19_31_VS17_1_arm64.semver=14.31.31107.0
+compiler.vcpp_v19_31_VS17_1_arm64.alias=vcpp_v19_31_arm64
+
+compiler.vcpp_v19_32_VS17_2_x86.exe=Z:/compilers/msvc/14.32.31326-14.32.31342.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_32_VS17_2_x86.libPath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib;Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib/x86;Z:/compilers/msvc/14.32.31326-14.32.31342.0/atlmfc/lib/x86;Z:/compilers/msvc/14.32.31326-14.32.31342.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_32_VS17_2_x86.includePath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_32_VS17_2_x86.name=x86 msvc v19.32 VS17.2
+compiler.vcpp_v19_32_VS17_2_x86.semver=14.32.31342.0
+compiler.vcpp_v19_32_VS17_2_x86.alias=vcpp_v19_32_x86
+
+compiler.vcpp_v19_32_VS17_2_x64.exe=Z:/compilers/msvc/14.32.31326-14.32.31342.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_32_VS17_2_x64.libPath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib;Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib/x64;Z:/compilers/msvc/14.32.31326-14.32.31342.0/atlmfc/lib/x64;Z:/compilers/msvc/14.32.31326-14.32.31342.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_32_VS17_2_x64.includePath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_32_VS17_2_x64.name=x64 msvc v19.32 VS17.2
+compiler.vcpp_v19_32_VS17_2_x64.semver=14.32.31342.0
+compiler.vcpp_v19_32_VS17_2_x64.alias=vcpp_v19_32_x64
+
+compiler.vcpp_v19_32_VS17_2_arm64.exe=Z:/compilers/msvc/14.32.31326-14.32.31342.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_32_VS17_2_arm64.libPath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib;Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib/arm64;Z:/compilers/msvc/14.32.31326-14.32.31342.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.32.31326-14.32.31342.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_32_VS17_2_arm64.includePath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_32_VS17_2_arm64.name=arm64 msvc v19.32 VS17.2
+compiler.vcpp_v19_32_VS17_2_arm64.semver=14.32.31342.0
+compiler.vcpp_v19_32_VS17_2_arm64.alias=vcpp_v19_32_arm64
 
 compiler.vcpp_v19_33_VS17_3_x86.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_33_VS17_3_x86.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/x86;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/x86;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_33_VS17_3_x86.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_33_VS17_3_x86.name=x86 msvc v19.33 VS17.3
 compiler.vcpp_v19_33_VS17_3_x86.semver=14.33.31630.0
+compiler.vcpp_v19_33_VS17_3_x86.alias=vcpp_v19_33_x86
 
 compiler.vcpp_v19_33_VS17_3_x64.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_33_VS17_3_x64.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/x64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/x64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_33_VS17_3_x64.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_33_VS17_3_x64.name=x64 msvc v19.33 VS17.3
 compiler.vcpp_v19_33_VS17_3_x64.semver=14.33.31630.0
+compiler.vcpp_v19_33_VS17_3_x64.alias=vcpp_v19_33_x64
 
 compiler.vcpp_v19_33_VS17_3_arm64.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_33_VS17_3_arm64.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/arm64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
 compiler.vcpp_v19_33_VS17_3_arm64.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_33_VS17_3_arm64.name=arm64 msvc v19.33 VS17.3
 compiler.vcpp_v19_33_VS17_3_arm64.semver=14.33.31630.0
+compiler.vcpp_v19_33_VS17_3_arm64.alias=vcpp_v19_33_arm64
+
+compiler.vcpp_v19_34_VS17_4_x86.exe=Z:/compilers/msvc/14.34.31933-14.34.31948.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_34_VS17_4_x86.libPath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib;Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib/x86;Z:/compilers/msvc/14.34.31933-14.34.31948.0/atlmfc/lib/x86;Z:/compilers/msvc/14.34.31933-14.34.31948.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_34_VS17_4_x86.includePath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_34_VS17_4_x86.name=x86 msvc v19.34 VS17.4
+compiler.vcpp_v19_34_VS17_4_x86.semver=14.34.31948.0
+compiler.vcpp_v19_34_VS17_4_x86.alias=vcpp_v19_34_x86
+
+compiler.vcpp_v19_34_VS17_4_x64.exe=Z:/compilers/msvc/14.34.31933-14.34.31948.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_34_VS17_4_x64.libPath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib;Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib/x64;Z:/compilers/msvc/14.34.31933-14.34.31948.0/atlmfc/lib/x64;Z:/compilers/msvc/14.34.31933-14.34.31948.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_34_VS17_4_x64.includePath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_34_VS17_4_x64.name=x64 msvc v19.34 VS17.4
+compiler.vcpp_v19_34_VS17_4_x64.semver=14.34.31948.0
+compiler.vcpp_v19_34_VS17_4_x64.alias=vcpp_v19_34_x64
+
+compiler.vcpp_v19_34_VS17_4_arm64.exe=Z:/compilers/msvc/14.34.31933-14.34.31948.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_34_VS17_4_arm64.libPath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib;Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib/arm64;Z:/compilers/msvc/14.34.31933-14.34.31948.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.34.31933-14.34.31948.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_34_VS17_4_arm64.includePath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_34_VS17_4_arm64.name=arm64 msvc v19.34 VS17.4
+compiler.vcpp_v19_34_VS17_4_arm64.semver=14.34.31948.0
+compiler.vcpp_v19_34_VS17_4_arm64.alias=vcpp_v19_34_arm64
 
 compiler.vcpp_v19_35_VS17_5_x86.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_35_VS17_5_x86.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/x86;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/x86;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_35_VS17_5_x86.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_35_VS17_5_x86.name=x86 msvc v19.35 VS17.5
 compiler.vcpp_v19_35_VS17_5_x86.semver=14.35.32217.1
+compiler.vcpp_v19_35_VS17_5_x86.alias=vcpp_v19_35_x86
 
 compiler.vcpp_v19_35_VS17_5_x64.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_35_VS17_5_x64.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/x64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/x64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_35_VS17_5_x64.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_35_VS17_5_x64.name=x64 msvc v19.35 VS17.5
 compiler.vcpp_v19_35_VS17_5_x64.semver=14.35.32217.1
+compiler.vcpp_v19_35_VS17_5_x64.alias=vcpp_v19_35_x64
 
 compiler.vcpp_v19_35_VS17_5_arm64.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_35_VS17_5_arm64.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/arm64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/arm64;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
 compiler.vcpp_v19_35_VS17_5_arm64.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_35_VS17_5_arm64.name=arm64 msvc v19.35 VS17.5
 compiler.vcpp_v19_35_VS17_5_arm64.semver=14.35.32217.1
+compiler.vcpp_v19_35_VS17_5_arm64.alias=vcpp_v19_35_arm64
+
+compiler.vcpp_v19_36_VS17_6_x86.exe=Z:/compilers/msvc/14.36.32532-14.36.32544.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_36_VS17_6_x86.libPath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib;Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib/x86;Z:/compilers/msvc/14.36.32532-14.36.32544.0/atlmfc/lib/x86;Z:/compilers/msvc/14.36.32532-14.36.32544.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_36_VS17_6_x86.includePath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_36_VS17_6_x86.name=x86 msvc v19.36 VS17.6
+compiler.vcpp_v19_36_VS17_6_x86.semver=14.36.32544.0
+compiler.vcpp_v19_36_VS17_6_x86.alias=vcpp_v19_36_x86
+
+compiler.vcpp_v19_36_VS17_6_x64.exe=Z:/compilers/msvc/14.36.32532-14.36.32544.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_36_VS17_6_x64.libPath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib;Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib/x64;Z:/compilers/msvc/14.36.32532-14.36.32544.0/atlmfc/lib/x64;Z:/compilers/msvc/14.36.32532-14.36.32544.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_36_VS17_6_x64.includePath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_36_VS17_6_x64.name=x64 msvc v19.36 VS17.6
+compiler.vcpp_v19_36_VS17_6_x64.semver=14.36.32544.0
+compiler.vcpp_v19_36_VS17_6_x64.alias=vcpp_v19_36_x64
+
+compiler.vcpp_v19_36_VS17_6_arm64.exe=Z:/compilers/msvc/14.36.32532-14.36.32544.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_36_VS17_6_arm64.libPath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib;Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib/arm64;Z:/compilers/msvc/14.36.32532-14.36.32544.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.36.32532-14.36.32544.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_36_VS17_6_arm64.includePath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_36_VS17_6_arm64.name=arm64 msvc v19.36 VS17.6
+compiler.vcpp_v19_36_VS17_6_arm64.semver=14.36.32544.0
+compiler.vcpp_v19_36_VS17_6_arm64.alias=vcpp_v19_36_arm64
 
 compiler.vcpp_v19_37_VS17_7_x86.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_37_VS17_7_x86.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/x86;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/x86;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_37_VS17_7_x86.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_37_VS17_7_x86.name=x86 msvc v19.37 VS17.7
 compiler.vcpp_v19_37_VS17_7_x86.semver=14.37.32826.1
+compiler.vcpp_v19_37_VS17_7_x86.alias=vcpp_v19_37_x86
 
 compiler.vcpp_v19_37_VS17_7_x64.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_37_VS17_7_x64.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/x64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/x64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_37_VS17_7_x64.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_37_VS17_7_x64.name=x64 msvc v19.37 VS17.7
 compiler.vcpp_v19_37_VS17_7_x64.semver=14.37.32826.1
+compiler.vcpp_v19_37_VS17_7_x64.alias=vcpp_v19_37_x64
 
 compiler.vcpp_v19_37_VS17_7_arm64.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_37_VS17_7_arm64.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/arm64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/arm64;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
 compiler.vcpp_v19_37_VS17_7_arm64.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_37_VS17_7_arm64.name=arm64 msvc v19.37 VS17.7
 compiler.vcpp_v19_37_VS17_7_arm64.semver=14.37.32826.1
+compiler.vcpp_v19_37_VS17_7_arm64.alias=vcpp_v19_37_arm64
+
+compiler.vcpp_v19_38_VS17_8_x86.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_38_VS17_8_x86.libPath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib;Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib/x86;Z:/compilers/msvc/14.38.33130-14.38.33133.0/atlmfc/lib/x86;Z:/compilers/msvc/14.38.33130-14.38.33133.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_38_VS17_8_x86.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_38_VS17_8_x86.name=x86 msvc v19.38 VS17.8
+compiler.vcpp_v19_38_VS17_8_x86.semver=14.38.33133.0
+
+compiler.vcpp_v19_38_VS17_8_x64.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_38_VS17_8_x64.libPath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib;Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib/x64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/atlmfc/lib/x64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_38_VS17_8_x64.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_38_VS17_8_x64.name=x64 msvc v19.38 VS17.8
+compiler.vcpp_v19_38_VS17_8_x64.semver=14.38.33133.0
+
+compiler.vcpp_v19_38_VS17_8_arm64.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_38_VS17_8_arm64.libPath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib;Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib/arm64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_38_VS17_8_arm64.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_38_VS17_8_arm64.name=arm64 msvc v19.38 VS17.8
+compiler.vcpp_v19_38_VS17_8_arm64.semver=14.38.33133.0
 
 
 tools=MicrosoftAnalysisTool

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -62,7 +62,7 @@ group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
 group.vcpp_x86.supportsExecute=true
 group.vcpp_x86.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vcpp_x86.category=msvc
+group.vcpp_x86.compilerCategories=msvc
 
 group.vcpp_x64.options=-EHsc
 group.vcpp_x64.compilerType=win32-vc
@@ -76,7 +76,7 @@ group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
 group.vcpp_x64.supportsExecute=true
 group.vcpp_x64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vcpp_x64.category=msvc
+group.vcpp_x64.compilerCategories=msvc
 
 group.vcpp_arm64.options=-EHsc
 group.vcpp_arm64.compilerType=win32-vc
@@ -90,7 +90,7 @@ group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
 group.vcpp_arm64.supportsExecute=false
 group.vcpp_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vcpp_arm64.category=msvc
+group.vcpp_arm64.compilerCategories=msvc
 
 compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -62,6 +62,7 @@ group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
 group.vcpp_x86.supportsExecute=true
 group.vcpp_x86.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp_x86.demanglerType=win32
 group.vcpp_x86.compilerCategories=msvc
 
 group.vcpp_x64.options=-EHsc
@@ -76,6 +77,7 @@ group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
 group.vcpp_x64.supportsExecute=true
 group.vcpp_x64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp_x64.demanglerType=win32
 group.vcpp_x64.compilerCategories=msvc
 
 group.vcpp_arm64.options=-EHsc
@@ -90,136 +92,137 @@ group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
 group.vcpp_arm64.supportsExecute=false
 group.vcpp_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp_arm64.demanglerType=win32
 group.vcpp_arm64.compilerCategories=msvc
 
 compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_24_VS16_4_x86.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_x86.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_24_VS16_4_x86.name=x86 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_x86.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_x86.alias=vcpp_v19_24_x86
 
 compiler.vcpp_v19_24_VS16_4_x64.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_24_VS16_4_x64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_24_VS16_4_x64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_x64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_24_VS16_4_x64.name=x64 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_x64.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_x64.alias=vcpp_v19_24_x64
 
 compiler.vcpp_v19_24_VS16_4_arm64.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_24_VS16_4_arm64.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.283lmfc/lib/arm64;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_24_VS16_4_arm64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_24_VS16_4_arm64.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_24_VS16_4_arm64.name=arm64 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_arm64.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_arm64.alias=vcpp_v19_24_arm64
 
 compiler.vcpp_v19_25_VS16_5_x86.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_25_VS16_5_x86.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_25_VS16_5_x86.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_x86.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_25_VS16_5_x86.name=x86 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_x86.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_x86.alias=vcpp_v19_25_x86
 
 compiler.vcpp_v19_25_VS16_5_x64.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_25_VS16_5_x64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_25_VS16_5_x64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_x64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_25_VS16_5_x64.name=x64 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_x64.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_x64.alias=vcpp_v19_25_x64
 
 compiler.vcpp_v19_25_VS16_5_arm64.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_25_VS16_5_arm64.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.286lmfc/lib/arm64;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_25_VS16_5_arm64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_25_VS16_5_arm64.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_25_VS16_5_arm64.name=arm64 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_arm64.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_arm64.alias=vcpp_v19_25_arm64
 
 compiler.vcpp_v19_27_VS16_7_x86.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_27_VS16_7_x86.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_27_VS16_7_x86.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_x86.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_27_VS16_7_x86.name=x86 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_x86.semver=14.27.29120.0
 compiler.vcpp_v19_27_VS16_7_x86.alias=vcpp_v19_27_x86
 
 compiler.vcpp_v19_27_VS16_7_x64.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_27_VS16_7_x64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_27_VS16_7_x64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_x64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_27_VS16_7_x64.name=x64 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_x64.semver=14.27.29120.0
 compiler.vcpp_v19_27_VS16_7_x64.alias=vcpp_v19_27_x64
 
 compiler.vcpp_v19_27_VS16_7_arm64.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_27_VS16_7_arm64.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.291lmfc/lib/arm64;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_27_VS16_7_arm64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_27_VS16_7_arm64.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_27_VS16_7_arm64.name=arm64 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_arm64.semver=14.27.29120.0
 
 compiler.vcpp_v19_28_VS16_8_x86.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_28_VS16_8_x86.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_28_VS16_8_x86.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_x86.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_28_VS16_8_x86.name=x86 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_x86.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_x86.alias=vcpp_v19_28_x86
 
 compiler.vcpp_v19_28_VS16_8_x64.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_28_VS16_8_x64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_28_VS16_8_x64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_x64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_28_VS16_8_x64.name=x64 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_x64.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_x64.alias=vcpp_v19_28_x64
 
 compiler.vcpp_v19_28_VS16_8_arm64.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_28_VS16_8_arm64.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.293lmfc/lib/arm64;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_28_VS16_8_arm64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_8_arm64.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_28_VS16_8_arm64.name=arm64 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_arm64.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_arm64.alias=vcpp_v19_28_arm64
 
 compiler.vcpp_v19_28_VS16_9_x86.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_28_VS16_9_x86.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_28_VS16_9_x86.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_x86.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_28_VS16_9_x86.name=x86 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_x86.semver=14.28.29921.0
 
 compiler.vcpp_v19_28_VS16_9_x64.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_28_VS16_9_x64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_28_VS16_9_x64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10e/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_x64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_28_VS16_9_x64.name=x64 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_x64.semver=14.28.29921.0
 
 compiler.vcpp_v19_28_VS16_9_arm64.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_28_VS16_9_arm64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.299lmfc/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
-compiler.vcpp_v19_28_VS16_9_arm64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-ude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_28_VS16_9_arm64.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/arm64;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_28_VS16_9_arm64.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_28_VS16_9_arm64.name=arm64 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_arm64.semver=14.28.29921.0
 
 compiler.vcpp_v19_29_VS16_10_x86.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_29_VS16_10_x86.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.c/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_29_VS16_10_x86.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-1de/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_x86.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_29_VS16_10_x86.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_29_VS16_10_x86.name=x86 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_x86.semver=14.29.30040.0
 
 compiler.vcpp_v19_29_VS16_10_x64.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_29_VS16_10_x64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.c/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_29_VS16_10_x64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-1de/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_x64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_29_VS16_10_x64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_29_VS16_10_x64.name=x64 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_x64.semver=14.29.30040.0
 
 compiler.vcpp_v19_29_VS16_10_arm64.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_29_VS16_10_arm64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30tlmfc/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64; 
-compiler.vcpp_v19_29_VS16_10_arm64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kitslude/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_10_arm64.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64
+compiler.vcpp_v19_29_VS16_10_arm64.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_29_VS16_10_arm64.name=arm64 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_arm64.semver=14.29.30040.0
 
 compiler.vcpp_v19_29_VS16_11_x86.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx86/x86/cl.exe
-compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.c/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
-compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z10/include/10.0.22621.0/wi:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86
+compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_29_VS16_11_x86.name=x64 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_x86.semver=14.29.30153.0
 
 compiler.vcpp_v19_29_VS16_11_x64.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.c/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/comp621.0/um/x64;ilers/windows-kits-10/lib/10.0.22621.0/um/x64
-compiler.vcpp_v19_29_VS16_11_x64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z10/include/10.0.22621.0/wi:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
+compiler.vcpp_v19_29_VS16_11_x64.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x64;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/comp621.0/um/x64;ilers/windows-kits-10/lib/10.0.22621.0/um/x64
+compiler.vcpp_v19_29_VS16_11_x64.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt
 compiler.vcpp_v19_29_VS16_11_x64.name=x64 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_x64.semver=14.29.30153.0
 

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -90,12 +90,13 @@ group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vc
 group.vcpp_arm64.groupName=MSVC arm64
 group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
+group.vcpp_arm64.supportsBinaryObject=false
 group.vcpp_arm64.supportsExecute=false
 group.vcpp_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
 group.vcpp_arm64.demanglerType=win32
 group.vcpp_arm64.compilerCategories=msvc
 
-compiler.vcpp_v19_20_VS16_0_x86.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_20_VS16_0_x86.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_20_VS16_0_x86.libPath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib;Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/atlmfc/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_20_VS16_0_x86.includePath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_20_VS16_0_x86.name=x86 msvc v19.20 VS16.0
@@ -113,7 +114,7 @@ compiler.vcpp_v19_20_VS16_0_arm64.includePath=Z:/compilers/msvc/14.20.27508-14.2
 compiler.vcpp_v19_20_VS16_0_arm64.name=arm64 msvc v19.20 VS16.0
 compiler.vcpp_v19_20_VS16_0_arm64.semver=14.20.27525.0
 
-compiler.vcpp_v19_21_VS16_1_x86.exe=Z:/compilers/msvc/14.21.27702-14.21.27702.2/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_21_VS16_1_x86.exe=Z:/compilers/msvc/14.21.27702-14.21.27702.2/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_21_VS16_1_x86.libPath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib;Z:/compilers/msvc/14.21.27702-14.21.27702.2/lib/x86;Z:/compilers/msvc/14.21.27702-14.21.27702.2/atlmfc/lib/x86;Z:/compilers/msvc/14.21.27702-14.21.27702.2/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_21_VS16_1_x86.includePath=Z:/compilers/msvc/14.21.27702-14.21.27702.2/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_21_VS16_1_x86.name=x86 msvc v19.21 VS16.1
@@ -131,7 +132,7 @@ compiler.vcpp_v19_21_VS16_1_arm64.includePath=Z:/compilers/msvc/14.21.27702-14.2
 compiler.vcpp_v19_21_VS16_1_arm64.name=arm64 msvc v19.21 VS16.1
 compiler.vcpp_v19_21_VS16_1_arm64.semver=14.21.27702.2
 
-compiler.vcpp_v19_22_VS16_2_x86.exe=Z:/compilers/msvc/14.22.27905-14.22.27905.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_22_VS16_2_x86.exe=Z:/compilers/msvc/14.22.27905-14.22.27905.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_22_VS16_2_x86.libPath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib;Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib/x86;Z:/compilers/msvc/14.22.27905-14.22.27905.0/atlmfc/lib/x86;Z:/compilers/msvc/14.22.27905-14.22.27905.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_22_VS16_2_x86.includePath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_22_VS16_2_x86.name=x86 msvc v19.22 VS16.2
@@ -149,7 +150,7 @@ compiler.vcpp_v19_22_VS16_2_arm64.includePath=Z:/compilers/msvc/14.22.27905-14.2
 compiler.vcpp_v19_22_VS16_2_arm64.name=arm64 msvc v19.22 VS16.2
 compiler.vcpp_v19_22_VS16_2_arm64.semver=14.22.27905.0
 
-compiler.vcpp_v19_23_VS16_3_x86.exe=Z:/compilers/msvc/14.23.28105-14.23.28105.4/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_23_VS16_3_x86.exe=Z:/compilers/msvc/14.23.28105-14.23.28105.4/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_23_VS16_3_x86.libPath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib;Z:/compilers/msvc/14.23.28105-14.23.28105.4/lib/x86;Z:/compilers/msvc/14.23.28105-14.23.28105.4/atlmfc/lib/x86;Z:/compilers/msvc/14.23.28105-14.23.28105.4/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_23_VS16_3_x86.includePath=Z:/compilers/msvc/14.23.28105-14.23.28105.4/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_23_VS16_3_x86.name=x86 msvc v19.23 VS16.3
@@ -167,7 +168,7 @@ compiler.vcpp_v19_23_VS16_3_arm64.includePath=Z:/compilers/msvc/14.23.28105-14.2
 compiler.vcpp_v19_23_VS16_3_arm64.name=arm64 msvc v19.23 VS16.3
 compiler.vcpp_v19_23_VS16_3_arm64.semver=14.23.28105.4
 
-compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/atlmfc/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_24_VS16_4_x86.includePath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_24_VS16_4_x86.name=x86 msvc v19.24 VS16.4
@@ -188,7 +189,7 @@ compiler.vcpp_v19_24_VS16_4_arm64.name=arm64 msvc v19.24 VS16.4
 compiler.vcpp_v19_24_VS16_4_arm64.semver=14.24.28325.0
 compiler.vcpp_v19_24_VS16_4_arm64.alias=vcpp_v19_24_arm64
 
-compiler.vcpp_v19_25_VS16_5_x86.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_25_VS16_5_x86.exe=Z:/compilers/msvc/14.25.28610-14.25.28614.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_25_VS16_5_x86.libPath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib;Z:/compilers/msvc/14.25.28610-14.25.28614.0/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/atlmfc/lib/x86;Z:/compilers/msvc/14.25.28610-14.25.28614.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_25_VS16_5_x86.includePath=Z:/compilers/msvc/14.25.28610-14.25.28614.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_25_VS16_5_x86.name=x86 msvc v19.25 VS16.5
@@ -209,7 +210,7 @@ compiler.vcpp_v19_25_VS16_5_arm64.name=arm64 msvc v19.25 VS16.5
 compiler.vcpp_v19_25_VS16_5_arm64.semver=14.25.28614.0
 compiler.vcpp_v19_25_VS16_5_arm64.alias=vcpp_v19_25_arm64
 
-compiler.vcpp_v19_26_VS16_6_x86.exe=Z:/compilers/msvc/14.26.28801-14.26.28806.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_26_VS16_6_x86.exe=Z:/compilers/msvc/14.26.28801-14.26.28806.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_26_VS16_6_x86.libPath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib;Z:/compilers/msvc/14.26.28801-14.26.28806.0/lib/x86;Z:/compilers/msvc/14.26.28801-14.26.28806.0/atlmfc/lib/x86;Z:/compilers/msvc/14.26.28801-14.26.28806.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_26_VS16_6_x86.includePath=Z:/compilers/msvc/14.26.28801-14.26.28806.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_26_VS16_6_x86.name=x86 msvc v19.26 VS16.6
@@ -227,7 +228,7 @@ compiler.vcpp_v19_26_VS16_6_arm64.includePath=Z:/compilers/msvc/14.26.28801-14.2
 compiler.vcpp_v19_26_VS16_6_arm64.name=arm64 msvc v19.26 VS16.6
 compiler.vcpp_v19_26_VS16_6_arm64.semver=14.26.28806.0
 
-compiler.vcpp_v19_27_VS16_7_x86.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_27_VS16_7_x86.exe=Z:/compilers/msvc/14.27.29110-14.27.29120.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_27_VS16_7_x86.libPath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib;Z:/compilers/msvc/14.27.29110-14.27.29120.0/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/atlmfc/lib/x86;Z:/compilers/msvc/14.27.29110-14.27.29120.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_27_VS16_7_x86.includePath=Z:/compilers/msvc/14.27.29110-14.27.29120.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_27_VS16_7_x86.name=x86 msvc v19.27 VS16.7
@@ -247,7 +248,7 @@ compiler.vcpp_v19_27_VS16_7_arm64.includePath=Z:/compilers/msvc/14.27.29110-14.2
 compiler.vcpp_v19_27_VS16_7_arm64.name=arm64 msvc v19.27 VS16.7
 compiler.vcpp_v19_27_VS16_7_arm64.semver=14.27.29120.0
 
-compiler.vcpp_v19_28_VS16_8_x86.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_28_VS16_8_x86.exe=Z:/compilers/msvc/14.28.29333-14.28.29335.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_28_VS16_8_x86.libPath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib;Z:/compilers/msvc/14.28.29333-14.28.29335.0/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/atlmfc/lib/x86;Z:/compilers/msvc/14.28.29333-14.28.29335.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_28_VS16_8_x86.includePath=Z:/compilers/msvc/14.28.29333-14.28.29335.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_8_x86.name=x86 msvc v19.28 VS16.8
@@ -268,7 +269,7 @@ compiler.vcpp_v19_28_VS16_8_arm64.name=arm64 msvc v19.28 VS16.8
 compiler.vcpp_v19_28_VS16_8_arm64.semver=14.28.29335.0
 compiler.vcpp_v19_28_VS16_8_arm64.alias=vcpp_v19_28_arm64
 
-compiler.vcpp_v19_28_VS16_9_x86.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_28_VS16_9_x86.exe=Z:/compilers/msvc/14.28.29910-14.28.29921.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_28_VS16_9_x86.libPath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib;Z:/compilers/msvc/14.28.29910-14.28.29921.0/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/atlmfc/lib/x86;Z:/compilers/msvc/14.28.29910-14.28.29921.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_28_VS16_9_x86.includePath=Z:/compilers/msvc/14.28.29910-14.28.29921.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_28_VS16_9_x86.name=x86 msvc v19.28 VS16.9
@@ -286,7 +287,7 @@ compiler.vcpp_v19_28_VS16_9_arm64.includePath=Z:/compilers/msvc/14.28.29910-14.2
 compiler.vcpp_v19_28_VS16_9_arm64.name=arm64 msvc v19.28 VS16.9
 compiler.vcpp_v19_28_VS16_9_arm64.semver=14.28.29921.0
 
-compiler.vcpp_v19_29_VS16_10_x86.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_29_VS16_10_x86.exe=Z:/compilers/msvc/14.29.30037-14.29.30040.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_29_VS16_10_x86.libPath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib;Z:/compilers/msvc/14.29.30037-14.29.30040.0/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30037-14.29.30040.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_29_VS16_10_x86.includePath=Z:/compilers/msvc/14.29.30037-14.29.30040.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_10_x86.name=x86 msvc v19.29 VS16.10
@@ -304,7 +305,7 @@ compiler.vcpp_v19_29_VS16_10_arm64.includePath=Z:/compilers/msvc/14.29.30037-14.
 compiler.vcpp_v19_29_VS16_10_arm64.name=arm64 msvc v19.29 VS16.10
 compiler.vcpp_v19_29_VS16_10_arm64.semver=14.29.30040.0
 
-compiler.vcpp_v19_29_VS16_11_x86.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_29_VS16_11_x86.exe=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_29_VS16_11_x86.libPath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib;Z:/compilers/msvc/14.29.30133-14.29.30153.0/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/atlmfc/lib/x86;Z:/compilers/msvc/14.29.30133-14.29.30153.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_29_VS16_11_x86.includePath=Z:/compilers/msvc/14.29.30133-14.29.30153.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_29_VS16_11_x86.name=x86 msvc v19.29 VS16.11
@@ -322,7 +323,7 @@ compiler.vcpp_v19_29_VS16_11_arm64.includePath=Z:/compilers/msvc/14.29.30133-14.
 compiler.vcpp_v19_29_VS16_11_arm64.name=arm64 msvc v19.29 VS16.11
 compiler.vcpp_v19_29_VS16_11_arm64.semver=14.29.30153.0
 
-compiler.vcpp_v19_30_VS17_0_x86.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_30_VS17_0_x86.exe=Z:/compilers/msvc/14.30.30705-14.30.30715.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_30_VS17_0_x86.libPath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib;Z:/compilers/msvc/14.30.30705-14.30.30715.0/lib/x86;Z:/compilers/msvc/14.30.30705-14.30.30715.0/atlmfc/lib/x86;Z:/compilers/msvc/14.30.30705-14.30.30715.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_30_VS17_0_x86.includePath=Z:/compilers/msvc/14.30.30705-14.30.30715.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_30_VS17_0_x86.name=x86 msvc v19.30 VS17.0
@@ -343,7 +344,7 @@ compiler.vcpp_v19_30_VS17_0_arm64.name=arm64 msvc v19.30 VS17.0
 compiler.vcpp_v19_30_VS17_0_arm64.semver=14.30.30715.0
 compiler.vcpp_v19_30_VS17_0_arm64.alias=vcpp_v19_30_arm64
 
-compiler.vcpp_v19_31_VS17_1_x86.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_31_VS17_1_x86.exe=Z:/compilers/msvc/14.31.31103-14.31.31107.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_31_VS17_1_x86.libPath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib;Z:/compilers/msvc/14.31.31103-14.31.31107.0/lib/x86;Z:/compilers/msvc/14.31.31103-14.31.31107.0/atlmfc/lib/x86;Z:/compilers/msvc/14.31.31103-14.31.31107.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_31_VS17_1_x86.includePath=Z:/compilers/msvc/14.31.31103-14.31.31107.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_31_VS17_1_x86.name=x86 msvc v19.31 VS17.1
@@ -364,7 +365,7 @@ compiler.vcpp_v19_31_VS17_1_arm64.name=arm64 msvc v19.31 VS17.1
 compiler.vcpp_v19_31_VS17_1_arm64.semver=14.31.31107.0
 compiler.vcpp_v19_31_VS17_1_arm64.alias=vcpp_v19_31_arm64
 
-compiler.vcpp_v19_32_VS17_2_x86.exe=Z:/compilers/msvc/14.32.31326-14.32.31342.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_32_VS17_2_x86.exe=Z:/compilers/msvc/14.32.31326-14.32.31342.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_32_VS17_2_x86.libPath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib;Z:/compilers/msvc/14.32.31326-14.32.31342.0/lib/x86;Z:/compilers/msvc/14.32.31326-14.32.31342.0/atlmfc/lib/x86;Z:/compilers/msvc/14.32.31326-14.32.31342.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_32_VS17_2_x86.includePath=Z:/compilers/msvc/14.32.31326-14.32.31342.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_32_VS17_2_x86.name=x86 msvc v19.32 VS17.2
@@ -385,7 +386,7 @@ compiler.vcpp_v19_32_VS17_2_arm64.name=arm64 msvc v19.32 VS17.2
 compiler.vcpp_v19_32_VS17_2_arm64.semver=14.32.31342.0
 compiler.vcpp_v19_32_VS17_2_arm64.alias=vcpp_v19_32_arm64
 
-compiler.vcpp_v19_33_VS17_3_x86.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_33_VS17_3_x86.exe=Z:/compilers/msvc/14.33.31629-14.33.31630.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_33_VS17_3_x86.libPath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib;Z:/compilers/msvc/14.33.31629-14.33.31630.0/lib/x86;Z:/compilers/msvc/14.33.31629-14.33.31630.0/atlmfc/lib/x86;Z:/compilers/msvc/14.33.31629-14.33.31630.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_33_VS17_3_x86.includePath=Z:/compilers/msvc/14.33.31629-14.33.31630.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_33_VS17_3_x86.name=x86 msvc v19.33 VS17.3
@@ -406,7 +407,7 @@ compiler.vcpp_v19_33_VS17_3_arm64.name=arm64 msvc v19.33 VS17.3
 compiler.vcpp_v19_33_VS17_3_arm64.semver=14.33.31630.0
 compiler.vcpp_v19_33_VS17_3_arm64.alias=vcpp_v19_33_arm64
 
-compiler.vcpp_v19_34_VS17_4_x86.exe=Z:/compilers/msvc/14.34.31933-14.34.31948.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_34_VS17_4_x86.exe=Z:/compilers/msvc/14.34.31933-14.34.31948.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_34_VS17_4_x86.libPath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib;Z:/compilers/msvc/14.34.31933-14.34.31948.0/lib/x86;Z:/compilers/msvc/14.34.31933-14.34.31948.0/atlmfc/lib/x86;Z:/compilers/msvc/14.34.31933-14.34.31948.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_34_VS17_4_x86.includePath=Z:/compilers/msvc/14.34.31933-14.34.31948.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_34_VS17_4_x86.name=x86 msvc v19.34 VS17.4
@@ -427,7 +428,7 @@ compiler.vcpp_v19_34_VS17_4_arm64.name=arm64 msvc v19.34 VS17.4
 compiler.vcpp_v19_34_VS17_4_arm64.semver=14.34.31948.0
 compiler.vcpp_v19_34_VS17_4_arm64.alias=vcpp_v19_34_arm64
 
-compiler.vcpp_v19_35_VS17_5_x86.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_35_VS17_5_x86.exe=Z:/compilers/msvc/14.35.32215-14.35.32217.1/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_35_VS17_5_x86.libPath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib;Z:/compilers/msvc/14.35.32215-14.35.32217.1/lib/x86;Z:/compilers/msvc/14.35.32215-14.35.32217.1/atlmfc/lib/x86;Z:/compilers/msvc/14.35.32215-14.35.32217.1/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_35_VS17_5_x86.includePath=Z:/compilers/msvc/14.35.32215-14.35.32217.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_35_VS17_5_x86.name=x86 msvc v19.35 VS17.5
@@ -448,7 +449,7 @@ compiler.vcpp_v19_35_VS17_5_arm64.name=arm64 msvc v19.35 VS17.5
 compiler.vcpp_v19_35_VS17_5_arm64.semver=14.35.32217.1
 compiler.vcpp_v19_35_VS17_5_arm64.alias=vcpp_v19_35_arm64
 
-compiler.vcpp_v19_36_VS17_6_x86.exe=Z:/compilers/msvc/14.36.32532-14.36.32544.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_36_VS17_6_x86.exe=Z:/compilers/msvc/14.36.32532-14.36.32544.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_36_VS17_6_x86.libPath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib;Z:/compilers/msvc/14.36.32532-14.36.32544.0/lib/x86;Z:/compilers/msvc/14.36.32532-14.36.32544.0/atlmfc/lib/x86;Z:/compilers/msvc/14.36.32532-14.36.32544.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_36_VS17_6_x86.includePath=Z:/compilers/msvc/14.36.32532-14.36.32544.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_36_VS17_6_x86.name=x86 msvc v19.36 VS17.6
@@ -469,7 +470,7 @@ compiler.vcpp_v19_36_VS17_6_arm64.name=arm64 msvc v19.36 VS17.6
 compiler.vcpp_v19_36_VS17_6_arm64.semver=14.36.32544.0
 compiler.vcpp_v19_36_VS17_6_arm64.alias=vcpp_v19_36_arm64
 
-compiler.vcpp_v19_37_VS17_7_x86.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_37_VS17_7_x86.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_37_VS17_7_x86.libPath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib;Z:/compilers/msvc/14.37.32822-14.37.32826.1/lib/x86;Z:/compilers/msvc/14.37.32822-14.37.32826.1/atlmfc/lib/x86;Z:/compilers/msvc/14.37.32822-14.37.32826.1/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_37_VS17_7_x86.includePath=Z:/compilers/msvc/14.37.32822-14.37.32826.1/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_37_VS17_7_x86.name=x86 msvc v19.37 VS17.7
@@ -490,7 +491,7 @@ compiler.vcpp_v19_37_VS17_7_arm64.name=arm64 msvc v19.37 VS17.7
 compiler.vcpp_v19_37_VS17_7_arm64.semver=14.37.32826.1
 compiler.vcpp_v19_37_VS17_7_arm64.alias=vcpp_v19_37_arm64
 
-compiler.vcpp_v19_38_VS17_8_x86.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx86/x86/cl.exe
+compiler.vcpp_v19_38_VS17_8_x86.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_38_VS17_8_x86.libPath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib;Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib/x86;Z:/compilers/msvc/14.38.33130-14.38.33133.0/atlmfc/lib/x86;Z:/compilers/msvc/14.38.33130-14.38.33133.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
 compiler.vcpp_v19_38_VS17_8_x86.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_38_VS17_8_x86.name=x86 msvc v19.38 VS17.8

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -60,8 +60,9 @@ group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_
 group.vcpp_x86.groupName=MSVC x86
 group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
-group.vcpp_x86.supportsExecute=false
-group.vcpp_x86.demangler=C:/data/msvc/14.38.32919-Pre-v1/bin/Hostx64/x64/undname.exe
+group.vcpp_x86.supportsExecute=true
+group.vcpp_x86.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp_x86.category=msvc
 
 group.vcpp_x64.options=-EHsc
 group.vcpp_x64.compilerType=win32-vc
@@ -73,7 +74,9 @@ group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_
 group.vcpp_x64.groupName=MSVC x64
 group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
-group.vcpp_x64.supportsExecute=false
+group.vcpp_x64.supportsExecute=true
+group.vcpp_x64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp_x64.category=msvc
 
 group.vcpp_arm64.options=-EHsc
 group.vcpp_arm64.compilerType=win32-vc
@@ -86,6 +89,8 @@ group.vcpp_arm64.groupName=MSVC arm64
 group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
 group.vcpp_arm64.supportsExecute=false
+group.vcpp_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp_arm64.category=msvc
 
 compiler.vcpp_v19_24_VS16_4_x86.exe=Z:/compilers/msvc/14.24.28314-14.24.28325.0/bin/Hostx86/x86/cl.exe
 compiler.vcpp_v19_24_VS16_4_x86.libPath=Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/lib/x86;Z:/compilers/msvc/14.24.28314-14.24.28325.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -512,7 +512,7 @@ libs=
 
 tools=MicrosoftAnalysisTool
 tools.MicrosoftAnalysisTool.exe=Z:/compilers/msvc/14.37.32822-14.37.32826.1/bin/Hostx64/x64/cl.exe
-tools.MicrosoftAnalysisTool.exclude=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_30_arm64:vcpp_v19_31_arm64:vcpp_v19_32_arm64:vcpp_v19_33_arm64:vcpp_v19_34_arm64:vcpp_v19_35_arm64:vcpp_v19_36_arm64:vcpp_v19_37_arm64:vcpp_v19_latest_arm64
+tools.MicrosoftAnalysisTool.exclude=mingw64:arm64
 tools.MicrosoftAnalysisTool.name=Static Analysis
 tools.MicrosoftAnalysisTool.type=independent
 tools.MicrosoftAnalysisTool.class=microsoft-analysis-tool

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3237,7 +3237,7 @@ but nothing was dumped. Possible causes are:
         // OptionsHandlerLibrary should maybe be yeeted.
         this.supportedLibraries = this.getSupportedLibraries(
             this.compiler.libsArr,
-            clientOptions.libs[this.lang.id],
+            clientOptions.libs[this.lang.id] || [],
         ) as any as Record<string, Library>;
     }
 

--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -121,6 +121,9 @@ export class Win32Compiler extends BaseCompiler {
         }
 
         userOptions = this.filterUserOptions(userOptions) || [];
+        options = this.fixIncompatibleOptions(options, userOptions);
+        options = this.changeOptionsBasedOnOverrides(options, overrides);
+
         return options.concat(
             libIncludes,
             libOptions,


### PR DESCRIPTION
* Adds number of VS2019 compilers, compatible with list from godbolt.ms
* Missing VS2022 (and theres a few for 2017)
* Missing tools
* Missing libraries
* Missing C

