### PR TITLE
Add missing ExecutionEnvironmentClass for dotnet

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -2,6 +2,7 @@ compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80csharpcoreclr
+executionEnvironmentClass=local-dotnet
 
 group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet80csharpcoreclr:dotnet70csharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -2,6 +2,7 @@ compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80csharpcoreclr
+executionEnvironmentClass=local-dotnet
 
 group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet80csharpcoreclr:dotnet70csharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -2,6 +2,7 @@ compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80fsharpcoreclr
+executionEnvironmentClass=local-dotnet
 
 group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet80fsharpcoreclr:dotnet70fsharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -2,6 +2,7 @@ compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80fsharpcoreclr
+executionEnvironmentClass=local-dotnet
 
 group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet80fsharpcoreclr:dotnet70fsharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -2,6 +2,7 @@ compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80vbcoreclr
+executionEnvironmentClass=local-dotnet
 
 group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet80vbcoreclr:dotnet70vbcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -2,6 +2,7 @@ compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80vbcoreclr
+executionEnvironmentClass=local-dotnet
 
 group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet80vbcoreclr:dotnet70vbcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr


### PR DESCRIPTION
This config was removed unexpectedly. Adding it back to make dotnet execution work.

Fixes #6620 