### PR TITLE
Comply with some MS terms

### DIFF
--- a/docs/Privacy.md
+++ b/docs/Privacy.md
@@ -13,9 +13,7 @@ world. The main way to think about the GDPR, and privacy in general, is the user
 such we go to great pains to explain what we do with their data, and that we don't store any user-identifying
 information. Of course, we _do_ (at least temporarily) store their source code, which may be precious and sensitive. We
 are transparent with what we do with their data. When making short links, we send an encoding of their source code for
-storage, and again we must be clear how that process works. When compiling with some Microsoft compilers we send data to
-the sister site www.godbolt.ms and that data is covered by
-[Microsoft's Privacy Policy](https://go.microsoft.com/fwlink/?LinkId=521839).
+storage, and again we must be clear how that process works.
 
 Users have rights over the data they create: so in theory they could ask for any data stored on them to be removed. We
 have no way of tracking data (a short link, perhaps) back to an individual user, and when I asked some experts on this

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -1,4 +1,4 @@
-compilers=&mingw64:&vcpp_x86:&vcpp_x64:&vcpp_arm64
+compilers=&mingw64:&vcpp
 objdumper=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/objdump.exe
 demangler=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/c++filt.exe
 
@@ -49,52 +49,38 @@ compiler.mingw64_ucrt_clang_1406.semver=14.0.6
 compiler.mingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0-ucrt-r3/bin/clang++.exe
 compiler.mingw64_ucrt_clang_1403.semver=14.0.3
 
+group.vcpp.compilers=&vcpp_x86:&vcpp_x64:&vcpp_arm64
+group.vcpp.options=-EHsc
+group.vcpp.compilerType=win32-vc
+group.vcpp.needsMulti=false
+group.vcpp.includeFlag=/I
+group.vcpp.versionFlag=/?
+group.vcpp.versionRe=^.*Microsoft \(R\).*$
+group.vcpp.isSemVer=true
+group.vcpp.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vcpp.demanglerType=win32
+group.vcpp.compilerCategories=msvc
+group.vcpp.notification=The use of this compiler is only permitted for internal evaluation purposes<br>and is otherwise governed by the <a href="https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/" target="_blank">MSVC License Agreement</a>.
+group.vcpp.licenseName=MSVC Proprietary
+group.vcpp.licenseLink=https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/
+group.vcpp.licensePreamble=The use of this compiler is only permitted for internal evaluation purposes and is otherwise governed by the MSVC License Agreement.
+group.vcpp.licenseInvasive=true
 
-group.vcpp_x86.options=-EHsc
-group.vcpp_x86.compilerType=win32-vc
-group.vcpp_x86.needsMulti=false
-group.vcpp_x86.includeFlag=/I
-group.vcpp_x86.versionFlag=/?
-group.vcpp_x86.versionRe=^.*Microsoft \(R\).*$
 group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86:vcpp_v19_32_VS17_2_x86:vcpp_v19_34_VS17_4_x86:vcpp_v19_36_VS17_6_x86:vcpp_v19_38_VS17_8_x86
 group.vcpp_x86.groupName=MSVC x86
 group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
 group.vcpp_x86.supportsExecute=true
-group.vcpp_x86.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vcpp_x86.demanglerType=win32
-group.vcpp_x86.compilerCategories=msvc
 
-group.vcpp_x64.options=-EHsc
-group.vcpp_x64.compilerType=win32-vc
-group.vcpp_x64.needsMulti=false
-group.vcpp_x64.includeFlag=/I
-group.vcpp_x64.versionFlag=/?
-group.vcpp_x64.versionRe=^.*Microsoft \(R\).*$
 group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64:vcpp_v19_32_VS17_2_x64:vcpp_v19_34_VS17_4_x64:vcpp_v19_36_VS17_6_x64:vcpp_v19_38_VS17_8_x64
 group.vcpp_x64.groupName=MSVC x64
-group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
 group.vcpp_x64.supportsExecute=true
-group.vcpp_x64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vcpp_x64.demanglerType=win32
-group.vcpp_x64.compilerCategories=msvc
 
-group.vcpp_arm64.options=-EHsc
-group.vcpp_arm64.compilerType=win32-vc
-group.vcpp_arm64.needsMulti=false
-group.vcpp_arm64.includeFlag=/I
-group.vcpp_arm64.versionFlag=/?
-group.vcpp_arm64.versionRe=^.*Microsoft \(R\).*$
 group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64:vcpp_v19_32_VS17_2_arm64:vcpp_v19_34_VS17_4_arm64:vcpp_v19_36_VS17_6_arm64:vcpp_v19_38_VS17_8_arm64
-group.vcpp_arm64.groupName=MSVC arm64
-group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
 group.vcpp_arm64.supportsBinaryObject=false
 group.vcpp_arm64.supportsExecute=false
-group.vcpp_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vcpp_arm64.demanglerType=win32
-group.vcpp_arm64.compilerCategories=msvc
 
 compiler.vcpp_v19_20_VS16_0_x86.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_20_VS16_0_x86.libPath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib;Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/atlmfc/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -1,4 +1,4 @@
-compilers=&cmingw64:&vc_x86:&vc_x64:&vc_arm64
+compilers=&cmingw64:&vc
 objdumper=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/objdump.exe
 demangler=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/c++filt.exe
 
@@ -49,51 +49,39 @@ compiler.cmingw64_ucrt_clang_1406.semver=14.0.6
 compiler.cmingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0-ucrt-r3/bin/clang.exe
 compiler.cmingw64_ucrt_clang_1403.semver=14.0.3
 
-group.vc_x86.options=-EHsc
-group.vc_x86.compilerType=win32-vc
-group.vc_x86.needsMulti=false
-group.vc_x86.includeFlag=/I
-group.vc_x86.versionFlag=/?
-group.vc_x86.versionRe=^.*Microsoft \(R\).*$
+group.vc.compilers=&vc_x86:&vc_x64:&vc_arm64
+group.vc.options=-EHsc
+group.vc.compilerType=win32-vc
+group.vc.needsMulti=false
+group.vc.includeFlag=/I
+group.vc.versionFlag=/?
+group.vc.versionRe=^.*Microsoft \(R\).*$
+group.vc.isSemVer=true
+group.vc.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
+group.vc.demanglerType=win32
+group.vc.compilerCategories=msvc
+group.vc.notification=The use of this compiler is only permitted for internal evaluation purposes<br>and is otherwise governed by the <a href="https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/" target="_blank">MSVC License Agreement</a>.
+group.vc.licenseName=MSVC Proprietary
+group.vc.licenseLink=https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/
+group.vc.licensePreamble=The use of this compiler is only permitted for internal evaluation purposes and is otherwise governed by the MSVC License Agreement.
+group.vc.licenseInvasive=true
+
 group.vc_x86.compilers=vc_v19_24_VS16_4_x86:vc_v19_25_VS16_5_x86:vc_v19_27_VS16_7_x86:vc_v19_28_VS16_8_x86:vc_v19_28_VS16_9_x86:vc_v19_29_VS16_10_x86:vc_v19_29_VS16_11_x86:vc_v19_20_VS16_0_x86:vc_v19_21_VS16_1_x86:vc_v19_22_VS16_2_x86:vc_v19_23_VS16_3_x86:vc_v19_26_VS16_6_x86:vc_v19_30_VS17_0_x86:vc_v19_31_VS17_1_x86:vc_v19_33_VS17_3_x86:vc_v19_35_VS17_5_x86:vc_v19_37_VS17_7_x86:vc_v19_32_VS17_2_x86:vc_v19_34_VS17_4_x86:vc_v19_36_VS17_6_x86:vc_v19_38_VS17_8_x86
 group.vc_x86.groupName=MSVC x86
-group.vc_x86.isSemVer=true
 group.vc_x86.supportsBinary=true
 group.vc_x86.supportsExecute=true
-group.vc_x86.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vc_x86.demanglerType=win32
-group.vc_x86.compilerCategories=msvc
 
-group.vc_x64.options=-EHsc
-group.vc_x64.compilerType=win32-vc
-group.vc_x64.needsMulti=false
-group.vc_x64.includeFlag=/I
-group.vc_x64.versionFlag=/?
-group.vc_x64.versionRe=^.*Microsoft \(R\).*$
 group.vc_x64.compilers=vc_v19_24_VS16_4_x64:vc_v19_25_VS16_5_x64:vc_v19_27_VS16_7_x64:vc_v19_28_VS16_8_x64:vc_v19_28_VS16_9_x64:vc_v19_29_VS16_10_x64:vc_v19_29_VS16_11_x64:vc_v19_20_VS16_0_x64:vc_v19_21_VS16_1_x64:vc_v19_22_VS16_2_x64:vc_v19_23_VS16_3_x64:vc_v19_26_VS16_6_x64:vc_v19_30_VS17_0_x64:vc_v19_31_VS17_1_x64:vc_v19_33_VS17_3_x64:vc_v19_35_VS17_5_x64:vc_v19_37_VS17_7_x64:vc_v19_32_VS17_2_x64:vc_v19_34_VS17_4_x64:vc_v19_36_VS17_6_x64:vc_v19_38_VS17_8_x64
 group.vc_x64.groupName=MSVC x64
-group.vc_x64.isSemVer=true
 group.vc_x64.supportsBinary=true
 group.vc_x64.supportsExecute=true
-group.vc_x64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vc_x64.demanglerType=win32
-group.vc_x64.compilerCategories=msvc
 
-group.vc_arm64.options=-EHsc
-group.vc_arm64.compilerType=win32-vc
-group.vc_arm64.needsMulti=false
-group.vc_arm64.includeFlag=/I
-group.vc_arm64.versionFlag=/?
-group.vc_arm64.versionRe=^.*Microsoft \(R\).*$
 group.vc_arm64.compilers=vc_v19_28_VS16_9_arm64:vc_v19_29_VS16_10_arm64:vc_v19_29_VS16_11_arm64:vc_v19_25_VS16_5_arm64:vc_v19_27_VS16_7_arm64:vc_v19_24_VS16_4_arm64:vc_v19_28_VS16_8_arm64:vc_v19_20_VS16_0_arm64:vc_v19_21_VS16_1_arm64:vc_v19_22_VS16_2_arm64:vc_v19_23_VS16_3_arm64:vc_v19_26_VS16_6_arm64:vc_v19_30_VS17_0_arm64:vc_v19_31_VS17_1_arm64:vc_v19_33_VS17_3_arm64:vc_v19_35_VS17_5_arm64:vc_v19_37_VS17_7_arm64:vc_v19_32_VS17_2_arm64:vc_v19_34_VS17_4_arm64:vc_v19_36_VS17_6_arm64:vc_v19_38_VS17_8_arm64
 group.vc_arm64.groupName=MSVC arm64
 group.vc_arm64.isSemVer=true
 group.vc_arm64.supportsBinary=false
 group.vc_arm64.supportsBinaryObject=false
 group.vc_arm64.supportsExecute=false
-group.vc_arm64.demangler=Z:/compilers/msvc/14.29.30133-14.29.30153.0/bin/Hostx64/x64/undname.exe
-group.vc_arm64.demanglerType=win32
-group.vc_arm64.compilerCategories=msvc
 
 compiler.vc_v19_20_VS16_0_x86.exe=Z:/compilers/msvc/14.20.27508-14.20.27525.0/bin/Hostx64/x86/cl.exe
 compiler.vc_v19_20_VS16_0_x86.libPath=Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib;Z:/compilers/msvc/14.20.27508-14.20.27525.0/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/atlmfc/lib/x86;Z:/compilers/msvc/14.20.27508-14.20.27525.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;

--- a/etc/scripts/parsed-pug/parsed_pug_file.js
+++ b/etc/scripts/parsed-pug/parsed_pug_file.js
@@ -1,5 +1,5 @@
-const { execSync } = require('child_process');
-const { getHashDigest } = require('loader-utils');
+const {execSync} = require('child_process');
+const {getHashDigest} = require('loader-utils');
 const pug = require('pug');
 const path = require('path');
 
@@ -9,7 +9,7 @@ const path = require('path');
 // just update the hash here.
 const expectedHashes = {
     cookies: '08712179739d3679',
-    privacy: '71de7cb46bfc8e5f',
+    privacy: 'c0dad1f48a56b761',
 };
 
 function _execGit(command) {
@@ -20,7 +20,7 @@ function _execGit(command) {
     return gitResult.toString();
 }
 
-module.exports = function(content) {
+module.exports = function (content) {
     const filePath = this.resourcePath;
     const filename = path.basename(filePath, '.pug');
     const options = this.getOptions();
@@ -40,7 +40,7 @@ module.exports = function(content) {
 
     // When calculating the hash we ignore the hard-to-predict values like lastTime and lastCommit, else every time
     // we merge changes in policies to main we get a new hash after checking in, and that breaks the build.
-    const htmlTextForHash = compiled({gitChanges, lastTime:'some-last-time', lastCommit:'some-last-commit'});
+    const htmlTextForHash = compiled({gitChanges, lastTime: 'some-last-time', lastCommit: 'some-last-commit'});
     const hashDigest = getHashDigest(htmlTextForHash, 'sha256', 'hex', 16);
     const expectedHash = expectedHashes[filename];
     if (options.useGit && expectedHash !== undefined && expectedHash !== hashDigest) {
@@ -58,4 +58,4 @@ module.exports = function(content) {
         text: htmlText,
     };
     return `export default ${JSON.stringify(result)};`;
-}
+};

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2867,6 +2867,15 @@ export class BaseCompiler implements ICompiler {
 
         result = this.postCompilationPreCacheHook(result);
 
+        if (this.compiler.license?.invasive) {
+            result.asm = [
+                {text: `# License: ${this.compiler.license.name}`},
+                {text: `# ${this.compiler.license.preamble}`},
+                {text: `# See ${this.compiler.license.link}`},
+                ...result.asm,
+            ];
+        }
+
         if (result.okToCache) {
             await this.env.cachePut(key, result, undefined);
         }
@@ -3152,12 +3161,12 @@ but nothing was dumped. Possible causes are:
                           return result;
                       }
                       if (postProcess.length > 0) {
-                          return await this.execPostProcess(result, postProcess, outputFilename, maxSize);
+                          result = await this.execPostProcess(result, postProcess, outputFilename, maxSize);
                       } else {
                           const contents = await fs.readFile(outputFilename);
                           result.asm = contents.toString();
-                          return result;
                       }
+                      return result;
                   })();
         return Promise.all([asmPromise, optPromise, stackUsagePromise]);
     }

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3161,12 +3161,12 @@ but nothing was dumped. Possible causes are:
                           return result;
                       }
                       if (postProcess.length > 0) {
-                          result = await this.execPostProcess(result, postProcess, outputFilename, maxSize);
+                          return await this.execPostProcess(result, postProcess, outputFilename, maxSize);
                       } else {
                           const contents = await fs.readFile(outputFilename);
                           result.asm = contents.toString();
+                          return result;
                       }
-                      return result;
                   })();
         return Promise.all([asmPromise, optPromise, stackUsagePromise]);
     }

--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -343,6 +343,7 @@ export class CompilerFinder {
                 link: props<string>('licenseLink'),
                 name: props<string>('licenseName'),
                 preamble: props<string>('licensePreamble'),
+                invasive: props<boolean>('licenseInvasive', false),
             },
             possibleOverrides: [],
             possibleRuntimeTools: [],

--- a/static/generated/privacy.pug
+++ b/static/generated/privacy.pug
@@ -48,12 +48,6 @@ html(lang="en")
       | purposes of debugging the site: we will never share your code with anyone.
 
     p
-      | If you choose a Microsoft compiler, then your code may be sent to and compiled on a machine administrated by
-      | Microsoft. Such code is covered by the
-      |
-      a(href="https://go.microsoft.com/fwlink/?LinkId=521839" target="_blank") Microsoft Privacy Policy.
-
-    p
       | The source code and options are also subject to a one-way hash, which is used to cache the results to speed up
       | subsequent compilations of the same code. The cache is in-memory and on-disk. It's impossible to reconstruct the
       | source code from the hash, but the resulting assembly code or binary output (the compilation result) is stored as

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -119,6 +119,7 @@ export type CompilerInfo = {
         link?: string;
         name?: string;
         preamble?: string;
+        invasive?: boolean;
     };
     remote?: {
         target: string;


### PR DESCRIPTION
- Ensure MSVC license terms are clearly shown to the user.
- Simplify config of vc and vcpp slightly by extracting common stuff into a group.
- Remove reference to MS privacy policy
