### PR TITLE
Upgrade gcc-toolchain version used for clang 7-9

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -332,27 +332,32 @@ compiler.clang600.semver=6.0.0
 compiler.clang601.exe=/opt/compiler-explorer/clang-6.0.1/bin/clang++
 compiler.clang601.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.3.0
 compiler.clang601.semver=6.0.1
+
+# The usual policy for gcc-toolchain version is "latest at the time of clang version release").
+# For clang 7-9 we deviate from since it caused some warnings:
+# https://github.com/compiler-explorer/compiler-explorer/issues/6622
+
 compiler.clang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
 compiler.clang700.semver=7.0.0
-compiler.clang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.clang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang701.exe=/opt/compiler-explorer/clang-7.0.1/bin/clang++
 compiler.clang701.semver=7.0.1
-compiler.clang701.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.clang701.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang710.exe=/opt/compiler-explorer/clang-7.1.0/bin/clang++
 compiler.clang710.semver=7.1.0
-compiler.clang710.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.clang710.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang++
 compiler.clang800.semver=8.0.0
-compiler.clang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
+compiler.clang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang801.exe=/opt/compiler-explorer/clang-8.0.1/bin/clang++
 compiler.clang801.semver=8.0.1
-compiler.clang801.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
+compiler.clang801.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.clang900.semver=9.0.0
-compiler.clang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.clang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.clang901.semver=9.0.1
-compiler.clang901.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.clang901.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.clang1000.semver=10.0.0
 compiler.clang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -262,29 +262,34 @@ compiler.cclang600.exe=/opt/compiler-explorer/clang-6.0.0/bin/clang
 compiler.cclang600.semver=6.0.0
 compiler.cclang601.exe=/opt/compiler-explorer/clang-6.0.1/bin/clang
 compiler.cclang601.semver=6.0.1
-# Clang 7 and above: let's try the latest stable GCC as of the time of build
+
+# The usual policy for gcc-toolchain version is "latest at the time of clang version release").
+# For clang 7-9 we deviate from since it caused some warnings:
+# https://github.com/compiler-explorer/compiler-explorer/issues/6622
+
 compiler.cclang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang
 compiler.cclang700.semver=7.0.0
-compiler.cclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.cclang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang701.exe=/opt/compiler-explorer/clang-7.0.1/bin/clang
 compiler.cclang701.semver=7.0.1
-compiler.cclang701.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.cclang701.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang710.exe=/opt/compiler-explorer/clang-7.1.0/bin/clang
 compiler.cclang710.semver=7.1.0
-compiler.cclang710.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.cclang710.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang
 compiler.cclang800.semver=8.0.0
-compiler.cclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
+compiler.cclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang801.exe=/opt/compiler-explorer/clang-8.0.1/bin/clang
 compiler.cclang801.semver=8.0.1
-compiler.cclang801.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
+compiler.cclang801.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.cclang900.semver=9.0.0
-compiler.cclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
 compiler.cclang901.semver=9.0.1
-compiler.cclang901.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang901.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.1.0
 compiler.cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+
 compiler.cclang1000.semver=10.0.0
 compiler.cclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
 compiler.cclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang


### PR DESCRIPTION
Fix #6622 