### PR TITLE
Setup temporary msvc latest aliases for the latest versions we have

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -482,21 +482,21 @@ compiler.vcpp_v19_38_VS17_8_x86.libPath=Z:/compilers/msvc/14.38.33130-14.38.3313
 compiler.vcpp_v19_38_VS17_8_x86.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_38_VS17_8_x86.name=x86 msvc v19.38 VS17.8
 compiler.vcpp_v19_38_VS17_8_x86.semver=14.38.33133.0
-compiler.vcpp_v19_38_VS17_8_x86.alias=vcpp_v19_38_x86
+compiler.vcpp_v19_38_VS17_8_x86.alias=vcpp_v19_38_x86:vcpp_v19_latest_x86
 
 compiler.vcpp_v19_38_VS17_8_x64.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_38_VS17_8_x64.libPath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib;Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib/x64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/atlmfc/lib/x64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_38_VS17_8_x64.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_38_VS17_8_x64.name=x64 msvc v19.38 VS17.8
 compiler.vcpp_v19_38_VS17_8_x64.semver=14.38.33133.0
-compiler.vcpp_v19_38_VS17_8_x64.alias=vcpp_v19_38_x64
+compiler.vcpp_v19_38_VS17_8_x64.alias=vcpp_v19_38_x64:vcpp_v19_latest_x64
 
 compiler.vcpp_v19_38_VS17_8_arm64.exe=Z:/compilers/msvc/14.38.33130-14.38.33133.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_38_VS17_8_arm64.libPath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib;Z:/compilers/msvc/14.38.33130-14.38.33133.0/lib/arm64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.38.33130-14.38.33133.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
 compiler.vcpp_v19_38_VS17_8_arm64.includePath=Z:/compilers/msvc/14.38.33130-14.38.33133.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_38_VS17_8_arm64.name=arm64 msvc v19.38 VS17.8
 compiler.vcpp_v19_38_VS17_8_arm64.semver=14.38.33133.0
-compiler.vcpp_v19_38_VS17_8_arm64.alias=vcpp_v19_38_arm64
+compiler.vcpp_v19_38_VS17_8_arm64.alias=vcpp_v19_38_arm64:vcpp_v19_latest_arm64
 
 libs=
 


### PR DESCRIPTION
Microsoft's latest versions were more recent, however, if we can at least provide the latest we have links will be a little less broken.