### PR TITLE
Add Beman.Optional26 library trunk version

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3557,7 +3557,7 @@ compiler.vast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/li
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2:widberg-defs:jwt-cpp
+libs=abseil:array:async_simple:belleviews:beman_optional26:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2:widberg-defs:jwt-cpp
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -3586,6 +3586,12 @@ libs.belleviews.versions=trunk
 libs.belleviews.description=A library of C++ views that just works for all basic use cases as expected.
 libs.belleviews.versions.trunk.version=trunk
 libs.belleviews.versions.trunk.path=/opt/compiler-explorer/libs/belleviews/trunk/sources
+
+libs.beman_optional26.name=Beman.Optional26
+libs.beman_optional26.versions=trunk
+libs.beman_optional26.url=https://github.com/beman-project/Optional26
+libs.beman_optional26.versions.trunk.version=trunk
+libs.beman_optional26.versions.trunk.path=/opt/compiler-explorer/libs/beman_optional26/main/include
 
 libs.benchmark.name=Google Benchmark
 libs.benchmark.versions=trunk:120:130:140:141:150:161:162


### PR DESCRIPTION
Add Beman.Optional26 library trunk version - #6651. 
Infra linked PR [#1347](https://github.com/compiler-explorer/infra/pull/1347).

Notes: 
* Tested these changes on my local VM, Ubuntu 24.04, arm64:  https://github.com/compiler-explorer/infra/assets/8947836/075c29cf-1417-4110-beb3-caa46c21054d
* It's not clear for me if the infrastructure will automatically re-install `main` version of this library over night (`nightly`). If not, but it can be done, please help me to adjust my diff.
* Currently we don't have an official release version. We would like to be able to play with latest `main` from Beman.Optional26 this week in WG21 Saint Louis meeting. Please help us to deploy this "alpha" version.



