### PR TITLE
Change the default delay before re-compilation from 750 to 1500 ms

### DIFF
--- a/static/settings.ts
+++ b/static/settings.ts
@@ -405,7 +405,7 @@ export class Settings {
             if (this.settings.delayAfterChange === 0 || this.settings.delayAfterChange === 750) {
                 // 750 was the default before we added the autoDelayBeforeCompile checkbox
                 // 0 was probably something much older.
-                this.settings.delayAfterChange = this.defaultDelayAfterChange;
+                this.settings.autoDelayBeforeCompile = true;
             }
             localStorage.set('checkedAutoDelay', 'true');
         }

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -48,6 +48,7 @@ export interface SiteSettings {
     colourScheme: ColourScheme;
     compileOnChange: boolean;
     defaultLanguage?: LanguageKey;
+    autoDelayBeforeCompile: boolean;
     delayAfterChange: number;
     enableCodeLens: boolean;
     colouriseBrackets: boolean;
@@ -208,6 +209,11 @@ export class Settings {
     private readonly settingsObjs: BaseSetting[];
     private eventHub: EventHub;
 
+    // The delay between a change and re-compilation is a substantial factor in site traffic load.
+    // We want to be able to control it centrally - but only for users that didn't explicitly set it.
+    // This is the place.
+    private defaultDelayAfterChange = 1500;
+
     constructor(
         hub: Hub,
         private root: JQuery,
@@ -229,6 +235,8 @@ export class Settings {
         this.fillColourSchemeSelector(this.root.find('.colourScheme'), this.settings.theme);
         this.setSettings(this.settings);
         this.handleThemes();
+
+        this.eventHub.on('settingsChange', this.onSettingsChange.bind(this));
     }
 
     public static getStoredSettings(): SiteSettings {
@@ -253,6 +261,12 @@ export class Settings {
 
     private onSettingsChange(settings: SiteSettings) {
         this.settings = settings;
+        if (this.settings.autoDelayBeforeCompile) {
+            this.settings.delayAfterChange = this.defaultDelayAfterChange;
+        }
+        const delaySliderElement = this.root.find('.delay');
+        delaySliderElement.prop('disabled', this.settings.autoDelayBeforeCompile);
+
         for (const setting of this.settingsObjs) {
             setting.putUi(this.settings[setting.name]);
         }
@@ -277,6 +291,7 @@ export class Settings {
             ['.colourise', 'colouriseAsm', true],
             ['.colouriseBrackets', 'colouriseBrackets', true],
             ['.compileOnChange', 'compileOnChange', true],
+            ['.autoDelayBeforeCompile', 'autoDelayBeforeCompile', true],
             ['.editorsFLigatures', 'editorsFLigatures', false],
             ['.enableCodeLens', 'enableCodeLens', true],
             ['.enableCommunityAds', 'enableCommunityAds', true],
@@ -386,9 +401,17 @@ export class Settings {
 
     private addSliders() {
         // Handle older settings
-        if (this.settings.delayAfterChange === 0) {
-            this.settings.delayAfterChange = 750;
-            this.settings.compileOnChange = false;
+        if (localStorage.get('checkedAutoDelay', 'false') === 'false') {
+            if (this.settings.delayAfterChange === 0 || this.settings.delayAfterChange === 750) {
+                // 750 was the default before we added the autoDelayBeforeCompile checkbox
+                // 0 was probably something much older.
+                this.settings.delayAfterChange = this.defaultDelayAfterChange;
+            }
+            localStorage.set('checkedAutoDelay', 'true');
+        }
+
+        if (this.settings.autoDelayBeforeCompile) {
+            this.settings.delayAfterChange = this.defaultDelayAfterChange;
         }
 
         const delayAfterChangeSettings: SliderSettings = {
@@ -398,7 +421,10 @@ export class Settings {
             display: this.root.find('.delay-current-value'),
             formatter: x => (x / 1000.0).toFixed(2) + 's',
         };
-        this.add(new Slider(this.root.find('.delay'), 'delayAfterChange', delayAfterChangeSettings), 750);
+        this.add(
+            new Slider(this.root.find('.delay'), 'delayAfterChange', delayAfterChangeSettings),
+            this.settings.delayAfterChange,
+        );
     }
 
     private addNumerics() {

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -404,7 +404,7 @@ export class Settings {
         if (localStorage.get('checkedAutoDelay', 'false') === 'false') {
             if (this.settings.delayAfterChange === 0 || this.settings.delayAfterChange === 750) {
                 // 750 was the default before we added the autoDelayBeforeCompile checkbox
-                // 0 was probably something much older.
+                // 0 was something much older. Check those values to handle older settings
                 this.settings.autoDelayBeforeCompile = true;
             }
             localStorage.set('checkedAutoDelay', 'true');

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -100,6 +100,7 @@ mixin input(cls, type, text, style)
             #compilation.tab-pane.form-group(role="group")
               div
                 +checkbox("compileOnChange", "Compile automatically when source changes")
+                +checkbox("autoDelayBeforeCompile", "Use automatic delay before compiling")
                 div
                   label Delay before compiling:&nbsp;
                     span.delay-current-value &nbsp;


### PR DESCRIPTION
Following some high-traffic alerts an idea was raised on discord to increase the default delay between typing and re-compilation - as today every slight hesitation triggers re-compilation.

The default delay was 750ms. This PR doubles it while trying to limit the change to users who didn't set it explicitly. On first navigation after this fix *all* 750's would be converted to 1500, but if a user later sets the delay to 750 it *won't* be converted (with a little help from `localStorage`).

This also sets a single place to centrally control the default delay in the future (personally I think it can be higher, but it can wait).

A new checkbox in the settings is added, and future modifications to the default delay would apply only when this is checked:
![autodelay](https://github.com/compiler-explorer/compiler-explorer/assets/73080/ed5b773a-a253-4508-9d9f-9b6117e5c8e0)

