### PR TITLE
Stop fixing stack-usage/opt-remarks font size

### DIFF
--- a/static/styles/themes/default-theme.scss
+++ b/static/styles/themes/default-theme.scss
@@ -183,7 +183,6 @@ a.navbar-brand img.logo.normal {
 }
 
 .stack-usage {
-    font-size: x-small;
     &.static {
         background: #fdfd96;
     }
@@ -198,7 +197,6 @@ a.navbar-brand img.logo.normal {
 }
 
 .opt-line {
-    font-size: x-small;
     &.analysis {
         background: #ffffae;
     }


### PR DESCRIPTION
Setting font-size in css does not respond to resizing:
![badresize](https://github.com/compiler-explorer/compiler-explorer/assets/73080/ab19084c-c494-4932-a94c-17733e8da2e5)

I suspect (1) this is a monaco limitation (based on [this](https://github.com/microsoft/monaco-editor/discussions/3717#discussioncomment-5190536)), and (2) they're not keen on improving their font control (based on [this](https://github.com/microsoft/monaco-editor/issues/2242#issuecomment-1433466832)).

Reverting the css fontsize makes it behave properly:
![goodresize](https://github.com/compiler-explorer/compiler-explorer/assets/73080/f337bd99-9239-4a0f-8a1d-9b96f52265ce)


@RubenRBS Sorry, I too preferred your idea of smaller decoration text.