### PR TITLE
Adding ruby 3.2.2 to ruby.amazon.properties

### DIFF
--- a/etc/config/ruby.amazon.properties
+++ b/etc/config/ruby.amazon.properties
@@ -1,12 +1,14 @@
 compilers=&ruby
-defaultCompiler=ruby302
+defaultCompiler=ruby322
 
-group.ruby.compilers=ruby302:ruby274:ruby268:ruby259
+group.ruby.compilers=ruby322:ruby302:ruby274:ruby268:ruby259
 group.ruby.isSemVer=true
 group.ruby.baseName=Ruby
 group.ruby.groupName=Ruby YARV
 group.ruby.compilerType=ruby
 
+compiler.ruby322.semver=3.2.2
+compiler.ruby322.exe=/opt/compiler-explorer/ruby-3.2.2/bin/ruby
 compiler.ruby302.semver=3.0.2
 compiler.ruby302.exe=/opt/compiler-explorer/ruby-3.0.2/bin/ruby
 compiler.ruby274.semver=2.7.4


### PR DESCRIPTION
Not the latest 3.2 version, but what is listed at:

https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.5.html