### PR TITLE
Pass instructionSet, -mcpu, -march and -mtriple through to llvm-mca

### DIFF
--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -148,8 +148,8 @@ export class InstructionSets {
                 path: [],
             },
             amd64: {
-                target: [],
-                path: [],
+                target: ['x86_64'],
+                path: ['/x86_64'],
             },
             evm: {
                 target: [],
@@ -180,6 +180,14 @@ export class InstructionSets {
                 path: [],
             },
         };
+    }
+
+    // Return the first spelling of the target for the instruction set,
+    // or null if data is missing from the 'supported' table.
+    getInstructionSetTarget(instructionSet: InstructionSet): string | null {
+        if (!(instructionSet in this.supported)) return null;
+        if (this.supported[instructionSet].target.length === 0) return null;
+        return this.supported[instructionSet].target[0];
     }
 
     getCompilerInstructionSetHint(compilerArch: string | boolean, exe?: string): InstructionSet {

--- a/lib/tooling/llvm-mca-tool.ts
+++ b/lib/tooling/llvm-mca-tool.ts
@@ -24,6 +24,8 @@
 
 import fs from 'fs-extra';
 
+import {InstructionSets} from '../instructionsets.js';
+
 import {BaseTool} from './base-tool.js';
 
 export class LLVMMcaTool extends BaseTool {
@@ -44,6 +46,16 @@ export class LLVMMcaTool extends BaseTool {
     }
 
     override async runTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[]) {
+        const isets = new InstructionSets();
+        const target = isets.getInstructionSetTarget(compilationInfo.compiler.instructionSet);
+        if (target != null) args?.push('-mtriple=' + target);
+
+        for (const arg of compilationInfo.options) {
+            if (arg.startsWith('-mcpu') || arg.startsWith('-march') || arg.startsWith('-mtriple')) {
+                args?.push(arg);
+            }
+        }
+
         if (compilationInfo.filters.binary || compilationInfo.filters.binaryObject) {
             return this.createErrorResponse('<cannot run analysis on binary>');
         }


### PR DESCRIPTION
Currently if an MCA instance is constructed on a compiler, MCA runs with
the default target for the host it is running on.

Make it respect the target architecture by passing an -mtarget to MCA
conditioned on the detected instructionSet of the compiler.

Additionally, pass through any -mcpu, -march or -mtriple specified to
the compiler.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
