### PR TITLE
Fix HIP/CUDA for rocm-6.1.2

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -337,19 +337,19 @@ compiler.hipclang-rocm-60102.semver=6.1.2
 compiler.hipclang-rocm-60102.name=clang rocm-6.1.2
 compiler.hipclang-rocm-60102.nvdisasm=/opt/compiler-explorer/clang-rocm-6.1.2/bin/llvm-objdump
 compiler.hipclang-rocm-60102.objdumper=/opt/compiler-explorer/clang-rocm-6.1.2/bin/llvm-objdump
-compiler.hipclang-rocm-60102.options=-x hip --cuda-device-only -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/6.1.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/6.1.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-6.1.2/amdgcn/bitcode -include hip/hip_runtime.h
+compiler.hipclang-rocm-60102.options=-x hip --cuda-device-only -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/6.1.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/6.1.2 -include hip/hip_runtime.h
 compiler.hipclang-trunk-rocm-60102.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
 compiler.hipclang-trunk-rocm-60102.semver=trunk-6.1.2
 compiler.hipclang-trunk-rocm-60102.name=clang trunk rocm-6.1.2
 compiler.hipclang-trunk-rocm-60102.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
 compiler.hipclang-trunk-rocm-60102.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-60102.options=-x hip --cuda-device-only -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/6.1.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/6.1.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-6.1.2/amdgcn/bitcode -include hip/hip_runtime.h
+compiler.hipclang-trunk-rocm-60102.options=-x hip --cuda-device-only -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/6.1.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/6.1.2 -include hip/hip_runtime.h
 compiler.hipclang-staging-rocm-60102.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
 compiler.hipclang-staging-rocm-60102.semver=staging-6.1.2
 compiler.hipclang-staging-rocm-60102.name=clang staging rocm-6.1.2
 compiler.hipclang-staging-rocm-60102.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-60102.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-60102.options=-x hip --cuda-device-only -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/6.1.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/6.1.2 --rocm-device-lib-path=/opt/compiler-explorer/clang-rocm-6.1.2/amdgcn/bitcode -include hip/hip_runtime.h
+compiler.hipclang-staging-rocm-60102.options=-x hip --cuda-device-only -O3 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -isystem /opt/compiler-explorer/libs/rocm/6.1.2/include --rocm-path=/opt/compiler-explorer/libs/rocm/6.1.2 -include hip/hip_runtime.h
 
 group.nvrtc.compilers=nvrtc121:nvrtc120u1:nvrtc120:nvrtc118:nvrtc117u1:nvrtc117:nvrtc116u2:nvrtc116u1:nvrtc116:nvrtc115u2:nvrtc115u1:nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11:nvrtc102:nvrtc101u2:nvrtc101u1:nvrtc101:nvrtc100:nvrtc92:nvrtc91
 group.nvrtc.compilerType=nvrtc


### PR DESCRIPTION
Use default device libs path determined by --rocm-path

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
