### PR TITLE
Remove note about context menu

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3630,7 +3630,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                                 isWholeLine: false,
                                 hoverMessage: [
                                     {
-                                        value: response.tooltip + '\n\nMore information available in the context menu.',
+                                        value: response.tooltip,
                                         isTrusted: true,
                                     },
                                 ],

--- a/static/panes/device-view.ts
+++ b/static/panes/device-view.ts
@@ -453,7 +453,7 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
                                 isWholeLine: false,
                                 hoverMessage: [
                                     {
-                                        value: response.tooltip + '\n\nMore information available in the context menu.',
+                                        value: response.tooltip,
                                         isTrusted: true,
                                     },
                                 ],


### PR DESCRIPTION
Reading this dozens of times is annoying

<img width="995" alt="Screenshot 2024-07-03 at 19 27 44" src="https://github.com/compiler-explorer/compiler-explorer/assets/5687998/8fb6a1c3-fb57-4e4d-8f94-d46b4f3823ed">
