### PR TITLE
Add p3309 (+ fix description of P3068 clang)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -415,7 +415,7 @@ compiler.clang1810.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 compiler.clang1810.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 compiler.clang1810.debugPatched=true
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_bb_p2996:clang_p3068:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_p1974
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_bb_p2996:clang_p3068:clang_p3309:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_p1974
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -460,7 +460,10 @@ compiler.clang_bb_p2996.notification=Experimental Reflection Support; see <a hre
 compiler.clang_bb_p2996.options=-std=c++26 -freflection -stdlib=libc++
 compiler.clang_p3068.exe=/opt/compiler-explorer/clang-p3068-trunk/bin/clang++
 compiler.clang_p3068.semver=(experimental P3068)
-compiler.clang_p3068.notification=Experimental constexpr Exception Support; see <a href="https://github.com/hanickadot/llvm-project/tree/P3068-constexpr-exceptions" target="_blank" rel="noopener noreferrer">P2996<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_p3068.notification=Experimental constexpr Exception Support; see <a href="https://github.com/hanickadot/llvm-project/tree/P3068-constexpr-exceptions" target="_blank" rel="noopener noreferrer">P3068<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_p3309.exe=/opt/compiler-explorer/clang-p3309-trunk/bin/clang++
+compiler.clang_p3309.semver=(experimental P3309)
+compiler.clang_p3309.notification=Experimental constexpr atomic and atomic_ref; see <a href="https://github.com/hanickadot/llvm-project/tree/P3309-constexpr-atomic-and-atomic-ref" target="_blank" rel="noopener noreferrer">P3309<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_p1061.exe=/opt/compiler-explorer/clang-p1061-trunk/bin/clang++
 compiler.clang_p1061.semver=(experimental P1061)
 compiler.clang_p1061.notification=Experimental Structure Bindings can introduce a Pack; see <a href="https://wg21.link/P1061" target="_blank" rel="noopener noreferrer">P1061<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
Adding experimental clang to support P3309 (constexpr atomic & atomic_ref)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
