### PR TITLE
 Set default min API to 27 for R8/D8

### DIFF
--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -161,7 +161,6 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
 
         const files = await fs.readdir(preliminaryCompilePath, {encoding: 'utf8', recursive: true});
         const classFiles = files.filter(f => f.endsWith('.class'));
-
         const d8Options = [
             '-cp',
             this.compiler.exe, // R8 jar.


### PR DESCRIPTION
The minimum API is currently not set, meaning that some bytecodes are
mising (invoke-polymorphic from API level 26; const-method-handle and
const-method-type from API level 27). This change sets a default minimum
API level of 27, while allowing for the option to still be overridden.