### PR TITLE
Bump all extant versions of ruby, add ruby 3.1 for completeness

### DIFF
--- a/etc/config/ruby.amazon.properties
+++ b/etc/config/ruby.amazon.properties
@@ -1,18 +1,25 @@
 compilers=&ruby
-defaultCompiler=ruby322
+defaultCompiler=ruby334
 
-group.ruby.compilers=ruby322:ruby302:ruby274:ruby268:ruby259
+group.ruby.compilers=ruby334:ruby324:ruby316:ruby307:ruby278:ruby268:ruby259
 group.ruby.isSemVer=true
 group.ruby.baseName=Ruby
 group.ruby.groupName=Ruby YARV
 group.ruby.compilerType=ruby
 
-compiler.ruby322.semver=3.2.2
-compiler.ruby322.exe=/opt/compiler-explorer/ruby-3.2.2/bin/ruby
-compiler.ruby302.semver=3.0.2
-compiler.ruby302.exe=/opt/compiler-explorer/ruby-3.0.2/bin/ruby
-compiler.ruby274.semver=2.7.4
-compiler.ruby274.exe=/opt/compiler-explorer/ruby-2.7.4/bin/ruby
+compiler.ruby334.semver=3.3.4
+compiler.ruby334.exe=/opt/compiler-explorer/ruby-3.3.4/bin/ruby
+compiler.ruby324.semver=3.2.4
+compiler.ruby324.exe=/opt/compiler-explorer/ruby-3.2.4/bin/ruby
+compiler.ruby324.alias=ruby322
+compiler.ruby316.semver=3.1.6
+compiler.ruby316.exe=/opt/compiler-explorer/ruby-3.1.6/bin/ruby
+compiler.ruby307.semver=3.0.7
+compiler.ruby307.exe=/opt/compiler-explorer/ruby-3.0.7/bin/ruby
+compiler.ruby307.alias=ruby302
+compiler.ruby278.semver=2.7.8
+compiler.ruby278.exe=/opt/compiler-explorer/ruby-2.7.8/bin/ruby
+compiler.ruby278.alias=ruby274
 compiler.ruby268.semver=2.6.8
 compiler.ruby268.exe=/opt/compiler-explorer/ruby-2.6.8/bin/ruby
 compiler.ruby259.semver=2.5.9


### PR DESCRIPTION
Made changes that I think will help maintainability, dropping the patch level version from all the variables... 

You might want to consider dropping 2.5 and 2.6... they're ancient. Happy to add.