### PR TITLE
Add zig 0.12.1 and 0.13.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3321,7 +3321,7 @@ compiler.djggp494.semver=4.9.4
 
 #################################
 # Zig c++
-group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxxtrunk
+group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxxtrunk
 group.zigcxx.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcxx.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcxx.options=
@@ -3351,6 +3351,8 @@ compiler.zcxx0110.exe=/opt/compiler-explorer/zig-0.11.0/zig
 compiler.zcxx0110.semver=0.11.0
 compiler.zcxx0120.exe=/opt/compiler-explorer/zig-0.12.0/zig
 compiler.zcxx0120.semver=0.12.0
+compiler.zcxx0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
+compiler.zcxx0121.semver=0.12.1
 compiler.zcxxtrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcxxtrunk.semver=trunk
 compiler.zcxxtrunk.isNightly=true

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3321,7 +3321,7 @@ compiler.djggp494.semver=4.9.4
 
 #################################
 # Zig c++
-group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxxtrunk
+group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxx0130:zcxxtrunk
 group.zigcxx.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcxx.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcxx.options=
@@ -3353,6 +3353,8 @@ compiler.zcxx0120.exe=/opt/compiler-explorer/zig-0.12.0/zig
 compiler.zcxx0120.semver=0.12.0
 compiler.zcxx0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
 compiler.zcxx0121.semver=0.12.1
+compiler.zcxx0130.exe=/opt/compiler-explorer/zig-0.13.0/zig
+compiler.zcxx0130.semver=0.13.0
 compiler.zcxxtrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcxxtrunk.semver=trunk
 compiler.zcxxtrunk.isNightly=true

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3332,7 +3332,7 @@ group.zigcxx.compilerType=zigcxx
 group.zigcxx.versionFlag=version
 group.zigcxx.licenseLink=https://github.com/ziglang/zig/blob/master/LICENSE
 group.zigcxx.licenseName=The MIT License (Expat)
-group.zigcxx.licensePreamble=Copyright (c) 2015-2022, Zig contributors
+group.zigcxx.licensePreamble=Copyright (c) Zig contributors
 group.zigcxx.compilerCategories=zig
 
 compiler.zcxx060.exe=/opt/compiler-explorer/zig-0.6.0/zig

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3080,7 +3080,7 @@ group.zigcc.compilerType=zigcc
 group.zigcc.versionFlag=version
 group.zigcc.licenseLink=https://github.com/ziglang/zig/blob/master/LICENSE
 group.zigcc.licenseName=The MIT License (Expat)
-group.zigcc.licensePreamble=Copyright (c) 2015-2022, Zig contributors
+group.zigcc.licensePreamble=Copyright (c) Zig contributors
 
 compiler.zcc060.exe=/opt/compiler-explorer/zig-0.6.0/zig
 compiler.zcc060.semver=0.6.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3069,7 +3069,7 @@ compiler.tinycc0927.semver=0.9.27
 
 #################################
 # Zig cc
-group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcctrunk
+group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcctrunk
 group.zigcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcc.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcc.options=
@@ -3098,6 +3098,8 @@ compiler.zcc0110.exe=/opt/compiler-explorer/zig-0.11.0/zig
 compiler.zcc0110.semver=0.11.0
 compiler.zcc0120.exe=/opt/compiler-explorer/zig-0.12.0/zig
 compiler.zcc0120.semver=0.12.0
+compiler.zcc0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
+compiler.zcc0121.semver=0.12.1
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 compiler.zcctrunk.isNightly=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3069,7 +3069,7 @@ compiler.tinycc0927.semver=0.9.27
 
 #################################
 # Zig cc
-group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcctrunk
+group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcc0130:zcctrunk
 group.zigcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcc.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcc.options=
@@ -3100,6 +3100,8 @@ compiler.zcc0120.exe=/opt/compiler-explorer/zig-0.12.0/zig
 compiler.zcc0120.semver=0.12.0
 compiler.zcc0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
 compiler.zcc0121.semver=0.12.1
+compiler.zcc0130.exe=/opt/compiler-explorer/zig-0.13.0/zig
+compiler.zcc0130.semver=0.13.0
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 compiler.zcctrunk.isNightly=true

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -2,7 +2,7 @@ compilers=&zig
 defaultCompiler=z0120
 
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
-group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120
+group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
@@ -40,6 +40,8 @@ compiler.z0110.exe=/opt/compiler-explorer/zig-0.11.0/zig
 compiler.z0110.semver=0.11.0
 compiler.z0120.exe=/opt/compiler-explorer/zig-0.12.0/zig
 compiler.z0120.semver=0.12.0
+compiler.z0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
+compiler.z0121.semver=0.12.1
 
 #################################
 #################################

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -10,7 +10,7 @@ group.zig.compilerType=zig
 group.zig.versionFlag=version
 group.zig.licenseLink=https://github.com/ziglang/zig/blob/master/LICENSE
 group.zig.licenseName=The MIT License (Expat)
-group.zig.licensePreamble=Copyright (c) 2015-2022, Zig contributors
+group.zig.licensePreamble=Copyright (c) Zig contributors
 
 compiler.ztrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.ztrunk.semver=trunk

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -2,7 +2,7 @@ compilers=&zig
 defaultCompiler=z0120
 
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
-group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121
+group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
@@ -42,6 +42,8 @@ compiler.z0120.exe=/opt/compiler-explorer/zig-0.12.0/zig
 compiler.z0120.semver=0.12.0
 compiler.z0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
 compiler.z0121.semver=0.12.1
+compiler.z0130.exe=/opt/compiler-explorer/zig-0.13.0/zig
+compiler.z0130.semver=0.13.0
 
 #################################
 #################################


### PR DESCRIPTION
zig `0.12.1` released on 2024-06-08
zig `0.13.0` released on 2024-06-07

I also updated the zig license preamble, which was changed in 2023.

infra PR: https://github.com/compiler-explorer/infra/pull/1366