### PR TITLE
Implement more diff types

### DIFF
--- a/static/panes/diff.interfaces.ts
+++ b/static/panes/diff.interfaces.ts
@@ -32,6 +32,11 @@ export enum DiffType {
     GNAT_ExpandedCode = 5,
     GNAT_Tree = 6,
     DeviceView = 7,
+    AstOutput = 8,
+    IrOutput = 9,
+    RustMirOutput = 10,
+    RustMacroExpOutput = 11,
+    RustHirOutput = 12,
 }
 
 export type DiffState = {

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -32,7 +32,6 @@ import {Container} from 'golden-layout';
 import {MonacoPane} from './pane.js';
 import {MonacoPaneState} from './pane.interfaces.js';
 import {DiffState, DiffType} from './diff.interfaces.js';
-import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {CompilationResult} from '../../types/compilation/compilation.interfaces.js';
 import {CompilerInfo} from '../../types/compiler.interfaces.js';
 
@@ -102,7 +101,7 @@ class DiffStateObject {
     }
 
     refresh() {
-        let output: ResultLine[] = [];
+        let output: {text: string}[] = [];
         if (this.result) {
             switch (this.difftype) {
                 case DiffType.ASM:
@@ -115,10 +114,18 @@ class DiffStateObject {
                     output = this.result.stderr;
                     break;
                 case DiffType.ExecStdOut:
-                    if (this.result.execResult) output = this.result.execResult.stdout;
+                    if (this.result.execResult) {
+                        output = this.result.execResult.stdout;
+                    } else {
+                        output = [{text: "<activate 'Output...' → 'Execute the code' in this compiler's pane>"}];
+                    }
                     break;
                 case DiffType.ExecStdErr:
-                    if (this.result.execResult) output = this.result.execResult.stderr;
+                    if (this.result.execResult) {
+                        output = this.result.execResult.stderr;
+                    } else {
+                        output = [{text: "<activate 'Output...' → 'Execute the code' in this compiler's pane>"}];
+                    }
                     break;
                 case DiffType.GNAT_ExpandedCode:
                     output = this.result.gnatDebugOutput || [];
@@ -130,6 +137,29 @@ class DiffStateObject {
                     if (this.result.devices && this.extraoption && this.extraoption in this.result.devices) {
                         output = this.result.devices[this.extraoption].asm || [];
                     }
+                    break;
+                case DiffType.AstOutput:
+                    output = this.result.astOutput || [{text: "<select 'Add new...' → 'AST' in this compiler's pane>"}];
+                    break;
+                case DiffType.IrOutput:
+                    output = this.result.irOutput?.asm || [
+                        {text: "<select 'Add new...' → 'LLVM IR' in this compiler's pane>"},
+                    ];
+                    break;
+                case DiffType.RustMirOutput:
+                    output = this.result.rustMirOutput || [
+                        {text: "<select 'Add new...' → 'Rust MIR' in this compiler's pane>"},
+                    ];
+                    break;
+                case DiffType.RustMacroExpOutput:
+                    output = this.result.rustMacroExpOutput || [
+                        {text: "<select 'Add new...' → 'Rust Macro Expansion' in this compiler's pane>"},
+                    ];
+                    break;
+                case DiffType.RustHirOutput:
+                    output = this.result.rustHirOutput || [
+                        {text: "<select 'Add new...' → 'Rust HIR' in this compiler's pane>"},
+                    ];
                     break;
             }
         }
@@ -423,10 +453,30 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
             }
         }
 
+        for (const options of [lhsextraoptions, rhsextraoptions]) {
+            if (compiler.supportsAstView) {
+                options.push({id: DiffType.AstOutput.toString(), name: 'AST'});
+            }
+            if (compiler.supportsIrView) {
+                options.push({id: DiffType.IrOutput.toString(), name: 'LLVM IR'});
+            }
+            if (compiler.supportsRustMirView) {
+                options.push({id: DiffType.RustMirOutput.toString(), name: 'Rust MIR'});
+            }
+            if (compiler.supportsRustMacroExpView) {
+                options.push({id: DiffType.RustMacroExpOutput.toString(), name: 'Rust Macro Expansion'});
+            }
+            if (compiler.supportsRustHirView) {
+                options.push({id: DiffType.RustHirOutput.toString(), name: 'Rust HIR'});
+            }
+        }
+
         const lhsoptions = this.getDiffableOptions(this.selectize.lhs, lhsextraoptions);
+        this.selectize.lhsdifftype.clearOptions();
         this.selectize.lhsdifftype.addOptions(lhsoptions);
 
         const rhsoptions = this.getDiffableOptions(this.selectize.rhs, rhsextraoptions);
+        this.selectize.rhsdifftype.clearOptions();
         this.selectize.rhsdifftype.addOptions(rhsoptions);
     }
 


### PR DESCRIPTION
Add support for diffing clang ASTs, LLVM IR, and Rust HIR, MIR and macro expansions. These new options are only shown in the picker when the compiler supports the respective output type (e. g. when diffing `g++` output, there will be no item to select LLVM IR).

Because the specified output must be activated manually, this PR also adds help texts so that the user isn’t shown an empty pane. E. g. when diffing execution stdout but “Execute the code” is not checked, the diff viewer will show “<activate 'Output...' → 'Execute the code' in this compiler's pane>”.

Resolves #6726.