### PR TITLE
Attempt to add CPU sysfs entries to the jail.

### DIFF
--- a/etc/nsjail/compilers-and-tools.cfg
+++ b/etc/nsjail/compilers-and-tools.cfg
@@ -182,6 +182,12 @@ mount {
 }
 
 mount {
+    src: "/sys/devices/system/cpu"
+    dst: "/sys/devices/system/cpu"
+    is_bind: true
+}
+
+mount {
     src: "/opt/compiler-explorer"
     dst: "/opt/compiler-explorer"
     is_bind: true


### PR DESCRIPTION
This allows running compilers that use these, for example ones that link in TCMalloc. I'm just implementing the suggestion in #6734, it seems reasonable and targeted. Hoping a PR lets a fix move forward here.

I've left this as mandatory given that `/proc` is mandatory. This might still have an issue on more unusual Linux images, but I suspect not.

Not sure how to test this, wasn't clear how to just check the contents of a file in the jail from the test suite examples I looked at. That said, if you can point me to some example for how to do it, happy to add one.

Fixes #6734