### PR TITLE
Rewrite the llvm-opt-transformer functionality

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1291,11 +1291,11 @@ export class BaseCompiler implements ICompiler {
         produceCfg: boolean,
         filters: ParseFiltersAndOutputOptions,
     ) {
-        // These options make Clang produce an IR
         const newOptions = options
-            // `-E` causes some mayhem. See #5854
-            .filter(option => option !== '-fcolor-diagnostics' && option !== '-E')
-            .concat(unwrap(this.compiler.irArg));
+            // `-E` /`-fsave-optimization-record` switches caused simultaneus writes into some output files,
+            // see bugs #5854 / #6745
+            .filter(option => !['-fcolor-diagnostics', '-E', '-fsave-optimization-record'].includes(option))
+            .concat(unwrap(this.compiler.irArg)); // produce IR
 
         if (irOptions.noDiscardValueNames && this.compiler.optPipeline?.noDiscardValueNamesArg) {
             newOptions.push(...this.compiler.optPipeline.noDiscardValueNamesArg);

--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -66,7 +66,6 @@ export function processRawOptRemarks(buffer: string, compileFileName: string = '
     const remarks: any = parseAllDocuments(buffer);
     for (const doc of remarks) {
         if (doc.errors !== undefined && doc.errors.length > 0) {
-            // This actually happens: https://github.com/llvm/llvm-project/issues/101839
             logger.warn('YAMLParseError: ' + JSON.stringify(doc.errors[0]));
             continue;
         }

--- a/lib/llvm-opt-transformer.ts
+++ b/lib/llvm-opt-transformer.ts
@@ -17,13 +17,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import {Transform, TransformCallback, TransformOptions} from 'stream';
-
-import yaml from 'yaml';
+import {parseAllDocuments} from 'yaml';
 
 import {logger} from './logger.js';
 
-type Path = string;
 type OptType = 'Missed' | 'Passed' | 'Analysis';
 
 type OptInfo = {
@@ -40,7 +37,7 @@ export type LLVMOptInfo = OptInfo & {
 };
 
 type DebugLoc = {
-    File: Path;
+    File: string;
     Line: number;
     Column: number;
 };
@@ -63,65 +60,28 @@ function DisplayOptInfo(optInfo: LLVMOptInfo) {
     return displayString;
 }
 
-const optTypeMatcher = /---\s(.*)\r?\n/;
-const docStart = '---';
-const docEnd = '\n...';
-const IsDocumentStart = (x: string) => x.startsWith(docStart);
-const FindDocumentEnd = (x: string) => {
-    const index = x.indexOf(docEnd);
-    return {found: index > -1, endpos: index + docEnd.length};
-};
-const splitAt = (index, xs) => [xs.slice(0, index), xs.slice(index)];
-
-export class LLVMOptTransformer extends Transform {
-    _buffer: string;
-    _prevOpts: Set<string>; // Avoid duplicate display of remarks
-    constructor(options?: TransformOptions) {
-        super({...options, objectMode: true});
-        this._buffer = '';
-        this._prevOpts = new Set<string>();
-    }
-
-    override _flush(done: TransformCallback) {
-        this.processBuffer();
-        done();
-    }
-
-    override _transform(chunk: any, encoding: string, done: TransformCallback) {
-        // See https://stackoverflow.com/a/40928431/390318 - we have to catch all exceptions here
-        try {
-            this._buffer += chunk.toString();
-            this.processBuffer();
-        } catch (exception) {
-            done(exception as Error);
-            return;
+export function processRawOptRemarks(buffer: string, compileFileName: string = ''): LLVMOptInfo[] {
+    const output: LLVMOptInfo[] = [];
+    const remarksSet: Set<string> = new Set<string>();
+    const remarks: any = parseAllDocuments(buffer);
+    for (const doc of remarks) {
+        if (doc.errors !== undefined && doc.errors.length > 0) {
+            // This actually happens: https://github.com/llvm/llvm-project/issues/101839
+            logger.warn('YAMLParseError: ' + JSON.stringify(doc.errors[0]));
+            continue;
         }
-        done();
-    }
 
-    processBuffer() {
-        while (IsDocumentStart(this._buffer)) {
-            const {found, endpos} = FindDocumentEnd(this._buffer);
-            if (found) {
-                const [head, tail] = splitAt(endpos, this._buffer);
-                const optTypeMatch = head.match(optTypeMatcher);
-                const opt = yaml.parse(head, {logLevel: 'error'});
-                const strOpt = JSON.stringify(opt);
-                if (!this._prevOpts.has(strOpt)) {
-                    this._prevOpts.add(strOpt);
+        const opt = doc.toJS();
+        if (!opt.DebugLoc || !opt.DebugLoc.File || !opt.DebugLoc.File.includes(compileFileName)) continue;
 
-                    if (optTypeMatch) {
-                        opt.optType = optTypeMatch[1].replace('!', '');
-                    } else {
-                        logger.warn('missing optimization type');
-                    }
-                    opt.displayString = DisplayOptInfo(opt);
-                    this.push(opt as LLVMOptInfo);
-                }
-                this._buffer = tail.replace(/^\n/, '');
-            } else {
-                break;
-            }
+        const strOpt = JSON.stringify(opt);
+        if (!remarksSet.has(strOpt)) {
+            remarksSet.add(strOpt);
+            opt.optType = doc.contents.tag.substring(1); // remove leading '!'
+            opt.displayString = DisplayOptInfo(opt);
+            output.push(opt as LLVMOptInfo);
         }
     }
+
+    return output;
 }


### PR DESCRIPTION
… to be synchronous and not fail on bad document
Fixes #6745.

The main problem is already described in [this comment](https://github.com/compiler-explorer/compiler-explorer/issues/6745#issuecomment-2266054446). Beyond it, this addresses cases where clang actually generates [invalid yaml documents](https://github.com/llvm/llvm-project/issues/101839).

Also, moved to the library function `yaml.parseAllDocuments` which doesn't throw. Which means one test and several sentry calls were eliminated.