### PR TITLE
Remove '-p' from forced demangler args

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2950,7 +2950,7 @@ export class BaseCompiler implements ICompiler {
             const result = JSON.stringify(output, null, 4);
             const demangleResult: UnprocessedExecResult = await this.exec(
                 this.compiler.demangler,
-                [...this.compiler.demanglerArgs, '-n', '-p'],
+                [...this.compiler.demanglerArgs, '-n'],
                 {input: result},
             );
             if (demangleResult.stdout.length > 0 && !demangleResult.truncated) {
@@ -2966,7 +2966,7 @@ export class BaseCompiler implements ICompiler {
         return output;
     }
 
-    async processStackUsageOutput(suPath) {
+    async processStackUsageOutput(suPath): Promise<StackUsageTransformer.StackUsageInfo[]> {
         const output = StackUsageTransformer.parse(await fs.readFile(suPath, 'utf8'));
 
         if (this.compiler.demangler) {
@@ -2974,7 +2974,7 @@ export class BaseCompiler implements ICompiler {
             try {
                 const demangleResult = await this.exec(
                     this.compiler.demangler,
-                    [...this.compiler.demanglerArgs, '-n', '-p'],
+                    [...this.compiler.demanglerArgs, '-n'],
                     {input: result},
                 );
                 return JSON.parse(demangleResult.stdout);

--- a/lib/stack-usage-transformer.ts
+++ b/lib/stack-usage-transformer.ts
@@ -36,7 +36,7 @@ type DebugLoc = {
     Column: number;
 };
 
-export function parse(suText: string) {
+export function parse(suText: string): StackUsageInfo[] {
     const output: StackUsageInfo[] = [];
     for (const line of suText.split('\n').filter(Boolean)) {
         const c = line.split('\t');


### PR DESCRIPTION
Minor added tsification

Fixes #6714 : "No demangling in opt-remarks for clang <=17"

This is probably a regression introduced by my PR #6451 - which changed the version of the llvm-cxxfilt demanglers used. Up until llvm 18 these demanglers did not support the `-p` switch ("Skip function parameters and return types"). 
The fix here is to remove the switch (why would we want it?? We wish to distinguish overloads in opt remarks too).


