### PR TITLE
Add 23 cross GCC 14.2

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -78,7 +78,7 @@ group.gnatcross.compilerCategories=gcc
 
 ################################
 # GNAT for loongarch64
-group.gnatloongarch64.compilers=gnatloongarch641410
+group.gnatloongarch64.compilers=gnatloongarch641410:gnatloongarch641420
 group.gnatloongarch64.groupName=LOONGARCH64 GNAT
 group.gnatloongarch64.baseName=loongarch64 gnat
 
@@ -87,9 +87,14 @@ compiler.gnatloongarch641410.semver=14.1.0
 compiler.gnatloongarch641410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.gnatloongarch641410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.gnatloongarch641420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gnatmake
+compiler.gnatloongarch641420.semver=14.2.0
+compiler.gnatloongarch641420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gnatloongarch641420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for sparc-leon
-group.gnatsparcleons.compilers=gnatsparcleon1310:gnatsparcleon1320:gnatsparcleon1330:gnatsparcleon1410
+group.gnatsparcleons.compilers=gnatsparcleon1310:gnatsparcleon1320:gnatsparcleon1330:gnatsparcleon1410:gnatsparcleon1420
 group.gnatsparcleons.groupName=SPARC LEON GNAT
 group.gnatsparcleons.baseName=sparc leon gnat
 
@@ -113,9 +118,14 @@ compiler.gnatsparcleon1410.semver=14.1.0
 compiler.gnatsparcleon1410.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.gnatsparcleon1410.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
+compiler.gnatsparcleon1420.exe=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gnatmake
+compiler.gnatsparcleon1420.semver=14.2.0
+compiler.gnatsparcleon1420.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gnatsparcleon1420.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 ################################
 # GNAT for sparc
-group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1240:gnatsparc1310:gnatsparc1320:gnatsparc1330:gnatsparc1410
+group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1240:gnatsparc1310:gnatsparc1320:gnatsparc1330:gnatsparc1410:gnatsparc1420
 group.gnatsparcs.groupName=SPARC GNAT
 group.gnatsparcs.baseName=sparc gnat
 
@@ -154,9 +164,14 @@ compiler.gnatsparc1410.semver=14.1.0
 compiler.gnatsparc1410.objdumper=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gnatsparc1410.demangler=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.gnatsparc1420.exe=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
+compiler.gnatsparc1420.semver=14.2.0
+compiler.gnatsparc1420.objdumper=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gnatsparc1420.demangler=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for sparc64
-group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641240:gnatsparc641310:gnatsparc641320:gnatsparc641330:gnatsparc641410
+group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641240:gnatsparc641310:gnatsparc641320:gnatsparc641330:gnatsparc641410:gnatsparc641420
 group.gnatsparc64s.groupName=SPARC64 GNAT
 group.gnatsparc64s.baseName=sparc64 gnat
 
@@ -195,9 +210,14 @@ compiler.gnatsparc641410.semver=14.1.0
 compiler.gnatsparc641410.objdumper=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gnatsparc641410.demangler=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.gnatsparc641420.exe=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
+compiler.gnatsparc641420.semver=14.2.0
+compiler.gnatsparc641420.objdumper=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gnatsparc641420.demangler=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 ################################
 # GNAT for riscv64
-group.gnatriscv64.compilers=gnatriscv64103:gnatriscv64112:gnatriscv641230:gnatriscv641240:gnatriscv641310:gnatriscv641320:gnatriscv641330:gnatriscv641410
+group.gnatriscv64.compilers=gnatriscv64103:gnatriscv64112:gnatriscv641230:gnatriscv641240:gnatriscv641310:gnatriscv641320:gnatriscv641330:gnatriscv641410:gnatriscv641420
 group.gnatriscv64.groupName=RISCV64 GNAT
 group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.instructionSet=riscv64
@@ -242,9 +262,14 @@ compiler.gnatriscv641410.semver=14.1.0
 compiler.gnatriscv641410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gnatriscv641410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.gnatriscv641420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
+compiler.gnatriscv641420.semver=14.2.0
+compiler.gnatriscv641420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gnatriscv641420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for s390x
-group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1240:gnats390x1310:gnats390x1320:gnats390x1330:gnats390x1410
+group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1240:gnats390x1310:gnats390x1320:gnats390x1330:gnats390x1410:gnats390x1420
 group.gnats390x.groupName=S390X GNAT
 group.gnats390x.baseName=S390X GNAT
 
@@ -290,6 +315,11 @@ compiler.gnats390x1410.semver=14.1.0
 compiler.gnats390x1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gnats390x1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.gnats390x1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1420.semver=14.2.0
+compiler.gnats390x1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gnats390x1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ################################
 # GNAT for ppc
 group.gnatppcs.compilers=&gnatppc:&gnatppc64:&gnatppc64le
@@ -297,7 +327,7 @@ group.gnatppcs.instructionSet=powerpc
 
 ## POWER
 group.gnatppc.groupName=POWERPC GNAT
-group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1240:gnatppc1310:gnatppc1320:gnatppc1330:gnatppc1410
+group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1240:gnatppc1310:gnatppc1320:gnatppc1330:gnatppc1410:gnatppc1420
 group.gnatppc.baseName=powerpc gnat
 
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
@@ -343,10 +373,15 @@ compiler.gnatppc1410.semver=14.1.0
 compiler.gnatppc1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gnatppc1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.gnatppc1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1420.semver=14.2.0
+compiler.gnatppc1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gnatppc1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ## POWER64
 group.gnatppc64.groupName=POWER64 GNAT
 group.gnatppc64.baseName=powerpc64 gnat
-group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641410
+group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641410:gnatppc641420
 
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
@@ -391,6 +426,11 @@ compiler.gnatppc641410.semver=14.1.0
 compiler.gnatppc641410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gnatppc641410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.gnatppc641420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641420.semver=14.2.0
+compiler.gnatppc641420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gnatppc641420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.gnatppc64trunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc64trunk.semver=trunk
 compiler.gnatppc64trunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -399,7 +439,7 @@ compiler.gnatppc64trunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/pow
 ## POWER64LE
 group.gnatppc64le.groupName=POWER64LE GNAT
 group.gnatppc64le.baseName=powerpc64le gnat
-group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310:gnatppc64le1320:gnatppc64letrunk:gnatppc64le1410:gnatppc64le1330:gnatppc64le1240
+group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310:gnatppc64le1320:gnatppc64letrunk:gnatppc64le1410:gnatppc64le1330:gnatppc64le1240:gnatppc64le1420
 
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1120.demangler=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
@@ -444,6 +484,11 @@ compiler.gnatppc64le1410.semver=14.1.0
 compiler.gnatppc64le1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gnatppc64le1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.gnatppc64le1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1420.semver=14.2.0
+compiler.gnatppc64le1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gnatppc64le1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.gnatppc64letrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64letrunk.semver=trunk
 compiler.gnatppc64letrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -457,7 +502,7 @@ group.gnatmipss.compilers=&gnatmips:&gnatmips64
 ## MIPS
 group.gnatmips.groupName=MIPS GNAT
 group.gnatmips.baseName=mips gnat
-group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1240:gnatmips1310:gnatmips1320:gnatmips1330:gnatmips1410
+group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1240:gnatmips1310:gnatmips1320:gnatmips1330:gnatmips1410:gnatmips1420
 
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1120.demangler=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
@@ -502,10 +547,15 @@ compiler.gnatmips1410.semver=14.1.0
 compiler.gnatmips1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gnatmips1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.gnatmips1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1420.semver=14.2.0
+compiler.gnatmips1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gnatmips1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS64
 group.gnatmips64.groupName=MIPS64 GNAT
 group.gnatmips64.baseName=mips64 gnat
-group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641240:gnatmips641310:gnatmips641320:gnatmips641330:gnatmips641410
+group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641240:gnatmips641310:gnatmips641320:gnatmips641330:gnatmips641410:gnatmips641420
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641120.demangler=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
@@ -550,9 +600,14 @@ compiler.gnatmips641410.semver=14.1.0
 compiler.gnatmips641410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gnatmips641410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.gnatmips641420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641420.semver=14.2.0
+compiler.gnatmips641420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gnatmips641420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for arm64
-group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641240:gnatarm641310:gnatarm641320:gnatarm641330:gnatarm641410
+group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641240:gnatarm641310:gnatarm641320:gnatarm641330:gnatarm641410:gnatarm641420
 group.gnatarm64.groupName=ARM64 GNAT
 group.gnatarm64.baseName=arm64 gnat
 group.gnatarm64.instructionSet=aarch64
@@ -596,9 +651,14 @@ compiler.gnatarm641410.semver=14.1.0
 compiler.gnatarm641410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gnatarm641410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.gnatarm641420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
+compiler.gnatarm641420.semver=14.2.0
+compiler.gnatarm641420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gnatarm641420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 ################################
 # GNAT for arm
-group.gnatarm.compilers=gnatarm103:gnatarm112:gnatarm1310:gnatarm1320:gnatarm1330:gnatarm1410
+group.gnatarm.compilers=gnatarm103:gnatarm112:gnatarm1310:gnatarm1320:gnatarm1330:gnatarm1410:gnatarm1420
 group.gnatarm.groupName=ARM GNAT
 group.gnatarm.baseName=arm gnat
 group.gnatarm.instructionSet=arm32
@@ -632,6 +692,11 @@ compiler.gnatarm1410.exe=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux
 compiler.gnatarm1410.semver=14.1.0
 compiler.gnatarm1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gnatarm1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.gnatarm1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gnatmake
+compiler.gnatarm1420.semver=14.2.0
+compiler.gnatarm1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gnatarm1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 #################################
 #################################

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1360,7 +1360,7 @@ compiler.m68kclangtrunk.isNightly=true
 
 
 # GCC for m68k
-group.gccm68k.compilers=m68kg1310:m68kg1320:m68kg1410:m68kg1330
+group.gccm68k.compilers=m68kg1310:m68kg1320:m68kg1410:m68kg1330:m68kg1420
 group.gccm68k.supportsBinary=true
 group.gccm68k.supportsExecute=false
 group.gccm68k.baseName=M68K gcc
@@ -1387,6 +1387,11 @@ compiler.m68kg1410.exe=/opt/compiler-explorer/m68k/gcc-14.1.0/m68k-unknown-elf/b
 compiler.m68kg1410.semver=14.1.0
 compiler.m68kg1410.objdumper=/opt/compiler-explorer/m68k/gcc-14.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
 compiler.m68kg1410.demangler=/opt/compiler-explorer/m68k/gcc-14.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
+compiler.m68kg1420.exe=/opt/compiler-explorer/m68k/gcc-14.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-g++
+compiler.m68kg1420.semver=14.2.0
+compiler.m68kg1420.objdumper=/opt/compiler-explorer/m68k/gcc-14.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
+compiler.m68kg1420.demangler=/opt/compiler-explorer/m68k/gcc-14.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
 
 ###############################
 # Cross for BPF
@@ -1429,7 +1434,7 @@ compiler.bpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.bpfclang1300.semver=13.0.0
 
 # GCC for BPF
-group.gccbpf.compilers=bpfg1310:bpfg1320:bpfg1330:bpfg1410:bpfgtrunk
+group.gccbpf.compilers=bpfg1310:bpfg1320:bpfg1330:bpfg1410:bpfg1420:bpfgtrunk
 group.gccbpf.supportsBinary=true
 group.gccbpf.supportsExecute=false
 group.gccbpf.baseName=BPF gcc
@@ -1458,6 +1463,11 @@ compiler.bpfg1410.semver=14.1.0
 compiler.bpfg1410.objdumper=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.bpfg1410.demangler=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
+compiler.bpfg1420.exe=/opt/compiler-explorer/bpf/gcc-14.2.0/bpf-unknown-none/bin/bpf-unknown-none-g++
+compiler.bpfg1420.semver=14.2.0
+compiler.bpfg1420.objdumper=/opt/compiler-explorer/bpf/gcc-14.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.bpfg1420.demangler=/opt/compiler-explorer/bpf/gcc-14.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
 compiler.bpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-g++
 compiler.bpfgtrunk.semver=trunk
 compiler.bpfgtrunk.isNightly=true
@@ -1467,7 +1477,7 @@ compiler.bpfgtrunk.isNightly=true
 group.sparc.compilers=&gccsparc
 
 # GCC for SPARC
-group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1240:sparcg1310:sparcg1320:sparcg1330:sparcg1410
+group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1240:sparcg1310:sparcg1320:sparcg1330:sparcg1410:sparcg1420
 group.gccsparc.baseName=SPARC gcc
 group.gccsparc.groupName=SPARC GCC
 group.gccsparc.isSemVer=true
@@ -1507,12 +1517,17 @@ compiler.sparcg1410.semver=14.1.0
 compiler.sparcg1410.objdumper=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.sparcg1410.demangler=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.sparcg1420.exe=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
+compiler.sparcg1420.semver=14.2.0
+compiler.sparcg1420.objdumper=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.sparcg1420.demangler=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 ###############################
 # Cross for SPARC64
 group.sparc64.compilers=&gccsparc64
 
 # GCC for SPARC64
-group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310:sparc64g1320:sparc64g1410:sparc64g1330:sparc64g1240
+group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310:sparc64g1320:sparc64g1410:sparc64g1330:sparc64g1240:sparc64g1420
 group.gccsparc64.baseName=SPARC64 gcc
 group.gccsparc64.groupName=SPARC64 GCC
 group.gccsparc64.isSemVer=true
@@ -1552,12 +1567,17 @@ compiler.sparc64g1410.semver=14.1.0
 compiler.sparc64g1410.objdumper=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.sparc64g1410.demangler=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.sparc64g1420.exe=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
+compiler.sparc64g1420.semver=14.2.0
+compiler.sparc64g1420.objdumper=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.sparc64g1420.demangler=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 ###############################
 # Cross for SPARC-LEON
 group.sparcleon.compilers=&gccsparcleon
 
 # GCC for SPARC-LEON
-group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1240:sparcleong1310:sparcleong1320:sparcleong1330:sparcleong1410
+group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1240:sparcleong1310:sparcleong1320:sparcleong1330:sparcleong1410:sparcleong1420
 group.gccsparcleon.baseName=SPARC LEON gcc
 group.gccsparcleon.groupName=SPARC LEON GCC
 group.gccsparcleon.isSemVer=true
@@ -1599,6 +1619,11 @@ compiler.sparcleong1410.semver=14.1.0
 compiler.sparcleong1410.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1410.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
+compiler.sparcleong1420.exe=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1420.semver=14.2.0
+compiler.sparcleong1420.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.sparcleong1420.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 compiler.sparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
 compiler.sparcleong1220-1.semver=12.2.0
 compiler.sparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
@@ -1609,7 +1634,7 @@ compiler.sparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0
 group.c6x.compilers=&gccc6x
 
 # GCC for TI C6x
-group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310:c6xg1320:c6xg1410:c6xg1330:c6xg1240
+group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310:c6xg1320:c6xg1410:c6xg1330:c6xg1240:c6xg1420
 group.gccc6x.baseName=TI C6x gcc
 group.gccc6x.groupName=TI C6x GCC
 group.gccc6x.isSemVer=true
@@ -1649,6 +1674,11 @@ compiler.c6xg1410.semver=14.1.0
 compiler.c6xg1410.objdumper=/opt/compiler-explorer/c6x/gcc-14.1.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.c6xg1410.demangler=/opt/compiler-explorer/c6x/gcc-14.1.0/tic6x-elf/bin/tic6x-elf-c++filt
 
+compiler.c6xg1420.exe=/opt/compiler-explorer/c6x/gcc-14.2.0/tic6x-elf/bin/tic6x-elf-g++
+compiler.c6xg1420.semver=14.2.0
+compiler.c6xg1420.objdumper=/opt/compiler-explorer/c6x/gcc-14.2.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.c6xg1420.demangler=/opt/compiler-explorer/c6x/gcc-14.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+
 ###############################
 # Cross for loongarch64
 group.loongarch64.compilers=&gccloongarch64
@@ -1656,7 +1686,7 @@ group.loongarch64.compilers=&gccloongarch64
 # GCC for loongarch64
 group.gccloongarch64.baseName=loongarch64 gcc
 group.gccloongarch64.groupName=loongarch64 gcc
-group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310:loongarch64g1320:loongarch64g1410:loongarch64g1330:loongarch64g1240
+group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310:loongarch64g1320:loongarch64g1410:loongarch64g1330:loongarch64g1240:loongarch64g1420
 group.gccloongarch64.isSemVer=true
 
 compiler.loongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
@@ -1694,6 +1724,11 @@ compiler.loongarch64g1410.semver=14.1.0
 compiler.loongarch64g1410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.loongarch64g1410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.loongarch64g1420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
+compiler.loongarch64g1420.semver=14.2.0
+compiler.loongarch64g1420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.loongarch64g1420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # Cross for sh
 group.sh.compilers=&gccsh
@@ -1701,7 +1736,7 @@ group.sh.compilers=&gccsh
 # GCC for sh
 group.gccsh.baseName=sh gcc
 group.gccsh.groupName=sh gcc
-group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1240:shg1310:shg1320:shg1330:shg1410
+group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1240:shg1310:shg1320:shg1330:shg1410:shg1420
 group.gccsh.isSemVer=true
 
 compiler.shg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-g++
@@ -1749,6 +1784,11 @@ compiler.shg1410.semver=14.1.0
 compiler.shg1410.objdumper=/opt/compiler-explorer/sh/gcc-14.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.shg1410.demangler=/opt/compiler-explorer/sh/gcc-14.1.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
+compiler.shg1420.exe=/opt/compiler-explorer/sh/gcc-14.2.0/sh-unknown-elf/bin/sh-unknown-elf-g++
+compiler.shg1420.semver=14.2.0
+compiler.shg1420.objdumper=/opt/compiler-explorer/sh/gcc-14.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg1420.demangler=/opt/compiler-explorer/sh/gcc-14.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
 ###############################
 # Cross for s390x
 group.s390x.compilers=&gccs390x
@@ -1756,7 +1796,7 @@ group.s390x.compilers=&gccs390x
 # GCC for s390x
 group.gccs390x.baseName=s390x gcc
 group.gccs390x.groupName=s390x gcc
-group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310:s390xg1320:s390xg1410:s390xg1330:s390xg1240
+group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310:s390xg1320:s390xg1410:s390xg1330:s390xg1240:s390xg1420
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
@@ -1803,6 +1843,11 @@ compiler.s390xg1410.semver=14.1.0
 compiler.s390xg1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.s390xg1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.s390xg1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.s390xg1420.semver=14.2.0
+compiler.s390xg1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.s390xg1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # Cross compilers for PPC
 group.ppcs.compilers=&ppc:&ppc64:&ppc64le
@@ -1810,7 +1855,7 @@ group.ppcs.isSemVer=true
 group.ppcs.instructionSet=powerpc
 
 ## POWER
-group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1240:ppcg1310:ppcg1320:ppcg1330:ppcg1410
+group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1240:ppcg1310:ppcg1320:ppcg1330:ppcg1410:ppcg1420
 group.ppc.groupName=POWER GCC
 group.ppc.baseName=power gcc
 
@@ -1861,10 +1906,15 @@ compiler.ppcg1410.semver=14.1.0
 compiler.ppcg1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppcg1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.ppcg1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1420.semver=14.2.0
+compiler.ppcg1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ## POWER64
 group.ppc64.groupName=POWER64 GCC
 group.ppc64.baseName=power64 gcc
-group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310:ppc64g1320:ppc64gtrunk:ppc64g1410:ppc64g1330:ppc64g1240
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310:ppc64g1320:ppc64gtrunk:ppc64g1410:ppc64g1330:ppc64g1240:ppc64g1420
 
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -1919,6 +1969,11 @@ compiler.ppc64g1410.semver=14.1.0
 compiler.ppc64g1410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g1410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.ppc64g1420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1420.semver=14.2.0
+compiler.ppc64g1420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.ppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64gtrunk.semver=trunk
 compiler.ppc64gtrunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -1938,7 +1993,7 @@ compiler.ppc64clang.compilerCategories=clang
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE GCC
-group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310:ppc64leg1320:ppc64legtrunk:ppc64leg1410:ppc64leg1330:ppc64leg1240
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310:ppc64leg1320:ppc64legtrunk:ppc64leg1410:ppc64leg1330:ppc64leg1240:ppc64leg1420
 group.ppc64le.baseName=power64le gcc
 
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
@@ -1998,6 +2053,11 @@ compiler.ppc64leg1410.semver=14.1.0
 compiler.ppc64leg1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.ppc64leg1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1420.semver=14.2.0
+compiler.ppc64leg1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.ppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64legtrunk.semver=trunk
 compiler.ppc64legtrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -2025,7 +2085,7 @@ group.gccarm.includeFlag=-I
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
 group.gcc32arm.baseName=ARM GCC
-group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1310:armg1320:armug1320:armg1330:armg1410:armgtrunk
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1310:armg1320:armug1320:armg1330:armg1410:armg1420:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -2115,6 +2175,11 @@ compiler.armg1410.semver=14.1.0
 compiler.armg1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.armg1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1420.semver=14.2.0
+compiler.armg1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.armug1320.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
 compiler.armug1320.name=ARM GCC 13.2.0 (unknown-eabi)
 compiler.armug1320.semver=13.2.0
@@ -2187,7 +2252,7 @@ compiler.armgtrunk.isNightly=true
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g494:arm64g550:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050:arm64g1320:arm64g1410:arm64g1330:arm64g1240
+group.gcc64arm.compilers=aarchg54:arm64g494:arm64g550:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050:arm64g1320:arm64g1410:arm64g1330:arm64g1240:arm64g1420
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -2286,6 +2351,11 @@ compiler.arm64g1410.exe=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-
 compiler.arm64g1410.semver=14.1.0
 compiler.arm64g1410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.arm64g1420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1420.semver=14.2.0
+compiler.arm64g1420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 compiler.arm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64gtrunk.semver=trunk
 compiler.arm64gtrunk.isNightly=true
@@ -2483,7 +2553,7 @@ compiler.cl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1310:avrg1320:avrg1330:avrg1410
+group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1310:avrg1320:avrg1330:avrg1410:avrg1420
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -2555,6 +2625,11 @@ compiler.avrg1410.exe=/opt/compiler-explorer/avr/gcc-14.1.0/avr/bin/avr-g++
 compiler.avrg1410.semver=14.1.0
 compiler.avrg1410.objdumper=/opt/compiler-explorer/avr/gcc-14.1.0/avr/bin/avr-objdump
 compiler.avrg1410.demangler=/opt/compiler-explorer/avr/gcc-14.1.0/avr/bin/avr-c++filt
+
+compiler.avrg1420.exe=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/avr-g++
+compiler.avrg1420.semver=14.2.0
+compiler.avrg1420.objdumper=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/avr-objdump
+compiler.avrg1420.demangler=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/avr-c++filt
 
 ###############################
 # Cross compiler for MIPS
@@ -2686,7 +2761,7 @@ compiler.mips64el-clang1300.semver=13.0.0
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1240:mipsg1310:mipsg1320:mipsg1330:mipsg1410
+group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1240:mipsg1310:mipsg1320:mipsg1330:mipsg1410:mipsg1420
 group.mips.baseName=mips gcc
 
 compiler.mipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
@@ -2756,9 +2831,14 @@ compiler.mipsg1410.semver=14.1.0
 compiler.mipsg1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.mipsg1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.mipsg1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg1420.semver=14.2.0
+compiler.mipsg1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips64g1410:mips64g1330:mips64g1240:mips564:mips112064
+group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips64g1410:mips64g1330:mips64g1240:mips64g1420:mips564:mips112064
 group.mips64.baseName=mips64 gcc
 
 compiler.mips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
@@ -2823,9 +2903,14 @@ compiler.mips64g1410.semver=14.1.0
 compiler.mips64g1410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.mips64g1410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.mips64g1420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g1420.semver=14.2.0
+compiler.mips64g1420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g1420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el:mipselg494:mipselg550:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1240:mipselg1310:mipselg1320:mipselg1330:mipselg1410
+group.mipsel.compilers=mips5el:mipselg494:mipselg550:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1240:mipselg1310:mipselg1320:mipselg1330:mipselg1410:mipselg1420
 group.mipsel.baseName=mipsel gcc
 
 compiler.mipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
@@ -2886,9 +2971,14 @@ compiler.mipselg1410.semver=14.1.0
 compiler.mipselg1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.mipselg1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.mipselg1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.mipselg1420.semver=14.2.0
+compiler.mipselg1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.mipselg1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips64elg1410:mips64elg1330:mips64elg1240:mips564el
+group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips64elg1410:mips64elg1330:mips64elg1240:mips64elg1420:mips564el
 group.mips64el.baseName=mips64 (el) gcc
 group.mips64el.compilerCategories=gcc
 
@@ -2950,6 +3040,11 @@ compiler.mips64elg1410.semver=14.1.0
 compiler.mips64elg1410.objdumper=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.mips64elg1410.demangler=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
+compiler.mips64elg1420.exe=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.mips64elg1420.semver=14.2.0
+compiler.mips64elg1420.objdumper=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.mips64elg1420.demangler=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 ###############################
 # GCC for nanoMIPS
 group.nanomips.compilers=nanomips630
@@ -2984,7 +3079,7 @@ group.rvgcc.supportsBinary=true
 group.rvgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 32-bits
-group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310:rv64-gcc1320:rv64-gcc1410:rv64-gcc1330:rv64-gcc1240
+group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310:rv64-gcc1320:rv64-gcc1410:rv64-gcc1330:rv64-gcc1240:rv64-gcc1420
 group.rv64gcc.groupName=RISC-V (64-bits) gcc
 group.rv64gcc.baseName=RISC-V (64-bits) gcc
 
@@ -3061,6 +3156,11 @@ compiler.rv64-gcc1410.semver=14.1.0
 compiler.rv64-gcc1410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gcc1410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.rv64-gcc1420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1420.semver=14.2.0
+compiler.rv64-gcc1420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc1420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.rv64-gcctrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcctrunk.semver=(trunk)
 compiler.rv64-gcctrunk.isNightly=true
@@ -3068,7 +3168,7 @@ compiler.rv64-gcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv6
 compiler.rv64-gcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ## GCC for RISC-V 32-bits
-group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310:rv32-gcc1320:rv32-gcc1410:rv32-gcc1330:rv32-gcc1240
+group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310:rv32-gcc1320:rv32-gcc1410:rv32-gcc1330:rv32-gcc1240:rv32-gcc1420
 group.rv32gcc.groupName=RISC-V (32-bits) gcc
 group.rv32gcc.baseName=RISC-V (32-bits) gcc
 
@@ -3143,6 +3243,11 @@ compiler.rv32-gcc1410.exe=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unkn
 compiler.rv32-gcc1410.semver=14.1.0
 compiler.rv32-gcc1410.objdumper=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gcc1410.demangler=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-gcc1420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1420.semver=14.2.0
+compiler.rv32-gcc1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1420.demangler=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-gcctrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.rv32-gcctrunk.semver=(trunk)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1031,7 +1031,7 @@ compiler.cbpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.cbpfclang1300.semver=13.0.0
 
 # GCC for BPF
-group.cgccbpf.compilers=cbpfg1310:cbpfg1320:cbpfg1330:cbpfg1410:cbpfgtrunk
+group.cgccbpf.compilers=cbpfg1310:cbpfg1320:cbpfg1330:cbpfg1410:cbpfg1420:cbpfgtrunk
 group.cgccbpf.supportsBinary=true
 group.cgccbpf.supportsExecute=false
 group.cgccbpf.baseName=BPF gcc
@@ -1058,6 +1058,11 @@ compiler.cbpfg1410.exe=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bi
 compiler.cbpfg1410.semver=14.1.0
 compiler.cbpfg1410.objdumper=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.cbpfg1410.demangler=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
+compiler.cbpfg1420.exe=/opt/compiler-explorer/bpf/gcc-14.2.0/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.cbpfg1420.semver=14.2.0
+compiler.cbpfg1420.objdumper=/opt/compiler-explorer/bpf/gcc-14.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.cbpfg1420.demangler=/opt/compiler-explorer/bpf/gcc-14.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 compiler.cbpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-gcc
 compiler.cbpfgtrunk.semver=trunk
@@ -1088,7 +1093,7 @@ compiler.cm68kclangtrunk.semver=(trunk)
 compiler.cm68kclangtrunk.isNightly=true
 
 # GCC for m68k
-group.cgccm68k.compilers=cm68kg1310:cm68kg1320:cm68kg1410:cm68kg1330
+group.cgccm68k.compilers=cm68kg1310:cm68kg1320:cm68kg1410:cm68kg1330:cm68kg1420
 group.cgccm68k.supportsBinary=true
 group.cgccm68k.supportsExecute=false
 group.cgccm68k.baseName=M68K gcc
@@ -1116,12 +1121,17 @@ compiler.cm68kg1410.semver=14.1.0
 compiler.cm68kg1410.objdumper=/opt/compiler-explorer/m68k/gcc-14.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
 compiler.cm68kg1410.demangler=/opt/compiler-explorer/m68k/gcc-14.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
 
+compiler.cm68kg1420.exe=/opt/compiler-explorer/m68k/gcc-14.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-gcc
+compiler.cm68kg1420.semver=14.2.0
+compiler.cm68kg1420.objdumper=/opt/compiler-explorer/m68k/gcc-14.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
+compiler.cm68kg1420.demangler=/opt/compiler-explorer/m68k/gcc-14.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
 ###############################
 # Cross for SPARC
 group.csparc.compilers=&cgccsparc
 
 # GCC for SPARC
-group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1240:csparcg1310:csparcg1320:csparcg1330:csparcg1410
+group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1240:csparcg1310:csparcg1320:csparcg1330:csparcg1410:csparcg1420
 group.cgccsparc.baseName=SPARC gcc
 group.cgccsparc.groupName=SPARC GCC
 group.cgccsparc.isSemVer=true
@@ -1161,12 +1171,17 @@ compiler.csparcg1410.semver=14.1.0
 compiler.csparcg1410.objdumper=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.csparcg1410.demangler=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.csparcg1420.exe=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.csparcg1420.semver=14.2.0
+compiler.csparcg1420.objdumper=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.csparcg1420.demangler=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 ###############################
 # Cross for SPARC64
 group.csparc64.compilers=&cgccsparc64
 
 # GCC for SPARC64
-group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310:csparc64g1320:csparc64g1410:csparc64g1330:csparc64g1240
+group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310:csparc64g1320:csparc64g1410:csparc64g1330:csparc64g1240:csparc64g1420
 group.cgccsparc64.baseName=SPARC64 gcc
 group.cgccsparc64.groupName=SPARC64 GCC
 group.cgccsparc64.isSemVer=true
@@ -1206,12 +1221,17 @@ compiler.csparc64g1410.semver=14.1.0
 compiler.csparc64g1410.objdumper=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.csparc64g1410.demangler=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.csparc64g1420.exe=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.csparc64g1420.semver=14.2.0
+compiler.csparc64g1420.objdumper=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.csparc64g1420.demangler=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 ###############################
 # Cross for SPARC-LEON
 group.csparcleon.compilers=&cgccsparcleon
 
 # GCC for SPARC-LEON
-group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1240:csparcleong1310:csparcleong1320:csparcleong1330:csparcleong1410
+group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1240:csparcleong1310:csparcleong1320:csparcleong1330:csparcleong1410:csparcleong1420
 group.cgccsparcleon.baseName=SPARC LEON gcc
 group.cgccsparcleon.groupName=SPARC LEON GCC
 group.cgccsparcleon.isSemVer=true
@@ -1253,6 +1273,11 @@ compiler.csparcleong1410.semver=14.1.0
 compiler.csparcleong1410.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.csparcleong1410.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
+compiler.csparcleong1420.exe=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.csparcleong1420.semver=14.2.0
+compiler.csparcleong1420.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.csparcleong1420.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 compiler.csparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.csparcleong1220-1.semver=12.2.0
 compiler.csparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
@@ -1263,7 +1288,7 @@ compiler.csparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.
 group.cc6x.compilers=&cgccc6x
 
 # GCC for TI C6x
-group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310:cc6xg1320:cc6xg1410:cc6xg1330:cc6xg1240
+group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310:cc6xg1320:cc6xg1410:cc6xg1330:cc6xg1240:cc6xg1420
 group.cgccc6x.baseName=TI C6x gcc
 group.cgccc6x.groupName=TI C6x GCC
 group.cgccc6x.isSemVer=true
@@ -1303,12 +1328,17 @@ compiler.cc6xg1410.semver=14.1.0
 compiler.cc6xg1410.objdumper=/opt/compiler-explorer/c6x/gcc-14.1.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.cc6xg1410.demangler=/opt/compiler-explorer/c6x/gcc-14.1.0/tic6x-elf/bin/tic6x-elf-c++filt
 
+compiler.cc6xg1420.exe=/opt/compiler-explorer/c6x/gcc-14.2.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.cc6xg1420.semver=14.2.0
+compiler.cc6xg1420.objdumper=/opt/compiler-explorer/c6x/gcc-14.2.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.cc6xg1420.demangler=/opt/compiler-explorer/c6x/gcc-14.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+
 ###############################
 # Cross for loongarch64
 group.cloongarch64.compilers=&cgccloongarch64
 
 # GCC for loongarch64
-group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310:cloongarch64g1320:cloongarch64g1410:cloongarch64g1330:cloongarch64g1240
+group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310:cloongarch64g1320:cloongarch64g1410:cloongarch64g1330:cloongarch64g1240:cloongarch64g1420
 group.cgccloongarch64.baseName=loongarch64 gcc
 group.cgccloongarch64.groupName=loongarch64 GCC
 group.cgccloongarch64.isSemVer=true
@@ -1348,12 +1378,17 @@ compiler.cloongarch64g1410.semver=14.1.0
 compiler.cloongarch64g1410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.cloongarch64g1410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.cloongarch64g1420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.cloongarch64g1420.semver=14.2.0
+compiler.cloongarch64g1420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.cloongarch64g1420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # Cross for sh
 group.csh.compilers=&cgccsh
 
 # GCC for sh
-group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1240:cshg1310:cshg1320:cshg1330:cshg1410
+group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1240:cshg1310:cshg1320:cshg1330:cshg1410:cshg1420
 group.cgccsh.baseName=sh gcc
 group.cgccsh.groupName=sh GCC
 group.cgccsh.isSemVer=true
@@ -1403,12 +1438,17 @@ compiler.cshg1410.semver=14.1.0
 compiler.cshg1410.objdumper=/opt/compiler-explorer/sh/gcc-14.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.cshg1410.demangler=/opt/compiler-explorer/sh/gcc-14.1.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
+compiler.cshg1420.exe=/opt/compiler-explorer/sh/gcc-14.2.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.cshg1420.semver=14.2.0
+compiler.cshg1420.objdumper=/opt/compiler-explorer/sh/gcc-14.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg1420.demangler=/opt/compiler-explorer/sh/gcc-14.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
 ###############################
 # Cross for s390x
 group.cs390x.compilers=&cgccs390x
 
 # GCC for s390x
-group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310:cs390xg1320:cs390xg1410:cs390xg1330:cs390xg1240
+group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310:cs390xg1320:cs390xg1410:cs390xg1330:cs390xg1240:cs390xg1420
 group.cgccs390x.baseName=s390x gcc
 group.cgccs390x.groupName=s390x GCC
 group.cgccs390x.isSemVer=true
@@ -1456,13 +1496,18 @@ compiler.cs390xg1410.semver=14.1.0
 compiler.cs390xg1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.cs390xg1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.cs390xg1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cs390xg1420.semver=14.2.0
+compiler.cs390xg1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.cs390xg1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # Cross compilers for PPC
 group.cppcs.compilers=&cppc:&cppc64:&cppc64le
 group.cppcs.isSemVer=true
 group.cppcs.instructionSet=powerpc
 
-group.cppc.compilers=cppcg48:cppcg1120:cppcg1210:cppcg1220:cppcg1230:cppcg1240:cppcg1310:cppcg1320:cppcg1330:cppcg1410
+group.cppc.compilers=cppcg48:cppcg1120:cppcg1210:cppcg1220:cppcg1230:cppcg1240:cppcg1310:cppcg1320:cppcg1330:cppcg1410:cppcg1420
 group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
@@ -1513,7 +1558,12 @@ compiler.cppcg1410.semver=14.1.0
 compiler.cppcg1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310:cppc64g1320:cppc64gtrunk:cppc64g1410:cppc64g1330:cppc64g1240
+compiler.cppcg1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1420.semver=14.2.0
+compiler.cppcg1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310:cppc64g1320:cppc64gtrunk:cppc64g1410:cppc64g1330:cppc64g1240:cppc64g1420
 group.cppc64.groupName=POWER64
 group.cppc64.baseName=POWER64 gcc
 
@@ -1570,6 +1620,11 @@ compiler.cppc64g1410.semver=14.1.0
 compiler.cppc64g1410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.cppc64g1420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1420.semver=14.2.0
+compiler.cppc64g1420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.cppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64gtrunk.semver=trunk
 compiler.cppc64gtrunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -1584,7 +1639,7 @@ compiler.cppc64clang.semver=(snapshot)
 compiler.cppc64clang.isNightly=true
 compiler.cppc64clang.compilerCategories=clang
 
-group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310:cppc64leg1320:cppc64legtrunk:cppc64leg1410:cppc64leg1330:cppc64leg1240
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310:cppc64leg1320:cppc64legtrunk:cppc64leg1410:cppc64leg1330:cppc64leg1240:cppc64leg1420
 group.cppc64le.groupName=POWER64LE GCC
 group.cppc64le.baseName=power64le gcc
 
@@ -1645,6 +1700,11 @@ compiler.cppc64leg1410.semver=14.1.0
 compiler.cppc64leg1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.cppc64leg1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1420.semver=14.2.0
+compiler.cppc64leg1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.cppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64legtrunk.semver=trunk
 compiler.cppc64legtrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -1671,7 +1731,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1310:carmg1320:carmug1320:carmg1330:carmg1410:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1310:carmg1320:carmug1320:carmg1330:carmg1410:carmg1420:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -1748,6 +1808,11 @@ compiler.carmg1410.semver=14.1.0
 compiler.carmg1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.carmg1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.carmg1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1420.semver=14.2.0
+compiler.carmg1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.carmug1320.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
 compiler.carmug1320.name=ARM GCC 13.2.0 (unknown-eabi)
 compiler.carmug1320.semver=13.2.0
@@ -1801,7 +1866,7 @@ compiler.carmgtrunk.isNightly=true
 # 64 bit
 group.cgcc64arm.groupName=ARM64 gcc
 group.cgcc64arm.baseName=ARM64 GCC
-group.cgcc64arm.compilers=caarchg54:carm64g494:carm64g550:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050:carm64g1320:carm64g1410:carm64g1330:carm64g1240
+group.cgcc64arm.compilers=caarchg54:carm64g494:carm64g550:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050:carm64g1320:carm64g1410:carm64g1330:carm64g1240:carm64g1420
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -1898,6 +1963,11 @@ compiler.carm64g1410.exe=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown
 compiler.carm64g1410.semver=14.1.0
 compiler.carm64g1410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.carm64g1420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1420.semver=14.2.0
+compiler.carm64g1420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.carm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64gtrunk.semver=trunk
@@ -2061,7 +2131,7 @@ compiler.carduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hard
 
 ################################
 # GCC for MSP
-group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220:cmsp430g1230:cmsp430g1310:cmsp430g1320:cmsp430g1410:cmsp430g1330:cmsp430g1240
+group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220:cmsp430g1230:cmsp430g1310:cmsp430g1320:cmsp430g1410:cmsp430g1330:cmsp430g1240:cmsp430g1420
 group.cmsp.groupName=MSP GCC
 group.cmsp.baseName=MSP430 gcc
 group.cmsp.isSemVer=true
@@ -2115,6 +2185,11 @@ compiler.cmsp430g1410.semver=14.1.0
 compiler.cmsp430g1410.objdumper=/opt/compiler-explorer/msp430/gcc-14.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
 compiler.cmsp430g1410.demangler=/opt/compiler-explorer/msp430/gcc-14.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
 
+compiler.cmsp430g1420.exe=/opt/compiler-explorer/msp430/gcc-14.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.cmsp430g1420.semver=14.2.0
+compiler.cmsp430g1420.objdumper=/opt/compiler-explorer/msp430/gcc-14.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.cmsp430g1420.demangler=/opt/compiler-explorer/msp430/gcc-14.2.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
 ################################
 # CL430 (Texas Instruments MSP430 compiler)
 group.ccl430.compilers=ccl4302161
@@ -2133,7 +2208,7 @@ compiler.ccl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1310:cavrg1320:cavrg1330:cavrg1410
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1310:cavrg1320:cavrg1330:cavrg1410:cavrg1420
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -2203,6 +2278,11 @@ compiler.cavrg1410.exe=/opt/compiler-explorer/avr/gcc-14.1.0/avr/bin/avr-gcc
 compiler.cavrg1410.semver=14.1.0
 compiler.cavrg1410.objdumper=/opt/compiler-explorer/avr/gcc-14.1.0/avr/bin/avr-objdump
 compiler.cavrg1410.demangler=/opt/compiler-explorer/avr/gcc-14.1.0/avr/bin/avr-c++filt
+
+compiler.cavrg1420.exe=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/avr-gcc
+compiler.cavrg1420.semver=14.2.0
+compiler.cavrg1420.objdumper=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/avr-objdump
+compiler.cavrg1420.demangler=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/avr-c++filt
 
 ###############################
 # Cross compilers for MIPS
@@ -2336,7 +2416,7 @@ compiler.mips64el-cclang1300.semver=13.0.0
 
 # GCC for all MIPS
 ## MIPS
-group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1240:cmipsg1310:cmipsg1320:cmipsg1330:cmipsg1410
+group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1240:cmipsg1310:cmipsg1320:cmipsg1330:cmipsg1410:cmipsg1420
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
 
@@ -2407,9 +2487,14 @@ compiler.cmipsg1410.semver=14.1.0
 compiler.cmipsg1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.cmipsg1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.cmipsg1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg1420.semver=14.2.0
+compiler.cmipsg1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips64g1410:cmips64g1330:cmips64g1240:cmips564:cmips112064
+group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips64g1410:cmips64g1330:cmips64g1240:cmips64g1420:cmips564:cmips112064
 group.cmips64.baseName=mips64 gcc
 
 compiler.cmips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -2474,9 +2559,14 @@ compiler.cmips64g1410.semver=14.1.0
 compiler.cmips64g1410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.cmips64g1410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.cmips64g1420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g1420.semver=14.2.0
+compiler.cmips64g1420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g1420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el:cmipselg494:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1240:cmipselg1310:cmipselg1320:cmipselg1330:cmipselg1410
+group.cmipsel.compilers=cmips5el:cmipselg494:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1240:cmipselg1310:cmipselg1320:cmipselg1330:cmipselg1410:cmipselg1420
 group.cmipsel.baseName=mips (el) gcc
 
 compiler.cmipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
@@ -2537,9 +2627,14 @@ compiler.cmipselg1410.semver=14.1.0
 compiler.cmipselg1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.cmipselg1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.cmipselg1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.cmipselg1420.semver=14.2.0
+compiler.cmipselg1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.cmipselg1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips64elg1410:cmips64elg1330:cmips64elg1240:cmips564el
+group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips64elg1410:cmips64elg1330:cmips64elg1240:cmips64elg1420:cmips564el
 group.cmips64el.baseName=mips64 (el) gcc
 
 compiler.cmips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
@@ -2600,6 +2695,11 @@ compiler.cmips64elg1410.semver=14.1.0
 compiler.cmips64elg1410.objdumper=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.cmips64elg1410.demangler=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
+compiler.cmips64elg1420.exe=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.cmips64elg1420.semver=14.2.0
+compiler.cmips64elg1420.objdumper=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.cmips64elg1420.demangler=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 ###############################
 # GCC for nanoMIPS
 group.cnanomips.compilers=cnanomips630
@@ -2635,7 +2735,7 @@ group.rvcgcc.supportsBinary=true
 group.rvcgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 64-bits
-group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310:rv64-cgcc1320:rv64-cgcc1410:rv64-cgcc1330:rv64-cgcc1240
+group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310:rv64-cgcc1320:rv64-cgcc1410:rv64-cgcc1330:rv64-cgcc1240:rv64-cgcc1420
 group.rv64-cgccs.groupName=RISC-V (64-bits) gcc
 group.rv64-cgccs.baseName=RISC-V (64-bits) gcc
 
@@ -2712,6 +2812,11 @@ compiler.rv64-cgcc1410.semver=14.1.0
 compiler.rv64-cgcc1410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.rv64-cgcc1420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1420.semver=14.2.0
+compiler.rv64-cgcc1420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.rv64-cgcctrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcctrunk.semver=(trunk)
 compiler.rv64-cgcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -2719,7 +2824,7 @@ compiler.rv64-cgcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv
 compiler.rv64-cgcctrunk.isNightly=true
 
 ## GCC for RISC-V 32-bits
-group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230:rv32-cgcc1320:rv32-cgcc1410:rv32-cgcc1330:rv32-cgcc1240
+group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230:rv32-cgcc1320:rv32-cgcc1410:rv32-cgcc1330:rv32-cgcc1240:rv32-cgcc1420
 group.rv32-cgccs.groupName=RISC-V (32-bits) gcc
 group.rv32-cgccs.baseName=RISC-V (32-bits) gcc
 
@@ -2794,6 +2899,11 @@ compiler.rv32-cgcc1410.exe=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unk
 compiler.rv32-cgcc1410.semver=14.1.0
 compiler.rv32-cgcc1410.objdumper=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-cgcc1410.demangler=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-cgcc1420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1420.semver=14.2.0
+compiler.rv32-cgcc1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1420.demangler=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-cgcctrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.rv32-cgcctrunk.semver=(trunk)

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -69,7 +69,7 @@ group.gdccross.supportsBinary=true
 group.gdccross.supportsBinaryObject=true
 
 ### GDC for Loongarch64
-group.gdcloongarch64.compilers=gdcloongarch641410
+group.gdcloongarch64.compilers=gdcloongarch641410:gdcloongarch641420
 group.gdcloongarch64.groupName=GDC loongarch64
 group.gdcloongarch64.includeFlag=-isystem
 group.gdcloongarch64.isSemVer=true
@@ -80,8 +80,13 @@ compiler.gdcloongarch641410.semver=14.1.0
 compiler.gdcloongarch641410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.gdcloongarch641410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.gdcloongarch641420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gdc
+compiler.gdcloongarch641420.semver=14.2.0
+compiler.gdcloongarch641420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gdcloongarch641420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 ### GDC for RISCV32
-group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220:gdcriscv1230:gdcriscv1240:gdcriscv1310:gdcriscv1320:gdcriscv1330:gdcriscv1410
+group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220:gdcriscv1230:gdcriscv1240:gdcriscv1310:gdcriscv1320:gdcriscv1330:gdcriscv1410:gdcriscv1420
 group.gdcriscv.groupName=GDC riscv
 group.gdcriscv.includeFlag=-isystem
 group.gdcriscv.isSemVer=true
@@ -122,13 +127,18 @@ compiler.gdcriscv1410.semver=14.1.0
 compiler.gdcriscv1410.objdumper=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.gdcriscv1410.demangler=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
+compiler.gdcriscv1420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
+compiler.gdcriscv1420.semver=14.2.0
+compiler.gdcriscv1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.gdcriscv1420.demangler=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
 compiler.gdcriscv32trunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
 compiler.gdcriscv32trunk.semver=trunk
 compiler.gdcriscv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.gdcriscv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 ### GDC for RISCV64
-group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220:gdcriscv641230:gdcriscv641240:gdcriscv641310:gdcriscv641320:gdcriscv641330:gdcriscv641410
+group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220:gdcriscv641230:gdcriscv641240:gdcriscv641310:gdcriscv641320:gdcriscv641330:gdcriscv641410:gdcriscv641420
 group.gdcriscv64.groupName=GDC riscv64
 group.gdcriscv64.includeFlag=-isystem
 group.gdcriscv64.isSemVer=true
@@ -169,6 +179,11 @@ compiler.gdcriscv641410.semver=14.1.0
 compiler.gdcriscv641410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gdcriscv641410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.gdcriscv641420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
+compiler.gdcriscv641420.semver=14.2.0
+compiler.gdcriscv641420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gdcriscv641420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.gdcriscv64trunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
 compiler.gdcriscv64trunk.semver=trunk
 compiler.gdcriscv64trunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -176,7 +191,7 @@ compiler.gdcriscv64trunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/risc
 compiler.gdcriscv64trunk.isNightly=true
 
 ### GDC for ARM64
-group.gdcarm64.compilers=gdcarm641220:gdcarm641230:gdcarm641240:gdcarm641310:gdcarm641320:gdcarm641330:gdcarm641410
+group.gdcarm64.compilers=gdcarm641220:gdcarm641230:gdcarm641240:gdcarm641310:gdcarm641320:gdcarm641330:gdcarm641410:gdcarm641420
 group.gdcarm64.groupName=GDC arm64
 group.gdcarm64.includeFlag=-isystem
 group.gdcarm64.isSemVer=true
@@ -217,8 +232,13 @@ compiler.gdcarm641410.semver=14.1.0
 compiler.gdcarm641410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gdcarm641410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.gdcarm641420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gdc
+compiler.gdcarm641420.semver=14.2.0
+compiler.gdcarm641420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gdcarm641420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 ### GDC for ARM 32-bits
-group.gdcarm.compilers=gdcarm1220:gdcarm1230:gdcarm1240:gdcarm1310:gdcarm1320:gdcarm1330:gdcarm1410
+group.gdcarm.compilers=gdcarm1220:gdcarm1230:gdcarm1240:gdcarm1310:gdcarm1320:gdcarm1330:gdcarm1410:gdcarm1420
 group.gdcarm.groupName=GDC arm
 group.gdcarm.includeFlag=-isystem
 group.gdcarm.isSemVer=true
@@ -259,8 +279,13 @@ compiler.gdcarm1410.semver=14.1.0
 compiler.gdcarm1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gdcarm1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.gdcarm1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gdc
+compiler.gdcarm1420.semver=14.2.0
+compiler.gdcarm1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gdcarm1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 ### GDC for s390x
-group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220:gdcs390x1230:gdcs390x1310:gdcs390x1320:gdcs390x1410:gdcs390x1330:gdcs390x1240
+group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220:gdcs390x1230:gdcs390x1310:gdcs390x1320:gdcs390x1410:gdcs390x1330:gdcs390x1240:gdcs390x1420
 group.gdcs390x.groupName=GDC s390x
 group.gdcs390x.includeFlag=-isystem
 group.gdcs390x.isSemVer=true
@@ -305,8 +330,13 @@ compiler.gdcs390x1410.semver=14.1.0
 compiler.gdcs390x1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gdcs390x1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.gdcs390x1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
+compiler.gdcs390x1420.semver=14.2.0
+compiler.gdcs390x1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gdcs390x1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ### GDC for powerpc
-group.gdcppc.compilers=gdcppc1210:gdcppc1220:gdcppc1230:gdcppc1240:gdcppc1310:gdcppc1320:gdcppc1330:gdcppc1410
+group.gdcppc.compilers=gdcppc1210:gdcppc1220:gdcppc1230:gdcppc1240:gdcppc1310:gdcppc1320:gdcppc1330:gdcppc1410:gdcppc1420
 group.gdcppc.groupName=GDC powerpc
 group.gdcppc.includeFlag=-isystem
 group.gdcppc.isSemVer=true
@@ -352,8 +382,13 @@ compiler.gdcppc1410.semver=14.1.0
 compiler.gdcppc1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gdcppc1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.gdcppc1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
+compiler.gdcppc1420.semver=14.2.0
+compiler.gdcppc1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gdcppc1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ### GDC for powerpc64
-group.gdcppc64.compilers=gdcppc64trunk:gdcppc641210:gdcppc641220:gdcppc641230:gdcppc641240:gdcppc641310:gdcppc641320:gdcppc641330:gdcppc641410
+group.gdcppc64.compilers=gdcppc64trunk:gdcppc641210:gdcppc641220:gdcppc641230:gdcppc641240:gdcppc641310:gdcppc641320:gdcppc641330:gdcppc641410:gdcppc641420
 group.gdcppc64.groupName=GDC powerpc64
 group.gdcppc64.includeFlag=-isystem
 group.gdcppc64.isSemVer=true
@@ -398,13 +433,18 @@ compiler.gdcppc641410.semver=14.1.0
 compiler.gdcppc641410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gdcppc641410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.gdcppc641420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
+compiler.gdcppc641420.semver=14.2.0
+compiler.gdcppc641420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gdcppc641420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.gdcppc64trunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
 compiler.gdcppc64trunk.semver=trunk
 compiler.gdcppc64trunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gdcppc64trunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 ### GDC for powerpc64le
-group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220:gdcppc64le1230:gdcppc64le1310:gdcppc64le1320:gdcppc64letrunk:gdcppc64le1410:gdcppc64le1330:gdcppc64le1240
+group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220:gdcppc64le1230:gdcppc64le1310:gdcppc64le1320:gdcppc64letrunk:gdcppc64le1410:gdcppc64le1330:gdcppc64le1240:gdcppc64le1420
 group.gdcppc64le.groupName=GDC powerpc64le
 group.gdcppc64le.includeFlag=-isystem
 group.gdcppc64le.isSemVer=true
@@ -449,13 +489,18 @@ compiler.gdcppc64le1410.semver=14.1.0
 compiler.gdcppc64le1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gdcppc64le1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.gdcppc64le1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
+compiler.gdcppc64le1420.semver=14.2.0
+compiler.gdcppc64le1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gdcppc64le1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.gdcppc64letrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
 compiler.gdcppc64letrunk.semver=trunk
 compiler.gdcppc64letrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gdcppc64letrunk.demangler=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 ### GDC for mips64
-group.gdcmips64.compilers=gdcmips641210:gdcmips641220:gdcmips641230:gdcmips641240:gdcmips641310:gdcmips641320:gdcmips641330:gdcmips641410
+group.gdcmips64.compilers=gdcmips641210:gdcmips641220:gdcmips641230:gdcmips641240:gdcmips641310:gdcmips641320:gdcmips641330:gdcmips641410:gdcmips641420
 group.gdcmips64.groupName=GDC mips64
 group.gdcmips64.includeFlag=-isystem
 group.gdcmips64.isSemVer=true
@@ -500,8 +545,13 @@ compiler.gdcmips641410.semver=14.1.0
 compiler.gdcmips641410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gdcmips641410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.gdcmips641420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
+compiler.gdcmips641420.semver=14.2.0
+compiler.gdcmips641420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gdcmips641420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ### GDC for mips
-group.gdcmips.compilers=gdcmips1210:gdcmips1220:gdcmips1230:gdcmips1240:gdcmips1310:gdcmips1320:gdcmips1330:gdcmips1410
+group.gdcmips.compilers=gdcmips1210:gdcmips1220:gdcmips1230:gdcmips1240:gdcmips1310:gdcmips1320:gdcmips1330:gdcmips1410:gdcmips1420
 group.gdcmips.groupName=GDC mips
 group.gdcmips.includeFlag=-isystem
 group.gdcmips.isSemVer=true
@@ -546,8 +596,13 @@ compiler.gdcmips1410.semver=14.1.0
 compiler.gdcmips1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gdcmips1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.gdcmips1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
+compiler.gdcmips1420.semver=14.2.0
+compiler.gdcmips1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gdcmips1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ### GDC for mipsel
-group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220:gdcmipsel1230:gdcmipsel1240:gdcmipsel1310:gdcmipsel1320:gdcmipsel1330:gdcmipsel1410
+group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220:gdcmipsel1230:gdcmipsel1240:gdcmipsel1310:gdcmipsel1320:gdcmipsel1330:gdcmipsel1410:gdcmipsel1420
 group.gdcmipsel.groupName=GDC mipsel
 group.gdcmipsel.includeFlag=-isystem
 group.gdcmipsel.isSemVer=true
@@ -591,6 +646,11 @@ compiler.gdcmipsel1410.exe=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multi
 compiler.gdcmipsel1410.semver=14.1.0
 compiler.gdcmipsel1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gdcmipsel1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gdcmipsel1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
+compiler.gdcmipsel1420.semver=14.2.0
+compiler.gdcmipsel1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gdcmipsel1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 group.ldc.compilers=ldc017:ldc100:ldc110:ldc120:ldc130:ldc140:ldc150:ldc160:ldc170:ldc180:ldc190:ldc1_10:ldc1_11:ldc1_12:ldc1_13:ldc1_14:ldc1_15:ldc1_16:ldc1_17:ldc1_18:ldc1_19:ldc1_20:ldc1_21:ldc1_22:ldc1_23:ldc1_24:ldc1_25:ldc1_26:ldc1_27:ldc1_28:ldc1_29:ldc1_30:ldc1_31:ldc1_32:ldc1_33:ldc1_34:ldc1_35:ldc1_36:ldc1_37:ldc1_38:ldc1_39:ldcbeta:ldclatestci
 group.ldc.compilerType=ldc

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -267,7 +267,7 @@ group.cross.groupName=Cross GCC
 
 ###############################
 # GCC for SPARC
-group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1410
+group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1410:fsparcg1420
 group.gccsparc.groupName=SPARC gfortran
 group.gccsparc.baseName=SPARC gfortran
 
@@ -306,9 +306,14 @@ compiler.fsparcg1410.semver=14.1.0
 compiler.fsparcg1410.objdumper=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.fsparcg1410.demangler=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.fsparcg1420.exe=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
+compiler.fsparcg1420.semver=14.2.0
+compiler.fsparcg1420.objdumper=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.fsparcg1420.demangler=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for SPARC64
-group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240
+group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240:fsparc64g1420
 group.gccsparc64.groupName=SPARC64 gfortran
 group.gccsparc64.baseName=SPARC64 gfortran
 
@@ -347,9 +352,14 @@ compiler.fsparc64g1410.semver=14.1.0
 compiler.fsparc64g1410.objdumper=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.fsparc64g1410.demangler=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.fsparc64g1420.exe=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
+compiler.fsparc64g1420.semver=14.2.0
+compiler.fsparc64g1420.objdumper=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.fsparc64g1420.demangler=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 ###############################
 # GCC for SPARC LEON
-group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1410
+group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1410:fsparcleong1420
 group.gccsparcleon.groupName=SPARC LEON gfortran
 group.gccsparcleon.baseName=SPARC LEON gfortran
 
@@ -395,9 +405,14 @@ compiler.fsparcleong1410.semver=14.1.0
 compiler.fsparcleong1410.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.fsparcleong1410.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
+compiler.fsparcleong1420.exe=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
+compiler.fsparcleong1420.semver=14.2.0
+compiler.fsparcleong1420.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.fsparcleong1420.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 ###############################
 # GCC for LOONGARCH64
-group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240
+group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240:floongarch64g1420
 group.gccloongarch64.groupName=LOONGARCH64 gfortran
 group.gccloongarch64.baseName=LOONGARCH64 gfortran
 
@@ -436,9 +451,14 @@ compiler.floongarch64g1410.semver=14.1.0
 compiler.floongarch64g1410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.floongarch64g1410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.floongarch64g1420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
+compiler.floongarch64g1420.semver=14.2.0
+compiler.floongarch64g1420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.floongarch64g1420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for RISCV64
-group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240
+group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240:friscv64g1420
 group.gccriscv64.groupName=RISCV64 gfortran
 group.gccriscv64.baseName=RISCV64 gfortran
 
@@ -482,9 +502,14 @@ compiler.friscv64g1410.semver=14.1.0
 compiler.friscv64g1410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.friscv64g1410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.friscv64g1420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.friscv64g1420.semver=14.2.0
+compiler.friscv64g1420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.friscv64g1420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for RISCV
-group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1310:friscvg1320:friscvg1330:friscvg1410
+group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1310:friscvg1320:friscvg1330:friscvg1410:friscvg1420
 group.gccriscv.groupName=RISCV (32bit) gfortran
 group.gccriscv.baseName=RISCV (32bit) gfortran
 
@@ -528,9 +553,14 @@ compiler.friscvg1410.semver=14.1.0
 compiler.friscvg1410.objdumper=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.friscvg1410.demangler=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
+compiler.friscvg1420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
+compiler.friscvg1420.semver=14.2.0
+compiler.friscvg1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.friscvg1420.demangler=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1310:farmg1320:farmg1330:farmg1410
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1310:farmg1320:farmg1330:farmg1410:farmg1420
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
 
@@ -591,9 +621,14 @@ compiler.farmg1410.semver=14.1.0
 compiler.farmg1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.farmg1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.farmg1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1420.semver=14.2.0
+compiler.farmg1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 ###############################
 ## GCC for s390x
-group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240
+group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240:fs390xg1420
 group.gccs390x.groupName=s390x gfortran
 group.gccs390x.baseName=s390x gfortran
 
@@ -636,6 +671,11 @@ compiler.fs390xg1410.semver=14.1.0
 compiler.fs390xg1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.fs390xg1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.fs390xg1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
+compiler.fs390xg1420.semver=14.2.0
+compiler.fs390xg1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.fs390xg1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # LLVM Flang for X86
 group.clang_llvmflang.compilers=flangtrunk:flangtrunknew:flangtrunknew-fc
@@ -664,7 +704,7 @@ compiler.flangtrunknew-fc.supportsBinaryExecute=false
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240
+group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240:farm64g1420
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 group.gccaarch64.baseName=AARCH64 gfortran
 
@@ -735,6 +775,11 @@ compiler.farm64g1410.semver=14.1.0
 compiler.farm64g1410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.farm64g1410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.farm64g1420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1420.semver=14.2.0
+compiler.farm64g1420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for PPCs
 group.ppcs.compilers=&ppc64:&ppc64le:&ppc
@@ -743,7 +788,7 @@ group.ppcs.instructionSet=powerpc
 
 ###############################
 # GCC for PPC
-group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1310:fppcg1320:fppcg1330:fppcg1410
+group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1310:fppcg1320:fppcg1330:fppcg1410:fppcg1420
 group.ppc.groupName=POWER gfortran
 group.ppc.baseName=POWER gfortran
 
@@ -786,9 +831,14 @@ compiler.fppcg1410.semver=14.1.0
 compiler.fppcg1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.fppcg1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.fppcg1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
+compiler.fppcg1420.semver=14.2.0
+compiler.fppcg1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.fppcg1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for PPC64
-group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240
+group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240:fppc64g1420
 group.ppc64.groupName=POWER64 gfortran
 group.ppc64.baseName=POWER64 gfortran
 
@@ -839,6 +889,11 @@ compiler.fppc64g1410.semver=14.1.0
 compiler.fppc64g1410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.fppc64g1410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.fppc64g1420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.fppc64g1420.semver=14.2.0
+compiler.fppc64g1420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.fppc64g1420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.fppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64gtrunk.semver=trunk
 compiler.fppc64gtrunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -846,7 +901,7 @@ compiler.fppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/power
 
 ###############################
 # GCC for PPC64LE
-group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240
+group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240:fppc64leg1420
 group.ppc64le.groupName=POWER64le gfortran
 group.ppc64le.baseName=POWER64le gfortran
 
@@ -897,6 +952,11 @@ compiler.fppc64leg1410.semver=14.1.0
 compiler.fppc64leg1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.fppc64leg1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.fppc64leg1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg1420.semver=14.2.0
+compiler.fppc64leg1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.fppc64leg1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.fppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
 compiler.fppc64legtrunk.semver=trunk
 compiler.fppc64legtrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -938,7 +998,7 @@ compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-
 
 ################################
 # GCC for MIPS
-group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1410
+group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1410:fmipsg1420
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
 
@@ -996,9 +1056,14 @@ compiler.fmipsg1410.semver=14.1.0
 compiler.fmipsg1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.fmipsg1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.fmipsg1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg1420.semver=14.2.0
+compiler.fmipsg1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ################################
 # GCC for MIPS64
-group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240
+group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240:fmips64g1420
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
 
@@ -1056,9 +1121,14 @@ compiler.fmips64g1410.semver=14.1.0
 compiler.fmips64g1410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.fmips64g1410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.fmips64g1420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g1420.semver=14.2.0
+compiler.fmips64g1420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g1420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ################################
 # GCC for MIPSEL
-group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1410
+group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1410:fmipselg1420
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
 
@@ -1116,9 +1186,14 @@ compiler.fmipselg1410.semver=14.1.0
 compiler.fmipselg1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.fmipselg1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.fmipselg1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
+compiler.fmipselg1420.semver=14.2.0
+compiler.fmipselg1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.fmipselg1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ################################
 # GCC for MIPS64el
-group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240
+group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240:fmips64elg1420
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
 
@@ -1175,6 +1250,11 @@ compiler.fmips64elg1410.exe=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-
 compiler.fmips64elg1410.semver=14.1.0
 compiler.fmips64elg1410.objdumper=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.fmips64elg1410.demangler=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.fmips64elg1420.exe=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
+compiler.fmips64elg1420.semver=14.2.0
+compiler.fmips64elg1420.objdumper=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.fmips64elg1420.demangler=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 #################################
 #################################

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -496,7 +496,7 @@ group.cross.groupName=Cross Go
 
 ###############################
 # GCC for sparc
-group.gccgosparc.compilers=gccgosparc1220:gccgosparc1230:gccgosparc1240:gccgosparc1310:gccgosparc1320:gccgosparc1330:gccgosparc1410
+group.gccgosparc.compilers=gccgosparc1220:gccgosparc1230:gccgosparc1240:gccgosparc1310:gccgosparc1320:gccgosparc1330:gccgosparc1410:gccgosparc1420
 group.gccgosparc.groupName=SPARC GCCGO
 group.gccgosparc.baseName=SPARC gccgo
 group.gccgosparc.isSemVer=true
@@ -536,9 +536,14 @@ compiler.gccgosparc1410.semver=14.1.0
 compiler.gccgosparc1410.objdumper=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gccgosparc1410.demangler=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.gccgosparc1420.exe=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
+compiler.gccgosparc1420.semver=14.2.0
+compiler.gccgosparc1420.objdumper=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gccgosparc1420.demangler=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for sparc64
-group.gccgosparc64.compilers=gccgosparc641220:gccgosparc641230:gccgosparc641240:gccgosparc641310:gccgosparc641320:gccgosparc641330:gccgosparc641410
+group.gccgosparc64.compilers=gccgosparc641220:gccgosparc641230:gccgosparc641240:gccgosparc641310:gccgosparc641320:gccgosparc641330:gccgosparc641410:gccgosparc641420
 group.gccgosparc64.groupName=SPARC64 GCCGO
 group.gccgosparc64.baseName=SPARC64 gccgo
 group.gccgosparc64.isSemVer=true
@@ -579,9 +584,14 @@ compiler.gccgosparc641410.semver=14.1.0
 compiler.gccgosparc641410.objdumper=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gccgosparc641410.demangler=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.gccgosparc641420.exe=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
+compiler.gccgosparc641420.semver=14.2.0
+compiler.gccgosparc641420.objdumper=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gccgosparc641420.demangler=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 ###############################
 # GCC for mips64el
-group.gccgomips64el.compilers=gccgomips64el1220:gccgomips64el1230:gccgomips64el1310:gccgomips64el1320:gccgomips64el1410:gccgomips64el1330:gccgomips64el1240
+group.gccgomips64el.compilers=gccgomips64el1220:gccgomips64el1230:gccgomips64el1310:gccgomips64el1320:gccgomips64el1410:gccgomips64el1330:gccgomips64el1240:gccgomips64el1420
 group.gccgomips64el.groupName=MIPS64EL GCCGO
 group.gccgomips64el.baseName=MIPS64EL gccgo
 group.gccgomips64el.isSemVer=true
@@ -621,9 +631,14 @@ compiler.gccgomips64el1410.semver=14.1.0
 compiler.gccgomips64el1410.objdumper=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.gccgomips64el1410.demangler=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
+compiler.gccgomips64el1420.exe=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
+compiler.gccgomips64el1420.semver=14.2.0
+compiler.gccgomips64el1420.objdumper=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gccgomips64el1420.demangler=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 ###############################
 # GCC for mipsel
-group.gccgomipsel.compilers=gccgomipsel1220:gccgomipsel1230:gccgomipsel1240:gccgomipsel1310:gccgomipsel1320:gccgomipsel1330:gccgomipsel1410
+group.gccgomipsel.compilers=gccgomipsel1220:gccgomipsel1230:gccgomipsel1240:gccgomipsel1310:gccgomipsel1320:gccgomipsel1330:gccgomipsel1410:gccgomipsel1420
 group.gccgomipsel.groupName=MIPSEL GCCGO
 group.gccgomipsel.baseName=MIPSEL gccgo
 group.gccgomipsel.isSemVer=true
@@ -663,9 +678,14 @@ compiler.gccgomipsel1410.semver=14.1.0
 compiler.gccgomipsel1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gccgomipsel1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.gccgomipsel1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
+compiler.gccgomipsel1420.semver=14.2.0
+compiler.gccgomipsel1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gccgomipsel1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ###############################
 # GCC for riscv64
-group.gccgoriscv64.compilers=gccgoriscv641220:gccgoriscv641230:gccgoriscv641240:gccgoriscv641310:gccgoriscv641320:gccgoriscv641330:gccgoriscv641410
+group.gccgoriscv64.compilers=gccgoriscv641220:gccgoriscv641230:gccgoriscv641240:gccgoriscv641310:gccgoriscv641320:gccgoriscv641330:gccgoriscv641410:gccgoriscv641420
 group.gccgoriscv64.groupName=RISC-V 64 GCCGO
 group.gccgoriscv64.baseName=RISC-V 64 gccgo
 group.gccgoriscv64.isSemVer=true
@@ -705,9 +725,14 @@ compiler.gccgoriscv641410.semver=14.1.0
 compiler.gccgoriscv641410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gccgoriscv641410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.gccgoriscv641420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
+compiler.gccgoriscv641420.semver=14.2.0
+compiler.gccgoriscv641420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gccgoriscv641420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for s390x
-group.gccgos390x.compilers=gccgos390x1220:gccgos390x1230:gccgos390x1310:gccgos390x1320:gccgos390x1410:gccgos390x1330:gccgos390x1240
+group.gccgos390x.compilers=gccgos390x1220:gccgos390x1230:gccgos390x1310:gccgos390x1320:gccgos390x1410:gccgos390x1330:gccgos390x1240:gccgos390x1420
 group.gccgos390x.groupName=S390X GCCGO
 group.gccgos390x.baseName=S390X gccgo
 group.gccgos390x.isSemVer=true
@@ -747,9 +772,14 @@ compiler.gccgos390x1410.semver=14.1.0
 compiler.gccgos390x1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gccgos390x1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.gccgos390x1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
+compiler.gccgos390x1420.semver=14.2.0
+compiler.gccgos390x1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gccgos390x1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # GCC for MIPS
-group.gccgomips.compilers=gccgomips1220:gccgomips1230:gccgomips1240:gccgomips1310:gccgomips1320:gccgomips1330:gccgomips1410
+group.gccgomips.compilers=gccgomips1220:gccgomips1230:gccgomips1240:gccgomips1310:gccgomips1320:gccgomips1330:gccgomips1410:gccgomips1420
 group.gccgomips.groupName=MIPS GCCGO
 group.gccgomips.baseName=MIPS gccgo
 group.gccgomips.isSemVer=true
@@ -789,9 +819,14 @@ compiler.gccgomips1410.semver=14.1.0
 compiler.gccgomips1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gccgomips1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.gccgomips1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
+compiler.gccgomips1420.semver=14.2.0
+compiler.gccgomips1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gccgomips1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for MIPS64
-group.gccgomips64.compilers=gccgomips641220:gccgomips641230:gccgomips641240:gccgomips641310:gccgomips641320:gccgomips641330:gccgomips641410
+group.gccgomips64.compilers=gccgomips641220:gccgomips641230:gccgomips641240:gccgomips641310:gccgomips641320:gccgomips641330:gccgomips641410:gccgomips641420
 group.gccgomips64.groupName=MIPS64 GCCGO
 group.gccgomips64.baseName=MIPS64 gccgo
 group.gccgomips64.isSemVer=true
@@ -831,9 +866,14 @@ compiler.gccgomips641410.semver=14.1.0
 compiler.gccgomips641410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gccgomips641410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.gccgomips641420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
+compiler.gccgomips641420.semver=14.2.0
+compiler.gccgomips641420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gccgomips641420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for ARM64
-group.gccgoarm64.compilers=gccgoarm641220:gccgoarm641230:gccgoarm641240:gccgoarm641310:gccgoarm641320:gccgoarm641330:gccgoarm641410
+group.gccgoarm64.compilers=gccgoarm641220:gccgoarm641230:gccgoarm641240:gccgoarm641310:gccgoarm641320:gccgoarm641330:gccgoarm641410:gccgoarm641420
 group.gccgoarm64.groupName=ARM64 GCCGO
 group.gccgoarm64.baseName=ARM64 gccgo
 group.gccgoarm64.isSemVer=true
@@ -873,9 +913,14 @@ compiler.gccgoarm641410.semver=14.1.0
 compiler.gccgoarm641410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gccgoarm641410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.gccgoarm641420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
+compiler.gccgoarm641420.semver=14.2.0
+compiler.gccgoarm641420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gccgoarm641420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for ARM
-group.gccgoarm.compilers=gccgoarm1220:gccgoarm1230:gccgoarm1240:gccgoarm1310:gccgoarm1320:gccgoarm1330:gccgoarm1410
+group.gccgoarm.compilers=gccgoarm1220:gccgoarm1230:gccgoarm1240:gccgoarm1310:gccgoarm1320:gccgoarm1330:gccgoarm1410:gccgoarm1420
 group.gccgoarm.groupName=ARM GCCGO
 group.gccgoarm.baseName=ARM gccgo
 group.gccgoarm.isSemVer=true
@@ -915,9 +960,14 @@ compiler.gccgoarm1410.semver=14.1.0
 compiler.gccgoarm1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gccgoarm1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.gccgoarm1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
+compiler.gccgoarm1420.semver=14.2.0
+compiler.gccgoarm1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gccgoarm1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 ###############################
 # GCC for PPC
-group.gccgoppc.compilers=gccgoppc1220:gccgoppc1230:gccgoppc1240:gccgoppc1310:gccgoppc1320:gccgoppc1330:gccgoppc1410
+group.gccgoppc.compilers=gccgoppc1220:gccgoppc1230:gccgoppc1240:gccgoppc1310:gccgoppc1320:gccgoppc1330:gccgoppc1410:gccgoppc1420
 group.gccgoppc.groupName=POWER GCCGO
 group.gccgoppc.baseName=POWER gccgo
 group.gccgoppc.isSemVer=true
@@ -957,9 +1007,14 @@ compiler.gccgoppc1410.semver=14.1.0
 compiler.gccgoppc1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gccgoppc1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.gccgoppc1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
+compiler.gccgoppc1420.semver=14.2.0
+compiler.gccgoppc1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gccgoppc1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for PPC64LE
-group.gccgoppc64le.compilers=gccgoppc64le1220:gccgoppc64le1230:gppc64leg9:gppc64leg8:gccgoppc64le1310:gccgoppc64le1320:gccgoppc64letrunk:gccgoppc64le1410:gccgoppc64le1330:gccgoppc64le1240
+group.gccgoppc64le.compilers=gccgoppc64le1220:gccgoppc64le1230:gppc64leg9:gppc64leg8:gccgoppc64le1310:gccgoppc64le1320:gccgoppc64letrunk:gccgoppc64le1410:gccgoppc64le1330:gccgoppc64le1240:gccgoppc64le1420
 group.gccgoppc64le.groupName=POWER64LE GCCGO
 group.gccgoppc64le.baseName=POWER64LE gccgo
 group.gccgoppc64le.isSemVer=true
@@ -999,6 +1054,11 @@ compiler.gccgoppc64le1410.semver=14.1.0
 compiler.gccgoppc64le1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gccgoppc64le1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.gccgoppc64le1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
+compiler.gccgoppc64le1420.semver=14.2.0
+compiler.gccgoppc64le1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gccgoppc64le1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.gccgoppc64letrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
 compiler.gccgoppc64letrunk.semver=trunk
 compiler.gccgoppc64letrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -1012,7 +1072,7 @@ compiler.gppc64leg8.semver=AT12.0
 
 ###############################
 # GCC for PPC64
-group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc64trunk:gccgoppc641220:gccgoppc641230:gccgoppc641240:gccgoppc641310:gccgoppc641320:gccgoppc641330:gccgoppc641410
+group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc64trunk:gccgoppc641220:gccgoppc641230:gccgoppc641240:gccgoppc641310:gccgoppc641320:gccgoppc641330:gccgoppc641410:gccgoppc641420
 group.gccgoppc64.groupName=POWER64 GCCGO
 group.gccgoppc64.baseName=POWER64 gccgo
 group.gccgoppc64.isSemVer=true
@@ -1051,6 +1111,11 @@ compiler.gccgoppc641410.exe=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc6
 compiler.gccgoppc641410.semver=14.1.0
 compiler.gccgoppc641410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gccgoppc641410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gccgoppc641420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
+compiler.gccgoppc641420.semver=14.2.0
+compiler.gccgoppc641420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gccgoppc641420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gccgoppc64trunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
 compiler.gccgoppc64trunk.semver=trunk

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -69,7 +69,7 @@ group.objcppgccs.compilers=&objcppgccloongarch64:&objcppgccrvs:&objcppgccarm:&ob
 
 ###############################
 # GCC for Loongarch64
-group.objcppgccloongarch64.compilers=objcpploongarch64g1410
+group.objcppgccloongarch64.compilers=objcpploongarch64g1410:objcpploongarch64g1420
 group.objcppgccloongarch64.groupName=LOONGARCH64 GCC
 group.objcppgccloongarch64.isSemVer=true
 group.objcppgccloongarch64.supportsExecute=false
@@ -81,9 +81,14 @@ compiler.objcpploongarch64g1410.semver=14.1.0
 compiler.objcpploongarch64g1410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.objcpploongarch64g1410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.objcpploongarch64g1420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
+compiler.objcpploongarch64g1420.semver=14.2.0
+compiler.objcpploongarch64g1420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.objcpploongarch64g1420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for POWERPC64LE
-group.objcppgccpowerpc64le.compilers=objcppppc64leg1230:objcppppc64leg1310:objcppppc64leg1320:objcppppc64legtrunk:objcppppc64leg1410:objcppppc64leg1330:objcppppc64leg1240
+group.objcppgccpowerpc64le.compilers=objcppppc64leg1230:objcppppc64leg1310:objcppppc64leg1320:objcppppc64legtrunk:objcppppc64leg1410:objcppppc64leg1330:objcppppc64leg1240:objcppppc64leg1420
 group.objcppgccpowerpc64le.groupName=POWERPC64LE GCC
 group.objcppgccpowerpc64le.baseName=POWERPC64LE GCC
 group.objcppgccpowerpc64le.isSemVer=true
@@ -122,6 +127,11 @@ compiler.objcppppc64leg1410.semver=14.1.0
 compiler.objcppppc64leg1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.objcppppc64leg1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.objcppppc64leg1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.objcppppc64leg1420.semver=14.2.0
+compiler.objcppppc64leg1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.objcppppc64leg1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.objcppppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.objcppppc64legtrunk.semver=trunk
 compiler.objcppppc64legtrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -129,7 +139,7 @@ compiler.objcppppc64legtrunk.demangler=/opt/compiler-explorer/powerpc64le/gcc-tr
 
 ###############################
 # GCC for POWERPC64
-group.objcppgccpowerpc64.compilers=objcppppc64g1230:objcppppc64g1310:objcppppc64g1320:objcppppc64gtrunk:objcppppc64g1410:objcppppc64g1330:objcppppc64g1240
+group.objcppgccpowerpc64.compilers=objcppppc64g1230:objcppppc64g1310:objcppppc64g1320:objcppppc64gtrunk:objcppppc64g1410:objcppppc64g1330:objcppppc64g1240:objcppppc64g1420
 group.objcppgccpowerpc64.groupName=POWERPC64 GCC
 group.objcppgccpowerpc64.baseName=POWERPC64 GCC
 group.objcppgccpowerpc64.isSemVer=true
@@ -168,6 +178,11 @@ compiler.objcppppc64g1410.semver=14.1.0
 compiler.objcppppc64g1410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppppc64g1410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.objcppppc64g1420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.objcppppc64g1420.semver=14.2.0
+compiler.objcppppc64g1420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.objcppppc64g1420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.objcppppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.objcppppc64gtrunk.semver=trunk
 compiler.objcppppc64gtrunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -175,7 +190,7 @@ compiler.objcppppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/
 
 ###############################
 # GCC for POWERPC
-group.objcppgccpowerpc.compilers=objcppppcg1230:objcppppcg1240:objcppppcg1310:objcppppcg1320:objcppppcg1330:objcppppcg1410
+group.objcppgccpowerpc.compilers=objcppppcg1230:objcppppcg1240:objcppppcg1310:objcppppcg1320:objcppppcg1330:objcppppcg1410:objcppppcg1420
 group.objcppgccpowerpc.groupName=POWERPC GCC
 group.objcppgccpowerpc.baseName=POWERPC GCC
 group.objcppgccpowerpc.isSemVer=true
@@ -214,9 +229,14 @@ compiler.objcppppcg1410.semver=14.1.0
 compiler.objcppppcg1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppppcg1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
+compiler.objcppppcg1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.objcppppcg1420.semver=14.2.0
+compiler.objcppppcg1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.objcppppcg1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for MIPSEL
-group.objcppgccmipsel.compilers=objcppmipselg1230:objcppmipselg1240:objcppmipselg1310:objcppmipselg1320:objcppmipselg1330:objcppmipselg1410
+group.objcppgccmipsel.compilers=objcppmipselg1230:objcppmipselg1240:objcppmipselg1310:objcppmipselg1320:objcppmipselg1330:objcppmipselg1410:objcppmipselg1420
 group.objcppgccmipsel.groupName=MIPS (EL) GCC
 group.objcppgccmipsel.baseName=MIPS (EL) GCC
 group.objcppgccmipsel.isSemVer=true
@@ -254,9 +274,14 @@ compiler.objcppmipselg1410.semver=14.1.0
 compiler.objcppmipselg1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.objcppmipselg1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.objcppmipselg1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.objcppmipselg1420.semver=14.2.0
+compiler.objcppmipselg1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.objcppmipselg1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ###############################
 # GCC for MIPS64EL
-group.objcppgccmips64el.compilers=objcppmips64elg1230:objcppmips64elg1310:objcppmips64elg1320:objcppmips64elg1410:objcppmips64elg1330:objcppmips64elg1240
+group.objcppgccmips64el.compilers=objcppmips64elg1230:objcppmips64elg1310:objcppmips64elg1320:objcppmips64elg1410:objcppmips64elg1330:objcppmips64elg1240:objcppmips64elg1420
 group.objcppgccmips64el.groupName=MIPS64 (EL) GCC
 group.objcppgccmips64el.baseName=MIPS64 (EL) GCC
 group.objcppgccmips64el.isSemVer=true
@@ -294,9 +319,14 @@ compiler.objcppmips64elg1410.semver=14.1.0
 compiler.objcppmips64elg1410.objdumper=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.objcppmips64elg1410.demangler=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
+compiler.objcppmips64elg1420.exe=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.objcppmips64elg1420.semver=14.2.0
+compiler.objcppmips64elg1420.objdumper=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.objcppmips64elg1420.demangler=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 ###############################
 # GCC for MIPS64
-group.objcppgccmips64.compilers=objcppmips64g1230:objcppmips64g1310:objcppmips64g1320:objcppmips64g1410:objcppmips64g1330:objcppmips64g1240
+group.objcppgccmips64.compilers=objcppmips64g1230:objcppmips64g1310:objcppmips64g1320:objcppmips64g1410:objcppmips64g1330:objcppmips64g1240:objcppmips64g1420
 group.objcppgccmips64.groupName=MIPS64 GCC
 group.objcppgccmips64.baseName=MIPS64 GCC
 group.objcppgccmips64.isSemVer=true
@@ -334,10 +364,15 @@ compiler.objcppmips64g1410.semver=14.1.0
 compiler.objcppmips64g1410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.objcppmips64g1410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.objcppmips64g1420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.objcppmips64g1420.semver=14.2.0
+compiler.objcppmips64g1420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.objcppmips64g1420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 
 ###############################
 # GCC for MIPS
-group.objcppgccmips.compilers=objcppmipsg1230:objcppmipsg1240:objcppmipsg1310:objcppmipsg1320:objcppmipsg1330:objcppmipsg1410
+group.objcppgccmips.compilers=objcppmipsg1230:objcppmipsg1240:objcppmipsg1310:objcppmipsg1320:objcppmipsg1330:objcppmipsg1410:objcppmipsg1420
 group.objcppgccmips.groupName=MIPS GCC
 group.objcppgccmips.baseName=MIPS GCC
 group.objcppgccmips.isSemVer=true
@@ -375,9 +410,14 @@ compiler.objcppmipsg1410.semver=14.1.0
 compiler.objcppmipsg1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.objcppmipsg1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.objcppmipsg1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.objcppmipsg1420.semver=14.2.0
+compiler.objcppmipsg1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.objcppmipsg1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for s390
-group.objcppgccs390x.compilers=objcpps390xg1230:objcpps390xg1310:objcpps390xg1320:objcpps390xg1410:objcpps390xg1330:objcpps390xg1240
+group.objcppgccs390x.compilers=objcpps390xg1230:objcpps390xg1310:objcpps390xg1320:objcpps390xg1410:objcpps390xg1330:objcpps390xg1240:objcpps390xg1420
 group.objcppgccs390x.groupName=S390X GCC
 group.objcppgccs390x.baseName=S390X GCC
 group.objcppgccs390x.isSemVer=true
@@ -415,9 +455,14 @@ compiler.objcpps390xg1410.semver=14.1.0
 compiler.objcpps390xg1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.objcpps390xg1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.objcpps390xg1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.objcpps390xg1420.semver=14.2.0
+compiler.objcpps390xg1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.objcpps390xg1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # GCC for ARM
-group.objcppgccarm.compilers=objcpparmg1230:objcpparmg1240:objcpparmg1310:objcpparmg1320:objcpparmg1330:objcpparmg1410
+group.objcppgccarm.compilers=objcpparmg1230:objcpparmg1240:objcpparmg1310:objcpparmg1320:objcpparmg1330:objcpparmg1410:objcpparmg1420
 group.objcppgccarm.groupName=ARM GCC
 group.objcppgccarm.baseName=ARM GCC
 group.objcppgccarm.isSemVer=true
@@ -455,10 +500,15 @@ compiler.objcpparmg1410.semver=14.1.0
 compiler.objcpparmg1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.objcpparmg1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.objcpparmg1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.objcpparmg1420.semver=14.2.0
+compiler.objcpparmg1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.objcpparmg1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 ###############################
 # GCC for ARM64
 
-group.objcppgccarm64.compilers=objcpparm64g1230:objcpparm64g1310:objcpparm64g1320:objcpparm64g1410:objcpparm64g1330:objcpparm64g1240
+group.objcppgccarm64.compilers=objcpparm64g1230:objcpparm64g1310:objcpparm64g1320:objcpparm64g1410:objcpparm64g1330:objcpparm64g1240:objcpparm64g1420
 group.objcppgccarm64.groupName=ARM64 GCC
 group.objcppgccarm64.baseName=ARM64 GCC
 group.objcppgccarm64.isSemVer=true
@@ -496,6 +546,11 @@ compiler.objcpparm64g1410.semver=14.1.0
 compiler.objcpparm64g1410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.objcpparm64g1410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.objcpparm64g1420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.objcpparm64g1420.semver=14.2.0
+compiler.objcpparm64g1420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.objcpparm64g1420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 ###############################
 # GCC for RISC-V
 
@@ -507,7 +562,7 @@ group.objcppgccrvs.supportsBinary=true
 group.objcppgccrvs.supportsBinaryObject=true
 
 ## Subgroup for riscv32
-group.objcppgccrv32.compilers=objcppgccrv32trunk:objcppgccrv321230:objcppgccrv321240:objcppgccrv321310:objcppgccrv321320:objcppgccrv321330:objcppgccrv321410
+group.objcppgccrv32.compilers=objcppgccrv32trunk:objcppgccrv321230:objcppgccrv321240:objcppgccrv321310:objcppgccrv321320:objcppgccrv321330:objcppgccrv321410:objcppgccrv321420
 group.objcppgccrv32.groupName=RISC-V 32-bits
 group.objcppgccrv32.baseName=RISC-V 32 GCC
 
@@ -541,6 +596,11 @@ compiler.objcppgccrv321410.semver=14.1.0
 compiler.objcppgccrv321410.objdumper=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.objcppgccrv321410.demangler=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
+compiler.objcppgccrv321420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.objcppgccrv321420.semver=14.2.0
+compiler.objcppgccrv321420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.objcppgccrv321420.demangler=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
 compiler.objcppgccrv32trunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.objcppgccrv32trunk.semver=(trunk)
 compiler.objcppgccrv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
@@ -548,7 +608,7 @@ compiler.objcppgccrv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/r
 compiler.objcppgccrv32trunk.isNightly=true
 
 ## Subgroup for riscv64
-group.objcppgccrv64.compilers=objcppgccrv64trunk:objcppgccrv641230:objcppgccrv641240:objcppgccrv641310:objcppgccrv641320:objcppgccrv641330:objcppgccrv641410
+group.objcppgccrv64.compilers=objcppgccrv64trunk:objcppgccrv641230:objcppgccrv641240:objcppgccrv641310:objcppgccrv641320:objcppgccrv641330:objcppgccrv641410:objcppgccrv641420
 group.objcppgccrv64.groupName=RISC-V 64-bits
 group.objcppgccrv64.baseName=RISC-V 64 GCC
 
@@ -581,6 +641,11 @@ compiler.objcppgccrv641410.exe=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64
 compiler.objcppgccrv641410.semver=14.1.0
 compiler.objcppgccrv641410.objdumper=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.objcppgccrv641410.demangler=/opt/compiler-explorer/riscv64/gcc-14.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.objcppgccrv641420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.objcppgccrv641420.semver=14.2.0
+compiler.objcppgccrv641420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.objcppgccrv641420.demangler=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.objcppgccrv64trunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.objcppgccrv64trunk.semver=(trunk)

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -79,7 +79,7 @@ group.objccross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc
 group.objcsparc.compilers=&objcgccsparc
 
 # GCC for SPARC
-group.objcgccsparc.compilers=objcsparcg1220:objcsparcg1230:objcsparcg1240:objcsparcg1310:objcsparcg1320:objcsparcg1330:objcsparcg1410
+group.objcgccsparc.compilers=objcsparcg1220:objcsparcg1230:objcsparcg1240:objcsparcg1310:objcsparcg1320:objcsparcg1330:objcsparcg1410:objcsparcg1420
 group.objcgccsparc.supportsBinary=true
 group.objcgccsparc.supportsExecute=false
 group.objcgccsparc.baseName=SPARC gcc
@@ -121,12 +121,17 @@ compiler.objcsparcg1410.semver=14.1.0
 compiler.objcsparcg1410.objdumper=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.objcsparcg1410.demangler=/opt/compiler-explorer/sparc/gcc-14.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
+compiler.objcsparcg1420.exe=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.objcsparcg1420.semver=14.2.0
+compiler.objcsparcg1420.objdumper=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.objcsparcg1420.demangler=/opt/compiler-explorer/sparc/gcc-14.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 ###############################
 # Cross for SPARC64
 group.objcsparc64.compilers=&objcgccsparc64
 
 # GCC for SPARC64
-group.objcgccsparc64.compilers=objcsparc64g1220:objcsparc64g1230:objcsparc64g1310:objcsparc64g1320:objcsparc64g1410:objcsparc64g1330:objcsparc64g1240
+group.objcgccsparc64.compilers=objcsparc64g1220:objcsparc64g1230:objcsparc64g1310:objcsparc64g1320:objcsparc64g1410:objcsparc64g1330:objcsparc64g1240:objcsparc64g1420
 group.objcgccsparc64.supportsBinary=true
 group.objcgccsparc64.supportsExecute=false
 group.objcgccsparc64.baseName=SPARC64 gcc
@@ -168,12 +173,17 @@ compiler.objcsparc64g1410.semver=14.1.0
 compiler.objcsparc64g1410.objdumper=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.objcsparc64g1410.demangler=/opt/compiler-explorer/sparc64/gcc-14.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
+compiler.objcsparc64g1420.exe=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.objcsparc64g1420.semver=14.2.0
+compiler.objcsparc64g1420.objdumper=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.objcsparc64g1420.demangler=/opt/compiler-explorer/sparc64/gcc-14.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 ###############################
 # Cross for SPARC-LEON
 group.objcsparcleon.compilers=&objcgccsparcleon
 
 # GCC for SPARC-LEON
-group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1:objcsparcleong1230:objcsparcleong1240:objcsparcleong1310:objcsparcleong1320:objcsparcleong1330:objcsparcleong1410
+group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1:objcsparcleong1230:objcsparcleong1240:objcsparcleong1310:objcsparcleong1320:objcsparcleong1330:objcsparcleong1410:objcsparcleong1420
 group.objcgccsparcleon.supportsBinary=true
 group.objcgccsparcleon.supportsExecute=false
 group.objcgccsparcleon.baseName=SPARC LEON gcc
@@ -217,6 +227,11 @@ compiler.objcsparcleong1410.semver=14.1.0
 compiler.objcsparcleong1410.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.objcsparcleong1410.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
+compiler.objcsparcleong1420.exe=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.objcsparcleong1420.semver=14.2.0
+compiler.objcsparcleong1420.objdumper=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.objcsparcleong1420.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 compiler.objcsparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.objcsparcleong1220-1.semver=12.2.0
 compiler.objcsparcleong1220-1.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
@@ -227,7 +242,7 @@ compiler.objcsparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12
 group.objcloongarch64.compilers=&objcgccloongarch64
 
 # GCC for loongarch64
-group.objcgccloongarch64.compilers=objcloongarch64g1220:objcloongarch64g1230:objcloongarch64g1310:objcloongarch64g1320:objcloongarch64g1410:objcloongarch64g1330:objcloongarch64g1240
+group.objcgccloongarch64.compilers=objcloongarch64g1220:objcloongarch64g1230:objcloongarch64g1310:objcloongarch64g1320:objcloongarch64g1410:objcloongarch64g1330:objcloongarch64g1240:objcloongarch64g1420
 group.objcgccloongarch64.supportsBinary=true
 group.objcgccloongarch64.supportsExecute=false
 group.objcgccloongarch64.baseName=loongarch64 gcc
@@ -269,13 +284,18 @@ compiler.objcloongarch64g1410.semver=14.1.0
 compiler.objcloongarch64g1410.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.objcloongarch64g1410.demangler=/opt/compiler-explorer/loongarch64/gcc-14.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
+compiler.objcloongarch64g1420.exe=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.objcloongarch64g1420.semver=14.2.0
+compiler.objcloongarch64g1420.objdumper=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.objcloongarch64g1420.demangler=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 
 ###############################
 # Cross for s390x
 group.objcs390x.compilers=&objcgccs390x
 
 # GCC for s390x
-group.objcgccs390x.compilers=objcs390xg1220:objcs390xg1230:objcs390xg1310:objcs390xg1320:objcs390xg1410:objcs390xg1330:objcs390xg1240
+group.objcgccs390x.compilers=objcs390xg1220:objcs390xg1230:objcs390xg1310:objcs390xg1320:objcs390xg1410:objcs390xg1330:objcs390xg1240:objcs390xg1420
 group.objcgccs390x.supportsBinary=true
 group.objcgccs390x.supportsExecute=false
 group.objcgccs390x.baseName=s390x gcc
@@ -317,6 +337,11 @@ compiler.objcs390xg1410.semver=14.1.0
 compiler.objcs390xg1410.objdumper=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.objcs390xg1410.demangler=/opt/compiler-explorer/s390x/gcc-14.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
+compiler.objcs390xg1420.exe=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.objcs390xg1420.semver=14.2.0
+compiler.objcs390xg1420.objdumper=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.objcs390xg1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 ###############################
 # Cross compilers for PPC
 group.objcppcs.compilers=&objcppc:&objcppc64:&objcppc64le
@@ -325,7 +350,7 @@ group.objcppcs.supportsBinary=true
 group.objcppcs.supportsExecute=false
 group.objcppcs.instructionSet=powerpc
 
-group.objcppc.compilers=objcppcg1220:objcppcg1230:objcppcg1240:objcppcg1310:objcppcg1320:objcppcg1330:objcppcg1410
+group.objcppc.compilers=objcppcg1220:objcppcg1230:objcppcg1240:objcppcg1310:objcppcg1320:objcppcg1330:objcppcg1410:objcppcg1420
 group.objcppc.groupName=POWER
 group.objcppc.baseName=POWER GCC
 
@@ -364,7 +389,12 @@ compiler.objcppcg1410.semver=14.1.0
 compiler.objcppcg1410.objdumper=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppcg1410.demangler=/opt/compiler-explorer/powerpc/gcc-14.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.objcppc64.compilers=objcppc64g1220:objcppc64g1230:objcppc64g1310:objcppc64g1320:objcppc64gtrunk:objcppc64g1410:objcppc64g1330:objcppc64g1240
+compiler.objcppcg1420.exe=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.objcppcg1420.semver=14.2.0
+compiler.objcppcg1420.objdumper=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.objcppcg1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+group.objcppc64.compilers=objcppc64g1220:objcppc64g1230:objcppc64g1310:objcppc64g1320:objcppc64gtrunk:objcppc64g1410:objcppc64g1330:objcppc64g1240:objcppc64g1420
 group.objcppc64.groupName=POWER64
 group.objcppc64.baseName=POWER64 GCC
 
@@ -403,12 +433,17 @@ compiler.objcppc64g1410.semver=14.1.0
 compiler.objcppc64g1410.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppc64g1410.demangler=/opt/compiler-explorer/powerpc64/gcc-14.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
+compiler.objcppc64g1420.exe=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.objcppc64g1420.semver=14.2.0
+compiler.objcppc64g1420.objdumper=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.objcppc64g1420.demangler=/opt/compiler-explorer/powerpc64/gcc-14.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 compiler.objcppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.objcppc64gtrunk.semver=trunk
 compiler.objcppc64gtrunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
-group.objcppc64le.compilers=objcppc64leg1220:objcppc64leg1230:objcppc64leg1310:objcppc64leg1320:objcppc64legtrunk:objcppc64leg1410:objcppc64leg1330:objcppc64leg1240
+group.objcppc64le.compilers=objcppc64leg1220:objcppc64leg1230:objcppc64leg1310:objcppc64leg1320:objcppc64legtrunk:objcppc64leg1410:objcppc64leg1330:objcppc64leg1240:objcppc64leg1420
 group.objcppc64le.groupName=POWER64LE
 group.objcppc64le.baseName=POWER64LE GCC
 
@@ -447,6 +482,11 @@ compiler.objcppc64leg1410.semver=14.1.0
 compiler.objcppc64leg1410.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.objcppc64leg1410.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
+compiler.objcppc64leg1420.exe=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.objcppc64leg1420.semver=14.2.0
+compiler.objcppc64leg1420.objdumper=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.objcppc64leg1420.demangler=/opt/compiler-explorer/powerpc64le/gcc-14.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 compiler.objcppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.objcppc64legtrunk.semver=trunk
 compiler.objcppc64legtrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
@@ -463,7 +503,7 @@ group.objcgccarm.includeFlag=-I
 
 # 32 bit
 group.objcgcc32arm.groupName=Arm 32-bit GCC
-group.objcgcc32arm.compilers=objcarmg1220:objcarmg1230:objcarmg1240:objcarmg1310:objcarmg1320:objcarmg1330:objcarmg1410:objcarmgtrunk
+group.objcgcc32arm.compilers=objcarmg1220:objcarmg1230:objcarmg1240:objcarmg1310:objcarmg1320:objcarmg1330:objcarmg1410:objcarmg1420:objcarmgtrunk
 group.objcgcc32arm.isSemVer=true
 group.objcgcc32arm.instructionSet=arm32
 group.objcgcc32arm.baseName=ARM gcc
@@ -503,6 +543,11 @@ compiler.objcarmg1410.semver=14.1.0
 compiler.objcarmg1410.objdumper=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.objcarmg1410.demangler=/opt/compiler-explorer/arm/gcc-14.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
+compiler.objcarmg1420.exe=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.objcarmg1420.semver=14.2.0
+compiler.objcarmg1420.objdumper=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.objcarmg1420.demangler=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 compiler.objcarmgtrunk.exe=/opt/compiler-explorer/arm/gcc-trunk/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.objcarmgtrunk.demangler=/opt/compiler-explorer/arm/gcc-trunk/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 compiler.objcarmgtrunk.name=ARM gcc trunk (linux)
@@ -512,7 +557,7 @@ compiler.objcarmgtrunk.isNightly=true
 # 64 bit
 group.objcgcc64arm.groupName=Arm 64-bit GCC
 group.objcgcc64arm.baseName=ARM64 GCC
-group.objcgcc64arm.compilers=objcarm64gtrunk:objcarm64g1220:objcarm64g1230:objcarm64g1310:objcarm64g1320:objcarm64g1410:objcarm64g1330:objcarm64g1240
+group.objcgcc64arm.compilers=objcarm64gtrunk:objcarm64g1220:objcarm64g1230:objcarm64g1310:objcarm64g1320:objcarm64g1410:objcarm64g1330:objcarm64g1240:objcarm64g1420
 group.objcgcc64arm.isSemVer=true
 group.objcgcc64arm.instructionSet=aarch64
 
@@ -551,6 +596,11 @@ compiler.objcarm64g1410.semver=14.1.0
 compiler.objcarm64g1410.objdumper=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.objcarm64g1410.demangler=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.objcarm64g1420.exe=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.objcarm64g1420.semver=14.2.0
+compiler.objcarm64g1420.objdumper=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.objcarm64g1420.demangler=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 compiler.objcarm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.objcarm64gtrunk.objdumper=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.objcarm64gtrunk.demangler=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
@@ -566,7 +616,7 @@ group.objcmipss.supportsBinary=true
 group.objcmipss.supportsExecute=false
 
 ## MIPS
-group.objcmips.compilers=objcmipsg1220:objcmipsg1230:objcmipsg1240:objcmipsg1310:objcmipsg1320:objcmipsg1330:objcmipsg1410
+group.objcmips.compilers=objcmipsg1220:objcmipsg1230:objcmipsg1240:objcmipsg1310:objcmipsg1320:objcmipsg1330:objcmipsg1410:objcmipsg1420
 group.objcmips.groupName=MIPS GCC
 group.objcmips.baseName=mips gcc
 
@@ -605,9 +655,14 @@ compiler.objcmipsg1410.semver=14.1.0
 compiler.objcmipsg1410.objdumper=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.objcmipsg1410.demangler=/opt/compiler-explorer/mips/gcc-14.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.objcmipsg1420.exe=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.objcmipsg1420.semver=14.2.0
+compiler.objcmipsg1420.objdumper=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.objcmipsg1420.demangler=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 ## MIPS64
 group.objcmips64.groupName=MIPS64 GCC
-group.objcmips64.compilers=objcmips64g1220:objcmips64g1230:objcmips64g1310:objcmips64g1320:objcmips64g1410:objcmips64g1330:objcmips64g1240
+group.objcmips64.compilers=objcmips64g1220:objcmips64g1230:objcmips64g1310:objcmips64g1320:objcmips64g1410:objcmips64g1330:objcmips64g1240:objcmips64g1420
 group.objcmips64.baseName=MIPS64 gcc
 
 compiler.objcmips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -645,9 +700,14 @@ compiler.objcmips64g1410.semver=14.1.0
 compiler.objcmips64g1410.objdumper=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.objcmips64g1410.demangler=/opt/compiler-explorer/mips64/gcc-14.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.objcmips64g1420.exe=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.objcmips64g1420.semver=14.2.0
+compiler.objcmips64g1420.objdumper=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.objcmips64g1420.demangler=/opt/compiler-explorer/mips64/gcc-14.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 ## MIPS EL
 group.objcmipsel.groupName=MIPSEL GCC
-group.objcmipsel.compilers=objcmipselg1220:objcmipselg1230:objcmipselg1240:objcmipselg1310:objcmipselg1320:objcmipselg1330:objcmipselg1410
+group.objcmipsel.compilers=objcmipselg1220:objcmipselg1230:objcmipselg1240:objcmipselg1310:objcmipselg1320:objcmipselg1330:objcmipselg1410:objcmipselg1420
 group.objcmipsel.baseName=mips (el) gcc
 
 compiler.objcmipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
@@ -685,9 +745,14 @@ compiler.objcmipselg1410.semver=14.1.0
 compiler.objcmipselg1410.objdumper=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.objcmipselg1410.demangler=/opt/compiler-explorer/mipsel/gcc-14.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
+compiler.objcmipselg1420.exe=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.objcmipselg1420.semver=14.2.0
+compiler.objcmipselg1420.objdumper=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.objcmipselg1420.demangler=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 ## MIPS64 EL
 group.objcmips64el.groupName=MIPS64EL GCC
-group.objcmips64el.compilers=objcmips64elg1220:objcmips64elg1230:objcmips64elg1310:objcmips64elg1320:objcmips64elg1410:objcmips64elg1330:objcmips64elg1240
+group.objcmips64el.compilers=objcmips64elg1220:objcmips64elg1230:objcmips64elg1310:objcmips64elg1320:objcmips64elg1410:objcmips64elg1330:objcmips64elg1240:objcmips64elg1420
 group.objcmips64el.baseName=mips64 (el) gcc
 
 compiler.objcmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
@@ -725,6 +790,11 @@ compiler.objcmips64elg1410.semver=14.1.0
 compiler.objcmips64elg1410.objdumper=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.objcmips64elg1410.demangler=/opt/compiler-explorer/mips64el/gcc-14.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
+compiler.objcmips64elg1420.exe=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.objcmips64elg1420.semver=14.2.0
+compiler.objcmips64elg1420.objdumper=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.objcmips64elg1420.demangler=/opt/compiler-explorer/mips64el/gcc-14.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 
 ###############################
 # GCC for RISC-V
@@ -738,7 +808,7 @@ group.objcrv.supportsBinaryObject=true
 ## Subgroup for riscv32
 group.objcrv32.groupName=RISC-V 32-bits
 group.objcrv32.baseName=RISC-V 32 GCC
-group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220:objcrv32g1230:objcrv32g1310:objcrv32g1320:objcrv32g1410:objcrv32g1330:objcrv32g1240
+group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220:objcrv32g1230:objcrv32g1310:objcrv32g1320:objcrv32g1410:objcrv32g1330:objcrv32g1240:objcrv32g1420
 
 compiler.objcrv32g1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32g1220.semver=12.2.0
@@ -774,6 +844,11 @@ compiler.objcrv32g1410.exe=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unk
 compiler.objcrv32g1410.semver=14.1.0
 compiler.objcrv32g1410.objdumper=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.objcrv32g1410.demangler=/opt/compiler-explorer/riscv32/gcc-14.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.objcrv32g1420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.objcrv32g1420.semver=14.2.0
+compiler.objcrv32g1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.objcrv32g1420.demangler=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.objcrv32gtrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32gtrunk.semver=(trunk)


### PR DESCRIPTION
Left out sh GNAT and GDC.

But they are installed, so at least GDC 14.2 can be added along with the rest in https://github.com/compiler-explorer/compiler-explorer/issues/6520.

refs https://github.com/compiler-explorer/compiler-explorer/issues/6741