### PR TITLE
add quill 6.1.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3699,7 +3699,7 @@ compiler.vast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/li
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:beman_optional26:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:pcre2:widberg-defs:jwt-cpp
+libs=abseil:array:async_simple:belleviews:beman_optional26:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -4909,6 +4909,15 @@ libs.qt.versions.652.version=6.5.2
 libs.qt.versions.652.path=/app/qt/include/QtCore
 libs.qt.versions.660.version=6.6.0
 libs.qt.versions.660.path=/app/qt/include/QtCore
+
+libs.quill.name=Quill
+libs.quill.description=C++ Low Latency Logging Library
+libs.quill.versions=trunk:611
+libs.quill.url=https://github.com/odygrd/quill
+libs.quill.versions.trunk.version=trunk
+libs.quill.versions.trunk.path=/opt/compiler-explorer/libs/quill/trunk/quill/include
+libs.quill.versions.611.version=6.1.1
+libs.quill.versions.611.path=/opt/compiler-explorer/libs/quill/v6.1.1/quill/include
 
 libs.rangesv3.name=range-v3
 libs.rangesv3.versions=trunk:030:035:036:091:0100:0110:0120


### PR DESCRIPTION
Infra PR: https://github.com/compiler-explorer/infra/pull/1388

This PR introduces Quill, a low-latency logging library, to Compiler Explorer. As this is my first contribution, please let me know if there's anything that needs adjustment. Thank you!