### PR TITLE
fix `Alert`

### DIFF
--- a/static/utils.ts
+++ b/static/utils.ts
@@ -40,21 +40,6 @@ export function updateAndCalcTopBarHeight(domRoot: JQuery, topBar: JQuery, hidea
     return topBarHeight;
 }
 
-/**
- *  Subscribe and unsubscribe the event listener.
- *
- * @param  {JQuery} element
- * @param  {string} eventName
- * @param  {(event:JQuery.Event)=>void} callback
- * @returns void
- */
-export function toggleEventListener(element: JQuery, eventName: string, callback: (event: JQuery.Event) => void): void {
-    element.on(eventName, (event: JQuery.Event) => {
-        callback(event);
-        element.off(eventName);
-    });
-}
-
 export function formatDateTimeWithSpaces(d: Date) {
     const t = x => x.slice(-2);
     // Hopefully some day we can use the temporal api to make this less of a pain

--- a/static/widgets/alert.ts
+++ b/static/widgets/alert.ts
@@ -25,7 +25,6 @@
 import $ from 'jquery';
 
 import {AlertAskOptions, AlertEnterTextOptions, AlertNotifyOptions} from './alert.interfaces.js';
-import {toggleEventListener} from '../utils.js';
 
 export class Alert {
     yesHandler: ((answer?: string | string[] | number) => void) | null = null;
@@ -42,6 +41,14 @@ export class Alert {
         });
     }
 
+    private toggleEventListener(element: JQuery, eventName: string, callback: (event: JQuery.Event) => void): void {
+        element.on(eventName, (event: JQuery.Event) => {
+            callback(event);
+            element.off(eventName);
+            this.yesHandler = null;
+            this.noHandler = null;
+        });
+    }
     /**
      * Display an alert with a title and a body
      */
@@ -140,13 +147,13 @@ export class Alert {
         modal.find('.modal-body .question').html(question);
 
         const yesButton = modal.find('.modal-footer .yes');
-        toggleEventListener(yesButton, 'click', () => {
+        this.toggleEventListener(yesButton, 'click', () => {
             const answer = modal.find('.question-answer');
             this.yesHandler?.(answer.val());
         });
 
         const noButton = modal.find('.modal-footer .no');
-        toggleEventListener(noButton, 'click', () => {
+        this.toggleEventListener(noButton, 'click', () => {
             this.noHandler?.();
         });
 


### PR DESCRIPTION
All `Alert` modal windows reuse the same yesButton/noButton.
The callback are setup in the Alert ctor -
```
        const yesNoModal = $('#yes-no');
        yesNoModal.find('button.yes').on('click', () => {
            this.yesHandler?.();
        });
        yesNoModal.find('button.no').on('click', () => {
            this.noHandler?.();
        });
    }
```
On every yes/no click, *All* callbacks of *All* alert instances are called.
So each `Alert` instance needs to cleanup its callbacks after usage, and it tries to - via the weirdly named `toggleEventListener`. `toggleEventListener` only did

```
element.off(eventName);
```
Some of the renaming problems were caused by persistance of [this callback](https://github.com/compiler-explorer/compiler-explorer/blob/00648a7e1c38c9172c5226d1f64511b8bebfe1c9/static/widgets/pane-renaming.ts#L68-L72).
Extending the cleanup to -
```
        element.off(eventName);
        this.yesHandler = null;
        this.noHandler = null;
```
seems to solve it this particular problem - not even sure `element.off` is even needed.