### PR TITLE
Make pane-renaming central

### DIFF
--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -136,6 +136,7 @@ export type EventMap = {
     ppViewClosed: (compilerId: number) => void;
     ppViewOpened: (compilerId: number) => void;
     ppViewOptionsUpdated: (compilerId: number, options: PPOptions, recompile: boolean) => void;
+    renamePane: () => void;
     requestCompilation: (editorId: number | boolean, treeId: boolean | number) => void;
     requestMotd: () => void;
     requestSettings: () => void;

--- a/static/panes/ast-view.ts
+++ b/static/panes/ast-view.ts
@@ -89,7 +89,7 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
         this.editor.onMouseMove(e => mouseMoveThrottledFunction(e));
 
         this.fontScale.on('change', this.updateState.bind(this));
-        this.paneRenaming.on('renamePane', this.updateState.bind(this));
+        this.eventHub.on('renamePane', this.updateState.bind(this));
 
         this.container.on('destroy', this.close, this);
 

--- a/static/panes/conformance-view.ts
+++ b/static/panes/conformance-view.ts
@@ -93,7 +93,7 @@ export class Conformance extends Pane<ConformanceViewState> {
 
         this.stateByLang = {};
 
-        this.paneRenaming = new PaneRenaming(this, state);
+        this.paneRenaming = new PaneRenaming(this, state, hub);
 
         this.initButtons();
         this.initCallbacks();
@@ -174,7 +174,7 @@ export class Conformance extends Pane<ConformanceViewState> {
             if (this.compilerInfo.editorId) this.eventHub.emit('conformanceViewClose', this.compilerInfo.editorId);
         });
 
-        this.paneRenaming.on('renamePane', this.saveState.bind(this));
+        this.eventHub.on('renamePane', this.saveState.bind(this));
 
         this.container.on('destroy', this.close, this);
         this.container.on('open', () => {

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -207,7 +207,7 @@ export class Executor extends Pane<ExecutorState> {
         this.options = state.options || options.compileOptions[this.currentLangId];
         this.executionArguments = state.execArgs || '';
         this.executionStdin = state.execStdin || '';
-        this.paneRenaming = new PaneRenaming(this, state);
+        this.paneRenaming = new PaneRenaming(this, state, this.hub);
     }
 
     override getInitialHTML(): string {
@@ -909,7 +909,7 @@ export class Executor extends Pane<ExecutorState> {
     initListeners(): void {
         // this.filters.on('change', this.onFilterChange.bind(this));
         this.fontScale.on('change', this.onFontScale.bind(this));
-        this.paneRenaming.on('renamePane', this.updateState.bind(this));
+        this.eventHub.on('renamePane', this.updateState.bind(this));
         this.toggleWrapButton.on('change', this.onToggleWrapChange.bind(this));
 
         this.container.on('destroy', this.close, this);

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -199,7 +199,7 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
         const onMouseMove = _.throttle(this.onMouseMove.bind(this), 50);
         const onDidChangeCursorSelection = _.throttle(this.onDidChangeCursorSelection.bind(this), 500);
 
-        this.paneRenaming.on('renamePane', this.updateState.bind(this));
+        this.eventHub.on('renamePane', this.updateState.bind(this));
 
         this.eventHub.on('compileResult', this.onCompileResult.bind(this));
         this.eventHub.on('colours', this.onColours.bind(this));

--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -76,7 +76,7 @@ export abstract class Pane<S> {
         this.initializeCompilerInfo(state);
         this.topBar = this.domRoot.find('.top-bar');
 
-        this.paneRenaming = new PaneRenaming(this, state);
+        this.paneRenaming = new PaneRenaming(this, state, hub);
 
         this.initializeDefaults();
         this.initializeGlobalDependentProperties();
@@ -200,7 +200,7 @@ export abstract class Pane<S> {
 
     /** Initialize standard lifecycle hooks */
     protected registerStandardCallbacks(): void {
-        this.paneRenaming.on('renamePane', this.updateState.bind(this));
+        this.eventHub.on('renamePane', this.updateState.bind(this));
         this.container.on('destroy', this.close.bind(this));
         this.container.on('resize', this.resize.bind(this));
         this.eventHub.on('compileResult', this.onCompileResult.bind(this));

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -116,7 +116,7 @@ export class Tree {
         this.busyCompilers = {};
         this.asmByCompiler = {};
 
-        this.paneRenaming = new PaneRenaming(this, state);
+        this.paneRenaming = new PaneRenaming(this, state, hub);
 
         this.initInputs(state);
         this.initButtons(state);
@@ -198,7 +198,7 @@ export class Tree {
         });
         this.container.on('destroy', this.close, this);
 
-        this.paneRenaming.on('renamePane', this.updateState.bind(this));
+        this.eventHub.on('renamePane', this.updateState.bind(this));
 
         this.eventHub.on('editorOpen', this.onEditorOpen, this);
         this.eventHub.on('editorClose', this.onEditorClose, this);

--- a/static/widgets/pane-renaming.ts
+++ b/static/widgets/pane-renaming.ts
@@ -24,19 +24,20 @@
 
 import $ from 'jquery';
 import {Tab} from 'golden-layout';
-import {EventEmitter} from 'events';
 import {Alert} from './alert.js';
+import {Hub} from '../hub.js';
 
-export class PaneRenaming extends EventEmitter.EventEmitter {
+export class PaneRenaming {
     private pane: any;
     private alertSystem: any;
     private state: any;
+    private hub: Hub;
 
-    constructor(pane: any, state: any) {
-        super();
+    constructor(pane: any, state: any, hub: Hub) {
         this.pane = pane;
         this.alertSystem = this.pane.alertSystem ?? new Alert();
         this.state = state;
+        this.hub = hub;
 
         this.loadSavedPaneName();
         this.registerCallbacks();
@@ -69,7 +70,7 @@ export class PaneRenaming extends EventEmitter.EventEmitter {
                     // Update title and emit event to save it into the state
                     this.pane.paneName = value;
                     this.pane.updateTitle();
-                    this.emit('renamePane');
+                    this.hub.layout.eventHub.emit('renamePane');
                 },
                 yesClass: 'btn btn-primary',
                 yesHtml: 'Rename',


### PR DESCRIPTION
When each `Pane` (and others) create their own `PaneRenaming`, which extends `EventEmitter.EventEmitter`, when one actor emits `renamePane` no other actor can hear it.

This PR makes `PaneRenaming` stop using its own event emission, and instead use the central `Hub` it now  receives at its ctor.