### PR TITLE
add paneName fallback to filename in editor.getPaneName()

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1914,6 +1914,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     override getPaneName(): string {
         if (this.filename) {
             return this.filename;
+        } else if (this.paneName) {
+            return this.paneName;
         } else {
             return this.currentLanguage?.name + ' source #' + this.id;
         }


### PR DESCRIPTION
Pane has `Pane.paneName`, and Editor - which extends it - has `Editor.filename`. 
Is there really any reason to keep these two distinct? This seems to just add opportunities for bugs.

If you think not, I'll remove `Editor.filename` in a future PR.