### PR TITLE
More fixes for pane-renaming in various scenarios

### DIFF
--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -512,10 +512,13 @@ export class MultifileService {
                         if (!this.fileExists(value, file)) {
                             file.filename = value;
 
-                            if (editor) {
-                                editor.setFilename(file.filename);
+                            // The rename click opened the editor if it was closed
+                            if (file.isOpen && file.editorId > 0) {
+                                editor = this.hub.getEditorById(file.editorId);
+                                if (editor) {
+                                    editor.setFilename(file.filename);
+                                }
                             }
-
                             resolve(true);
                         } else {
                             this.alertSystem.alert('Rename file', 'Filename already exists');

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1912,10 +1912,10 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     }
 
     override getPaneName(): string {
-        if (this.filename) {
-            return this.filename;
-        } else if (this.paneName) {
+        if (this.paneName) {
             return this.paneName;
+        } else if (this.filename) {
+            return this.filename;
         } else {
             return this.currentLanguage?.name + ' source #' + this.id;
         }

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -191,9 +191,12 @@ export class Tree {
     }
 
     private paneRenamedExternally() {
-        this.multifileService.forEachFile(
-            (file: MultifileFile) => (file.filename = this.hub.getEditorById(file.editorId)?.getPaneName() ?? ''),
-        );
+        this.multifileService.forEachFile((file: MultifileFile) => {
+            const editor = this.hub.getEditorById(file.editorId);
+            if (editor) {
+                file.filename = editor.getPaneName();
+            }
+        });
         this.refresh();
     }
 


### PR DESCRIPTION
I gave renaming a proper beat-up, and a few more fixes ensued.
TODO: eliminate `editor.filename` in favour of `pane.paneName`, this could have saved some of these fixes.
