### PR TITLE
Fix in clang-format arg handling

### DIFF
--- a/lib/tooling/clang-format-tool.ts
+++ b/lib/tooling/clang-format-tool.ts
@@ -54,9 +54,11 @@ export class ClangFormatTool extends BaseTool {
         }
 
         await fs.writeFile(path.join(dir, 'compile_flags.txt'), compileFlags.join('\n'));
-        const clang_format_file = path.join(dir, 'clang_format_options.txt');
-        await fs.writeFile(clang_format_file, stdin);
-        args.push(`-style=file:${clang_format_file}`);
+        if (stdin !== '') {
+            const clang_format_file = path.join(dir, 'clang_format_options.txt');
+            await fs.writeFile(clang_format_file, stdin);
+            args.push(`-style=file:${clang_format_file}`);
+        }
         return await super.runTool(compilationInfo, sourcefile, args, stdin);
     }
 }


### PR DESCRIPTION
Fix #6765: don't let an empty `stdin` override explicit args