### PR TITLE
Add new R8 and ART versions

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -1,11 +1,20 @@
 compilers=&android-d8:&android-r8:&dex2oat
 
-group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242:java-d8-8247:java-d8-8336:java-d8-8337
+group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242:java-d8-8247:java-d8-8336:java-d8-8337:java-d8-8510:java-d8-8527:java-d8-8535
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
+
+compiler.java-d8-8535.name=d8 8.5.35
+compiler.java-d8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
+
+compiler.java-d8-8527.name=d8 8.5.27
+compiler.java-d8-8527.exe=/opt/compiler-explorer/r8-8.5.27/r8-8.5.27.jar
+
+compiler.java-d8-8510.name=d8 8.5.10
+compiler.java-d8-8510.exe=/opt/compiler-explorer/r8-8.5.10/r8-8.5.10.jar
 
 compiler.java-d8-8337.name=d8 8.3.37
 compiler.java-d8-8337.exe=/opt/compiler-explorer/r8-8.3.37/r8-8.3.37.jar
@@ -28,12 +37,21 @@ compiler.java-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.java-d8-8156.name=d8 8.1.56
 compiler.java-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
-group.android-r8.compilers=java-r8-8233:java-r8-8242:java-r8-8247:java-r8-8336:java-r8-8337
+group.android-r8.compilers=java-r8-8233:java-r8-8242:java-r8-8247:java-r8-8336:java-r8-8337:java-r8-8510:java-r8-8527:java-r8-8535
 group.android-r8.compilerType=android-r8
 group.android-r8.isSemVer=true
 group.android-r8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-r8.javaId=java1601
 group.android-r8.kotlinId=kotlinc1920
+
+compiler.java-r8-8535.name=r8 8.5.35
+compiler.java-r8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
+
+compiler.java-r8-8527.name=r8 8.5.27
+compiler.java-r8-8527.exe=/opt/compiler-explorer/r8-8.5.27/r8-8.5.27.jar
+
+compiler.java-r8-8510.name=r8 8.5.10
+compiler.java-r8-8510.exe=/opt/compiler-explorer/r8-8.5.10/r8-8.5.10.jar
 
 compiler.java-r8-8337.name=r8 8.3.37
 compiler.java-r8-8337.exe=/opt/compiler-explorer/r8-8.3.37/r8-8.3.37.jar
@@ -50,7 +68,7 @@ compiler.java-r8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.java-r8-8233.name=r8 8.2.33
 compiler.java-r8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
 
-group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3310:java-dex2oat-3411:java-dex2oat-3413:java-dex2oat-3414:java-dex2oat-3415:java-dex2oat-3416
+group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3310:java-dex2oat-3411:java-dex2oat-3413:java-dex2oat-3414:java-dex2oat-3415:java-dex2oat-3416:java-dex2oat-3417:java-dex2oat-3418
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
@@ -59,9 +77,23 @@ compiler.java-dex2oat-latest.name=ART dex2oat latest
 compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
-compiler.java-dex2oat-latest.d8Id=java-d8-8337
+compiler.java-dex2oat-latest.d8Id=java-d8-8535
 compiler.java-dex2oat-latest.isNightly=true
 compiler.java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+compiler.java-dex2oat-3418.name=ART dex2oat aml_art_341810020 (Jun 2024)
+compiler.java-dex2oat-3418.artArtifactDir=/opt/compiler-explorer/dex2oat-34.18
+compiler.java-dex2oat-3418.exe=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3418.objdumper=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/oatdump
+compiler.java-dex2oat-3418.d8Id=java-d8-8535
+compiler.java-dex2oat-3418.profmanPath=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/profman
+
+compiler.java-dex2oat-3417.name=ART dex2oat aml_art_341711000 (May 2024)
+compiler.java-dex2oat-3417.artArtifactDir=/opt/compiler-explorer/dex2oat-34.17
+compiler.java-dex2oat-3417.exe=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3417.objdumper=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/oatdump
+compiler.java-dex2oat-3417.d8Id=java-d8-8535
+compiler.java-dex2oat-3417.profmanPath=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/profman
 
 compiler.java-dex2oat-3416.name=ART dex2oat aml_art_341615020 (Apr 2024)
 compiler.java-dex2oat-3416.artArtifactDir=/opt/compiler-explorer/dex2oat-34.16

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -1,11 +1,20 @@
 compilers=&android-d8:&android-r8:&dex2oat
 
-group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242:kotlin-d8-8247:kotlin-d8-8336:kotlin-d8-8337
+group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242:kotlin-d8-8247:kotlin-d8-8336:kotlin-d8-8337:kotlin-d8-8510:kotlin-d8-8527:kotlin-d8-8535
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
+
+compiler.kotlin-d8-8535.name=d8 8.5.35
+compiler.kotlin-d8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
+
+compiler.kotlin-d8-8527.name=d8 8.5.27
+compiler.kotlin-d8-8527.exe=/opt/compiler-explorer/r8-8.5.27/r8-8.5.27.jar
+
+compiler.kotlin-d8-8510.name=d8 8.5.10
+compiler.kotlin-d8-8510.exe=/opt/compiler-explorer/r8-8.5.10/r8-8.5.10.jar
 
 compiler.kotlin-d8-8337.name=d8 8.3.37
 compiler.kotlin-d8-8337.exe=/opt/compiler-explorer/r8-8.3.37/r8-8.3.37.jar
@@ -28,13 +37,22 @@ compiler.kotlin-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.kotlin-d8-8156.name=d8 8.1.56
 compiler.kotlin-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
-group.android-r8.compilers=kotlin-r8-8233:kotlin-r8-8242:kotlin-r8-8247:kotlin-r8-8336:kotlin-r8-8337
+group.android-r8.compilers=kotlin-r8-8233:kotlin-r8-8242:kotlin-r8-8247:kotlin-r8-8336:kotlin-r8-8337:kotlin-r8-8510:kotlin-r8-8527:kotlin-r8-8535
 group.android-r8.compilerType=android-r8
 group.android-r8.isSemVer=true
 group.android-r8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-r8.javaId=java1601
 group.android-r8.kotlinId=kotlinc1920
 group.android-r8.kotlinLibPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/lib
+
+compiler.kotlin-r8-8535.name=r8 8.5.35
+compiler.kotlin-r8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
+
+compiler.kotlin-r8-8527.name=r8 8.5.27
+compiler.kotlin-r8-8527.exe=/opt/compiler-explorer/r8-8.5.27/r8-8.5.27.jar
+
+compiler.kotlin-r8-8510.name=r8 8.5.10
+compiler.kotlin-r8-8510.exe=/opt/compiler-explorer/r8-8.5.10/r8-8.5.10.jar
 
 compiler.kotlin-r8-8337.name=r8 8.3.37
 compiler.kotlin-r8-8337.exe=/opt/compiler-explorer/r8-8.3.37/r8-8.3.37.jar
@@ -51,7 +69,7 @@ compiler.kotlin-r8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.kotlin-r8-8233.name=r8 8.2.33
 compiler.kotlin-r8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
 
-group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3310:kotlin-dex2oat-3411:kotlin-dex2oat-3413:kotlin-dex2oat-3414:kotlin-dex2oat-3415:kotlin-dex2oat-3416
+group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3310:kotlin-dex2oat-3411:kotlin-dex2oat-3413:kotlin-dex2oat-3414:kotlin-dex2oat-3415:kotlin-dex2oat-3416:kotlin-dex2oat-3417:kotlin-dex2oat-3418
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
@@ -60,9 +78,23 @@ compiler.kotlin-dex2oat-latest.name=ART dex2oat latest
 compiler.kotlin-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.kotlin-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.kotlin-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
-compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8337
+compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8535
 compiler.kotlin-dex2oat-latest.isNightly=true
 compiler.kotlin-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3418.name=ART dex2oat aml_art_341810020 (Jun 2024)
+compiler.kotlin-dex2oat-3418.artArtifactDir=/opt/compiler-explorer/dex2oat-34.18
+compiler.kotlin-dex2oat-3418.exe=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3418.objdumper=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3418.d8Id=kotlin-d8-8535
+compiler.kotlin-dex2oat-3418.profmanPath=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3417.name=ART dex2oat aml_art_341711000 (May 2024)
+compiler.kotlin-dex2oat-3417.artArtifactDir=/opt/compiler-explorer/dex2oat-34.17
+compiler.kotlin-dex2oat-3417.exe=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3417.objdumper=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3417.d8Id=kotlin-d8-8535
+compiler.kotlin-dex2oat-3417.profmanPath=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/profman
 
 compiler.kotlin-dex2oat-3416.name=ART dex2oat aml_art_341615020 (Apr 2024)
 compiler.kotlin-dex2oat-3416.artArtifactDir=/opt/compiler-explorer/dex2oat-34.16


### PR DESCRIPTION
This change adds newer R8 versions (8.5.10, 8.5.27, 8.5.35) and ART dex2oat versions (34.17, 34.18) for Android Java/Kotlin. This should be submitted after:
- https://github.com/compiler-explorer/infra/pull/1392
- https://github.com/compiler-explorer/infra/pull/1394

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
