### PR TITLE
.NET: Add mono and NativeAOT support

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80csharpcoreclr
@@ -8,10 +8,22 @@ group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet80csharpcoreclr:dot
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
+
 group.dotnetcrossgen2.compilers=dotnettrunkcsharpcrossgen2:dotnet80csharpcrossgen2:dotnet70csharpcrossgen2:dotnet60csharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
+
+group.dotnetmono.compilers=dotnettrunkcsharpmono
+group.dotnetmono.compilerCategories=mono
+group.dotnetmono.compilerType=dotnetmono
+group.dotnetmono.groupName=.NET Mono
+
+group.dotnetnativeaot.compilers=dotnettrunkcsharpnativeaot
+group.dotnetnativeaot.compilerCategories=nativeaot
+group.dotnetnativeaot.compilerType=dotnetnativeaot
+group.dotnetnativeaot.groupName=.NET NativeAOT
+
 group.dotnetlegacy.compilers=dotnettrunkcsharp:dotnet707csharp:dotnet703csharp:dotnet701csharp:dotnet6018csharp:dotnet6014csharp:dotnet6011csharp
 group.dotnetlegacy.compilerCategories=legacy
 group.dotnetlegacy.compilerType=dotnetlegacy
@@ -64,6 +76,24 @@ compiler.dotnettrunkcsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkcsharpcrossgen2.langVersion=preview
 compiler.dotnettrunkcsharpcrossgen2.isNightly=true
+
+# Mono compilers
+
+compiler.dotnettrunkcsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharpmono.name=.NET (main)
+compiler.dotnettrunkcsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharpmono.buildConfig=Release
+compiler.dotnettrunkcsharpmono.langVersion=preview
+compiler.dotnettrunkcsharpmono.isNightly=true
+
+# NativeAOT compilers
+
+compiler.dotnettrunkcsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkcsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharpnativeaot.buildConfig=Release
+compiler.dotnettrunkcsharpnativeaot.langVersion=preview
+compiler.dotnettrunkcsharpnativeaot.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -1,4 +1,4 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80csharpcoreclr
@@ -8,10 +8,22 @@ group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet80csharpcoreclr:dot
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
+
 group.dotnetcrossgen2.compilers=dotnettrunkcsharpcrossgen2:dotnet80csharpcrossgen2:dotnet70csharpcrossgen2:dotnet60csharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
+
+group.dotnetmono.compilers=dotnettrunkcsharpmono
+group.dotnetmono.compilerCategories=mono
+group.dotnetmono.compilerType=dotnetmono
+group.dotnetmono.groupName=.NET Mono
+
+group.dotnetnativeaot.compilers=dotnettrunkcsharpnativeaot
+group.dotnetnativeaot.compilerCategories=nativeaot
+group.dotnetnativeaot.compilerType=dotnetnativeaot
+group.dotnetnativeaot.groupName=.NET NativeAOT
+
 group.dotnetlegacy.compilers=dotnettrunkcsharp:dotnet707csharp:dotnet703csharp:dotnet701csharp:dotnet6018csharp:dotnet6014csharp:dotnet6011csharp
 group.dotnetlegacy.compilerCategories=legacy
 group.dotnetlegacy.compilerType=dotnetlegacy
@@ -64,6 +76,24 @@ compiler.dotnettrunkcsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkcsharpcrossgen2.langVersion=preview
 compiler.dotnettrunkcsharpcrossgen2.isNightly=true
+
+# Mono compilers
+
+compiler.dotnettrunkcsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharpmono.name=.NET (main)
+compiler.dotnettrunkcsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharpmono.buildConfig=Release
+compiler.dotnettrunkcsharpmono.langVersion=preview
+compiler.dotnettrunkcsharpmono.isNightly=true
+
+# NativeAOT compilers
+
+compiler.dotnettrunkcsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkcsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharpnativeaot.buildConfig=Release
+compiler.dotnettrunkcsharpnativeaot.langVersion=preview
+compiler.dotnettrunkcsharpnativeaot.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80fsharpcoreclr
@@ -8,10 +8,22 @@ group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet80fsharpcoreclr:dot
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
+
 group.dotnetcrossgen2.compilers=dotnettrunkfsharpcrossgen2:dotnet80fsharpcrossgen2:dotnet70fsharpcrossgen2:dotnet60fsharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
+
+group.dotnetmono.compilers=dotnettrunkfsharpmono
+group.dotnetmono.compilerCategories=mono
+group.dotnetmono.compilerType=dotnetmono
+group.dotnetmono.groupName=.NET Mono
+
+group.dotnetnativeaot.compilers=dotnettrunkfsharpnativeaot
+group.dotnetnativeaot.compilerCategories=nativeaot
+group.dotnetnativeaot.compilerType=dotnetnativeaot
+group.dotnetnativeaot.groupName=.NET NativeAOT
+
 group.dotnetlegacy.compilers=dotnettrunkfsharp:dotnet707fsharp:dotnet703fsharp:dotnet701fsharp:dotnet6018fsharp:dotnet6014fsharp:dotnet6011fsharp
 group.dotnetlegacy.compilerCategories=legacy
 group.dotnetlegacy.compilerType=dotnetlegacy
@@ -64,6 +76,24 @@ compiler.dotnettrunkfsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkfsharpcrossgen2.langVersion=preview
 compiler.dotnettrunkfsharpcrossgen2.isNightly=true
+
+# Mono compilers
+
+compiler.dotnettrunkfsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharpmono.name=.NET (main)
+compiler.dotnettrunkfsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharpmono.buildConfig=Release
+compiler.dotnettrunkfsharpmono.langVersion=preview
+compiler.dotnettrunkfsharpmono.isNightly=true
+
+# NativeAOT compilers
+
+compiler.dotnettrunkfsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkfsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharpnativeaot.buildConfig=Release
+compiler.dotnettrunkfsharpnativeaot.langVersion=preview
+compiler.dotnettrunkfsharpnativeaot.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -1,4 +1,4 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80fsharpcoreclr
@@ -8,10 +8,22 @@ group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet80fsharpcoreclr:dot
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
+
 group.dotnetcrossgen2.compilers=dotnettrunkfsharpcrossgen2:dotnet80fsharpcrossgen2:dotnet70fsharpcrossgen2:dotnet60fsharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
+
+group.dotnetmono.compilers=dotnettrunkfsharpmono
+group.dotnetmono.compilerCategories=mono
+group.dotnetmono.compilerType=dotnetmono
+group.dotnetmono.groupName=.NET Mono
+
+group.dotnetnativeaot.compilers=dotnettrunkfsharpnativeaot
+group.dotnetnativeaot.compilerCategories=nativeaot
+group.dotnetnativeaot.compilerType=dotnetnativeaot
+group.dotnetnativeaot.groupName=.NET NativeAOT
+
 group.dotnetlegacy.compilers=dotnettrunkfsharp:dotnet707fsharp:dotnet703fsharp:dotnet701fsharp:dotnet6018fsharp:dotnet6014fsharp:dotnet6011fsharp
 group.dotnetlegacy.compilerCategories=legacy
 group.dotnetlegacy.compilerType=dotnetlegacy
@@ -64,6 +76,24 @@ compiler.dotnettrunkfsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkfsharpcrossgen2.langVersion=preview
 compiler.dotnettrunkfsharpcrossgen2.isNightly=true
+
+# Mono compilers
+
+compiler.dotnettrunkfsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharpmono.name=.NET (main)
+compiler.dotnettrunkfsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharpmono.buildConfig=Release
+compiler.dotnettrunkfsharpmono.langVersion=preview
+compiler.dotnettrunkfsharpmono.isNightly=true
+
+# NativeAOT compilers
+
+compiler.dotnettrunkfsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkfsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharpnativeaot.buildConfig=Release
+compiler.dotnettrunkfsharpnativeaot.langVersion=preview
+compiler.dotnettrunkfsharpnativeaot.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80vbcoreclr
@@ -8,10 +8,22 @@ group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet80vbcoreclr:dotnet70vbc
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
+
 group.dotnetcrossgen2.compilers=dotnettrunkvbcrossgen2:dotnet80vbcrossgen2:dotnet70vbcrossgen2:dotnet60vbcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
+
+group.dotnetmono.compilers=dotnettrunkvbmono
+group.dotnetmono.compilerCategories=mono
+group.dotnetmono.compilerType=dotnetmono
+group.dotnetmono.groupName=.NET Mono
+
+group.dotnetnativeaot.compilers=dotnettrunkvbnativeaot
+group.dotnetnativeaot.compilerCategories=nativeaot
+group.dotnetnativeaot.compilerType=dotnetnativeaot
+group.dotnetnativeaot.groupName=.NET NativeAOT
+
 group.dotnetlegacy.compilers=dotnettrunkvb:dotnet707vb:dotnet703vb:dotnet701vb:dotnet6018vb:dotnet6014vb:dotnet6011vb
 group.dotnetlegacy.compilerCategories=legacy
 group.dotnetlegacy.compilerType=dotnetlegacy
@@ -64,6 +76,24 @@ compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
 compiler.dotnettrunkvbcrossgen2.langVersion=preview
 compiler.dotnettrunkvbcrossgen2.isNightly=true
+
+# Mono compilers
+
+compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvbmono.name=.NET (main)
+compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvbmono.buildConfig=Release
+compiler.dotnettrunkvbmono.langVersion=preview
+compiler.dotnettrunkvbmono.isNightly=true
+
+# NativeAOT compilers
+
+compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvbnativeaot.name=.NET (main)
+compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvbnativeaot.buildConfig=Release
+compiler.dotnettrunkvbnativeaot.langVersion=preview
+compiler.dotnettrunkvbnativeaot.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -1,4 +1,4 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
 defaultCompiler=dotnet80vbcoreclr
@@ -8,10 +8,22 @@ group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet80vbcoreclr:dotnet70vbc
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
+
 group.dotnetcrossgen2.compilers=dotnettrunkvbcrossgen2:dotnet80vbcrossgen2:dotnet70vbcrossgen2:dotnet60vbcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
+
+group.dotnetmono.compilers=dotnettrunkvbmono
+group.dotnetmono.compilerCategories=mono
+group.dotnetmono.compilerType=dotnetmono
+group.dotnetmono.groupName=.NET Mono
+
+group.dotnetnativeaot.compilers=dotnettrunkvbnativeaot
+group.dotnetnativeaot.compilerCategories=nativeaot
+group.dotnetnativeaot.compilerType=dotnetnativeaot
+group.dotnetnativeaot.groupName=.NET NativeAOT
+
 group.dotnetlegacy.compilers=dotnettrunkvb:dotnet707vb:dotnet703vb:dotnet701vb:dotnet6018vb:dotnet6014vb:dotnet6011vb
 group.dotnetlegacy.compilerCategories=legacy
 group.dotnetlegacy.compilerType=dotnetlegacy
@@ -64,6 +76,24 @@ compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
 compiler.dotnettrunkvbcrossgen2.langVersion=preview
 compiler.dotnettrunkvbcrossgen2.isNightly=true
+
+# Mono compilers
+
+compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvbmono.name=.NET (main)
+compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvbmono.buildConfig=Release
+compiler.dotnettrunkvbmono.langVersion=preview
+compiler.dotnettrunkvbmono.isNightly=true
+
+# NativeAOT compilers
+
+compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvbnativeaot.name=.NET (main)
+compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvbnativeaot.buildConfig=Release
+compiler.dotnettrunkvbnativeaot.langVersion=preview
+compiler.dotnettrunkvbnativeaot.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -53,9 +53,13 @@ export {DartCompiler} from './dart.js';
 export {DefaultCompiler} from './default.js';
 export {Dex2OatCompiler} from './dex2oat.js';
 export {DMDCompiler} from './dmd.js';
-export {DotNetCoreClrCompiler} from './dotnet.js';
-export {DotNetCrossgen2Compiler} from './dotnet.js';
-export {DotNetLegacyCompiler} from './dotnet.js';
+export {
+    DotNetCoreClrCompiler,
+    DotNetCrossgen2Compiler,
+    DotNetLegacyCompiler,
+    DotNetMonoCompiler,
+    DotNetNativeAotCompiler,
+} from './dotnet.js';
 export {EDGCompiler} from './edg.js';
 export {EllccCompiler} from './ellcc.js';
 export {ElixirCompiler} from './elixir.js';

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -244,8 +244,6 @@ class DotNetCompiler extends BaseCompiler {
         const toolOptions: string[] = [
             '--codegenopt',
             this.sdkMajorVersion === 6 ? 'NgenDisasm=*' : 'JitDisasm=*',
-            '--codegenopt',
-            'JitDisasmAssemblies=CompilerExplorer',
             '--parallelism', '1',
         ];
         const toolSwitches: string[] = [];

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -45,6 +45,7 @@ class DotNetCompiler extends BaseCompiler {
     private readonly corerunPath: string;
     private readonly disassemblyLoaderPath: string;
     private readonly crossgen2Path: string;
+    private readonly ilcPath: string;
     private readonly sdkMajorVersion: number;
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env) {
@@ -63,6 +64,7 @@ class DotNetCompiler extends BaseCompiler {
 
         this.corerunPath = path.join(this.clrBuildDir, 'corerun');
         this.crossgen2Path = path.join(this.clrBuildDir, 'crossgen2', 'crossgen2.dll');
+        this.ilcPath = path.join(this.clrBuildDir, 'ilc-published', 'ilc');
         this.asm = new DotNetAsmParser();
         this.disassemblyLoaderPath = path.join(this.clrBuildDir, 'DisassemblyLoader', 'DisassemblyLoader.dll');
     }
@@ -85,6 +87,18 @@ class DotNetCompiler extends BaseCompiler {
             '--maxgenericcycle',
             '--maxgenericcyclebreadth',
             '--max-vectort-bitwidth',
+            '--runtimeopt',
+            '--runtimeknob',
+            '--feature',
+            '--directpinvoke',
+            '--root',
+            '--conditionalroot',
+            '--trim',
+            '--jitpath',
+            '--generateunmanagedentrypoints',
+            '--guard',
+            '--initassembly',
+            '--reflectiondata',
         ];
     }
 
@@ -103,6 +117,17 @@ class DotNetCompiler extends BaseCompiler {
             '--compilebubblegenerics',
             '--aot',
             '--crossgen2',
+            '--dehydrate',
+            '--scanreflection',
+            '--methodbodyfolding',
+            '--stacktracedata',
+            '--defaultrooting',
+            '--preinitstatics',
+            '--nopreinitstatics',
+            '--scan',
+            '--noscan',
+            '--noinlinetls',
+            '--completetypemetadata',
         ];
     }
 
@@ -150,6 +175,8 @@ class DotNetCompiler extends BaseCompiler {
         // Try to be less chatty
         execOptions.env.DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true';
         execOptions.env.DOTNET_NOLOGO = 'true';
+
+        execOptions.maxOutput = 1024 * 1024 * 1024;
 
         execOptions.customCwd = programDir;
 
@@ -205,92 +232,20 @@ class DotNetCompiler extends BaseCompiler {
         return compilerResult;
     }
 
-    async publishAot(
-        compiler: string,
-        ilcOptions: string[],
-        ilcSwitches: string[],
-        inputFilename: string,
-        execOptions: ExecutionOptions & {env: Record<string, string>},
-    ): Promise<CompilationResult> {
-        const programDir = path.dirname(inputFilename);
-
-        this.setCompilerExecOptions(execOptions, programDir, true);
-
-        // serialize ['a', 'b', 'c;d', '*e*'] into a=b;c%3Bd=%2Ae%2A;
-        const msbuildOptions = ilcOptions
-            .map(val => val.replaceAll('*', '%2A').replaceAll(';', '%3B'))
-            .reduce((acc, val, idx) => (idx % 2 === 0 ? (acc ? `${acc}${val}` : `${val}`) : `${acc}=${val};`), '');
-
-        // serialize ['a', 'b', 'c', 'd'] into a;b;c;d
-        const msbuildSwitches = ilcSwitches.join(';');
-
-        const toolVersion = await fs.readFile(`${this.clrBuildDir}/aot/package-version.txt`, 'utf8');
-        const jitOutFile = `${programDir}/jitout`;
-
-        ilcOptions.push('--codegenopt', `JitDisasmAssemblies=${AssemblyName}`);
-
-        await fs.writeFile(
-            path.join(programDir, `${AssemblyName}${this.lang.extensions[0]}proj`),
-            `<Project Sdk="Microsoft.NET.Sdk">
-               <PropertyGroup>
-                 <TargetFramework>${this.targetFramework}</TargetFramework>
-                 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-                 <AssemblyName>${AssemblyName}</AssemblyName>
-                 <LangVersion>${this.langVersion}</LangVersion>
-                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                 <Nullable>enable</Nullable>
-                 <OutputType>Library</OutputType>
-                 <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-               </PropertyGroup>
-               <ItemGroup>
-                 <Compile Include="${path.basename(this.filename(inputFilename))}" />
-                 <PackageReference
-                   Include="Microsoft.DotNet.ILCompiler;runtime.linux-x64.Microsoft.DotNet.ILCompiler"
-                   Version="${toolVersion}" />
-                 <IlcArg Include="${msbuildOptions}${msbuildSwitches};--codegenopt=JitStdOutFile=${jitOutFile}" />
-               </ItemGroup>
-             </Project>`,
-        );
-
-        // prettier-ignore
-        const publishOptions = ['publish', '-c', this.buildConfig, '-v', 'q', '--nologo', '/clp:NoSummary',
-            '--property', 'PublishAot=true', '--packages', `${this.clrBuildDir}/aot`];
-
-        // .NET 7 doesn't support JitStdOutFile, so higher max output is needed for stdout
-        execOptions.maxOutput = 1024 * 1024 * 1024;
-
-        const compilerResult = await super.runCompiler(compiler, publishOptions, inputFilename, execOptions);
-        if (compilerResult.code !== 0) {
-            return compilerResult;
-        }
-
-        await fs.createFile(this.getOutputFilename(programDir, this.outputFilebase));
-
-        const version = '// ilc ' + toolVersion;
-        const output = await fs.readFile(jitOutFile);
-
-        // .NET 7 doesn't support JitStdOutFile, so read from stdout
-        const outputString = output.length > 0 ? output.toString().split('\n') : compilerResult.stdout.map(o => o.text);
-
-        await fs.writeFile(
-            this.getOutputFilename(programDir, this.outputFilebase),
-            `${version}\n\n${outputString.reduce((a, n) => `${a}\n${n}`, '')}`,
-        );
-
-        return compilerResult;
-    }
-
     override async runCompiler(
         compiler: string,
         options: string[],
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
+        filters: ParseFiltersAndOutputOptions,
     ): Promise<CompilationResult> {
         const corerunArgs: string[] = [];
         // prettier-ignore
         const toolOptions: string[] = [
             '--codegenopt',
             this.sdkMajorVersion === 6 ? 'NgenDisasm=*' : 'JitDisasm=*',
+            '--codegenopt',
+            'JitDisasmAssemblies=CompilerExplorer',
             '--parallelism', '1',
         ];
         const toolSwitches: string[] = [];
@@ -304,8 +259,9 @@ class DotNetCompiler extends BaseCompiler {
             'DOTNET_JitDisasmAssemblies=CompilerExplorer',
             'DOTNET_TieredCompilation=0',
         ];
-        let isAot = false;
         let overrideDiffable = false;
+        let isAot = this.compiler.group === 'dotnetnativeaot';
+        let isMono = this.compiler.group === 'dotnetmono';
         let isCrossgen2 = this.compiler.group === 'dotnetlegacy' && this.sdkMajorVersion === 6;
 
         while (options.length > 0) {
@@ -338,6 +294,8 @@ class DotNetCompiler extends BaseCompiler {
                         isAot = true;
                     } else if (currentOption === '--crossgen2') {
                         isCrossgen2 = true;
+                    } else if (currentOption === '--mono') {
+                        isMono = true;
                     }
                 } else {
                     toolSwitches.push(currentOption);
@@ -370,56 +328,56 @@ class DotNetCompiler extends BaseCompiler {
         }
 
         this.setCompilerExecOptions(execOptions, programDir);
-        let compilerResult;
 
-        if (isAot) {
-            if (!fs.existsSync(`${this.clrBuildDir}/aot`)) {
-                return {
-                    code: -1,
-                    timedOut: false,
-                    didExecute: false,
-                    stdout: [],
-                    stderr: [{text: '--aot is not supported with this version.'}],
-                };
+        const compilerResult = await this.buildToDll(compiler, inputFilename, execOptions);
+        if (compilerResult.code !== 0) {
+            return compilerResult;
+        }
+
+        if (isCrossgen2) {
+            const crossgen2Result = await this.runCrossgen2(
+                compiler,
+                execOptions,
+                this.clrBuildDir,
+                programDllPath,
+                toolOptions,
+                toolSwitches,
+                this.getOutputFilename(programDir, this.outputFilebase),
+            );
+
+            if (crossgen2Result.code !== 0) {
+                return crossgen2Result;
             }
+        } else if (isAot) {
+            const ilcResult = await this.runIlc(
+                this.ilcPath,
+                execOptions,
+                programDllPath,
+                toolOptions,
+                toolSwitches,
+                this.getOutputFilename(programDir, this.outputFilebase),
+                filters.binary ?? false,
+            );
 
-            compilerResult = await this.publishAot(compiler, toolOptions, toolSwitches, inputFilename, execOptions);
+            if (ilcResult.code !== 0) {
+                return ilcResult;
+            }
         } else {
-            compilerResult = await this.buildToDll(compiler, inputFilename, execOptions);
-            if (compilerResult.code !== 0) {
-                return compilerResult;
-            }
+            const envVarFilePath = path.join(programDir, '.env');
+            await fs.writeFile(envVarFilePath, envVarFileContents.join('\n'));
 
-            if (isCrossgen2) {
-                const crossgen2Result = await this.runCrossgen2(
-                    compiler,
-                    execOptions,
-                    this.clrBuildDir,
-                    programDllPath,
-                    toolOptions,
-                    toolSwitches,
-                    this.getOutputFilename(programDir, this.outputFilebase),
-                );
+            const corerunResult = await this.runCorerunForDisasm(
+                execOptions,
+                this.clrBuildDir,
+                envVarFilePath,
+                programDllPath,
+                corerunArgs,
+                this.getOutputFilename(programDir, this.outputFilebase),
+                isMono,
+            );
 
-                if (crossgen2Result.code !== 0) {
-                    return crossgen2Result;
-                }
-            } else {
-                const envVarFilePath = path.join(programDir, '.env');
-                await fs.writeFile(envVarFilePath, envVarFileContents.join('\n'));
-
-                const corerunResult = await this.runCorerunForDisasm(
-                    execOptions,
-                    this.clrBuildDir,
-                    envVarFilePath,
-                    programDllPath,
-                    corerunArgs,
-                    this.getOutputFilename(programDir, this.outputFilebase),
-                );
-
-                if (corerunResult.code !== 0) {
-                    return corerunResult;
-                }
+            if (corerunResult.code !== 0) {
+                return corerunResult;
             }
         }
 
@@ -447,7 +405,12 @@ class DotNetCompiler extends BaseCompiler {
         dllPath: string,
         options: string[],
         outputPath: string,
+        isMono: boolean,
     ) {
+        if (isMono) {
+            coreRoot = path.join(coreRoot, 'mono');
+        }
+
         const corerunOptions = ['--clr-path', coreRoot, '--env', envPath].concat([
             ...options,
             this.disassemblyLoaderPath,
@@ -458,7 +421,7 @@ class DotNetCompiler extends BaseCompiler {
 
         await fs.writeFile(
             outputPath,
-            `// coreclr ${await this.getRuntimeVersion()}\n\n${result.stdout
+            `// ${isMono ? 'mono' : 'coreclr'} ${await this.getRuntimeVersion()}\n\n${result.stdout
                 .map(o => o.text)
                 .reduce((a, n) => `${a}\n${n}`, '')}`,
         );
@@ -497,6 +460,51 @@ class DotNetCompiler extends BaseCompiler {
         return result;
     }
 
+    async runIlc(
+        compiler: string,
+        execOptions: ExecutionOptions,
+        dllPath: string,
+        toolOptions: string[],
+        toolSwitches: string[],
+        outputPath: string,
+        buildToBinary: boolean,
+    ) {
+        // prettier-ignore
+        const ilcOptions = [
+            dllPath,
+            '-o', `${AssemblyName}.obj`,
+            '-r', this.disassemblyLoaderPath,
+            '-r', path.join(this.clrBuildDir, 'aotsdk', '/'),
+            '-r', path.join(this.clrBuildDir, '/'),
+            '--initassembly:System.Private.CoreLib',
+            '--initassembly:System.Private.StackTraceMetadata',
+            '--initassembly:System.Private.TypeLoader',
+            '--initassembly:System.Private.Reflection.Execution',
+            '--directpinvoke:System.Globalization.Native',
+            '--directpinvoke:System.IO.Compression.Native',
+            '--resilient',
+            '--singlewarn',
+            '--nosinglewarnassembly:CompilerExplorer',
+            '--generateunmanagedentrypoints:System.Private.CoreLib',
+        ].concat(toolOptions).concat(toolSwitches);
+
+        if (!buildToBinary) {
+            ilcOptions.push('--nativelib');
+        }
+
+        const compilerExecResult = await this.exec(compiler, ilcOptions, execOptions);
+        const result = this.transformToCompilationResult(compilerExecResult, dllPath);
+
+        await fs.writeFile(
+            outputPath,
+            `// ilc ${await this.getRuntimeVersion()}\n\n${result.stdout
+                .map(o => o.text)
+                .reduce((a, n) => `${a}\n${n}`, '')}`,
+        );
+
+        return result;
+    }
+
     override runExecutable(executable: string, executeParameters: ExecutableExecutionOptions, homeDir) {
         const execOptionsCopy: ExecutableExecutionOptions = JSON.parse(
             JSON.stringify(executeParameters),
@@ -507,9 +515,11 @@ class DotNetCompiler extends BaseCompiler {
             executable = this.compiler.executionWrapper;
         }
 
+        const isMono = this.compiler.group === 'dotnetmono';
+
         const extraConfiguration: DotnetExtraConfiguration = {
             buildConfig: this.buildConfig,
-            clrBuildDir: this.clrBuildDir,
+            clrBuildDir: isMono ? path.join(this.clrBuildDir, 'mono') : this.clrBuildDir,
             langVersion: this.langVersion,
             targetFramework: this.targetFramework,
             corerunPath: this.corerunPath,
@@ -529,6 +539,18 @@ export class DotNetCoreClrCompiler extends DotNetCompiler {
 export class DotNetCrossgen2Compiler extends DotNetCompiler {
     static get key() {
         return 'dotnetcrossgen2';
+    }
+}
+
+export class DotNetMonoCompiler extends DotNetCompiler {
+    static get key() {
+        return 'dotnetmono';
+    }
+}
+
+export class DotNetNativeAotCompiler extends DotNetCompiler {
+    static get key() {
+        return 'dotnetnativeaot';
     }
 }
 

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -128,6 +128,7 @@ class DotNetCompiler extends BaseCompiler {
             '--noscan',
             '--noinlinetls',
             '--completetypemetadata',
+            '--noaotwarn',
         ];
     }
 
@@ -484,6 +485,7 @@ class DotNetCompiler extends BaseCompiler {
             '--singlewarn',
             '--nosinglewarnassembly:CompilerExplorer',
             '--generateunmanagedentrypoints:System.Private.CoreLib',
+            '--notrimwarn',
         ].concat(toolOptions).concat(toolSwitches);
 
         if (!buildToBinary) {


### PR DESCRIPTION
Adding support for mono and NativeAOT.

As for NativeAOT, we have some upstream issues need to be resolved before we can use `JitDisasmAssemblies` to print disasm for the specified assembly only, where it would fail with: 
```
Unhandled exception: ILCompiler.CodeGenerationFailedException: Code generation failed for method '[S.P.CoreLib]<Module>..cctor()'
 ---> System.NotImplementedException: getClassModule
   at Internal.JitInterface.CorInfoImpl.getClassModule(CORINFO_CLASS_STRUCT_*) + 0x2b
   at Internal.JitInterface.CorInfoImpl._getClassModule(IntPtr, IntPtr*, CORINFO_CLASS_STRUCT_*) + 0x39
   --- End of inner exception stack trace ---
   at Internal.JitInterface.CorInfoImpl.CompileMethodInternal(IMethodNode, MethodIL) + 0x273
   at Internal.JitInterface.CorInfoImpl.CompileMethod(MethodCodeNode, MethodIL) + 0x63
   at ILCompiler.RyuJitCompilation.CompileSingleMethod(CorInfoImpl, MethodCodeNode) + 0x97
   at ILCompiler.RyuJitCompilation.CompileSingleThreaded(List`1) + 0xee
   at ILCompiler.RyuJitCompilation.ComputeDependencyNodeDependencies(List`1) + 0x173
   at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ComputeMarkedNodes() + 0x159
   at ILCompiler.RyuJitCompilation.CompileInternal(String, ObjectDumper) + 0x26
   at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String, ObjectDumper) + 0x5d
   at ILCompiler.Program.Run() + 0x2a55
   at ILCompiler.ILCompilerRootCommand.<>c__DisplayClass240_0.<.ctor>b__0(ParseResult) + 0x321
   at System.CommandLine.Invocation.InvocationPipeline.Invoke(ParseResult) + 0x6f
```
For now, workaround with removing `JitDisasmAssemblies` and print disasm for all assemblies instead. (see the second commit)

/cc: @MichalStrehovsky We need to implement `getClassModule`, `getModuleAssembly` and `getAssemblyName` in ilc to make `JitDisasmAssemblies` work correctly. 

Closes #5668
