### PR TITLE
When rust `edition` appears in both overrides and compiler-options, prefer the options

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1044,7 +1044,7 @@ export class BaseCompiler implements ICompiler {
         return false;
     }
 
-    changeOptionsBasedOnOverrides(options: string[], overrides: ConfiguredOverrides): string[] {
+    changeOptionsBasedOnOverrides(options: string[], overrides: ConfiguredOverrides): void {
         const overriddenToolchainPath = this.getOverridenToolchainPath(overrides);
         const sysrootPath: string | false =
             overriddenToolchainPath ?? getSysrootByToolchainPath(overriddenToolchainPath);
@@ -1099,8 +1099,6 @@ export class BaseCompiler implements ICompiler {
                 }
             }
         }
-
-        return options;
     }
 
     prepareArguments(
@@ -1147,8 +1145,8 @@ export class BaseCompiler implements ICompiler {
         }
 
         userOptions = this.filterUserOptions(userOptions) || [];
-        options = this.fixIncompatibleOptions(options, userOptions);
-        options = this.changeOptionsBasedOnOverrides(options, overrides);
+        this.fixIncompatibleOptions(options, userOptions, overrides);
+        this.changeOptionsBasedOnOverrides(options, overrides);
 
         return this.orderArguments(
             options,
@@ -1162,9 +1160,7 @@ export class BaseCompiler implements ICompiler {
         );
     }
 
-    protected fixIncompatibleOptions(options: string[], userOptions: string[]): string[] {
-        return options;
-    }
+    protected fixIncompatibleOptions(options: string[], userOptions: string[], overrides: ConfiguredOverrides): void {}
 
     filterUserOptions(userOptions: string[]): string[] {
         return userOptions;

--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -121,8 +121,8 @@ export class Win32Compiler extends BaseCompiler {
         }
 
         userOptions = this.filterUserOptions(userOptions) || [];
-        options = this.fixIncompatibleOptions(options, userOptions);
-        options = this.changeOptionsBasedOnOverrides(options, overrides);
+        this.fixIncompatibleOptions(options, userOptions, overrides);
+        this.changeOptionsBasedOnOverrides(options, overrides);
 
         return options.concat(
             libIncludes,


### PR DESCRIPTION
Fix #5429, #6559 

This particular fix was chosen -
(1) To make the behavior match future rust versions ([as this suggestion](https://github.com/rust-lang/compiler-team/issues/731) was accepted), 
(2) because of the pains reported [here](https://github.com/compiler-explorer/compiler-explorer/issues/3765#issuecomment-1666847807) and [here](https://github.com/compiler-explorer/compiler-explorer/issues/3765#issuecomment-1666861622)

Along the way made `fixIncompatibleOptions` and `changeOptionsBasedOnOverrides` operate on arguments by reference, just seem to make more sense.