### PR TITLE
.NET: Enhance NativeAOT compilation

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -32,19 +32,19 @@ group.dotnetlegacy.groupName=Legacy
 # CoreCLR compilers
 
 compiler.dotnet70csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcoreclr.name=.NET 7.0
+compiler.dotnet70csharpcoreclr.name=.NET CoreCLR 7.0
 compiler.dotnet70csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70csharpcoreclr.buildConfig=Release
 compiler.dotnet70csharpcoreclr.langVersion=latest
 
 compiler.dotnet80csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcoreclr.name=.NET 8.0
+compiler.dotnet80csharpcoreclr.name=.NET CoreCLR 8.0
 compiler.dotnet80csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80csharpcoreclr.buildConfig=Release
 compiler.dotnet80csharpcoreclr.langVersion=latest
 
 compiler.dotnettrunkcsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcoreclr.name=.NET (main)
+compiler.dotnettrunkcsharpcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkcsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkcsharpcoreclr.langVersion=preview
@@ -53,25 +53,25 @@ compiler.dotnettrunkcsharpcoreclr.isNightly=true
 # Crossgen2 compilers
 
 compiler.dotnet60csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60csharpcrossgen2.name=.NET 6.0
+compiler.dotnet60csharpcrossgen2.name=.NET Crossgen2 6.0
 compiler.dotnet60csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
 compiler.dotnet60csharpcrossgen2.buildConfig=Release
 compiler.dotnet60csharpcrossgen2.langVersion=latest
 
 compiler.dotnet70csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcrossgen2.name=.NET 7.0
+compiler.dotnet70csharpcrossgen2.name=.NET Crossgen2 7.0
 compiler.dotnet70csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70csharpcrossgen2.buildConfig=Release
 compiler.dotnet70csharpcrossgen2.langVersion=latest
 
 compiler.dotnet80csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcrossgen2.name=.NET 8.0
+compiler.dotnet80csharpcrossgen2.name=.NET Crossgen2 8.0
 compiler.dotnet80csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80csharpcrossgen2.buildConfig=Release
 compiler.dotnet80csharpcrossgen2.langVersion=latest
 
 compiler.dotnettrunkcsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcrossgen2.name=.NET (main)
+compiler.dotnettrunkcsharpcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkcsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkcsharpcrossgen2.langVersion=preview
@@ -80,7 +80,7 @@ compiler.dotnettrunkcsharpcrossgen2.isNightly=true
 # Mono compilers
 
 compiler.dotnettrunkcsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpmono.name=.NET (main)
+compiler.dotnettrunkcsharpmono.name=.NET Mono (main)
 compiler.dotnettrunkcsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpmono.buildConfig=Release
 compiler.dotnettrunkcsharpmono.langVersion=preview
@@ -89,7 +89,7 @@ compiler.dotnettrunkcsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkcsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkcsharpnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkcsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkcsharpnativeaot.langVersion=preview

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -32,19 +32,19 @@ group.dotnetlegacy.groupName=Legacy
 # CoreCLR compilers
 
 compiler.dotnet70csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcoreclr.name=.NET 7.0
+compiler.dotnet70csharpcoreclr.name=.NET CoreCLR 7.0
 compiler.dotnet70csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70csharpcoreclr.buildConfig=Release
 compiler.dotnet70csharpcoreclr.langVersion=latest
 
 compiler.dotnet80csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcoreclr.name=.NET 8.0
+compiler.dotnet80csharpcoreclr.name=.NET CoreCLR 8.0
 compiler.dotnet80csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80csharpcoreclr.buildConfig=Release
 compiler.dotnet80csharpcoreclr.langVersion=latest
 
 compiler.dotnettrunkcsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcoreclr.name=.NET (main)
+compiler.dotnettrunkcsharpcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkcsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkcsharpcoreclr.langVersion=preview
@@ -53,25 +53,25 @@ compiler.dotnettrunkcsharpcoreclr.isNightly=true
 # Crossgen2 compilers
 
 compiler.dotnet60csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60csharpcrossgen2.name=.NET 6.0
+compiler.dotnet60csharpcrossgen2.name=.NET Crossgen2 6.0
 compiler.dotnet60csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
 compiler.dotnet60csharpcrossgen2.buildConfig=Release
 compiler.dotnet60csharpcrossgen2.langVersion=latest
 
 compiler.dotnet70csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcrossgen2.name=.NET 7.0
+compiler.dotnet70csharpcrossgen2.name=.NET Crossgen2 7.0
 compiler.dotnet70csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70csharpcrossgen2.buildConfig=Release
 compiler.dotnet70csharpcrossgen2.langVersion=latest
 
 compiler.dotnet80csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcrossgen2.name=.NET 8.0
+compiler.dotnet80csharpcrossgen2.name=.NET Crossgen2 8.0
 compiler.dotnet80csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80csharpcrossgen2.buildConfig=Release
 compiler.dotnet80csharpcrossgen2.langVersion=latest
 
 compiler.dotnettrunkcsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcrossgen2.name=.NET (main)
+compiler.dotnettrunkcsharpcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkcsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkcsharpcrossgen2.langVersion=preview
@@ -80,7 +80,7 @@ compiler.dotnettrunkcsharpcrossgen2.isNightly=true
 # Mono compilers
 
 compiler.dotnettrunkcsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpmono.name=.NET (main)
+compiler.dotnettrunkcsharpmono.name=.NET Mono (main)
 compiler.dotnettrunkcsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpmono.buildConfig=Release
 compiler.dotnettrunkcsharpmono.langVersion=preview
@@ -89,7 +89,7 @@ compiler.dotnettrunkcsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkcsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkcsharpnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkcsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkcsharpnativeaot.langVersion=preview

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -32,19 +32,19 @@ group.dotnetlegacy.groupName=Legacy
 # CoreCLR compilers
 
 compiler.dotnet70fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcoreclr.name=.NET 7.0
+compiler.dotnet70fsharpcoreclr.name=.NET CoreCLR 7.0
 compiler.dotnet70fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70fsharpcoreclr.buildConfig=Release
 compiler.dotnet70fsharpcoreclr.langVersion=latest
 
 compiler.dotnet80fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcoreclr.name=.NET 8.0
+compiler.dotnet80fsharpcoreclr.name=.NET CoreCLR 8.0
 compiler.dotnet80fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80fsharpcoreclr.buildConfig=Release
 compiler.dotnet80fsharpcoreclr.langVersion=latest
 
 compiler.dotnettrunkfsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcoreclr.name=.NET (main)
+compiler.dotnettrunkfsharpcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkfsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkfsharpcoreclr.langVersion=preview
@@ -53,25 +53,25 @@ compiler.dotnettrunkfsharpcoreclr.isNightly=true
 # Crossgen2 compilers
 
 compiler.dotnet60fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60fsharpcrossgen2.name=.NET 6.0
+compiler.dotnet60fsharpcrossgen2.name=.NET Crossgen2 6.0
 compiler.dotnet60fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
 compiler.dotnet60fsharpcrossgen2.buildConfig=Release
 compiler.dotnet60fsharpcrossgen2.langVersion=latest
 
 compiler.dotnet70fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcrossgen2.name=.NET 7.0
+compiler.dotnet70fsharpcrossgen2.name=.NET Crossgen2 7.0
 compiler.dotnet70fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70fsharpcrossgen2.buildConfig=Release
 compiler.dotnet70fsharpcrossgen2.langVersion=latest
 
 compiler.dotnet80fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcrossgen2.name=.NET 8.0
+compiler.dotnet80fsharpcrossgen2.name=.NET Crossgen2 8.0
 compiler.dotnet80fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80fsharpcrossgen2.buildConfig=Release
 compiler.dotnet80fsharpcrossgen2.langVersion=latest
 
 compiler.dotnettrunkfsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcrossgen2.name=.NET (main)
+compiler.dotnettrunkfsharpcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkfsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkfsharpcrossgen2.langVersion=preview
@@ -80,7 +80,7 @@ compiler.dotnettrunkfsharpcrossgen2.isNightly=true
 # Mono compilers
 
 compiler.dotnettrunkfsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpmono.name=.NET (main)
+compiler.dotnettrunkfsharpmono.name=.NET Mono (main)
 compiler.dotnettrunkfsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpmono.buildConfig=Release
 compiler.dotnettrunkfsharpmono.langVersion=preview
@@ -89,7 +89,7 @@ compiler.dotnettrunkfsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkfsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkfsharpnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkfsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkfsharpnativeaot.langVersion=preview

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -32,19 +32,19 @@ group.dotnetlegacy.groupName=Legacy
 # CoreCLR compilers
 
 compiler.dotnet70fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcoreclr.name=.NET 7.0
+compiler.dotnet70fsharpcoreclr.name=.NET CoreCLR 7.0
 compiler.dotnet70fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70fsharpcoreclr.buildConfig=Release
 compiler.dotnet70fsharpcoreclr.langVersion=latest
 
 compiler.dotnet80fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcoreclr.name=.NET 8.0
+compiler.dotnet80fsharpcoreclr.name=.NET CoreCLR 8.0
 compiler.dotnet80fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80fsharpcoreclr.buildConfig=Release
 compiler.dotnet80fsharpcoreclr.langVersion=latest
 
 compiler.dotnettrunkfsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcoreclr.name=.NET (main)
+compiler.dotnettrunkfsharpcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkfsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkfsharpcoreclr.langVersion=preview
@@ -53,25 +53,25 @@ compiler.dotnettrunkfsharpcoreclr.isNightly=true
 # Crossgen2 compilers
 
 compiler.dotnet60fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60fsharpcrossgen2.name=.NET 6.0
+compiler.dotnet60fsharpcrossgen2.name=.NET Crossgen2 6.0
 compiler.dotnet60fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
 compiler.dotnet60fsharpcrossgen2.buildConfig=Release
 compiler.dotnet60fsharpcrossgen2.langVersion=latest
 
 compiler.dotnet70fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcrossgen2.name=.NET 7.0
+compiler.dotnet70fsharpcrossgen2.name=.NET Crossgen2 7.0
 compiler.dotnet70fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70fsharpcrossgen2.buildConfig=Release
 compiler.dotnet70fsharpcrossgen2.langVersion=latest
 
 compiler.dotnet80fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcrossgen2.name=.NET 8.0
+compiler.dotnet80fsharpcrossgen2.name=.NET Crossgen2 8.0
 compiler.dotnet80fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80fsharpcrossgen2.buildConfig=Release
 compiler.dotnet80fsharpcrossgen2.langVersion=latest
 
 compiler.dotnettrunkfsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcrossgen2.name=.NET (main)
+compiler.dotnettrunkfsharpcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkfsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkfsharpcrossgen2.langVersion=preview
@@ -80,7 +80,7 @@ compiler.dotnettrunkfsharpcrossgen2.isNightly=true
 # Mono compilers
 
 compiler.dotnettrunkfsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpmono.name=.NET (main)
+compiler.dotnettrunkfsharpmono.name=.NET Mono (main)
 compiler.dotnettrunkfsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpmono.buildConfig=Release
 compiler.dotnettrunkfsharpmono.langVersion=preview
@@ -89,7 +89,7 @@ compiler.dotnettrunkfsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkfsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpnativeaot.name=.NET (main)
+compiler.dotnettrunkfsharpnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkfsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkfsharpnativeaot.langVersion=preview

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -32,19 +32,19 @@ group.dotnetlegacy.groupName=Legacy
 # CoreCLR compilers
 
 compiler.dotnet70vbcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcoreclr.name=.NET 7.0
+compiler.dotnet70vbcoreclr.name=.NET CoreCLR 7.0
 compiler.dotnet70vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70vbcoreclr.buildConfig=Release
 compiler.dotnet70vbcoreclr.langVersion=latest
 
 compiler.dotnet80vbcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcoreclr.name=.NET 8.0
+compiler.dotnet80vbcoreclr.name=.NET CoreCLR 8.0
 compiler.dotnet80vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80vbcoreclr.buildConfig=Release
 compiler.dotnet80vbcoreclr.langVersion=latest
 
 compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcoreclr.name=.NET (main)
+compiler.dotnettrunkvbcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
 compiler.dotnettrunkvbcoreclr.langVersion=preview
@@ -53,25 +53,25 @@ compiler.dotnettrunkvbcoreclr.isNightly=true
 # Crossgen2 compilers
 
 compiler.dotnet60vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60vbcrossgen2.name=.NET 6.0
+compiler.dotnet60vbcrossgen2.name=.NET Crossgen2 6.0
 compiler.dotnet60vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
 compiler.dotnet60vbcrossgen2.buildConfig=Release
 compiler.dotnet60vbcrossgen2.langVersion=latest
 
 compiler.dotnet70vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcrossgen2.name=.NET 7.0
+compiler.dotnet70vbcrossgen2.name=.NET Crossgen2 7.0
 compiler.dotnet70vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70vbcrossgen2.buildConfig=Release
 compiler.dotnet70vbcrossgen2.langVersion=latest
 
 compiler.dotnet80vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcrossgen2.name=.NET 8.0
+compiler.dotnet80vbcrossgen2.name=.NET Crossgen2 8.0
 compiler.dotnet80vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80vbcrossgen2.buildConfig=Release
 compiler.dotnet80vbcrossgen2.langVersion=latest
 
 compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcrossgen2.name=.NET (main)
+compiler.dotnettrunkvbcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
 compiler.dotnettrunkvbcrossgen2.langVersion=preview
@@ -80,7 +80,7 @@ compiler.dotnettrunkvbcrossgen2.isNightly=true
 # Mono compilers
 
 compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbmono.name=.NET (main)
+compiler.dotnettrunkvbmono.name=.NET Mono (main)
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
 compiler.dotnettrunkvbmono.langVersion=preview
@@ -89,7 +89,7 @@ compiler.dotnettrunkvbmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbnativeaot.name=.NET (main)
+compiler.dotnettrunkvbnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
 compiler.dotnettrunkvbnativeaot.langVersion=preview

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -32,19 +32,19 @@ group.dotnetlegacy.groupName=Legacy
 # CoreCLR compilers
 
 compiler.dotnet70vbcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcoreclr.name=.NET 7.0
+compiler.dotnet70vbcoreclr.name=.NET CoreCLR 7.0
 compiler.dotnet70vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70vbcoreclr.buildConfig=Release
 compiler.dotnet70vbcoreclr.langVersion=latest
 
 compiler.dotnet80vbcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcoreclr.name=.NET 8.0
+compiler.dotnet80vbcoreclr.name=.NET CoreCLR 8.0
 compiler.dotnet80vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80vbcoreclr.buildConfig=Release
 compiler.dotnet80vbcoreclr.langVersion=latest
 
 compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcoreclr.name=.NET (main)
+compiler.dotnettrunkvbcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
 compiler.dotnettrunkvbcoreclr.langVersion=preview
@@ -53,25 +53,25 @@ compiler.dotnettrunkvbcoreclr.isNightly=true
 # Crossgen2 compilers
 
 compiler.dotnet60vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60vbcrossgen2.name=.NET 6.0
+compiler.dotnet60vbcrossgen2.name=.NET Crossgen2 6.0
 compiler.dotnet60vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
 compiler.dotnet60vbcrossgen2.buildConfig=Release
 compiler.dotnet60vbcrossgen2.langVersion=latest
 
 compiler.dotnet70vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcrossgen2.name=.NET 7.0
+compiler.dotnet70vbcrossgen2.name=.NET Crossgen2 7.0
 compiler.dotnet70vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
 compiler.dotnet70vbcrossgen2.buildConfig=Release
 compiler.dotnet70vbcrossgen2.langVersion=latest
 
 compiler.dotnet80vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcrossgen2.name=.NET 8.0
+compiler.dotnet80vbcrossgen2.name=.NET Crossgen2 8.0
 compiler.dotnet80vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
 compiler.dotnet80vbcrossgen2.buildConfig=Release
 compiler.dotnet80vbcrossgen2.langVersion=latest
 
 compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcrossgen2.name=.NET (main)
+compiler.dotnettrunkvbcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
 compiler.dotnettrunkvbcrossgen2.langVersion=preview
@@ -80,7 +80,7 @@ compiler.dotnettrunkvbcrossgen2.isNightly=true
 # Mono compilers
 
 compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbmono.name=.NET (main)
+compiler.dotnettrunkvbmono.name=.NET Mono (main)
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
 compiler.dotnettrunkvbmono.langVersion=preview
@@ -89,7 +89,7 @@ compiler.dotnettrunkvbmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbnativeaot.name=.NET (main)
+compiler.dotnettrunkvbnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
 compiler.dotnettrunkvbnativeaot.langVersion=preview

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -118,7 +118,6 @@ class DotNetCompiler extends BaseCompiler {
             '--aot',
             '--crossgen2',
             '--dehydrate',
-            '--scanreflection',
             '--methodbodyfolding',
             '--stacktracedata',
             '--defaultrooting',
@@ -128,7 +127,6 @@ class DotNetCompiler extends BaseCompiler {
             '--noscan',
             '--noinlinetls',
             '--completetypemetadata',
-            '--noaotwarn',
         ];
     }
 
@@ -473,19 +471,24 @@ class DotNetCompiler extends BaseCompiler {
             dllPath,
             '-o', `${AssemblyName}.obj`,
             '-r', this.disassemblyLoaderPath,
-            '-r', path.join(this.clrBuildDir, 'aotsdk', '/'),
-            '-r', path.join(this.clrBuildDir, '/'),
+            '-r', path.join(this.clrBuildDir, 'aotsdk', '*.dll'),
+            '-r', path.join(this.clrBuildDir, '*.dll'),
             '--initassembly:System.Private.CoreLib',
             '--initassembly:System.Private.StackTraceMetadata',
             '--initassembly:System.Private.TypeLoader',
             '--initassembly:System.Private.Reflection.Execution',
-            '--directpinvoke:System.Globalization.Native',
-            '--directpinvoke:System.IO.Compression.Native',
+            '--directpinvoke:libSystem.Native',
+            '--directpinvoke:libSystem.Globalization.Native',
+            '--directpinvoke:libSystem.IO.Compression.Native',
+            '--directpinvoke:libSystem.Net.Security.Native',
+            '--directpinvoke:libSystem.Security.Cryptography.Native.OpenSsl',
             '--resilient',
             '--singlewarn',
+            '--scanreflection',
             '--nosinglewarnassembly:CompilerExplorer',
             '--generateunmanagedentrypoints:System.Private.CoreLib',
             '--notrimwarn',
+            '--noaotwarn',
         ].concat(toolOptions).concat(toolSwitches);
 
         if (!buildToBinary) {


### PR DESCRIPTION
1. filter out non-assemblies from reference
2. scan reflection by default
3. suppress aot warnings
4. update compiler names to distinguish between each other