### PR TITLE
[loongarch] Add Loongarch64 LLVM support

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -1101,6 +1101,32 @@ compiler.hexagonclang1605.name=hexagon-clang 16.0.5
 compiler.hexagonclang1605.exe=/opt/compiler-explorer/clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl/x86_64-linux-gnu/bin/clang++
 compiler.hexagonclang1605.compilerType=clang-hexagon
 compiler.hexagonclang1605.compilerCategories=clang-hexagon
+
+################################
+# Clang for Loongarch
+group.loongarch-clang.compilers=&loongarch64clang
+group.loongarch-clang.supportsBinary=true
+group.loongarch-clang.supportsExecute=false
+group.loongarch-clang.isSemVer=true
+group.loongarch-clang.licenseName=LLVM Apache 2
+group.loongarch-clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.loongarch-clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+
+group.loongarch64clang.compilers=loongarch64-clangtrunk:loongarch64-clang1701:loongarch64-clang1810
+group.loongarch64clang.options=-target loongarch64-unknown-elf --gcc-toolchain=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot
+group.loongarch64clang.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+group.loongarch64clang.baseName=Loongarch64 clang
+group.loongarch64clang.groupName=Loongarch64 Clang
+group.loongarch64clang.compilerCategories=clang
+group.loongarch64clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.loongarch64-clang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang++
+compiler.loongarch64-clang1701.semver=17.0.1
+compiler.loongarch64-clang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
+compiler.loongarch64-clang1810.semver=18.1.0
+compiler.loongarch64-clangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.loongarch64-clangtrunk.semver=(trunk)
+compiler.loongarch64-clangtrunk.isNightly=true
 
 ################################
 # icc for x86


### PR DESCRIPTION
Since version 16.0.0, LLVM has supported the LoongArch64[^1], and now we are attempting to integrate it.

[^1]: https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#loongarch-support

Closes #6794, closes #4191

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
