### PR TITLE
Exclude `bloaty` tool from running on `djggp` compiler output 

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5569,4 +5569,5 @@ tools.bloaty11.name=bloaty (1.1)
 tools.bloaty11.exe=/opt/compiler-explorer/bloaty-1.1/bin/bloaty
 tools.bloaty11.type=postcompilation
 tools.bloaty11.class=bloaty-tool
+tools.bloaty11.exclude=djggp
 tools.bloaty11.stdinHint=disabled

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3574,4 +3574,5 @@ tools.bloaty11.name=bloaty (1.1)
 tools.bloaty11.exe=/opt/compiler-explorer/bloaty-1.1/bin/bloaty
 tools.bloaty11.type=postcompilation
 tools.bloaty11.class=bloaty-tool
+tools.bloaty11.exclude=djggp
 tools.bloaty11.stdinHint=disabled


### PR DESCRIPTION
- Seems like `djggp` compiler output is incompatible with serveral tools including `bloaty` tool. `bloaty: unknown file type for file '<source>'`