### PR TITLE
Specify dex2oat's output instruction set is aarch64

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -72,6 +72,7 @@ group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3310:java-dex2oat-3411:
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
+group.dex2oat.instructionSet=aarch64
 
 compiler.java-dex2oat-latest.name=ART dex2oat latest
 compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -15,6 +15,8 @@ compiler.android-java-d8-default.exe=/usr/local/bin/r8.jar
 
 group.dex2oat.compilers=android-java-dex2oat-default
 group.dex2oat.groupName=ART
+group.dex2oat.instructionSet=aarch64
+
 compiler.android-java-dex2oat-default.name=ART dex2oat default
 compiler.android-java-dex2oat-default.compilerType=dex2oat
 

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -73,6 +73,7 @@ group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3310:kotlin-dex2oat
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
+group.dex2oat.instructionSet=aarch64
 
 compiler.kotlin-dex2oat-latest.name=ART dex2oat latest
 compiler.kotlin-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -14,6 +14,8 @@ compiler.android-kotlin-d8-default.exe=/usr/local/bin/r8.jar
 
 group.dex2oat.compilers=android-kotlin-dex2oat-default
 group.dex2oat.groupName=ART
+group.dex2oat.instructionSet=aarch64
+
 compiler.android-kotlin-dex2oat-default.name=ART dex2oat default
 compiler.android-kotlin-dex2oat-default.compilerType=dex2oat
 


### PR DESCRIPTION
This ensures that the looked-up hovertext instruction documentation is for the correct architecture.

Towards #6807.