### PR TITLE
Add library lookupname to support binary builds for boost

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3830,8 +3830,10 @@ libs.boost.versions.183.version=1.83.0
 libs.boost.versions.183.path=/opt/compiler-explorer/libs/boost_1_83_0
 libs.boost.versions.184.version=1.84.0
 libs.boost.versions.184.path=/opt/compiler-explorer/libs/boost_1_84_0
+
 libs.boost.versions.185.version=1.85.0
-libs.boost.versions.185.path=/opt/compiler-explorer/libs/boost_1_85_0
+libs.boost.versions.185.packagedheaders=true
+libs.boost.versions.185.lookupname=boost_bin
 
 libs.bmulti.name=B-Multi
 libs.bmulti.url=https://gitlab.com/correaa/boost-multi

--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -50,6 +50,7 @@ export type VersionInfo = {
     path: string[];
     libpath: string[];
     liblink: string[];
+    lookupname?: PropertyValue;
     lookupversion?: PropertyValue;
     options: string[];
     hidden: boolean;
@@ -327,6 +328,11 @@ export class ClientOptionsHandler {
                             const lookupversion = this.compilerProps(lang, libVersionName + '.lookupversion');
                             if (lookupversion) {
                                 versionObject.lookupversion = lookupversion;
+                            }
+
+                            const lookupname = this.compilerProps(lang, libVersionName + '.lookupname');
+                            if (lookupname) {
+                                versionObject.lookupname = lookupname;
                             }
 
                             const includes = this.compilerProps<string>(lang, libVersionName + '.path');

--- a/static/options.interfaces.ts
+++ b/static/options.interfaces.ts
@@ -32,6 +32,8 @@ export type LibraryVersion = {
     libId: string;
     used: boolean;
     version?: string;
+    lookupname?: string;
+    lookupversion?: string;
 };
 
 export type Library = {

--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -120,7 +120,7 @@ function shortenMachineName(name: string): string {
     } else if (name === 'Intel 80386') {
         return '386';
     } else if (name === '') {
-        return 'amd64';
+        return 'default target';
     }
 
     return name;
@@ -477,6 +477,10 @@ export class LibsWidget {
             }
             option.attr('value', versionId);
             option.html(version.version || versionId);
+
+            option.data('lookupname', version.lookupname || libId);
+            option.data('lookupversion', version.lookupversion || version.version || versionId);
+
             if (version.used || !version.hidden) {
                 hasVisibleVersions = true;
                 versions.append(option);
@@ -501,8 +505,10 @@ export class LibsWidget {
                 const popupId = `build-info-content-${nowts}`;
                 const option = versions.find('option:selected');
                 const semver = option.html();
+                const lookupname = option.data('lookupname');
+                const lookupversion = option.data('lookupversion');
                 if (semver !== '-') {
-                    this.loadBuildInfoIntoPopup(popupId, libId, semver, lib.url);
+                    this.loadBuildInfoIntoPopup(popupId, lookupname, lookupversion, lib.url);
                     return `<div id="${popupId}">Loading...</div>`;
                 } else {
                     return `<div id="${popupId}">No version selected</div>`;


### PR DESCRIPTION
Etc etc we build boost now, but its under a different name otherwise it would have become even more of a mess

(why arent the unittests failing? im confused?)