### PR TITLE
Add a new dex instruction set

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -6,6 +6,7 @@ group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
+group.android-d8.instructionSet=dex
 
 compiler.java-d8-8535.name=d8 8.5.35
 compiler.java-d8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -6,6 +6,7 @@ group.android-d8.compilers=android-java-d8-default
 group.android-d8.javaId=javacdefault
 group.android-d8.javaPath=/usr/bin/java
 group.android-d8.kotlinId=kotlincdefault
+group.android-d8.instructionSet=dex
 
 compiler.android-java-d8-default.name=android d8 default
 compiler.android-java-d8-default.compilerType=android-d8

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -6,6 +6,7 @@ group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
+group.android-d8.instructionSet=dex
 
 compiler.kotlin-d8-8535.name=d8 8.5.35
 compiler.kotlin-d8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar

--- a/etc/config/android-kotlin.defaults.properties
+++ b/etc/config/android-kotlin.defaults.properties
@@ -5,6 +5,7 @@ group.android-d8.compilers=android-kotlin-d8-default
 # reflect the paths in the java and kotlin default config.
 group.android-d8.javaId=javacdefault
 group.android-d8.kotlinId=kotlincdefault
+group.android-d8.instructionSet=dex
 
 compiler.android-kotlin-d8-default.name=android d8 default
 compiler.android-kotlin-d8-default.compilerType=android-d8

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -51,6 +51,10 @@ export class InstructionSets {
                 target: ['c6x'],
                 path: ['/tic6x-'],
             },
+            dex: {
+                target: [],
+                path: [],
+            },
             ebpf: {
                 target: ['bpf'],
                 path: ['/bpf-'],

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -30,6 +30,7 @@ export const InstructionSetsList = [
     'avr',
     'beam',
     'c6x',
+    'dex',
     'ebpf',
     'evm',
     'eravm',


### PR DESCRIPTION
And use it for Android d8 compiler.

It's empty for now. But it lets you filter in the compiler pop out box. And it may let us attach hover assembly documentation later.

I've left it empty in `lib/instructionsets.ts` like `java` is, which I'm modelling this off.

Towards #6819