### PR TITLE
Add explicit arm64, arm32, x86, x86_64 variants of Android Java dex2oat

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -1,5 +1,7 @@
-compilers=&android-d8:&android-r8:&dex2oat
+compilers=&android-d8:&android-r8:&dex2oat:&arm32-dex2oat:&x86-dex2oat:&x86_64-dex2oat
 
+###############################
+# D8
 group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242:java-d8-8247:java-d8-8336:java-d8-8337:java-d8-8510:java-d8-8527:java-d8-8535
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
@@ -37,6 +39,8 @@ compiler.java-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.java-d8-8156.name=d8 8.1.56
 compiler.java-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
+###############################
+# R8
 group.android-r8.compilers=java-r8-8233:java-r8-8242:java-r8-8247:java-r8-8336:java-r8-8337:java-r8-8510:java-r8-8527:java-r8-8535
 group.android-r8.compilerType=android-r8
 group.android-r8.isSemVer=true
@@ -68,13 +72,16 @@ compiler.java-r8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.java-r8-8233.name=r8 8.2.33
 compiler.java-r8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
 
+###############################
+# dex2oat --instruction-set=arm64
 group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3310:java-dex2oat-3411:java-dex2oat-3413:java-dex2oat-3414:java-dex2oat-3415:java-dex2oat-3416:java-dex2oat-3417:java-dex2oat-3418
-group.dex2oat.groupName=ART
+group.dex2oat.groupName=arm64 ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
 group.dex2oat.instructionSet=aarch64
+group.dex2oat.dex2oatInstructionSet=arm64
 
-compiler.java-dex2oat-latest.name=ART dex2oat latest
+compiler.java-dex2oat-latest.name=arm64 ART dex2oat latest
 compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
@@ -82,61 +89,112 @@ compiler.java-dex2oat-latest.d8Id=java-d8-8535
 compiler.java-dex2oat-latest.isNightly=true
 compiler.java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
 
-compiler.java-dex2oat-3418.name=ART dex2oat aml_art_341810020 (Jun 2024)
+compiler.java-dex2oat-3418.name=arm64 ART dex2oat aml_art_341810020 (Jun 2024)
 compiler.java-dex2oat-3418.artArtifactDir=/opt/compiler-explorer/dex2oat-34.18
 compiler.java-dex2oat-3418.exe=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3418.objdumper=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/oatdump
 compiler.java-dex2oat-3418.d8Id=java-d8-8535
 compiler.java-dex2oat-3418.profmanPath=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/profman
 
-compiler.java-dex2oat-3417.name=ART dex2oat aml_art_341711000 (May 2024)
+compiler.java-dex2oat-3417.name=arm64 ART dex2oat aml_art_341711000 (May 2024)
 compiler.java-dex2oat-3417.artArtifactDir=/opt/compiler-explorer/dex2oat-34.17
 compiler.java-dex2oat-3417.exe=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3417.objdumper=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/oatdump
 compiler.java-dex2oat-3417.d8Id=java-d8-8535
 compiler.java-dex2oat-3417.profmanPath=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/profman
 
-compiler.java-dex2oat-3416.name=ART dex2oat aml_art_341615020 (Apr 2024)
+compiler.java-dex2oat-3416.name=arm64 ART dex2oat aml_art_341615020 (Apr 2024)
 compiler.java-dex2oat-3416.artArtifactDir=/opt/compiler-explorer/dex2oat-34.16
 compiler.java-dex2oat-3416.exe=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3416.objdumper=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/oatdump
 compiler.java-dex2oat-3416.d8Id=java-d8-8337
 compiler.java-dex2oat-3416.profmanPath=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/profman
 
-compiler.java-dex2oat-3415.name=ART dex2oat aml_art_341514410 (Mar 2024)
+compiler.java-dex2oat-3415.name=arm64 ART dex2oat aml_art_341514410 (Mar 2024)
 compiler.java-dex2oat-3415.artArtifactDir=/opt/compiler-explorer/dex2oat-34.15
 compiler.java-dex2oat-3415.exe=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3415.objdumper=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/oatdump
 compiler.java-dex2oat-3415.d8Id=java-d8-8337
 compiler.java-dex2oat-3415.profmanPath=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/profman
 
-compiler.java-dex2oat-3414.name=ART dex2oat aml_art_341411300 (Feb 2024)
+compiler.java-dex2oat-3414.name=arm64 ART dex2oat aml_art_341411300 (Feb 2024)
 compiler.java-dex2oat-3414.artArtifactDir=/opt/compiler-explorer/dex2oat-34.14
 compiler.java-dex2oat-3414.exe=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3414.objdumper=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/oatdump
 compiler.java-dex2oat-3414.d8Id=java-d8-8337
 compiler.java-dex2oat-3414.profmanPath=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/profman
 
-compiler.java-dex2oat-3413.name=ART dex2oat aml_art_341311100 (Jan 2024)
+compiler.java-dex2oat-3413.name=arm64 ART dex2oat aml_art_341311100 (Jan 2024)
 compiler.java-dex2oat-3413.artArtifactDir=/opt/compiler-explorer/dex2oat-34.13
 compiler.java-dex2oat-3413.exe=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3413.objdumper=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/oatdump
 compiler.java-dex2oat-3413.d8Id=java-d8-8337
 compiler.java-dex2oat-3413.profmanPath=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/profman
 
-compiler.java-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
+compiler.java-dex2oat-3411.name=arm64 ART dex2oat aml_art_341110060 (Nov 2023)
 compiler.java-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11
 compiler.java-dex2oat-3411.exe=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3411.objdumper=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/oatdump
 compiler.java-dex2oat-3411.d8Id=java-d8-8242
 compiler.java-dex2oat-3411.profmanPath=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/profman
 
-compiler.java-dex2oat-3310.name=ART dex2oat aml_art_331012050 (Oct 2022)
+compiler.java-dex2oat-3310.name=arm64 ART dex2oat aml_art_331012050 (Oct 2022)
 compiler.java-dex2oat-3310.artArtifactDir=/opt/compiler-explorer/dex2oat-33.10
 compiler.java-dex2oat-3310.exe=/opt/compiler-explorer/dex2oat-33.10/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3310.objdumper=/opt/compiler-explorer/dex2oat-33.10/x86_64/bin/oatdump
 compiler.java-dex2oat-3310.d8Id=java-d8-8242
 compiler.java-dex2oat-3310.profmanPath=/opt/compiler-explorer/dex2oat-33.10/x86_64/bin/profman
+
+###############################
+# dex2oat --instruction-set=arm32
+group.arm32-dex2oat.compilers=arm32-java-dex2oat-latest
+group.arm32-dex2oat.groupName=arm32 ART
+group.arm32-dex2oat.compilerType=dex2oat
+group.arm32-dex2oat.isSemVer=true
+group.arm32-dex2oat.instructionSet=arm32
+group.arm32-dex2oat.dex2oatInstructionSet=arm
+
+compiler.arm32-java-dex2oat-latest.name=arm ART dex2oat latest
+compiler.arm32-java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
+compiler.arm32-java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
+compiler.arm32-java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
+compiler.arm32-java-dex2oat-latest.d8Id=java-d8-8535
+compiler.arm32-java-dex2oat-latest.isNightly=true
+compiler.arm32-java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+###############################
+# dex2oat --instruction-set=x86
+group.x86-dex2oat.compilers=x86-java-dex2oat-latest
+group.x86-dex2oat.groupName=x86 ART
+group.x86-dex2oat.compilerType=dex2oat
+group.x86-dex2oat.isSemVer=true
+group.x86-dex2oat.instructionSet=amd64
+group.x86-dex2oat.dex2oatInstructionSet=x86
+
+compiler.x86-java-dex2oat-latest.name=x86 ART dex2oat latest
+compiler.x86-java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
+compiler.x86-java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
+compiler.x86-java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
+compiler.x86-java-dex2oat-latest.d8Id=java-d8-8535
+compiler.x86-java-dex2oat-latest.isNightly=true
+compiler.x86-java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+###############################
+# dex2oat --instruction-set=x86_64
+group.x86_64-dex2oat.compilers=x86_64-java-dex2oat-latest
+group.x86_64-dex2oat.groupName=x86_64 ART
+group.x86_64-dex2oat.compilerType=dex2oat
+group.x86_64-dex2oat.isSemVer=true
+group.x86_64-dex2oat.instructionSet=amd64
+group.x86_64-dex2oat.dex2oatInstructionSet=x86_64
+
+compiler.x86_64-java-dex2oat-latest.name=x86_64 ART dex2oat latest
+compiler.x86_64-java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
+compiler.x86_64-java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
+compiler.x86_64-java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
+compiler.x86_64-java-dex2oat-latest.d8Id=java-d8-8535
+compiler.x86_64-java-dex2oat-latest.isNightly=true
+compiler.x86_64-java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
 
 defaultCompiler=java-dex2oat-latest
 

--- a/etc/config/android-java.defaults.properties
+++ b/etc/config/android-java.defaults.properties
@@ -1,4 +1,4 @@
-compilers=&android-d8:&dex2oat
+compilers=&android-d8:&dex2oat:&arm32-dex2oat:&x86-dex2oat:&x86_64-dex2oat
 
 group.android-d8.compilers=android-java-d8-default
 # When testing locally, these paths must be valid and should
@@ -13,21 +13,72 @@ compiler.android-java-d8-default.objdumper=/usr/local/bin/baksmali.jar
 compiler.android-java-d8-default.exe=/usr/local/bin/r8.jar
 
 
+###############################
+# dex2oat --instruction-set=arm64
 group.dex2oat.compilers=android-java-dex2oat-default
-group.dex2oat.groupName=ART
+group.dex2oat.groupName=arm64 ART
 group.dex2oat.instructionSet=aarch64
+group.dex2oat.dex2oatInstructionSet=arm64
 
-compiler.android-java-dex2oat-default.name=ART dex2oat default
+compiler.android-java-dex2oat-default.name=arm64 ART dex2oat default
 compiler.android-java-dex2oat-default.compilerType=dex2oat
-
 # artArtifactDir should point to the directory extracted from the ART artifacts zip.
 compiler.android-java-dex2oat-default.artArtifactDir=/usr/bin/dex2oat
 compiler.android-java-dex2oat-default.exe=/usr/bin/dex2oat/x86_64/bin/dex2oat64
 compiler.android-java-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatdump
 compiler.android-java-dex2oat-default.profmanPath=/usr/bin/dex2oat/x86_64/bin/profman
-
 # This should reflect the ID and exe for android-java-d8-default.
 compiler.android-java-dex2oat-default.d8Id=android-java-d8-default
 
+###############################
+# dex2oat --instruction-set=arm32
+group.arm32-dex2oat.compilers=arm32-android-java-dex2oat-default
+group.arm32-dex2oat.groupName=arm32 ART
+group.arm32-dex2oat.instructionSet=arm32
+group.arm32-dex2oat.dex2oatInstructionSet=arm
+
+compiler.arm32-android-java-dex2oat-default.name=arm32 ART dex2oat default
+compiler.arm32-android-java-dex2oat-default.compilerType=dex2oat
+# artArtifactDir should point to the directory extracted from the ART artifacts zip.
+compiler.arm32-android-java-dex2oat-default.artArtifactDir=/usr/bin/dex2oat
+compiler.arm32-android-java-dex2oat-default.exe=/usr/bin/dex2oat/x86_64/bin/dex2oat64
+compiler.arm32-android-java-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatdump
+compiler.arm32-android-java-dex2oat-default.profmanPath=/usr/bin/dex2oat/x86_64/bin/profman
+# This should reflect the ID and exe for android-java-d8-default.
+compiler.arm32-android-java-dex2oat-default.d8Id=android-java-d8-default
+
+###############################
+# dex2oat --instruction-set=x86
+group.x86-dex2oat.compilers=x86-android-java-dex2oat-default
+group.x86-dex2oat.groupName=x86 ART
+group.x86-dex2oat.instructionSet=amd64
+group.x86-dex2oat.dex2oatInstructionSet=x86
+
+compiler.x86-android-java-dex2oat-default.name=x86 ART dex2oat default
+compiler.x86-android-java-dex2oat-default.compilerType=dex2oat
+# artArtifactDir should point to the directory extracted from the ART artifacts zip.
+compiler.x86-android-java-dex2oat-default.artArtifactDir=/usr/bin/dex2oat
+compiler.x86-android-java-dex2oat-default.exe=/usr/bin/dex2oat/x86_64/bin/dex2oat64
+compiler.x86-android-java-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatdump
+compiler.x86-android-java-dex2oat-default.profmanPath=/usr/bin/dex2oat/x86_64/bin/profman
+# This should reflect the ID and exe for android-java-d8-default.
+compiler.x86-android-java-dex2oat-default.d8Id=android-java-d8-default
+
+###############################
+# dex2oat --instruction-set=x86_64
+group.x86_64-dex2oat.compilers=x86_64-android-java-dex2oat-default
+group.x86_64-dex2oat.groupName=x86_64 ART
+group.x86_64-dex2oat.instructionSet=amd64
+group.x86_64-dex2oat.dex2oatInstructionSet=x86_64
+
+compiler.x86_64-android-java-dex2oat-default.name=x86_64 ART dex2oat default
+compiler.x86_64-android-java-dex2oat-default.compilerType=dex2oat
+# artArtifactDir should point to the directory extracted from the ART artifacts zip.
+compiler.x86_64-android-java-dex2oat-default.artArtifactDir=/usr/bin/dex2oat
+compiler.x86_64-android-java-dex2oat-default.exe=/usr/bin/dex2oat/x86_64/bin/dex2oat64
+compiler.x86_64-android-java-dex2oat-default.objdumper=/usr/bin/dex2oat/x86_64/bin/oatdump
+compiler.x86_64-android-java-dex2oat-default.profmanPath=/usr/bin/dex2oat/x86_64/bin/profman
+# This should reflect the ID and exe for android-java-d8-default.
+compiler.x86_64-android-java-dex2oat-default.d8Id=android-java-d8-default
 
 defaultCompiler=android-java-dex2oat-default

--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -69,6 +69,7 @@ export class Dex2OatCompiler extends BaseCompiler {
     fullOutput: boolean;
 
     d8Id: string;
+    dex2oatInstructionSet: string;
     artArtifactDir: string;
     profmanPath: string;
 
@@ -113,6 +114,13 @@ export class Dex2OatCompiler extends BaseCompiler {
 
         // The underlying D8 version+exe.
         this.d8Id = this.compilerProps<string>(`compiler.${this.compiler.id}.d8Id`);
+
+        // dex2oat --instruction-set= argument
+        // Valid values are found at:
+        // https://cs.android.com/android/platform/superproject/main/+/main:art/libartbase/arch/instruction_set.cc;l=59;drc=77c14d181dcec8cec240cf2a99a401397582c6d8
+        // Note this uses different values from Compiler Explorer's instructionSet:
+        // e.g. instructionSet=aarch64, dex2oatInstructionSet=arm64.
+        this.dex2oatInstructionSet = this.compilerProps<string>(`group.${this.compiler.group}.dex2oatInstructionSet`);
 
         // The directory containing ART artifacts necessary for dex2oat to run.
         this.artArtifactDir = this.compilerProps<string>(`compiler.${this.compiler.id}.artArtifactDir`);
@@ -252,7 +260,7 @@ export class Dex2OatCompiler extends BaseCompiler {
             ...userOptions,
         ];
         if (useDefaultInsnSet) {
-            dex2oatOptions.push('--instruction-set=arm64');
+            dex2oatOptions.push(`--instruction-set=${this.dex2oatInstructionSet}`);
         }
         if (useDefaultCompilerFilter) {
             if (profileAndResult == null) {


### PR DESCRIPTION
This was possible before in the UI by adding `--instruction-set=arm64`, but not very discoverable, and not consistent with how we do other compilers, and doesn't let us override the instruction set output for assembly hovertext documentation purposes.

I've kept the old compiler names the same (which by default output aarch64) in case they are referred to by permanent links anywhere.

I've only added the latest compilers for the new architectures, to avoid this patch getting too long.

There are two properties in play:
- instructionSet, which Compiler Explorer uses to choose which assembly documentation hovertext to use. e.g. `aarch64`.
- dex2oatInstructionSet, which informs the `dex2oat --instruction-set` flag. e.g. `arm64.

These have slightly different representations for the same concept.

Towards #6818 

cc @kevinjeon-g 