### PR TITLE
Add missing arm-unknown GCC cross for latest versions

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2105,7 +2105,7 @@ group.gccarm.includeFlag=-I
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
 group.gcc32arm.baseName=ARM GCC
-group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1310:armg1320:armug1320:armg1330:armg1410:armg1420:armgtrunk
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1310:armg1320:armug1320:armg1330:armug1330:armg1410:armug1410:armg1420:armug1420:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -2205,6 +2205,24 @@ compiler.armug1320.name=ARM GCC 13.2.0 (unknown-eabi)
 compiler.armug1320.semver=13.2.0
 compiler.armug1320.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.armug1320.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+
+compiler.armug1330.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
+compiler.armug1330.semver=13.3.0
+compiler.armug1330.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.armug1330.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.armug1330.name=ARM GCC 13.3.0 (unknown-eabi)
+
+compiler.armug1410.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
+compiler.armug1410.semver=14.1.0
+compiler.armug1410.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.armug1410.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.armug1410.name=ARM GCC 14.1.0 (unknown-eabi)
+
+compiler.armug1420.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
+compiler.armug1420.semver=14.2.0
+compiler.armug1420.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.armug1420.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.armug1420.name=ARM GCC 14.2.0 (unknown-eabi)
 
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1731,7 +1731,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1310:carmg1320:carmug1320:carmg1330:carmg1410:carmg1420:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1410:carmug1410:carmg1420:carmug1420:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -1818,6 +1818,24 @@ compiler.carmug1320.name=ARM GCC 13.2.0 (unknown-eabi)
 compiler.carmug1320.semver=13.2.0
 compiler.carmug1320.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.carmug1320.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+
+compiler.carmug1330.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.carmug1330.semver=13.3.0
+compiler.carmug1330.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.carmug1330.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.carmug1330.name=ARM GCC 13.3.0 (unknown-eabi)
+
+compiler.carmug1410.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.carmug1410.semver=14.1.0
+compiler.carmug1410.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.carmug1410.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.carmug1410.name=ARM GCC 14.1.0 (unknown-eabi)
+
+compiler.carmug1420.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.carmug1420.semver=14.2.0
+compiler.carmug1420.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.carmug1420.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.carmug1420.name=ARM GCC 14.2.0 (unknown-eabi)
 
 compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc
 compiler.carmce820.semver=8.2.0 (WinCE)

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -1103,7 +1103,7 @@ group.gimplegccarm.includeFlag=-I
 # 32 bit
 group.gimplegcc32arm.groupName=Arm 32-bit GCC
 group.gimplegcc32arm.baseName=ARM GCC
-group.gimplegcc32arm.compilers=gimplearm921:gimplearm930:gimplearm1020:gimplearm1021:gimplearm1030:gimplearm1031_07:gimplearm1031_10:gimplearmg1050:gimplearm1100:gimplearm1120:gimplearm1121:gimplearm1130:gimplearmg1140:gimplearm1210:gimplearmg1220:gimplearmg1230:gimplearmg1310:gimplearmg1320:gimplearmug1320:gimplearmg1330:gimplearmg1410:gimplearmg1420:gimplearmgtrunk
+group.gimplegcc32arm.compilers=gimplearm921:gimplearm930:gimplearm1020:gimplearm1021:gimplearm1030:gimplearm1031_07:gimplearm1031_10:gimplearmg1050:gimplearm1100:gimplearm1120:gimplearm1121:gimplearm1130:gimplearmg1140:gimplearm1210:gimplearmg1220:gimplearmg1230:gimplearmg1310:gimplearmg1320:gimplearmug1320:gimplearmg1330:gimplearmug1330:gimplearmg1410:gimplearmug1410:gimplearmg1420:gimplearmug1420:gimplearmgtrunk
 group.gimplegcc32arm.isSemVer=true
 group.gimplegcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gimplegcc32arm.instructionSet=arm32
@@ -1158,6 +1158,24 @@ compiler.gimplearmug1320.name=ARM GCC 13.2.0 (unknown-eabi)
 compiler.gimplearmug1320.semver=13.2.0
 compiler.gimplearmug1320.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.gimplearmug1320.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+
+compiler.gimplearmug1330.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.gimplearmug1330.semver=13.3.0
+compiler.gimplearmug1330.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.gimplearmug1330.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-13.3.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.gimplearmug1330.name=ARM GCC 13.3.0 (unknown-eabi)
+
+compiler.gimplearmug1410.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.gimplearmug1410.semver=14.1.0
+compiler.gimplearmug1410.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.gimplearmug1410.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-14.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.gimplearmug1410.name=ARM GCC 14.1.0 (unknown-eabi)
+
+compiler.gimplearmug1420.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.gimplearmug1420.semver=14.2.0
+compiler.gimplearmug1420.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.gimplearmug1420.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-14.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.gimplearmug1420.name=ARM GCC 14.2.0 (unknown-eabi)
 
 compiler.gimplearm921.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc
 compiler.gimplearm921.semver=9.2.1 (none)


### PR DESCRIPTION
Compilers were missing their config.

fixes #6767