### PR TITLE
[LoongArch] Fix llvm config for #6793

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1113,10 +1113,10 @@ group.loongarch-clang.licenseLink=https://github.com/llvm/llvm-project/blob/main
 group.loongarch-clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
 group.loongarch64clang.compilers=loongarch64-clangtrunk:loongarch64-clang1701:loongarch64-clang1810
-group.loongarch64clang.options=-target loongarch64-unknown-elf --gcc-toolchain=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot
-group.loongarch64clang.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
-group.loongarch64clang.baseName=Loongarch64 clang
-group.loongarch64clang.groupName=Loongarch64 Clang
+group.loongarch64clang.options=-target loongarch64-unknown-linux-gnu --gcc-toolchain=/opt/compiler-explorer/loongarch64/gcc-13.3.0/loongarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/loongarch64/gcc-13.3.0/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot
+group.loongarch64clang.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+group.loongarch64clang.baseName=LoongArch64 clang
+group.loongarch64clang.groupName=LoongArch64 Clang
 group.loongarch64clang.compilerCategories=clang
 group.loongarch64clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 


### PR DESCRIPTION
In pr #6793, we misconfigured the `target`. This patch addresses and corrects the problem. Additionally, the GCC toolchain has been updated to handle the `ld` linker’s mismatch with the latest relocation type.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
