### PR TITLE
Adapt upstream fixes and update asm-parser

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -241,9 +241,6 @@ class DotNetCompiler extends BaseCompiler {
     ): Promise<CompilationResult> {
         const corerunArgs: string[] = [];
         const toolOptions: string[] = ['--parallelism', '1'];
-        if (this.sdkMajorVersion >= 9) {
-            toolOptions.push('--codegenopt:JitDisasmAssemblies=CompilerExplorer');
-        }
         const toolSwitches: string[] = [];
         const programDir = path.dirname(inputFilename);
         const programOutputPath = path.join(programDir, 'bin', this.buildConfig, this.targetFramework);
@@ -332,7 +329,9 @@ class DotNetCompiler extends BaseCompiler {
         }
 
         if (!overrideAssembly) {
-            toolOptions.push('--codegenopt', 'JitDisasmAssemblies=CompilerExplorer');
+            if (this.sdkMajorVersion >= 9) {
+                toolOptions.push('--codegenopt', 'JitDisasmAssemblies=CompilerExplorer');
+            }
             envVarFileContents.push('DOTNET_JitDisasmAssemblies=CompilerExplorer');
         }
 

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -246,6 +246,9 @@ class DotNetCompiler extends BaseCompiler {
             this.sdkMajorVersion === 6 ? 'NgenDisasm=*' : 'JitDisasm=*',
             '--parallelism', '1',
         ];
+        if (this.sdkMajorVersion >= 9) {
+            toolOptions.push('--codegenopt:JitDisasmAssemblies=CompilerExplorer');
+        }
         const toolSwitches: string[] = [];
         const programDir = path.dirname(inputFilename);
         const programOutputPath = path.join(programDir, 'bin', this.buildConfig, this.targetFramework);
@@ -444,6 +447,11 @@ class DotNetCompiler extends BaseCompiler {
             dllPath,
             '-o', `${AssemblyName}.r2r.dll`,
         ].concat(toolOptions).concat(toolSwitches);
+
+        if (this.sdkMajorVersion >= 9) {
+            crossgen2Options.push('--inputbubble');
+            crossgen2Options.push('--compilebubblegenerics');
+        }
 
         const compilerExecResult = await this.exec(compiler, crossgen2Options, execOptions);
         const result = this.transformToCompilationResult(compilerExecResult, dllPath);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -449,8 +449,7 @@ class DotNetCompiler extends BaseCompiler {
         ].concat(toolOptions).concat(toolSwitches);
 
         if (this.sdkMajorVersion >= 9) {
-            crossgen2Options.push('--inputbubble');
-            crossgen2Options.push('--compilebubblegenerics');
+            crossgen2Options.push('--inputbubble', '--compilebubblegenerics');
         }
 
         const compilerExecResult = await this.exec(compiler, crossgen2Options, execOptions);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -64,7 +64,7 @@ class DotNetCompiler extends BaseCompiler {
         this.langVersion = this.compilerProps<string>(`compiler.${this.compiler.id}.langVersion`);
 
         this.corerunPath = path.join(this.clrBuildDir, 'corerun');
-        this.crossgen2Path = path.join(this.clrBuildDir, 'crossgen2', 'crossgen2.dll');
+        this.crossgen2Path = path.join(this.clrBuildDir, 'crossgen2', 'crossgen2');
         this.ilcPath = path.join(this.clrBuildDir, 'ilc-published', 'ilc');
         this.asm = new DotNetAsmParser();
         this.disassemblyLoaderPath = path.join(this.clrBuildDir, 'DisassemblyLoader', 'DisassemblyLoader.dll');
@@ -441,7 +441,6 @@ class DotNetCompiler extends BaseCompiler {
     ) {
         // prettier-ignore
         const crossgen2Options = [
-            this.crossgen2Path,
             '-r', path.join(bclPath, '/'),
             '-r', this.disassemblyLoaderPath,
             dllPath,
@@ -450,6 +449,12 @@ class DotNetCompiler extends BaseCompiler {
 
         if (this.sdkMajorVersion >= 9) {
             crossgen2Options.push('--inputbubble', '--compilebubblegenerics');
+        }
+
+        if (await fs.exists(this.crossgen2Path)) {
+            compiler = this.crossgen2Path;
+        } else {
+            crossgen2Options.unshift(this.crossgen2Path + '.dll');
         }
 
         const compilerExecResult = await this.exec(compiler, crossgen2Options, execOptions);


### PR DESCRIPTION
- We now have the upstream issue of `JitDisasmAssemblies` fixed. Enable it for net9.0+.
- Update asm-parser to support CoreCLR and NativeAOT (Fixes #6833)