### PR TITLE
Apply the font scale when we know the target

### DIFF
--- a/static/widgets/fontscale.ts
+++ b/static/widgets/fontscale.ts
@@ -146,5 +146,6 @@ export class FontScale extends EventEmitter.EventEmitter {
     setTarget(target: JQuery | string | IEditor) {
         this.fontSelectorOrEditor = target;
         this.isFontOfStr = typeof this.fontSelectorOrEditor === 'string';
+        this.apply();
     }
 }


### PR DESCRIPTION
This fixes an ordering issue with font scales. The issue would happen if you changed the default font scale and then e.g. opened a tool window. It would have the "default" size selected; but it wouldn't apply to the editor window.

