### PR TITLE
LLVM TableGen: Add 19.1.0 compiler

### DIFF
--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&llvmtblgen
-defaultCompiler=llvmtblgen1810
+defaultCompiler=llvmtblgen_trunk
 compilerType=tablegen
 supportsBinary=false
 supportsExecute=false
 
-group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701:llvmtblgen1810
+group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701:llvmtblgen1810:llvmtblgen1910
 group.llvmtblgen.groupName=LLVM TableGen
 group.llvmtblgen.baseName=LLVM TableGen
 group.llvmtblgen.isSemVer=true
@@ -28,3 +28,7 @@ compiler.llvmtblgen1701.includePath=/opt/compiler-explorer/clang-17.0.1/include/
 compiler.llvmtblgen1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llvm-tblgen
 compiler.llvmtblgen1810.semver=18.1.0
 compiler.llvmtblgen1810.includePath=/opt/compiler-explorer/clang-18.1.0/include/
+
+compiler.llvmtblgen1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llvm-tblgen
+compiler.llvmtblgen1910.semver=19.1.0
+compiler.llvmtblgen1910.includePath=/opt/compiler-explorer/clang-19.1.0/include/


### PR DESCRIPTION
From the same Clang install added in 6139c19e3b81d1a3d437eb413dfb00c187069578.

And change the default version to trunk.
