### PR TITLE
Changes for NVIDIA HPC SDK 24.9

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3601,7 +3601,7 @@ compiler.gcc6502_1110.notification=This uses AVR-GCC 11.1.0 to compile C++ and u
 #################################
 # NVHPC nvc++
 
-group.nvcxx_x86_cxx.compilers=nvcxx_x86_cxx22_7:nvcxx_x86_cxx22_9:nvcxx_x86_cxx22_11:nvcxx_x86_cxx23_1:nvcxx_x86_cxx23_3:nvcxx_x86_cxx23_5:nvcxx_x86_cxx23_7:nvcxx_x86_cxx23_9:nvcxx_x86_cxx23_11:nvcxx_x86_cxx24_1:nvcxx_x86_cxx24_3:nvcxx_x86_cxx24_5:nvcxx_x86_cxx24_7
+group.nvcxx_x86_cxx.compilers=nvcxx_x86_cxx22_7:nvcxx_x86_cxx22_9:nvcxx_x86_cxx22_11:nvcxx_x86_cxx23_1:nvcxx_x86_cxx23_3:nvcxx_x86_cxx23_5:nvcxx_x86_cxx23_7:nvcxx_x86_cxx23_9:nvcxx_x86_cxx23_11:nvcxx_x86_cxx24_1:nvcxx_x86_cxx24_3:nvcxx_x86_cxx24_5:nvcxx_x86_cxx24_7:nvcxx_x86_cxx24_9
 group.nvcxx_x86_cxx.options=
 group.nvcxx_x86_cxx.binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*|_dl_relocate_static_pie)$
 group.nvcxx_x86_cxx.needsMulti=false
@@ -3694,7 +3694,13 @@ compiler.nvcxx_x86_cxx24_7.nvdisasm=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/
 compiler.nvcxx_x86_cxx24_7.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.7/compilers/bin/nvc++
 compiler.nvcxx_x86_cxx24_7.semver=24.7
 
-group.nvcxx_arm_cxx.compilers=nvcxx_arm_cxx22_7:nvcxx_arm_cxx22_9:nvcxx_arm_cxx22_11:nvcxx_arm_cxx23_1:nvcxx_arm_cxx23_3:nvcxx_arm_cxx23_5:nvcxx_arm_cxx23_7:nvcxx_arm_cxx23_9:nvcxx_arm_cxx23_11:nvcxx_arm_cxx24_1:nvcxx_arm_cxx24_3:nvcxx_arm_cxx24_5:nvcxx_arm_cxx24_7
+compiler.nvcxx_x86_cxx24_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvdecode
+compiler.nvcxx_x86_cxx24_9.cuobjdump=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/cuobjdump
+compiler.nvcxx_x86_cxx24_9.nvdisasm=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/nvdisasm
+compiler.nvcxx_x86_cxx24_9.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvc++
+compiler.nvcxx_x86_cxx24_9.semver=24.9
+
+group.nvcxx_arm_cxx.compilers=nvcxx_arm_cxx22_7:nvcxx_arm_cxx22_9:nvcxx_arm_cxx22_11:nvcxx_arm_cxx23_1:nvcxx_arm_cxx23_3:nvcxx_arm_cxx23_5:nvcxx_arm_cxx23_7:nvcxx_arm_cxx23_9:nvcxx_arm_cxx23_11:nvcxx_arm_cxx24_1:nvcxx_arm_cxx24_3:nvcxx_arm_cxx24_5:nvcxx_arm_cxx24_7:nvcxx_arm_cxx24_9
 group.nvcxx_arm_cxx.options=
 group.nvcxx_arm_cxx.supportsBinary=true
 group.nvcxx_arm_cxx.binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*|_dl_relocate_static_pie)$
@@ -3761,6 +3767,10 @@ compiler.nvcxx_arm_cxx24_5.semver=24.5
 compiler.nvcxx_arm_cxx24_7.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/24.7/compilers/bin/nvdecode
 compiler.nvcxx_arm_cxx24_7.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/24.7/compilers/bin/nvc++
 compiler.nvcxx_arm_cxx24_7.semver=24.7
+
+compiler.nvcxx_arm_cxx24_7.demangler=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/24.9/compilers/bin/nvdecode
+compiler.nvcxx_arm_cxx24_7.exe=/opt/compiler-explorer/hpc_sdk/Linux_aarch64/24.9/compilers/bin/nvc++
+compiler.nvcxx_arm_cxx24_7.semver=24.9
 
 #################################
 # EDG compiler

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast
+compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast
 defaultCompiler=cg142
 demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
@@ -354,6 +354,31 @@ compiler.cclang_widberg.semver=(widberg)
 compiler.cclang_widberg.isNightly=true
 compiler.cclang_widberg.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0
 compiler.cclang_widberg.notification=Experimental Reverse Engineering Compiler; see <a href="https://github.com/widberg/llvm-project-widberg-extensions" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+
+#################################
+# NVHPC nvc
+
+group.nvc_x86.compilers=nvc_x86_24_9
+group.nvc_x86.options=
+group.nvc_x86.binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|\.plt.*|_dl_relocate_stat
+ic_pie)$
+group.nvc_x86.needsMulti=false
+group.nvc_x86.stubRe=\bmain\b
+group.nvc_x86.stubText=int main(void){return 0;/*stub provided by Compiler Explorer*/}
+group.nvc_x86.supportsBinary=true
+group.nvc_x86.supportsExecute=true
+group.nvc_x86.supportsLibraryCodeFilter=true
+group.nvc_x86.demanglerType=nvhpc
+group.nvc_x86.groupName=nvc x86
+group.nvc_x86.baseName=x86 nvc
+group.nvc_x86.isSemVer=true
+group.nvc_x86.compilerCategories=nvc
+
+compiler.nvc_x86_24_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvdecode
+compiler.nvc_x86_24_9.cuobjdump=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/cuobjdump
+compiler.nvc_x86_24_9.nvdisasm=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/nvdisasm
+compiler.nvc_x86_24_9.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvc
+
 
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -9,7 +9,7 @@ supportsExecute=false
 # Details of GPUs/features supported by CUDA compilers can be found here:
 # gist.github.com/ax3l/9489132#clang--x-cuda
 
-group.nvcc.compilers=nvcc125u1:nvcc124u1:nvcc123u1:nvcc122u1:nvcc121:nvcc120u1:nvcc120:nvcc118:nvcc117u1:nvcc117:nvcc116u2:nvcc116u1:nvcc116:nvcc115u2:nvcc115u1:nvcc115:nvcc114u4:nvcc114u3:nvcc114u2:nvcc114u1:nvcc114:nvcc113u1:nvcc113:nvcc112u2:nvcc112u1:nvcc112:nvcc111u1:nvcc111:nvcc11u1:nvcc11:nvcc102:nvcc101u2:nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
+group.nvcc.compilers==nvcc126u1:nvcc125u1:nvcc124u1:nvcc123u1:nvcc122u1:nvcc121:nvcc120u1:nvcc120:nvcc118:nvcc117u1:nvcc117:nvcc116u2:nvcc116u1:nvcc116:nvcc115u2:nvcc115u1:nvcc115:nvcc114u4:nvcc114u3:nvcc114u2:nvcc114u1:nvcc114:nvcc113u1:nvcc113:nvcc112u2:nvcc112u1:nvcc112:nvcc111u1:nvcc111:nvcc11u1:nvcc11:nvcc102:nvcc101u2:nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
 group.nvcc.versionRe=^Cuda.*
 group.nvcc.compilerType=nvcc
 group.nvcc.isSemVer=true
@@ -240,6 +240,12 @@ compiler.nvcc125u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/b
 compiler.nvcc125u1.nvdisasm=/opt/compiler-explorer/cuda/12.5.1/bin/nvdisasm
 compiler.nvcc125u1.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 compiler.nvcc125u1.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
+compiler.nvcc126u1.semver=12.6.1
+compiler.nvcc126u1.exe=/opt/compiler-explorer/cuda/12.6.1/bin/nvcc
+compiler.nvcc126u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/bin
+compiler.nvcc126u1.nvdisasm=/opt/compiler-explorer/cuda/12.6.1/bin/nvdisasm
+compiler.nvcc126u1.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
+compiler.nvcc126u1.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cltrunk
 group.cuclang.isSemVer=true
 group.cuclang.baseName=clang

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gfortran_86:&ifort:&ifx:&cross:&clang_llvmflang
+compilers=&gfortran_86:&ifort:&ifx:&nvfortran_x86:&cross:&clang_llvmflang
 defaultCompiler=gfortran142
 demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
@@ -255,6 +255,26 @@ compiler.ifxlatest.ldPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/co
 compiler.ifxlatest.libPath=/opt/compiler-explorer/intel-fortran-2024.0.0.49493/compiler/latest/lib
 compiler.ifxlatest.semver=(latest)
 compiler.ifxlatest.options=-gxx-name=/opt/compiler-explorer/gcc-13.2.0/bin/g++
+
+#################################
+# NVHPC nvfortran
+
+group.nvfortran_x86.compilers=nvfortran_x86_24_7
+group.nvfortran_x86.options=
+group.nvfortran_x86.needsMulti=false
+group.nvfortran_x86.supportsBinary=true
+group.nvfortran_x86.supportsExecute=true
+group.nvfortran_x86.supportsLibraryCodeFilter=true
+group.nvfortran_x86.groupName=nvfortran x86
+group.nvfortran_x86.baseName=x86 nvfortran
+group.nvfortran_x86.isSemVer=true
+group.nvfortran_x86.compilerCategories=nvfortran
+
+compiler.nvfortran_x86_24_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvdecode
+compiler.nvfortran_x86_24_9.cuobjdump=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/cuobjdump
+compiler.nvfortran_x86_24_9.nvdisasm=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/nvdisasm
+compiler.nvfortran_x86_24_9.exe=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvfortran
+compiler.nvfortran_x86_24_9.semver=24.9
 
 ###############################
 # GCC Cross-Compilers


### PR DESCRIPTION
Add nvc 24.9 (x86-64) to etc/config/c.amazon.properties
Add nvc++ (x86-64) 24.9 to etc/config/c++.amazon.properties
Add nvfortran (x86-64) 24.9 to etc/config/fortran.amazon.properties
Add CUDA 12.6.1 to etc/config/cuda.amazon.properties

nvc and nvfortran are new additions to CE.  They work on my local installation but let me know if there are needed any changes needed for CE.
