### PR TITLE
Flang: Remove flang-to-external-fc support and "new" from names

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -690,29 +690,24 @@ compiler.fs390xg1420.demangler=/opt/compiler-explorer/s390x/gcc-14.2.0/s390x-ibm
 
 ###############################
 # LLVM Flang for X86
-group.clang_llvmflang.compilers=flangtrunk:flangtrunknew:flangtrunknew-fc
+group.clang_llvmflang.compilers=flangtrunk:flangtrunk-fc
 group.clang_llvmflang.groupName=LLVM-FLANG x86-64
 group.clang_llvmflang.compilerType=flang
 
-compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-to-external-fc
-compiler.flangtrunk.name=flang-trunk (flang-to-external-fc)
-compiler.flangtrunk.gfortranPath=/opt/compiler-explorer/gcc-snapshot/bin
+compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
+compiler.flangtrunk.name=flang-trunk
 compiler.flangtrunk.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
 compiler.flangtrunk.isNightly=true
+compiler.flangtrunk.alias=flangtrunknew
 
-compiler.flangtrunknew.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
-compiler.flangtrunknew.name=flang-trunk (flang-new)
-compiler.flangtrunknew.gfortranPath=/opt/compiler-explorer/gcc-snapshot/bin
-compiler.flangtrunknew.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
-compiler.flangtrunknew.isNightly=true
-
-compiler.flangtrunknew-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
-compiler.flangtrunknew-fc.name=flang-trunk-fc1 (flang-new)
-compiler.flangtrunknew-fc.compilerType=flang-fc1
-compiler.flangtrunknew-fc.isNightly=true
-compiler.flangtrunknew-fc.supportsBinary=false
-compiler.flangtrunknew-fc.supportsBinaryObject=false
-compiler.flangtrunknew-fc.supportsBinaryExecute=false
+compiler.flangtrunk-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
+compiler.flangtrunk-fc.name=flang-trunk-fc1
+compiler.flangtrunk-fc.compilerType=flang-fc1
+compiler.flangtrunk-fc.isNightly=true
+compiler.flangtrunk-fc.supportsBinary=false
+compiler.flangtrunk-fc.supportsBinaryObject=false
+compiler.flangtrunk-fc.supportsBinaryExecute=false
+compiler.flangtrunk-fc.alias=flangtrunknew-fc
 
 ###############################
 # GCC for ARM 64bit

--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -97,16 +97,10 @@ compiler.gfortran.name=gfortran
 
 ###############################
 # LLVM Flang
-group.clang_llvmflang.compilers=flangtrunk:flangtrunknew
+group.clang_llvmflang.compilers=flangtrunk
 group.clang_llvmflang.groupName=LLVM-FLANG
 group.clang_llvmflang.compilerType=flang
 
-compiler.flangtrunk.exe=/usr/local/bin/flang-to-external-fc
-compiler.flangtrunk.name=flang-trunk (flang-to-external-fc)
-compiler.flangtrunk.gfortranPath=/usr/bin/
+compiler.flangtrunk.exe=/usr/local/bin/flang-new
+compiler.flangtrunk.name=flang-trunk
 compiler.flangtrunk.isNightly=true
-
-compiler.flangtrunknew.exe=/usr/local/bin/flang-new
-compiler.flangtrunknew.name=flang-trunk (flang-new)
-compiler.flangtrunknew.gfortranPath=/usr/bin/
-compiler.flangtrunknew.isNightly=true

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1062,12 +1062,8 @@ export class FlangParser extends ClangParser {
             compiler.compiler.minIrArgs = ['-emit-llvm'];
         }
 
-        // We're not going to use -mllvm, this just tells us whether we are flang
-        // or flang-to-external-fc. The latter does not support -masm.
-        if (this.hasSupport(options, '-mllvm')) {
-            compiler.compiler.supportsIntel = true;
-            compiler.compiler.intelAsm = '-masm=intel';
-        }
+        compiler.compiler.supportsIntel = true;
+        compiler.compiler.intelAsm = '-masm=intel';
     }
 
     static override hasSupport(options, param) {

--- a/lib/compilers/flang.ts
+++ b/lib/compilers/flang.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import path from 'path';
-
 import {LLVMIrBackendOptions} from '../../types/compilation/ir.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {unwrap} from '../assert.js';
@@ -51,15 +49,6 @@ export class FlangCompiler extends FortranCompiler {
             options = options.concat('-S');
         }
         return options;
-    }
-
-    override getDefaultExecOptions() {
-        const result = super.getDefaultExecOptions();
-        const gfortranPath = this.compilerProps(`compiler.${this.compiler.id}.gfortranPath`);
-        if (gfortranPath) {
-            result.env.PATH = result.env.PATH + path.delimiter + gfortranPath;
-        }
-        return result;
     }
 
     override async generateIR(


### PR DESCRIPTION
In anticipation of https://discourse.llvm.org/t/proposal-rename-flang-new-to-flang/69462 happening, which will rename flang-new to simply "flang".

I have added aliases to keep old links working.

gfortranpath has been removed because it was only used for flang-to-external-fc to find the gfortran binary. It was not adding any library paths current flang would need for linking. It was set for the `flang-new` compiler but this was a mistake, `flang-new` can generate code without the help of `gfortran`.

The binary name will remain "flang-new" until main llvm makes the change.