### PR TITLE
Update OatCFGParser's jump target format

### DIFF
--- a/lib/cfg/cfg-parsers/oat.ts
+++ b/lib/cfg/cfg-parsers/oat.ts
@@ -95,11 +95,12 @@ export class OatCFGParser extends BaseCFGParser {
         return result;
     }
 
-    // In this example, '0x416c' will be returned.
+    // In these examples, '0x416c' and '0x8074' will be returned.
     //     0x00004144    b #+0x28 (addr 0x416c)
+    //     0x00008050    b.hs #+0x24 (addr 0x00008074)
     getJmpAddr(inst: string): string {
         const match = inst.match(this.jmpAddrRegex);
-        if (match) return match[1];
+        if (match) return this.shortenHex(match[1]);
         return '';
     }
 


### PR DESCRIPTION
We need to account for latest versions of dex2oat saving jump targets in non-truncated form, for example,

(old) "b #+0x28 (addr 0x416c)" vs. (new) "b.hs #+0x24 (addr 0x00008074)"

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
