### PR TITLE
Introduce opt-pipeline for ClangIr

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -80,7 +80,14 @@ import {BuildEnvSetupBase, getBuildEnvTypeByKey} from './buildenvsetup/index.js'
 import * as cfg from './cfg/cfg.js';
 import {CompilationEnvironment} from './compilation-env.js';
 import {CompilerArguments} from './compiler-arguments.js';
-import {ClangCParser, ClangParser, GCCCParser, GCCParser, ICCParser} from './compilers/argument-parsers.js';
+import {
+    ClangCParser,
+    ClangirParser,
+    ClangParser,
+    GCCCParser,
+    GCCParser,
+    ICCParser,
+} from './compilers/argument-parsers.js';
 import {BaseDemangler, getDemanglerTypeByKey} from './demangler/index.js';
 import {LLVMIRDemangler} from './demangler/llvm.js';
 import * as exec from './exec.js';
@@ -3221,6 +3228,8 @@ but nothing was dumped. Possible causes are:
         const exeFilename = path.basename(exe);
         if (exeFilename.includes('icc')) {
             return ICCParser;
+        } else if (exe.includes('clangir')) {
+            return ClangirParser;
         } else if (exeFilename.includes('clang++') || exeFilename.includes('icpx')) {
             // check this first as "clang++" matches "g++"
             return ClangParser;

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -449,7 +449,9 @@ export class ClangirParser extends ClangParser {
             arg: [],
             moduleScopeArg: ['-mmlir', '--mlir-print-ir-before-all', '-mmlir', '--mlir-print-ir-after-all'],
             noDiscardValueNamesArg: [],
-            supportedOptions: ['dump-full-module', 'demangle-symbols'],
+            // Currently 'dump-full-module' is locked to checked by the front-end
+            // supportedOptions: ['dump-full-module', 'demangle-symbols'],
+            supportedOptions: ['demangle-symbols'],
             supportedFilters: [],
         };
     }

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -441,6 +441,20 @@ export class ClangParser extends BaseParser {
     }
 }
 
+export class ClangirParser extends ClangParser {
+    static override setCompilerSettingsFromOptions(compiler, options) {
+        ClangParser.setCompilerSettingsFromOptions(compiler, options);
+
+        compiler.compiler.optPipeline = {
+            arg: [],
+            moduleScopeArg: ['-mmlir', '--mlir-print-ir-before-all', '-mmlir', '--mlir-print-ir-after-all'],
+            noDiscardValueNamesArg: [],
+            supportedOptions: ['dump-full-module', 'demangle-symbols'],
+            supportedFilters: [],
+        };
+    }
+}
+
 export class GCCCParser extends GCCParser {
     static override getLanguageSpecificHelpFlags(): string[] {
         return ['-fsyntax-only', '--help=c'];

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -449,10 +449,14 @@ export class ClangirParser extends ClangParser {
             arg: [],
             moduleScopeArg: ['-mmlir', '--mlir-print-ir-before-all', '-mmlir', '--mlir-print-ir-after-all'],
             noDiscardValueNamesArg: [],
-            // Currently 'dump-full-module' is locked to checked by the front-end
-            // supportedOptions: ['dump-full-module', 'demangle-symbols'],
             supportedOptions: ['demangle-symbols'],
             supportedFilters: [],
+            initialOptionsState: {
+                'dump-full-module': true,
+                'demangle-symbols': true,
+                '-fno-discard-value-names': false,
+            },
+            initialFiltersState: {'filter-debug-info': false, 'filter-instruction-metadata': false},
         };
     }
 }

--- a/lib/parsers/llvm-pass-dump-parser.ts
+++ b/lib/parsers/llvm-pass-dump-parser.ts
@@ -73,6 +73,7 @@ export class LlvmPassDumpParser {
     metadataLineFilters: RegExp[];
     irDumpHeader: RegExp;
     machineCodeDumpHeader: RegExp;
+    cirDumpHeader: RegExp;
     functionDefine: RegExp;
     machineFunctionBegin: RegExp;
     functionEnd: RegExp;
@@ -121,6 +122,10 @@ export class LlvmPassDumpParser {
         // or "(loop: %x)" at the end
         this.irDumpHeader = /^;?\s?\*{3} (.+) \*{3}(?:\s+\((?:function: |loop: )(%?[\w$.]+)\))?(?:;.+)?$/;
         this.machineCodeDumpHeader = /^# \*{3} (.+) \*{3}:$/;
+        // ClangIr dump headers look like "// -----// IR Dump Before XYZ (cir-xyz) //----- //
+        // and currently do not refer to functions
+        this.cirDumpHeader = /^\/\/ -----\/\/ (.+) \/\/----- \/\/$/;
+
         // Ir dumps are "define T @_Z3fooi(...) . .. {" or "# Machine code for function _Z3fooi: <attributes>"
         // Some interesting edge cases found when testing:
         // `define internal %"struct.libassert::detail::assert_static_parameters"* @"_ZZ4mainENK3$_0clEv"(
@@ -149,7 +154,8 @@ export class LlvmPassDumpParser {
             //}
             const irMatch = line.text.match(this.irDumpHeader);
             const machineMatch = line.text.match(this.machineCodeDumpHeader);
-            const header = irMatch || machineMatch;
+            const cirMatch = line.text.match(this.cirDumpHeader);
+            const header = irMatch || machineMatch || cirMatch;
             if (header) {
                 if (pass !== null) {
                     raw_passes.push(pass);
@@ -481,7 +487,12 @@ export class LlvmPassDumpParser {
     process(output: ResultLine[], _: ParseFiltersAndOutputOptions, optPipelineOptions: OptPipelineBackendOptions) {
         // Crop out any junk before the pass dumps (e.g. warnings)
         const ir = output.slice(
-            output.findIndex(line => line.text.match(this.irDumpHeader) || line.text.match(this.machineCodeDumpHeader)),
+            output.findIndex(
+                line =>
+                    this.irDumpHeader.test(line.text) ||
+                    this.machineCodeDumpHeader.test(line.text) ||
+                    this.cirDumpHeader.test(line.text),
+            ),
         );
         const preprocessed_lines = this.applyIrFilters(ir, optPipelineOptions);
         return this.breakdownOutput(preprocessed_lines, optPipelineOptions);

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -230,7 +230,8 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
     updateButtons() {
         if (!this.compiler || !this.compiler.optPipeline) return;
 
-        const {supportedOptions, supportedFilters} = this.compiler.optPipeline;
+        const {supportedOptions, supportedFilters, initialOptionsState, initialFiltersState} =
+            this.compiler.optPipeline;
         if (supportedOptions) {
             for (const key of ['dump-full-module', '-fno-discard-value-names', 'demangle-symbols']) {
                 this.options.enableToggle(key, supportedOptions.includes(key));
@@ -239,6 +240,16 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         if (supportedFilters) {
             for (const key of ['filter-debug-info', 'filter-instruction-metadata']) {
                 this.filters.enableToggle(key, supportedFilters.includes(key));
+            }
+        }
+        if (initialOptionsState) {
+            for (const key in initialOptionsState) {
+                this.options.set(key, initialOptionsState[key]);
+            }
+        }
+        if (initialFiltersState) {
+            for (const key in initialFiltersState) {
+                this.filters.set(key, initialFiltersState[key]);
             }
         }
     }
@@ -338,19 +349,11 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.updateTitle();
         this.compiler = compiler;
         this.updateGroupName();
+        this.updateButtons();
         this.updateEditor();
         if (compiler && !compiler.optPipeline) {
             //this.editor.setValue('<Opt pipeline output is not supported for this compiler>');
         }
-
-        // TODO: un-hackify this
-        if (this.compilerInfo.compilerName.includes('clangir')) {
-            this.options.set('dump-full-module', true);
-            this.filters.set('filter-debug-info', false);
-            this.filters.set('filter-instruction-metadata', false);
-        }
-
-        this.updateButtons();
     }
 
     updateGroupName() {

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -229,12 +229,14 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
 
     updateButtons() {
         if (!this.compiler || !this.compiler.optPipeline) return;
-        const {supportedOptions, supportedFilters} = this.compiler.optPipeline;
+
+        const supportedOptions = this.compiler.optPipeline.supportedOptions;
         if (supportedOptions) {
             for (const key of ['dump-full-module', '-fno-discard-value-names', 'demangle-symbols']) {
                 this.options.enableToggle(key, supportedOptions.includes(key));
             }
         }
+        const supportedFilters = this.compiler.optPipeline.supportedFilters;
         if (supportedFilters) {
             for (const key of ['filter-debug-info', 'filter-instruction-metadata']) {
                 this.filters.enableToggle(key, supportedFilters.includes(key));
@@ -341,6 +343,11 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.updateEditor();
         if (compiler && !compiler.optPipeline) {
             //this.editor.setValue('<Opt pipeline output is not supported for this compiler>');
+        }
+
+        // TODO: un-hackify this
+        if (this.compilerInfo.compilerName.includes('clangir')) {
+            this.options.enableToggle('dump-full-module', false, true);
         }
     }
 

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -230,13 +230,12 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
     updateButtons() {
         if (!this.compiler || !this.compiler.optPipeline) return;
 
-        const supportedOptions = this.compiler.optPipeline.supportedOptions;
+        const {supportedOptions, supportedFilters} = this.compiler.optPipeline;
         if (supportedOptions) {
             for (const key of ['dump-full-module', '-fno-discard-value-names', 'demangle-symbols']) {
                 this.options.enableToggle(key, supportedOptions.includes(key));
             }
         }
-        const supportedFilters = this.compiler.optPipeline.supportedFilters;
         if (supportedFilters) {
             for (const key of ['filter-debug-info', 'filter-instruction-metadata']) {
                 this.filters.enableToggle(key, supportedFilters.includes(key));
@@ -339,7 +338,6 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         this.updateTitle();
         this.compiler = compiler;
         this.updateGroupName();
-        this.updateButtons();
         this.updateEditor();
         if (compiler && !compiler.optPipeline) {
             //this.editor.setValue('<Opt pipeline output is not supported for this compiler>');
@@ -347,8 +345,12 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
 
         // TODO: un-hackify this
         if (this.compilerInfo.compilerName.includes('clangir')) {
-            this.options.enableToggle('dump-full-module', false, true);
+            this.options.set('dump-full-module', true);
+            this.filters.set('filter-debug-info', false);
+            this.filters.set('filter-instruction-metadata', false);
         }
+
+        this.updateButtons();
     }
 
     updateGroupName() {

--- a/static/widgets/toggles.ts
+++ b/static/widgets/toggles.ts
@@ -107,15 +107,12 @@ export class Toggles extends EventEmitter {
         this.emit('change', before, this.get());
     }
 
-    enableToggle(key: string, enable: boolean, lockChecked: boolean = false) {
+    enableToggle(key: string, enable: boolean) {
         for (const element of this.buttons) {
             const widget = $(element);
             const button = widget.find('button');
             const bind = button.data('bind');
             if (bind === key) {
-                if (lockChecked) {
-                    this.set(key, true); // Ensure the toggle is checked
-                }
                 button.prop('disabled', !enable);
             }
         }

--- a/static/widgets/toggles.ts
+++ b/static/widgets/toggles.ts
@@ -107,12 +107,15 @@ export class Toggles extends EventEmitter {
         this.emit('change', before, this.get());
     }
 
-    enableToggle(key: string, enable: boolean) {
+    enableToggle(key: string, enable: boolean, lockChecked: boolean = false) {
         for (const element of this.buttons) {
             const widget = $(element);
             const button = widget.find('button');
             const bind = button.data('bind');
             if (bind === key) {
+                if (lockChecked) {
+                    this.set(key, true); // Ensure the toggle is checked
+                }
                 button.prop('disabled', !enable);
             }
         }

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -146,6 +146,8 @@ export type CompilerInfo = {
         moduleScopeArg?: string[];
         noDiscardValueNamesArg?: string[];
         monacoLanguage?: string;
+        initialOptionsState?: Record<string, boolean>;
+        initialFiltersState?: Record<string, boolean>;
     };
     cachedPossibleArguments?: any;
     nvdisasm?: string;


### PR DESCRIPTION
Thank @Lancern for the CIR flags analogous to clang's `--print-before|after-all.`

![cir](https://github.com/user-attachments/assets/78742d83-799d-40cd-bcef-7a2e69a83c54)
