### PR TITLE
Temporarily disable linking and execution for clang-cl

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -15,8 +15,8 @@ group.clang-cl.instructionSet=amd64
 group.clang-cl.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.clang-cl.licenseName=LLVM Apache 2
 group.clang-cl.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
-group.clang-cl.supportsBinary=true
-group.clang-cl.supportsExecute=true
+group.clang-cl.supportsBinary=false
+group.clang-cl.supportsExecute=false
 
 compiler.clang-cl1810.exe=Z:/compilers/clang-cl-18.1.0/bin/clang-cl.exe
 compiler.clang-cl1810.semver=18.1.0


### PR DESCRIPTION
As pointed out in https://github.com/compiler-explorer/compiler-explorer/pull/6738#issuecomment-2384120341, it doesn't really work, and I don't have the bandwidth to fix this in a timely manner.