### PR TITLE
.NET: Invoke compiler directly to speed up compilation

### DIFF
--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -52,7 +52,7 @@ compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/do
 compiler.dotnettrunkvbcoreclr.name=.NET CoreCLR (main)
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
-compiler.dotnettrunkvbcoreclr.langVersion=preview
+compiler.dotnettrunkvbcoreclr.langVersion=latest
 compiler.dotnettrunkvbcoreclr.isNightly=true
 
 # Crossgen2 compilers
@@ -79,7 +79,7 @@ compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/
 compiler.dotnettrunkvbcrossgen2.name=.NET Crossgen2 (main)
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
-compiler.dotnettrunkvbcrossgen2.langVersion=preview
+compiler.dotnettrunkvbcrossgen2.langVersion=latest
 compiler.dotnettrunkvbcrossgen2.isNightly=true
 
 # Mono compilers
@@ -88,7 +88,7 @@ compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotne
 compiler.dotnettrunkvbmono.name=.NET Mono (main)
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
-compiler.dotnettrunkvbmono.langVersion=preview
+compiler.dotnettrunkvbmono.langVersion=latest
 compiler.dotnettrunkvbmono.isNightly=true
 
 # NativeAOT compilers
@@ -97,7 +97,7 @@ compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/
 compiler.dotnettrunkvbnativeaot.name=.NET NativeAOT (main)
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
-compiler.dotnettrunkvbnativeaot.langVersion=preview
+compiler.dotnettrunkvbnativeaot.langVersion=latest
 compiler.dotnettrunkvbnativeaot.isNightly=true
 
 # IL disassembler compilers
@@ -106,7 +106,7 @@ compiler.dotnettrunkvbildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dot
 compiler.dotnettrunkvbildasm.name=.NET IL Disassembler (main)
 compiler.dotnettrunkvbildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbildasm.buildConfig=Release
-compiler.dotnettrunkvbildasm.langVersion=preview
+compiler.dotnettrunkvbildasm.langVersion=latest
 compiler.dotnettrunkvbildasm.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
@@ -151,5 +151,5 @@ compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvb.buildConfig=Release
-compiler.dotnettrunkvb.langVersion=preview
+compiler.dotnettrunkvb.langVersion=latest
 compiler.dotnettrunkvb.isNightly=true

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -281,14 +281,7 @@ class DotNetCompiler extends BaseCompiler {
         return {refAssemblies, analyzers};
     }
 
-    async runCsc(
-        compiler: string,
-        inputFilename: string,
-        outputFilename: string,
-        execOptions: ExecutionOptionsWithEnv,
-        buildToBinary?: boolean,
-    ) {
-        const {refAssemblies, analyzers} = this.getRefAssembliesAndAnalyzers(compiler, 'csharp');
+    getPreprocessorDefines(lang: LanguageKey) {
         const defines = [
             'TRACE',
             'NET',
@@ -303,9 +296,29 @@ class DotNetCompiler extends BaseCompiler {
             'NETCOREAPP3_0_OR_GREATER',
             'NETCOREAPP3_1_OR_GREATER',
         ];
+
         for (let version = this.sdkMajorVersion; version >= 5; version--) {
             defines.push(`NET${version}_0_OR_GREATER`);
         }
+
+        if (lang === 'vb') {
+            const vbDefines = defines.map(d => `${d}=-1`);
+            vbDefines.push('CONFIG="Release"', 'PLATFORM="AnyCPU"', '_MyType="Empty"');
+            return vbDefines;
+        }
+
+        return defines;
+    }
+
+    async runCsc(
+        compiler: string,
+        inputFilename: string,
+        outputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+        buildToBinary?: boolean,
+    ) {
+        const {refAssemblies, analyzers} = this.getRefAssembliesAndAnalyzers(compiler, 'csharp');
+        const defines = this.getPreprocessorDefines('csharp');
         const options = [
             '-nologo',
             `-target:${buildToBinary ? 'exe' : 'library'}`,
@@ -364,26 +377,7 @@ using System.Reflection;
         buildToBinary?: boolean,
     ) {
         const {refAssemblies, analyzers} = this.getRefAssembliesAndAnalyzers(compiler, 'vb');
-        const defines = [
-            'CONFIG="Release"',
-            'TRACE=-1',
-            'PLATFORM="AnyCPU"',
-            'NET=-1',
-            `NET${this.sdkMajorVersion}_0=-1`,
-            'RELEASE=-1',
-            '_MyType="Empty"',
-            'NETCOREAPP=-1',
-            'NETCOREAPP1_0_OR_GREATER=-1',
-            'NETCOREAPP1_1_OR_GREATER=-1',
-            'NETCOREAPP2_0_OR_GREATER=-1',
-            'NETCOREAPP2_1_OR_GREATER=-1',
-            'NETCOREAPP2_2_OR_GREATER=-1',
-            'NETCOREAPP3_0_OR_GREATER=-1',
-            'NETCOREAPP3_1_OR_GREATER=-1',
-        ];
-        for (let version = this.sdkMajorVersion; version >= 5; version--) {
-            defines.push(`NET${version}_0_OR_GREATER=-1`);
-        }
+        const defines = this.getPreprocessorDefines('vb');
         const options = [
             '-nologo',
             `-target:${buildToBinary ? 'exe' : 'library'}`,
@@ -453,23 +447,7 @@ Imports System.Reflection
         buildToBinary?: boolean,
     ) {
         const {refAssemblies} = this.getRefAssembliesAndAnalyzers(compiler, 'fsharp');
-        const defines = [
-            'TRACE',
-            'NET',
-            `NET${this.sdkMajorVersion}_0`,
-            'RELEASE',
-            'NETCOREAPP',
-            'NETCOREAPP1_0_OR_GREATER',
-            'NETCOREAPP1_1_OR_GREATER',
-            'NETCOREAPP2_0_OR_GREATER',
-            'NETCOREAPP2_1_OR_GREATER',
-            'NETCOREAPP2_2_OR_GREATER',
-            'NETCOREAPP3_0_OR_GREATER',
-            'NETCOREAPP3_1_OR_GREATER',
-        ];
-        for (let version = this.sdkMajorVersion; version >= 5; version--) {
-            defines.push(`NET${version}_0_OR_GREATER`);
-        }
+        const defines = this.getPreprocessorDefines('fsharp');
         const options = [
             '--nologo',
             `--target:${buildToBinary ? 'exe' : 'library'}`,

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -115,12 +115,6 @@ class DotNetCompiler extends BaseCompiler {
         ];
     }
 
-    getCompilerOptions() {
-        return this.lang.id === 'il'
-            ? ['-nologo', '-quiet', '-optimize']
-            : ['build', '-c', this.buildConfig, '-v', 'q', '--nologo', '--no-restore', '/clp:NoSummary'];
-    }
-
     get configurableSwitches() {
         return [
             '-o',
@@ -717,7 +711,7 @@ do()
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions) {
-        return this.getCompilerOptions();
+        return [];
     }
 
     async getRuntimeVersion() {

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -509,13 +509,13 @@ do()
         buildToBinary?: boolean,
     ) {
         const assemblyInfo = `.assembly extern DisassemblyLoader { }
-        .assembly CompilerExplorer
-        {
-            .ver 1:0:0:0
-        }
-        .module CompilerExplorer.dll
-        #include "${path.basename(inputFilename)}"
-        `;
+.assembly CompilerExplorer
+{
+    .ver 1:0:0:0
+}
+.module CompilerExplorer.dll
+#include "${path.basename(inputFilename)}"
+`;
 
         const programDir = path.dirname(inputFilename);
         const assemblyInfoPath = path.join(programDir, 'AssemblyInfo.il');

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -525,7 +525,7 @@ do()
             '-quiet',
             '-optimize',
             buildToBinary ? '-exe' : '-dll',
-            path.join(programDir, 'AssemblyInfo.il'),
+            assemblyInfoPath,
             `-include:${programDir}`,
             `-output:${outputFilename}`,
         ];

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -853,7 +853,7 @@ do()
         ].concat(toolOptions).concat(toolSwitches);
 
         if (!buildToBinary) {
-            ilcOptions.push('--nativelib');
+            ilcOptions.push('--nativelib', '--root:CompilerExplorer');
         }
 
         const compilerExecResult = await this.exec(compiler, ilcOptions, execOptions);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -272,6 +272,7 @@ class DotNetCompiler extends BaseCompiler {
                 break;
             }
         }
+        refAssemblies.push(this.disassemblyLoaderPath);
         return {refAssemblies, analyzers};
     }
 


### PR DESCRIPTION
After this PR, compilers will be invoked directly instead of relying on the built-in `dotnet build` command which involves restore and many other expensive resolution operations.
This should speed up the compilation process a lot.