### PR TITLE
zig: update default version to 0.13.0

### DIFF
--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&zig
-defaultCompiler=z0120
+defaultCompiler=z0130
 
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
 group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130


### PR DESCRIPTION
I missed this in #6706.