### PR TITLE
feat: update grammar of Cpp2

### DIFF
--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -65,8 +65,8 @@ function definition(): monaco.languages.IMonarchLanguage {
     parseCpp2Balanced('squares', 'square', /\[/, /\]/);
     parseCpp2Balanced('curlies', 'curly', /{/, /}/);
     cppfront.tokenizer.parse_cpp2_balanced_punctuators = [
-        // `$S2.$S3` is the parser.
-        [/</, {token: '@rematch', switchTo: 'parse_cpp2_balanced_angles.$S2'}],
+        // `$S2` is the parser.
+        [/</, {token: '@rematch', switchTo: 'parse_cpp2_balanced_angles.$S2.$S3'}],
         [/\(/, {token: '@rematch', switchTo: 'parse_cpp2_balanced_parentheses.$S2'}],
         [/\[/, {token: '@rematch', switchTo: 'parse_cpp2_balanced_squares.$S2.$S3'}],
         [/{/, {token: '@rematch', switchTo: 'parse_cpp2_balanced_curlies.$S2.$S3.$S4'}],
@@ -676,7 +676,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             ],
             [
                 /@at_cpp2_declaration_head|@at_cpp2_unnamed_declaration_head/,
-                {token: '@rematch', switchTo: 'parse_cpp2_declaration.parameter'},
+                {token: '@rematch', switchTo: 'parse_cpp2_declaration.parameter.$S2'},
             ],
             [
                 /(@at_cpp2_parameter_direction)(\s+)(@at_cpp2_declaration_head)/,
@@ -719,12 +719,15 @@ function definition(): monaco.languages.IMonarchLanguage {
         cppfront.tokenizer.parse_cpp2_parameter_declaration_seq = parseCommaSeparated([
             /@at_cpp2_parameter_declaration/,
             '@rematch',
-            'parse_cpp2_parameter_declaration',
+            'parse_cpp2_parameter_declaration.$S2',
         ]);
         cppfront.tokenizer.parse_cpp2_parameter_declaration_list = [
             [
                 /./,
-                {token: '@rematch', switchTo: 'parse_cpp2_balanced_punctuators.parse_cpp2_parameter_declaration_seq'},
+                {
+                    token: '@rematch',
+                    switchTo: 'parse_cpp2_balanced_punctuators.parse_cpp2_parameter_declaration_seq.$S2',
+                },
             ],
         ];
 
@@ -770,11 +773,11 @@ function definition(): monaco.languages.IMonarchLanguage {
         cppfront.tokenizer.parse_cpp2_declaration_signature = [
             {include: '@whitespace'},
             [/@/, '@rematch', 'parse_cpp2_meta_functions_list'],
-            [/</, '@rematch', 'parse_cpp2_parameter_declaration_list'],
+            [/</, '@rematch', 'parse_cpp2_parameter_declaration_list.template'],
             [/\(/, '@rematch', 'parse_cpp2_function_type'],
             [/requires\b/, 'keyword', 'parse_cpp2_logical_or_expression'],
             [/final\b/, 'keyword'],
-            [/type\b/, {token: 'keyword', switchTo: 'parse_cpp2_declaration_signature.type'}],
+            [/type\b/, {token: 'keyword', switchTo: 'parse_cpp2_declaration_signature.type.$S3'}],
             [/namespace\b/, 'keyword'],
             [/@at_cpp2_iteration_statement_head/, {token: '@rematch', switchTo: 'parse_cpp2_iteration_statement'}],
             [/@at_cpp2_is_as_operator/, '@rematch', 'parse_cpp2_is_as_expression_target.pop.pop'],
@@ -788,7 +791,15 @@ function definition(): monaco.languages.IMonarchLanguage {
                     },
                 },
             ],
-            [/==?/, {token: 'delimiter', switchTo: 'parse_cpp2_declaration_initializer.$S2'}],
+            [
+                /=/,
+                {
+                    cases: {
+                        '$S3==template': {token: 'delimiter', next: 'parse_cpp2_type_id'},
+                        '@': {token: 'delimiter', switchTo: 'parse_cpp2_declaration_initializer.$S2'},
+                    },
+                },
+            ],
             [
                 /;/,
                 {
@@ -815,11 +826,11 @@ function definition(): monaco.languages.IMonarchLanguage {
             [/\.\.\./, 'delimiter.ellipsis'],
             [
                 /@at_cpp2_unnamed_declaration_head/,
-                {token: 'identifier.definition', switchTo: 'parse_cpp2_declaration_signature.$S2'},
+                {token: 'identifier.definition', switchTo: 'parse_cpp2_declaration_signature.$S2.$S3'},
             ],
         ];
         cppfront.tokenizer.parse_cpp2_declaration = [
-            [/./, {token: '@rematch', switchTo: 'parse_cpp2_declaration_head.$S2'}],
+            [/./, {token: '@rematch', switchTo: 'parse_cpp2_declaration_head.$S2.$S3'}],
         ];
     }
     setupDeclarationParsers();

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -647,7 +647,7 @@ function definition(): monaco.languages.IMonarchLanguage {
 
     function setupDeclarationParsers() {
         cppfront.at_cpp2_builtin_meta_function =
-            /(?:ordered|weakly_ordered|partially_ordered|copyable|basic_value|value|weakly_ordered_value|partially_ordered_value|struct|interface|polymorphic_base|enum|flag_enum|union|regex|cpp1_rule_of_zero|print)\b/;
+            /(?:ordered|weakly_ordered|partially_ordered|copyable|basic_value|value|weakly_ordered_value|partially_ordered_value|struct|hashable|interface|polymorphic_base|enum|flag_enum|union|regex|cpp1_rule_of_zero|print)\b/;
         cppfront.tokenizer.parse_cpp2_meta_functions_list = [
             [/[^@]/, '@rematch', '@pop'],
             [

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -739,24 +739,13 @@ function definition(): monaco.languages.IMonarchLanguage {
             [/->/, 'invalid', '@pop'],
         ];
 
-        cppfront.tokenizer.parse_cpp2_full_function_type = [
+        cppfront.tokenizer.parse_cpp2_function_type = [
             {include: '@whitespace'},
+            [/\(/, '@rematch', 'parse_cpp2_parameter_declaration_list'],
             [/throws\b/, 'keyword'],
             [/->/, '@rematch', 'parse_cpp2_return_list'],
             [/@at_cpp2_contract_kind/, '@rematch', 'parse_cpp2_contract'],
             [/./, '@rematch', '@pop'],
-        ];
-        cppfront.at_cpp2_function_type_id_tail = /throws\b|->|@at_cpp2_contract_kind/;
-        cppfront.tokenizer.parse_cpp2_terse_function = [
-            {include: '@whitespace'},
-            [/\(/, '@rematch', 'parse_cpp2_parameter_declaration_list'],
-            [/@at_cpp2_function_type_id_tail/, {token: '@rematch', switchTo: 'parse_cpp2_full_function_type'}],
-            [/requires\b|==?|;/, '@rematch', '@pop'],
-            [/@at_cpp2_expression/, {token: '@rematch', switchTo: 'parse_cpp2_expression'}],
-            [/./, '@rematch', '@pop'],
-        ];
-        cppfront.tokenizer.parse_cpp2_function_type = [
-            [/./, {token: '@rematch', switchTo: 'parse_cpp2_terse_function'}],
         ];
 
         cppfront.tokenizer.parse_cpp2_declaration_initializer = [

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -91,14 +91,7 @@ function definition(): monaco.languages.IMonarchLanguage {
     }
 
     function setupLiteralParsers() {
-        function balancedParenthesesRegex(max_nesting) {
-            const front = String.raw`\((?:[^\\()]*|`;
-            const back = String.raw`)*\)`;
-            return front.repeat(max_nesting + 1) + back.repeat(max_nesting + 1);
-        }
-        cppfront.at_cpp2_balanced_parentheses = balancedParenthesesRegex(5);
-
-        cppfront.at_cpp2_interpolation = /@at_cpp2_balanced_parentheses\$/;
+        cppfront.at_cpp2_interpolation = /\([^"]+\)\$/;
         cppfront.tokenizer.parse_cpp2_interpolation = [
             [/(\()(.)/, ['delimiter.parenthesis', {token: '@rematch', next: 'parse_cpp2_expression'}]],
             [/:[^)]*/, 'string'],

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -425,7 +425,7 @@ function definition(): monaco.languages.IMonarchLanguage {
         ];
 
         cppfront.at_cpp2_prefix_expression = /@at_cpp2_prefix_operator_delimiter|@at_cpp2_primary_expression/;
-        cppfront.at_cpp2_parameter_direction = /(?:in|inout|copy|out|move|forward)\b/;
+        cppfront.at_cpp2_parameter_direction = /(?:in(?:_ref)?|inout|copy|out|move|forward(?:_ref)?)\b/;
         cppfront.at_cpp2_prefix_operator_delimiter = /!|-|\+/;
         cppfront.tokenizer.parse_cpp2_prefix_expression = [
             {include: '@whitespace'},

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -224,7 +224,7 @@ function definition(): monaco.languages.IMonarchLanguage {
         ];
 
         cppfront.at_cpp2_unqualified_id_template_type_keyword = /(?:finally|cpp1_ref|cpp1_rvalue_ref)\b/;
-        cppfront.at_cpp2_unqualified_id_template_expression_keyword = /(?:new|unsafe_narrow|unsafe_cast)\b/;
+        cppfront.at_cpp2_unqualified_id_template_expression_keyword = /(?:new|unchecked_(?:narrow|cast))\b/;
         cppfront.at_cpp2_unqualified_id_type_function_keyword = /(?:type_of|static_assert)\b(?=\s*\()/;
         cppfront.at_cpp2_unqualified_id_keywords = /(unique|shared)(\.)(new(?=<))/;
         cppfront.at_cpp2_unqualified_id_keyword =

--- a/static/modes/cppfront-mode.ts
+++ b/static/modes/cppfront-mode.ts
@@ -322,6 +322,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             [/./, {token: '@rematch', switchTo: 'parse_cpp2_template_argument_rest'}],
         ];
         cppfront.tokenizer.parse_cpp2_template_argument_rest = [
+            [/@at_cpp2_function_type_id/, {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],
             [/@at_cpp2_type_qualifier/, {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],
             [/@at_cpp2_expression/, {token: '@rematch', switchTo: 'parse_cpp2_expression.template_argument'}],
             [/@at_cpp2_type_id/, {token: '@rematch', switchTo: 'parse_cpp2_type_id'}],


### PR DESCRIPTION
This is an update to #6913.
The test cases: <https://highlight-cpp2.godbolt.org/z/8hx8jKMoW>.

<details><summary>Preview</summary>

![1728489024](https://github.com/user-attachments/assets/fdce8a2c-299a-45fd-8926-3da40dcd74ca)

</details>