### PR TITLE
LLVM Flang: Use "flang" binary instead of "flang-new" symlink

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -714,13 +714,13 @@ group.clang_llvmflang.compilers=flangtrunk:flangtrunk-fc
 group.clang_llvmflang.groupName=LLVM-FLANG x86-64
 group.clang_llvmflang.compilerType=flang
 
-compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
+compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
 compiler.flangtrunk.name=flang-trunk
 compiler.flangtrunk.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64|/opt/compiler-explorer/gcc-snapshot/lib|/opt/compiler-explorer/gcc-snapshot/lib32|/opt/compiler-explorer/gcc-snapshot/lib64
 compiler.flangtrunk.isNightly=true
 compiler.flangtrunk.alias=flangtrunknew
 
-compiler.flangtrunk-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang-new
+compiler.flangtrunk-fc.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
 compiler.flangtrunk-fc.name=flang-trunk-fc1
 compiler.flangtrunk-fc.compilerType=flang-fc1
 compiler.flangtrunk-fc.isNightly=true

--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -101,6 +101,6 @@ group.clang_llvmflang.compilers=flangtrunk
 group.clang_llvmflang.groupName=LLVM-FLANG
 group.clang_llvmflang.compilerType=flang
 
-compiler.flangtrunk.exe=/usr/local/bin/flang-new
+compiler.flangtrunk.exe=/usr/local/bin/flang
 compiler.flangtrunk.name=flang-trunk
 compiler.flangtrunk.isNightly=true


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/commit/06eb10dadfaeaadc5d0d95d38bea4bfb5253e077 the binary is called "flang" not "flang-new". "flang-new" is now a symlink to "flang". This symlink will probably remain for the next release and then be removed.

So I see no reason to not move to "flang" now. You can see the new layout in the most recent nightly build logs:
```
2024-10-11T01:27:26.5073126Z -- Installing: /root/staging/bin/flang-20
2024-10-11T01:27:26.7519042Z -- Installing: /root/staging/bin/flang
2024-10-11T01:27:26.7519829Z -- Set runtime path of "/root/staging/bin/flang-20" to "$ORIGIN/../lib"
2024-10-11T01:27:26.7520792Z -- Up-to-date: /root/staging/bin/flang-20
2024-10-11T01:27:26.7521292Z -- Up-to-date: /root/staging/bin/flang
2024-10-11T01:27:26.7543999Z -- Creating flang-new
```

As Flang has never had release versions, we don't need to use "flang-new" in some places and "flang" in others.

(my plan is to start adding release versions once LLVM 20 is out)