### PR TITLE
Add mimic++ as c++ header-only library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4859,8 +4859,10 @@ libs.mfem.versions.47.packagedheaders=true
 
 libs.mimicpp.name=mimic++
 libs.mimicpp.description=A modern and (mostly) macro free mocking framework.
-libs.mimicpp.versions=1:2:3
+libs.mimicpp.versions=trunk:1:2:3
 libs.mimicpp.url=https://github.com/DNKpp/mimicpp
+libs.mimicpp.versions.trunk.version=trunk
+libs.mimicpp.versions.trunk.path=/opt/compiler-explorer/libs/mimicpp/trunk/include
 libs.mimicpp.versions.1.version=v1
 libs.mimicpp.versions.1.path=/opt/compiler-explorer/libs/mimicpp/v1/include
 libs.mimicpp.versions.2.version=v2

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3819,7 +3819,7 @@ compiler.vast-trunk.options=-resource-dir /opt/compiler-explorer/clang-17.0.1/li
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:beman_optional26:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp
+libs=abseil:array:async_simple:belleviews:beman_optional26:benchmark:benri:blaze:boost:bmulti:brigand:catch2:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:pugixml:pybind11:python:rangesv3:raberu:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp
 
 libs.abseil.name=Abseil
 libs.abseil.versions=trunk
@@ -4856,6 +4856,17 @@ libs.mfem.staticliblink=mfem
 libs.mfem.description=MFEM is a free, lightweight, scalable C++ library for finite element methods.<br /><br />Note that the trunk version is no longer available, use v4.7 instead.
 libs.mfem.versions.47.version=4.7
 libs.mfem.versions.47.packagedheaders=true
+
+libs.mimicpp.name=mimic++
+libs.mimicpp.description=A modern and (mostly) macro free mocking framework.
+libs.mimicpp.versions=1:2:3
+libs.mimicpp.url=https://github.com/DNKpp/mimicpp
+libs.mimicpp.versions.1.version=v1
+libs.mimicpp.versions.1.path=/opt/compiler-explorer/libs/mimicpp/v1/include
+libs.mimicpp.versions.2.version=v2
+libs.mimicpp.versions.2.path=/opt/compiler-explorer/libs/mimicpp/v2/include
+libs.mimicpp.versions.3.version=v3
+libs.mimicpp.versions.3.path=/opt/compiler-explorer/libs/mimicpp/v3/include
 
 libs.mlir.name=MLIR
 libs.mlir.description=MLIR


### PR DESCRIPTION
relates to: https://github.com/compiler-explorer/infra/pull/1430

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
