### PR TITLE
use OSACA v0.6.1

### DIFF
--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -22,7 +22,7 @@ group.osaca.supportsBinary=false
 group.osaca.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 group.osaca.compilerType=osaca
 
-compiler.osacatrunk.name=OSACA (0.5.2)
-compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+compiler.osacatrunk.name=OSACA (0.6.1)
+compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 # Intel syntax currently unsupported (WIP)
 # compiler.osacatrunk.intelAsm=--intel-syntax

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5660,8 +5660,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3580,8 +3580,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/clean.amazon.properties
+++ b/etc/config/clean.amazon.properties
@@ -49,8 +49,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=_32
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=_32

--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -40,8 +40,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_blue.amazon.properties
+++ b/etc/config/cppx_blue.amazon.properties
@@ -24,8 +24,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_gold.amazon.properties
+++ b/etc/config/cppx_gold.amazon.properties
@@ -24,8 +24,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -927,8 +927,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=dmd

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1347,8 +1347,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -1642,8 +1642,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -1145,8 +1145,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=gl:6g141
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=gl:6g141

--- a/etc/config/haskell.amazon.properties
+++ b/etc/config/haskell.amazon.properties
@@ -58,8 +58,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -68,8 +68,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -194,8 +194,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=opt
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=opt

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2158,8 +2158,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1059,8 +1059,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -68,8 +68,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 tools.llvm-mcatrunk.exclude=mptrunk
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -977,8 +977,8 @@ tools.llvm-dwarfdumptrunk.type=postcompilation
 tools.llvm-dwarfdumptrunk.class=llvm-dwarfdump-tool
 tools.llvm-dwarfdumptrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/spice.amazon.properties
+++ b/etc/config/spice.amazon.properties
@@ -57,8 +57,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -72,8 +72,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -70,8 +70,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.5.2)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.5.2/bin/osaca
+tools.osacatrunk.name=OSACA (0.6.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Updated OSACA from v0.5.2 to v0.6.1, which includes bug fixes, more supported instructions for existing architectures and new architectures like Intel Sapphire Rapids, Nvidia Grace Superchip/Neoverse V2, and AMD Zen 4.

