### PR TITLE
Add ISPC v1.25.0

### DIFF
--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -1,9 +1,11 @@
 compilers=&ispc
-defaultCompiler=ispc1240
+defaultCompiler=ispc1250
 
-group.ispc.compilers=ispc1240:ispc1230:ispc1220:ispc1210:ispc1200:ispc1190:ispc1180:ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk:ispc-templates_new-trunk
+group.ispc.compilers=ispc1250:ispc1240:ispc1230:ispc1220:ispc1210:ispc1200:ispc1190:ispc1180:ispc1170:ispc1161:ispc1160:ispc1150:ispc1141:ispc1140:ispc1130:ispc1120:ispc1110:ispc1100:ispc192:ispc191:ispc-trunk:ispc-templates_new-trunk
 group.ispc.isSemVer=true
 group.ispc.baseName=ispc
+compiler.ispc1250.exe=/opt/compiler-explorer/ispc-1.25.0/bin/ispc
+compiler.ispc1250.semver=1.25.0
 compiler.ispc1240.exe=/opt/compiler-explorer/ispc-1.24.0/bin/ispc
 compiler.ispc1240.semver=1.24.0
 compiler.ispc1230.exe=/opt/compiler-explorer/ispc-1.23.0/bin/ispc


### PR DESCRIPTION
Adding ISPC v1.25.0.

Corresponding infra commit PR, which needs to be merged before this PR: https://github.com/compiler-explorer/infra/pull/1434 (so ISPC v1.25.0 is available in the infra).
