### PR TITLE
[LIBRARY_REQUEST] beman_optional26: fix deployment after the library was renamed inside the Beman project

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3853,9 +3853,9 @@ libs.belleviews.description=A library of C++ views that just works for all basic
 libs.belleviews.versions.trunk.version=trunk
 libs.belleviews.versions.trunk.path=/opt/compiler-explorer/libs/belleviews/trunk/sources
 
-libs.beman_optional26.name=Beman.Optional26
+libs.beman_optional26.name=beman_optional26
 libs.beman_optional26.versions=trunk
-libs.beman_optional26.url=https://github.com/beman-project/Optional26
+libs.beman_optional26.url=https://github.com/beman-project/optional26
 libs.beman_optional26.versions.trunk.version=trunk
 libs.beman_optional26.versions.trunk.path=/opt/compiler-explorer/libs/beman_optional26/main/include
 


### PR DESCRIPTION
[LIBRARY_REQUEST] beman_optional26: fix deployment after the library was renamed inside the Beman project

Related to #6651
Library was introduced in #6652 

Current naming -> https://github.com/beman-project/optional26/tree/main/include/beman/optional26.