### PR TITLE
Mapping C and Core line numbers for Cerberus

### DIFF
--- a/lib/compilers/cerberus.ts
+++ b/lib/compilers/cerberus.ts
@@ -59,34 +59,6 @@ type SyntaxNodeWithLocation = {
     loc: LocationRange | undefined;
 };
 
-/*
-function point_to_string(point: Parser.Point): string {
-    return `${point.row}:${point.column}`;
-}
-
-function range_to_string(range: Range): string {
-    if (range === undefined || range === null)
-        return 'undefined'
-    else
-        return `${point_to_string(range.start)}-${point_to_string(range.end)}`;
-}
-
-function location_range_to_string(loc: LocationRange|undefined): string {
-    if (loc === undefined || loc === null)
-        return 'undefined';
-    else {
-        const location = range_to_string(loc.location);
-        if (loc.cursor === null)
-            return location;
-        else
-            if (loc.cursor instanceof Object && 'start' in loc.cursor && 'end' in loc.cursor)
-                return `${location} [${range_to_string(loc.cursor)}]`;
-            else
-                return `${location} [${point_to_string(loc.cursor)}]`;
-    }
-}
-*/
-
 export class CerberusCompiler extends BaseCompiler {
     static get key() {
         return 'cerberus';

--- a/lib/compilers/cerberus.ts
+++ b/lib/compilers/cerberus.ts
@@ -24,7 +24,11 @@
 
 import path from 'node:path';
 
-import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
+import Parser from 'tree-sitter';
+import coreLanguage from 'tree-sitter-core';
+import {isNull} from 'underscore';
+
+import {AsmResultSource, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
 import {BypassCache, CacheKey, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import {ExecutableExecutionOptions} from '../../types/execution/execution.interfaces.js';
@@ -34,6 +38,54 @@ import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 import {logger} from '../logger.js';
 import * as utils from '../utils.js';
+
+type Range = {
+    start: Parser.Point;
+    end: Parser.Point;
+};
+
+type LocationRange = {
+    location: Range;
+    cursor: Range | Parser.Point | null;
+};
+
+type ASTwithLocations = {
+    root: Parser.SyntaxNode;
+    locations: Map<number, LocationRange>;
+};
+
+type SyntaxNodeWithLocation = {
+    node: Parser.SyntaxNode;
+    loc: LocationRange | undefined;
+};
+
+/*
+function point_to_string(point: Parser.Point): string {
+    return `${point.row}:${point.column}`;
+}
+
+function range_to_string(range: Range): string {
+    if (range === undefined || range === null)
+        return 'undefined'
+    else
+        return `${point_to_string(range.start)}-${point_to_string(range.end)}`;
+}
+
+function location_range_to_string(loc: LocationRange|undefined): string {
+    if (loc === undefined || loc === null)
+        return 'undefined';
+    else {
+        const location = range_to_string(loc.location);
+        if (loc.cursor === null)
+            return location;
+        else
+            if (loc.cursor instanceof Object && 'start' in loc.cursor && 'end' in loc.cursor)
+                return `${location} [${range_to_string(loc.cursor)}]`;
+            else
+                return `${location} [${point_to_string(loc.cursor)}]`;
+    }
+}
+*/
 
 export class CerberusCompiler extends BaseCompiler {
     static get key() {
@@ -75,7 +127,7 @@ export class CerberusCompiler extends BaseCompiler {
             customCwd: (result.dirPath as string) || path.dirname(outputFilename),
         };
 
-        const args = ['--pp=core', outputFilename];
+        const args = ['--pp_flags=loc', '--pp=core', outputFilename];
 
         const objResult = await this.exec(this.compiler.objdumper, args, execOptions);
         if (objResult.code === 0) {
@@ -117,14 +169,129 @@ export class CerberusCompiler extends BaseCompiler {
         };
     }
 
-    override async processAsm(result): Promise<ParsedAsmResult> {
+    private parse_position(node: Parser.SyntaxNode): Parser.Point | null {
+        if (node.type !== 'position') return null;
+
+        const filenameNode = node.childForFieldName('filename');
+        if (!filenameNode || filenameNode.text !== 'example.c') return null;
+
+        const rowNode = node.childForFieldName('line');
+        const columnNode = node.childForFieldName('column');
+        if (!rowNode || !columnNode) return null;
+
+        const row = parseInt(rowNode.text, 10);
+        const column = parseInt(columnNode.text, 10);
+        if (isNaN(row) || isNaN(column)) return null;
+
+        return {row: row, column: column};
+    }
+
+    /* Attempt to parse 'location' node.
+       Returns null if the node does not correspond to location range.        
+     */
+    private parse_location(node: Parser.SyntaxNode): LocationRange | null {
+        if (node.firstNamedChild === null || node.firstNamedChild.type !== 'location_range') return null;
+
+        const startNode = node.firstNamedChild.childForFieldName('start');
+        const endNode = node.firstNamedChild.childForFieldName('end');
+        if (!startNode || !endNode) return null;
+
+        const start = this.parse_position(startNode);
+        const end = this.parse_position(endNode);
+        if (isNull(start) || isNull(end)) return null;
+
+        const startCursorNode = node.firstNamedChild.childForFieldName('start_cursor');
+        if (!startCursorNode) return {location: {start: start, end: end}, cursor: null};
+        const start_cursor = this.parse_position(startCursorNode);
+        if (!start_cursor) return {location: {start: start, end: end}, cursor: null};
+
+        const endCursorNode = node.firstNamedChild.childForFieldName('end_cursor');
+        if (!endCursorNode) return {location: {start: start, end: end}, cursor: start_cursor};
+        const end_cursor = this.parse_position(endCursorNode);
+        if (end_cursor) {
+            return {location: {start: start, end: end}, cursor: {start: start_cursor, end: end_cursor}};
+        } else {
+            return {location: {start: start, end: end}, cursor: start_cursor};
+        }
+    }
+
+    private annotate_ast(node: Parser.SyntaxNode, locmap: Map<number, LocationRange>): void {
+        let loc: LocationRange | null = null;
+        for (const n of node.children) {
+            if (n.type === 'location') {
+                loc = this.parse_location(n);
+            } else {
+                if (loc !== null && n.isNamed) {
+                    //console.log(`ANNOTATING ${n.id} ${n.type} at ${point_to_string(n.startPosition)}-${point_to_string(n.endPosition)} with location ${location_range_to_string(loc)}`);
+                    locmap[n.id] = loc;
+                    loc = null;
+                }
+                this.annotate_ast(n, locmap);
+            }
+        }
+    }
+
+    private findNodesByRange(ast: ASTwithLocations, range: Range): SyntaxNodeWithLocation[] {
+        const matchingNodes: SyntaxNodeWithLocation[] = [];
+
+        function search(n: Parser.SyntaxNode): void {
+            if (
+                (n.startPosition.row < range.start.row ||
+                    (n.startPosition.row === range.start.row && n.startPosition.column <= range.start.column)) &&
+                (n.endPosition.row > range.end.row ||
+                    (n.endPosition.row === range.end.row && n.endPosition.column >= range.end.column))
+            ) {
+                const loc = ast.locations[n.id];
+                matchingNodes.push({node: n, loc: loc});
+            }
+
+            for (const child of n.children) {
+                search(child);
+            }
+        }
+
+        search(ast.root);
+        return matchingNodes.reverse();
+    }
+
+    override async processAsm(result) {
         // Handle "error" documents.
         if (!result.asm.includes('\n') && result.asm[0] === '<') {
             return {asm: [{text: result.asm, source: null}]};
         }
 
-        const lines = result.asm.split('\n');
-        const plines = lines.map((l: string) => ({text: l}));
+        const core = result.asm.replaceAll(/\n{3,}/g, '\n\n');
+        const parser = new Parser();
+        parser.setLanguage(coreLanguage);
+
+        const tree = parser.parse(core);
+        const ast: ASTwithLocations = {root: tree.rootNode, locations: new Map<number, LocationRange>()};
+        this.annotate_ast(ast.root, ast.locations);
+
+        const lines = core.split('\n');
+        const plines: ParsedAsmResultLine[] = lines.map((l: string, n: number) => {
+            const ltrimmed = l.replace(/^\s*{-# .+ #-}\s*/, '');
+            const start_col = l.length - ltrimmed.length;
+            const rtrimmed = ltrimmed.trimEnd();
+            const r: Range = {start: {row: n, column: start_col}, end: {row: n, column: start_col + rtrimmed.length}};
+            const matchingNodes = this.findNodesByRange(ast, r);
+
+            const coreNode = matchingNodes.find(x => x.loc !== undefined);
+            // the second disjunct is redundant and added to make typechecker happy
+            if (coreNode === undefined || coreNode.loc === undefined) {
+                //console.log(`No node with location for ${range_to_string(r)}`);
+                return {text: l};
+            } else {
+                const loc = coreNode.loc;
+                //console.log(`Found ${coreNode.node.id} ${coreNode.node.type} at ${point_to_string(coreNode.node.startPosition)}-${point_to_string(coreNode.node.endPosition)} for ${range_to_string(r)} with location ${location_range_to_string(coreNode.loc)}`);
+                const src: AsmResultSource = {
+                    file: null,
+                    line: loc.location.start.row,
+                    column: loc.location.start.column,
+                };
+                return {text: l, source: src};
+            }
+        });
         return {
             asm: plines,
             languageId: 'core',

--- a/lib/compilers/cerberus.ts
+++ b/lib/compilers/cerberus.ts
@@ -151,9 +151,9 @@ export class CerberusCompiler extends BaseCompiler {
         const columnNode = node.childForFieldName('column');
         if (!rowNode || !columnNode) return null;
 
-        const row = parseInt(rowNode.text, 10);
-        const column = parseInt(columnNode.text, 10);
-        if (isNaN(row) || isNaN(column)) return null;
+        const row = Number.parseInt(rowNode.text, 10);
+        const column = Number.parseInt(columnNode.text, 10);
+        if (Number.isNaN(row) || Number.isNaN(column)) return null;
 
         return {row: row, column: column};
     }
@@ -182,9 +182,8 @@ export class CerberusCompiler extends BaseCompiler {
         const end_cursor = this.parse_position(endCursorNode);
         if (end_cursor) {
             return {location: {start: start, end: end}, cursor: {start: start_cursor, end: end_cursor}};
-        } else {
-            return {location: {start: start, end: end}, cursor: start_cursor};
         }
+        return {location: {start: start, end: end}, cursor: start_cursor};
     }
 
     private annotate_ast(node: Parser.SyntaxNode, locmap: Map<number, LocationRange>): void {
@@ -253,16 +252,16 @@ export class CerberusCompiler extends BaseCompiler {
             if (coreNode === undefined || coreNode.loc === undefined) {
                 //console.log(`No node with location for ${range_to_string(r)}`);
                 return {text: l};
-            } else {
-                const loc = coreNode.loc;
-                //console.log(`Found ${coreNode.node.id} ${coreNode.node.type} at ${point_to_string(coreNode.node.startPosition)}-${point_to_string(coreNode.node.endPosition)} for ${range_to_string(r)} with location ${location_range_to_string(coreNode.loc)}`);
-                const src: AsmResultSource = {
-                    file: null,
-                    line: loc.location.start.row,
-                    column: loc.location.start.column,
-                };
-                return {text: l, source: src};
             }
+
+            const loc = coreNode.loc;
+            //console.log(`Found ${coreNode.node.id} ${coreNode.node.type} at ${point_to_string(coreNode.node.startPosition)}-${point_to_string(coreNode.node.endPosition)} for ${range_to_string(r)} with location ${location_range_to_string(coreNode.loc)}`);
+            const src: AsmResultSource = {
+                file: null,
+                line: loc.location.start.row,
+                column: loc.location.start.column,
+            };
+            return {text: l, source: src};
         });
         return {
             asm: plines,

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,8 @@
         "temp": "^0.9.4",
         "tom-select": "^2.3.1",
         "tree-kill": "^1.2.2",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-core": "^1.0.0",
         "triple-beam": "^1.4.1",
         "tsx": "^4.19.2",
         "underscore": "^1.13.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9479,6 +9479,17 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -12284,6 +12295,54 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-core/-/tree-sitter-core-1.0.0.tgz",
+      "integrity": "sha512-Ty2mGty9QYqIr93Gqfr1KEjlyE0Z4rpdE+4UASfFkGDkfHdoTJRa1Fo9vWOsKtL0auS8JZSu99mYGuXo5OMIUA==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-core/node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/triple-beam": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "winston-papertrail": "^1.0.5",
     "winston-transport": "^4.8.0",
     "ws": "^8.18.0",
-    "yaml": "^2.6.0"
+    "yaml": "^2.6.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-core": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "winston-transport": "^4.8.0",
     "ws": "^8.18.0",
     "yaml": "^2.6.0"
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-core": "^1.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
For the Cerberus and Cerberus-CHERI backends, we now display an intermediate language called Core instead of assembly. This patch adds line number information that maps some Core sub-expressions to their corresponding lines in the C code.