### PR TITLE
Remove dangling references to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,11 +153,6 @@
     "webpack-dev-middleware": "^7.4.2",
     "webpack-manifest-plugin": "^5.0.0"
   },
-  "mocha": {
-    "require": [
-      "test/_setup.js"
-    ]
-  },
   "c8": {
     "reporter": [
       "text",

--- a/test/cfg-tests.ts
+++ b/test/cfg-tests.ts
@@ -44,16 +44,9 @@ async function DoCfgTest(cfgArg, filename, isLlvmIr = false) {
 describe('Cfg test cases', () => {
     const testcasespath = resolvePathFromTestRoot('cfg-cases');
 
-    /*
-     * NB: this readdir must *NOT* be async
-     *
-     * Mocha calls the function passed to `describe` synchronously
-     * and expects the test suite to be fully configured upon return.
-     *
-     * If you pass an async function to describe and setup test cases
-     * after an await there is no guarantee they will be found, and
-     * if they are they will not end up in the expected suite.
-     */
+    // For backwards compatability reasons, we have a sync readdir here. For details, see
+    // the git blame of this file.
+    // TODO: Consider replacing with https://github.com/vitest-dev/vitest/issues/703
     const files = fs.readdirSync(testcasespath);
 
     describe('gcc', () => {

--- a/test/demangler-tests.ts
+++ b/test/demangler-tests.ts
@@ -326,16 +326,9 @@ if (process.platform === 'linux') {
     describe('File demangling', () => {
         const testcasespath = resolvePathFromTestRoot('demangle-cases');
 
-        /*
-         * NB: this readdir must *NOT* be async
-         *
-         * Mocha calls the function passed to `describe` synchronously
-         * and expects the test suite to be fully configured upon return.
-         *
-         * If you pass an async function to describe and setup test cases
-         * after an await there is no guarantee they will be found, and
-         * if they are they will not end up in the expected suite.
-         */
+        // For backwards compatability reasons, we have a sync readdir here. For details, see
+        // the git blame of this file.
+        // TODO: Consider replacing with https://github.com/vitest-dev/vitest/issues/703
         const files = fs.readdirSync(testcasespath);
 
         for (const filename of files) {

--- a/test/filter-tests.ts
+++ b/test/filter-tests.ts
@@ -94,10 +94,6 @@ function testFilter(filename: string, suffix: string, filters: ParseFiltersAndOu
     ); // Bump the timeout a bit so that we don't fail for slow cases
 }
 
-/*
-    The before() hooks on mocha are for it()s - They don't execute before the describes!
-    That's sad because then we can't have cases be loaded in a before() for every describe child to see.
- */
 describe('Filter test cases', () => {
     if (process.platform === 'win32') {
         it('should skip filter-tests on Windows', () => {


### PR DESCRIPTION
_No functional change intended_

We migrated to Vitest a while back, so the mocha field in the package.json has no effect. A few comments describing mocha-specific behavior have been updated with a TODO/been removed