### PR TITLE
Remove legacy non-existing monaco worker route

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -749,41 +749,6 @@ async function main() {
     // Based on combined format, but: GDPR compliant IP, no timestamp & no unused fields for our usecase
     const morganFormat = isDevMode() ? 'dev' : ':gdpr_ip ":method :url" :status';
 
-    /*
-     * This is a workaround to make cross origin monaco web workers function
-     * in spite of the monaco webpack plugin hijacking the MonacoEnvironment global.
-     *
-     * see https://github.com/microsoft/monaco-editor-webpack-plugin/issues/42
-     *
-     * This workaround wouldn't be so bad, if it didn't _also_ rely on *another* bug to
-     * actually work.
-     *
-     * The webpack plugin incorrectly uses
-     *     window.__webpack_public_path__
-     * when it should use
-     *     __webpack_public_path__
-     *
-     * see https://github.com/microsoft/monaco-editor-webpack-plugin/pull/63
-     *
-     * We can leave __webpack_public_path__ with the correct value, which lets runtime chunk
-     * loading continue to function correctly.
-     *
-     * We can then set window.__webpack_public_path__ to the below handler, which lets us
-     * fabricate a worker on the fly.
-     *
-     * This is bad and I feel bad.
-     *
-     * This should no longer be needed, but is left here for safety because people with
-     * workers already installed from this url may still try to hit this page for some time
-     *
-     * TODO: remove this route in the future now that it is not needed
-     */
-    router.get('/workers/:worker', (req, res) => {
-        staticHeaders(res);
-        res.set('Content-Type', 'application/javascript');
-        res.end(`importScripts('${urljoin(staticRoot, req.params.worker)}');`);
-    });
-
     router
         .use(
             morgan(morganFormat, {


### PR DESCRIPTION
_No functional change intended_

According to https://github.com/compiler-explorer/compiler-explorer/commit/7ce90a33884e0a89ca14ba261be8caf47b9122ce and https://github.com/compiler-explorer/compiler-explorer/commit/0d0a52e249b18fe9363283bec3a6cab720fa8fb4 the route was added a very long time ago (4-5 years) to support compat for workers downloaded to the user's browsers.

In addition to this being very long ago to the point that the chance of anybody having an old CE worker being extremely low, those files no longer exist.

We tag our webpack bundles with a "magic version" (current .v53.) to force the browsers to re-fetch the bundles for major changes. That means that if somebody had `editor.v10.worker.[hash].js` from years ago, that file won't even be in our current bundle, and has to be in their browser's cache (unlikely because it's so old, but even then their browser wouldn't hit this route due to cache)