### PR TITLE
Show that pane is already open when disabling the button to create a new pane

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2693,7 +2693,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         if (!this.compiler) return;
 
         const addTool = (toolName: string, title: string, toolIcon?, toolIconDark?) => {
-            const btn = $("<button class='dropdown-item btn btn-light btn-sm'>");
+            const btn = $("<button class='dropdown-item btn btn-light btn-sm new-pane-button'>");
             btn.addClass('view-' + toolName);
             btn.data('toolname', toolName);
             if (toolIcon) {

--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -1632,3 +1632,7 @@ span.lib-info {
 .library-info-popover {
     max-width: 600px;
 }
+
+button.new-pane-button:disabled:after {
+    content: ' [already open]';
+}

--- a/views/templates/panes/compiler.pug
+++ b/views/templates/panes/compiler.pug
@@ -1,5 +1,5 @@
 mixin newPaneButton(classId, text, title, icon)
-  button(class="dropdown-item btn btn-sm btn-light " + classId title=title data-cy="new-" + classId + "-btn")
+  button(class="dropdown-item btn btn-sm btn-light new-pane-button " + classId title=title data-cy="new-" + classId + "-btn")
     span(class="dropdown-icon " + icon)
     | #{text}
 


### PR DESCRIPTION
When a new pane (such as the LLVM IR view) is opened using a button in the “Add new...” or “Add tool...” menu, the button is disabled. This can be confusing when the pane is not visible (e. g. when it is in a tab in the background), because it can also be interpreted as “this is not supported“.

This PR adds an `[already open]` to the button when it is disabled.