### PR TITLE
[rust] update `clap` crate

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -375,9 +375,11 @@ libs.chrono.versions.0419.path=libchrono.rlib
 
 libs.clap.name=clap
 libs.clap.url=https://crates.io/crates/clap
-libs.clap.versions=3118
+libs.clap.versions=3118:4520
 libs.clap.versions.3118.version=3.1.18
 libs.clap.versions.3118.path=libclap.rlib
+libs.clap.versions.4520.version=4.5.20
+libs.clap.versions.4520.path=libclap.rlib
 
 libs.color-eyre.name=color-eyre
 libs.color-eyre.url=https://crates.io/crates/color-eyre


### PR DESCRIPTION
see https://crates.io/crates/clap

`clap` is a popular argument parsing library. This PR adds version 4.5.20 because the version currently supported on CE is quite old and `clap` has had a major version bump in the meantime.

Infra PR: https://github.com/compiler-explorer/infra/pull/1442