### PR TITLE
Replace old utils with JavaScript builtins

### DIFF
--- a/compiler-args-app.ts
+++ b/compiler-args-app.ts
@@ -32,7 +32,6 @@ import {CompilerArguments} from './lib/compiler-arguments.js';
 import * as Parsers from './lib/compilers/argument-parsers.js';
 import {executeDirect} from './lib/exec.js';
 import {logger} from './lib/logger.js';
-import {padRight} from './lib/utils.js';
 
 const opts = nopt({
     parser: [String],
@@ -134,7 +133,8 @@ class CompilerArgsApp {
     async print() {
         const args = _.keys(this.compiler.possibleArguments.possibleArguments);
         for (const arg of args) {
-            console.log(padRight(arg, this.pad) + this.compiler.possibleArguments.possibleArguments[arg].description);
+            const description = this.compiler.possibleArguments.possibleArguments[arg].description;
+            console.log(`${arg.padEnd(this.pad, ' ')} ${description}`);
         }
 
         console.log('Stdvers:');

--- a/lib/cfg/cfg-parsers/clang.ts
+++ b/lib/cfg/cfg-parsers/clang.ts
@@ -25,7 +25,6 @@
 import _ from 'underscore';
 
 import type {ResultLine} from '../../../types/resultline/resultline.interfaces.js';
-import * as utils from '../../utils.js';
 
 import {BaseCFGParser} from './base.js';
 
@@ -42,8 +41,8 @@ export class ClangCFGParser extends BaseCFGParser {
         const removeComments = (x: ResultLine) => {
             const pos_x86 = x.text.indexOf('# ');
             const pos_arm = x.text.indexOf('// ');
-            if (pos_x86 !== -1) x.text = utils.trimRight(x.text.substring(0, pos_x86));
-            if (pos_arm !== -1) x.text = utils.trimRight(x.text.substring(0, pos_arm));
+            if (pos_x86 !== -1) x.text = x.text.substring(0, pos_x86).trimEnd();
+            if (pos_arm !== -1) x.text = x.text.substring(0, pos_arm).trimEnd();
             return x;
         };
 

--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -32,15 +32,14 @@ import {Language, LanguageKey} from '../../types/languages.interfaces.js';
 import {assert, unwrap} from '../assert.js';
 import {ClientStateNormalizer} from '../clientstate-normalizer.js';
 import {CompilationEnvironment} from '../compilation-env.js';
-import {LocalExecutionEnvironment} from '../execution/base-execution-env.js';
 import {IExecutionEnvironment} from '../execution/execution-env.interfaces.js';
+import {LocalExecutionEnvironment} from '../execution/index.js';
 import {logger} from '../logger.js';
 import {ClientOptionsHandler} from '../options-handler.js';
 import {PropertyGetter} from '../properties.interfaces.js';
 import {SentryCapture} from '../sentry.js';
 import {BaseShortener, getShortenerTypeByKey} from '../shortener/index.js';
 import {StorageBase} from '../storage/index.js';
-import * as utils from '../utils.js';
 
 import {withAssemblyDocumentationProviders} from './assembly-documentation.js';
 import {CompileHandler} from './compile.js';
@@ -238,12 +237,10 @@ export class ApiHandler {
                 .concat([title])
                 .map(item => item.length),
         );
+        const header = title.padEnd(maxLength, ' ') + ' | Name\n';
+        const body = list.map(lang => lang.id.padEnd(maxLength, ' ') + ' | ' + lang.name).join('\n');
         res.set('Content-Type', 'text/plain');
-        res.send(
-            utils.padRight(title, maxLength) +
-                ' | Name\n' +
-                list.map(lang => utils.padRight(lang.id, maxLength) + ' | ' + lang.name).join('\n'),
-        );
+        res.send(header + body);
     }
 
     getLibrariesAsArray(languageId: LanguageKey) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -261,17 +261,6 @@ export function parseRustOutput(lines: string, inputFilename?: string, pathPrefi
     return result;
 }
 
-export function padRight(name: string, len: number): string {
-    while (name.length < len) name = name + ' ';
-    return name;
-}
-
-export function trimRight(name: string): string {
-    let l = name.length;
-    while (l > 0 && name[l - 1] === ' ') l -= 1;
-    return name.substring(0, l);
-}
-
 /***
  * Anonymizes given IP.
  * For IPv4, it removes the last octet
@@ -393,27 +382,6 @@ export function toProperty(prop: string): boolean | number | string {
     if (/^-?(0|[1-9]\d*)$/.test(prop)) return parseInt(prop);
     if (/^-?\d*\.\d+$/.test(prop)) return parseFloat(prop);
     return prop;
-}
-
-/***
- * This function replaces all the "oldValues" in line with "newValue". It handles overlapping string replacement cases,
- * and is careful to return the exact same line object if there's no matches. This turns out to be super important for
- * performance.
- * @param {string} line
- * @param {string} oldValue
- * @param {string} newValue
- * @returns {string}
- */
-export function replaceAll(line: string, oldValue: string, newValue: string): string {
-    if (oldValue.length === 0) return line;
-    let startPoint = 0;
-    for (;;) {
-        const index = line.indexOf(oldValue, startPoint);
-        if (index === -1) break;
-        line = line.substring(0, index) + newValue + line.substring(index + oldValue.length);
-        startPoint = index + newValue.length;
-    }
-    return line;
 }
 
 // Initially based on http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -337,26 +337,6 @@ describe('Tool output', () => {
     });
 });
 
-describe('Pads right', () => {
-    it('works', () => {
-        expect(utils.padRight('abcd', 8)).toEqual('abcd    ');
-        expect(utils.padRight('a', 8)).toEqual('a       ');
-        expect(utils.padRight('', 8)).toEqual('        ');
-        expect(utils.padRight('abcd', 4)).toEqual('abcd');
-        expect(utils.padRight('abcd', 2)).toEqual('abcd');
-    });
-});
-
-describe('Trim right', () => {
-    it('works', () => {
-        expect(utils.trimRight('  ')).toEqual('');
-        expect(utils.trimRight('')).toEqual('');
-        expect(utils.trimRight(' ab ')).toEqual(' ab');
-        expect(utils.trimRight(' a  b ')).toEqual(' a  b');
-        expect(utils.trimRight('a    ')).toEqual('a');
-    });
-});
-
 describe('Anonymizes all kind of IPs', () => {
     it('Ignores localhost', () => {
         expect(utils.anonymizeIp('localhost')).toEqual('localhost');
@@ -476,35 +456,6 @@ describe('squashes horizontal whitespace', () => {
         expect(utils.squashHorizontalWhitespace('  abc abc')).toEqual('  abc abc');
         expect(utils.squashHorizontalWhitespace('  abc     abc')).toEqual('  abc abc');
         expect(utils.squashHorizontalWhitespace('    abc   abc')).toEqual('  abc abc');
-    });
-});
-
-describe('replaces all substrings', () => {
-    it('works with no substitutions', () => {
-        const string = 'This is a line with no replacements';
-        expect(utils.replaceAll(string, 'not present', "won't be substituted")).toEqual(string);
-    });
-    it('handles odd cases', () => {
-        expect(utils.replaceAll('', '', '')).toEqual('');
-        expect(utils.replaceAll('Hello', '', '')).toEqual('Hello');
-    });
-    it('works with single replacement', () => {
-        expect(utils.replaceAll('This is a line with a mistook in it', 'mistook', 'mistake')).toEqual(
-            'This is a line with a mistake in it',
-        );
-        expect(utils.replaceAll('This is a line with a mistook', 'mistook', 'mistake')).toEqual(
-            'This is a line with a mistake',
-        );
-        expect(utils.replaceAll('Mistooks were made', 'Mistooks', 'Mistakes')).toEqual('Mistakes were made');
-    });
-
-    it('works with multiple replacements', () => {
-        expect(utils.replaceAll('A mistook is a mistook', 'mistook', 'mistake')).toEqual('A mistake is a mistake');
-        expect(utils.replaceAll('aaaaaaaaaaaaaaaaaaaaaaaaaaa', 'a', 'b')).toEqual('bbbbbbbbbbbbbbbbbbbbbbbbbbb');
-    });
-
-    it('works with overlapping replacements', () => {
-        expect(utils.replaceAll('aaaaaaaa', 'a', 'ba')).toEqual('babababababababa');
     });
 });
 


### PR DESCRIPTION
_No functional change intended_

Our padRight and trimRight implementations have been in standard javascript for quite a long time now (node 10.x and 8.x repsectively) so I've replaced their usages with the builtins.

The replaceAll function had zero uses (as we already use String.replaceAll everywhere)