### PR TITLE
Make 'new source editor' preserve the origin language

### DIFF
--- a/static/components.ts
+++ b/static/components.ts
@@ -112,6 +112,7 @@ import {
 } from './components.interfaces.js';
 import {ConfiguredOverrides} from './compilation/compiler-overrides.interfaces.js';
 import {ConfiguredRuntimeTools} from './execution/execution.interfaces.js';
+import {LanguageKey} from './languages.interfaces.js';
 
 /** Get an empty compiler component. */
 export function getCompiler(editorId: number, lang: string): ComponentConfig<EmptyCompilerState> {
@@ -229,7 +230,7 @@ export function getExecutorForTree(treeId: number, lang: string): ComponentConfi
  *
  * TODO: main.js calls this with no arguments.
  */
-export function getEditor(langId: string, id?: number): ComponentConfig<EmptyEditorState> {
+export function getEditor(langId: LanguageKey, id?: number): ComponentConfig<EmptyEditorState> {
     return {
         type: 'component',
         componentName: EDITOR_COMPONENT_NAME,

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -42,7 +42,7 @@ export interface MultifileFile {
     filename: string;
     content: string;
     editorId: number;
-    langId: string;
+    langId: LanguageKey;
 }
 
 export interface MultifileServiceState {
@@ -60,8 +60,8 @@ export class MultifileService {
     private newFileId: number;
     private alertSystem: any;
     private validExtraFilenameExtensions: string[];
-    private readonly defaultLangIdUnknownExt: string;
-    private readonly cmakeLangId: string;
+    private readonly defaultLangIdUnknownExt: LanguageKey;
+    private readonly cmakeLangId: LanguageKey;
     private readonly cmakeMainSourceFilename: string;
     private readonly maxFilesize: number;
 
@@ -108,7 +108,7 @@ export class MultifileService {
         return path.basename(filename) === this.cmakeMainSourceFilename;
     }
 
-    private getLanguageIdFromFilename(filename: string): string {
+    private getLanguageIdFromFilename(filename: string): LanguageKey {
         const filenameExt = path.extname(filename);
 
         const possibleLang = _.filter(languages, lang => {
@@ -372,7 +372,7 @@ export class MultifileService {
             filename: '',
             content: '',
             editorId: editorId,
-            langId: '',
+            langId: 'c++',
         };
 
         this.addFile(file);

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -596,8 +596,11 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         };
 
         const getEditorConfig = () => {
+            if (this.currentLanguage) {
+                return Components.getEditor(this.currentLanguage.id);
+            }
             // TODO(jeremy-rifkin): Can this.settings.defaultLanguage really be undefined?
-            return Components.getEditor(this.settings.defaultLanguage as any);
+            return Components.getEditor(unwrap(this.settings.defaultLanguage));
         };
 
         const addPaneOpener = (dragSource: JQuery<HTMLElement>, dragConfig) => {

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -299,7 +299,7 @@ export class Tree {
         if (file) {
             file.isOpen = false;
             const editor = this.hub.getEditorById(editorId);
-            file.langId = editor?.currentLanguage?.id ?? '';
+            file.langId = editor?.currentLanguage?.id ?? 'c++';
             file.content = editor?.getSource() ?? '';
             file.editorId = -1;
         }


### PR DESCRIPTION
When doing 'Add new...'/'Source editor' from, e.g., a Rust editor - open a new Rust editor and not a C++ one.

![image](https://github.com/user-attachments/assets/861c53bc-fb1e-44c0-ac23-09d2ac839bdb)
