### PR TITLE
Reintroduce `[already open]` for “new tool” buttons

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2675,6 +2675,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 this.container.layoutManager.root.contentItems[0];
             insertPoint.addChild(createToolView());
         });
+        button.addClass('new-pane-button');
     }
 
     initToolButtons(): void {


### PR DESCRIPTION
Fixing the merge conflicts in #6974 accidentally removed the `new-pane-button` class from the buttons in the “Add tool...” menu from #7002:
https://github.com/compiler-explorer/compiler-explorer/pull/6974/files#diff-40ca496bc7fcf6c9bcd41d530708fe3a7bcc5f58cd9bad27ab919b5033f557deL2695-L2696

See https://godbolt.org/z/fd7v8zfE5 (click on “Add tool...”, `ldd` is disabled but does say `[already open]`).

This PR reintroduces that change. However, the implementation in #7002 would also show `[already open]` for the “No tools available” button if there are no tools. In this PR, the `new-pane-button` class is only added to the “real” new tool buttons.