### PR TITLE
fix: changed ClientStateExecutor.arguments type to string (was: any[]) - closes #7037

### DIFF
--- a/lib/clientstate.ts
+++ b/lib/clientstate.ts
@@ -121,7 +121,7 @@ export class ClientStateCompiler {
 export class ClientStateExecutor {
     compilerVisible = false;
     compilerOutputVisible = false;
-    arguments: any[] = [];
+    arguments: string = '';
     argumentsVisible = false;
     stdin = '';
     stdinVisible = false;
@@ -151,6 +151,10 @@ export class ClientStateExecutor {
         if (jsondata.stdin !== undefined) this.stdin = jsondata.stdin;
         if (jsondata.stdinVisible !== undefined) this.stdinVisible = jsondata.stdinVisible;
         if (jsondata.wrap !== undefined) this.wrap = jsondata.wrap;
+
+        if (typeof this.arguments !== 'string') {
+            throw new TypeError('unexpected: executor.arguments are supposed to be a string');
+        }
 
         if (jsondata.runtimeTools === undefined) {
             this.runtimeTools = [];


### PR DESCRIPTION
Just a small fix concerning the type (and the default value!) of `ClientStateExecutor.arguments`.

This solves #7037 .

**Please have a detailed look at my changes**, since I have no deep insight in all dependencies of this software (however, the tests pass)!

I tested the new code with the link in #7037 - and I tested the error (wrong type) with [this link (the arguments are a list here)](http://localhost:10240/clientstate/eNpNUEFqwzAQ/MqiQrCJS0jSk5205AW9hF7qHGRFuAJ5baQVpAj9vSvjmCKENLOj2dVE4bX3ZkQvaviOwtz53FcgrMQ+yF4zFGq7FUz5MTg1Ey2+GFQ23DWcJmeQ3lv05IIiuEBkDI/qt0lNiy2SHiYriZXKSu/hylqD1qAGxW0JrhsY5AOKBcFGVrDeuxIiu5DTFByChBN08MG7Bsn2KXfI/QZpsJi1AJ7udT2PZbFoBZsXx+qtPMfU8jeesGyydrebiUvcV4dUXSJXUq6k/GE1DpOx2s3Z3JjQD60CjW4JS7o+DBpprT8fMF6iFL1HOfmfkbKhNd2qHSdaYhevPPGZQz4cRfrn8hloCvRlvOlsjp0D1unG6w9dpIzQ).

**Note:** I check manually for the correct type and throw a `TypeError` in case of problems. We could add a proper JSON-Schema definition of important Data Types and include a Schema-check (I have good experience with `zod`, but there are many of such libs). **If you are interested**, I could prepare a demo-PR with e.g. `zod` for the  `ClientStateExecutor`?