### PR TITLE
Turn minimap off by default

### DIFF
--- a/static/settings.ts
+++ b/static/settings.ts
@@ -306,7 +306,7 @@ export class Settings {
             ['.keepMultipleTabs', 'keepMultipleTabs', false],
             ['.keepSourcesOnLangChange', 'keepSourcesOnLangChange', false],
             ['.newEditorLastLang', 'newEditorLastLang', true],
-            ['.showMinimap', 'showMinimap', true],
+            ['.showMinimap', 'showMinimap', false],
             ['.showQuickSuggestions', 'showQuickSuggestions', false],
             ['.useCustomContextMenu', 'useCustomContextMenu', true],
             ['.useSpaces', 'useSpaces', true],


### PR DESCRIPTION
For browsers that already navigated to CE, localStorage would override this. So this is more of a long-term thing..
