### PR TITLE
Add Glslang Argument Parser

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1257,3 +1257,20 @@ export class MadpascalParser extends GCCParser {
         return ['a8', 'c64', 'c4p', 'raw', 'neo'];
     }
 }
+
+export class GlslangParser extends BaseParser {
+    static override async parse(compiler: BaseCompiler) {
+        await this.getOptions(compiler, '--help');
+        return compiler;
+    }
+
+    static override async getOptions(compiler: BaseCompiler, helpArg: string) {
+        const optionFinder1 = /^ *(--?[\d#+,<=>[\]a-z|-]* ?[\d+,<=>[\]a-z|-]*)  +(.*)/i;
+        const optionFinder2 = /^ *(--?[\d#+,<=>[\]a-z|-]* ?[\d+,<=>[\]a-z|-]*)/i;
+        const result = await compiler.execCompilerCached(compiler.compiler.exe, [helpArg]);
+        // glslang will return a return code of 1 when calling --help (since it means nothing was compiled)
+        const options = this.parseLines(result.stdout + result.stderr, optionFinder1, optionFinder2);
+        compiler.possibleArguments.populateOptions(options);
+        return options;
+    }
+}

--- a/lib/compilers/glsl.ts
+++ b/lib/compilers/glsl.ts
@@ -31,6 +31,8 @@ import {logger} from '../logger.js';
 import {SPIRVAsmParser} from '../parsers/asm-parser-spirv.js';
 import * as utils from '../utils.js';
 
+import {GlslangParser} from './argument-parsers.js';
+
 export class GLSLCompiler extends BaseCompiler {
     protected disassemblerPath: string;
 
@@ -59,6 +61,10 @@ export class GLSLCompiler extends BaseCompiler {
     // TODO: Check this to see if it needs key (same in clspv)
     override getOutputFilename(dirPath: string, outputFilebase: string) {
         return path.join(dirPath, `${outputFilebase}.spvasm`);
+    }
+
+    override getArgumentParserClass() {
+        return GlslangParser;
     }
 
     override async runCompiler(


### PR DESCRIPTION
Currently when using `glslang` with `GLSL` you don't get any options

![image](https://github.com/user-attachments/assets/2dd4a4df-f228-4531-84d8-1a967a92cbc7)

After digging around I realize the issue is

1. Going `-fsyntax-only --help` with the default arg parer produces an error in glslang
2. glslang (for many other reasons that could argue are right or wrong) returns `1` and not `0` upon calling `glslang --help`