### PR TITLE
Add richer comments to SPIR-V assembly output

### DIFF
--- a/lib/compilers/clspv.ts
+++ b/lib/compilers/clspv.ts
@@ -85,7 +85,7 @@ export class CLSPVCompiler extends BaseCompiler {
         }
 
         const spvasmFilename = this.getOutputFilename(sourceDir, this.outputFilebase);
-        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename];
+        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename, '--comment'];
 
         const spvasmOutput = await this.exec(this.disassemblerPath, disassemblerFlags, execOptions);
         if (spvasmOutput.code !== 0) {

--- a/lib/compilers/glsl.ts
+++ b/lib/compilers/glsl.ts
@@ -83,7 +83,7 @@ export class GLSLCompiler extends BaseCompiler {
         }
 
         const spvasmFilename = this.getOutputFilename(sourceDir, this.outputFilebase);
-        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename];
+        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename, '--comment'];
 
         const spvasmOutput = await this.exec(this.disassemblerPath, disassemblerFlags, execOptions);
         if (spvasmOutput.code !== 0) {

--- a/lib/compilers/spirv-tools.ts
+++ b/lib/compilers/spirv-tools.ts
@@ -162,7 +162,7 @@ export class SPIRVToolsCompiler extends BaseCompiler {
         }
 
         const spvasmFilename = path.join(sourceDir, this.outputFilebase + '.spvasm');
-        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename];
+        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename, '--comment'];
 
         // Will likely never fail
         spvasmOutput = await this.exec(this.disassemblerPath, disassemblerFlags, execOptions);

--- a/lib/compilers/spirv.ts
+++ b/lib/compilers/spirv.ts
@@ -154,7 +154,7 @@ export class SPIRVCompiler extends BaseCompiler {
         }
 
         const spvasmFilename = path.join(sourceDir, this.outputFilebase + '.spvasm');
-        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename];
+        const disassemblerFlags = [spvBinFilename, '-o', spvasmFilename, '--comment'];
 
         const spvasmOutput = await this.exec(this.disassemblerPath, disassemblerFlags, execOptions);
         if (spvasmOutput.code !== 0) {

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -100,7 +100,8 @@ export class SPIRVAsmParser extends AsmParser {
 
         const sourceTag = /^\s*OpLine\s+%(\d+)\s+(\d+)\s+(\d*)$/;
         const endBlock = /OpFunctionEnd/;
-        const comment = /^;/;
+        const commentOnly = /^\s*;/; // the whole line is a comment
+        const emptyLine = /^\s*$/;
         const opLine = /OpLine/;
         const opNoLine = /OpNoLine/;
         const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;
@@ -143,8 +144,15 @@ export class SPIRVAsmParser extends AsmParser {
                 source = null;
             }
 
-            if (filters.commentOnly && comment.test(line)) {
-                continue;
+            if (filters.commentOnly) {
+                if (commentOnly.test(line) || emptyLine.test(line)) {
+                    continue;
+                }
+                // strip the comment at end of the line
+                const commentIndex = line.indexOf(';');
+                if (commentIndex > 0) {
+                    line = line.substring(0, commentIndex);
+                }
             }
             if (filters.directives) {
                 if (


### PR DESCRIPTION
`spirv-dis` has a `--comment` that provides nice information to the output of the SPIR-V

(Note that when the `comment` filter is on, the SPIR-V looks the same)

## Before 

We only showed the comments that appear at the top
![image](https://github.com/user-attachments/assets/b61e8189-1792-4b58-ba70-874a84c58fef)

## After

We will include the other comments/whitespace to help break up the SPIRV
![image](https://github.com/user-attachments/assets/832c7274-94cb-4b8c-9db1-531687773ae8)
