### PR TITLE
Fix OpLabel being in previous block

### DIFF
--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -109,6 +109,7 @@ export class SPIRVAsmParser extends AsmParser {
         const opSource = /OpSource/;
         const opName = /OpName/;
         const opMemberName = /OpMemberName/;
+        const opLabel = /OpLabel/;
 
         const labelDef = /^\s*(%\w+)\s*=\s*(?:OpFunction\s+|OpLabel)/;
 
@@ -117,6 +118,7 @@ export class SPIRVAsmParser extends AsmParser {
         let inString = false;
 
         let source: any = null;
+        let lastLine: string = '';
 
         for (let line of asmLines) {
             if (inString) {
@@ -138,9 +140,17 @@ export class SPIRVAsmParser extends AsmParser {
                 if (!isNaN(sourceCol) && sourceCol !== 0) {
                     source.column = sourceCol;
                 }
+                // generators will tend to go
+                //    OpLabel
+                //    OpLine
+                // but we want the OpLabel to be part of this line since that is when a Block starts
+                if (opLabel.test(lastLine)) {
+                    asm[asm.length - 1].source = source;
+                }
             }
 
-            if (endBlock.test(line) || opNoLine.test(line)) {
+            // OpLabel are by definition the start of a block, so don't include in previous source
+            if (endBlock.test(line) || opNoLine.test(line) || opLabel.test(line)) {
                 source = null;
             }
 
@@ -178,6 +188,7 @@ export class SPIRVAsmParser extends AsmParser {
                 source: source,
                 labels: labelsInLine,
             });
+            lastLine = line;
         }
 
         const endTime = process.hrtime.bigint();

--- a/lib/parsers/asm-parser-spirv.ts
+++ b/lib/parsers/asm-parser-spirv.ts
@@ -104,6 +104,7 @@ export class SPIRVAsmParser extends AsmParser {
         const opLine = /OpLine/;
         const opNoLine = /OpNoLine/;
         const opExtDbg = /OpExtInst\s+%void\s+%\d+\s+Debug/;
+        const opModuleProcessed = /OpModuleProcessed/;
         const opString = /OpString/;
         const opSource = /OpSource/;
         const opName = /OpName/;
@@ -150,6 +151,7 @@ export class SPIRVAsmParser extends AsmParser {
                 if (
                     opLine.test(line) ||
                     opExtDbg.test(line) ||
+                    opModuleProcessed.test(line) ||
                     opNoLine.test(line) ||
                     opString.test(line) ||
                     opSource.test(line) ||


### PR DESCRIPTION
SPIR-V is like LLVM in there are "Blocks" used for Control Flow, `OpLabel` has a special text in the SPIR-V spec

> A block always starts with an [OpLabel](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpLabel) instruction. This may be immediately preceded by an [OpLine](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpLine) instruction, but the OpLabel is considered as the beginning of the block.

But currently the coloring is off-by-1

![image](https://github.com/user-attachments/assets/4ec20d7d-0beb-49de-ba32-204f708a08c2)

This change now moves it up a line so it is the start of the block

![image](https://github.com/user-attachments/assets/3d6d1742-469f-4b29-a644-7677056bce9e)

This can be better seen why looking at the [SPIR-V Visualizer](spirv-visualizer) tool output

![image](https://github.com/user-attachments/assets/10cbad0b-f093-4bd5-98dd-b38e78615218)
