### PR TITLE
Add success message for validator tool

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3350,6 +3350,11 @@ but nothing was dumped. Possible causes are:
                       filters,
                   )
                 : (async () => {
+                      if (result.validatorTool && result.code === 0) {
+                          // A validator tool is unique because if successful, there will be no asm output
+                          result.asm = '<Validator was successful>';
+                          return result;
+                      }
                       if (result.asmSize === undefined) {
                           result.asm = '<No output file>';
                           return result;

--- a/lib/compilers/spirv-tools.ts
+++ b/lib/compilers/spirv-tools.ts
@@ -157,6 +157,10 @@ export class SPIRVToolsCompiler extends BaseCompiler {
 
         const spvBin = await this.exec(compiler, options, execOptions);
         result = this.transformToCompilationResult(spvBin, inputFilename);
+
+        if (isValidator) {
+            result.validatorTool = true;
+        }
         if (spvBin.code !== 0 || !(await utils.fileExists(spvBinFilename)) || isValidator) {
             return result;
         }

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -169,6 +169,7 @@ export type CompilationResult = {
     stderr: ResultLine[];
     truncated?: boolean;
     didExecute?: boolean;
+    validatorTool?: boolean;
     executableFilename?: string;
     execResult?: CompilationResult;
     gnatDebugOutput?: ResultLine[];


### PR DESCRIPTION
So SPIR-V, unlike probably everything else, can't be "executed" by itself (for graphics) because it lacks additional information. This is why there is a "Validator" tool, it ensures statically the IR is "good so far"

The issue because currently you get a non-obvious result, this PR allows the following to occur

![image](https://github.com/user-attachments/assets/273dfdc7-74d0-4e50-a834-bfbc21925d6e)
