### PR TITLE
Mark coverage as excluded in IntelliJ

### DIFF
--- a/.idea/compiler-explorer.iml
+++ b/.idea/compiler-explorer.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/static/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
@@ -8,6 +9,7 @@
       <excludeFolder url="file://$MODULE_DIR$/static/dist" />
       <excludeFolder url="file://$MODULE_DIR$/lib/storage/data" />
       <excludeFolder url="file://$MODULE_DIR$/etc/scripts/asm-docs" />
+      <excludeFolder url="file://$MODULE_DIR$/coverage" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
Vitest outputs coverage information into `/coverage`.