### PR TITLE
Remove void type from eachLine

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -51,8 +51,13 @@ export function splitLines(text: string): string[] {
     return result;
 }
 
-export function eachLine(text: string, func: (line: string) => ResultLine | void): (ResultLine | void)[] {
-    return splitLines(text).map(func);
+/**
+ * Applies a function to each line of text split by `splitLines`
+ */
+export function eachLine(text: string, func: (line: string) => void): void {
+    for (const line of splitLines(text)) {
+        func(line);
+    }
 }
 
 export function expandTabs(line: string): string {


### PR DESCRIPTION
eachLine is a small util around splitLines (I am wondering if we might as well just remove it alltogether..?) that previously had `() => ResultLine | void`, but none of the callers of eachLine use its return value ever.