### PR TITLE
Remove unnecessary type assertion

### DIFF
--- a/lib/compilation-queue.ts
+++ b/lib/compilation-queue.ts
@@ -102,7 +102,9 @@ export class CompilationQueue {
                     );
                 }
                 const jobAsyncId = executionAsyncId();
-                if (this._running.has(jobAsyncId)) throw new Error('somehow we entered the context twice');
+                if (this._running.has(jobAsyncId)) {
+                    throw new Error('somehow we entered the context twice');
+                }
                 try {
                     this._running.add(jobAsyncId);
                     return job();
@@ -111,8 +113,8 @@ export class CompilationQueue {
                     queueCompleted.inc();
                 }
             },
-            {priority: options?.highPriority ? 100 : 0},
-        ) as PromiseLike<Result>; // TODO(supergrecko): investigate why this assert is needed
+            {priority: options?.highPriority ? 100 : 0, throwOnTimeout: true, timeout: undefined},
+        );
     }
 
     status(): {busy: boolean; pending: number; size: number} {


### PR DESCRIPTION
Removes an old TODO of mine :)

p-queue conditionally returns `undefined` if throwOnTimeout is not set to true. We currently operate our own timeout check, so I haven't changed that.

Setting timeout to undefined should give us the correct type without affecting behavior. https://github.com/sindresorhus/p-queue/blob/main/source/index.ts#L253