### PR TITLE
[feat] Add LFortran as a new fortran compiler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -149,6 +149,7 @@
       - any-glob-to-any-file:
           - 'lib/compilers/flang.ts'
           - 'lib/compilers/flang-fc1.ts'
+          - 'lib/compilers/lfortran.ts'
           - 'lib/compilers/fortran.ts'
           - 'etc/config/fortran.*.properties'
           - 'static/modes/fortran-mode.ts'

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -739,6 +739,7 @@ compiler.lfortran.exe=/opt/compiler-explorer/lfortran/bin/lfortran
 compiler.lfortran.options=--generate-object-code
 compiler.lfortran.supportsBinary=true
 compiler.lfortran.supportsExecute=true
+compiler.lfortran.compilerType=lfortran
 
 ###############################
 # GCC for ARM 64bit

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gfortran_86:&ifort:&ifx:&nvfortran_x86:&cross:&clang_llvmflang
+compilers=&gfortran_86:&ifort:&ifx:&nvfortran_x86:&cross:&clang_llvmflang:&lfortran
 defaultCompiler=gfortran142
 demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
@@ -728,6 +728,17 @@ compiler.flangtrunk-fc.supportsBinary=false
 compiler.flangtrunk-fc.supportsBinaryObject=false
 compiler.flangtrunk-fc.supportsBinaryExecute=false
 compiler.flangtrunk-fc.alias=flangtrunknew-fc
+
+#################################
+# LFortran
+group.lfortran.compilers=lfortran
+group.lfortran.groupName=LFortran
+
+compiler.lfortran.name=lfortran (latest)
+compiler.lfortran.exe=/opt/compiler-explorer/lfortran/bin/lfortran
+compiler.lfortran.options=--generate-object-code
+compiler.lfortran.supportsBinary=true
+compiler.lfortran.supportsExecute=true
 
 ###############################
 # GCC for ARM 64bit

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -71,6 +71,7 @@ export {EWAVRCompiler} from './ewavr.js';
 export {FakeCompiler} from './fake-for-test.js';
 export {FlangCompiler} from './flang.js';
 export {FlangFC1Compiler} from './flang-fc1.js';
+export {LFortranCompiler} from './lfortran.js';
 export {FortranCompiler} from './fortran.js';
 export {FPCCompiler} from './pascal.js';
 export {GCCCompiler} from './gcc.js';

--- a/lib/compilers/lfortran.ts
+++ b/lib/compilers/lfortran.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+
+import {FortranCompiler} from './fortran.js';
+
+export class LFortranCompiler extends FortranCompiler {
+    static override get key() {
+        return 'lfortran';
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
+        // TODO add `-g` to the options
+        let options = ['-o', this.filename(outputFilename)];
+
+        if (!filters.binary && !filters.binaryObject) {
+            options = options.concat('-S');
+        } else if (filters.binaryObject) {
+            options = options.concat('-c');
+        }
+        return options;
+    }
+}


### PR DESCRIPTION
Details:
LFortran is a modern open-source (BSD licensed) interactive Fortran
 compiler built on top of LLVM. See, https://lfortran.org for more details.
 There was an interest in the community to add the compiler into the 
 Compiler Explorer: https://github.com/lfortran/lfortran/issues/623. 
 So, this PR adds it.

LFortran is in alpha (the source code compiles to binary and execute. 
 But, users are expected that their code can break). It can emits AST, 
 ASR, LLVM, C, C++, WAT, Julia, Fortran, etc. It has multiple backend
 like LLVM (default), C, C++, x86, WASM, fortran and mlir. 
 For more options run `--help`.

Changes in this PR:
- Add LFortran as a new Fortran compiler.
- `-g` options is enabled by default in `optionsForFilter`. Providing an option 
 to disabling it helps other compilers (that doesn't have complete support for
 debug information) to compile successfully