### PR TITLE
[FIX] fixed argument passing for ygen

### DIFF
--- a/lib/compilers/ylc.ts
+++ b/lib/compilers/ylc.ts
@@ -71,7 +71,7 @@ export class YLCCompiler extends BaseCompiler {
 
         return this.orderArguments(
             options,
-            '-in=' + inputFilename,
+            inputFilename,
             libIncludes,
             libOptions,
             libPathsAsFlags,


### PR DESCRIPTION
Hi all!
I recently changed argument passing for my compiler.
From:
```
ylc -in=<in> -o=<out>
```
to:
```
ylc <in> -o=<out>
```
Which makes ygen currently unusable 😭
So i fixed it in this pr

Bye