### PR TITLE
Add support for .NET 9.0 and ILSpy

### DIFF
--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy
+group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy:dotnet60csharpilspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -181,6 +181,12 @@ compiler.dotnettrunkcsharpildasm.langVersion=preview
 compiler.dotnettrunkcsharpildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60csharpilspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpilspy.name=.NET 6.0 ILSpy
+compiler.dotnet60csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpilspy.buildConfig=Release
+compiler.dotnet60csharpilspy.langVersion=latest
 
 compiler.dotnet70csharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70csharpilspy.name=.NET 7.0 ILSpy

--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80csharpcoreclr
+defaultCompiler=dotnet90csharpcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet80csharpcoreclr:dotnet70csharpcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet90csharpcoreclr:dotnet80csharpcoreclr:dotnet70csharpcoreclr:dotnet60csharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkcsharpcrossgen2:dotnet80csharpcrossgen2:dotnet70csharpcrossgen2:dotnet60csharpcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkcsharpcrossgen2:dotnet90csharpcrossgen2:dotnet80csharpcrossgen2:dotnet70csharpcrossgen2:dotnet60csharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkcsharpmono
+group.dotnetmono.compilers=dotnettrunkcsharpmono:dotnet90csharpmono:dotnet80csharpmono:dotnet70csharpmono:dotnet60csharpmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,10 +24,15 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkcsharpildasm
+group.dotnetildasm.compilers=dotnettrunkcsharpildasm:dotnet90csharpildasm:dotnet80csharpildasm:dotnet70csharpildasm:dotnet60csharpildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkcsharp:dotnet707csharp:dotnet703csharp:dotnet701csharp:dotnet6018csharp:dotnet6014csharp:dotnet6011csharp
 group.dotnetlegacy.compilerCategories=legacy
@@ -36,20 +41,32 @@ group.dotnetlegacy.groupName=Legacy
 
 # CoreCLR compilers
 
-compiler.dotnet70csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpcoreclr.buildConfig=Release
+compiler.dotnet60csharpcoreclr.langVersion=latest
+
+compiler.dotnet70csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70csharpcoreclr.buildConfig=Release
 compiler.dotnet70csharpcoreclr.langVersion=latest
 
-compiler.dotnet80csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80csharpcoreclr.buildConfig=Release
 compiler.dotnet80csharpcoreclr.langVersion=latest
 
+compiler.dotnet90csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpcoreclr.buildConfig=Release
+compiler.dotnet90csharpcoreclr.langVersion=latest
+
 compiler.dotnettrunkcsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkcsharpcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkcsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkcsharpcoreclr.langVersion=preview
@@ -57,26 +74,32 @@ compiler.dotnettrunkcsharpcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60csharpcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60csharpcrossgen2.buildConfig=Release
 compiler.dotnet60csharpcrossgen2.langVersion=latest
 
-compiler.dotnet70csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70csharpcrossgen2.buildConfig=Release
 compiler.dotnet70csharpcrossgen2.langVersion=latest
 
-compiler.dotnet80csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80csharpcrossgen2.buildConfig=Release
 compiler.dotnet80csharpcrossgen2.langVersion=latest
 
+compiler.dotnet90csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpcrossgen2.buildConfig=Release
+compiler.dotnet90csharpcrossgen2.langVersion=latest
+
 compiler.dotnettrunkcsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkcsharpcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkcsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkcsharpcrossgen2.langVersion=preview
@@ -84,8 +107,32 @@ compiler.dotnettrunkcsharpcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60csharpmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpmono.name=.NET 6.0 Mono
+compiler.dotnet60csharpmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpmono.buildConfig=Release
+compiler.dotnet60csharpmono.langVersion=latest
+
+compiler.dotnet70csharpmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpmono.name=.NET 7.0 Mono
+compiler.dotnet70csharpmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70csharpmono.buildConfig=Release
+compiler.dotnet70csharpmono.langVersion=latest
+
+compiler.dotnet80csharpmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpmono.name=.NET 8.0 Mono
+compiler.dotnet80csharpmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80csharpmono.buildConfig=Release
+compiler.dotnet80csharpmono.langVersion=latest
+
+compiler.dotnet90csharpmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpmono.name=.NET 9.0 Mono
+compiler.dotnet90csharpmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpmono.buildConfig=Release
+compiler.dotnet90csharpmono.langVersion=latest
+
 compiler.dotnettrunkcsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpmono.name=.NET Mono (main)
+compiler.dotnettrunkcsharpmono.name=.NET (main) Mono
 compiler.dotnettrunkcsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpmono.buildConfig=Release
 compiler.dotnettrunkcsharpmono.langVersion=preview
@@ -94,20 +141,71 @@ compiler.dotnettrunkcsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkcsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkcsharpnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkcsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkcsharpnativeaot.langVersion=preview
 compiler.dotnettrunkcsharpnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60csharpildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpildasm.buildConfig=Release
+compiler.dotnet60csharpildasm.langVersion=latest
+
+compiler.dotnet70csharpildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70csharpildasm.buildConfig=Release
+compiler.dotnet70csharpildasm.langVersion=latest
+
+compiler.dotnet80csharpildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80csharpildasm.buildConfig=Release
+compiler.dotnet80csharpildasm.langVersion=latest
+
+compiler.dotnet90csharpildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpildasm.buildConfig=Release
+compiler.dotnet90csharpildasm.langVersion=latest
 
 compiler.dotnettrunkcsharpildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkcsharpildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkcsharpildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpildasm.buildConfig=Release
 compiler.dotnettrunkcsharpildasm.langVersion=preview
 compiler.dotnettrunkcsharpildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70csharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpilspy.name=.NET 7.0 ILSpy
+compiler.dotnet70csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70csharpilspy.buildConfig=Release
+compiler.dotnet70csharpilspy.langVersion=latest
+
+compiler.dotnet80csharpilspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpilspy.name=.NET 8.0 ILSpy
+compiler.dotnet80csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80csharpilspy.buildConfig=Release
+compiler.dotnet80csharpilspy.langVersion=latest
+
+compiler.dotnet90csharpilspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpilspy.name=.NET 9.0 ILSpy
+compiler.dotnet90csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpilspy.buildConfig=Release
+compiler.dotnet90csharpilspy.langVersion=latest
+
+compiler.dotnettrunkcsharpilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharpilspy.name=.NET (main) ILSpy
+compiler.dotnettrunkcsharpilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharpilspy.buildConfig=Release
+compiler.dotnettrunkcsharpilspy.langVersion=preview
+compiler.dotnettrunkcsharpilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/csharp.amazon.properties
+++ b/etc/config/csharp.amazon.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy:dotnet60csharpilspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkcsharp:dotnet707csharp:dotnet703csharp:dotnet701csharp:dotnet6018csharp:dotnet6014csharp:dotnet6011csharp

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy
+group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy:dotnet60csharpilspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -181,6 +181,12 @@ compiler.dotnettrunkcsharpildasm.langVersion=preview
 compiler.dotnettrunkcsharpildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60csharpilspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpilspy.name=.NET 6.0 ILSpy
+compiler.dotnet60csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpilspy.buildConfig=Release
+compiler.dotnet60csharpilspy.langVersion=latest
 
 compiler.dotnet70csharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70csharpilspy.name=.NET 7.0 ILSpy

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80csharpcoreclr
+defaultCompiler=dotnet90csharpcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet80csharpcoreclr:dotnet70csharpcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkcsharpcoreclr:dotnet90csharpcoreclr:dotnet80csharpcoreclr:dotnet70csharpcoreclr:dotnet60csharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkcsharpcrossgen2:dotnet80csharpcrossgen2:dotnet70csharpcrossgen2:dotnet60csharpcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkcsharpcrossgen2:dotnet90csharpcrossgen2:dotnet80csharpcrossgen2:dotnet70csharpcrossgen2:dotnet60csharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkcsharpmono
+group.dotnetmono.compilers=dotnettrunkcsharpmono:dotnet90csharpmono:dotnet80csharpmono:dotnet70csharpmono:dotnet60csharpmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,10 +24,15 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkcsharpildasm
+group.dotnetildasm.compilers=dotnettrunkcsharpildasm:dotnet90csharpildasm:dotnet80csharpildasm:dotnet70csharpildasm:dotnet60csharpildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkcsharp:dotnet707csharp:dotnet703csharp:dotnet701csharp:dotnet6018csharp:dotnet6014csharp:dotnet6011csharp
 group.dotnetlegacy.compilerCategories=legacy
@@ -36,20 +41,32 @@ group.dotnetlegacy.groupName=Legacy
 
 # CoreCLR compilers
 
-compiler.dotnet70csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpcoreclr.buildConfig=Release
+compiler.dotnet60csharpcoreclr.langVersion=latest
+
+compiler.dotnet70csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70csharpcoreclr.buildConfig=Release
 compiler.dotnet70csharpcoreclr.langVersion=latest
 
-compiler.dotnet80csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80csharpcoreclr.buildConfig=Release
 compiler.dotnet80csharpcoreclr.langVersion=latest
 
+compiler.dotnet90csharpcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90csharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpcoreclr.buildConfig=Release
+compiler.dotnet90csharpcoreclr.langVersion=latest
+
 compiler.dotnettrunkcsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkcsharpcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkcsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkcsharpcoreclr.langVersion=preview
@@ -57,26 +74,32 @@ compiler.dotnettrunkcsharpcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60csharpcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60csharpcrossgen2.buildConfig=Release
 compiler.dotnet60csharpcrossgen2.langVersion=latest
 
-compiler.dotnet70csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70csharpcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70csharpcrossgen2.buildConfig=Release
 compiler.dotnet70csharpcrossgen2.langVersion=latest
 
-compiler.dotnet80csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80csharpcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80csharpcrossgen2.buildConfig=Release
 compiler.dotnet80csharpcrossgen2.langVersion=latest
 
+compiler.dotnet90csharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90csharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpcrossgen2.buildConfig=Release
+compiler.dotnet90csharpcrossgen2.langVersion=latest
+
 compiler.dotnettrunkcsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkcsharpcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkcsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkcsharpcrossgen2.langVersion=preview
@@ -84,8 +107,32 @@ compiler.dotnettrunkcsharpcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60csharpmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpmono.name=.NET 6.0 Mono
+compiler.dotnet60csharpmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpmono.buildConfig=Release
+compiler.dotnet60csharpmono.langVersion=latest
+
+compiler.dotnet70csharpmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpmono.name=.NET 7.0 Mono
+compiler.dotnet70csharpmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70csharpmono.buildConfig=Release
+compiler.dotnet70csharpmono.langVersion=latest
+
+compiler.dotnet80csharpmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpmono.name=.NET 8.0 Mono
+compiler.dotnet80csharpmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80csharpmono.buildConfig=Release
+compiler.dotnet80csharpmono.langVersion=latest
+
+compiler.dotnet90csharpmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpmono.name=.NET 9.0 Mono
+compiler.dotnet90csharpmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpmono.buildConfig=Release
+compiler.dotnet90csharpmono.langVersion=latest
+
 compiler.dotnettrunkcsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpmono.name=.NET Mono (main)
+compiler.dotnettrunkcsharpmono.name=.NET (main) Mono
 compiler.dotnettrunkcsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpmono.buildConfig=Release
 compiler.dotnettrunkcsharpmono.langVersion=preview
@@ -94,20 +141,71 @@ compiler.dotnettrunkcsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkcsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkcsharpnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkcsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkcsharpnativeaot.langVersion=preview
 compiler.dotnettrunkcsharpnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60csharpildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60csharpildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60csharpildasm.buildConfig=Release
+compiler.dotnet60csharpildasm.langVersion=latest
+
+compiler.dotnet70csharpildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70csharpildasm.buildConfig=Release
+compiler.dotnet70csharpildasm.langVersion=latest
+
+compiler.dotnet80csharpildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80csharpildasm.buildConfig=Release
+compiler.dotnet80csharpildasm.langVersion=latest
+
+compiler.dotnet90csharpildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90csharpildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpildasm.buildConfig=Release
+compiler.dotnet90csharpildasm.langVersion=latest
 
 compiler.dotnettrunkcsharpildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkcsharpildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkcsharpildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkcsharpildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkcsharpildasm.buildConfig=Release
 compiler.dotnettrunkcsharpildasm.langVersion=preview
 compiler.dotnettrunkcsharpildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70csharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70csharpilspy.name=.NET 7.0 ILSpy
+compiler.dotnet70csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70csharpilspy.buildConfig=Release
+compiler.dotnet70csharpilspy.langVersion=latest
+
+compiler.dotnet80csharpilspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80csharpilspy.name=.NET 8.0 ILSpy
+compiler.dotnet80csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80csharpilspy.buildConfig=Release
+compiler.dotnet80csharpilspy.langVersion=latest
+
+compiler.dotnet90csharpilspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90csharpilspy.name=.NET 9.0 ILSpy
+compiler.dotnet90csharpilspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90csharpilspy.buildConfig=Release
+compiler.dotnet90csharpilspy.langVersion=latest
+
+compiler.dotnettrunkcsharpilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkcsharpilspy.name=.NET (main) ILSpy
+compiler.dotnettrunkcsharpilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkcsharpilspy.buildConfig=Release
+compiler.dotnettrunkcsharpilspy.langVersion=preview
+compiler.dotnettrunkcsharpilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/csharp.defaults.properties
+++ b/etc/config/csharp.defaults.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkcsharpilspy:dotnet90csharpilspy:dotnet80csharpilspy:dotnet70csharpilspy:dotnet60csharpilspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkcsharp:dotnet707csharp:dotnet703csharp:dotnet701csharp:dotnet6018csharp:dotnet6014csharp:dotnet6011csharp

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy:dotnet60fsharpilspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkfsharp:dotnet707fsharp:dotnet703fsharp:dotnet701fsharp:dotnet6018fsharp:dotnet6014fsharp:dotnet6011fsharp

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80fsharpcoreclr
+defaultCompiler=dotnet90fsharpcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet80fsharpcoreclr:dotnet70fsharpcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet90fsharpcoreclr:dotnet80fsharpcoreclr:dotnet70fsharpcoreclr:dotnet60fsharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkfsharpcrossgen2:dotnet80fsharpcrossgen2:dotnet70fsharpcrossgen2:dotnet60fsharpcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkfsharpcrossgen2:dotnet90fsharpcrossgen2:dotnet80fsharpcrossgen2:dotnet70fsharpcrossgen2:dotnet60fsharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkfsharpmono
+group.dotnetmono.compilers=dotnettrunkfsharpmono:dotnet90fsharpmono:dotnet80fsharpmono:dotnet70fsharpmono:dotnet60fsharpmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,10 +24,15 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkfsharpildasm
+group.dotnetildasm.compilers=dotnettrunkfsharpildasm:dotnet90fsharpildasm:dotnet80fsharpildasm:dotnet70fsharpildasm:dotnet60fsharpildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkfsharp:dotnet707fsharp:dotnet703fsharp:dotnet701fsharp:dotnet6018fsharp:dotnet6014fsharp:dotnet6011fsharp
 group.dotnetlegacy.compilerCategories=legacy
@@ -36,20 +41,32 @@ group.dotnetlegacy.groupName=Legacy
 
 # CoreCLR compilers
 
-compiler.dotnet70fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpcoreclr.buildConfig=Release
+compiler.dotnet60fsharpcoreclr.langVersion=latest
+
+compiler.dotnet70fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70fsharpcoreclr.buildConfig=Release
 compiler.dotnet70fsharpcoreclr.langVersion=latest
 
-compiler.dotnet80fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80fsharpcoreclr.buildConfig=Release
 compiler.dotnet80fsharpcoreclr.langVersion=latest
 
+compiler.dotnet90fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpcoreclr.buildConfig=Release
+compiler.dotnet90fsharpcoreclr.langVersion=latest
+
 compiler.dotnettrunkfsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkfsharpcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkfsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkfsharpcoreclr.langVersion=preview
@@ -57,26 +74,32 @@ compiler.dotnettrunkfsharpcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60fsharpcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60fsharpcrossgen2.buildConfig=Release
 compiler.dotnet60fsharpcrossgen2.langVersion=latest
 
-compiler.dotnet70fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70fsharpcrossgen2.buildConfig=Release
 compiler.dotnet70fsharpcrossgen2.langVersion=latest
 
-compiler.dotnet80fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80fsharpcrossgen2.buildConfig=Release
 compiler.dotnet80fsharpcrossgen2.langVersion=latest
 
+compiler.dotnet90fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpcrossgen2.buildConfig=Release
+compiler.dotnet90fsharpcrossgen2.langVersion=latest
+
 compiler.dotnettrunkfsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkfsharpcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkfsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkfsharpcrossgen2.langVersion=preview
@@ -84,8 +107,32 @@ compiler.dotnettrunkfsharpcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60fsharpmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpmono.name=.NET 6.0 Mono
+compiler.dotnet60fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpmono.buildConfig=Release
+compiler.dotnet60fsharpmono.langVersion=latest
+
+compiler.dotnet70fsharpmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpmono.name=.NET 7.0 Mono
+compiler.dotnet70fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70fsharpmono.buildConfig=Release
+compiler.dotnet70fsharpmono.langVersion=latest
+
+compiler.dotnet80fsharpmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpmono.name=.NET 8.0 Mono
+compiler.dotnet80fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80fsharpmono.buildConfig=Release
+compiler.dotnet80fsharpmono.langVersion=latest
+
+compiler.dotnet90fsharpmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpmono.name=.NET 9.0 Mono
+compiler.dotnet90fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpmono.buildConfig=Release
+compiler.dotnet90fsharpmono.langVersion=latest
+
 compiler.dotnettrunkfsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpmono.name=.NET Mono (main)
+compiler.dotnettrunkfsharpmono.name=.NET (main) Mono
 compiler.dotnettrunkfsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpmono.buildConfig=Release
 compiler.dotnettrunkfsharpmono.langVersion=preview
@@ -94,20 +141,71 @@ compiler.dotnettrunkfsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkfsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkfsharpnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkfsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkfsharpnativeaot.langVersion=preview
 compiler.dotnettrunkfsharpnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60fsharpildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpildasm.buildConfig=Release
+compiler.dotnet60fsharpildasm.langVersion=latest
+
+compiler.dotnet70fsharpildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70fsharpildasm.buildConfig=Release
+compiler.dotnet70fsharpildasm.langVersion=latest
+
+compiler.dotnet80fsharpildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80fsharpildasm.buildConfig=Release
+compiler.dotnet80fsharpildasm.langVersion=latest
+
+compiler.dotnet90fsharpildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpildasm.buildConfig=Release
+compiler.dotnet90fsharpildasm.langVersion=latest
 
 compiler.dotnettrunkfsharpildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkfsharpildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkfsharpildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpildasm.buildConfig=Release
 compiler.dotnettrunkfsharpildasm.langVersion=preview
 compiler.dotnettrunkfsharpildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70fsharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpilspy.name=.NET 7.0 ILSpy
+compiler.dotnet70fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70fsharpilspy.buildConfig=Release
+compiler.dotnet70fsharpilspy.langVersion=latest
+
+compiler.dotnet80fsharpilspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpilspy.name=.NET 8.0 ILSpy
+compiler.dotnet80fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80fsharpilspy.buildConfig=Release
+compiler.dotnet80fsharpilspy.langVersion=latest
+
+compiler.dotnet90fsharpilspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpilspy.name=.NET 9.0 ILSpy
+compiler.dotnet90fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpilspy.buildConfig=Release
+compiler.dotnet90fsharpilspy.langVersion=latest
+
+compiler.dotnettrunkfsharpilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharpilspy.name=.NET (main) ILSpy
+compiler.dotnettrunkfsharpilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharpilspy.buildConfig=Release
+compiler.dotnettrunkfsharpilspy.langVersion=preview
+compiler.dotnettrunkfsharpilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/fsharp.amazon.properties
+++ b/etc/config/fsharp.amazon.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy
+group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy:dotnet60fsharpilspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -181,6 +181,12 @@ compiler.dotnettrunkfsharpildasm.langVersion=preview
 compiler.dotnettrunkfsharpildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60fsharpilspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpilspy.name=.NET 6.0 ILSpy
+compiler.dotnet60fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpilspy.buildConfig=Release
+compiler.dotnet60fsharpilspy.langVersion=latest
 
 compiler.dotnet70fsharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70fsharpilspy.name=.NET 7.0 ILSpy

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy:dotnet60fsharpilspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkfsharp:dotnet707fsharp:dotnet703fsharp:dotnet701fsharp:dotnet6018fsharp:dotnet6014fsharp:dotnet6011fsharp

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80fsharpcoreclr
+defaultCompiler=dotnet90fsharpcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet80fsharpcoreclr:dotnet70fsharpcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkfsharpcoreclr:dotnet90fsharpcoreclr:dotnet80fsharpcoreclr:dotnet70fsharpcoreclr:dotnet60fsharpcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkfsharpcrossgen2:dotnet80fsharpcrossgen2:dotnet70fsharpcrossgen2:dotnet60fsharpcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkfsharpcrossgen2:dotnet90fsharpcrossgen2:dotnet80fsharpcrossgen2:dotnet70fsharpcrossgen2:dotnet60fsharpcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkfsharpmono
+group.dotnetmono.compilers=dotnettrunkfsharpmono:dotnet90fsharpmono:dotnet80fsharpmono:dotnet70fsharpmono:dotnet60fsharpmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,10 +24,15 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkfsharpildasm
+group.dotnetildasm.compilers=dotnettrunkfsharpildasm:dotnet90fsharpildasm:dotnet80fsharpildasm:dotnet70fsharpildasm:dotnet60fsharpildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkfsharp:dotnet707fsharp:dotnet703fsharp:dotnet701fsharp:dotnet6018fsharp:dotnet6014fsharp:dotnet6011fsharp
 group.dotnetlegacy.compilerCategories=legacy
@@ -36,20 +41,32 @@ group.dotnetlegacy.groupName=Legacy
 
 # CoreCLR compilers
 
-compiler.dotnet70fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpcoreclr.buildConfig=Release
+compiler.dotnet60fsharpcoreclr.langVersion=latest
+
+compiler.dotnet70fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70fsharpcoreclr.buildConfig=Release
 compiler.dotnet70fsharpcoreclr.langVersion=latest
 
-compiler.dotnet80fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80fsharpcoreclr.buildConfig=Release
 compiler.dotnet80fsharpcoreclr.langVersion=latest
 
+compiler.dotnet90fsharpcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90fsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpcoreclr.buildConfig=Release
+compiler.dotnet90fsharpcoreclr.langVersion=latest
+
 compiler.dotnettrunkfsharpcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkfsharpcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkfsharpcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcoreclr.buildConfig=Release
 compiler.dotnettrunkfsharpcoreclr.langVersion=preview
@@ -57,26 +74,32 @@ compiler.dotnettrunkfsharpcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60fsharpcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60fsharpcrossgen2.buildConfig=Release
 compiler.dotnet60fsharpcrossgen2.langVersion=latest
 
-compiler.dotnet70fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70fsharpcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70fsharpcrossgen2.buildConfig=Release
 compiler.dotnet70fsharpcrossgen2.langVersion=latest
 
-compiler.dotnet80fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80fsharpcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80fsharpcrossgen2.buildConfig=Release
 compiler.dotnet80fsharpcrossgen2.langVersion=latest
 
+compiler.dotnet90fsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90fsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpcrossgen2.buildConfig=Release
+compiler.dotnet90fsharpcrossgen2.langVersion=latest
+
 compiler.dotnettrunkfsharpcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkfsharpcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkfsharpcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpcrossgen2.buildConfig=Release
 compiler.dotnettrunkfsharpcrossgen2.langVersion=preview
@@ -84,8 +107,32 @@ compiler.dotnettrunkfsharpcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60fsharpmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpmono.name=.NET 6.0 Mono
+compiler.dotnet60fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpmono.buildConfig=Release
+compiler.dotnet60fsharpmono.langVersion=latest
+
+compiler.dotnet70fsharpmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpmono.name=.NET 7.0 Mono
+compiler.dotnet70fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70fsharpmono.buildConfig=Release
+compiler.dotnet70fsharpmono.langVersion=latest
+
+compiler.dotnet80fsharpmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpmono.name=.NET 8.0 Mono
+compiler.dotnet80fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80fsharpmono.buildConfig=Release
+compiler.dotnet80fsharpmono.langVersion=latest
+
+compiler.dotnet90fsharpmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpmono.name=.NET 9.0 Mono
+compiler.dotnet90fsharpmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpmono.buildConfig=Release
+compiler.dotnet90fsharpmono.langVersion=latest
+
 compiler.dotnettrunkfsharpmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpmono.name=.NET Mono (main)
+compiler.dotnettrunkfsharpmono.name=.NET (main) Mono
 compiler.dotnettrunkfsharpmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpmono.buildConfig=Release
 compiler.dotnettrunkfsharpmono.langVersion=preview
@@ -94,20 +141,71 @@ compiler.dotnettrunkfsharpmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkfsharpnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkfsharpnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkfsharpnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpnativeaot.buildConfig=Release
 compiler.dotnettrunkfsharpnativeaot.langVersion=preview
 compiler.dotnettrunkfsharpnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60fsharpildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpildasm.buildConfig=Release
+compiler.dotnet60fsharpildasm.langVersion=latest
+
+compiler.dotnet70fsharpildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70fsharpildasm.buildConfig=Release
+compiler.dotnet70fsharpildasm.langVersion=latest
+
+compiler.dotnet80fsharpildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80fsharpildasm.buildConfig=Release
+compiler.dotnet80fsharpildasm.langVersion=latest
+
+compiler.dotnet90fsharpildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90fsharpildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpildasm.buildConfig=Release
+compiler.dotnet90fsharpildasm.langVersion=latest
 
 compiler.dotnettrunkfsharpildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkfsharpildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkfsharpildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkfsharpildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkfsharpildasm.buildConfig=Release
 compiler.dotnettrunkfsharpildasm.langVersion=preview
 compiler.dotnettrunkfsharpildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70fsharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70fsharpilspy.name=.NET 7.0 ILSpy
+compiler.dotnet70fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70fsharpilspy.buildConfig=Release
+compiler.dotnet70fsharpilspy.langVersion=latest
+
+compiler.dotnet80fsharpilspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80fsharpilspy.name=.NET 8.0 ILSpy
+compiler.dotnet80fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80fsharpilspy.buildConfig=Release
+compiler.dotnet80fsharpilspy.langVersion=latest
+
+compiler.dotnet90fsharpilspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90fsharpilspy.name=.NET 9.0 ILSpy
+compiler.dotnet90fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90fsharpilspy.buildConfig=Release
+compiler.dotnet90fsharpilspy.langVersion=latest
+
+compiler.dotnettrunkfsharpilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkfsharpilspy.name=.NET (main) ILSpy
+compiler.dotnettrunkfsharpilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkfsharpilspy.buildConfig=Release
+compiler.dotnettrunkfsharpilspy.langVersion=preview
+compiler.dotnettrunkfsharpilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/fsharp.defaults.properties
+++ b/etc/config/fsharp.defaults.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy
+group.dotnetilspy.compilers=dotnettrunkfsharpilspy:dotnet90fsharpilspy:dotnet80fsharpilspy:dotnet70fsharpilspy:dotnet60fsharpilspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -181,6 +181,12 @@ compiler.dotnettrunkfsharpildasm.langVersion=preview
 compiler.dotnettrunkfsharpildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60fsharpilspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60fsharpilspy.name=.NET 6.0 ILSpy
+compiler.dotnet60fsharpilspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60fsharpilspy.buildConfig=Release
+compiler.dotnet60fsharpilspy.langVersion=latest
 
 compiler.dotnet70fsharpilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70fsharpilspy.name=.NET 7.0 ILSpy

--- a/etc/config/il.amazon.properties
+++ b/etc/config/il.amazon.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy:dotnet60ililspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 # CoreCLR compilers

--- a/etc/config/il.amazon.properties
+++ b/etc/config/il.amazon.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80ilcoreclr
+defaultCompiler=dotnet90ilcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkilcoreclr:dotnet80ilcoreclr:dotnet70ilcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkilcoreclr:dotnet90ilcoreclr:dotnet80ilcoreclr:dotnet70ilcoreclr:dotnet60ilcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkilcrossgen2:dotnet80ilcrossgen2:dotnet70ilcrossgen2:dotnet60ilcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkilcrossgen2:dotnet90ilcrossgen2:dotnet80ilcrossgen2:dotnet70ilcrossgen2:dotnet60ilcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkilmono
+group.dotnetmono.compilers=dotnettrunkilmono:dotnet90ilmono:dotnet80ilmono:dotnet70ilmono:dotnet60ilmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,27 +24,44 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkilildasm
+group.dotnetildasm.compilers=dotnettrunkilildasm:dotnet90ilildasm:dotnet80ilildasm:dotnet70ilildasm:dotnet60ilildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 # CoreCLR compilers
 
-compiler.dotnet70ilcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70ilcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60ilcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ilcoreclr.buildConfig=Release
+compiler.dotnet60ilcoreclr.langVersion=latest
+
+compiler.dotnet70ilcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70ilcoreclr.buildConfig=Release
 compiler.dotnet70ilcoreclr.langVersion=latest
 
-compiler.dotnet80ilcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80ilcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80ilcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80ilcoreclr.buildConfig=Release
 compiler.dotnet80ilcoreclr.langVersion=latest
 
+compiler.dotnet90ilcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilcoreclr.buildConfig=Release
+compiler.dotnet90ilcoreclr.langVersion=latest
+
 compiler.dotnettrunkilcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkilcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkilcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilcoreclr.buildConfig=Release
 compiler.dotnettrunkilcoreclr.langVersion=preview
@@ -52,26 +69,32 @@ compiler.dotnettrunkilcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60ilcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60ilcrossgen2.buildConfig=Release
 compiler.dotnet60ilcrossgen2.langVersion=latest
 
-compiler.dotnet70ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70ilcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70ilcrossgen2.buildConfig=Release
 compiler.dotnet70ilcrossgen2.langVersion=latest
 
-compiler.dotnet80ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80ilcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80ilcrossgen2.buildConfig=Release
 compiler.dotnet80ilcrossgen2.langVersion=latest
 
+compiler.dotnet90ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilcrossgen2.buildConfig=Release
+compiler.dotnet90ilcrossgen2.langVersion=latest
+
 compiler.dotnettrunkilcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkilcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilcrossgen2.buildConfig=Release
 compiler.dotnettrunkilcrossgen2.langVersion=preview
@@ -79,8 +102,32 @@ compiler.dotnettrunkilcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60ilmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilmono.name=.NET 6.0 Mono
+compiler.dotnet60ilmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ilmono.buildConfig=Release
+compiler.dotnet60ilmono.langVersion=latest
+
+compiler.dotnet70ilmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilmono.name=.NET 7.0 Mono
+compiler.dotnet70ilmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70ilmono.buildConfig=Release
+compiler.dotnet70ilmono.langVersion=latest
+
+compiler.dotnet80ilmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilmono.name=.NET 8.0 Mono
+compiler.dotnet80ilmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80ilmono.buildConfig=Release
+compiler.dotnet80ilmono.langVersion=latest
+
+compiler.dotnet90ilmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilmono.name=.NET 9.0 Mono
+compiler.dotnet90ilmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilmono.buildConfig=Release
+compiler.dotnet90ilmono.langVersion=latest
+
 compiler.dotnettrunkilmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilmono.name=.NET Mono (main)
+compiler.dotnettrunkilmono.name=.NET (main) Mono
 compiler.dotnettrunkilmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilmono.buildConfig=Release
 compiler.dotnettrunkilmono.langVersion=preview
@@ -89,17 +136,68 @@ compiler.dotnettrunkilmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkilnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkilnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkilnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilnativeaot.buildConfig=Release
 compiler.dotnettrunkilnativeaot.langVersion=preview
 compiler.dotnettrunkilnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60ilildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60ilildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ilildasm.buildConfig=Release
+compiler.dotnet60ilildasm.langVersion=latest
+
+compiler.dotnet70ilildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70ilildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70ilildasm.buildConfig=Release
+compiler.dotnet70ilildasm.langVersion=latest
+
+compiler.dotnet80ilildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80ilildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80ilildasm.buildConfig=Release
+compiler.dotnet80ilildasm.langVersion=latest
+
+compiler.dotnet90ilildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90ilildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilildasm.buildConfig=Release
+compiler.dotnet90ilildasm.langVersion=latest
 
 compiler.dotnettrunkilildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkilildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkilildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilildasm.buildConfig=Release
 compiler.dotnettrunkilildasm.langVersion=preview
 compiler.dotnettrunkilildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70ililspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ililspy.name=.NET 7.0 ILSpy
+compiler.dotnet70ililspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70ililspy.buildConfig=Release
+compiler.dotnet70ililspy.langVersion=latest
+
+compiler.dotnet80ililspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ililspy.name=.NET 8.0 ILSpy
+compiler.dotnet80ililspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80ililspy.buildConfig=Release
+compiler.dotnet80ililspy.langVersion=latest
+
+compiler.dotnet90ililspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ililspy.name=.NET 9.0 ILSpy
+compiler.dotnet90ililspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ililspy.buildConfig=Release
+compiler.dotnet90ililspy.langVersion=latest
+
+compiler.dotnettrunkililspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkililspy.name=.NET (main) ILSpy
+compiler.dotnettrunkililspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkililspy.buildConfig=Release
+compiler.dotnettrunkililspy.langVersion=preview
+compiler.dotnettrunkililspy.isNightly=true

--- a/etc/config/il.amazon.properties
+++ b/etc/config/il.amazon.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy
+group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy:dotnet60ililspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -176,6 +176,12 @@ compiler.dotnettrunkilildasm.langVersion=preview
 compiler.dotnettrunkilildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60ililspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ililspy.name=.NET 6.0 ILSpy
+compiler.dotnet60ililspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ililspy.buildConfig=Release
+compiler.dotnet60ililspy.langVersion=latest
 
 compiler.dotnet70ililspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70ililspy.name=.NET 7.0 ILSpy

--- a/etc/config/il.defaults.properties
+++ b/etc/config/il.defaults.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy:dotnet60ililspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 # CoreCLR compilers

--- a/etc/config/il.defaults.properties
+++ b/etc/config/il.defaults.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80ilcoreclr
+defaultCompiler=dotnet90ilcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkilcoreclr:dotnet80ilcoreclr:dotnet70ilcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkilcoreclr:dotnet90ilcoreclr:dotnet80ilcoreclr:dotnet70ilcoreclr:dotnet60ilcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkilcrossgen2:dotnet80ilcrossgen2:dotnet70ilcrossgen2:dotnet60ilcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkilcrossgen2:dotnet90ilcrossgen2:dotnet80ilcrossgen2:dotnet70ilcrossgen2:dotnet60ilcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkilmono
+group.dotnetmono.compilers=dotnettrunkilmono:dotnet90ilmono:dotnet80ilmono:dotnet70ilmono:dotnet60ilmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,27 +24,44 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkilildasm
+group.dotnetildasm.compilers=dotnettrunkilildasm:dotnet90ilildasm:dotnet80ilildasm:dotnet70ilildasm:dotnet60ilildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 # CoreCLR compilers
 
-compiler.dotnet70ilcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70ilcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60ilcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ilcoreclr.buildConfig=Release
+compiler.dotnet60ilcoreclr.langVersion=latest
+
+compiler.dotnet70ilcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70ilcoreclr.buildConfig=Release
 compiler.dotnet70ilcoreclr.langVersion=latest
 
-compiler.dotnet80ilcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80ilcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80ilcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80ilcoreclr.buildConfig=Release
 compiler.dotnet80ilcoreclr.langVersion=latest
 
+compiler.dotnet90ilcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90ilcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilcoreclr.buildConfig=Release
+compiler.dotnet90ilcoreclr.langVersion=latest
+
 compiler.dotnettrunkilcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkilcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkilcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilcoreclr.buildConfig=Release
 compiler.dotnettrunkilcoreclr.langVersion=preview
@@ -52,26 +69,32 @@ compiler.dotnettrunkilcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60ilcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60ilcrossgen2.buildConfig=Release
 compiler.dotnet60ilcrossgen2.langVersion=latest
 
-compiler.dotnet70ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70ilcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70ilcrossgen2.buildConfig=Release
 compiler.dotnet70ilcrossgen2.langVersion=latest
 
-compiler.dotnet80ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80ilcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80ilcrossgen2.buildConfig=Release
 compiler.dotnet80ilcrossgen2.langVersion=latest
 
+compiler.dotnet90ilcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90ilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilcrossgen2.buildConfig=Release
+compiler.dotnet90ilcrossgen2.langVersion=latest
+
 compiler.dotnettrunkilcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkilcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkilcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilcrossgen2.buildConfig=Release
 compiler.dotnettrunkilcrossgen2.langVersion=preview
@@ -79,8 +102,32 @@ compiler.dotnettrunkilcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60ilmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilmono.name=.NET 6.0 Mono
+compiler.dotnet60ilmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ilmono.buildConfig=Release
+compiler.dotnet60ilmono.langVersion=latest
+
+compiler.dotnet70ilmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilmono.name=.NET 7.0 Mono
+compiler.dotnet70ilmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70ilmono.buildConfig=Release
+compiler.dotnet70ilmono.langVersion=latest
+
+compiler.dotnet80ilmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilmono.name=.NET 8.0 Mono
+compiler.dotnet80ilmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80ilmono.buildConfig=Release
+compiler.dotnet80ilmono.langVersion=latest
+
+compiler.dotnet90ilmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilmono.name=.NET 9.0 Mono
+compiler.dotnet90ilmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilmono.buildConfig=Release
+compiler.dotnet90ilmono.langVersion=latest
+
 compiler.dotnettrunkilmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilmono.name=.NET Mono (main)
+compiler.dotnettrunkilmono.name=.NET (main) Mono
 compiler.dotnettrunkilmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilmono.buildConfig=Release
 compiler.dotnettrunkilmono.langVersion=preview
@@ -89,17 +136,68 @@ compiler.dotnettrunkilmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkilnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkilnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkilnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilnativeaot.buildConfig=Release
 compiler.dotnettrunkilnativeaot.langVersion=preview
 compiler.dotnettrunkilnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60ilildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ilildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60ilildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ilildasm.buildConfig=Release
+compiler.dotnet60ilildasm.langVersion=latest
+
+compiler.dotnet70ilildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ilildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70ilildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70ilildasm.buildConfig=Release
+compiler.dotnet70ilildasm.langVersion=latest
+
+compiler.dotnet80ilildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ilildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80ilildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80ilildasm.buildConfig=Release
+compiler.dotnet80ilildasm.langVersion=latest
+
+compiler.dotnet90ilildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ilildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90ilildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ilildasm.buildConfig=Release
+compiler.dotnet90ilildasm.langVersion=latest
 
 compiler.dotnettrunkilildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkilildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkilildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkilildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkilildasm.buildConfig=Release
 compiler.dotnettrunkilildasm.langVersion=preview
 compiler.dotnettrunkilildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70ililspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70ililspy.name=.NET 7.0 ILSpy
+compiler.dotnet70ililspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70ililspy.buildConfig=Release
+compiler.dotnet70ililspy.langVersion=latest
+
+compiler.dotnet80ililspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80ililspy.name=.NET 8.0 ILSpy
+compiler.dotnet80ililspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80ililspy.buildConfig=Release
+compiler.dotnet80ililspy.langVersion=latest
+
+compiler.dotnet90ililspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90ililspy.name=.NET 9.0 ILSpy
+compiler.dotnet90ililspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90ililspy.buildConfig=Release
+compiler.dotnet90ililspy.langVersion=latest
+
+compiler.dotnettrunkililspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkililspy.name=.NET (main) ILSpy
+compiler.dotnettrunkililspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkililspy.buildConfig=Release
+compiler.dotnettrunkililspy.langVersion=preview
+compiler.dotnettrunkililspy.isNightly=true

--- a/etc/config/il.defaults.properties
+++ b/etc/config/il.defaults.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy
+group.dotnetilspy.compilers=dotnettrunkililspy:dotnet90ililspy:dotnet80ililspy:dotnet70ililspy:dotnet60ililspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -176,6 +176,12 @@ compiler.dotnettrunkilildasm.langVersion=preview
 compiler.dotnettrunkilildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60ililspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60ililspy.name=.NET 6.0 ILSpy
+compiler.dotnet60ililspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60ililspy.buildConfig=Release
+compiler.dotnet60ililspy.langVersion=latest
 
 compiler.dotnet70ililspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70ililspy.name=.NET 7.0 ILSpy

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy:dotnet60vbilspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkvb:dotnet707vb:dotnet703vb:dotnet701vb:dotnet6018vb:dotnet6014vb:dotnet6011vb

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80vbcoreclr
+defaultCompiler=dotnet90vbcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet80vbcoreclr:dotnet70vbcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet90vbcoreclr:dotnet80vbcoreclr:dotnet70vbcoreclr:dotnet60vbcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkvbcrossgen2:dotnet80vbcrossgen2:dotnet70vbcrossgen2:dotnet60vbcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkvbcrossgen2:dotnet90vbcrossgen2:dotnet80vbcrossgen2:dotnet70vbcrossgen2:dotnet60vbcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkvbmono
+group.dotnetmono.compilers=dotnettrunkvbmono:dotnet90vbmono:dotnet80vbmono:dotnet70vbmono:dotnet60vbmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,10 +24,15 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkvbildasm
+group.dotnetildasm.compilers=dotnettrunkvbildasm:dotnet90vbildasm:dotnet80vbildasm:dotnet70vbildasm:dotnet60vbildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkvb:dotnet707vb:dotnet703vb:dotnet701vb:dotnet6018vb:dotnet6014vb:dotnet6011vb
 group.dotnetlegacy.compilerCategories=legacy
@@ -36,20 +41,32 @@ group.dotnetlegacy.groupName=Legacy
 
 # CoreCLR compilers
 
-compiler.dotnet70vbcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60vbcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbcoreclr.buildConfig=Release
+compiler.dotnet60vbcoreclr.langVersion=latest
+
+compiler.dotnet70vbcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70vbcoreclr.buildConfig=Release
 compiler.dotnet70vbcoreclr.langVersion=latest
 
-compiler.dotnet80vbcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80vbcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80vbcoreclr.buildConfig=Release
 compiler.dotnet80vbcoreclr.langVersion=latest
 
+compiler.dotnet90vbcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbcoreclr.buildConfig=Release
+compiler.dotnet90vbcoreclr.langVersion=latest
+
 compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkvbcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
 compiler.dotnettrunkvbcoreclr.langVersion=preview
@@ -57,26 +74,32 @@ compiler.dotnettrunkvbcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60vbcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60vbcrossgen2.buildConfig=Release
 compiler.dotnet60vbcrossgen2.langVersion=latest
 
-compiler.dotnet70vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70vbcrossgen2.buildConfig=Release
 compiler.dotnet70vbcrossgen2.langVersion=latest
 
-compiler.dotnet80vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80vbcrossgen2.buildConfig=Release
 compiler.dotnet80vbcrossgen2.langVersion=latest
 
+compiler.dotnet90vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbcrossgen2.buildConfig=Release
+compiler.dotnet90vbcrossgen2.langVersion=latest
+
 compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkvbcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
 compiler.dotnettrunkvbcrossgen2.langVersion=preview
@@ -84,8 +107,32 @@ compiler.dotnettrunkvbcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60vbmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbmono.name=.NET 6.0 Mono
+compiler.dotnet60vbmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbmono.buildConfig=Release
+compiler.dotnet60vbmono.langVersion=latest
+
+compiler.dotnet70vbmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbmono.name=.NET 7.0 Mono
+compiler.dotnet70vbmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70vbmono.buildConfig=Release
+compiler.dotnet70vbmono.langVersion=latest
+
+compiler.dotnet80vbmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbmono.name=.NET 8.0 Mono
+compiler.dotnet80vbmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80vbmono.buildConfig=Release
+compiler.dotnet80vbmono.langVersion=latest
+
+compiler.dotnet90vbmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbmono.name=.NET 9.0 Mono
+compiler.dotnet90vbmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbmono.buildConfig=Release
+compiler.dotnet90vbmono.langVersion=latest
+
 compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbmono.name=.NET Mono (main)
+compiler.dotnettrunkvbmono.name=.NET (main) Mono
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
 compiler.dotnettrunkvbmono.langVersion=preview
@@ -94,20 +141,71 @@ compiler.dotnettrunkvbmono.isNightly=true
 # NativeAOT compilers
 
 compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkvbnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
 compiler.dotnettrunkvbnativeaot.langVersion=preview
 compiler.dotnettrunkvbnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60vbildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60vbildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbildasm.buildConfig=Release
+compiler.dotnet60vbildasm.langVersion=latest
+
+compiler.dotnet70vbildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70vbildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70vbildasm.buildConfig=Release
+compiler.dotnet70vbildasm.langVersion=latest
+
+compiler.dotnet80vbildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80vbildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80vbildasm.buildConfig=Release
+compiler.dotnet80vbildasm.langVersion=latest
+
+compiler.dotnet90vbildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90vbildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbildasm.buildConfig=Release
+compiler.dotnet90vbildasm.langVersion=latest
 
 compiler.dotnettrunkvbildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkvbildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkvbildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbildasm.buildConfig=Release
 compiler.dotnettrunkvbildasm.langVersion=preview
 compiler.dotnettrunkvbildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70vbilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbilspy.name=.NET 7.0 ILSpy
+compiler.dotnet70vbilspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70vbilspy.buildConfig=Release
+compiler.dotnet70vbilspy.langVersion=latest
+
+compiler.dotnet80vbilspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbilspy.name=.NET 8.0 ILSpy
+compiler.dotnet80vbilspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80vbilspy.buildConfig=Release
+compiler.dotnet80vbilspy.langVersion=latest
+
+compiler.dotnet90vbilspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbilspy.name=.NET 9.0 ILSpy
+compiler.dotnet90vbilspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbilspy.buildConfig=Release
+compiler.dotnet90vbilspy.langVersion=latest
+
+compiler.dotnettrunkvbilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvbilspy.name=.NET (main) ILSpy
+compiler.dotnettrunkvbilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvbilspy.buildConfig=Release
+compiler.dotnettrunkvbilspy.langVersion=preview
+compiler.dotnettrunkvbilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -69,7 +69,7 @@ compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/do
 compiler.dotnettrunkvbcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
-compiler.dotnettrunkvbcoreclr.langVersion=preview
+compiler.dotnettrunkvbcoreclr.langVersion=latest
 compiler.dotnettrunkvbcoreclr.isNightly=true
 
 # Crossgen2 compilers
@@ -102,7 +102,7 @@ compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/
 compiler.dotnettrunkvbcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
-compiler.dotnettrunkvbcrossgen2.langVersion=preview
+compiler.dotnettrunkvbcrossgen2.langVersion=latest
 compiler.dotnettrunkvbcrossgen2.isNightly=true
 
 # Mono compilers
@@ -135,7 +135,7 @@ compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotne
 compiler.dotnettrunkvbmono.name=.NET (main) Mono
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
-compiler.dotnettrunkvbmono.langVersion=preview
+compiler.dotnettrunkvbmono.langVersion=latest
 compiler.dotnettrunkvbmono.isNightly=true
 
 # NativeAOT compilers
@@ -144,7 +144,7 @@ compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/
 compiler.dotnettrunkvbnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
-compiler.dotnettrunkvbnativeaot.langVersion=preview
+compiler.dotnettrunkvbnativeaot.langVersion=latest
 compiler.dotnettrunkvbnativeaot.isNightly=true
 
 # ILDasm compilers
@@ -177,7 +177,7 @@ compiler.dotnettrunkvbildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dot
 compiler.dotnettrunkvbildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkvbildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbildasm.buildConfig=Release
-compiler.dotnettrunkvbildasm.langVersion=preview
+compiler.dotnettrunkvbildasm.langVersion=latest
 compiler.dotnettrunkvbildasm.isNightly=true
 
 # ILSpy compilers
@@ -204,7 +204,7 @@ compiler.dotnettrunkvbilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotn
 compiler.dotnettrunkvbilspy.name=.NET (main) ILSpy
 compiler.dotnettrunkvbilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbilspy.buildConfig=Release
-compiler.dotnettrunkvbilspy.langVersion=preview
+compiler.dotnettrunkvbilspy.langVersion=latest
 compiler.dotnettrunkvbilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
@@ -249,5 +249,5 @@ compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvb.buildConfig=Release
-compiler.dotnettrunkvb.langVersion=preview
+compiler.dotnettrunkvb.langVersion=latest
 compiler.dotnettrunkvb.isNightly=true

--- a/etc/config/vb.amazon.properties
+++ b/etc/config/vb.amazon.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy
+group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy:dotnet60vbilspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -181,6 +181,12 @@ compiler.dotnettrunkvbildasm.langVersion=latest
 compiler.dotnettrunkvbildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60vbilspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbilspy.name=.NET 6.0 ILSpy
+compiler.dotnet60vbilspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbilspy.buildConfig=Release
+compiler.dotnet60vbilspy.langVersion=latest
 
 compiler.dotnet70vbilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70vbilspy.name=.NET 7.0 ILSpy

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -30,8 +30,8 @@ group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
 group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy:dotnet60vbilspy
-group.dotnetilspy.compilerCategories=ildasm
-group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.compilerCategories=ilspy
+group.dotnetilspy.compilerType=dotnetilspy
 group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkvb:dotnet707vb:dotnet703vb:dotnet701vb:dotnet6018vb:dotnet6014vb:dotnet6011vb

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -69,7 +69,7 @@ compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/do
 compiler.dotnettrunkvbcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
-compiler.dotnettrunkvbcoreclr.langVersion=preview
+compiler.dotnettrunkvbcoreclr.langVersion=latest
 compiler.dotnettrunkvbcoreclr.isNightly=true
 
 # Crossgen2 compilers
@@ -102,7 +102,7 @@ compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/
 compiler.dotnettrunkvbcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
-compiler.dotnettrunkvbcrossgen2.langVersion=preview
+compiler.dotnettrunkvbcrossgen2.langVersion=latest
 compiler.dotnettrunkvbcrossgen2.isNightly=true
 
 # Mono compilers
@@ -135,7 +135,7 @@ compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotne
 compiler.dotnettrunkvbmono.name=.NET (main) Mono
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
-compiler.dotnettrunkvbmono.langVersion=preview
+compiler.dotnettrunkvbmono.langVersion=latest
 compiler.dotnettrunkvbmono.isNightly=true
 
 # NativeAOT compilers
@@ -144,7 +144,7 @@ compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/
 compiler.dotnettrunkvbnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
-compiler.dotnettrunkvbnativeaot.langVersion=preview
+compiler.dotnettrunkvbnativeaot.langVersion=latest
 compiler.dotnettrunkvbnativeaot.isNightly=true
 
 # ILDasm compilers
@@ -177,7 +177,7 @@ compiler.dotnettrunkvbildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dot
 compiler.dotnettrunkvbildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkvbildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbildasm.buildConfig=Release
-compiler.dotnettrunkvbildasm.langVersion=preview
+compiler.dotnettrunkvbildasm.langVersion=latest
 compiler.dotnettrunkvbildasm.isNightly=true
 
 # ILSpy compilers
@@ -204,7 +204,7 @@ compiler.dotnettrunkvbilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotn
 compiler.dotnettrunkvbilspy.name=.NET (main) ILSpy
 compiler.dotnettrunkvbilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbilspy.buildConfig=Release
-compiler.dotnettrunkvbilspy.langVersion=preview
+compiler.dotnettrunkvbilspy.langVersion=latest
 compiler.dotnettrunkvbilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
@@ -249,5 +249,5 @@ compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvb.buildConfig=Release
-compiler.dotnettrunkvb.langVersion=preview
+compiler.dotnettrunkvb.langVersion=latest
 compiler.dotnettrunkvb.isNightly=true

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -29,7 +29,7 @@ group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
 group.dotnetildasm.groupName=.NET ILDasm
 
-group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy
+group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy:dotnet60vbilspy
 group.dotnetilspy.compilerCategories=ildasm
 group.dotnetilspy.compilerType=dotnetildasm
 group.dotnetilspy.groupName=.NET ILSpy
@@ -181,6 +181,12 @@ compiler.dotnettrunkvbildasm.langVersion=latest
 compiler.dotnettrunkvbildasm.isNightly=true
 
 # ILSpy compilers
+
+compiler.dotnet60vbilspy.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbilspy.name=.NET 6.0 ILSpy
+compiler.dotnet60vbilspy.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbilspy.buildConfig=Release
+compiler.dotnet60vbilspy.langVersion=latest
 
 compiler.dotnet70vbilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
 compiler.dotnet70vbilspy.name=.NET 7.0 ILSpy

--- a/etc/config/vb.defaults.properties
+++ b/etc/config/vb.defaults.properties
@@ -1,20 +1,20 @@
-compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetlegacy
+compilers=&dotnetcoreclr:&dotnetcrossgen2:&dotnetmono:&dotnetnativeaot:&dotnetildasm:&dotnetilspy:&dotnetlegacy
 supportsBinary=true
 needsMulti=false
-defaultCompiler=dotnet80vbcoreclr
+defaultCompiler=dotnet90vbcoreclr
 executionEnvironmentClass=local-dotnet
 
-group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet80vbcoreclr:dotnet70vbcoreclr
+group.dotnetcoreclr.compilers=dotnettrunkvbcoreclr:dotnet90vbcoreclr:dotnet80vbcoreclr:dotnet70vbcoreclr:dotnet60vbcoreclr
 group.dotnetcoreclr.compilerCategories=coreclr
 group.dotnetcoreclr.compilerType=dotnetcoreclr
 group.dotnetcoreclr.groupName=.NET CoreCLR
 
-group.dotnetcrossgen2.compilers=dotnettrunkvbcrossgen2:dotnet80vbcrossgen2:dotnet70vbcrossgen2:dotnet60vbcrossgen2
+group.dotnetcrossgen2.compilers=dotnettrunkvbcrossgen2:dotnet90vbcrossgen2:dotnet80vbcrossgen2:dotnet70vbcrossgen2:dotnet60vbcrossgen2
 group.dotnetcrossgen2.compilerCategories=crossgen2
 group.dotnetcrossgen2.compilerType=dotnetcrossgen2
 group.dotnetcrossgen2.groupName=.NET Crossgen2
 
-group.dotnetmono.compilers=dotnettrunkvbmono
+group.dotnetmono.compilers=dotnettrunkvbmono:dotnet90vbmono:dotnet80vbmono:dotnet70vbmono:dotnet60vbmono
 group.dotnetmono.compilerCategories=mono
 group.dotnetmono.compilerType=dotnetmono
 group.dotnetmono.groupName=.NET Mono
@@ -24,10 +24,15 @@ group.dotnetnativeaot.compilerCategories=nativeaot
 group.dotnetnativeaot.compilerType=dotnetnativeaot
 group.dotnetnativeaot.groupName=.NET NativeAOT
 
-group.dotnetildasm.compilers=dotnettrunkvbildasm
+group.dotnetildasm.compilers=dotnettrunkvbildasm:dotnet90vbildasm:dotnet80vbildasm:dotnet70vbildasm:dotnet60vbildasm
 group.dotnetildasm.compilerCategories=ildasm
 group.dotnetildasm.compilerType=dotnetildasm
-group.dotnetildasm.groupName=.NET IL Disassembler
+group.dotnetildasm.groupName=.NET ILDasm
+
+group.dotnetilspy.compilers=dotnettrunkvbilspy:dotnet90vbilspy:dotnet80vbilspy:dotnet70vbilspy
+group.dotnetilspy.compilerCategories=ildasm
+group.dotnetilspy.compilerType=dotnetildasm
+group.dotnetilspy.groupName=.NET ILSpy
 
 group.dotnetlegacy.compilers=dotnettrunkvb:dotnet707vb:dotnet703vb:dotnet701vb:dotnet6018vb:dotnet6014vb:dotnet6011vb
 group.dotnetlegacy.compilerCategories=legacy
@@ -36,78 +41,171 @@ group.dotnetlegacy.groupName=Legacy
 
 # CoreCLR compilers
 
-compiler.dotnet70vbcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcoreclr.name=.NET CoreCLR 7.0
-compiler.dotnet70vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet60vbcoreclr.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbcoreclr.name=.NET 6.0 CoreCLR
+compiler.dotnet60vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbcoreclr.buildConfig=Release
+compiler.dotnet60vbcoreclr.langVersion=latest
+
+compiler.dotnet70vbcoreclr.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbcoreclr.name=.NET 7.0 CoreCLR
+compiler.dotnet70vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70vbcoreclr.buildConfig=Release
 compiler.dotnet70vbcoreclr.langVersion=latest
 
-compiler.dotnet80vbcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcoreclr.name=.NET CoreCLR 8.0
-compiler.dotnet80vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80vbcoreclr.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbcoreclr.name=.NET 8.0 CoreCLR
+compiler.dotnet80vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80vbcoreclr.buildConfig=Release
 compiler.dotnet80vbcoreclr.langVersion=latest
 
+compiler.dotnet90vbcoreclr.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbcoreclr.name=.NET 9.0 CoreCLR
+compiler.dotnet90vbcoreclr.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbcoreclr.buildConfig=Release
+compiler.dotnet90vbcoreclr.langVersion=latest
+
 compiler.dotnettrunkvbcoreclr.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcoreclr.name=.NET CoreCLR (main)
+compiler.dotnettrunkvbcoreclr.name=.NET (main) CoreCLR
 compiler.dotnettrunkvbcoreclr.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcoreclr.buildConfig=Release
-compiler.dotnettrunkvbcoreclr.langVersion=latest
+compiler.dotnettrunkvbcoreclr.langVersion=preview
 compiler.dotnettrunkvbcoreclr.isNightly=true
 
 # Crossgen2 compilers
 
-compiler.dotnet60vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.30/.dotnet/dotnet
-compiler.dotnet60vbcrossgen2.name=.NET Crossgen2 6.0
-compiler.dotnet60vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.30
+compiler.dotnet60vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbcrossgen2.name=.NET 6.0 Crossgen2
+compiler.dotnet60vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
 compiler.dotnet60vbcrossgen2.buildConfig=Release
 compiler.dotnet60vbcrossgen2.langVersion=latest
 
-compiler.dotnet70vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.19/.dotnet/dotnet
-compiler.dotnet70vbcrossgen2.name=.NET Crossgen2 7.0
-compiler.dotnet70vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.19
+compiler.dotnet70vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbcrossgen2.name=.NET 7.0 Crossgen2
+compiler.dotnet70vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
 compiler.dotnet70vbcrossgen2.buildConfig=Release
 compiler.dotnet70vbcrossgen2.langVersion=latest
 
-compiler.dotnet80vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.5/.dotnet/dotnet
-compiler.dotnet80vbcrossgen2.name=.NET Crossgen2 8.0
-compiler.dotnet80vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.5
+compiler.dotnet80vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbcrossgen2.name=.NET 8.0 Crossgen2
+compiler.dotnet80vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
 compiler.dotnet80vbcrossgen2.buildConfig=Release
 compiler.dotnet80vbcrossgen2.langVersion=latest
 
+compiler.dotnet90vbcrossgen2.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbcrossgen2.name=.NET 9.0 Crossgen2
+compiler.dotnet90vbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbcrossgen2.buildConfig=Release
+compiler.dotnet90vbcrossgen2.langVersion=latest
+
 compiler.dotnettrunkvbcrossgen2.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbcrossgen2.name=.NET Crossgen2 (main)
+compiler.dotnettrunkvbcrossgen2.name=.NET (main) Crossgen2
 compiler.dotnettrunkvbcrossgen2.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbcrossgen2.buildConfig=Release
-compiler.dotnettrunkvbcrossgen2.langVersion=latest
+compiler.dotnettrunkvbcrossgen2.langVersion=preview
 compiler.dotnettrunkvbcrossgen2.isNightly=true
 
 # Mono compilers
 
+compiler.dotnet60vbmono.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbmono.name=.NET 6.0 Mono
+compiler.dotnet60vbmono.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbmono.buildConfig=Release
+compiler.dotnet60vbmono.langVersion=latest
+
+compiler.dotnet70vbmono.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbmono.name=.NET 7.0 Mono
+compiler.dotnet70vbmono.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70vbmono.buildConfig=Release
+compiler.dotnet70vbmono.langVersion=latest
+
+compiler.dotnet80vbmono.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbmono.name=.NET 8.0 Mono
+compiler.dotnet80vbmono.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80vbmono.buildConfig=Release
+compiler.dotnet80vbmono.langVersion=latest
+
+compiler.dotnet90vbmono.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbmono.name=.NET 9.0 Mono
+compiler.dotnet90vbmono.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbmono.buildConfig=Release
+compiler.dotnet90vbmono.langVersion=latest
+
 compiler.dotnettrunkvbmono.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbmono.name=.NET Mono (main)
+compiler.dotnettrunkvbmono.name=.NET (main) Mono
 compiler.dotnettrunkvbmono.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbmono.buildConfig=Release
-compiler.dotnettrunkvbmono.langVersion=latest
+compiler.dotnettrunkvbmono.langVersion=preview
 compiler.dotnettrunkvbmono.isNightly=true
 
 # NativeAOT compilers
 
 compiler.dotnettrunkvbnativeaot.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbnativeaot.name=.NET NativeAOT (main)
+compiler.dotnettrunkvbnativeaot.name=.NET (main) NativeAOT
 compiler.dotnettrunkvbnativeaot.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbnativeaot.buildConfig=Release
-compiler.dotnettrunkvbnativeaot.langVersion=latest
+compiler.dotnettrunkvbnativeaot.langVersion=preview
 compiler.dotnettrunkvbnativeaot.isNightly=true
 
-# IL disassembler compilers
+# ILDasm compilers
+
+compiler.dotnet60vbildasm.exe=/opt/compiler-explorer/dotnet-v6.0.36/.dotnet/dotnet
+compiler.dotnet60vbildasm.name=.NET 6.0 ILDasm
+compiler.dotnet60vbildasm.clrDir=/opt/compiler-explorer/dotnet-v6.0.36
+compiler.dotnet60vbildasm.buildConfig=Release
+compiler.dotnet60vbildasm.langVersion=latest
+
+compiler.dotnet70vbildasm.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbildasm.name=.NET 7.0 ILDasm
+compiler.dotnet70vbildasm.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70vbildasm.buildConfig=Release
+compiler.dotnet70vbildasm.langVersion=latest
+
+compiler.dotnet80vbildasm.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbildasm.name=.NET 8.0 ILDasm
+compiler.dotnet80vbildasm.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80vbildasm.buildConfig=Release
+compiler.dotnet80vbildasm.langVersion=latest
+
+compiler.dotnet90vbildasm.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbildasm.name=.NET 9.0 ILDasm
+compiler.dotnet90vbildasm.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbildasm.buildConfig=Release
+compiler.dotnet90vbildasm.langVersion=latest
 
 compiler.dotnettrunkvbildasm.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
-compiler.dotnettrunkvbildasm.name=.NET IL Disassembler (main)
+compiler.dotnettrunkvbildasm.name=.NET (main) ILDasm
 compiler.dotnettrunkvbildasm.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvbildasm.buildConfig=Release
-compiler.dotnettrunkvbildasm.langVersion=latest
+compiler.dotnettrunkvbildasm.langVersion=preview
 compiler.dotnettrunkvbildasm.isNightly=true
+
+# ILSpy compilers
+
+compiler.dotnet70vbilspy.exe=/opt/compiler-explorer/dotnet-v7.0.20/.dotnet/dotnet
+compiler.dotnet70vbilspy.name=.NET 7.0 ILSpy
+compiler.dotnet70vbilspy.clrDir=/opt/compiler-explorer/dotnet-v7.0.20
+compiler.dotnet70vbilspy.buildConfig=Release
+compiler.dotnet70vbilspy.langVersion=latest
+
+compiler.dotnet80vbilspy.exe=/opt/compiler-explorer/dotnet-v8.0.11/.dotnet/dotnet
+compiler.dotnet80vbilspy.name=.NET 8.0 ILSpy
+compiler.dotnet80vbilspy.clrDir=/opt/compiler-explorer/dotnet-v8.0.11
+compiler.dotnet80vbilspy.buildConfig=Release
+compiler.dotnet80vbilspy.langVersion=latest
+
+compiler.dotnet90vbilspy.exe=/opt/compiler-explorer/dotnet-v9.0.0/.dotnet/dotnet
+compiler.dotnet90vbilspy.name=.NET 9.0 ILSpy
+compiler.dotnet90vbilspy.clrDir=/opt/compiler-explorer/dotnet-v9.0.0
+compiler.dotnet90vbilspy.buildConfig=Release
+compiler.dotnet90vbilspy.langVersion=latest
+
+compiler.dotnettrunkvbilspy.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
+compiler.dotnettrunkvbilspy.name=.NET (main) ILSpy
+compiler.dotnettrunkvbilspy.clrDir=/opt/compiler-explorer/dotnet-trunk
+compiler.dotnettrunkvbilspy.buildConfig=Release
+compiler.dotnettrunkvbilspy.langVersion=preview
+compiler.dotnettrunkvbilspy.isNightly=true
 
 # Legacy compilers (for backwards compatibility, don't add new compilers here)
 
@@ -151,5 +249,5 @@ compiler.dotnettrunkvb.exe=/opt/compiler-explorer/dotnet-trunk/.dotnet/dotnet
 compiler.dotnettrunkvb.name=.NET (main)
 compiler.dotnettrunkvb.clrDir=/opt/compiler-explorer/dotnet-trunk
 compiler.dotnettrunkvb.buildConfig=Release
-compiler.dotnettrunkvb.langVersion=latest
+compiler.dotnettrunkvb.langVersion=preview
 compiler.dotnettrunkvb.isNightly=true

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -57,6 +57,7 @@ export {
     DotNetCoreClrCompiler,
     DotNetCrossgen2Compiler,
     DotNetIlDasmCompiler,
+    DotNetIlSpyCompiler,
     DotNetLegacyCompiler,
     DotNetMonoCompiler,
     DotNetNativeAotCompiler,

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -738,6 +738,7 @@ do()
                 toolOptions,
                 toolSwitches,
                 this.getOutputFilename(programDir, this.outputFilebase),
+                compilerInfo.sdkMajorVersion <= 6,
             );
 
             if (ilSpyResult.code !== 0) {
@@ -854,6 +855,7 @@ do()
         toolOptions: string[],
         toolSwitches: string[],
         outputPath: string,
+        useDotNetHost: boolean,
     ) {
         const ilspyRoot = path.join(this.toolsPath, 'ilspycmd');
         const ilspyVersionDirs = await fs.readdir(ilspyRoot);
@@ -865,8 +867,8 @@ do()
 
         // prettier-ignore
         const ilspyOptions = [ilspyPath, dllPath, '--disable-updatecheck'].concat(toolOptions).concat(toolSwitches);
-
-        const compilerExecResult = await this.exec(this.corerunPath, ilspyOptions, execOptions);
+        const compilerPath = useDotNetHost ? this.compiler.exe : this.corerunPath;
+        const compilerExecResult = await this.exec(compilerPath, ilspyOptions, execOptions);
         const result = this.transformToCompilationResult(compilerExecResult, dllPath);
 
         await fs.writeFile(

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -51,6 +51,7 @@ class DotNetCompiler extends BaseCompiler {
     private readonly crossgen2Path: string;
     private readonly ilcPath: string;
     private readonly ildasmPath: string;
+    private readonly toolsPath: string;
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(compilerInfo, env);
@@ -65,6 +66,7 @@ class DotNetCompiler extends BaseCompiler {
         this.crossgen2Path = path.join(this.clrBuildDir, 'crossgen2', 'crossgen2');
         this.ilcPath = path.join(this.clrBuildDir, 'ilc-published', 'ilc');
         this.ildasmPath = path.join(this.clrBuildDir, 'ildasm');
+        this.toolsPath = path.join(this.clrBuildDir, 'dotnet-tools', '.store');
 
         this.asm = new DotNetAsmParser();
         this.disassemblyLoaderPath = path.join(this.clrBuildDir, 'DisassemblyLoader', 'DisassemblyLoader.dll');
@@ -271,7 +273,7 @@ class DotNetCompiler extends BaseCompiler {
                 break;
             }
             case 'il': {
-                compilerResult = await this.runIlasm(
+                compilerResult = await this.runIlAsm(
                     compilerInfo.compilerPath,
                     inputFilename,
                     outputFilename,
@@ -562,7 +564,7 @@ do()
         return await super.runCompiler(dotnetPath, [compilerInfo.compilerPath, ...options], inputFilename, execOptions);
     }
 
-    async runIlasm(
+    async runIlAsm(
         ilasmPath: string,
         inputFilename: string,
         outputFilename: string,
@@ -607,7 +609,8 @@ do()
         const programDllPath = path.join(programOutputPath, 'CompilerExplorer.dll');
         const envVarFileContents = ['DOTNET_EnableWriteXorExecute=0'];
         const isIlDasm = this.compiler.group === 'dotnetildasm';
-        const toolOptions: string[] = isIlDasm ? [] : ['--parallelism', '1'];
+        const isIlSpy = this.compiler.group === 'dotnetilspy';
+        const toolOptions: string[] = isIlDasm || isIlSpy ? [] : ['--parallelism', '1'];
         const toolSwitches: string[] = [];
 
         let overrideDiffable = false;
@@ -678,7 +681,7 @@ do()
             }
         }
 
-        if (!isIlDasm) {
+        if (!isIlDasm && !isIlSpy) {
             if (!overrideDiffable) {
                 if (compilerInfo.sdkMajorVersion < 8) {
                     toolOptions.push('--codegenopt', 'JitDiffableDasm=1');
@@ -728,6 +731,18 @@ do()
             if (ilDasmResult.code !== 0) {
                 return ilDasmResult;
             }
+        } else if (isIlSpy) {
+            const ilSpyResult = await this.runIlSpy(
+                execOptions,
+                programDllPath,
+                toolOptions,
+                toolSwitches,
+                this.getOutputFilename(programDir, this.outputFilebase),
+            );
+
+            if (ilSpyResult.code !== 0) {
+                return ilSpyResult;
+            }
         } else if (isCrossgen2) {
             const crossgen2Result = await this.runCrossgen2(
                 compiler,
@@ -758,17 +773,15 @@ do()
                 return ilcResult;
             }
         } else {
-            const envVarFilePath = path.join(programDir, '.env');
-            await fs.writeFile(envVarFilePath, envVarFileContents.join('\n'));
-
             const corerunResult = await this.runCorerunForDisasm(
                 execOptions,
                 this.clrBuildDir,
-                envVarFilePath,
+                envVarFileContents,
                 programDllPath,
                 corerunArgs,
                 this.getOutputFilename(programDir, this.outputFilebase),
                 isMono,
+                compilerInfo.sdkMajorVersion >= 7,
             );
 
             if (corerunResult.code !== 0) {
@@ -794,29 +807,71 @@ do()
     }
 
     async runCorerunForDisasm(
-        execOptions: ExecutionOptions,
+        execOptions: ExecutionOptionsWithEnv,
         coreRoot: string,
-        envPath: string,
+        envVars: string[],
         dllPath: string,
         options: string[],
         outputPath: string,
         isMono: boolean,
+        useEnvFile: boolean,
     ) {
         if (isMono) {
             coreRoot = path.join(coreRoot, 'mono');
         }
 
-        const corerunOptions = ['--clr-path', coreRoot, '--env', envPath].concat([
-            ...options,
-            this.disassemblyLoaderPath,
-            dllPath,
-        ]);
+        const corerunOptions = ['--clr-path', coreRoot].concat([...options, this.disassemblyLoaderPath, dllPath]);
+
+        if (useEnvFile) {
+            const envVarFilePath = path.join(path.dirname(outputPath), '.env');
+            await fs.writeFile(envVarFilePath, envVars.join('\n'));
+            corerunOptions.splice(0, 0, '--env', envVarFilePath);
+        } else {
+            for (const env of envVars) {
+                const delimiterIndex = env.indexOf('=');
+                if (delimiterIndex !== -1) {
+                    execOptions.env[env.substring(0, delimiterIndex)] = env.substring(delimiterIndex + 1);
+                }
+            }
+        }
+
         const compilerExecResult = await this.exec(this.corerunPath, corerunOptions, execOptions);
         const result = this.transformToCompilationResult(compilerExecResult, dllPath);
 
         await fs.writeFile(
             outputPath,
             `// ${isMono ? 'mono' : 'coreclr'} ${await this.getRuntimeVersion()}\n\n${result.stdout
+                .map(o => o.text)
+                .reduce((a, n) => `${a}\n${n}`, '')}`,
+        );
+
+        return result;
+    }
+
+    async runIlSpy(
+        execOptions: ExecutionOptions,
+        dllPath: string,
+        toolOptions: string[],
+        toolSwitches: string[],
+        outputPath: string,
+    ) {
+        const ilspyRoot = path.join(this.toolsPath, 'ilspycmd');
+        const ilspyVersionDirs = await fs.readdir(ilspyRoot);
+        const ilspyVersion = ilspyVersionDirs[0];
+        const ilspyToolsDir = path.join(ilspyRoot, ilspyVersion, 'ilspycmd', ilspyVersion, 'tools');
+        const targetFrameworkDirs = await fs.readdir(ilspyToolsDir);
+        const targetFramework = targetFrameworkDirs[0];
+        const ilspyPath = path.join(ilspyToolsDir, targetFramework, 'any', 'ilspycmd.dll');
+
+        // prettier-ignore
+        const ilspyOptions = [ilspyPath, dllPath, '--disable-updatecheck'].concat(toolOptions).concat(toolSwitches);
+
+        const compilerExecResult = await this.exec(this.corerunPath, ilspyOptions, execOptions);
+        const result = this.transformToCompilationResult(compilerExecResult, dllPath);
+
+        await fs.writeFile(
+            outputPath,
+            `// ilspy ${await this.getRuntimeVersion()}\n\n${result.stdout
                 .map(o => o.text)
                 .reduce((a, n) => `${a}\n${n}`, '')}`,
         );
@@ -998,6 +1053,12 @@ export class DotNetNativeAotCompiler extends DotNetCompiler {
 export class DotNetIlDasmCompiler extends DotNetCompiler {
     static get key() {
         return 'dotnetildasm';
+    }
+}
+
+export class DotNetIlSpyCompiler extends DotNetCompiler {
+    static get key() {
+        return 'dotnetilspy';
     }
 }
 


### PR DESCRIPTION
- Adding support for .NET 9.0
- Adding support for ILSpy
- Make some changes to the compiler name so that the meaning of the version is more cleared
- Adding missing compilers for existing .NET versions

cc: @mattgodbolt 