### PR TITLE
Add Bluesky to link sharing options and other menu

### DIFF
--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -58,6 +58,16 @@ const shareServices = {
         },
         text: 'Tweet',
     },
+    bluesky: {
+        embedValid: false,
+        logoClass: 'fab fa-bluesky',
+        cssClass: 'share-bluesky',
+        getLink: (title: string, url: string) => {
+            const text = `${title} ${url} via @compiler-explorer.com`;
+            return `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`;
+        },
+        text: 'Share on Bluesky',
+    },
     reddit: {
         embedValid: false,
         logoClass: 'fab fa-reddit',

--- a/static/styles/themes/dark-theme.scss
+++ b/static/styles/themes/dark-theme.scss
@@ -566,6 +566,11 @@ textarea.form-control {
     color: white !important;
 }
 
+.share-bluesky {
+    background-color: #0a7aff !important;
+    color: white !important;
+}
+
 #simplecook {
     background-color: #474747 !important;
 }

--- a/static/styles/themes/default-theme.scss
+++ b/static/styles/themes/default-theme.scss
@@ -259,6 +259,12 @@ a.navbar-brand img.logo.normal {
     color: white;
 }
 
+#socialshare .share-bluesky,
+.share-bluesky {
+    background-color: #0a7aff;
+    color: white;
+}
+
 #socialshare .share-reddit,
 .share-reddit {
     background-color: #ff4500;

--- a/static/styles/themes/one-dark-theme.scss
+++ b/static/styles/themes/one-dark-theme.scss
@@ -622,6 +622,11 @@ textarea.form-control {
     color: #eee !important;
 }
 
+.share-bluesky {
+    background-color: #0a7aff !important;
+    color: #eee !important;
+}
+
 #simplecook {
     background-color: #474747 !important;
 }

--- a/static/styles/themes/pink-theme.scss
+++ b/static/styles/themes/pink-theme.scss
@@ -586,6 +586,11 @@ textarea.form-control {
     color: white !important;
 }
 
+.share-bluesky {
+    background-color: #0a7aff !important;
+    color: white !important;
+}
+
 #simplecook {
     background-color: #474747 !important;
 }

--- a/views/menu-other.pug
+++ b/views/menu-other.pug
@@ -43,6 +43,10 @@ a.dropdown-item(href="https://hachyderm.io/@compiler_explorer" rel="me noopener"
     span.dropdown-icon.fas.fa-paper-plane
     | CE on Mastodon
     | &nbsp;
+a.dropdown-item(href="https://bsky.app/profile/compiler-explorer.com" rel="noopener")
+    span.dropdown-icon.fab.fa-bluesky
+    | CE on Bluesky
+    | &nbsp;
 a.dropdown-item(href="https://xania.org/MattGodbolt" rel="author" target="_blank")
     span.dropdown-icon.fas.fa-address-card
     | About the author


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Adds intent link for sharing a Compiler Explorer link to Bluesky. Also adds a link to the [Compiler Explorer Bluesky profile](https://bsky.app/profile/compiler-explorer.com) into the `Other` menu.

<details>
<summary><b>Screenshots of the new links:</b></summary>
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/2db4a9ee-a0db-4b32-b317-a671d4744b24">
<img width="244" alt="image" src="https://github.com/user-attachments/assets/5ebcee95-00b8-4219-b057-842f431bed92">

Shared post
<img width="628" alt="image" src="https://github.com/user-attachments/assets/57f8c264-5590-4cef-ad00-215af5008512">
</details>

I added the `via @compiler-explorer.com` to be the same as twitter, but since bsky does not fully support tagging yet, it gives the user a dropdown to select the compiler explorer user, which seems kinda janky. I left it in for now, but can remove it until bsky supports tagging automatically.

