### PR TITLE
.NET: Set languageId for ILSpy

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -797,6 +797,14 @@ do()
         return [];
     }
 
+    override postCompilationPreCacheHook(result: CompilationResult): CompilationResult {
+        const isIlSpy = this.compiler.group === 'dotnetilspy';
+        if (isIlSpy && result.code === 0) {
+            result.languageId = 'csharp';
+        }
+        return result;
+    }
+
     async getRuntimeVersion() {
         const versionFilePath = `${this.clrBuildDir}/version.txt`;
         if (fs.existsSync(versionFilePath)) {


### PR DESCRIPTION
The compile result of ILSpy is C# code, so use `csharp` for highlighting. 