### PR TITLE
Allow passing --help to compilers

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -173,6 +173,7 @@ class DotNetCompiler extends BaseCompiler {
             '--noscan',
             '--noinlinetls',
             '--completetypemetadata',
+            '--help',
             '-bytes',
             '-raweh',
             '-tokens',


### PR DESCRIPTION
As per https://github.com/compiler-explorer/compiler-explorer/issues/6199#issuecomment-2505980377, allowing passing `--help` to compilers so that users can know what options and switches are available (though part of them will be filtered out, but still better than having nothing). 