### PR TITLE
Introduce HttpController interface for http routers

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -872,9 +872,9 @@ async function main() {
             );
         })
         .use(bodyParser.json({limit: ceProps('bodyParserLimit', maxUploadSize)}))
-        .use('/', siteTemplateController.createRouter())
-        .use('/', sourceController.createRouter())
-        .use('/', assemblyDocumentationController.createRouter())
+        .use(siteTemplateController.createRouter())
+        .use(sourceController.createRouter())
+        .use(assemblyDocumentationController.createRouter())
         .get('/g/:id', oldGoogleUrlHandler)
         // Deprecated old route for this -- TODO remove in late 2021
         .post('/shortener', routeApi.apiHandler.shortener.handle.bind(routeApi.apiHandler.shortener));

--- a/app.ts
+++ b/app.ts
@@ -872,13 +872,9 @@ async function main() {
             );
         })
         .use(bodyParser.json({limit: ceProps('bodyParserLimit', maxUploadSize)}))
-        .get('/api/siteTemplates', siteTemplateController.getSiteTemplates.bind(siteTemplateController))
-        .get('/source/:source/list', sourceController.listEntries.bind(sourceController))
-        .get('/source/:source/load/:language/:filename', sourceController.loadEntry.bind(sourceController))
-        .get(
-            '/api/asm/:arch/:opcode',
-            assemblyDocumentationController.getOpcodeDocumentation.bind(assemblyDocumentationController),
-        )
+        .use('/', siteTemplateController.createRouter())
+        .use('/', sourceController.createRouter())
+        .use('/', assemblyDocumentationController.createRouter())
         .get('/g/:id', oldGoogleUrlHandler)
         // Deprecated old route for this -- TODO remove in late 2021
         .post('/shortener', routeApi.apiHandler.shortener.handle.bind(routeApi.apiHandler.shortener));

--- a/lib/handlers/api/assembly-documentation-controller.ts
+++ b/lib/handlers/api/assembly-documentation-controller.ts
@@ -27,7 +27,15 @@ import express from 'express';
 import {addStaticHeaders} from '../../../app.js';
 import {getDocumentationProviderTypeByKey} from '../../asm-docs/index.js';
 
-export class AssemblyDocumentationController {
+import {HttpController} from './controller.interfaces.js';
+
+export class AssemblyDocumentationController implements HttpController {
+    createRouter(): express.Router {
+        const router = express.Router();
+        router.get('/api/asm/:arch/:opcode', this.getOpcodeDocumentation.bind(this));
+        return router;
+    }
+
     /**
      * Handle request to `/asm/:arch/:opcode` endpoint
      */

--- a/lib/handlers/api/controller.interfaces.ts
+++ b/lib/handlers/api/controller.interfaces.ts
@@ -24,19 +24,12 @@
 
 import express from 'express';
 
-import {getSiteTemplates} from '../site-templates.js';
-
-import {HttpController} from './controller.interfaces.js';
-
-export class SiteTemplateController implements HttpController {
-    createRouter(): express.Router {
-        const router = express.Router();
-        router.get('/api/siteTemplates', this.getSiteTemplates.bind(this));
-        return router;
-    }
-
-    public async getSiteTemplates(req: express.Request, res: express.Response) {
-        const templates = await getSiteTemplates();
-        res.send(templates);
-    }
+export interface HttpController {
+    /**
+     * Create a separate express router for this controller.
+     *
+     * The purpose of this is to allow for a consistent API surface across both test and production, as well as being
+     * able to create multiple mergable routes for the final server.
+     */
+    createRouter(): express.Router;
 }

--- a/lib/handlers/api/source-controller.ts
+++ b/lib/handlers/api/source-controller.ts
@@ -28,8 +28,17 @@ import _ from 'underscore';
 import {addStaticHeaders} from '../../../app.js';
 import {Source} from '../../../types/source.interfaces.js';
 
-export class SourceController {
+import {HttpController} from './controller.interfaces.js';
+
+export class SourceController implements HttpController {
     public constructor(private readonly sources: Source[]) {}
+
+    createRouter(): express.Router {
+        const router = express.Router();
+        router.get('/source/:source/list', this.listEntries.bind(this));
+        router.get('/source/:source/load/:language/:filename', this.loadEntry.bind(this));
+        return router;
+    }
 
     /**
      * Handle request to `/source/<source>/list` endpoint

--- a/test/handlers/asm-docs-tests.ts
+++ b/test/handlers/asm-docs-tests.ts
@@ -111,10 +111,8 @@ describe('Assembly Documentation API', () => {
 
     beforeAll(() => {
         app = express();
-        const router = express.Router();
         const controller = new AssemblyDocumentationController();
-        router.get('/asm/:arch/:opcode', controller.getOpcodeDocumentation.bind(controller));
-        app.use('/api', router);
+        app.use('/', controller.createRouter());
     });
 
     it('should return 404 for unknown architecture', async () => {

--- a/test/handlers/site-templates-tests.ts
+++ b/test/handlers/site-templates-tests.ts
@@ -10,7 +10,7 @@ describe('Site Templates Backend', () => {
     beforeAll(() => {
         app = express();
         const controller = new SiteTemplateController();
-        app.use('/api/siteTemplates', controller.getSiteTemplates.bind(controller));
+        app.use('/', controller.createRouter());
     });
 
     it('should load site templates properly', async () => {

--- a/test/handlers/source-tests.ts
+++ b/test/handlers/source-tests.ts
@@ -38,8 +38,7 @@ describe('Sources', () => {
             load: (lang, name) => Promise.resolve({file: `File called ${name} in ${lang}`}),
         },
     ]);
-    app.use('/source/:source/list', handler.listEntries.bind(handler));
-    app.use('/source/:source/load/:language/:filename', handler.loadEntry.bind(handler));
+    app.use('/', handler.createRouter());
 
     it('should list', async () => {
         await request(app)


### PR DESCRIPTION
By requiring controllers to declare their own routes, we ensure consistency between tests and the actual server