### PR TITLE
Add lfortran and a slightly hacky path to clang

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -737,7 +737,6 @@ compiler.flangtrunk-fc.alias=flangtrunknew-fc
 
 #################################
 # LFortran
-clangForLFortran=/opt/compiler-explorer/clang-19.1.0/bin/clang
 group.lfortran.compilers=lfortran0420
 group.lfortran.groupName=LFortran
 group.lfortran.baseName=LFortran
@@ -748,6 +747,7 @@ group.lfortran.compilerType=lfortran
 group.lfortran.isSemVer=true
 compiler.lfortran0420.exe=/opt/compiler-explorer/lfortran/v0.42.0/bin/lfortran
 compiler.lfortran0420.semver=0.42.0
+compiler.lfortran0420.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 
 ###############################
 # GCC for ARM 64bit

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -737,15 +737,17 @@ compiler.flangtrunk-fc.alias=flangtrunknew-fc
 
 #################################
 # LFortran
-group.lfortran.compilers=lfortran
+clangForLFortran=/opt/compiler-explorer/clang-19.1.0/bin/clang
+group.lfortran.compilers=lfortran0420
 group.lfortran.groupName=LFortran
-
-compiler.lfortran.name=lfortran (latest)
-compiler.lfortran.exe=/opt/compiler-explorer/lfortran/bin/lfortran
-compiler.lfortran.options=--generate-object-code
-compiler.lfortran.supportsBinary=true
-compiler.lfortran.supportsExecute=true
-compiler.lfortran.compilerType=lfortran
+group.lfortran.baseName=LFortran
+group.lfortran.supportsBinary=true
+group.lfortran.supportsBinaryObject=true
+group.lfortran.supportsExecute=true
+group.lfortran.compilerType=lfortran
+group.lfortran.isSemVer=true
+compiler.lfortran0420.exe=/opt/compiler-explorer/lfortran/v0.42.0/bin/lfortran
+compiler.lfortran0420.semver=0.42.0
 
 ###############################
 # GCC for ARM 64bit

--- a/lib/compilers/lfortran.ts
+++ b/lib/compilers/lfortran.ts
@@ -22,18 +22,28 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import type {CompilationResult, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
+import {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {CompilationEnvironment} from '../compilation-env.js';
 
 import {FortranCompiler} from './fortran.js';
 
 export class LFortranCompiler extends FortranCompiler {
+    private clang: string;
+
     static override get key() {
         return 'lfortran';
     }
 
+    constructor(compilerInfo: PreliminaryCompilerInfo & {disabledFilters?: string[]}, env: CompilationEnvironment) {
+        super(compilerInfo, env);
+        this.clang = this.compilerProps<string>('clangForLFortran');
+    }
+
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
-        // TODO add `-g` to the options
-        let options = ['-o', this.filename(outputFilename)];
+        // TODO(@Thirumalai-Shaktivel) add `-g` to the options once that's supported in the compilers.
+        let options = ['-o', this.filename(outputFilename), '--generate-object-code'];
 
         if (!filters.binary && !filters.binaryObject) {
             options = options.concat('-S');
@@ -41,5 +51,18 @@ export class LFortranCompiler extends FortranCompiler {
             options = options.concat('-c');
         }
         return options;
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+    ): Promise<CompilationResult> {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+        execOptions.env.LFORTRAN_CC = this.clang;
+        return super.runCompiler(compiler, options, inputFilename, execOptions);
     }
 }

--- a/lib/compilers/lfortran.ts
+++ b/lib/compilers/lfortran.ts
@@ -38,7 +38,8 @@ export class LFortranCompiler extends FortranCompiler {
 
     constructor(compilerInfo: PreliminaryCompilerInfo & {disabledFilters?: string[]}, env: CompilationEnvironment) {
         super(compilerInfo, env);
-        this.clang = this.compilerProps<string>('clangForLFortran');
+        // TODO(#7150) consider a more general purpose version of this.
+        this.clang = this.compilerProps<string>(`compiler.${this.compiler.id}.clang`);
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {


### PR DESCRIPTION
Advice sought: I didn't want to plumb through a whole new compiler flag for `clang` so used a top-level one for `fortran` in the form of a `ceProp` (which doesn't cascade through all the groups etc). I think this is _ok_ but ugly and surprising (To me...) and I wonder if we should actually consider making each compiler's `ceProps` use the same logic as the logic in the discovery process with parent properties etc...or not. (cc @partouf in case I've missed something obvious!)