### PR TITLE
.NET: Fix the redundant options in some cases

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -559,7 +559,7 @@ do()
                 continue;
             }
 
-            if (isCoreRun && (currentOption === '-e' || currentOption === '--env')) {
+            if ((isCoreRun || isMono) && (currentOption === '-e' || currentOption === '--env')) {
                 const envVar = options.shift();
                 if (envVar) {
                     const [name] = envVar.split('=');
@@ -623,14 +623,14 @@ do()
 
         if (!isIlDasm && !isIlSpy) {
             if (!overrideDiffable && compilerInfo.sdkMajorVersion < 8) {
-                if (!isCoreRun) {
+                if (isCrossgen2 || isAot) {
                     toolOptions.push('--codegenopt', 'JitDiffableDasm=1');
                 }
                 envVarFileContents.push('DOTNET_JitDiffableDasm=1');
             }
 
             if (!overrideDisasm) {
-                if (!isCoreRun) {
+                if (isCrossgen2 || isAot) {
                     toolOptions.push(
                         '--codegenopt',
                         compilerInfo.sdkMajorVersion === 6 ? 'NgenDisasm=*' : 'JitDisasm=*',
@@ -640,7 +640,7 @@ do()
             }
 
             if (!overrideAssembly) {
-                if (!isCoreRun && compilerInfo.sdkMajorVersion >= 9) {
+                if ((isCrossgen2 || isAot) && compilerInfo.sdkMajorVersion >= 9) {
                     toolOptions.push('--codegenopt', 'JitDisasmAssemblies=CompilerExplorer');
                 }
                 envVarFileContents.push('DOTNET_JitDisasmAssemblies=CompilerExplorer');

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -816,7 +816,7 @@ do()
         const ilspyPath = path.join(ilspyToolsDir, targetFramework, 'any', 'ilspycmd.dll');
 
         // prettier-ignore
-        const ilspyOptions = [ilspyPath, dllPath, '--disable-updatecheck'].concat(options);
+        const ilspyOptions = [ilspyPath, dllPath, '--disable-updatecheck', '-r', this.clrBuildDir].concat(options);
         const compilerPath = useDotNetHost ? this.compiler.exe : this.corerunPath;
         const compilerExecResult = await this.exec(compilerPath, ilspyOptions, execOptions);
         const result = this.transformToCompilationResult(compilerExecResult, dllPath);

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -617,20 +617,22 @@ do()
             }
         }
 
-        if (isCrossgen2 || isAot) {
+        const needCodegenOptions = isCrossgen2 || isAot;
+
+        if (needCodegenOptions) {
             toolOptions.push('--parallelism', '1');
         }
 
         if (!isIlDasm && !isIlSpy) {
             if (!overrideDiffable && compilerInfo.sdkMajorVersion < 8) {
-                if (isCrossgen2 || isAot) {
+                if (needCodegenOptions) {
                     toolOptions.push('--codegenopt', 'JitDiffableDasm=1');
                 }
                 envVarFileContents.push('DOTNET_JitDiffableDasm=1');
             }
 
             if (!overrideDisasm) {
-                if (isCrossgen2 || isAot) {
+                if (needCodegenOptions) {
                     toolOptions.push(
                         '--codegenopt',
                         compilerInfo.sdkMajorVersion === 6 ? 'NgenDisasm=*' : 'JitDisasm=*',
@@ -640,7 +642,7 @@ do()
             }
 
             if (!overrideAssembly) {
-                if ((isCrossgen2 || isAot) && compilerInfo.sdkMajorVersion >= 9) {
+                if (needCodegenOptions && compilerInfo.sdkMajorVersion >= 9) {
                     toolOptions.push('--codegenopt', 'JitDisasmAssemblies=CompilerExplorer');
                 }
                 envVarFileContents.push('DOTNET_JitDisasmAssemblies=CompilerExplorer');

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -540,7 +540,7 @@ do()
         const isIlDasm = this.compiler.group === 'dotnetildasm';
         const isIlSpy = this.compiler.group === 'dotnetilspy';
         const isCoreRun = this.compiler.group === 'dotnetcoreclr';
-        const toolOptions: string[] = isIlDasm || isIlSpy || isCoreRun ? [] : ['--parallelism', '1'];
+        const toolOptions: string[] = [];
 
         let overrideDiffable = false;
         let overrideDisasm = false;
@@ -615,6 +615,10 @@ do()
                     }
                 }
             }
+        }
+
+        if (isCrossgen2 || isAot) {
+            toolOptions.push('--parallelism', '1');
         }
 
         if (!isIlDasm && !isIlSpy) {


### PR DESCRIPTION
#7143 accidentally broke the compilation for mono as it would pass an unnecessary option `--parallalism 1` to `mono`. Missed this in my local test as the result of mono was cached.
This option is only used by Crossgen2 and NativeAOT.