### PR TITLE
Add re-usable middleware functions to http server

### DIFF
--- a/lib/handlers/api/assembly-documentation-controller.ts
+++ b/lib/handlers/api/assembly-documentation-controller.ts
@@ -24,15 +24,15 @@
 
 import express from 'express';
 
-import {addStaticHeaders} from '../../../app.js';
 import {getDocumentationProviderTypeByKey} from '../../asm-docs/index.js';
+import {cached, cors} from '../middleware.js';
 
 import {HttpController} from './controller.interfaces.js';
 
 export class AssemblyDocumentationController implements HttpController {
     createRouter(): express.Router {
         const router = express.Router();
-        router.get('/api/asm/:arch/:opcode', this.getOpcodeDocumentation.bind(this));
+        router.get('/api/asm/:arch/:opcode', cors, cached, this.getOpcodeDocumentation.bind(this));
         return router;
     }
 
@@ -54,12 +54,10 @@ export class AssemblyDocumentationController implements HttpController {
             const contentType = req.accepts(['text', 'json']);
             switch (contentType) {
                 case 'text': {
-                    addStaticHeaders(res);
                     res.send(information.html);
                     break;
                 }
                 case 'json': {
-                    addStaticHeaders(res);
                     res.send(information);
                     break;
                 }

--- a/lib/handlers/api/source-controller.ts
+++ b/lib/handlers/api/source-controller.ts
@@ -25,8 +25,8 @@
 import express from 'express';
 import _ from 'underscore';
 
-import {addStaticHeaders} from '../../../app.js';
 import {Source} from '../../../types/source.interfaces.js';
+import {cached, cors} from '../middleware.js';
 
 import {HttpController} from './controller.interfaces.js';
 
@@ -35,8 +35,8 @@ export class SourceController implements HttpController {
 
     createRouter(): express.Router {
         const router = express.Router();
-        router.get('/source/:source/list', this.listEntries.bind(this));
-        router.get('/source/:source/load/:language/:filename', this.loadEntry.bind(this));
+        router.get('/source/:source/list', cors, cached, this.listEntries.bind(this));
+        router.get('/source/:source/load/:language/:filename', cors, cached, this.loadEntry.bind(this));
         return router;
     }
 
@@ -50,7 +50,6 @@ export class SourceController implements HttpController {
             return;
         }
         const entries = await source.list();
-        addStaticHeaders(res);
         res.json(entries);
     }
 
@@ -64,7 +63,6 @@ export class SourceController implements HttpController {
             return;
         }
         const entry = await source.load(req.params.language, req.params.filename);
-        addStaticHeaders(res);
         res.json(entry);
     }
 

--- a/lib/handlers/middleware.ts
+++ b/lib/handlers/middleware.ts
@@ -27,7 +27,7 @@ import express from 'express';
 import * as props from '../properties.js';
 
 const ceProps = props.propsFor('compiler-explorer');
-const staticMaxAge = ceProps('static-max-age', 31536000);
+const staticMaxAge = ceProps('staticMaxAgeSecs', 31536000);
 
 /** Add static headers to the response */
 export const cached: express.Handler = (_, res, next) => {

--- a/lib/handlers/middleware.ts
+++ b/lib/handlers/middleware.ts
@@ -24,20 +24,20 @@
 
 import express from 'express';
 
-import {getSiteTemplates} from '../../site-templates.js';
-import {cached, cors} from '../middleware.js';
+import * as props from '../properties.js';
 
-import {HttpController} from './controller.interfaces.js';
+const ceProps = props.propsFor('compiler-explorer');
+const staticMaxAge = ceProps('static-max-age', 31536000);
 
-export class SiteTemplateController implements HttpController {
-    createRouter(): express.Router {
-        const router = express.Router();
-        router.get('/api/siteTemplates', cors, cached, this.getSiteTemplates.bind(this));
-        return router;
-    }
+/** Add static headers to the response */
+export const cached: express.Handler = (_, res, next) => {
+    res.set('Cache-Control', `public, max-age=${staticMaxAge}, must-revalidate`);
+    return next();
+};
 
-    public async getSiteTemplates(req: express.Request, res: express.Response) {
-        const templates = await getSiteTemplates();
-        res.send(templates);
-    }
-}
+/** Allow any client to make cross-origin requests */
+export const cors: express.Handler = (_, res, next) => {
+    res.set('Access-Control-Allow-Origin', '*');
+    res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    return next();
+};

--- a/test/handlers/middleware-tests.ts
+++ b/test/handlers/middleware-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, Compiler Explorer Authors
+// Copyright (c) 2024, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/test/handlers/middleware-tests.ts
+++ b/test/handlers/middleware-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Compiler Explorer Authors
+// Copyright (c) 2014, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -23,21 +23,28 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import express from 'express';
+import request from 'supertest';
+import {describe, it} from 'vitest';
 
-import {getSiteTemplates} from '../../site-templates.js';
-import {cached, cors} from '../middleware.js';
+import {cached, cors} from '../../lib/handlers/middleware.js';
 
-import {HttpController} from './controller.interfaces.js';
+describe('middleware functions', () => {
+    it('adds cache controls headers with cached()', async () => {
+        const app = express();
+        app.use('/', cached, (_, res) => res.send('Hello World!'));
+        await request(app)
+            .get('/')
+            .expect(200, 'Hello World!')
+            .expect('cache-control', /public, max-age=\d+, must-revalidate/);
+    });
 
-export class SiteTemplateController implements HttpController {
-    createRouter(): express.Router {
-        const router = express.Router();
-        router.get('/api/siteTemplates', cors, cached, this.getSiteTemplates.bind(this));
-        return router;
-    }
-
-    public async getSiteTemplates(req: express.Request, res: express.Response) {
-        const templates = await getSiteTemplates();
-        res.send(templates);
-    }
-}
+    it('adds cors headers with cors()', async () => {
+        const app = express();
+        app.use('/', cors, (_, res) => res.send('Hello World!'));
+        await request(app)
+            .get('/')
+            .expect(200, 'Hello World!')
+            .expect('access-control-allow-origin', '*')
+            .expect('access-control-allow-headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    });
+});


### PR DESCRIPTION
Just add the headers you want to the handler list :)

It's basically the addStaticHeaders function again, but this time more composable. End goal is to replace that function and all its uses with this as I go with the api improvements

This technically also fixes a cors regression from earlier patches