### PR TITLE
Remove addStaticHeaders and contentPolicyHeader functions

### DIFF
--- a/lib/handlers/middleware.ts
+++ b/lib/handlers/middleware.ts
@@ -41,3 +41,10 @@ export const cors: express.Handler = (_, res, next) => {
     res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
     return next();
 };
+
+/** Add Content-Security-Policy header to the response */
+export const csp: express.Handler = (_, res, next) => {
+    // TODO: Consider if CSP should be re-enabled
+    // res.set('Content-Security-Policy', `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-src 'self';`);
+    return next();
+};

--- a/lib/handlers/route-api.ts
+++ b/lib/handlers/route-api.ts
@@ -43,6 +43,7 @@ import * as utils from '../utils.js';
 
 import {ApiHandler} from './api.js';
 import {CompileHandler} from './compile.js';
+import {cached, csp} from './middleware.js';
 
 export type HandlerConfig = {
     compileHandler: CompileHandler;
@@ -53,8 +54,6 @@ export type HandlerConfig = {
     defArgs: AppDefaultArguments;
     renderConfig: any;
     renderGoldenLayout: any;
-    staticHeaders: any;
-    contentPolicyHeader: any;
     compilationEnvironment: CompilationEnvironment;
 };
 
@@ -97,11 +96,11 @@ export class RouteAPI {
     InitializeRoutes() {
         this.router
             .use('/api', this.apiHandler.handle)
-            .get('/z/:id', this.storedStateHandler.bind(this))
-            .get('/z/:id/code/:session', this.storedCodeHandler.bind(this))
-            .get('/resetlayout/:id', this.storedStateHandlerResetLayout.bind(this))
-            .get('/clientstate/:clientstatebase64([^]*)', this.unstoredStateHandler.bind(this))
-            .get('/fromsimplelayout', this.simpleLayoutHandler.bind(this));
+            .get('/z/:id', cached, csp, this.storedStateHandler.bind(this))
+            .get('/z/:id/code/:session', cached, csp, this.storedCodeHandler.bind(this))
+            .get('/resetlayout/:id', cached, csp, this.storedStateHandlerResetLayout.bind(this))
+            .get('/clientstate/:clientstatebase64([^]*)', cached, csp, this.unstoredStateHandler.bind(this))
+            .get('/fromsimplelayout', cached, csp, this.simpleLayoutHandler.bind(this));
     }
 
     storedCodeHandler(req: express.Request, res: express.Response, next: express.NextFunction) {


### PR DESCRIPTION
Stops passing these functions around and instead configures the headers by chaining express handlers