### PR TITLE
Remove old shortener path

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -885,9 +885,7 @@ async function main() {
         .use(sourceController.createRouter())
         .use(assemblyDocumentationController.createRouter())
         .use(formattingController.createRouter())
-        .get('/g/:id', oldGoogleUrlHandler)
-        // Deprecated old route for this -- TODO remove in late 2021
-        .post('/shortener', routeApi.apiHandler.shortener.handle.bind(routeApi.apiHandler.shortener));
+        .get('/g/:id', oldGoogleUrlHandler);
 
     noscriptHandler.InitializeRoutes({limit: ceProps('bodyParserLimit', maxUploadSize)});
     routeApi.InitializeRoutes();


### PR DESCRIPTION
This has been dangling as a TODO from @mattgodbolt since 2021. Running the following Athena query:

```sql
SELECT COUNT(*) as reqs, uri, date
from cloudfront_logs
WHERE uri LIKE '/shortener%'
GROUP BY date, uri
```

Yields about 8-20 requests per day. I think this is an insignificant enough amount of traffic to justify removing it now.