### PR TITLE
gccbpf: disable C++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1529,6 +1529,11 @@ group.gccbpf.groupName=BPF GCC
 group.gccbpf.isSemVer=true
 group.gccbpf.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-objdump
 
+# hide them all, C++ is not really supported by gccbpf and is more confusing
+# than anything. It was kind of working (by chance) on older gcc, but broken on
+# more recent versions.
+group.gccbpf.hidden=true
+
 compiler.bpfg1310.exe=/opt/compiler-explorer/bpf/gcc-13.1.0/bpf-unknown-none/bin/bpf-unknown-none-g++
 compiler.bpfg1310.semver=13.1.0
 compiler.bpfg1310.objdumper=/opt/compiler-explorer/bpf/gcc-13.1.0/bpf-unknown-none/bin/bpf-unknown-objdump


### PR DESCRIPTION
Older g++ versions were kind of working (by chance) for the BPF target. With more recent, it's broken, so was not enabled. Having only "old" compilers available in C++, but not in C is confusing, and not really useful => hidding the existing C++ compilers.

fixes #7116