### PR TITLE
Fix #3264: move emitShortLinkEvent from editor-pane to main window

### DIFF
--- a/static/main.ts
+++ b/static/main.ts
@@ -644,6 +644,22 @@ function start() {
         sizeCheckNavHideables();
     }
 
+    new clipboard('.btn.clippy');
+
+    const [themer, settings] = setupSettings(hub);
+
+    function handleCtrlS(event: JQuery.KeyDownEvent<Window, undefined, Window, Window>): void {
+        event.preventDefault();
+        if (settings.enableCtrlS === 'false') {
+            // emit short link
+            if (settings.enableSharingPopover) {
+                hub.layout.eventHub.emit('displaySharingPopover');
+            } else {
+                hub.layout.eventHub.emit('copyShortLinkToClip');
+            }
+        }
+    }
+
     $(window)
         .on('resize', sizeRoot)
         .on('beforeunload', () => {
@@ -653,11 +669,12 @@ function start() {
                 if (layout.config.content && layout.config.content.length > 0)
                     sessionThenLocalStorage.set('gl', JSON.stringify(layout.toConfig()));
             }
+        })
+        .on('keydown', event => {
+            if ((event.ctrlKey || event.metaKey) && String.fromCharCode(event.which).toLowerCase() === 's') {
+                handleCtrlS(event);
+            }
         });
-
-    new clipboard('.btn.clippy');
-
-    const [themer, settings] = setupSettings(hub);
 
     // We assume no consent for embed users
     if (!options.embedded) {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -665,8 +665,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                 if (!loadSave.onSaveToFile(this.id.toString())) {
                     this.showLoadSaver();
                 }
-            } else if (this.settings.enableCtrlS === 'false') {
-                this.emitShortLinkEvent();
             } else if (this.settings.enableCtrlS === '2') {
                 this.runFormatDocumentAction();
             } else if (this.settings.enableCtrlS === '3') {
@@ -1054,14 +1052,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, () => {
             unwrap(this.editor.getAction('editor.action.duplicateSelection')).run();
         });
-    }
-
-    emitShortLinkEvent(): void {
-        if (this.settings.enableSharingPopover) {
-            this.eventHub.emit('displaySharingPopover');
-        } else {
-            this.eventHub.emit('copyShortLinkToClip');
-        }
     }
 
     runFormatDocumentAction(): void {


### PR DESCRIPTION
When settings are set to emit-short-link upon ctrl+S, managing the logic in `Editor` is problematic since the editor may lose focus and not receive the event.

Also logically this is a cross-site event, and doesn't belong in any particular editor (there can be multiple).
