### PR TITLE
Fix #3203: Apply the workaround suggested by OP

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -69,7 +69,7 @@ compiler.mingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0
 compiler.mingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vcpp.compilers=&vcpp_x86:&vcpp_x64:&vcpp_arm64
-group.vcpp.options=-EHsc
+group.vcpp.options=/source-charset:utf-8
 group.vcpp.compilerType=win32-vc
 group.vcpp.needsMulti=false
 group.vcpp.includeFlag=/I

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -69,7 +69,7 @@ compiler.mingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0
 compiler.mingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vcpp.compilers=&vcpp_x86:&vcpp_x64:&vcpp_arm64
-group.vcpp.options=/source-charset:utf-8
+group.vcpp.options=/EHsc /source-charset:utf-8
 group.vcpp.compilerType=win32-vc
 group.vcpp.needsMulti=false
 group.vcpp.includeFlag=/I

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -50,7 +50,7 @@ compiler.cmingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.
 compiler.cmingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vc.compilers=&vc_x86:&vc_x64:&vc_arm64
-group.vc.options=/EHsc /source-charset:utf-8
+group.vc.options=/source-charset:utf-8
 group.vc.compilerType=win32-vc
 group.vc.needsMulti=false
 group.vc.includeFlag=/I

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -50,7 +50,7 @@ compiler.cmingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.
 compiler.cmingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vc.compilers=&vc_x86:&vc_x64:&vc_arm64
-group.vc.options=-EHsc
+group.vc.options=/EHsc /source-charset:utf-8
 group.vc.compilerType=win32-vc
 group.vc.needsMulti=false
 group.vc.includeFlag=/I

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -50,7 +50,7 @@ compiler.cmingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.
 compiler.cmingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vc.compilers=&vc_x86:&vc_x64:&vc_arm64
-group.vc.options=/source-charset:utf-8
+group.vc.options=/EHsc /source-charset:utf-8
 group.vc.compilerType=win32-vc
 group.vc.needsMulti=false
 group.vc.includeFlag=/I


### PR DESCRIPTION
Adding a switch to all MSVC compilations that specifies the charset seems good enough.
