### PR TITLE
Add alias for long lost msvc id

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -152,6 +152,7 @@ compiler.vcpp_v19_22_VS16_2_x64.libPath=Z:/compilers/msvc/14.22.27905-14.22.2790
 compiler.vcpp_v19_22_VS16_2_x64.includePath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_22_VS16_2_x64.name=x64 msvc v19.22 VS16.2
 compiler.vcpp_v19_22_VS16_2_x64.semver=14.22.27905.0
+compiler.vcpp_v19_22_VS16_2_x64.alias=vcpp_v19_22_x64
 
 compiler.vcpp_v19_22_VS16_2_arm64.exe=Z:/compilers/msvc/14.22.27905-14.22.27905.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_22_VS16_2_arm64.libPath=Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib;Z:/compilers/msvc/14.22.27905-14.22.27905.0/lib/arm64;Z:/compilers/msvc/14.22.27905-14.22.27905.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.22.27905-14.22.27905.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/7169

But may be more compiler id's are missing.

We tried to address this as best as we could when transitioning to the new infra and new msvc installations, but we probably missed more than just this one.