### PR TITLE
Separate filenames for llvm IR in rust

### DIFF
--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -94,7 +94,12 @@ export class RustCompiler extends BaseCompiler {
                     ? this.getIrOutputFilename(inputFilename, filters)
                     : opt,
             );
-
+        // Rust intermediate files that get copied to the output get a name of the form "base-HASH-*" -- so
+        // if there are any other compiles running on the same code with `--emit-llvm` then those will clash
+        // with the output and lead to corruptions/missing files. We use a uniquifier here for each potentially
+        // concurrent pass. With thanks to @bjorn3.
+        // See https://github.com/compiler-explorer/compiler-explorer/issues/7012 for example
+        newOptions.push('--codegen', 'extra-filename=llvm-ir-gen');
         return await super.generateIR(inputFilename, newOptions, irOptions, produceCfg, filters);
     }
 


### PR DESCRIPTION
Rust compilers output to fixed-named intermediate files. When running a regular compiler with `--emit-llvm` _and_ an IR view on the same source, the outputs fight.

This ensures the intermediate files for IR are named differently.

Thanks @bjorn3

Closes #7012
