### PR TITLE
Add a sleep util

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -546,3 +546,10 @@ export function getEmptyExecutionResult(): BasicExecutionResult {
 export function deltaTimeNanoToMili(startTime: bigint, endTime: bigint): number {
     return Number((endTime - startTime) / BigInt(1_000_000));
 }
+
+/**
+ * Sleep for a number of milliseconds.
+ */
+export async function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Not used anywhere but useful in a pinch for trying to debug race condition type things with `await utils.sleep(1234)` etc around the code.
