### PR TITLE
Readd powerpc64 GNAT 11.2 compiler

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -381,7 +381,11 @@ compiler.gnatppc1420.demangler=/opt/compiler-explorer/powerpc/gcc-14.2.0/powerpc
 ## POWER64
 group.gnatppc64.groupName=POWER64 GNAT
 group.gnatppc64.baseName=powerpc64 gnat
-group.gnatppc64.compilers=gnatppc64trunk:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641410:gnatppc641420
+group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641410:gnatppc641420
+
+compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.gnatppc641120.semver=11.2.0
 
 compiler.gnatppc641210.exe=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641210.demangler=/opt/compiler-explorer/powerpc64/gcc-12.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt


### PR DESCRIPTION
The compiler was incorrectly reinstalled after I probably forgot to correct end #3701.

Fixes #7168