### PR TITLE
Add SPIR-V Cross to production

### DIFF
--- a/etc/config/spirv.amazon.properties
+++ b/etc/config/spirv.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&spirv-opt:&spirv-val
+compilers=&spirv-opt:&spirv-val:&spirv-cross
 defaultCompiler=spirv-opt-master
 
 supportsBinary=false
@@ -15,9 +15,17 @@ group.spirv-val.baseName=SPIRV-Tools Validator
 group.spirv-val.compilers=spirv-val-master
 group.spirv-val.compilerType=spirv-tools
 
+group.spirv-cross.groupName=Translate
+group.spirv-cross.baseName=SPIRV-Cross
+group.spirv-cross.compilers=spirv-cross-sdk-296
+group.spirv-cross.compilerType=spirv-tools
+
 assemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-as
 disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 compiler.spirv-opt-master.exe=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-opt
 compiler.spirv-opt-master.name=spirv-opt (trunk)
 compiler.spirv-val-master.exe=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-val
 compiler.spirv-val-master.name=spirv-val (trunk)
+
+compiler.spirv-cross-sdk-296.exe=/opt/compiler-explorer/vulkan-sdk/v1.3.296.0/x86_64/bin/spirv-cross
+compiler.spirv-cross-sdk-296.name=spirv-cross (sdk-296)


### PR DESCRIPTION
I added SPIRV-Cross support in https://github.com/compiler-explorer/compiler-explorer/pull/7056 and with the Infra changes in https://github.com/compiler-explorer/infra/pull/1475 we can have it up online

(note, the `spirv-reflect` needed a fix to the command line args which means will have to wait until next SDK to add it here) 