### PR TITLE
Fix error lines for GLSL output

### DIFF
--- a/lib/compilers/glsl.ts
+++ b/lib/compilers/glsl.ts
@@ -82,6 +82,11 @@ export class GLSLCompiler extends BaseCompiler {
         execOptions.customCwd = path.dirname(inputFilename);
 
         const spvBin = await this.exec(compiler, options, execOptions);
+
+        // glslang prefix things with 'ERROR:' which
+        // applyParse_SourceWithLine doesn't detect the line number then.
+        // For warnings, we need to adjust its position so parseSeverity works
+        spvBin.stdout = spvBin.stdout.replaceAll('ERROR: ', '').replaceAll(/WARNING: (.+?:\d+:) /g, '$1 warning: ');
         const result = this.transformToCompilationResult(spvBin, inputFilename);
 
         if (spvBin.code !== 0 || !(await utils.fileExists(spvBinFilename))) {


### PR DESCRIPTION
glslang outputs its message strangely (and it is not going to change, otherwise I would have made the changes there)

This will take an ouptut like

```
ERROR: <source>:4: Something bad
WARNING: <source>:5: Something less bad
```

to be

```
<source>:4: Something bad
<source>:5: warning: Something less bad
```

so it appears automatically in the UI

![image](https://github.com/user-attachments/assets/05454b10-abf7-4f81-8f26-17970028f3f8)
