### PR TITLE
fix versionFlag for gccrs

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -205,6 +205,7 @@ group.rustgcc.compilers=&gcc86:&gcccross
 group.rustgcc.supportsBinary=true
 group.rustgcc.supportsBinaryObject=true
 group.rustgcc.compilerType=gccrs
+group.rustgcc.versionFlag=--version
 group.rustgcc.isSemVer=true
 group.rustgcc.unwiseOptions=-march=native
 ## needed, until its support is on-par with rustc (at some arbitrary version).


### PR DESCRIPTION
The -vV set as default for rust is really for "rustc". As there are not many alternative compilers, and as rustc is really 99.99% of the rust compiler installs, it's simpler to override the value for gccrs.

fixes #7220