### PR TITLE
Set MSVC default option to /utf-8, remove it if the user specified /source-charset or /execution-charset

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -69,7 +69,7 @@ compiler.mingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0
 compiler.mingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vcpp.compilers=&vcpp_x86:&vcpp_x64:&vcpp_arm64
-group.vcpp.options=/EHsc /source-charset:utf-8
+group.vcpp.options=/EHsc /utf-8
 group.vcpp.compilerType=win32-vc
 group.vcpp.needsMulti=false
 group.vcpp.includeFlag=/I

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -50,7 +50,7 @@ compiler.cmingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.
 compiler.cmingw64_ucrt_clang_1403.semver=14.0.3
 
 group.vc.compilers=&vc_x86:&vc_x64:&vc_arm64
-group.vc.options=/EHsc /source-charset:utf-8
+group.vc.options=/EHsc /utf-8
 group.vc.compilerType=win32-vc
 group.vc.needsMulti=false
 group.vc.includeFlag=/I

--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -140,6 +140,20 @@ export class Win32Compiler extends BaseCompiler {
         );
     }
 
+    override fixIncompatibleOptions(
+        options: string[],
+        userOptions: string[],
+        overrides: ConfiguredOverrides,
+    ): [string[], ConfiguredOverrides] {
+        // If userOptions contains anything starting with /source-charset or /execution-charset, remove /utf-8 from options
+        if (
+            userOptions.some(option => option.startsWith('/source-charset') || option.startsWith('/execution-charset'))
+        ) {
+            options = options.filter(option => option !== '/utf-8');
+        }
+        return [options, overrides];
+    }
+
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
         if (filters.binary) {
             const mapFilename = outputFilename + '.map';


### PR DESCRIPTION
Following the discussion in #7164.
@partouf I believe this would solve also linkage against windows libs built with /utf-8

