### PR TITLE
Improve odin codegen processing

### DIFF
--- a/lib/compilers/odin.ts
+++ b/lib/compilers/odin.ts
@@ -116,7 +116,12 @@ export class OdinCompiler extends BaseCompiler {
                 lastLine = line;
             }
 
-            return outputLines.join('\n');
+            let text = outputLines.join('\n');
+            // append a final trailing newline
+            if (!text.endsWith('\n')) {
+                text += '\n';
+            }
+            return text;
         }
 
         return source;

--- a/lib/compilers/odin.ts
+++ b/lib/compilers/odin.ts
@@ -112,7 +112,10 @@ export class OdinCompiler extends BaseCompiler {
                 }
 
                 // @require the function so they dont get inlined
-                outputLines.push('@(require)', line);
+                // put @require on the same line so that output source
+                // has same number of lines so that asm<->source mapping
+                // in ui works correctly.
+                outputLines.push('@(require) ' + line);
                 lastLine = line;
             }
 

--- a/lib/parsers/asm-parser-odin.ts
+++ b/lib/parsers/asm-parser-odin.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {PropertyGetter} from '../properties.interfaces.js';
+
+import {AsmParser} from './asm-parser.js';
+
+export class OdinAsmParser extends AsmParser {
+    constructor(compilerProps?: PropertyGetter) {
+        super(compilerProps);
+
+        this.labelDef = /^(?:.proc\s+)?([\w"$.@-]+):/i;
+        this.labelFindNonMips = /[".A-Z_a-z][\w"$.-]*/g;
+    }
+}

--- a/static/modes/odin-mode.ts
+++ b/static/modes/odin-mode.ts
@@ -237,7 +237,39 @@ function definition(): monaco.languages.IMonarchLanguage {
     };
 }
 
+function configuration(): monaco.languages.LanguageConfiguration {
+    return {
+        comments: {
+            lineComment: '//',
+            blockComment: ['/*', '*/'],
+        },
+
+        brackets: [
+            ['{', '}'],
+            ['[', ']'],
+            ['(', ')'],
+        ],
+
+        autoClosingPairs: [
+            {open: '[', close: ']'},
+            {open: '{', close: '}'},
+            {open: '(', close: ')'},
+            {open: "'", close: "'", notIn: ['string', 'comment']},
+            {open: '"', close: '"', notIn: ['string']},
+        ],
+
+        surroundingPairs: [
+            {open: '{', close: '}'},
+            {open: '[', close: ']'},
+            {open: '(', close: ')'},
+            {open: '"', close: '"'},
+            {open: "'", close: "'"},
+        ],
+    };
+}
+
 monaco.languages.register({id: 'odin'});
 monaco.languages.setMonarchTokensProvider('odin', definition());
+monaco.languages.setLanguageConfiguration('odin', configuration());
 
 export {};

--- a/test/odin-tests.ts
+++ b/test/odin-tests.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {beforeAll, describe, expect, it} from 'vitest';
+
+import {OdinCompiler} from '../lib/compilers/odin.js';
+import {CompilerOutputOptions} from '../types/features/filters.interfaces.js';
+import {LanguageKey} from '../types/languages.interfaces.js';
+
+import {fs, makeCompilationEnvironment, makeFakeCompilerInfo} from './utils.js';
+
+const languages = {
+    odin: {id: 'odin' as LanguageKey},
+};
+
+let ce;
+const info = {
+    exe: '/dev/null',
+    remote: {
+        target: 'example',
+        path: 'dummy',
+        cmakePath: 'cmake',
+    },
+    lang: languages.odin.id,
+};
+
+describe('GO asm tests', () => {
+    beforeAll(() => {
+        ce = makeCompilationEnvironment({languages});
+    });
+
+    it('Test @require attribute is added correctly', async () => {
+        const compiler = new OdinCompiler(makeFakeCompilerInfo(info), ce);
+        const inputFile = 'test/odin/add_require.odin';
+        const filter: CompilerOutputOptions = {};
+        const output = compiler.preProcess(fs.readFileSync(inputFile).toString(), filter);
+        const expectedOutputFile = 'test/odin/add_require.odin.expected';
+        const expectedOutput = fs.readFileSync(expectedOutputFile).toString();
+        expect(output).toEqual(expectedOutput);
+    });
+
+    it('Test source unmodified with binary or execute filter', async () => {
+        const compiler = new OdinCompiler(makeFakeCompilerInfo(info), ce);
+        const inputFile = 'test/odin/add_require.odin';
+        const filter: CompilerOutputOptions = {execute: true};
+        const output = compiler.preProcess(fs.readFileSync(inputFile).toString(), filter);
+        const expectedOutputFile = 'test/odin/add_require.odin';
+        const expectedOutput = fs.readFileSync(expectedOutputFile).toString();
+        expect(output).toEqual(expectedOutput);
+    });
+});

--- a/test/odin/add_require.odin
+++ b/test/odin/add_require.odin
@@ -1,0 +1,18 @@
+package main
+
+import "core:fmt"
+
+test_proc :: proc() {
+}
+
+@(require)
+test_proc1 :: proc() {
+}
+
+@require
+test_proc2 :: proc() {
+}
+
+main :: proc() {
+    fmt.println("asd")
+}

--- a/test/odin/add_require.odin.expected
+++ b/test/odin/add_require.odin.expected
@@ -1,0 +1,19 @@
+package main
+
+import "core:fmt"
+
+@(require)
+test_proc :: proc() {
+}
+
+@(require)
+test_proc1 :: proc() {
+}
+
+@require
+test_proc2 :: proc() {
+}
+
+main :: proc() {
+    fmt.println("asd")
+}

--- a/test/odin/add_require.odin.expected
+++ b/test/odin/add_require.odin.expected
@@ -2,8 +2,7 @@ package main
 
 import "core:fmt"
 
-@(require)
-test_proc :: proc() {
+@(require) test_proc :: proc() {
 }
 
 @(require)


### PR DESCRIPTION
- Builtin runtime functions __$startup_runtime, __$cleanup_runtime, __$* are now filtered out
- Label matching regex is fixed for odin, see OdinAsmParser class. This ensures we filter out all labels that don't belong to the current file
- Slightly improved editor support, auto bracket closing and commenting via keyboard shortcuts works now
- procedures within the file are automatically @require as requested by GingerBill (odin lang creator).

There still are a lot of unused labels with data definitions that dont get filtered out.

#7210
