### PR TITLE
Add full oatdump output behind filters

### DIFF
--- a/examples/android-java/default.java
+++ b/examples/android-java/default.java
@@ -3,6 +3,9 @@
 // For R8, please load R8Example for an example with a keep annotation,
 // which will prevent unused code from being removed from the final output.
 //
+// For dex2oat, 'Filter...' > 'Directives' can be unchecked for full
+// oatdump output.
+//
 // (For advanced use only) Click "Templates > Android Java IDE" for
 // profile-guided compilation.
 

--- a/examples/android-kotlin/default.kt
+++ b/examples/android-kotlin/default.kt
@@ -3,6 +3,9 @@
 // For R8, please load R8Example for an example with a keep annotation,
 // which will prevent unused code from being removed from the final output.
 //
+// For dex2oat, 'Filter...' > 'Directives' can be unchecked for full
+// oatdump output.
+//
 // (For advanced use only) Click "Templates > Android Kotlin IDE" for
 // profile-guided compilation.
 

--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -361,7 +361,7 @@ export class Dex2OatCompiler extends BaseCompiler {
         };
     }
 
-    override async processAsm(result) {
+    override async processAsm(result, filters: ParseFiltersAndOutputOptions) {
         let asm: string = '';
 
         if (typeof result.asm === 'string') {
@@ -381,7 +381,7 @@ export class Dex2OatCompiler extends BaseCompiler {
         }
 
         const segments: ParsedAsmResultLine[] = [];
-        if (this.fullOutput) {
+        if (this.fullOutput || !filters.directives) {
             // Returns entire dex2oat output.
             segments.push({text: asm, source: null});
         } else {

--- a/test/android-tests.ts
+++ b/test/android-tests.ts
@@ -97,7 +97,7 @@ describe('dex2oat', () => {
         const objdumpResult = {
             asm,
         };
-        const processed = await compiler.processAsm(objdumpResult);
+        const processed = await compiler.processAsm(objdumpResult, compiler.getDefaultFilters());
         expect(processed).toHaveProperty('asm');
         const actualSegments = (processed as {asm: ParsedAsmResultLine[]}).asm;
 


### PR DESCRIPTION
This change makes full oatdump output visible behind the "Directives" filter. This does the same thing as the --full-output flag, but is more-easily used. The default code snippets have been updated to include this.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
