### PR TITLE
Add Monaco LangConfiguration to GPU languages

### DIFF
--- a/static/modes/glsl-mode.ts
+++ b/static/modes/glsl-mode.ts
@@ -737,5 +737,6 @@ function definition(): monaco.languages.IMonarchLanguage {
 
 monaco.languages.register({id: 'glsl'});
 monaco.languages.setMonarchTokensProvider('glsl', definition());
+monaco.languages.setLanguageConfiguration('glsl', cpp.conf);
 
 export {};

--- a/static/modes/hlsl-mode.ts
+++ b/static/modes/hlsl-mode.ts
@@ -321,5 +321,6 @@ function definition(): monaco.languages.IMonarchLanguage {
 
 monaco.languages.register({id: 'hlsl'});
 monaco.languages.setMonarchTokensProvider('hlsl', definition());
+monaco.languages.setLanguageConfiguration('hlsl', cpp.conf);
 
 export {};

--- a/static/modes/slang-mode.ts
+++ b/static/modes/slang-mode.ts
@@ -268,5 +268,6 @@ function definition(): monaco.languages.IMonarchLanguage {
 
 monaco.languages.register({id: 'slang'});
 monaco.languages.setMonarchTokensProvider('slang', definition());
+monaco.languages.setLanguageConfiguration('slang', cpp.conf);
 
 export {};

--- a/static/modes/spirv-mode.ts
+++ b/static/modes/spirv-mode.ts
@@ -47,7 +47,16 @@ export function definition(): monaco.languages.IMonarchLanguage {
     };
 }
 
+function configuration(): monaco.languages.LanguageConfiguration {
+    return {
+        comments: {
+            lineComment: ';',
+        },
+    };
+}
+
 monaco.languages.register({id: 'spirv'});
 monaco.languages.setMonarchTokensProvider('spirv', definition());
+monaco.languages.setLanguageConfiguration('spirv', configuration());
 
 export {};


### PR DESCRIPTION
I realize basic things like `ctrl`+`/` and auto complete `}` for my `{` were missing from HLSL/GLSL/Slang

After digging, found that it was just a lack of setting `setLanguageConfiguration` for the monaco-editor for each of them

Confirmed the config in `node_modules/monaco-editor/esm/vs/basic-languages/cpp/cpp.js` suites the 3 languages (as they are also all derived from C based languages) 