### PR TITLE
Fix #7237: account for potential warning/error matches

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3162,6 +3162,10 @@ export class BaseCompiler {
             if (match) {
                 const [_, file, lineNum, colNum, type, message] = match;
                 if (!file || (file !== '<source>' && !file.includes(compileFileName))) continue;
+                if (type === 'warning' || type === 'error') {
+                    nonRemarkStderr.push(line);
+                    continue;
+                }
 
                 // convert to llvm-emitted OptRemark format, just because it was here first
                 remarks.push({


### PR DESCRIPTION
A warning in an old gcc (4.8.1) had a format that was accidentally caught by the -fopt-info regex. Now accounting for potential errors/warnings caught accidentally.

I don't like that `processOptOutput` is being called regardless of whether `backendOptions.produceOptInfo` is set, maybe need to address it too.