### PR TITLE
Add clang 19 for more languages.

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -160,7 +160,7 @@ compiler.gnuasriscv32g1320.name=RISC-V binutils 2.38.0
 compiler.gnuasriscv32g1320.semver=2.38.0
 compiler.gnuasriscv32g1320.objdumper=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
-group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas_trunk:llvmas_assertions_trunk
+group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas1910:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version
 group.llvmas.options=-filetype=obj -o example.o
 group.llvmas.versionRe=LLVM version .*
@@ -235,6 +235,8 @@ compiler.llvmas1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llvm-mc
 compiler.llvmas1701.semver=17.0.1
 compiler.llvmas1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llvm-mc
 compiler.llvmas1810.semver=18.1.0
+compiler.llvmas1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llvm-mc
+compiler.llvmas1910.semver=19.1.0
 compiler.llvmas_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mc
 compiler.llvmas_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llvmas_trunk.semver=(trunk)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -426,7 +426,7 @@ compiler.nvc_x86_24_11.semver=24.11
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk
 group.armcclang32.groupName=Arm 32-bit clang
-group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang1200:armv7-cclang1201:armv7-cclang1300:armv7-cclang1301:armv7-cclang1400:armv7-cclang1500:armv7-cclang1600:armv7-cclang1701:armv7-cclang1810:armv7-cclang-trunk
+group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang1200:armv7-cclang1201:armv7-cclang1300:armv7-cclang1301:armv7-cclang1400:armv7-cclang1500:armv7-cclang1600:armv7-cclang1701:armv7-cclang1810:armv7-cclang1910:armv7-cclang-trunk
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
 group.armcclang32.supportsExecute=false
@@ -438,7 +438,7 @@ group.armcclang32.compilerCategories=clang
 group.armcclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.armcclang64.groupName=Arm 64-bit clang
-group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang1701:armv8-cclang1810:armv8-cclang-trunk:armv8-full-cclang-trunk
+group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang1701:armv8-cclang1810:armv8-cclang1910:armv8-cclang-trunk:armv8-full-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
@@ -448,6 +448,19 @@ group.armcclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LIC
 group.armcclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang64.compilerCategories=clang
 group.armcclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.armv7-cclang1910.name=armv7-a clang 19.1.0
+compiler.armv7-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.armv7-cclang1910.semver=19.1.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cclang1910.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+
+compiler.armv8-cclang1910.name=armv8-a clang 19.1.0
+compiler.armv8-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.armv8-cclang1910.semver=19.1.0
+# Arm v8-a
+compiler.armv8-cclang1910.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+
 
 compiler.armv7-cclang1810.name=armv7-a clang 18.1.0
 compiler.armv7-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
@@ -734,7 +747,7 @@ group.rvcclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENS
 group.rvcclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.rvcclang.compilerCategories=clang
 
-group.rv32cclang.compilers=rv32-cclang:rv32-cclang1810:rv32-cclang1701:rv32-cclang1600:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
+group.rv32cclang.compilers=rv32-cclang:rv32-cclang1910:rv32-cclang1810:rv32-cclang1701:rv32-cclang1600:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
 group.rv32cclang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 group.rv32cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 group.rv32cclang.baseName=RISC-V rv32gc clang
@@ -783,12 +796,15 @@ compiler.rv32-cclang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang
 compiler.rv32-cclang1701.semver=17.0.1
 compiler.rv32-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.rv32-cclang1810.semver=18.1.0
+compiler.rv32-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.rv32-cclang1910.semver=19.1.0
+compiler.rv32-cclang1910.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv32-cclang.alias=rv32cclang
 compiler.rv32-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv32-cclang.semver=(trunk)
 compiler.rv32-cclang.isNightly=true
 
-group.rv64cclang.compilers=rv64-cclang:rv64-cclang1810:rv64-cclang1701:rv64-cclang1600:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
+group.rv64cclang.compilers=rv64-cclang:rv64-cclang1910:rv64-cclang1810:rv64-cclang1701:rv64-cclang1600:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
 group.rv64cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 group.rv64cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64cclang.baseName=RISC-V rv64gc clang
@@ -834,6 +850,8 @@ compiler.rv64-cclang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang
 compiler.rv64-cclang1701.semver=17.0.1
 compiler.rv64-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.rv64-cclang1810.semver=18.1.0
+compiler.rv64-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.rv64-cclang1910.semver=19.1.0
 compiler.rv64-cclang.alias=rv64cclang
 compiler.rv64-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv64-cclang.semver=(trunk)
@@ -1068,7 +1086,7 @@ group.cbpf.compilers=&cgccbpf:&cclangbpf
 group.cbpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 # Clang for BPF
-group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang1810:cbpfclang1701:cbpfclang1600:cbpfclang1500:cbpfclang1400:cbpfclang1300
+group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang1910:cbpfclang1810:cbpfclang1701:cbpfclang1600:cbpfclang1500:cbpfclang1400:cbpfclang1300
 group.cclangbpf.supportsBinary=false
 group.cclangbpf.supportsExecute=false
 group.cclangbpf.baseName=BPF clang
@@ -1083,6 +1101,9 @@ group.cclangbpf.compilerCategories=clang
 compiler.cbpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cbpfclangtrunk.semver=(trunk)
 compiler.cbpfclangtrunk.isNightly=true
+
+compiler.cbpfclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.cbpfclang1910.semver=19.1.0
 
 compiler.cbpfclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.cbpfclang1810.semver=18.1.0
@@ -2406,7 +2427,7 @@ group.cmipss.supportsExecute=false
 # Clang for all MIPS
 
 ## MIPS
-group.mips-cclang.compilers=mips-cclang1810:mips-cclang1701:mips-cclang1600:mips-cclang1500:mips-cclang1400:mips-cclang1300
+group.mips-cclang.compilers=mips-cclang1910:mips-cclang1810:mips-cclang1701:mips-cclang1600:mips-cclang1500:mips-cclang1400:mips-cclang1300
 group.mips-cclang.instructionSet=mips
 group.mips-cclang.groupName=MIPS clang
 group.mips-cclang.baseName=mips clang
@@ -2416,6 +2437,9 @@ group.mips-cclang.supportsExecute=false
 group.mips-cclang.options=-target mips-elf
 group.mips-cclang.compilerCategories=clang
 group.mips-cclang.compilerCategories.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.mips-cclang1910.semver=19.1.0
 
 compiler.mips-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mips-cclang1810.semver=18.1.0
@@ -2436,7 +2460,7 @@ compiler.mips-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mips-cclang1300.semver=13.0.0
 
 ## MIPSEL
-group.mipsel-cclang.compilers=mipsel-cclang1810:mipsel-cclang1701:mipsel-cclang1600:mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
+group.mipsel-cclang.compilers=mipsel-cclang1910:mipsel-cclang1810:mipsel-cclang1701:mipsel-cclang1600:mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
 group.mipsel-cclang.instructionSet=mips
 group.mipsel-cclang.groupName=MIPSEL clang
 group.mipsel-cclang.baseName=mipsel clang
@@ -2447,11 +2471,14 @@ group.mipsel-cclang.options=-target mipsel-elf
 group.mipsel-cclang.compilerCategories=clang
 group.mipsel-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
-compiler.mipsel-cclang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang
-compiler.mipsel-cclang1701.semver=17.0.1
+compiler.mipsel-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.mipsel-cclang1910.semver=19.1.0
 
 compiler.mipsel-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mipsel-cclang1810.semver=18.1.0
+
+compiler.mipsel-cclang1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/clang
+compiler.mipsel-cclang1701.semver=17.0.1
 
 compiler.mipsel-cclang1600.exe=/opt/compiler-explorer/clang-16.0.0/bin/clang
 compiler.mipsel-cclang1600.semver=16.0.0
@@ -2466,7 +2493,7 @@ compiler.mipsel-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mipsel-cclang1300.semver=13.0.0
 
 ## MIPS64
-group.mips64-cclang.compilers=mips64-cclang1810:mips64-cclang1701:mips64-cclang1600:mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
+group.mips64-cclang.compilers=mips64-cclang1910:mips64-cclang1810:mips64-cclang1701:mips64-cclang1600:mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
 group.mips64-cclang.groupName=MIPS64 clang
 group.mips64-cclang.instructionSet=mips
 group.mips64-cclang.baseName=mips64 clang
@@ -2476,6 +2503,9 @@ group.mips64-cclang.supportsExecute=false
 group.mips64-cclang.options=-target mips64-elf
 group.mips64-cclang.compilerCategories=clang
 group.mips64-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips64-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.mips64-cclang1910.semver=19.1.0
 
 compiler.mips64-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mips64-cclang1810.semver=18.1.0
@@ -2496,7 +2526,7 @@ compiler.mips64-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mips64-cclang1300.semver=13.0.0
 
 ## MIPS64EL
-group.mips64el-cclang.compilers=mips64el-cclang1810:mips64el-cclang1701:mips64el-cclang1600:mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
+group.mips64el-cclang.compilers=mips64el-cclang1910:mips64el-cclang1810:mips64el-cclang1701:mips64el-cclang1600:mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
 group.mips64el-cclang.groupName=MIPS64EL clang
 group.mips64el-cclang.instructionSet=mips
 group.mips64el-cclang.baseName=mips64el clang
@@ -2506,6 +2536,9 @@ group.mips64el-cclang.supportsExecute=false
 group.mips64el-cclang.options=-target mips64el-elf
 group.mips64el-cclang.compilerCategories=clang
 group.mips64el-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips64el-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.mips64el-cclang1910.semver=19.1.0
 
 compiler.mips64el-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.mips64el-cclang1810.semver=18.1.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -798,7 +798,6 @@ compiler.rv32-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.rv32-cclang1810.semver=18.1.0
 compiler.rv32-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.rv32-cclang1910.semver=19.1.0
-compiler.rv32-cclang1910.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv32-cclang.alias=rv32cclang
 compiler.rv32-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv32-cclang.semver=(trunk)

--- a/etc/config/llvm_mir.amazon.properties
+++ b/etc/config/llvm_mir.amazon.properties
@@ -8,7 +8,7 @@ licenseName=LLVM Apache 2
 licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.mirllc.compilers=mirllc32:mirllc33:mirllc391:mirllc400:mirllc401:mirllc500:mirllc600:mirllc700:mirllc800:mirllc900:mirllc1000:mirllc1001:mirllc1100:mirllc1101:mirllc1200:mirllc1201:mirllc1300:mirllc1400:mirllc1500:mirllc1600:mirllc1701:mirllc1810:mirllctrunk:mirllc-assertions-trunk
+group.mirllc.compilers=mirllc32:mirllc33:mirllc391:mirllc400:mirllc401:mirllc500:mirllc600:mirllc700:mirllc800:mirllc900:mirllc1000:mirllc1001:mirllc1100:mirllc1101:mirllc1200:mirllc1201:mirllc1300:mirllc1400:mirllc1500:mirllc1600:mirllc1701:mirllc1810:mirllc1910:mirllctrunk:mirllc-assertions-trunk
 group.mirllc.compilerType=llc
 group.mirllc.supportsExecute=false
 group.mirllc.intelAsm=-masm=intel
@@ -61,6 +61,8 @@ compiler.mirllc1701.exe=/opt/compiler-explorer/clang-17.0.1/bin/llc
 compiler.mirllc1701.semver=17.0.1
 compiler.mirllc1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llc
 compiler.mirllc1810.semver=18.1.0
+compiler.mirllc1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llc
+compiler.mirllc1910.semver=19.1.0
 compiler.mirllctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.mirllctrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.mirllctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump


### PR DESCRIPTION
Add clang 19 for C for ARM, Mips, BPF, and RISC-V. C++ was already done a few months ago. Also add clang 19 for LLVM MIR and Assembly.

For ARM I used gcc 14.2.0 to match what was already done for C++.