### PR TITLE
Fix include path for Armv7-A compilers using gcc 12.2.0 sysroot

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -830,7 +830,7 @@ compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv7-clang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-clang-trunk.semver=(trunk)
 compiler.armv7-clang-trunk.isNightly=true
-compiler.armv7-clang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-clang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 ################################
 # Clang for Arm

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -656,7 +656,7 @@ compiler.armv7-cclang-trunk.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-
 compiler.armv7-cclang-trunk.semver=(trunk)
 compiler.armv7-cclang-trunk.isNightly=true
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-cclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -37,7 +37,7 @@ compiler.armv7-cpp4oclclang1500.name=armv7-a clang 15.0.0
 compiler.armv7-cpp4oclclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.armv7-cpp4oclclang1500.semver=15.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang1500.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cpp4oclclang1500.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-cpp4oclclang1500.name=armv8-a clang 15.0.0
 compiler.armv8-cpp4oclclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
@@ -50,7 +50,7 @@ compiler.armv7-cpp4oclclang1400.name=armv7-a clang 14.0.0
 compiler.armv7-cpp4oclclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
 compiler.armv7-cpp4oclclang1400.semver=14.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang1400.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cpp4oclclang1400.options=-target arm-linux-gnueabhf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-cpp4oclclang1400.name=armv8-a clang 14.0.0
 compiler.armv8-cpp4oclclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
@@ -143,7 +143,7 @@ compiler.armv7-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/
 compiler.armv7-cpp4oclclang-trunk.semver=(trunk)
 compiler.armv7-cpp4oclclang-trunk.isNightly=true
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cpp4oclclang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv7-cpp4oclclang-trunk-assertions.name=armv7-a clang (trunk, assertions)
 compiler.armv7-cpp4oclclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
@@ -151,7 +151,7 @@ compiler.armv7-cpp4oclclang-trunk-assertions.objdumper=/opt/compiler-explorer/gc
 compiler.armv7-cpp4oclclang-trunk-assertions.semver=(assertions trunk)
 compiler.armv7-cpp4oclclang-trunk-assertions.isNightly=true
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cpp4oclclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-cpp4oclclang-trunk-assertions.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-cpp4oclclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cpp4oclclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -37,7 +37,7 @@ compiler.armv7-oclcclang1500.name=armv7-a clang 15.0.0
 compiler.armv7-oclcclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
 compiler.armv7-oclcclang1500.semver=15.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang1500.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-oclcclang1500.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-oclcclang1500.name=armv8-a clang 15.0.0
 compiler.armv8-oclcclang1500.exe=/opt/compiler-explorer/clang-15.0.0/bin/clang
@@ -50,7 +50,7 @@ compiler.armv7-oclcclang1400.name=armv7-a clang 14.0.0
 compiler.armv7-oclcclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
 compiler.armv7-oclcclang1400.semver=14.0.0
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang1400.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-oclcclang1400.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-oclcclang1400.name=armv8-a clang 14.0.0
 compiler.armv8-oclcclang1400.exe=/opt/compiler-explorer/clang-14.0.0/bin/clang
@@ -167,14 +167,14 @@ compiler.armv7-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv7-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-oclcclang-trunk.semver=(trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang-trunk.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-oclcclang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv7-oclcclang-trunk-assertions.name=armv7-a clang (trunk, assertions)
 compiler.armv7-oclcclang-trunk-assertions.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang
 compiler.armv7-oclcclang-trunk-assertions.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv7-oclcclang-trunk-assertions.semver=(assertions trunk)
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-oclcclang-trunk-assertions.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/sysroot
+compiler.armv7-oclcclang-trunk-assertions.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-oclcclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang


### PR DESCRIPTION
It seems that 12.2.0 used to be built with the soft float ABI, "gnueabi", but at some point was rebuilt with the hard float ABI "gnueabihf".

I see this when using GCC 12.2.0 directly:
```
COLLECT_GCC=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
Target: arm-unknown-linux-gnueabihf
```

This broke any C or C++ example that uses a standard include. Like, at time of writing, https://godbolt.org/z/rKsnj9Mj7.

So I've updated all the compilers that referenced this sysroot. This includes updating the target setting, but judging from the nearby comments the intention was always to produce hard float code anyway.