### PR TITLE
upgrade mimic++ header-only library

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4991,7 +4991,7 @@ libs.mfem.versions.47.packagedheaders=true
 
 libs.mimicpp.name=mimic++
 libs.mimicpp.description=A modern and (mostly) macro free mocking framework.
-libs.mimicpp.versions=trunk:1:2:3
+libs.mimicpp.versions=trunk:1:2:3:4:5:6
 libs.mimicpp.url=https://github.com/DNKpp/mimicpp
 libs.mimicpp.versions.trunk.version=trunk
 libs.mimicpp.versions.trunk.path=/opt/compiler-explorer/libs/mimicpp/trunk/include
@@ -5001,6 +5001,12 @@ libs.mimicpp.versions.2.version=v2
 libs.mimicpp.versions.2.path=/opt/compiler-explorer/libs/mimicpp/v2/include
 libs.mimicpp.versions.3.version=v3
 libs.mimicpp.versions.3.path=/opt/compiler-explorer/libs/mimicpp/v3/include
+ibs.mimicpp.versions.4.version=v4
+libs.mimicpp.versions.4.path=/opt/compiler-explorer/libs/mimicpp/v4/include
+ibs.mimicpp.versions.5.version=v5
+libs.mimicpp.versions.5.path=/opt/compiler-explorer/libs/mimicpp/v5/include
+ibs.mimicpp.versions.6.version=v6
+libs.mimicpp.versions.6.path=/opt/compiler-explorer/libs/mimicpp/v6/include
 
 libs.mlir.name=MLIR
 libs.mlir.description=MLIR

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5001,11 +5001,11 @@ libs.mimicpp.versions.2.version=v2
 libs.mimicpp.versions.2.path=/opt/compiler-explorer/libs/mimicpp/v2/include
 libs.mimicpp.versions.3.version=v3
 libs.mimicpp.versions.3.path=/opt/compiler-explorer/libs/mimicpp/v3/include
-ibs.mimicpp.versions.4.version=v4
+libs.mimicpp.versions.4.version=v4
 libs.mimicpp.versions.4.path=/opt/compiler-explorer/libs/mimicpp/v4/include
-ibs.mimicpp.versions.5.version=v5
+libs.mimicpp.versions.5.version=v5
 libs.mimicpp.versions.5.path=/opt/compiler-explorer/libs/mimicpp/v5/include
-ibs.mimicpp.versions.6.version=v6
+libs.mimicpp.versions.6.version=v6
 libs.mimicpp.versions.6.path=/opt/compiler-explorer/libs/mimicpp/v6/include
 
 libs.mlir.name=MLIR


### PR DESCRIPTION
Adds v4, v5 and v6.

related to: [compiler-explorer/infra](https://github.com/compiler-explorer/infra/pull/1490)