### PR TITLE
[rust] switch to `-C debuginfo=2`

### DIFF
--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -247,7 +247,7 @@ export class RustCompiler extends BaseCompiler {
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
-        let options = ['-C', 'debuginfo=1', '-o', this.filename(outputFilename)];
+        let options = ['-C', 'debuginfo=2', '-o', this.filename(outputFilename)];
 
         const userRequestedEmit = _.any(unwrap(userOptions), opt => opt.includes('--emit'));
         if (filters.binary) {

--- a/test/base-compiler-tests.ts
+++ b/test/base-compiler-tests.ts
@@ -856,7 +856,7 @@ describe('Rust overrides', () => {
         );
         expect(originalOptions).toEqual([
             '-C',
-            'debuginfo=1',
+            'debuginfo=2',
             '-o',
             'output.txt',
             '--crate-type',
@@ -870,6 +870,6 @@ describe('Rust overrides', () => {
                     value: 'aarch64-linux-something',
                 },
             ]),
-        ).toEqual(['-C', 'debuginfo=1', '-o', 'output.txt', '--crate-type', 'bin', '-Clinker=/usr/aarch64/bin/gcc']);
+        ).toEqual(['-C', 'debuginfo=2', '-o', 'output.txt', '--crate-type', 'bin', '-Clinker=/usr/aarch64/bin/gcc']);
     });
 });


### PR DESCRIPTION
This is mainly for `pahole`, which requires type information that is only present with `-C debuginfo=2`:
https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo

CE originally passed `-g` to `rustc` (which is an alias for `-C debuginfo=2`), but this was changed in c4411ff2a135893b13d49a65c7da613caa93d6ba to `-C debuginfo=1` to work around https://github.com/rust-lang/rust/issues/11906. However, this workaround never actually removed frame pointers, so switching back to `-C debuginfo=2` should not affect codegen for very old `rustc` versions. See also #79.