### PR TITLE
Add Hexagon-clang support for LLVM IR

### DIFF
--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&irclang:&llc:&opt
+compilers=&irclang:&irhexagon-clang:&llc:&opt
 defaultCompiler=llctrunk
 
 demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
@@ -60,6 +60,18 @@ compiler.irclangtrunk.semver=(trunk)
 compiler.irclang-assertions-trunk.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
 compiler.irclang-assertions-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.irclang-assertions-trunk.semver=(assertions trunk)
+
+group.irhexagon-clang.groupName=Hexagon clang
+group.irhexagon-clang.baseName=hexagon-clang
+group.irhexagon-clang.compilers=irhexagonclang1605
+group.irhexagon-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+group.irhexagon-clang.options=-x ir
+
+compiler.irhexagonclang1605.semver=16.0.5
+compiler.irhexagonclang1605.name=hexagon-clang 16.0.5
+compiler.irhexagonclang1605.exe=/opt/compiler-explorer/clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl/x86_64-linux-gnu/bin/clang++
+compiler.irhexagonclang1605.compilerType=clang-hexagon
+compiler.irhexagonclang1605.compilerCategories=clang-hexagon
 
 group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llc1600:llc1701:llc1810:llc1910:llctrunk:llc-assertions-trunk
 group.llc.compilerType=llc


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->