### PR TITLE
Set demanglerType=win32 in Windows sample props

### DIFF
--- a/docs/WindowsLocal.properties
+++ b/docs/WindowsLocal.properties
@@ -8,6 +8,7 @@ includePath=c:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSV
 # replace with the result of `where undname.exe` from a developer command prompt
 
 demangler=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\Hostx64\x64\undname.exe
+demanglerType=win32
 
 # the compiler you want compiler explorer to start up in
 


### PR DESCRIPTION
Adds a missing property for the sample Windows props file. Without it, `Win32Demangler` isn't used and demangling fails:

```sh
error: Demangler output issue 5 > 1 {"0":"_num$","code":1,"execTime":24,"okToCache":true,"stderr":"","stdout":"Microsoft (R) C++ Name Undecorator\r\nCopyright (C) Microsoft Corporation. All rights reserved.\r\n\r\nUsage: undname [flags] fname [fname...]\r\n   or: undname [flags] file\r\n","timedOut":false,"truncated":false}
error: Error during compilation 2:  Internal issue in demangler {"stack":"Error: Internal issue in demangler\n    at CppDemangler.processOutput (c:\\Users\\sweet\\Source\\Repos\\compiler-explorer\\lib\\demangler\\base.ts:172:19)\n    at CppDemangler.process (c:\\Users\\sweet\\Source\\Repos\\compiler-explorer\\lib\\demangler\\base.ts:223:21)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at Win32VcCompiler.postProcessAsm (c:\\Users\\sweet\\Source\\Repos\\compiler-explorer\\lib\\base-compiler.ts:3137:16)\n    at Win32VcCompiler.afterCompilation (c:\\Users\\sweet\\Source\\Repos\\compiler-explorer\\lib\\base-compiler.ts:3071:41)\n    at <anonymous> (c:\\Users\\sweet\\Source\\Repos\\compiler-explorer\\lib\\base-compiler.ts:2988:28)\n    at env.enqueue.abandonIfStale (c:\\Users\\sweet\\Source\\Repos\\compiler-explorer\\lib\\base-compiler.ts:2956:29)\n    at async file:///C:/Users/sweet/Source/Repos/compiler-explorer/node_modules/p-queue/dist/index.js:187:36"}
```

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
