### PR TITLE
View Elixir jitted assembly

### DIFF
--- a/etc/config/elixir.defaults.properties
+++ b/etc/config/elixir.defaults.properties
@@ -1,14 +1,22 @@
 # Default settings for Elixir
-compilers=&elixir
-compilerType=elixir
+compilers=&elixir:&elixirasm
+
 versionFlag=--short-version
 objdumper=
-instructionSet=beam
 
 group.elixir.compilers=elixirdefault
+group.elixir.compilerType=elixir
+group.elixir.instructionSet=beam
 compiler.elixirdefault.exe=/urs/bin/elixir
 compiler.elixirdefault.runtime=/urs/bin/elixir
 compiler.elixirdefault.name=elixirc default
+
+group.elixirasm.compilers=elixirasmdefault
+group.elixirasm.compilerType=elixirasm
+group.elixirasm.instructionSet=amd64
+compiler.elixirasmdefault.exe=/urs/bin/elixir
+compiler.elixirasmdefault.runtime=/urs/bin/elixir
+compiler.elixirasmdefault.name=elixirc default
 
 defaultCompiler=elixirdefault
 demangler=

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -63,10 +63,11 @@ export {
     DotNetNativeAotCompiler,
 } from './dotnet.js';
 export {EDGCompiler} from './edg.js';
-export {EllccCompiler} from './ellcc.js';
+export {ElixirAsmCompiler} from './elixirasm.js';
 export {ElixirCompiler} from './elixir.js';
-export {ErlangCompiler} from './erlang.js';
+export {EllccCompiler} from './ellcc.js';
 export {ErlangAsmCompiler} from './erlangasm.js';
+export {ErlangCompiler} from './erlang.js';
 export {EWARMCompiler} from './ewarm.js';
 export {EWAVRCompiler} from './ewavr.js';
 export {FakeCompiler} from './fake-for-test.js';

--- a/lib/compilers/elixirasm.ts
+++ b/lib/compilers/elixirasm.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+
+import {ElixirParser} from './argument-parsers.js';
+
+export class ElixirAsmCompiler extends BaseCompiler {
+    static get key() {
+        return 'elixirasm';
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string): string[] {
+        return [
+            '--eval',
+            '[input] = Code.required_files();' +
+                'code = Code.compile_file(input);' +
+                ':erts_debug.set_internal_state(:available_internal_state, true);' +
+                ':erts_debug.set_internal_state(:jit_asm_dump, true);' +
+                'code = Code.compile_file(input)' +
+                '|> Enum.map(fn {module,_} -> File.read!(:erlang.atom_to_list(module) ++ ".asm") end) ' +
+                '|> Enum.join("\n"); ' +
+                `:ok = File.write("${outputFilename}", code);`,
+        ];
+    }
+
+    override orderArguments(
+        options: string[],
+        inputFilename: string,
+        libIncludes: string[],
+        libOptions: string[],
+        libPaths: string[],
+        libLinks: string[],
+        userOptions: string[],
+        staticLibLinks: string[],
+    ): string[] {
+        return ['-r', inputFilename]
+            .concat(options)
+            .concat(libIncludes, libOptions, libPaths, libLinks, userOptions, staticLibLinks);
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string): string {
+        return path.join(dirPath, `${outputFilebase}.asm`);
+    }
+
+    override getArgumentParserClass() {
+        return ElixirParser;
+    }
+}


### PR DESCRIPTION
Hi, this PR adds a way to view the assembly code of Elixir code.

This continue the work from #6081 and #6104