### PR TITLE
Add GCC 14.2.0 for esp32 xtensa

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3430,7 +3430,7 @@ compiler.rv32-gcctrunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv3
 
 ################################
 # GCC for Xtensa ESP32
-group.xtensaesp32.compilers=esp32g2019r2:esp32g2020r1:esp32g2020r2:esp32g2020r3:esp32g2021r1:esp32g2021r2:esp32g2022r1:esp32g20230208
+group.xtensaesp32.compilers=esp32g2019r2:esp32g2020r1:esp32g2020r2:esp32g2020r3:esp32g2021r1:esp32g2021r2:esp32g2022r1:esp32g20230208:esp32g20241119
 group.xtensaesp32.groupName=Xtensa ESP32 GCC
 group.xtensaesp32.supportsBinary=false
 group.xtensaesp32.instructionSet=xtensa
@@ -3452,10 +3452,12 @@ compiler.esp32g2022r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-gcc11_2
 compiler.esp32g2022r1.name=Xtensa ESP32 gcc 11.2.0 (2022r1)
 compiler.esp32g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-g++
 compiler.esp32g20230208.name=Xtensa ESP32 gcc 12.2.0 (20230208)
+compiler.esp32g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32-elf-g++
+compiler.esp32g20241119.name=Xtensa ESP32 gcc 14.2.0 (20241119)
 
 ################################
 # GCC for Xtensa ESP32-S2
-group.xtensaesp32s2.compilers=esp32s2g2019r2:esp32s2g2020r1:esp32s2g2020r2:esp32s2g2020r3:esp32s2g2021r1:esp32s2g2021r2:esp32s2g2022r1:esp32s2g20230208
+group.xtensaesp32s2.compilers=esp32s2g2019r2:esp32s2g2020r1:esp32s2g2020r2:esp32s2g2020r3:esp32s2g2021r1:esp32s2g2021r2:esp32s2g2022r1:esp32s2g20230208:esp32s2g20241119
 group.xtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.xtensaesp32s2.supportsBinary=false
 group.xtensaesp32s2.instructionSet=xtensa
@@ -3477,10 +3479,12 @@ compiler.esp32s2g2022r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-gcc
 compiler.esp32s2g2022r1.name=Xtensa ESP32-S2 gcc 11.2.0 (2022r1)
 compiler.esp32s2g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-g++
 compiler.esp32s2g20230208.name=Xtensa ESP32-S2 gcc 12.2.0 (20230208)
+compiler.esp32s2g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s2-elf-g++
+compiler.esp32s2g20241119.name=Xtensa ESP32-S2 gcc 14.2.0 (20241119)
 
 ################################
 # GCC for Xtensa ESP32-S3
-group.xtensaesp32s3.compilers=esp32s3g2020r3:esp32s3g2021r1:esp32s3g2021r2:esp32s3g2022r1:esp32s3g20230208
+group.xtensaesp32s3.compilers=esp32s3g2020r3:esp32s3g2021r1:esp32s3g2021r2:esp32s3g2022r1:esp32s3g20230208:esp32s3g20241119
 group.xtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.xtensaesp32s3.supportsBinary=false
 group.xtensaesp32s3.instructionSet=xtensa
@@ -3496,6 +3500,8 @@ compiler.esp32s3g2022r1.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-gcc
 compiler.esp32s3g2022r1.name=Xtensa ESP32-S3 gcc 11.2.0 (2022r1)
 compiler.esp32s3g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-g++
 compiler.esp32s3g20230208.name=Xtensa ESP32-S3 gcc 12.2.0 (20230208)
+compiler.esp32s3g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s3-elf-g++
+compiler.esp32s3g20241119.name=Xtensa ESP32-S3 gcc 14.2.0 (20241119)
 
 ################################
 # Windows Compilers

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3058,7 +3058,7 @@ compiler.rv32-cgcctrunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv
 
 ################################
 # GCC for Xtensa ESP32
-group.cxtensaesp32.compilers=cesp32g2019r2:cesp32g2020r1:cesp32g2020r2:cesp32g2020r3:cesp32g2021r1:cesp32g2021r2:cesp32g2022r1:cesp32g20230208
+group.cxtensaesp32.compilers=cesp32g2019r2:cesp32g2020r1:cesp32g2020r2:cesp32g2020r3:cesp32g2021r1:cesp32g2021r2:cesp32g2022r1:cesp32g20230208:cesp32g20241119
 group.cxtensaesp32.groupName=Xtensa ESP32 GCC
 group.cxtensaesp32.supportsBinary=false
 group.cxtensaesp32.instructionSet=xtensa
@@ -3089,10 +3089,13 @@ compiler.cesp32g2022r1.name=Xtensa ESP32 gcc 11.2.0 (2022r1)
 compiler.cesp32g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-gcc
 compiler.cesp32g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-objdump
 compiler.cesp32g20230208.name=Xtensa ESP32 gcc 12.2.0 (20230208)
+compiler.cesp32g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32-elf-gcc
+compiler.cesp32g20241119.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32-elf-objdump
+compiler.cesp32g20241119.name=Xtensa ESP32 gcc 14.2.0 (20241119)
 
 ################################
 # GCC for Xtensa ESP32-S2
-group.cxtensaesp32s2.compilers=cesp32s2g2019r2:cesp32s2g2020r1:cesp32s2g2020r2:cesp32s2g2020r3:cesp32s2g2021r1:cesp32s2g2021r2:cesp32s2g2022r1:cesp32s2g20230208
+group.cxtensaesp32s2.compilers=cesp32s2g2019r2:cesp32s2g2020r1:cesp32s2g2020r2:cesp32s2g2020r3:cesp32s2g2021r1:cesp32s2g2021r2:cesp32s2g2022r1:cesp32s2g20230208:cesp32s2g20241119
 group.cxtensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.cxtensaesp32s2.supportsBinary=false
 group.cxtensaesp32s2.instructionSet=xtensa
@@ -3123,10 +3126,13 @@ compiler.cesp32s2g2022r1.name=Xtensa ESP32-S2 gcc 11.2.0 (2022r1)
 compiler.cesp32s2g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-gcc
 compiler.cesp32s2g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-objdump
 compiler.cesp32s2g20230208.name=Xtensa ESP32-S2 gcc 12.2.0 (20230208)
+compiler.cesp32s2g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s2-elf-gcc
+compiler.cesp32s2g20241119.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s2-elf-objdump
+compiler.cesp32s2g20241119.name=Xtensa ESP32-S2 gcc 14.2.0 (20241119)
 
 ################################
 # GCC for Xtensa ESP32-S3
-group.cxtensaesp32s3.compilers=cesp32s3g2020r3:cesp32s3g2021r1:cesp32s3g2021r2:cesp32s3g2022r1:cesp32s3g20230208
+group.cxtensaesp32s3.compilers=cesp32s3g2020r3:cesp32s3g2021r1:cesp32s3g2021r2:cesp32s3g2022r1:cesp32s3g20230208:cesp32s3g20241119
 group.cxtensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.cxtensaesp32s3.supportsBinary=false
 group.cxtensaesp32s3.instructionSet=xtensa
@@ -3148,6 +3154,9 @@ compiler.cesp32s3g2022r1.name=Xtensa ESP32-S3 gcc 11.2.0 (2022r1)
 compiler.cesp32s3g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-gcc
 compiler.cesp32s3g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-objdump
 compiler.cesp32s3g20230208.name=Xtensa ESP32-S3 gcc 12.2.0 (20230208)
+compiler.cesp32s3g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s3-elf-gcc
+compiler.cesp32s3g20241119.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s3-elf-objdump
+compiler.cesp32s3g20241119.name=Xtensa ESP32-S3 gcc 14.2.0 (20241119)
 
 ################################
 # Windows Compilers

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -184,7 +184,7 @@ compiler.gimpleavrg1420.demangler=/opt/compiler-explorer/avr/gcc-14.2.0/avr/bin/
 
 ################################
 # GCC for Xtensa ESP32
-group.gimplextensaesp32.compilers=gimpleesp32g2022r1:gimpleesp32g20230208
+group.gimplextensaesp32.compilers=gimpleesp32g2022r1:gimpleesp32g20230208:gimpleesp32g20241119
 group.gimplextensaesp32.groupName=Xtensa ESP32 GCC
 group.gimplextensaesp32.supportsBinary=false
 group.gimplextensaesp32.instructionSet=xtensa
@@ -197,10 +197,13 @@ compiler.gimpleesp32g2022r1.name=Xtensa ESP32 gcc 11.2.0 (2022r1)
 compiler.gimpleesp32g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-gcc
 compiler.gimpleesp32g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32-elf-12.2.0_20230208/bin/xtensa-esp32-elf-objdump
 compiler.gimpleesp32g20230208.name=Xtensa ESP32 gcc 12.2.0 (20230208)
+compiler.gimpleesp32g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32-elf-gcc
+compiler.gimpleesp32g20241119.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32-elf-objdump
+compiler.gimpleesp32g20241119.name=Xtensa ESP32 gcc 14.2.0 (20241119)
 
 ################################
 # GCC for Xtensa ESP32-S2
-group.gimplextensaesp32s2.compilers=gimpleesp32s2g2022r1:gimpleesp32s2g20230208
+group.gimplextensaesp32s2.compilers=gimpleesp32s2g2022r1:gimpleesp32s2g20230208:gimpleesp32s2g20241119
 group.gimplextensaesp32s2.groupName=Xtensa ESP32-S2 GCC
 group.gimplextensaesp32s2.supportsBinary=false
 group.gimplextensaesp32s2.instructionSet=xtensa
@@ -213,10 +216,13 @@ compiler.gimpleesp32s2g2022r1.name=Xtensa ESP32-S2 gcc 11.2.0 (2022r1)
 compiler.gimpleesp32s2g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-gcc
 compiler.gimpleesp32s2g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s2-elf-12.2.0_20230208/bin/xtensa-esp32s2-elf-objdump
 compiler.gimpleesp32s2g20230208.name=Xtensa ESP32-S2 gcc 12.2.0 (20230208)
+compiler.gimpleesp32s2g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s2-elf-gcc
+compiler.gimpleesp32s2g20241119.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s2-elf-objdump
+compiler.gimpleesp32s2g20241119.name=Xtensa ESP32-S2 gcc 14.2.0 (20241119)
 
 ################################
 # GCC for Xtensa ESP32-S3
-group.gimplextensaesp32s3.compilers=gimpleesp32s3g2022r1:gimpleesp32s3g20230208
+group.gimplextensaesp32s3.compilers=gimpleesp32s3g2022r1:gimpleesp32s3g20230208:gimpleesp32s3g20241119
 group.gimplextensaesp32s3.groupName=Xtensa ESP32-S3 GCC
 group.gimplextensaesp32s3.supportsBinary=false
 group.gimplextensaesp32s3.instructionSet=xtensa
@@ -229,6 +235,9 @@ compiler.gimpleesp32s3g2022r1.name=Xtensa ESP32-S3 gcc 11.2.0 (2022r1)
 compiler.gimpleesp32s3g20230208.exe=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-gcc
 compiler.gimpleesp32s3g20230208.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp32s3-elf-12.2.0_20230208/bin/xtensa-esp32s3-elf-objdump
 compiler.gimpleesp32s3g20230208.name=Xtensa ESP32-S3 gcc 12.2.0 (20230208)
+compiler.gimpleesp32s3g20241119.exe=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s3-elf-gcc
+compiler.gimpleesp32s3g20241119.objdumper=/opt/compiler-explorer/xtensa/xtensa-esp-elf-14.2.0_20241119/bin/xtensa-esp32s3-elf-objdump
+compiler.gimpleesp32s3g20241119.name=Xtensa ESP32-S3 gcc 14.2.0 (20241119)
 
 ###############################
 # GCC for Kalray


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

update esp32 extensa target compiler to gcc 14.2.0

MR for relevant infra changes: https://github.com/compiler-explorer/infra/pull/1500
