### PR TITLE
Fix dex2oat on Android Kotlin

### DIFF
--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -145,7 +145,7 @@ export class Dex2OatCompiler extends BaseCompiler {
 
         // Regexes that apply to .smali files (R8/D8 dump output).
         this.smaliLineNumberRegex = /^\s+\.line\s+(\d+).*$/;
-        this.smaliClassRegex = /^\.class\s(.*)$/;
+        this.smaliClassRegex = /^\.class\s.*(L.*;)$/;
         this.smaliDexPcRegex = /^\s+#@(\w+).*$/;
         this.smaliMethodStartRegex = /^\.method\s(.*)$/;
         this.smaliMethodEndRegex = /^\s*\.end\smethod.*$/;


### PR DESCRIPTION
The Kotlin compilation step results in an added 'final' in the D8 .smali output, which we weren't accounting for. This change updates the class name regex for .smali files to collect only the 'L<class>;' string.

This change also fixes dex2oat for Android Java in cases where 'final' is applied to classes.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
