### PR TITLE
Update Android compilers

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -1,12 +1,24 @@
 compilers=&android-d8:&android-r8:&dex2oat:&android-openjdk
 
-group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242:java-d8-8247:java-d8-8336:java-d8-8337:java-d8-8510:java-d8-8527:java-d8-8535
+group.android-d8.compilers=java-d8-8156:java-d8-8172:java-d8-8233:java-d8-8242:java-d8-8247:java-d8-8336:java-d8-8337:java-d8-8510:java-d8-8527:java-d8-8535:java-d8-8617:java-d8-8627:java-d8-8714:java-d8-8718
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
 group.android-d8.instructionSet=dex
+
+compiler.java-d8-8718.name=d8 8.7.18
+compiler.java-d8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar
+
+compiler.java-d8-8714.name=d8 8.7.14
+compiler.java-d8-8714.exe=/opt/compiler-explorer/r8-8.7.14/r8-8.7.14.jar
+
+compiler.java-d8-8627.name=d8 8.6.27
+compiler.java-d8-8627.exe=/opt/compiler-explorer/r8-8.6.27/r8-8.6.27.jar
+
+compiler.java-d8-8617.name=d8 8.6.17
+compiler.java-d8-8617.exe=/opt/compiler-explorer/r8-8.6.17/r8-8.6.17.jar
 
 compiler.java-d8-8535.name=d8 8.5.35
 compiler.java-d8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
@@ -38,12 +50,24 @@ compiler.java-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.java-d8-8156.name=d8 8.1.56
 compiler.java-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
-group.android-r8.compilers=java-r8-8233:java-r8-8242:java-r8-8247:java-r8-8336:java-r8-8337:java-r8-8510:java-r8-8527:java-r8-8535
+group.android-r8.compilers=java-r8-8233:java-r8-8242:java-r8-8247:java-r8-8336:java-r8-8337:java-r8-8510:java-r8-8527:java-r8-8535:java-r8-8617:java-r8-8627:java-r8-8714:java-r8-8718
 group.android-r8.compilerType=android-r8
 group.android-r8.isSemVer=true
 group.android-r8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-r8.javaId=java1601
 group.android-r8.kotlinId=kotlinc1920
+
+compiler.java-r8-8718.name=r8 8.7.18
+compiler.java-r8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar
+
+compiler.java-r8-8714.name=r8 8.7.14
+compiler.java-r8-8714.exe=/opt/compiler-explorer/r8-8.7.14/r8-8.7.14.jar
+
+compiler.java-r8-8627.name=r8 8.6.27
+compiler.java-r8-8627.exe=/opt/compiler-explorer/r8-8.6.27/r8-8.6.27.jar
+
+compiler.java-r8-8617.name=r8 8.6.17
+compiler.java-r8-8617.exe=/opt/compiler-explorer/r8-8.6.17/r8-8.6.17.jar
 
 compiler.java-r8-8535.name=r8 8.5.35
 compiler.java-r8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
@@ -69,7 +93,7 @@ compiler.java-r8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.java-r8-8233.name=r8 8.2.33
 compiler.java-r8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
 
-group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3310:java-dex2oat-3411:java-dex2oat-3413:java-dex2oat-3414:java-dex2oat-3415:java-dex2oat-3416:java-dex2oat-3417:java-dex2oat-3418
+group.dex2oat.compilers=java-dex2oat-latest:java-dex2oat-3310:java-dex2oat-3411:java-dex2oat-3413:java-dex2oat-3414:java-dex2oat-3415:java-dex2oat-3416:java-dex2oat-3417:java-dex2oat-3418:java-dex2oat-3508:java-dex2oat-3509:java-dex2oat-3510:java-dex2oat-3511
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
@@ -79,9 +103,37 @@ compiler.java-dex2oat-latest.name=ART dex2oat latest
 compiler.java-dex2oat-latest.artArtifactDir=/opt/compiler-explorer/dex2oat-latest
 compiler.java-dex2oat-latest.exe=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/dex2oat64
 compiler.java-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/oatdump
-compiler.java-dex2oat-latest.d8Id=java-d8-8535
+compiler.java-dex2oat-latest.d8Id=java-d8-8718
 compiler.java-dex2oat-latest.isNightly=true
 compiler.java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+compiler.java-dex2oat-3511.name=ART dex2oat aml_art_351110180 (Nov 2024)
+compiler.java-dex2oat-3511.artArtifactDir=/opt/compiler-explorer/dex2oat-35.11
+compiler.java-dex2oat-3511.exe=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3511.objdumper=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/oatdump
+compiler.java-dex2oat-3511.d8Id=java-d8-8718
+compiler.java-dex2oat-3511.profmanPath=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/profman
+
+compiler.java-dex2oat-3510.name=ART dex2oat aml_art_351011240 (Oct 2024)
+compiler.java-dex2oat-3510.artArtifactDir=/opt/compiler-explorer/dex2oat-35.10
+compiler.java-dex2oat-3510.exe=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3510.objdumper=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/oatdump
+compiler.java-dex2oat-3510.d8Id=java-d8-8718
+compiler.java-dex2oat-3510.profmanPath=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/profman
+
+compiler.java-dex2oat-3509.name=ART dex2oat aml_art_350913340 (Sep 2024)
+compiler.java-dex2oat-3509.artArtifactDir=/opt/compiler-explorer/dex2oat-35.9
+compiler.java-dex2oat-3509.exe=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3509.objdumper=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/oatdump
+compiler.java-dex2oat-3509.d8Id=java-d8-8718
+compiler.java-dex2oat-3509.profmanPath=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/profman
+
+compiler.java-dex2oat-3508.name=ART dex2oat aml_art_350820960 (Aug 2024)
+compiler.java-dex2oat-3508.artArtifactDir=/opt/compiler-explorer/dex2oat-35.8
+compiler.java-dex2oat-3508.exe=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/dex2oat64
+compiler.java-dex2oat-3508.objdumper=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/oatdump
+compiler.java-dex2oat-3508.d8Id=java-d8-8718
+compiler.java-dex2oat-3508.profmanPath=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/profman
 
 compiler.java-dex2oat-3418.name=ART dex2oat aml_art_341810020 (Jun 2024)
 compiler.java-dex2oat-3418.artArtifactDir=/opt/compiler-explorer/dex2oat-34.18
@@ -248,8 +300,20 @@ libs.android-api-stubs.versions.11662386.version=11662386
 libs.android-api-stubs.versions.11662386.path=/opt/compiler-explorer/android-api-stubs-11662386/android.jar
 
 libs.r8-keepanno.name=R8 keep-annotations
-libs.r8-keepanno.versions=8233:8242:8247:8336:8337:8510:8527:8535
+libs.r8-keepanno.versions=8233:8242:8247:8336:8337:8510:8527:8535:8617:8627:8714:8718
 libs.r8-keepanno.url=https://r8.googlesource.com/r8/+/refs/heads/main/doc/keepanno-guide.md
+
+libs.r8-keepanno.versions.8718.version=8.7.18
+libs.r8-keepanno.versions.8718.path=/opt/compiler-explorer/r8-8.7.18-keepanno/keepanno-annotations.jar
+
+libs.r8-keepanno.versions.8714.version=8.7.14
+libs.r8-keepanno.versions.8714.path=/opt/compiler-explorer/r8-8.7.14-keepanno/keepanno-annotations.jar
+
+libs.r8-keepanno.versions.8627.version=8.6.27
+libs.r8-keepanno.versions.8627.path=/opt/compiler-explorer/r8-8.6.27-keepanno/keepanno-annotations.jar
+
+libs.r8-keepanno.versions.8617.version=8.6.17
+libs.r8-keepanno.versions.8617.path=/opt/compiler-explorer/r8-8.6.17-keepanno/keepanno-annotations.jar
 
 libs.r8-keepanno.versions.8535.version=8.5.35
 libs.r8-keepanno.versions.8535.path=/opt/compiler-explorer/r8-8.5.35-keepanno/keepanno-annotations.jar
@@ -304,4 +368,4 @@ libs.androidx-annotation.versions.191.version=1.9.1
 libs.androidx-annotation.versions.191.path=/opt/compiler-explorer/androidx-annotation-1.9.1/annotation-jvm.jar
 
 
-defaultLibs=android-api-stubs.11662386:r8-keepanno.8535:androidx-annotation.versions.191
+defaultLibs=android-api-stubs.11662386:r8-keepanno.8718:androidx-annotation.versions.191

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -1,12 +1,24 @@
 compilers=&android-d8:&android-r8:&dex2oat:&android-kotlinc
 
-group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242:kotlin-d8-8247:kotlin-d8-8336:kotlin-d8-8337:kotlin-d8-8510:kotlin-d8-8527:kotlin-d8-8535
+group.android-d8.compilers=kotlin-d8-8156:kotlin-d8-8172:kotlin-d8-8233:kotlin-d8-8242:kotlin-d8-8247:kotlin-d8-8336:kotlin-d8-8337:kotlin-d8-8510:kotlin-d8-8527:kotlin-d8-8535:kotlin-d8-8617:kotlin-d8-8627:kotlin-d8-8714:kotlin-d8-8718
 group.android-d8.compilerType=android-d8
 group.android-d8.isSemVer=true
 group.android-d8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-d8.javaId=java1601
 group.android-d8.kotlinId=kotlinc1920
 group.android-d8.instructionSet=dex
+
+compiler.kotlin-d8-8718.name=d8 8.7.18
+compiler.kotlin-d8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar
+
+compiler.kotlin-d8-8714.name=d8 8.7.14
+compiler.kotlin-d8-8714.exe=/opt/compiler-explorer/r8-8.7.14/r8-8.7.14.jar
+
+compiler.kotlin-d8-8627.name=d8 8.6.27
+compiler.kotlin-d8-8627.exe=/opt/compiler-explorer/r8-8.6.27/r8-8.6.27.jar
+
+compiler.kotlin-d8-8617.name=d8 8.6.17
+compiler.kotlin-d8-8617.exe=/opt/compiler-explorer/r8-8.6.17/r8-8.6.17.jar
 
 compiler.kotlin-d8-8535.name=d8 8.5.35
 compiler.kotlin-d8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
@@ -38,13 +50,25 @@ compiler.kotlin-d8-8172.exe=/opt/compiler-explorer/r8-8.1.72/r8-8.1.72.jar
 compiler.kotlin-d8-8156.name=d8 8.1.56
 compiler.kotlin-d8-8156.exe=/opt/compiler-explorer/r8-8.1.56/r8-8.1.56.jar
 
-group.android-r8.compilers=kotlin-r8-8233:kotlin-r8-8242:kotlin-r8-8247:kotlin-r8-8336:kotlin-r8-8337:kotlin-r8-8510:kotlin-r8-8527:kotlin-r8-8535
+group.android-r8.compilers=kotlin-r8-8233:kotlin-r8-8242:kotlin-r8-8247:kotlin-r8-8336:kotlin-r8-8337:kotlin-r8-8510:kotlin-r8-8527:kotlin-r8-8535:kotlin-r8-8617:kotlin-r8-8627:kotlin-r8-8714:kotlin-r8-8718
 group.android-r8.compilerType=android-r8
 group.android-r8.isSemVer=true
 group.android-r8.objdumper=/opt/compiler-explorer/baksmali-3.0.3/baksmali-3.0.3-fat.jar
 group.android-r8.javaId=java1601
 group.android-r8.kotlinId=kotlinc1920
 group.android-r8.kotlinLibPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/lib
+
+compiler.kotlin-r8-8718.name=r8 8.7.18
+compiler.kotlin-r8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar
+
+compiler.kotlin-r8-8714.name=r8 8.7.14
+compiler.kotlin-r8-8714.exe=/opt/compiler-explorer/r8-8.7.14/r8-8.7.14.jar
+
+compiler.kotlin-r8-8627.name=r8 8.6.27
+compiler.kotlin-r8-8627.exe=/opt/compiler-explorer/r8-8.6.27/r8-8.6.27.jar
+
+compiler.kotlin-r8-8617.name=r8 8.6.17
+compiler.kotlin-r8-8617.exe=/opt/compiler-explorer/r8-8.6.17/r8-8.6.17.jar
 
 compiler.kotlin-r8-8535.name=r8 8.5.35
 compiler.kotlin-r8-8535.exe=/opt/compiler-explorer/r8-8.5.35/r8-8.5.35.jar
@@ -70,7 +94,7 @@ compiler.kotlin-r8-8242.exe=/opt/compiler-explorer/r8-8.2.42/r8-8.2.42.jar
 compiler.kotlin-r8-8233.name=r8 8.2.33
 compiler.kotlin-r8-8233.exe=/opt/compiler-explorer/r8-8.2.33/r8-8.2.33.jar
 
-group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3310:kotlin-dex2oat-3411:kotlin-dex2oat-3413:kotlin-dex2oat-3414:kotlin-dex2oat-3415:kotlin-dex2oat-3416:kotlin-dex2oat-3417:kotlin-dex2oat-3418
+group.dex2oat.compilers=kotlin-dex2oat-latest:kotlin-dex2oat-3310:kotlin-dex2oat-3411:kotlin-dex2oat-3413:kotlin-dex2oat-3414:kotlin-dex2oat-3415:kotlin-dex2oat-3416:kotlin-dex2oat-3417:kotlin-dex2oat-3418:kotlin-dex2oat-3508:kotlin-dex2oat-3509:kotlin-dex2oat-3510:kotlin-dex2oat-3511
 group.dex2oat.groupName=ART
 group.dex2oat.compilerType=dex2oat
 group.dex2oat.isSemVer=true
@@ -83,6 +107,34 @@ compiler.kotlin-dex2oat-latest.objdumper=/opt/compiler-explorer/dex2oat-latest/x
 compiler.kotlin-dex2oat-latest.d8Id=kotlin-d8-8535
 compiler.kotlin-dex2oat-latest.isNightly=true
 compiler.kotlin-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3511.name=ART dex2oat aml_art_351110180 (Nov 2024)
+compiler.kotlin-dex2oat-3511.artArtifactDir=/opt/compiler-explorer/dex2oat-35.11
+compiler.kotlin-dex2oat-3511.exe=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3511.objdumper=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3511.d8Id=kotlin-d8-8718
+compiler.kotlin-dex2oat-3511.profmanPath=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3510.name=ART dex2oat aml_art_351011240 (Oct 2024)
+compiler.kotlin-dex2oat-3510.artArtifactDir=/opt/compiler-explorer/dex2oat-35.10
+compiler.kotlin-dex2oat-3510.exe=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3510.objdumper=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3510.d8Id=kotlin-d8-8718
+compiler.kotlin-dex2oat-3510.profmanPath=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3509.name=ART dex2oat aml_art_350913340 (Sep 2024)
+compiler.kotlin-dex2oat-3509.artArtifactDir=/opt/compiler-explorer/dex2oat-35.9
+compiler.kotlin-dex2oat-3509.exe=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3509.objdumper=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3509.d8Id=kotlin-d8-8718
+compiler.kotlin-dex2oat-3509.profmanPath=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/profman
+
+compiler.kotlin-dex2oat-3508.name=ART dex2oat aml_art_350820960 (Aug 2024)
+compiler.kotlin-dex2oat-3508.artArtifactDir=/opt/compiler-explorer/dex2oat-35.8
+compiler.kotlin-dex2oat-3508.exe=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/dex2oat64
+compiler.kotlin-dex2oat-3508.objdumper=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/oatdump
+compiler.kotlin-dex2oat-3508.d8Id=kotlin-d8-8718
+compiler.kotlin-dex2oat-3508.profmanPath=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/profman
 
 compiler.kotlin-dex2oat-3418.name=ART dex2oat aml_art_341810020 (Jun 2024)
 compiler.kotlin-dex2oat-3418.artArtifactDir=/opt/compiler-explorer/dex2oat-34.18
@@ -306,8 +358,20 @@ libs.android-api-stubs.versions.11662386.version=11662386
 libs.android-api-stubs.versions.11662386.path=/opt/compiler-explorer/android-api-stubs-11662386/android.jar
 
 libs.r8-keepanno.name=R8 keep-annotations
-libs.r8-keepanno.versions=8233:8242:8247:8336:8337:8510:8527:8535
+libs.r8-keepanno.versions=8233:8242:8247:8336:8337:8510:8527:8535:8617:8627:8714:8718
 libs.r8-keepanno.url=https://r8.googlesource.com/r8/+/refs/heads/main/doc/keepanno-guide.md
+
+libs.r8-keepanno.versions.8718.version=8.7.18
+libs.r8-keepanno.versions.8718.path=/opt/compiler-explorer/r8-8.7.18-keepanno/keepanno-annotations.jar
+
+libs.r8-keepanno.versions.8714.version=8.7.14
+libs.r8-keepanno.versions.8714.path=/opt/compiler-explorer/r8-8.7.14-keepanno/keepanno-annotations.jar
+
+libs.r8-keepanno.versions.8627.version=8.6.27
+libs.r8-keepanno.versions.8627.path=/opt/compiler-explorer/r8-8.6.27-keepanno/keepanno-annotations.jar
+
+libs.r8-keepanno.versions.8617.version=8.6.17
+libs.r8-keepanno.versions.8617.path=/opt/compiler-explorer/r8-8.6.17-keepanno/keepanno-annotations.jar
 
 libs.r8-keepanno.versions.8535.version=8.5.35
 libs.r8-keepanno.versions.8535.path=/opt/compiler-explorer/r8-8.5.35-keepanno/keepanno-annotations.jar
@@ -362,4 +426,4 @@ libs.androidx-annotation.versions.191.version=1.9.1
 libs.androidx-annotation.versions.191.path=/opt/compiler-explorer/androidx-annotation-1.9.1/annotation-jvm.jar
 
 
-defaultLibs=android-api-stubs.11662386:r8-keepanno.8535:androidx-annotation.versions.191
+defaultLibs=android-api-stubs.11662386:r8-keepanno.8718:androidx-annotation.versions.191


### PR DESCRIPTION
This change adds recent ART mainline releases (version 35) and R8 versions (8.6, 8.7).

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
