### PR TITLE
Let user execution `stdbuf`

### DIFF
--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -131,6 +131,20 @@ mount {
     is_bind: true
 }
 
+###
+# Support for stdbuf
+mount {
+    src: "/usr/bin/stdbuf"
+    dst: "/usr/bin/stdbuf"
+    is_bind: true
+}
+mount {
+    src: "/usr/libexec/coreutils/libstdbuf.so"
+    dst: "/usr/libexec/coreutils/libstdbuf.so"
+    is_bind: true
+}
+###
+
 mount {
     src: "/dev/nvidia0"
     dst: "/dev/nvidia0"


### PR DESCRIPTION
Currently only maps in the stdbuf and the lib it needs. Tested locally and paths confirmed to exist on prod boxes.

See #7239
