### PR TITLE
odin: require main function

### DIFF
--- a/lib/compilers/odin.ts
+++ b/lib/compilers/odin.ts
@@ -98,13 +98,6 @@ export class OdinCompiler extends BaseCompiler {
                     continue;
                 }
 
-                // skip main
-                if (match[1] === 'main') {
-                    outputLines.push(line);
-                    lastLine = line;
-                    continue;
-                }
-
                 // last line already has require?
                 if (lastLine.includes('@require') || lastLine.includes('@(require)')) {
                     outputLines.push(line);

--- a/test/odin-tests.ts
+++ b/test/odin-tests.ts
@@ -46,7 +46,7 @@ const info = {
     lang: languages.odin.id,
 };
 
-describe('GO asm tests', () => {
+describe('Odin source preprocessing tests', () => {
     beforeAll(() => {
         ce = makeCompilationEnvironment({languages});
     });

--- a/test/odin/add_require.odin.expected
+++ b/test/odin/add_require.odin.expected
@@ -13,6 +13,6 @@ test_proc1 :: proc() {
 test_proc2 :: proc() {
 }
 
-main :: proc() {
+@(require) main :: proc() {
     fmt.println("asd")
 }


### PR DESCRIPTION
In optimized build, odin inlines the world and even ends up inlining the user visible `main` function into the entry point main. The result is empty asm output which is confusing. Thus, @require main so that the compiler doesn't inline user visible main function

 #7210