### PR TITLE
Fix .smali class regex in Dex2OatCompiler 

### DIFF
--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -145,7 +145,7 @@ export class Dex2OatCompiler extends BaseCompiler {
 
         // Regexes that apply to .smali files (R8/D8 dump output).
         this.smaliLineNumberRegex = /^\s+\.line\s+(\d+).*$/;
-        this.smaliClassRegex = /^\.class\s.*(L.*;)$/;
+        this.smaliClassRegex = /^\.class.*\s(L.*;)$/;
         this.smaliDexPcRegex = /^\s+#@(\w+).*$/;
         this.smaliMethodStartRegex = /^\.method\s(.*)$/;
         this.smaliMethodEndRegex = /^\s*\.end\smethod.*$/;

--- a/test/android-tests.ts
+++ b/test/android-tests.ts
@@ -80,7 +80,7 @@ describe('dex2oat', () => {
         });
 
         it('Inner classes are correctly read in .smali files', () => {
-            return testParseSmaliInnerClasses(androidKotlinInfo, 'test/android/parse-data');
+            return testParseSmaliInnerClasses(androidJavaInfo, 'test/android/parse-data');
         });
 
         it('Dex PCs are correctly extracted from classes.cfg', () => {

--- a/test/android/parse-data/ClassWithL.smali
+++ b/test/android/parse-data/ClassWithL.smali
@@ -1,0 +1,27 @@
+.class LLSLqLuLaLrLeL;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# direct methods
+.method constructor <init>()V
+    .registers 1
+
+    #@0
+    .line 12
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@3
+    return-void
+.end method
+
+.method static square(I)I
+    .registers 1
+
+    #@0
+    .line 14
+    mul-int/2addr p0, p0
+
+    #@1
+    return p0
+.end method

--- a/test/android/parse-data/InnerClassCases.smali
+++ b/test/android/parse-data/InnerClassCases.smali
@@ -1,0 +1,187 @@
+.class final LInnerClassCases$FinalInnerClass;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = LInnerClassCases;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x10
+    name = "FinalInnerClass"
+.end annotation
+
+
+# instance fields
+.field final synthetic this$0:LInnerClassCases;
+
+
+# direct methods
+.method constructor <init>(LInnerClassCases;)V
+    .registers 2
+
+    #@0
+    .line 3
+    iput-object p1, p0, LInnerClassCases$FinalInnerClass;->this$0:LInnerClassCases;
+
+    #@2
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@5
+    return-void
+.end method
+
+
+.class LInnerClassCases$InnerClass;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = LInnerClassCases;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x0
+    name = "InnerClass"
+.end annotation
+
+
+# instance fields
+.field final synthetic this$0:LInnerClassCases;
+
+
+# direct methods
+.method constructor <init>(LInnerClassCases;)V
+    .registers 2
+
+    #@0
+    .line 2
+    iput-object p1, p0, LInnerClassCases$InnerClass;->this$0:LInnerClassCases;
+
+    #@2
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@5
+    return-void
+.end method
+
+
+.class final LInnerClassCases$LStartsWithL;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = LInnerClassCases;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x18
+    name = "LStartsWithL"
+.end annotation
+
+
+# direct methods
+.method constructor <init>()V
+    .registers 1
+
+    #@0
+    .line 6
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@3
+    return-void
+.end method
+
+
+.class final LInnerClassCases$StaticFinalInnerClass;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = LInnerClassCases;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x18
+    name = "StaticFinalInnerClass"
+.end annotation
+
+
+# direct methods
+.method constructor <init>()V
+    .registers 1
+
+    #@0
+    .line 5
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@3
+    return-void
+.end method
+
+
+.class LInnerClassCases$StaticInnerClass;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = LInnerClassCases;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x8
+    name = "StaticInnerClass"
+.end annotation
+
+
+# direct methods
+.method constructor <init>()V
+    .registers 1
+
+    #@0
+    .line 4
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@3
+    return-void
+.end method
+
+
+.class LInnerClassCases;
+.super Ljava/lang/Object;
+.source "example.java"
+
+
+# annotations
+.annotation system Ldalvik/annotation/MemberClasses;
+    value = {
+        LInnerClassCases$LStartsWithL;,
+        LInnerClassCases$StaticFinalInnerClass;,
+        LInnerClassCases$StaticInnerClass;,
+        LInnerClassCases$FinalInnerClass;,
+        LInnerClassCases$InnerClass;
+    }
+.end annotation
+
+
+# direct methods
+.method constructor <init>()V
+    .registers 1
+
+    #@0
+    .line 1
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    #@3
+    return-void
+.end method


### PR DESCRIPTION
This fixes the case where compilations of classes including a 'L'
character would fail. A test case has been added for this, and for inner
classes.