### PR TITLE
Decommision the "AWS" magic compiler name

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -546,7 +546,7 @@ async function main() {
     const compileHandler = new CompileHandler(compilationEnvironment, awsProps);
     const storageType = getStorageTypeByKey(storageSolution);
     const storageHandler = new storageType(httpRoot, compilerProps, awsProps);
-    const compilerFinder = new CompilerFinder(compileHandler, compilerProps, awsProps, defArgs, clientOptionsHandler);
+    const compilerFinder = new CompilerFinder(compileHandler, compilerProps, defArgs, clientOptionsHandler);
 
     const isExecutionWorker = ceProps<boolean>('execqueue.is_worker', false);
     const healthCheckFilePath = ceProps('healthCheckFilePath', null) as string | null;

--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -39,7 +39,6 @@ import type {Language, LanguageKey} from '../types/languages.interfaces.js';
 import {Tool, ToolInfo} from '../types/tool.interfaces.js';
 
 import {assert, unwrap, unwrapString} from './assert.js';
-import {InstanceFetcher} from './aws.js';
 import {CompileHandler} from './handlers/compile.js';
 import {logger} from './logger.js';
 import {ClientOptionsHandler} from './options-handler.js';
@@ -55,34 +54,24 @@ const sleep = promisify(setTimeout);
 export class CompilerFinder {
     compilerProps: CompilerProps['get'];
     ceProps: PropertyGetter;
-    awsProps: PropertyGetter;
     args: AppDefaultArguments;
     compileHandler: CompileHandler;
     languages: Record<string, Language>;
-    awsPoller: InstanceFetcher | null = null;
     optionsHandler: ClientOptionsHandler;
     //visitedCompilers = new Set<string>();
 
     constructor(
         compileHandler: CompileHandler,
         compilerProps: CompilerProps,
-        awsProps: PropertyGetter,
         args: AppDefaultArguments,
         optionsHandler: ClientOptionsHandler,
     ) {
         this.compilerProps = compilerProps.get.bind(compilerProps);
         this.ceProps = compilerProps.ceProps;
-        this.awsProps = awsProps;
         this.args = args;
         this.compileHandler = compileHandler;
         this.languages = compilerProps.languages;
-        this.awsPoller = null;
         this.optionsHandler = optionsHandler;
-    }
-
-    awsInstances() {
-        if (!this.awsPoller) this.awsPoller = new InstanceFetcher(this.awsProps);
-        return this.awsPoller.getInstances();
     }
 
     static prepareRemoteUrlParts(host: string, port: number, uriBase: string, langId: string | null) {
@@ -159,12 +148,6 @@ export class CompilerFinder {
                                 res.on('end', () => {
                                     try {
                                         const compilers = (JSON.parse(str) as CompilerInfo[]).map(compiler => {
-                                            // Fix up old upstream implementations of Compiler Explorer
-                                            // e.g. https://www.godbolt.ms
-                                            // (see https://github.com/compiler-explorer/compiler-explorer/issues/1768)
-                                            if (!compiler.alias) compiler.alias = [];
-                                            if (typeof compiler.alias == 'string') compiler.alias = [compiler.alias];
-                                            // End fixup
                                             compiler.exe = '/dev/null';
                                             compiler.remote = CompilerFinder.getRemoteInfo(
                                                 uriSchema,
@@ -185,7 +168,7 @@ export class CompilerFinder {
                         )
                         .on('error', reject)
                         .on('timeout', () => reject('timeout'));
-                    request.setTimeout(this.awsProps('proxyTimeout', 1000));
+                    request.setTimeout(this.ceProps('proxyTimeout', 1000));
                 });
             },
             `${host}:${port}`,
@@ -195,22 +178,6 @@ export class CompilerFinder {
             logger.warn(`Unable to contact ${host}:${port}; skipping`);
             return [];
         });
-    }
-
-    async fetchAws() {
-        logger.info('Fetching instances from AWS');
-        const instances = await this.awsInstances();
-        const mapped = await Promise.all(
-            instances.map(instance => {
-                logger.info('Checking instance ' + instance.InstanceId);
-                const address = this.awsProps('externalTestMode', false)
-                    ? instance.PublicDnsName
-                    : instance.PrivateDnsName;
-                return this.fetchRemote(unwrap(address), this.args.port, '', this.awsProps, null);
-            }),
-        );
-
-        return remove(mapped.flat(), null);
     }
 
     async compilerConfigFor(
@@ -425,7 +392,6 @@ export class CompilerFinder {
             );
             return allCompilers.flat();
         }
-        if (compilerName === 'AWS') return this.fetchAws();
         const configs = [await this.compilerConfigFor(langId, compilerName, parentProps)];
         return remove(configs, null);
     }

--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -58,7 +58,6 @@ export class CompilerFinder {
     compileHandler: CompileHandler;
     languages: Record<string, Language>;
     optionsHandler: ClientOptionsHandler;
-    //visitedCompilers = new Set<string>();
 
     constructor(
         compileHandler: CompileHandler,

--- a/test/compiler-finder-tests.ts
+++ b/test/compiler-finder-tests.ts
@@ -121,72 +121,36 @@ describe('Compiler-finder', () => {
     });
 
     it('should not hang for undefined groups (Bug #860)', async () => {
-        const finder = new CompilerFinder(
-            {} as any,
-            compilerProps,
-            properties.fakeProps({}),
-            {} as any,
-            optionsHandler,
-        );
+        const finder = new CompilerFinder({} as any, compilerProps, {} as any, optionsHandler);
         await expect(finder.getCompilers()).resolves.toHaveLength(1);
     });
 
     it('should behave properly if no options are provided at all', async () => {
-        const finder = new CompilerFinder(
-            {} as any,
-            noOptionsAtAllProps,
-            properties.fakeProps({}),
-            {} as any,
-            optionsHandler,
-        );
+        const finder = new CompilerFinder({} as any, noOptionsAtAllProps, {} as any, optionsHandler);
         const compilers = await finder.getCompilers();
         expect(compilers[0].options).toEqual('');
     });
 
     it('should behave properly if no base options are provided', async () => {
-        const finder = new CompilerFinder(
-            {} as any,
-            noBaseOptionsProps,
-            properties.fakeProps({}),
-            {} as any,
-            optionsHandler,
-        );
+        const finder = new CompilerFinder({} as any, noBaseOptionsProps, {} as any, optionsHandler);
         const compilers = await finder.getCompilers();
         expect(compilers[0].options).toEqual('bar');
     });
 
     it('should behave properly if only base options are provided', async () => {
-        const finder = new CompilerFinder(
-            {} as any,
-            onlyBaseOptionsProps,
-            properties.fakeProps({}),
-            {} as any,
-            optionsHandler,
-        );
+        const finder = new CompilerFinder({} as any, onlyBaseOptionsProps, {} as any, optionsHandler);
         const compilers = await finder.getCompilers();
         expect(compilers[0].options).toEqual('foo');
     });
 
     it('should behave properly if both options are provided', async () => {
-        const finder = new CompilerFinder(
-            {} as any,
-            bothOptionsProps,
-            properties.fakeProps({}),
-            {} as any,
-            optionsHandler,
-        );
+        const finder = new CompilerFinder({} as any, bothOptionsProps, {} as any, optionsHandler);
         const compilers = await finder.getCompilers();
         expect(compilers[0].options).toEqual('foo bar');
     });
 
     it('should be able to filter libraries', async () => {
-        const finder = new CompilerFinder(
-            {} as any,
-            libraryCompilerProps,
-            properties.fakeProps({}),
-            {} as any,
-            optionsHandler,
-        );
+        const finder = new CompilerFinder({} as any, libraryCompilerProps, {} as any, optionsHandler);
         const compilers = await finder.getCompilers();
         const libsArr = compilers[0].libsArr;
         expect(libsArr).toEqual(['fmt', 'catch2.2101']);


### PR DESCRIPTION
Nothing was using it, we're using other methods these days to discover remote compilers (and have been for years), and it was broken (see #1790).

Also cleans up some config (moving it from aws to ceProps; though it was unused, default used only), and also some workarounds for remote compilers that refer back to the MS compiler era (#1768).

This leaves the ability in `aws.ts` to fetch instances in case we ever need the functionality, as this is tested and still works.

Closes #1790 