### PR TITLE
Handle ARM's .set usage

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -60,6 +60,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
     definesFunction: RegExp;
     definesGlobal: RegExp;
     definesWeak: RegExp;
+    definesAlias: RegExp;
     indentedLabelDef: RegExp;
     assignmentDef: RegExp;
     directive: RegExp;
@@ -109,6 +110,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.definesFunction = /^\s*\.(type.*,\s*[#%@]function|proc\s+[.A-Z_a-z][\w$.]*:.*)$/;
         this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*)/;
         this.definesWeak = /^\s*\.(?:weakext|weak)\s*([.A-Z_a-z][\w$.]*)/;
+        this.definesAlias = /^\s*\.set\s*([.A-Z_a-z][\w$.]*\s*),\s*\.\s*(\+\s*0)?$/;
         this.indentedLabelDef = /^\s*([$.A-Z_a-z][\w$.]*):/;
         this.assignmentDef = /^\s*([$.A-Z_a-z][\w$.]*)\s*=\s*(.*)/;
         this.directive = /^\s*\..*$/;
@@ -209,6 +211,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         let inFunction = false;
         let inNvccCode = false;
         let inVLIWpacket = false;
+        let definingAlias: string | undefined;
 
         // Scan through looking for definite label usages (ones used by opcodes),
         // and ones that are weakly used: that is, their use is conditional on another label.
@@ -244,14 +247,29 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 if (inLabelGroup) currentLabelSet.push(match[1]);
                 else currentLabelSet = [match[1]];
                 inLabelGroup = true;
+                if (definingAlias) {
+                    // If we're defining an alias, then any labels in this group are weakly used by the alias.
+                    if (!weakUsages[definingAlias]) weakUsages[definingAlias] = [];
+                    weakUsages[definingAlias].push(match[1]);
+                }
             } else {
-                inLabelGroup = false;
+                if (inLabelGroup) {
+                    inLabelGroup = false;
+                    // Once we exit the label group after an alias, we're no longer defining an alias.
+                    definingAlias = undefined;
+                }
             }
             match = line.match(this.definesGlobal);
             if (!match) match = line.match(this.definesWeak);
             if (!match) match = line.match(this.cudaBeginDef);
             if (match) {
                 labelsUsed[match[1]] = true;
+            }
+
+            const definesAlias = line.match(this.definesAlias);
+            if (definesAlias) {
+                // We are defining an alias for match[1]; so the next label definition is the _same_ as this.
+                definingAlias = definesAlias[1];
             }
 
             const definesFunction = line.match(this.definesFunction);
@@ -269,11 +287,11 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 const isDataDefinition = !!this.dataDefn.test(line);
                 const isOpcode = this.hasOpcode(line, inNvccCode, inVLIWpacket);
                 if (isDataDefinition || isOpcode) {
-                    for (const currentLabel of currentLabelSet) {
-                        if (inFunction && isDataDefinition) {
-                            // Data definitions in the middle of code should be treated as if they were used strongly.
-                            for (const label of match) labelsUsed[label] = true;
-                        } else {
+                    if (inFunction && isDataDefinition) {
+                        // Data definitions in the middle of code should be treated as if they were used strongly.
+                        for (const label of match) labelsUsed[label] = true;
+                    } else {
+                        for (const currentLabel of currentLabelSet) {
                             if (!weakUsages[currentLabel]) weakUsages[currentLabel] = [];
                             for (const label of match) weakUsages[currentLabel].push(label);
                         }
@@ -300,7 +318,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 });
             });
             if (!toAdd) break;
-            _.each(toAdd, markUsed);
+            for (const label of toAdd) markUsed(label);
         }
         return labelsUsed;
     }
@@ -648,8 +666,9 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 if (this.dataDefn.test(line) && context.prevLabel) {
                     // We're defining data that's being used somewhere.
                 } else {
-                    // .inst generates an opcode, so does not count as a directive
-                    if (this.directive.test(line) && !this.instOpcodeRe.test(line)) {
+                    // .inst generates an opcode, so does not count as a directive, nor does an alias definition that's
+                    // used.
+                    if (this.directive.test(line) && !this.instOpcodeRe.test(line) && !this.definesAlias.test(line)) {
                         continue;
                     }
                 }

--- a/test/filters-cases/bug-1799.asm
+++ b/test/filters-cases/bug-1799.asm
@@ -1,0 +1,120 @@
+  .cpu arm7tdmi
+  .eabi_attribute 20, 1
+  .eabi_attribute 21, 1
+  .eabi_attribute 23, 3
+  .eabi_attribute 24, 1
+  .eabi_attribute 25, 1
+  .eabi_attribute 26, 1
+  .eabi_attribute 30, 2
+  .eabi_attribute 34, 0
+  .eabi_attribute 18, 4
+  .file "example.cpp"
+  .text
+.Ltext0:
+  .cfi_sections .debug_frame
+  .align 2
+  .global DaysInMonth2()
+  .arch armv4t
+  .syntax unified
+  .arm
+  .fpu softvfp
+  .type DaysInMonth2(), %function
+DaysInMonth2():
+  .fnstart
+.LFB2:
+  .file 1 "/app/example.cpp"
+  .loc 1 22 20 view -0
+  .cfi_startproc
+  .loc 1 22 22 view .LVU1
+  .loc 1 22 40 is_stmt 0 view .LVU2
+  ldr r3, .L8
+  ldr r3, [r3]
+  ldr r2, .L8+4
+.LBB8:
+  .loc 1 13 18 view .LVU3
+  cmp r3, #1
+.LBE8:
+  .loc 1 22 40 view .LVU4
+  ldr r2, [r2]
+.LVL0:
+.LBB13:
+.LBI8:
+  .loc 1 10 15 is_stmt 1 view .LVU5
+  .loc 1 13 3 view .LVU6
+  .loc 1 13 18 is_stmt 0 view .LVU7
+  beq .L7
+.L2:
+  .loc 1 17 3 is_stmt 1 view .LVU8
+  .loc 1 17 23 is_stmt 0 view .LVU9
+  ldr r2, .L8+8
+.LVL1:
+  .loc 1 17 23 view .LVU10
+  ldr r0, [r2, r3, lsl #2]
+  bx lr
+.LVL2:
+.L7:
+.LBB10:
+.LBI10:
+  .loc 1 1 16 is_stmt 1 view .LVU11
+  .loc 1 4 3 view .LVU12
+  .loc 1 4 26 is_stmt 0 view .LVU13
+  tst r2, #3
+  bne .L2
+  .loc 1 4 36 view .LVU14
+  ldr r1, .L8+12
+  smull ip, r0, r1, r2
+  asr r1, r2, #31
+  rsb r1, r1, r0, asr #3
+  add r1, r1, r1, lsl #2
+  add r1, r1, r1, lsl #2
+  .loc 1 4 26 view .LVU15
+  cmp r2, r1
+  bne .L5
+  .loc 1 4 47 view .LVU16
+  tst r2, #15
+  bne .L2
+.L5:
+  .loc 1 4 47 view .LVU17
+.LBE10:
+  .loc 1 14 12 view .LVU18
+  mov r0, #29
+.LVL3:
+  .loc 1 14 12 view .LVU19
+.LBE13:
+  .loc 1 22 48 view .LVU20
+  bx lr
+  .align 2
+.L8:
+  .word b
+  .word a
+  .word .LANCHOR0
+  .word 1374389535
+  .cfi_endproc
+.LFE2:
+  .cantunwind
+  .fnend
+  .size DaysInMonth2(), .-DaysInMonth2()
+  .section .rodata
+  .align 2
+  .set .LANCHOR0,. + 0
+  .type sg_days, %object
+  .size sg_days, 48
+sg_days:
+  .word 31
+  .word 28
+  .word 31
+  .word 30
+  .word 31
+  .word 30
+  .word 31
+  .word 31
+  .word 30
+  .word 31
+  .word 30
+  .word 31
+  .text
+.Letext0:
+  .section .debug_info,"",%progbits
+.Ldebug_info0:
+  .4byte 0x135
+  .2byte 0x4

--- a/test/filters-cases/bug-1799.asm.binary.directives.labels.comments.json
+++ b/test/filters-cases/bug-1799.asm.binary.directives.labels.comments.json
@@ -1,0 +1,4 @@
+{
+  "asm": [],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/bug-1799.asm.directives.comments.json
+++ b/test/filters-cases/bug-1799.asm.directives.comments.json
@@ -1,0 +1,482 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB13:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI8:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB10:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI10:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE10:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE13:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 15,
+    ".L5": 36,
+    ".L7": 21,
+    ".L8": 42,
+    "sg_days": 49
+  }
+}

--- a/test/filters-cases/bug-1799.asm.directives.json
+++ b/test/filters-cases/bug-1799.asm.directives.json
@@ -1,0 +1,482 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB13:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI8:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB10:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI10:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE10:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE13:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 15,
+    ".L5": 36,
+    ".L7": 21,
+    ".L8": 42,
+    "sg_days": 49
+  }
+}

--- a/test/filters-cases/bug-1799.asm.directives.labels.comments.json
+++ b/test/filters-cases/bug-1799.asm.directives.labels.comments.json
@@ -1,0 +1,397 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 8,
+    ".L5": 25,
+    ".L7": 12,
+    ".L8": 28,
+    "sg_days": 34
+  }
+}

--- a/test/filters-cases/bug-1799.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/bug-1799.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -1,0 +1,420 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": "example.cpp",
+        "line": 22,
+        "mainsource": true
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": "example.cpp",
+        "line": 22,
+        "mainsource": true
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": "example.cpp",
+        "line": 22,
+        "mainsource": true
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": "example.cpp",
+        "line": 13,
+        "mainsource": true
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": "example.cpp",
+        "line": 22,
+        "mainsource": true
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": "example.cpp",
+        "line": 13,
+        "mainsource": true
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": "example.cpp",
+        "line": 17,
+        "mainsource": true
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": "example.cpp",
+        "line": 17,
+        "mainsource": true
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": "example.cpp",
+        "line": 17,
+        "mainsource": true
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": "example.cpp",
+        "line": 4,
+        "mainsource": true
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": "example.cpp",
+        "line": 14,
+        "mainsource": true
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": "example.cpp",
+        "line": 22,
+        "mainsource": true
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 8,
+    ".L5": 25,
+    ".L7": 12,
+    ".L8": 28,
+    "sg_days": 34
+  }
+}

--- a/test/filters-cases/bug-1799.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/bug-1799.asm.directives.labels.comments.library.json
@@ -1,0 +1,397 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 8,
+    ".L5": 25,
+    ".L7": 12,
+    ".L8": 28,
+    "sg_days": 34
+  }
+}

--- a/test/filters-cases/bug-1799.asm.directives.labels.json
+++ b/test/filters-cases/bug-1799.asm.directives.labels.json
@@ -1,0 +1,397 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 8,
+    ".L5": 25,
+    ".L7": 12,
+    ".L8": 28,
+    "sg_days": 34
+  }
+}

--- a/test/filters-cases/bug-1799.asm.directives.library.json
+++ b/test/filters-cases/bug-1799.asm.directives.library.json
@@ -1,0 +1,482 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE8:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB13:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI8:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB10:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI10:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE10:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE13:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 15,
+    ".L5": 36,
+    ".L7": 21,
+    ".L8": 42,
+    "sg_days": 49
+  }
+}

--- a/test/filters-cases/bug-1799.asm.none.json
+++ b/test/filters-cases/bug-1799.asm.none.json
@@ -1,0 +1,783 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .cpu arm7tdmi"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 20, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 21, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 23, 3"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 24, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 25, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 26, 1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 30, 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 34, 0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .eabi_attribute 18, 4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .file \"example.cpp\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .text"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .cfi_sections .debug_frame"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .align 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .global DaysInMonth2()"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .arch armv4t"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .syntax unified"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .arm"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .fpu softvfp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .type DaysInMonth2(), %function"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "DaysInMonth2():"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .fnstart"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .file 1 \"/app/example.cpp\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 22 20 view -0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .cfi_startproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 22 22 view .LVU1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 22 40 is_stmt 0 view .LVU2"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, .L8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r3, [r3]"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, .L8+4"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 13 18 view .LVU3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  cmp r3, #1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 22 40 view .LVU4"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 40,
+        "file": null,
+        "line": 22
+      },
+      "text": "  ldr r2, [r2]"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB13:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 10 15 is_stmt 1 view .LVU5"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 13 3 view .LVU6"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 13 18 is_stmt 0 view .LVU7"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L7",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 18,
+        "file": null,
+        "line": 13
+      },
+      "text": "  beq .L7"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 17 3 is_stmt 1 view .LVU8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 17 23 is_stmt 0 view .LVU9"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r2, .L8+8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL1:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 17 23 view .LVU10"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  ldr r0, [r2, r3, lsl #2]"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 23,
+        "file": null,
+        "line": 17
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L7:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBB10:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBI10:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 1 16 is_stmt 1 view .LVU11"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 4 3 view .LVU12"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 4 26 is_stmt 0 view .LVU13"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #3"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 4 36 view .LVU14"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L8",
+          "range": {
+            "endCol": 14,
+            "startCol": 11
+          }
+        }
+      ],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  ldr r1, .L8+12"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  smull ip, r0, r1, r2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  asr r1, r2, #31"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  rsb r1, r1, r0, asr #3"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 36,
+        "file": null,
+        "line": 4
+      },
+      "text": "  add r1, r1, r1, lsl #2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 4 26 view .LVU15"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  cmp r2, r1"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L5",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 26,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L5"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 4 47 view .LVU16"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  tst r2, #15"
+    },
+    {
+      "labels": [
+        {
+          "name": ".L2",
+          "range": {
+            "endCol": 10,
+            "startCol": 7
+          }
+        }
+      ],
+      "source": {
+        "column": 47,
+        "file": null,
+        "line": 4
+      },
+      "text": "  bne .L2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L5:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 4 47 view .LVU17"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE10:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 14 12 view .LVU18"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 12,
+        "file": null,
+        "line": 14
+      },
+      "text": "  mov r0, #29"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LVL3:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 14 12 view .LVU19"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LBE13:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .loc 1 22 48 view .LVU20"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 48,
+        "file": null,
+        "line": 22
+      },
+      "text": "  bx lr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .align 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".L8:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word b"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word a"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word .LANCHOR0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 1374389535"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .cfi_endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE2:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .cantunwind"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .fnend"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .size DaysInMonth2(), .-DaysInMonth2()"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .section .rodata"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .align 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .set .LANCHOR0,. + 0"
+    },
+    {
+      "labels": [
+        {
+          "name": "sg_days",
+          "range": {
+            "endCol": 16,
+            "startCol": 9
+          }
+        }
+      ],
+      "source": null,
+      "text": "  .type sg_days, %object"
+    },
+    {
+      "labels": [
+        {
+          "name": "sg_days",
+          "range": {
+            "endCol": 16,
+            "startCol": 9
+          }
+        }
+      ],
+      "source": null,
+      "text": "  .size sg_days, 48"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "sg_days:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 28"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 30"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .word 31"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .text"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Letext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .section .debug_info,\"\",%progbits"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ldebug_info0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .4byte 0x135"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "  .2byte 0x4"
+    }
+  ],
+  "labelDefinitions": {
+    ".L2": 46,
+    ".L5": 76,
+    ".L7": 55,
+    ".L8": 87,
+    "sg_days": 102
+  }
+}


### PR DESCRIPTION
Treats `.set` as an "alias" for the set of labels referred to, and doesn't filter alias-creating `.set` in used paths even if directive filtering is on. Only works for `.set <something>, .` with an optional `+ 0`.

Also changes a silly loop that was looping N times doing the same thing if `inFunction && isDataDefinition`, though quite possibly that's broken in a different way. No tests changed, anyway.

Adds a new test for the new behaviour.

Closes #1799
