### PR TITLE
Ensure that content type for formatting requests is JSON

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -188,7 +188,8 @@ JSON request corresponds to one of the `formatters.<key>.type` found in
 
 ### `POST /api/format/<formatter>` - perform a formatter run
 
-Formats a piece of code according to the given base style using the provided formatter
+Formats a piece of code according to the given base style using the provided formatter. Be aware that this endpoint only
+accepts JSON (e.g `content-type: application/json`).
 
 Formatters available can be found with `GET /api/formats`
 

--- a/lib/handlers/api/formatting-controller.ts
+++ b/lib/handlers/api/formatting-controller.ts
@@ -41,6 +41,10 @@ export class FormattingController implements HttpController {
 
     /** Handle requests to /api/format/:tool */
     public async format(req: express.Request, res: express.Response) {
+        if (req.headers['content-type'] !== 'application/json') {
+            return res.status(400).json({exit: 1, answer: `Invalid content type, expected application/json`});
+        }
+
         const formatter = this.formattingService.getFormatterById(req.params.tool);
         // Ensure the target formatter exists
         if (formatter === null) {

--- a/test/handlers/api/formatting-controller.tests.ts
+++ b/test/handlers/api/formatting-controller.tests.ts
@@ -54,8 +54,17 @@ describe('FormattingController', () => {
         await request(app)
             .post('/api/format/invalid')
             .set('Accept', 'application/json')
+            .set('Content-Type', 'application/json')
             .expect('Content-Type', /json/)
             .expect(422, {exit: 2, answer: "Unknown format tool 'invalid'"});
+    });
+
+    it('should reject requests with no content type', async () => {
+        await request(app)
+            .post('/api/format/formatt')
+            .send('{ base: "something", source: "int main() {}" }')
+            .expect('Content-Type', /json/)
+            .expect(400);
     });
 
     it('should not go through with invalid base styles', async () => {
@@ -66,6 +75,7 @@ describe('FormattingController', () => {
                 source: 'i am source',
             })
             .set('Accept', 'application/json')
+            .set('Content-Type', 'application/json')
             .expect(422, {exit: 3, answer: "Style 'bad-base' is not supported"})
             .expect('Content-Type', /json/);
     });


### PR DESCRIPTION
Ideally I'd add a middleware or something else that requires JSON, but I suppose this is fine for now.

cc @dkm 