### PR TITLE
Some tidying up of the asm parser code

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -32,7 +32,7 @@ import {
     ParsedAsmResultLine,
 } from '../../types/asmresult/asmresult.interfaces.js';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
-import {assert} from '../assert.js';
+import {assert, unwrap} from '../assert.js';
 import {PropertyGetter} from '../properties.interfaces.js';
 import * as utils from '../utils.js';
 
@@ -114,8 +114,8 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.indentedLabelDef = /^\s*([$.A-Z_a-z][\w$.]*):/;
         this.assignmentDef = /^\s*([$.A-Z_a-z][\w$.]*)\s*=\s*(.*)/;
         this.directive = /^\s*\..*$/;
-        // These four regexes when phrased as /\s*#APP.*/ etc exhibit costly polynomial backtracking
-        // Instead use ^$ and test with regex.test(line.trim()), more robust anyway
+        // These four regexes when phrased as /\s*#APP.*/ etc exhibit costly polynomial backtracking. Instead use ^$ and
+        // test with regex.test(line.trim()), more robust anyway
         this.startAppBlock = /^#APP.*$/;
         this.endAppBlock = /^#NO_APP.*$/;
         this.startAsmNesting = /^# Begin ASM.*$/;
@@ -144,8 +144,8 @@ export class AsmParser extends AsmRegex implements IAsmParser {
             this.lineRe = /^(\/[^:]+):(?<line>\d+).*/;
         }
 
-        // labelRe is made very greedy as it's also used with demangled objdump
-        // output (eg. it can have c++ template with <>).
+        // labelRe is made very greedy as it's also used with demangled objdump output (eg. it can have c++ template
+        // with <>).
         this.labelRe = /^([\da-f]+)\s+<(.+)>:$/;
         this.destRe = /\s([\da-f]+)\s+<([^+>]+)(\+0x[\da-f]+)?>$/;
         this.commentRe = /[#;]/;
@@ -167,11 +167,11 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.blockComments = /^[\t ]*\/\*(\*(?!\/)|[^*])*\*\/\s*/gm;
     }
 
-    checkVLIWpacket(line: string, inVLIWpacket: boolean) {
+    checkVLIWpacket(_line: string, inVLIWpacket: boolean) {
         return inVLIWpacket;
     }
 
-    hasOpcode(line: string, inNvccCode: boolean = false, inVLIWpacket: boolean = false) {
+    hasOpcode(line: string, inNvccCode: boolean = false, _inVLIWpacket: boolean = false) {
         // Remove any leading label definition...
         const match = line.match(this.labelDef);
         if (match) {
@@ -184,19 +184,25 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         // Detect assignment, that's not an opcode...
         if (this.assignmentDef.test(line)) return false;
         if (inNvccCode) {
-            return !!this.hasNvccOpcodeRe.test(line);
+            return this.hasNvccOpcodeRe.test(line);
         }
-        return !!this.hasOpcodeRe.test(line);
+        return this.hasOpcodeRe.test(line);
     }
 
     labelFindFor(asmLines: string[]) {
-        const isMips = _.any(asmLines, line => !!this.mipsLabelDefinition.test(line));
+        const isMips = _.any(asmLines, line => this.mipsLabelDefinition.test(line));
         return isMips ? this.labelFindMips : this.labelFindNonMips;
     }
 
-    findUsedLabels(asmLines: string[], filterDirectives?: boolean) {
-        const labelsUsed: Record<string, boolean> = {};
-        const weakUsages: Record<string, Array<string>> = {};
+    findUsedLabels(asmLines: string[], filterDirectives?: boolean): Set<string> {
+        const labelsUsed: Set<string> = new Set();
+        const weakUsages: Map<string, Set<string>> = new Map();
+
+        function markWeak(fromLabel: string, toLabel: string) {
+            if (!weakUsages.has(fromLabel)) weakUsages.set(fromLabel, new Set());
+            unwrap(weakUsages.get(fromLabel)).add(toLabel);
+        }
+
         const labelFind = this.labelFindFor(asmLines);
         // The current label set is the set of labels all pointing at the current code, so:
         // foo:
@@ -213,17 +219,15 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         let inVLIWpacket = false;
         let definingAlias: string | undefined;
 
-        // Scan through looking for definite label usages (ones used by opcodes),
-        // and ones that are weakly used: that is, their use is conditional on another label.
-        // For example:
+        // Scan through looking for definite label usages (ones used by opcodes), and ones that are weakly used: that
+        // is, their use is conditional on another label. For example:
         // .foo: .string "moo"
         // .baz: .quad .foo
         //       mov eax, .baz
         // In this case, the '.baz' is used by an opcode, and so is strongly used.
         // The '.foo' is weakly used by .baz.
-        // Also, if we have random data definitions within a block of a function (between
-        // cfi_startproc and cfi_endproc), we assume they are strong usages. This covers things
-        // like jump tables embedded in ARM code.
+        // Also, if we have random data definitions within a block of a function (between cfi_startproc and
+        // cfi_endproc), we assume they are strong usages. This covers things like jump tables embedded in ARM code.
         // See https://github.com/compiler-explorer/compiler-explorer/issues/2788
         for (let line of asmLines) {
             if (this.startAppBlock.test(line.trim()) || this.startAsmNesting.test(line.trim())) {
@@ -249,8 +253,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 inLabelGroup = true;
                 if (definingAlias) {
                     // If we're defining an alias, then any labels in this group are weakly used by the alias.
-                    if (!weakUsages[definingAlias]) weakUsages[definingAlias] = [];
-                    weakUsages[definingAlias].push(match[1]);
+                    markWeak(definingAlias, match[1]);
                 }
             } else {
                 if (inLabelGroup) {
@@ -262,9 +265,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
             match = line.match(this.definesGlobal);
             if (!match) match = line.match(this.definesWeak);
             if (!match) match = line.match(this.cudaBeginDef);
-            if (match) {
-                labelsUsed[match[1]] = true;
-            }
+            if (match) labelsUsed.add(match[1]);
 
             const definesAlias = line.match(this.definesAlias);
             if (definesAlias) {
@@ -280,45 +281,41 @@ export class AsmParser extends AsmRegex implements IAsmParser {
 
             if (!filterDirectives || this.hasOpcode(line, inNvccCode, inVLIWpacket) || definesFunction) {
                 // Only count a label as used if it's used by an opcode, or else we're not filtering directives.
-                for (const label of match) labelsUsed[label] = true;
+                for (const label of match) labelsUsed.add(label);
             } else {
                 // If we have a current label, then any subsequent opcode or data definition's labels are referred to
                 // weakly by that label.
-                const isDataDefinition = !!this.dataDefn.test(line);
+                const isDataDefinition = this.dataDefn.test(line);
                 const isOpcode = this.hasOpcode(line, inNvccCode, inVLIWpacket);
                 if (isDataDefinition || isOpcode) {
                     if (inFunction && isDataDefinition) {
                         // Data definitions in the middle of code should be treated as if they were used strongly.
-                        for (const label of match) labelsUsed[label] = true;
+                        for (const label of match) labelsUsed.add(label);
                     } else {
                         for (const currentLabel of currentLabelSet) {
-                            if (!weakUsages[currentLabel]) weakUsages[currentLabel] = [];
-                            for (const label of match) weakUsages[currentLabel].push(label);
+                            for (const label of match) markWeak(currentLabel, label);
                         }
                     }
                 }
             }
         }
 
-        // Now follow the chains of used labels, marking any weak references they refer
-        // to as also used. We iteratively do this until either no new labels are found,
-        // or we hit a limit (only here to prevent a pathological case from hanging).
-        function markUsed(label: string) {
-            labelsUsed[label] = true;
-        }
-
+        // Now follow the chains of used labels, marking any weak references they refer to as also used. We iteratively
+        // do this until either no new labels are found, or we hit a limit (only here to prevent a pathological case
+        // from hanging).
         const MaxLabelIterations = 10;
         for (let iter = 0; iter < MaxLabelIterations; ++iter) {
-            const toAdd: string[] = [];
-            _.each(labelsUsed, (t, label) => {
-                // jshint ignore:line
-                _.each(weakUsages[label], (nowused: string) => {
-                    if (labelsUsed[nowused]) return;
-                    toAdd.push(nowused);
-                });
-            });
-            if (!toAdd) break;
-            for (const label of toAdd) markUsed(label);
+            const toAdd: Set<string> = new Set(); // used as we can't update labelsUsed while iterating.
+            for (const label of labelsUsed) {
+                const usages = weakUsages.get(label);
+                if (!usages) continue;
+                for (const nowUsed of usages) {
+                    if (!labelsUsed.has(nowUsed)) toAdd.add(nowUsed);
+                }
+            }
+            // If we didn't add any new labels, we're done.
+            if (toAdd.size === 0) break;
+            for (const used of toAdd) labelsUsed.add(used);
         }
         return labelsUsed;
     }
@@ -414,7 +411,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                     context.source = {
                         file: file,
                         line: sourceLine,
-                        mainsource: !!this.stdInLooking.test(file),
+                        mainsource: this.stdInLooking.test(file),
                     };
                 } else {
                     context.source = {
@@ -447,7 +444,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                         context.source = {
                             file: file,
                             line: sourceLine,
-                            mainsource: !!this.stdInLooking.test(file),
+                            mainsource: this.stdInLooking.test(file),
                         };
                     } else {
                         context.source = {
@@ -491,7 +488,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 context.source = {
                     file: file,
                     line: sourceLine,
-                    mainsource: !!this.stdInLooking.test(file),
+                    mainsource: this.stdInLooking.test(file),
                 };
             } else {
                 context.source = {
@@ -636,11 +633,11 @@ export class AsmParser extends AsmRegex implements IAsmParser {
             if (match) {
                 // It's a label definition.
 
-                // g-as shows local labels as eg: "1:  call  mcount". We characterize such a label as
-                // "the label-matching part doesn't equal the whole line" and treat it as used.
-                // As a special case, consider assignments of the form "symbol = ." to be labels.
+                // g-as shows local labels as eg: "1:  call  mcount". We characterize such a label as "the
+                // label-matching part doesn't equal the whole line" and treat it as used. As a special case, consider
+                // assignments of the form "symbol = ." to be labels.
                 if (
-                    labelsUsed[match[1]] === undefined &&
+                    !labelsUsed.has(match[1]) &&
                     match[0] === line &&
                     (match[2] === undefined || match[2].trim() === '.')
                 ) {
@@ -662,8 +659,8 @@ export class AsmParser extends AsmRegex implements IAsmParser {
             if (inNvccDef) {
                 if (this.cudaEndDef.test(line)) inNvccDef = false;
             } else if (!match && filters.directives) {
-                // Check for directives only if it wasn't a label; the regexp would
-                // otherwise misinterpret labels as directives.
+                // Check for directives only if it wasn't a label; the regexp would otherwise misinterpret labels as
+                // directives.
                 if (this.dataDefn.test(line) && context.prevLabel) {
                     // We're defining data that's being used somewhere.
                 } else {
@@ -783,9 +780,9 @@ export class AsmParser extends AsmRegex implements IAsmParser {
 
             if (!func || !this.isUserFunction(func)) continue;
 
-            // note: normally the source.file will be null if it's code from example.ext
-            //  but with filters.dontMaskFilenames it will be filled with the actual filename
-            //  instead we can test source.mainsource in that situation
+            // note: normally the source.file will be null if it's code from example.ext but with
+            //  filters.dontMaskFilenames it will be filled with the actual filename instead we can test
+            //  source.mainsource in that situation
             const isMainsource = source && (source.file === null || source.mainsource);
             if (filters.libraryCode && !isMainsource) {
                 if (mayRemovePreviousLabel && asm.length > 0) {


### PR DESCRIPTION
- use `Set` and `Map`
- reflow comments
- remove redundant `!!`
- rephrase iterative "follow the chain of weak symbols" to be recursive, removing artificial limit.