### PR TITLE
Update objdump version to 14.2.0 for RISC-V clang trunk.

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1090,6 +1090,7 @@ compiler.rv32-clang1910.semver=19.1.0
 compiler.rv32-clang1910.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
 compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv32-clang.semver=(trunk)
+compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang.isNightly=true
 compiler.rv32-clang.alias=rv32clang
 compiler.rv32-clang.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
@@ -1145,6 +1146,7 @@ compiler.rv64-clang1910.semver=19.1.0
 compiler.rv64-clang1910.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv64-clang.semver=(trunk)
+compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.isNightly=true
 compiler.rv64-clang.alias=rv64clang
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot


### PR DESCRIPTION
The default objdump version for RISC-V clang is 10.2.0. This doesn't support newer RISC-V extensions.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
