### PR TITLE
Strip hyperlink escape sequences from editor pane diagnostics hover widget

### DIFF
--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -164,6 +164,25 @@ describe('Parses compiler output', () => {
             },
         ]);
     });
+
+    it('removes hyperlink escape sequences', () => {
+        expect(
+            utils.parseOutput(
+                't.c:3:1: warning: control reaches end of non-void function [\x1B]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wno-return-type\x1B\\-Wreturn-type\x1B]8;;\x1B\\]',
+            ),
+        ).toEqual([
+            {
+                tag: {
+                    file: 't.c',
+                    line: 3,
+                    column: 1,
+                    text: 'warning: control reaches end of non-void function [-Wreturn-type]',
+                    severity: 2,
+                },
+                text: 't.c:3:1: warning: control reaches end of non-void function [\x1B]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wno-return-type\x1B\\-Wreturn-type\x1B]8;;\x1B\\]',
+            },
+        ]);
+    });
 });
 
 describe('Pascal compiler output', () => {
@@ -273,6 +292,33 @@ describe('Rust compiler output', () => {
             {
                 tag: {column: 25, line: 120, text: '', severity: 3},
                 text: ' --> <source>:120:25',
+            },
+        ]);
+    });
+
+    it('removes hyperlink escape sequences', () => {
+        expect(
+            utils.parseRustOutput(
+                'error[\x1B]8;;https://doc.rust-lang.org/error_codes/E0425.html\x07E0425\x1B]8;;\x07]: cannot find value `x` in this scope\n --> <source>:42:27',
+            ),
+        ).toEqual([
+            {
+                tag: {
+                    line: 42,
+                    column: 27,
+                    text: 'error[E0425]: cannot find value `x` in this scope',
+                    severity: 3,
+                },
+                text: 'error[\x1B]8;;https://doc.rust-lang.org/error_codes/E0425.html\x07E0425\x1B]8;;\x07]: cannot find value `x` in this scope',
+            },
+            {
+                tag: {
+                    line: 42,
+                    column: 27,
+                    text: '',
+                    severity: 3,
+                },
+                text: ' --> <source>:42:27',
             },
         ]);
     });


### PR DESCRIPTION
When passing `-fdiagnostics-urls=always`/`-Z terminal-urls=yes`, the hyperlink escape sequence was not stripped from the mouse hover widget in the editor pane.

Link: https://godbolt.org/z/3cP8jj8jc

Hover over the empty braces in the C++ editor or the `i32` in the Rust editor:

Before:
```
warning: no return statement in function returning non-void []8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wno-return-type-Wreturn-type]8;;]x86-64 gcc 14.2 #1
error[]8;;https://doc.rust-lang.org/error_codes/E0308.htmlE0308]8;;]: mismatched typesrustc nightly #2
```

Now:
```
warning: no return statement in function returning non-void [-Wreturn-type]x86-64 gcc 14.2 #1
error[E0308]: mismatched typesrustc nightly #2
```