### PR TITLE
Parse Rust error message locations with multiple leading spaces

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -228,7 +228,7 @@ export function parseOutput(
 }
 
 export function parseRustOutput(lines: string, inputFilename?: string, pathPrefix?: string) {
-    const re = /^ --> <source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+    const re = /^\s+-->\s+<source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
     const result: ResultLine[] = [];
     eachLine(lines, line => {
         line = _parseOutputLine(line, inputFilename, pathPrefix);

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -249,6 +249,16 @@ describe('Rust compiler output', () => {
                 text: ' --> <source>:1:5',
             },
         ]);
+        expect(utils.parseRustOutput('Multiple spaces\n   --> bob.rs:1:5', 'bob.rs')).toEqual([
+            {
+                tag: {column: 5, line: 1, text: 'Multiple spaces', severity: 3},
+                text: 'Multiple spaces',
+            },
+            {
+                tag: {column: 5, line: 1, text: '', severity: 3},
+                text: '   --> <source>:1:5',
+            },
+        ]);
     });
 
     it('replaces all references to input source', () => {


### PR DESCRIPTION
Rust error message locations (` --> <source>:<line>:<col>`) can have more than one leading space, e. g. when the source code snippet that is shown has line numbers greater than ten.

In this example (https://godbolt.org/z/9W8xPv36c), the error message is not be recognised as an error and there are no red squigglies in the editor pane.