### PR TITLE
Overhaul 'history' look

### DIFF
--- a/static/widgets/history-widget.ts
+++ b/static/widgets/history-widget.ts
@@ -131,10 +131,10 @@ export class HistoryWidget {
     }
 
     private resizeLayout() {
-        const tabcontent = unwrap(this.modal).find('div.src-content');
+        const content = unwrap(this.modal).find('div.src-content');
         this.srcDisplay?.layout({
-            width: unwrap(tabcontent.width()),
-            height: unwrap(tabcontent.height()) - 20,
+            width: unwrap(content.width()),
+            height: unwrap(content.height()) - 20,
         });
     }
 

--- a/static/widgets/history-widget.ts
+++ b/static/widgets/history-widget.ts
@@ -32,19 +32,11 @@ import {unwrap} from '../assert.js';
 type Entry = {dt: number; name: string; load: () => void};
 
 export class HistoryWidget {
-    private modal: JQuery | null;
-    private srcDisplay: editor.ICodeEditor | null;
-    private model: ITextModel;
-    private currentList: HistoryEntry[];
-    private onLoadCallback: (data: HistoryEntry) => void;
-
-    constructor() {
-        this.modal = null;
-        this.srcDisplay = null;
-        this.currentList = [];
-        this.onLoadCallback = () => {};
-        this.model = editor.createModel('', 'c++');
-    }
+    private modal: JQuery | null = null;
+    private srcDisplay: editor.ICodeEditor | null = null;
+    private model: ITextModel = editor.createModel('', 'c++');
+    private currentList: HistoryEntry[] = [];
+    private onLoadCallback: (data: HistoryEntry) => void = () => {};
 
     private initializeIfNeeded() {
         if (this.modal === null) {

--- a/static/widgets/history-widget.ts
+++ b/static/widgets/history-widget.ts
@@ -26,52 +26,24 @@ import $ from 'jquery';
 import {pluck} from 'underscore';
 import {sortedList, HistoryEntry, EditorSource} from '../history.js';
 import {editor} from 'monaco-editor';
-
-import IStandaloneDiffEditor = editor.IStandaloneDiffEditor;
 import ITextModel = editor.ITextModel;
 import {unwrap} from '../assert.js';
-
-export class HistoryDiffState {
-    public model: ITextModel;
-    private result: EditorSource[];
-
-    constructor(model: ITextModel) {
-        this.model = model;
-        this.result = [];
-    }
-
-    update(result: HistoryEntry) {
-        this.result = result.sources;
-        this.refresh();
-
-        return true;
-    }
-
-    private refresh() {
-        const output = this.result;
-        const content = output.map(val => `/****** ${val.lang} ******/\n${val.source}`).join('\n');
-
-        this.model.setValue(content);
-    }
-}
 
 type Entry = {dt: number; name: string; load: () => void};
 
 export class HistoryWidget {
     private modal: JQuery | null;
-    private diffEditor: IStandaloneDiffEditor | null;
-    private lhs: HistoryDiffState | null;
-    private rhs: HistoryDiffState | null;
+    private srcDisplay: editor.ICodeEditor | null;
+    private model: ITextModel;
     private currentList: HistoryEntry[];
     private onLoadCallback: (data: HistoryEntry) => void;
 
     constructor() {
         this.modal = null;
-        this.diffEditor = null;
-        this.lhs = null;
-        this.rhs = null;
+        this.srcDisplay = null;
         this.currentList = [];
         this.onLoadCallback = () => {};
+        this.model = editor.createModel('', 'c++');
     }
 
     private initializeIfNeeded() {
@@ -79,27 +51,16 @@ export class HistoryWidget {
             this.modal = $('#history');
 
             const placeholder = this.modal.find('.monaco-placeholder');
-            this.diffEditor = editor.createDiffEditor(placeholder[0], {
+            this.srcDisplay = editor.create(placeholder[0], {
                 fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',
                 scrollBeyondLastLine: true,
                 readOnly: true,
-                // language: 'c++',
                 minimap: {
-                    enabled: true,
+                    enabled: false,
                 },
             });
 
-            this.lhs = new HistoryDiffState(editor.createModel('', 'c++'));
-            this.rhs = new HistoryDiffState(editor.createModel('', 'c++'));
-            this.diffEditor.setModel({original: this.lhs.model, modified: this.rhs.model});
-
-            this.modal.find('.inline-diff-checkbox').on('click', event => {
-                const inline = $(event.target).prop('checked');
-                this.diffEditor?.updateOptions({
-                    renderSideBySide: !inline,
-                });
-                this.resizeLayout();
-            });
+            this.srcDisplay.setModel(this.model);
         }
     }
 
@@ -126,56 +87,29 @@ export class HistoryWidget {
         );
     }
 
-    private hideRadiosAndSetDiff() {
+    private getContent(src: EditorSource[]) {
+        return src.map(val => `/****** ${val.lang} ******/\n${val.source}`).join('\n');
+    }
+
+    private showPreview() {
         const root = unwrap(this.modal).find('.historiccode');
-        const items = root.find('li:not(.template)');
+        const elements = root.find('li:not(.template)');
 
-        let foundbase = false;
-        let foundcomp = false;
-
-        for (const elem of items) {
+        for (const elem of elements) {
             const li = $(elem);
             const dt = li.data('dt');
 
-            const base = li.find('.base');
-            const comp = li.find('.comp');
+            const preview = li.find('.preview');
 
-            let baseShouldBeVisible = true;
-            let compShouldBeVisible = true;
+            if (preview.prop('checked')) {
+                const item = this.currentList.find(item => item.dt === dt);
+                const text: string = this.getContent(item!.sources);
+                this.model.setValue(text);
 
-            if (comp.prop('checked')) {
-                foundcomp = true;
-                baseShouldBeVisible = false;
-
-                const itemRight = this.currentList.find(item => item.dt === dt);
-                if (itemRight) {
-                    unwrap(this.rhs).update(itemRight);
-                }
-            } else if (base.prop('checked')) {
-                foundbase = true;
-
-                const itemLeft = this.currentList.find(item => item.dt === dt);
-                if (itemLeft) {
-                    unwrap(this.lhs).update(itemLeft);
-                }
-            }
-
-            if (foundbase && foundcomp) {
-                compShouldBeVisible = false;
-            } else if (!foundbase && !foundcomp) {
-                baseShouldBeVisible = false;
-            }
-
-            if (compShouldBeVisible) {
-                comp.css('visibility', '');
-            } else {
-                comp.css('visibility', 'hidden');
-            }
-
-            if (baseShouldBeVisible) {
-                base.css('visibility', '');
-            } else {
-                base.css('visibility', 'hidden');
+                // Syntax-highlight by the language of the 1st source
+                let firstLang = HistoryWidget.getLanguagesFromHistoryEntry(item!)[0];
+                firstLang = firstLang === 'c++' ? 'cpp' : firstLang;
+                editor.setModelLanguage(this.model, firstLang);
             }
         }
     }
@@ -184,37 +118,21 @@ export class HistoryWidget {
         root.find('li:not(.template)').remove();
         const template = root.find('.template');
 
-        let baseMarked = false;
-        let compMarked = false;
-
         for (const elem of list) {
             const li = template.clone().removeClass('template').appendTo(root);
 
             li.data('dt', elem.dt);
 
-            const base = li.find('.base');
-            const comp = li.find('.comp');
+            const preview = li.find('.preview');
 
-            if (!compMarked) {
-                comp.prop('checked', 'checked');
-                compMarked = true;
-            } else if (!baseMarked) {
-                base.prop('checked', 'checked');
-                baseMarked = true;
-            }
-
-            base.on('click', () => this.hideRadiosAndSetDiff());
-            comp.on('click', () => this.hideRadiosAndSetDiff());
-
+            preview.on('click', () => this.showPreview());
             li.find('a').text(elem.name).on('click', elem.load);
         }
-
-        this.hideRadiosAndSetDiff();
     }
 
     private resizeLayout() {
-        const tabcontent = unwrap(this.modal).find('div.tab-content');
-        this.diffEditor?.layout({
+        const tabcontent = unwrap(this.modal).find('div.src-content');
+        this.srcDisplay?.layout({
             width: unwrap(tabcontent.width()),
             height: unwrap(tabcontent.height()) - 20,
         });

--- a/views/popups/history.pug
+++ b/views/popups/history.pug
@@ -9,27 +9,13 @@
       .modal-body
         .card
           .card-body
-            ul.nav.nav-tabs(role="tablist")
-              li.nav-item
-                a.nav-link.active(data-toggle="tab" role="tab" href="#load-history" aria-controls="load-history" aria-selected="true")
-                  | History
-              li.nav-item
-                a.nav-link(data-toggle="tab" role="tab" href="#load-history-diff-display" aria-controls="load-history-diff-display" aria-selected="false")
-                  | Diff
-
-            div.tab-content#historyTabs(style="height:600px;overflow-y:scroll")
-              div.tab-pane.show.active#load-history(role="tabpanel")
-                ul.historiccode
+            .d-flex
+              div.src-content#load-history(style="height:600px;overflow-y:scroll;flex:1")
+                ul.historiccode(style="list-style-type: none;")
                   li.template
-                    input.base(type="radio" name="base")
-                    input.comp(type="radio" name="comp")
-                    | &nbsp;
+                    input.preview(type="radio" name="preview" style="margin-right: 10px;")
                     a(href="javascript:;")
-              div.tab-pane#load-history-diff-display(role="tabpanel")
-                .checkbox
-                  label.control-label
-                    input.inline-diff-checkbox(type="checkbox" value="")
-                    | Inline diff
+              div#load-history-src-display(style="height:600px;overflow-y:scroll;flex:1")
                 div.monaco-placeholder#history-diff
       .modal-footer
         button.btn.btn-outline-primary(type="button" data-dismiss="modal") Close

--- a/views/popups/history.pug
+++ b/views/popups/history.pug
@@ -10,12 +10,12 @@
         .card
           .card-body
             .d-flex
-              div.src-content#load-history(style="height:600px;overflow-y:scroll;flex:1")
+              div.list-content#load-history(style="height:600px;overflow-y:scroll;flex:1")
                 ul.historiccode(style="list-style-type: none;")
                   li.template
                     input.preview(type="radio" name="preview" style="margin-right: 10px;")
                     a(href="javascript:;")
-              div#load-history-src-display(style="height:600px;overflow-y:scroll;flex:1")
-                div.monaco-placeholder#history-diff
+              div.src-content#load-history-src-display(style="height:600px;overflow-y:scroll;flex:2")
+                div.monaco-placeholder
       .modal-footer
         button.btn.btn-outline-primary(type="button" data-dismiss="modal") Close


### PR DESCRIPTION
Single tab, no diffs - single source display, no list bullets, added spacing, added syntax highlighting.
That's it, I think.
![hist](https://github.com/user-attachments/assets/881ccbe3-38e9-42c8-a281-ac2368a39e87)
