### PR TITLE
Zig improvements

### DIFF
--- a/etc/config/zig.defaults.properties
+++ b/etc/config/zig.defaults.properties
@@ -6,6 +6,7 @@ versionFlag=version
 binaryHideFuncRe=^(_.*|call_gmon_start|(de)?register_tm_clones|frame_dummy|.*@plt.*)$
 isSemVer=true
 semver=trunk
+supportsLibraryCodeFilter=true
 
 #################################
 #################################

--- a/etc/config/zig.defaults.properties
+++ b/etc/config/zig.defaults.properties
@@ -1,9 +1,11 @@
-compilers=/usr/bin/zig
+compilers=zig:/usr/bin/zig
 supportsBinary=true
 compilerType=zig
 objdumper=objdump
 versionFlag=version
 binaryHideFuncRe=^(_.*|call_gmon_start|(de)?register_tm_clones|frame_dummy|.*@plt.*)$
+isSemVer=true
+semver=trunk
 
 #################################
 #################################

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -121,7 +121,8 @@ export class ZigCompiler extends BaseCompiler {
         if (this.self_hosted_cli) {
             // Versions after 0.6.0 use a different command line interface.
             const outputDir = path.dirname(outputFilename);
-            options.push('--cache-dir', outputDir, '--name', name);
+            // -fno-strip: Do not strip debug info
+            options.push('--cache-dir', outputDir, '--name', name, '-fno-strip');
 
             if (filters.binary) {
                 options.push('-femit-bin=' + desiredName);


### PR DESCRIPTION
- Make it easy/possible to run compiler-explorer-zig locally (see first commit)
- Dont strip debug info, add explicit flag for this (second commit)
- Allow filtering library functions. (it doesn't work super great atm, but at least some of the hundreds of thousands of lines get filtered out).