### PR TITLE
Deduplicate npm scripts used for CI

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run checks
         run: |
           npm run lint-check
-          npm run ci-test
+          npm run test
           npm run ts-check
           python3 ./etc/scripts/util/propscheck.py
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -29,5 +29,5 @@ jobs:
         run: npm run ts-check
         shell: cmd
       - name: Test
-        run: npm run ci-test
+        run: npm run test
         shell: cmd

--- a/package.json
+++ b/package.json
@@ -144,8 +144,6 @@
     "@rollup/rollup-win32-x64-msvc": "*"
   },
   "scripts": {
-    "ci-test": "vitest run",
-    "ci-lint": "biome check .",
     "cypress": "cypress run",
     "lint": "biome check . --write",
     "lint-check": "biome check .",


### PR DESCRIPTION
There's nothing special with these anymore. They are the same both locally and in CI now, because our Vitest and Biome setups don't behave differently there
