### PR TITLE
[rust] Add quickfixes for missing imports and feature flags

### DIFF
--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -249,7 +249,7 @@ describe('Rust compiler output', () => {
         expect(utils.parseRustOutput('Unrelated\nLine one\n --> bob.rs:1\nUnrelated', 'bob.rs')).toEqual([
             {text: 'Unrelated'},
             {
-                tag: {column: 0, line: 1, text: 'Line one', severity: 3},
+                tag: {column: 0, line: 1, text: 'Line one', severity: 3, fixes: []},
                 text: 'Line one',
             },
             {
@@ -260,7 +260,7 @@ describe('Rust compiler output', () => {
         ]);
         expect(utils.parseRustOutput('Line one\n --> bob.rs:1:5', 'bob.rs')).toEqual([
             {
-                tag: {column: 5, line: 1, text: 'Line one', severity: 3},
+                tag: {column: 5, line: 1, text: 'Line one', severity: 3, fixes: []},
                 text: 'Line one',
             },
             {
@@ -270,7 +270,7 @@ describe('Rust compiler output', () => {
         ]);
         expect(utils.parseRustOutput('Multiple spaces\n   --> bob.rs:1:5', 'bob.rs')).toEqual([
             {
-                tag: {column: 5, line: 1, text: 'Multiple spaces', severity: 3},
+                tag: {column: 5, line: 1, text: 'Multiple spaces', severity: 3, fixes: []},
                 text: 'Multiple spaces',
             },
             {
@@ -283,7 +283,7 @@ describe('Rust compiler output', () => {
     it('replaces all references to input source', () => {
         expect(utils.parseRustOutput('error: Error in bob.rs\n --> bob.rs:1', 'bob.rs')).toEqual([
             {
-                tag: {column: 0, line: 1, text: 'error: Error in <source>', severity: 3},
+                tag: {column: 0, line: 1, text: 'error: Error in <source>', severity: 3, fixes: []},
                 text: 'error: Error in <source>',
             },
             {
@@ -296,7 +296,7 @@ describe('Rust compiler output', () => {
     it('treats <stdin> as if it were the compiler source', () => {
         expect(utils.parseRustOutput('error: <stdin> is sad\n --> <stdin>:120:25', 'bob.rs')).toEqual([
             {
-                tag: {column: 25, line: 120, text: 'error: <source> is sad', severity: 3},
+                tag: {column: 25, line: 120, text: 'error: <source> is sad', severity: 3, fixes: []},
                 text: 'error: <source> is sad',
             },
             {
@@ -318,6 +318,7 @@ describe('Rust compiler output', () => {
                     column: 27,
                     text: 'error[E0425]: cannot find value `x` in this scope',
                     severity: 3,
+                    fixes: [],
                 },
                 text: 'error[\x1B]8;;https://doc.rust-lang.org/error_codes/E0425.html\x07E0425\x1B]8;;\x07]: cannot find value `x` in this scope',
             },
@@ -330,6 +331,84 @@ describe('Rust compiler output', () => {
                 },
                 text: ' --> <source>:42:27',
             },
+        ]);
+    });
+
+    it('emits quickfixes', () => {
+        expect(utils.parseRustOutput('error\n --> <source>:42:27\n15  + use std::collections::HashMap;')).toEqual([
+            {
+                tag: {
+                    line: 42,
+                    column: 27,
+                    text: 'error',
+                    severity: 3,
+                    fixes: [
+                        {
+                            title: 'Add import for `std::collections::HashMap`',
+                            edits: [
+                                {
+                                    line: 15,
+                                    column: 1,
+                                    endline: 15,
+                                    endcolumn: 1,
+                                    text: 'use std::collections::HashMap;\n',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: 'error',
+            },
+            {
+                tag: {
+                    line: 42,
+                    column: 27,
+                    text: '',
+                    severity: 3,
+                },
+                text: ' --> <source>:42:27',
+            },
+            {text: '15  + use std::collections::HashMap;'},
+        ]);
+
+        expect(
+            utils.parseRustOutput(
+                'error\n --> <source>:42:27\n   = help: add `#![feature(num_midpoint_signed)]` to the crate attributes to enable',
+            ),
+        ).toEqual([
+            {
+                tag: {
+                    line: 42,
+                    column: 27,
+                    text: 'error',
+                    severity: 3,
+                    fixes: [
+                        {
+                            title: 'Add feature flag `num_midpoint_signed`',
+                            edits: [
+                                {
+                                    line: 1,
+                                    column: 1,
+                                    endline: 1,
+                                    endcolumn: 1,
+                                    text: '#![feature(num_midpoint_signed)]\n',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: 'error',
+            },
+            {
+                tag: {
+                    line: 42,
+                    column: 27,
+                    text: '',
+                    severity: 3,
+                },
+                text: ' --> <source>:42:27',
+            },
+            {text: '   = help: add `#![feature(num_midpoint_signed)]` to the crate attributes to enable'},
         ]);
     });
 });


### PR DESCRIPTION
The Rust compiler emits error messages that are (in some cases) detailed enough that they can be parsed to generate quickfixes, e. g. when missing an import or a nightly feature flag.

Example: https://godbolt.org/z/jh3bY19P4 With this PR, hitting `Ctrl-.` with the cursor above any of the two errors in the editor will open a quickfix popup that can fix the respective error:

![import_quickfix](https://github.com/user-attachments/assets/0271f6d8-5c6c-4528-ac37-8e87e5699d21)
![feature_quickfix](https://github.com/user-attachments/assets/8842139b-5a4d-4a13-a472-75b27ebd46ab)
=>
![quickfixes_applied](https://github.com/user-attachments/assets/bc994222-fe89-4ac6-9ce4-c1afee2e2354)



## Alternatives

This feature could also be implemented (more robustly) by using `rustc`’s JSON output. However, `rustc` can’t output *both* human-readable and structured diagnostics, so it would be necessary to invoke the compiler twice to do this. Considering that the Rust Playground also parses the normal human-readable error format, I’d argue that the regex-based approach is good enough.

---

Requested in #5284.