### PR TITLE
Changes for newer NVidia drivers

### DIFF
--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -145,6 +145,8 @@ mount {
 }
 ###
 
+###
+# NVidia support
 mount {
     src: "/dev/nvidia0"
     dst: "/dev/nvidia0"
@@ -172,10 +174,33 @@ mount {
     is_bind: true
     mandatory: false
 }
+mount {
+    src: "/dev/nvidia-uvm-tools"
+    dst: "/dev/nvidia-uvm-tools"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+  src: "/sys/module/nvidia"
+  dst: "/sys/module/nvidia"
+  is_bind: true
+  mandatory: false
+}
+
+mount {
+  src: "/sys/module/nvidia_uvm"
+  dst: "/sys/module/nvidia_uvm"
+  is_bind: true
+  mandatory: false
+}
+# End NVidia support
+###
 
 mount {
     dst: "/proc"
     fstype: "proc"
+    rw: true # Needed for NVidia driver
 }
 
 mount {


### PR DESCRIPTION
Mounts some newer `/dev` and `/sys` directories needed by the newer NVidia drivers into the sandbox. Also make `/proc` read-write which is needed as the driver writes to `/proc/self/task/tid/comm` to try and change its name.

CC @rwarmstr

I don't believe there's a security risk in making `/proc` writeable, though it's annoying that the NVidia process actually errors on the inability to rename its own process name.