### PR TITLE
[Zig] Fix target/arch parsing so assembly docs query the correct ISA

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -152,3 +152,4 @@ From oldest to newest contributor, we would like to thank:
 - [Pierre Bayerl](https://github.com/goto40)
 - [James Touton](https://github.com/Bekenn)
 - [Waqar Ahmed](https://github.com/waqar144)
+- [Niles Salter](https://github.com/Validark)

--- a/compiler-args-app.ts
+++ b/compiler-args-app.ts
@@ -61,6 +61,7 @@ const compilerParsers = {
     ghc: Parsers.GHCParser,
     tendra: Parsers.TendraParser,
     golang: Parsers.GolangParser,
+    zig: Parsers.ZigParser,
 };
 
 class CompilerArgsApp {
@@ -119,6 +120,8 @@ class CompilerArgsApp {
             console.log('supportsTargetIs');
         } else if (parser.hasSupportStartsWith(options, '--target ')) {
             console.log('supportsTarget');
+        } else if (parser.hasSupportStartsWith(options, '-target ')) {
+            console.log('supportsHyphenTarget');
         } else if (parser.hasSupportStartsWith(options, '--march=')) {
             console.log('supportsMarch');
         } else {

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3662,7 +3662,7 @@ but nothing was dumped. Possible causes are:
         if (this.compiler.supportsMarch) return [`-march=${c_value_placeholder}`];
         if (this.compiler.supportsTargetIs) return [`--target=${c_value_placeholder}`];
         if (this.compiler.supportsTarget) return ['--target', c_value_placeholder];
-
+        if (this.compiler.supportsHyphenTarget) return ['-target', c_value_placeholder];
         return [];
     }
 
@@ -3671,7 +3671,7 @@ but nothing was dumped. Possible causes are:
         if (this.compiler.supportsMarch) all.push([`-march=${c_value_placeholder}`]);
         if (this.compiler.supportsTargetIs) all.push([`--target=${c_value_placeholder}`]);
         if (this.compiler.supportsTarget) all.push(['--target', c_value_placeholder]);
-
+        if (this.compiler.supportsHyphenTarget) all.push(['-target', c_value_placeholder]);
         return all;
     }
 

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1061,6 +1061,16 @@ export class WasmtimeParser extends BaseParser {
     }
 }
 
+export class ZigParser extends GCCParser {
+    static override async parse(compiler: BaseCompiler) {
+        const results = await Promise.all([ZigParser.getOptions(compiler, 'build-obj --help')]);
+        const options = Object.assign({}, ...results);
+        await GCCParser.setCompilerSettingsFromOptions(compiler, options);
+        if (GCCParser.hasSupportStartsWith(options, '-target ')) compiler.compiler.supportsHyphenTarget = true;
+        return compiler;
+    }
+}
+
 export class ZigCxxParser extends ClangParser {
     static override getMainHelpOptions(): string[] {
         return ['c++', '--help'];

--- a/lib/compilers/zig.ts
+++ b/lib/compilers/zig.ts
@@ -33,6 +33,7 @@ import type {SelectedLibraryVersion} from '../../types/libraries/libraries.inter
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 import {asSafeVer} from '../utils.js';
+import {ZigParser} from './argument-parsers.js';
 
 export class ZigCompiler extends BaseCompiler {
     private readonly self_hosted_cli: boolean;
@@ -177,6 +178,10 @@ export class ZigCompiler extends BaseCompiler {
     override filterUserOptions(userOptions: string[]): string[] {
         const forbiddenOptions = /^(((--(cache-dir|name|output|verbose))|(-(mllvm|f(no-)?emit-))).*)$/;
         return userOptions.filter(option => !forbiddenOptions.test(option));
+    }
+
+    protected override getArgumentParserClass() {
+        return ZigParser;
     }
 
     override isCfgCompiler(): boolean {

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -94,6 +94,7 @@ export type CompilerInfo = {
     supportsMarch?: boolean;
     supportsTarget?: boolean;
     supportsTargetIs?: boolean;
+    supportsHyphenTarget?: boolean;
     executionWrapper: string;
     executionWrapperArgs: string[];
     postProcess: string[];


### PR DESCRIPTION
This makes it so the Zig compiler can now use the compiler flag following `-target ` to query the correct ISA for assembly docs!

![image](https://github.com/user-attachments/assets/06764d4e-b233-47c7-95da-293adcd839f3)

![image](https://github.com/user-attachments/assets/f1c50c26-8f8f-4b6f-9915-f8500e952cea)

Not sure if it still defaults to amd64 on an aarch64 computer when `-target ` is not present. But I will leave that problem for another day.