### PR TITLE
Fix execution for Rust 1.83+ with dynamically linked standard library

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -21,8 +21,10 @@ group.rust.supportsBinary=true
 group.rust.supportsBinaryObject=true
 compiler.r1840.exe=/opt/compiler-explorer/rust-1.84.0/bin/rustc
 compiler.r1840.semver=1.84.0
+compiler.r1840.libPath=${exePath}/../lib/rustlib/x86_64-unknown-linux-gnu/lib
 compiler.r1830.exe=/opt/compiler-explorer/rust-1.83.0/bin/rustc
 compiler.r1830.semver=1.83.0
+compiler.r1830.libPath=${exePath}/../lib/rustlib/x86_64-unknown-linux-gnu/lib
 compiler.r1820.exe=/opt/compiler-explorer/rust-1.82.0/bin/rustc
 compiler.r1820.semver=1.82.0
 compiler.r1810.exe=/opt/compiler-explorer/rust-1.81.0/bin/rustc
@@ -196,9 +198,11 @@ compiler.r100.semver=1.0.0
 compiler.nightly.exe=/opt/compiler-explorer/rust-nightly/bin/rustc
 compiler.nightly.semver=nightly
 compiler.nightly.isNightly=true
+compiler.nightly.libPath=${exePath}/../lib/rustlib/x86_64-unknown-linux-gnu/lib
 compiler.beta.exe=/opt/compiler-explorer/rust-beta/bin/rustc
 compiler.beta.semver=beta
 compiler.beta.isNightly=true
+compiler.beta.libPath=${exePath}/../lib/rustlib/x86_64-unknown-linux-gnu/lib
 
 # gccrs: main development for the Rust GCC Frontend (github)
 # gcc: regular gcc dev/releases


### PR DESCRIPTION
Rust 1.83+ changed the location of `libstd-*.so` so that it is no longer in the default `LD_LIBRARY_PATH` that CE sets:
```console
$ fd --glob 'libstd-*.so' /opt/compiler-explorer
/opt/compiler-explorer/rust-1.82.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-22be60875a4ac8d7.so
/opt/compiler-explorer/rust-1.82.0/lib/libstd-22be60875a4ac8d7.so
/opt/compiler-explorer/rust-1.83.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-ca74a2d9c5166d9f.so
```

This broke execution: https://godbolt.org/z/7fc11afKa