### PR TITLE
Re-enable noConfusingVoidType and noVoidTypeReturn Biome rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,8 +23,7 @@
         "noControlCharactersInRegex": "off",
         "noShadowRestrictedNames": "off",
         "noFallthroughSwitchClause": "off",
-        "noDoubleEquals": "off",
-        "noConfusingVoidType": "off"
+        "noDoubleEquals": "off"
       },
       "style": {
         "noParameterAssign": "off",
@@ -34,7 +33,6 @@
         "useTemplate": "off"
       },
       "correctness": {
-        "noVoidTypeReturn": "off",
         "noUnsafeOptionalChaining": "off"
       },
       "performance": {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1152,10 +1152,11 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         const lang = this.currentLanguage;
 
         if (!Object.prototype.hasOwnProperty.call(lang, 'formatter')) {
-            return this.alertSystem.notify('This language does not support in-editor formatting', {
+            this.alertSystem.notify('This language does not support in-editor formatting', {
                 group: 'formatting',
                 alertClass: 'notification-error',
             });
+            return;
         }
 
         $.ajax({


### PR DESCRIPTION
Re-enables these rules and fixes the one spot it was applicable. Infact, noConfusingVoidType had zero matches (because they were fixed in #7080)