### PR TITLE
Re-enable useLiteralEnumMembers Biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,6 @@
       "style": {
         "noParameterAssign": "off",
         "noNonNullAssertion": "off",
-        "useLiteralEnumMembers": "off",
         "useImportType": "off",
         "useTemplate": "off"
       },

--- a/static/graph-layout-core.ts
+++ b/static/graph-layout-core.ts
@@ -616,6 +616,7 @@ export class GraphLayoutCore {
             VERTICAL = 0,
             RIGHTCORNER = 1,
             RIGHTU = 2,
+            // biome-ignore lint/style/useLiteralEnumMembers: ported from cutter
             NULL = Number.NaN,
         }
         const segments: {


### PR DESCRIPTION
Disabled the lint for the only match as the code is mostly ported from cutter's graph engine.