### PR TITLE
Re-enable noBannedTypes Biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,6 @@
       "complexity": {
         "noStaticOnlyClass": "off",
         "noForEach": "off",
-        "noBannedTypes": "off",
         "useLiteralKeys": "off"
       }
     }

--- a/types/cache.interfaces.ts
+++ b/types/cache.interfaces.ts
@@ -36,6 +36,6 @@ export type CacheableValue =
     | boolean
     | undefined
     | null
-    | Function
+    | ((...args: any) => any)
     | {[x: string]: CacheableValue}
     | Array<CacheableValue>;


### PR DESCRIPTION
Function is usually frowned upon in TS because it gives no description of what type of function.
