### PR TITLE
Fix #7359: use llvm-cxxfilt by default for all compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3,7 +3,8 @@ compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rv
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
 defaultCompiler=g142
-demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
+# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind 
+demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 needsMulti=false
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,6 +1,7 @@
 compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast
 defaultCompiler=cg142
-demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
+# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind 
+demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 needsMulti=false
 


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

I tested `gcc-snapshot`s `c++filt` and it still doesn't handle `require` well. llvm does.