### PR TITLE
executionType/sandBoxType no longer stored per compiler

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -120,7 +120,6 @@ import type {IAsmParser} from './parsers/asm-parser.interfaces.js';
 import {AsmParser} from './parsers/asm-parser.js';
 import {LlvmPassDumpParser} from './parsers/llvm-pass-dump-parser.js';
 import type {PropertyGetter} from './properties.interfaces.js';
-import {propsFor} from './properties.js';
 import {HeaptrackWrapper} from './runtime-tools/heaptrack-wrapper.js';
 import {LibSegFaultHelper} from './runtime-tools/libsegfault-helper.js';
 import {SentryCapture} from './sentry.js';
@@ -212,8 +211,6 @@ export class BaseCompiler {
     protected externalparser: null | ExternalParserBase;
     protected supportedLibraries?: Record<string, OptionsHandlerLibrary>;
     protected packager: Packager;
-    protected executionType: string;
-    protected sandboxType: string;
     protected defaultRpathFlag = '-Wl,-rpath,';
     private static objdumpAndParseCounter = new PromClient.Counter({
         name: 'ce_objdumpandparsetime_total',
@@ -257,10 +254,6 @@ export class BaseCompiler {
             // TODO(jeremy-rifkin): branch may now be obsolete?
             this.compiler.disabledFilters = (this.compiler.disabledFilters as any).split(',');
         }
-
-        const execProps = propsFor('execution');
-        this.executionType = execProps('executionType', 'none');
-        this.sandboxType = execProps('sandboxType', 'none');
 
         this.asm = new AsmParser(this.compilerProps);
         const irDemangler = new LLVMIRDemangler(this.compiler.demangler, this);

--- a/lib/compilers/clean.ts
+++ b/lib/compilers/clean.ts
@@ -29,6 +29,7 @@ import fs from 'fs-extra';
 import type {ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
+import {propsFor} from '../properties.js';
 import * as utils from '../utils.js';
 
 export class CleanCompiler extends BaseCompiler {
@@ -114,7 +115,8 @@ export class CleanCompiler extends BaseCompiler {
         await fs.mkdir(execOptions.env.CLEANABCPATH);
         await fs.mkdir(execOptions.env.CLEANOPATH);
 
-        if (this.executionType === 'nsjail') {
+        const execProps = propsFor('execution');
+        if (execProps<string>('executionType') === 'nsjail') {
             execOptions.env.CLEANABCPATH = '/app/Clean System Files';
             execOptions.env.CLEANOPATH = '/app/obj';
         }

--- a/test/library-tests.ts
+++ b/test/library-tests.ts
@@ -111,7 +111,7 @@ describe('Library directories (c++)', () => {
         } as unknown as ClientOptionsType);
     });
 
-    it('should add libpaths and link to libraries', () => {
+    it('should add libpaths and link to libraries 1', () => {
         const links = compiler.getSharedLibraryLinks([{id: 'fmt', version: '10'}]);
         expect(links).toContain('-lfmtd');
 
@@ -133,9 +133,7 @@ describe('Library directories (c++)', () => {
         expect(qtpaths).toContain('-L' + path.normalize('/tmp/compiler-explorer-compiler-123/qt/lib'));
     });
 
-    it('should add libpaths and link to libraries when using nsjail', () => {
-        (compiler as any).executionType = 'nsjail';
-
+    it('should add libpaths and link to libraries 2', () => {
         const fmtpaths = (compiler as any).getSharedLibraryPathsAsArguments(
             [{id: 'fmt', version: '10'}],
             undefined,
@@ -156,8 +154,6 @@ describe('Library directories (c++)', () => {
     });
 
     it('should add extra include paths when using packagedheaders', () => {
-        (compiler as any).executionType = 'nsjail';
-
         const fmtpaths = (compiler as any).getIncludeArguments(
             [{id: 'fmt', version: '10'}],
             '/tmp/compiler-explorer-compiler-123',
@@ -176,8 +172,6 @@ describe('Library directories (c++)', () => {
     });
 
     it('should set LD_LIBRARY_PATH when executing', () => {
-        (compiler as any).sandboxType = 'nsjail';
-
         const qtpaths = (compiler as BaseCompiler).getSharedLibraryPathsAsLdLibraryPathsForExecution(
             {
                 libraries: [{id: 'qt', version: '660'}],
@@ -195,8 +189,6 @@ describe('Library directories (c++)', () => {
     });
 
     it('should add libpaths and link when statically linking', () => {
-        (compiler as any).executionType = 'nsjail';
-
         const staticlinks = compiler.getStaticLibraryLinks([{id: 'cpptrace', version: '030'}], []);
         expect(staticlinks).toContain('-lcpptrace');
         expect(staticlinks).toContain('-ldwarf');
@@ -272,8 +264,6 @@ describe('Library directories (fortran)', () => {
     });
 
     it('should not add libpaths and link to libraries when they dont exist', async () => {
-        (compiler as any).executionType = 'nsjail';
-
         const dirPath = await compiler.newTempDir();
 
         const libPath = path.join(dirPath, 'json_fortran/lib');
@@ -289,8 +279,6 @@ describe('Library directories (fortran)', () => {
     });
 
     it('should add libpaths and link to libraries', async () => {
-        (compiler as any).executionType = 'nsjail';
-
         const dirPath = await compiler.newTempDir();
         const libPath = path.join(dirPath, 'json_fortran/lib');
         await fs.mkdir(libPath, {recursive: true});
@@ -315,7 +303,6 @@ describe('Library directories (fortran)', () => {
     });
 
     it('should add includes for packaged libraries', async () => {
-        (compiler as any).executionType = 'nsjail';
         (compiler as any).compiler.includeFlag = '-isystem';
 
         const dirPath = await compiler.newTempDir();
@@ -328,7 +315,6 @@ describe('Library directories (fortran)', () => {
     });
 
     it('should add includes for non-packaged C libraries', async () => {
-        (compiler as any).executionType = 'nsjail';
         (compiler as any).compiler.includeFlag = '-isystem';
 
         const dirPath = await compiler.newTempDir();


### PR DESCRIPTION
.. as they're uniform execution options


Note the removal of `(compiler as any).executionType = 'nsjail'` from tests - seems it didn't do anything.

But better test execution in staging, as I'm having trouble using nsjail locally.