### PR TITLE
Use Java 22 for latest Android compilers

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -10,6 +10,7 @@ group.android-d8.instructionSet=dex
 
 compiler.java-d8-latest.name=d8 latest
 compiler.java-d8-latest.exe=/opt/compiler-explorer/r8-latest/r8-latest.jar
+compiler.java-d8-latest.javaId=java2200
 
 compiler.java-d8-8718.name=d8 8.7.18
 compiler.java-d8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar
@@ -62,6 +63,7 @@ group.android-r8.kotlinId=kotlinc1920
 
 compiler.java-r8-latest.name=r8 latest
 compiler.java-r8-latest.exe=/opt/compiler-explorer/r8-latest/r8-latest.jar
+compiler.java-r8-latest.javaId=java2200
 
 compiler.java-r8-8718.name=r8 8.7.18
 compiler.java-r8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar

--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -10,6 +10,7 @@ group.android-d8.instructionSet=dex
 
 compiler.kotlin-d8-latest.name=d8 latest
 compiler.kotlin-d8-latest.exe=/opt/compiler-explorer/r8-latest/r8-latest.jar
+compiler.kotlin-d8-latest.javaId=java2200
 
 compiler.kotlin-d8-8718.name=d8 8.7.18
 compiler.kotlin-d8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar
@@ -63,6 +64,7 @@ group.android-r8.kotlinLibPath=/opt/compiler-explorer/kotlin-jvm-1.9.20/lib
 
 compiler.kotlin-r8-latest.name=r8 latest
 compiler.kotlin-r8-latest.exe=/opt/compiler-explorer/r8-latest/r8-latest.jar
+compiler.kotlin-r8-latest.javaId=java2200
 
 compiler.kotlin-r8-8718.name=r8 8.7.18
 compiler.kotlin-r8-8718.exe=/opt/compiler-explorer/r8-8.7.18/r8-8.7.18.jar

--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -70,7 +70,11 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         this.jvmSyspropArgRegex = /^-J.*$/;
         this.syspropArgRegex = /^-D.*$/;
 
-        this.javaId = this.compilerProps<string>(`group.${this.compiler.group}.javaId`);
+        this.javaId = this.compilerProps<string>(`compiler.${this.compiler.id}.javaId`);
+        if (!this.javaId) {
+            this.javaId = this.compilerProps<string>(`group.${this.compiler.group}.javaId`);
+        }
+
         this.kotlinId = this.compilerProps<string>(`group.${this.compiler.group}.kotlinId`);
 
         this.libPaths = [];


### PR DESCRIPTION
This change updates the Java version used for R8/D8/dex2oat latest to the most recent Java version available to help investigate newer Java features.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
