### PR TITLE
Add carbon native compiler

### DIFF
--- a/etc/config/carbon.amazon.properties
+++ b/etc/config/carbon.amazon.properties
@@ -1,10 +1,23 @@
 # Amazon prod environment settings
-compilers=carbon-trunk
+compilers=carbon-trunk:carbon-explorer-trunk
 defaultCompiler=carbon-trunk
 compilerType=carbon
 needsMulti=false
+supportsBinaryObject=true
+# Supporting execution or binary would require doing a `carbon link` step.
+supportExecute=false
+supportsBinary=false
+objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 
-compiler.carbon-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon-explorer
-compiler.carbon-trunk.name=Explorer (trunk)
+compiler.carbon-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon
+compiler.carbon-trunk.name=Carbon (trunk)
+
+# Older deprecated explorer
+compiler.carbon-explorer-trunk.compilerType=carbon-explorer
+compiler.carbon-explorer-trunk.exe=/opt/compiler-explorer/carbon-explorer-trunk/bin/carbon-explorer
+compiler.carbon-explorer-trunk.name=Explorer (trunk)
+compiler.carbon-explorer-trunk.supportsExecute=true
+compiler.carbon-explorer-trunk.supportsBinary=false
+compiler.carbon-explorer-trunk.supportsBinaryObject=false
 
 libs=

--- a/etc/config/carbon.amazon.properties
+++ b/etc/config/carbon.amazon.properties
@@ -1,12 +1,6 @@
 # Amazon prod environment settings
 compilers=carbon-trunk:carbon-explorer-trunk
 defaultCompiler=carbon-trunk
-compilerType=carbon
-needsMulti=false
-supportsBinaryObject=true
-# Supporting execution or binary would require doing a `carbon link` step.
-supportExecute=false
-supportsBinary=false
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 
 compiler.carbon-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon

--- a/etc/config/carbon.defaults.properties
+++ b/etc/config/carbon.defaults.properties
@@ -3,8 +3,9 @@ compilers=carbon-trunkdef
 defaultCompiler=carbon-trunkdef
 compilerType=carbon
 needsMulti=false
-supportsExecute=false
-supportsBinary=false
+supportsExecute=true
+supportsBinary=true
+supportsBinaryObject=true
 
 compiler.carbon-trunkdef.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon-explorer
 compiler.carbon-trunkdef.name=Explorer (trunk)

--- a/examples/carbon/default.carbon
+++ b/examples/carbon/default.carbon
@@ -5,6 +5,7 @@ fn Square(x: i32) -> i32 {
   return x * x;
 }
 
-fn Main() -> i32 {
+// To run this in Carbon Explorer you'll need to rename this "Main()".
+fn Run() -> i32 {
   return Square(12);
 }

--- a/examples/carbon/default.carbon
+++ b/examples/carbon/default.carbon
@@ -1,4 +1,4 @@
-// To run this in Carbon Explorer you'll need to comment out the following line:
+// To run this in Carbon Explorer you'll need to uncomment the following line:
 // package sample api;
 
 fn Square(x: i32) -> i32 {

--- a/examples/carbon/default.carbon
+++ b/examples/carbon/default.carbon
@@ -1,4 +1,5 @@
-package sample api;
+// To run this in Carbon Explorer you'll need to comment out the following line:
+// package sample api;
 
 fn Square(x: i32) -> i32 {
   return x * x;

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -32,7 +32,7 @@ export {CIRCTCompiler} from './circt.js';
 export {CL430Compiler} from './cl430.js';
 export {CLSPVCompiler} from './clspv.js';
 export {CMakeScriptCompiler} from './cmakescript.js';
-export {CarbonCompiler} from './carbon.js';
+export {CarbonCompiler, CarbonExplorerCompiler} from './carbon.js';
 export {Cc65Compiler} from './cc65.js';
 export {CerberusCompiler} from './cerberus.js';
 export {CircleCompiler} from './circle.js';

--- a/lib/compilers/carbon.ts
+++ b/lib/compilers/carbon.ts
@@ -23,15 +23,15 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
-import type {CompilationResult} from '../../types/compilation/compilation.interfaces.js';
+import {CompilationResult, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import type {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 
-import {ConfiguredOverrides} from '../../types/compilation/compiler-overrides.interfaces.js';
-import {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
+import fs from 'fs-extra';
+import {unwrap} from '../assert.js';
 import {BaseParser} from './argument-parsers.js';
 
 export class CarbonCompiler extends BaseCompiler {
@@ -39,35 +39,59 @@ export class CarbonCompiler extends BaseCompiler {
         return 'carbon';
     }
 
-    override prepareArguments(
-        userOptions: string[],
-        filters: ParseFiltersAndOutputOptions,
-        backendOptions: Record<string, any>,
+    override orderArguments(
+        options: string[],
         inputFilename: string,
-        outputFilename: string,
-        libraries: SelectedLibraryVersion[],
-        overrides: ConfiguredOverrides,
+        libIncludes: string[],
+        libOptions: string[],
+        libPaths: string[],
+        libLinks: string[],
+        userOptions: string[],
+        staticLibLinks: string[],
     ): string[] {
-        const args = super.prepareArguments(
+        return ['compile'].concat(
+            options,
             userOptions,
-            filters,
-            backendOptions,
-            inputFilename,
-            outputFilename,
-            libraries,
-            overrides,
+            [this.filename(inputFilename)],
+            // We don't support libraries in Carbon, so drop all the `-L` args
         );
-        // To support execution, we would need to work out how to run a separate "carbon link" stage
-        // after generation. We have this with a couple of other compilers that can't do a compile-and-link in one step
-        // and we've not yet got a good solution.
-        args.unshift('compile');
-        return args;
+    }
+
+    override isCfgCompiler() {
+        return true;
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string): string[] {
         const args = [`--output=${outputFilename}`];
         if (!filters.binary && !filters.binaryObject) args.push('--asm-output');
         return args;
+    }
+
+    async linkExecutable(options: string[], execOptions: ExecutionOptionsWithEnv) {
+        // Rely on the fact we definitely put a `--output=` in the options.
+        const outputArg = unwrap(options.filter(opt => opt.startsWith('--output='))[0]);
+        const outputFile = outputArg.split('=', 2)[1];
+        const renamedFile = outputFile + '.tmp';
+        await fs.rename(outputFile, renamedFile);
+        return await this.exec(this.compiler.exe, ['link', outputArg, renamedFile], execOptions);
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+        filters?: ParseFiltersAndOutputOptions,
+    ): Promise<CompilationResult> {
+        const result = await super.runCompiler(compiler, options, inputFilename, execOptions, filters);
+        if (result.code !== 0) return result;
+        if (filters?.binary) {
+            const linkResult = await this.linkExecutable(options, execOptions);
+            if (linkResult.code !== 0) {
+                return {...result, ...this.transformToCompilationResult(linkResult, inputFilename)};
+            }
+        }
+        return result;
     }
 }
 

--- a/lib/compilers/carbon.ts
+++ b/lib/compilers/carbon.ts
@@ -30,11 +30,50 @@ import type {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 
+import {ConfiguredOverrides} from '../../types/compilation/compiler-overrides.interfaces.js';
+import {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
 import {BaseParser} from './argument-parsers.js';
 
 export class CarbonCompiler extends BaseCompiler {
     static get key() {
         return 'carbon';
+    }
+
+    override prepareArguments(
+        userOptions: string[],
+        filters: ParseFiltersAndOutputOptions,
+        backendOptions: Record<string, any>,
+        inputFilename: string,
+        outputFilename: string,
+        libraries: SelectedLibraryVersion[],
+        overrides: ConfiguredOverrides,
+    ): string[] {
+        const args = super.prepareArguments(
+            userOptions,
+            filters,
+            backendOptions,
+            inputFilename,
+            outputFilename,
+            libraries,
+            overrides,
+        );
+        // To support execution, we would need to work out how to run a separate "carbon link" stage
+        // after generation. We have this with a couple of other compilers that can't do a compile-and-link in one step
+        // and we've not yet got a good solution.
+        args.unshift('compile');
+        return args;
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string): string[] {
+        const args = [`--output=${outputFilename}`];
+        if (!filters.binary && !filters.binaryObject) args.push('--asm-output');
+        return args;
+    }
+}
+
+export class CarbonExplorerCompiler extends BaseCompiler {
+    static get key() {
+        return 'carbon-explorer';
     }
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {


### PR DESCRIPTION
- Renames existing carbon stuff to carbon-explorer. Will need a quick infra install and will temporarily (like, for 2m) break things during deploy.
- Adds carbon binary support
- Supports binary, execute, and binary objects
- Updates the default carbon file as best I can
 
Closes #5402 