### PR TITLE
Enable execution and compilation to binary for `rustc-cg-gcc`

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -266,12 +266,12 @@ compiler.rustbpfgtrunk.isNightly=true
 # Rustc CG GCC (GCC backend for rustc compiler)
 group.rustccggcc.compilers=rustccggcc-master
 group.rustccggcc.compilerType=rustc-cg-gcc
-group.rustccggcc.supportsExecute=false
-group.rustccggcc.supportsBinary=false
-group.rustccggcc.supportsBinaryObject=false
+group.rustccggcc.supportsBinary=true
+group.rustccggcc.supportsBinaryObject=true
 group.rustccggcc.unwiseOptions=-Ctarget-cpu=native|target-cpu=native
 compiler.rustccggcc-master.exe=/opt/compiler-explorer/rustc-cg-gcc-master/bin/rustc
 compiler.rustccggcc-master.name=rustc-cg-gcc (master)
+compiler.rustccggcc-master.libPath=${exePath}/../sysroot/lib/rustlib/x86_64-unknown-linux-gnu/lib
 compiler.rustccggcc-master.isNightly=true
 
 # mrustc (compiler used to bootstrap rustc)


### PR DESCRIPTION
The binary options’ output will (like for `rustc`) contain the complete standard library (see #2708, #7337), but this can be worked around with `-C prefer-dynamic`.

Execution should (according to my local tests) just work™.