### PR TITLE
Fix #7398: call layout.init only after SiteSettings are in place

### DIFF
--- a/static/hub.ts
+++ b/static/hub.ts
@@ -228,10 +228,13 @@ export class Hub {
             },
             this,
         );
+    }
 
-        layout.init();
+    public initLayout() {
+        // To be called after setupSettings, as layout.init depends on them
+        this.layout.init();
         this.undefer();
-        layout.eventHub.emit('initialised');
+        this.layout.eventHub.emit('initialised');
     }
 
     public nextTreeId(): number {

--- a/static/main.ts
+++ b/static/main.ts
@@ -626,6 +626,9 @@ function start() {
         hub = new Hub(layout, subLangId, defaultLangId);
     }
 
+    const [themer, settings] = setupSettings(hub);
+    hub.initLayout();
+
     setSentryLayout(layout);
 
     if (hub.hasTree()) {
@@ -640,8 +643,6 @@ function start() {
     }
 
     new clipboard('.btn.clippy');
-
-    const [themer, settings] = setupSettings(hub);
 
     function handleCtrlS(event: JQuery.KeyDownEvent<Window, undefined, Window, Window>): void {
         event.preventDefault();


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
