### PR TITLE
Misc fixes for unbuffering

### DIFF
--- a/etc/nsjail/compilers-and-tools.cfg
+++ b/etc/nsjail/compilers-and-tools.cfg
@@ -24,7 +24,7 @@ detect_cgroupv2: true
 
 # for cgroups v1:
 # must run following as root during system startup
-# F
+# cgcreate -a $USER:$USER -g memory,pids,cpu,net_cls:ce-compile
 cgroup_mem_parent: "ce-compile"
 cgroup_pids_parent: "ce-compile"
 cgroup_net_cls_parent: "ce-compile"

--- a/etc/nsjail/compilers-and-tools.cfg
+++ b/etc/nsjail/compilers-and-tools.cfg
@@ -24,7 +24,7 @@ detect_cgroupv2: true
 
 # for cgroups v1:
 # must run following as root during system startup
-# cgcreate -a $USER:$USER -g memory,pids,cpu,net_cls:ce-compile
+# F
 cgroup_mem_parent: "ce-compile"
 cgroup_pids_parent: "ce-compile"
 cgroup_net_cls_parent: "ce-compile"
@@ -148,6 +148,22 @@ mount {
     is_bind: true
 }
 
+###
+# Support for stdbuf
+mount {
+    src: "/usr/bin/stdbuf"
+    dst: "/usr/bin/stdbuf"
+    is_bind: true
+}
+mount {
+    src: "/usr/libexec/coreutils/libstdbuf.so"
+    dst: "/usr/libexec/coreutils/libstdbuf.so"
+    is_bind: true
+}
+###
+
+###
+# NVidia support
 mount {
     src: "/dev/nvidia0"
     dst: "/dev/nvidia0"
@@ -175,6 +191,28 @@ mount {
     is_bind: true
     mandatory: false
 }
+mount {
+    src: "/dev/nvidia-uvm-tools"
+    dst: "/dev/nvidia-uvm-tools"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+  src: "/sys/module/nvidia"
+  dst: "/sys/module/nvidia"
+  is_bind: true
+  mandatory: false
+}
+
+mount {
+  src: "/sys/module/nvidia_uvm"
+  dst: "/sys/module/nvidia_uvm"
+  is_bind: true
+  mandatory: false
+}
+# End NVidia support
+###
 
 mount {
     dst: "/proc"

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -26,7 +26,6 @@ import buffer from 'buffer';
 import child_process from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
-// @ts-ignore
 import which from 'which';
 
 import {Stream} from 'node:stream';
@@ -53,7 +52,7 @@ type NsJailOptions = {
 
 const execProps = propsFor('execution');
 
-let stdbufPath = null;
+let stdbufPath: null | string = null;
 
 function checkExecOptions(options: ExecutionOptions) {
     if (options.env) {
@@ -72,6 +71,25 @@ function setupOnError(stream: Stream, name: string) {
     stream.on('error', err => {
         logger.error(`Error with ${name} stream:`, err);
     });
+}
+
+async function maybeUnbuffer(command: string, args: string[]): Promise<string> {
+    if (!stdbufPath) {
+        const unbufferStdoutExe = execProps<string>('unbufferStdoutExe');
+        if (unbufferStdoutExe) {
+            stdbufPath = await which(unbufferStdoutExe).catch(() => null);
+            if (!stdbufPath) logger.error(`Could not find ${unbufferStdoutExe} in PATH`);
+            else logger.info(`Unbuffering with ${stdbufPath}`);
+        }
+    }
+
+    if (stdbufPath) {
+        const stdbufArgs = splitArguments(execProps<string>('unbufferStdoutArgs'));
+        args.unshift(...stdbufArgs, command);
+        command = stdbufPath;
+    }
+
+    return command;
 }
 
 export async function executeDirect(
@@ -95,20 +113,6 @@ export async function executeDirect(
         command = options.wrapper;
 
         if (command.startsWith('./')) command = path.join(process.cwd(), command);
-    }
-
-    if (stdbufPath == null) {
-        const unbufferStdoutExe = execProps<string>('unbufferStdoutExe', undefined); // by default 'stdout'
-        if (unbufferStdoutExe) {
-            stdbufPath = await which(unbufferStdoutExe);
-            if (!stdbufPath) logger.error(`Could not find ${unbufferStdoutExe} in PATH`);
-        }
-    }
-
-    if (stdbufPath) {
-        const stdbufArgs = splitArguments(execProps<string>('unbufferStdoutArgs', undefined)); // by default ['-o0']
-        args.unshift(...stdbufArgs, command);
-        command = stdbufPath;
     }
 
     let okToCache = true;
@@ -431,6 +435,7 @@ export async function sandbox(
     const dispatchEntry = sandboxDispatchTable[type as 'none' | 'nsjail' | 'firejail' | 'cewrapper'];
     if (!dispatchEntry) throw new Error(`Bad sandbox type ${type}`);
     if (!command) throw new Error('No executable provided');
+    command = await maybeUnbuffer(command, args);
     return await dispatchEntry(command, args, options);
 }
 
@@ -649,5 +654,6 @@ export async function execute(
     const dispatchEntry = executeDispatchTable[type];
     if (!dispatchEntry) throw new Error(`Bad sandbox type ${type}`);
     if (!command) throw new Error('No executable provided');
+    command = await maybeUnbuffer(command, args);
     return await dispatchEntry(command, args, options);
 }

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -31,8 +31,6 @@ import Server from 'http-proxy';
 import PromClient, {Counter} from 'prom-client';
 import temp from 'temp';
 import _ from 'underscore';
-
-// @ts-ignore
 import which from 'which';
 
 import {remove, splitArguments} from '../../shared/common-utils.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "@types/underscore": "^1.13.0",
         "@types/url-join": "^4.0.3",
         "@types/webpack-env": "^1.18.8",
+        "@types/which": "^3.0.4",
         "@types/ws": "^8.5.14",
         "@vitest/coverage-v8": "^2.1.9",
         "aws-sdk-client-mock": "^4.1.0",
@@ -5033,6 +5034,13 @@
       "version": "1.18.8",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.8.tgz",
       "integrity": "sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/which": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
+      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@types/underscore": "^1.13.0",
     "@types/url-join": "^4.0.3",
     "@types/webpack-env": "^1.18.8",
+    "@types/which": "^3.0.4",
     "@types/ws": "^8.5.14",
     "@vitest/coverage-v8": "^2.1.9",
     "aws-sdk-client-mock": "^4.1.0",


### PR DESCRIPTION
- Wrap the executable in `stdbuf` higher up than in `executeDirect` which means we run `stdbuf` _inside_ the jail instead of outside it when running. This fixes jail/stdbuf interactions.
- Install `which` types to avoid a `no-ts`
- Ensure `stdbuf` et al is mapped in compilers-and-tools
- As a fly-by also unify the configuration of NVidia devices between execution and compilation.
