### PR TITLE
Add version info for R8/D8

### DIFF
--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -297,8 +297,8 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
     override async getVersion() {
         const versionFile = path.join(path.dirname(this.compiler.exe), 'r8-version.properties');
         let versionCode;
-        if (fs.existsSync(versionFile)) {
-            const versionInfo = fs.readFileSync(versionFile, {encoding: 'utf8'});
+        if (await fs.exists(versionFile)) {
+            const versionInfo = await fs.readFile(versionFile, {encoding: 'utf8'});
             for (const l of versionInfo.split(/\n/)) {
                 if (this.versionFromPropsRegex.test(l)) {
                     versionCode = l.match(this.versionFromPropsRegex)![1];

--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -57,6 +57,9 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
     javaId: string;
     kotlinId: string;
 
+    versionFromPropsRegex: RegExp;
+    versionFromJarRegex: RegExp;
+
     libPaths: string[];
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
@@ -75,6 +78,9 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         if (!this.javaId) {
             this.javaId = this.compilerProps<string>(`group.${this.compiler.group}.javaId`);
         }
+
+        this.versionFromPropsRegex = /^version\.version=(.*)$/;
+        this.versionFromJarRegex = /^.*r8-(.*)\.jar$/;
 
         this.kotlinId = this.compilerProps<string>(`group.${this.compiler.group}.kotlinId`);
 
@@ -286,5 +292,26 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
             return foundVersion.path;
         });
         return this.libPaths;
+    }
+
+    override async getVersion() {
+        const versionFile = path.join(path.dirname(this.compiler.exe), 'r8-version.properties');
+        let versionCode;
+        if (fs.existsSync(versionFile)) {
+            const versionInfo = fs.readFileSync(versionFile, {encoding: 'utf8'});
+            for (const l of versionInfo.split(/\n/)) {
+                if (this.versionFromPropsRegex.test(l)) {
+                    versionCode = l.match(this.versionFromPropsRegex)![1];
+                }
+            }
+        } else {
+            // Non-latest R8 already has the version in the filename.
+            versionCode = this.compiler.exe.match(this.versionFromJarRegex)![1];
+        }
+        return {
+            stdout: versionCode,
+            stderr: '',
+            code: 0,
+        };
     }
 }


### PR DESCRIPTION
This fixes the version info button in the compiler window for R8/D8. Version info is pulled from the version properties file for latest, and from the filename for named releases.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
