### PR TITLE
Disable external parser for ORCA/C

### DIFF
--- a/lib/compilers/orca.ts
+++ b/lib/compilers/orca.ts
@@ -43,6 +43,7 @@ export class ORCACompiler extends BaseCompiler {
     constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(compilerInfo, env);
         this.goldenGate = this.compilerProps<string>(`compiler.${this.compiler.id}.goldenGate`);
+        this.externalparser = null;
         this.asm = new ORCAAsmParser(this.compilerProps);
         this.compiler.demangler = '';
         this.demanglerClass = null;


### PR DESCRIPTION
ORCA/C uses its own asm format, and the external parser is not appropriate for it.