### PR TITLE
Stdbuf fixes and updates for llvm IR

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -140,6 +140,7 @@ import {
 } from './toolchain-utils.js';
 import type {ITool} from './tooling/base-tool.interface.js';
 import * as utils from './utils.js';
+import {resultLinesToText} from './utils.js';
 
 const compilationTimeHistogram = new PromClient.Histogram({
     name: 'ce_base_compiler_compilation_duration_seconds',
@@ -1485,6 +1486,14 @@ export class BaseCompiler {
         const compileStart = performance.now();
         const output = await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
         const compileEnd = performance.now();
+
+        if (output.code) {
+            return {
+                error: `Invocation failed: ${resultLinesToText(output.stderr)}${resultLinesToText(output.stdout)}}`,
+                results: {},
+                compileTime: output.execTime || compileEnd - compileStart,
+            };
+        }
 
         if (output.timedOut) {
             return {

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -73,7 +73,7 @@ function setupOnError(stream: Stream, name: string) {
     });
 }
 
-async function maybeUnbuffer(command: string, args: string[]): Promise<string> {
+async function maybeUnbuffer(command: string, args: string[]): Promise<{command: string; args: string[]}> {
     if (!stdbufPath) {
         const unbufferStdoutExe = execProps<string>('unbufferStdoutExe');
         if (unbufferStdoutExe) {
@@ -85,11 +85,11 @@ async function maybeUnbuffer(command: string, args: string[]): Promise<string> {
 
     if (stdbufPath) {
         const stdbufArgs = splitArguments(execProps<string>('unbufferStdoutArgs'));
-        args.unshift(...stdbufArgs, command);
-        command = stdbufPath;
+        stdbufArgs.push(command);
+        logger.info(`Unbuffering ${command} with ${stdbufPath} ${stdbufArgs.join(' ')}`);
+        return {command: stdbufPath, args: stdbufArgs.concat([command], args)};
     }
-
-    return command;
+    return {command, args};
 }
 
 export async function executeDirect(
@@ -435,8 +435,8 @@ export async function sandbox(
     const dispatchEntry = sandboxDispatchTable[type as 'none' | 'nsjail' | 'firejail' | 'cewrapper'];
     if (!dispatchEntry) throw new Error(`Bad sandbox type ${type}`);
     if (!command) throw new Error('No executable provided');
-    command = await maybeUnbuffer(command, args);
-    return await dispatchEntry(command, args, options);
+    const unbuffered = await maybeUnbuffer(command, args);
+    return await dispatchEntry(unbuffered.command, unbuffered.args, options);
 }
 
 const wineSandboxName = 'ce-wineserver';
@@ -654,6 +654,6 @@ export async function execute(
     const dispatchEntry = executeDispatchTable[type];
     if (!dispatchEntry) throw new Error(`Bad sandbox type ${type}`);
     if (!command) throw new Error('No executable provided');
-    command = await maybeUnbuffer(command, args);
-    return await dispatchEntry(command, args, options);
+    const unbuffered = await maybeUnbuffer(command, args);
+    return await dispatchEntry(unbuffered.command, unbuffered.args, options);
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -592,3 +592,7 @@ export function deltaTimeNanoToMili(startTime: bigint, endTime: bigint): number 
 export async function sleep(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function resultLinesToText(lines: ResultLine[]): string {
+    return lines.map(line => line.text).join('\n');
+}


### PR DESCRIPTION
- Don't mutate the `args` in-place which exposes the `-o0` of the stdbuf args to the rest of the code (breaking a bunch of things)
- Check the return code of the LLVM parser dump and error if it's a problem.

Found looking into #7410 but doesn't fix it