### PR TITLE
Test the numba wrapper in test-and-deploy

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -26,6 +26,9 @@ jobs:
           npm run ts-check
           python3 ./etc/scripts/util/propscheck.py
           python3 ./etc/scripts/util/propschecktest.py
+          # TODO: use actions to set up python, use a separate virtual environment?
+          python3 -m pip install numba
+          python3 ./etc/scripts/test_numba_wrapper.py
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -18,7 +18,9 @@ jobs:
           check-latest: true
           cache: npm
       - name: Install prerequisites
-        run: make prereqs
+        run: |
+          make prereqs
+          python3 -m pip install numba
       - name: Run checks
         run: |
           npm run lint-check
@@ -26,8 +28,6 @@ jobs:
           npm run ts-check
           python3 ./etc/scripts/util/propscheck.py
           python3 ./etc/scripts/util/propschecktest.py
-          # TODO: use actions to set up python, use a separate virtual environment?
-          python3 -m pip install numba
           python3 ./etc/scripts/test_numba_wrapper.py
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -25,6 +25,7 @@ jobs:
           npm run test
           npm run ts-check
           python3 ./etc/scripts/util/propscheck.py
+          python3 ./etc/scripts/util/propschecktest.py
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/etc/scripts/test_numba_wrapper.py
+++ b/etc/scripts/test_numba_wrapper.py
@@ -30,9 +30,8 @@ import os
 import sys
 import unittest
 import unittest.mock
-
+import tempfile
 import numba
-from numba.core.caching import tempfile
 
 from . import numba_wrapper
 

--- a/etc/scripts/test_numba_wrapper.py
+++ b/etc/scripts/test_numba_wrapper.py
@@ -33,7 +33,7 @@ import unittest.mock
 import tempfile
 import numba
 
-from . import numba_wrapper
+import numba_wrapper
 
 
 class TestMain(unittest.TestCase):
@@ -187,3 +187,6 @@ class TestOpenOrStdout(unittest.TestCase):
     def test_stdout(self) -> None:
         with numba_wrapper._open_or_stdout(None) as file_:
             self.assertIs(file_, sys.stdout)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/scripts/util/propscheck.py
+++ b/etc/scripts/util/propscheck.py
@@ -102,7 +102,7 @@ def check_suspicious_path_and_add(line: Line, m, s):
         s.add(Line(line.number, m.group(2)))
 
 
-def process_file(file: str, args: Namespace) -> dict[str, set[Line]]:
+def process_file(file: str, args: Namespace):
     default_compiler = set()
 
     listed_groups = set()

--- a/etc/scripts/util/propscheck.py
+++ b/etc/scripts/util/propscheck.py
@@ -27,6 +27,7 @@ from os import listdir
 from os.path import isfile, join
 import re
 import argparse
+from argparse import Namespace
 
 parser = argparse.ArgumentParser(description='Checks for incorrect/suspicious properties.')
 parser.add_argument ('--check-suspicious-in-default-prop', required=False, action="store_true")
@@ -101,7 +102,7 @@ def check_suspicious_path_and_add(line: Line, m, s):
         s.add(Line(line.number, m.group(2)))
 
 
-def process_file(file: str, args):
+def process_file(file: str, args: Namespace) -> dict[str, set[Line]]:
     default_compiler = set()
 
     listed_groups = set()
@@ -270,7 +271,7 @@ def print_issue(name, result):
         print(f"{name}:\n  {sep.join(sorted([str(issue) for issue in result]))}")
 
 
-def find_orphans(args: dict):
+def find_orphans(args: Namespace):
     folder = args.config_dir
     result = sorted([(f, r) for (f, r) in process_folder(folder, args) if problems_found(r)], key=lambda x: x[0])
     if result:

--- a/etc/scripts/util/propschecktest.py
+++ b/etc/scripts/util/propschecktest.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import unittest
-
+import argparse
 from propscheck import process_file, Line
 
 
@@ -9,7 +9,8 @@ class PropsCheckTests(unittest.TestCase):
     def run_test(self, filename, expected_key, expected_contents):
         base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
         test_case_file = os.path.join(base_path, 'test', 'cases', f"{filename}.properties")
-        result = process_file(test_case_file)
+        args = argparse.Namespace(check_suspicious_in_default_prop=False)
+        result = process_file(test_case_file, args=args)
         self.assertEqual(result[expected_key], {Line(-1, text) for text in expected_contents})
 
     def test_bad_compilers_exe(self):
@@ -77,7 +78,8 @@ class PropsCheckTests(unittest.TestCase):
     def test_good_file(self):
         base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
         test_case_file = os.path.join(base_path, '..', '..', 'config', 'c++.amazon.properties')
-        result = process_file(test_case_file)
+        args = argparse.Namespace(check_suspicious_in_default_prop=False)
+        result = process_file(test_case_file, args)
         for k in result:
             self.assertEqual(result[k], set(), f"{k} has output in known good file")
 

--- a/etc/scripts/util/propschecktest.py
+++ b/etc/scripts/util/propschecktest.py
@@ -1,7 +1,8 @@
-import sys
-import os
-import unittest
 import argparse
+import os
+import sys
+import unittest
+
 from propscheck import process_file, Line
 
 
@@ -10,7 +11,7 @@ class PropsCheckTests(unittest.TestCase):
         base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
         test_case_file = os.path.join(base_path, 'test', 'cases', f"{filename}.properties")
         args = argparse.Namespace(check_suspicious_in_default_prop=False)
-        result = process_file(test_case_file, args=args)
+        result = process_file(test_case_file, args)
         self.assertEqual(result[expected_key], {Line(-1, text) for text in expected_contents})
 
     def test_bad_compilers_exe(self):

--- a/etc/scripts/util/propschecktest.py
+++ b/etc/scripts/util/propschecktest.py
@@ -10,7 +10,7 @@ class PropsCheckTests(unittest.TestCase):
     def run_test(self, filename, expected_key, expected_contents):
         base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
         test_case_file = os.path.join(base_path, 'test', 'cases', f"{filename}.properties")
-        args = argparse.Namespace(check_suspicious_in_default_prop=False)
+        args = argparse.Namespace(check_suspicious_in_default_prop=True)
         result = process_file(test_case_file, args)
         self.assertEqual(result[expected_key], {Line(-1, text) for text in expected_contents})
 


### PR DESCRIPTION
- Resolve comments from #5592:
  - Replace a silly indirect import https://github.com/compiler-explorer/compiler-explorer/pull/5592#discussion_r1962004963
  - Run `test_numba_wrapper` in `.github/workflows/test-and-deploy.yml`. https://github.com/compiler-explorer/compiler-explorer/pull/5592#discussion_r1962004131
- Patch minor errors in `etc/scripts/util/propschecktest.py` and also test it. 