### PR TITLE
Quash some warnings in tests

### DIFF
--- a/lib/asm-docs/generated/asm-docs-avr.ts
+++ b/lib/asm-docs/generated/asm-docs-avr.ts
@@ -474,7 +474,6 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
             };
 
         case "LDS":
-        case "AVRrc":
             return {
                 "html": "<p>Loads one byte from the data space to a register. The data space usually consists of the Register File, I/O memory, and SRAM, refer to the device data sheet for a detailed definition of the data space.</p><p>A 16-bit address must be supplied. Memory access is limited to the current data segment of 64 KB. The LDS instruction uses the RAMPD Register to access memory above 64 KB. To access another data segment in devices with more than 64 KB data space, the RAMPD in the register in the I/O area has to be changed.</p><p>This instruction is not available on all devices. Refer to Appendix A.</p>",
                 "tooltip": "Load Direct from Data Space",
@@ -771,7 +770,6 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
             };
 
         case "STS":
-        case "AVRrc":
             return {
                 "html": "<p>Stores one byte from a Register to the data space. The data space usually consists of the Register File, I/O memory, and SRAM, refer to the device data sheet for a detailed definition of the data space.</p><p>A 16-bit address must be supplied. Memory access is limited to the current data segment of 64 KB. The STS instruction uses the RAMPD Register to access memory above 64 KB. To access another data segment in devices with more than 64 KB data space, the RAMPD in the register in the I/O area has to be changed.</p><p>This instruction is not available on all devices. Refer to Appendix A.</p>",
                 "tooltip": "Store Direct to Data Space",

--- a/lib/asm-docs/generated/asm-docs-power.ts
+++ b/lib/asm-docs/generated/asm-docs-power.ts
@@ -1678,13 +1678,6 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
                 "tooltip": "Rotate Left Double Word then Clear Left",
                 "url": "https://www.ibm.com/docs/en/aix/7.3?topic=is-rldcl-rotate-left-double-word-then-clear-left-instruction"
             };
-        case "RLDICL":
-        case "RLDICL.":
-            return {
-                "html": `<p>The contents of rS are rotated left the number of bits specified by operand SH. A mask is generated having 1 bits from bit MB through bit 63 and 0 bits elsewhere. The rotated data is ANDed with the generated mask and the result is placed into rA.</p>`,
-                "tooltip": "Rotate Left Double Word Immediate then Clear Left",
-                "url": "https://www.ibm.com/docs/en/aix/7.3?topic=is-rldicl-rotate-left-double-word-immediate-then-clear-left-instruction"
-            };
         case "RLDCR":
         case "RLDCR.":
             return {

--- a/test/filter-tests.ts
+++ b/test/filter-tests.ts
@@ -83,15 +83,16 @@ function testFilter(filename: string, suffix: string, filters: ParseFiltersAndOu
     const testName = path.basename(filename + suffix);
     it(
         testName,
-        () => {
+        // Bump the timeout a bit so that we don't fail for slow cases
+        {timeout: 10000},
+        async () => {
             const result = processAsm(filename, filters);
             delete result.parsingTime;
             delete result.filteredCount;
             // TODO normalize line endings?
-            expect(stringifyKeysInOrder(result)).toMatchFileSnapshot(path.join(casesRoot, testName + '.json'));
+            await expect(stringifyKeysInOrder(result)).toMatchFileSnapshot(path.join(casesRoot, testName + '.json'));
         },
-        {timeout: 10000},
-    ); // Bump the timeout a bit so that we don't fail for slow cases
+    );
 }
 
 describe('Filter test cases', () => {


### PR DESCRIPTION
- Prevent some warnings in the `test-and-deploy` action; see, for example, `Run checks` at https://github.com/compiler-explorer/compiler-explorer/actions/runs/13421609790/job/37495341332:
  - Await a result to avoid:
```text
Promise returned by `expect(actual).toMatchFileSnapshot(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at it.timeout(/home/runner/work/compiler-explorer/compiler-explorer/test/filter-tests.ts:91:50)
```
  - Remove `AVRrc` entries in `lib/asm-docs/generated/asm-docs-avr.ts`. `AVRrc` is a [reduced core AVR](https://ww1.microchip.com/downloads/en/DeviceDoc/AVR-InstructionSet-Manual-DS40002198.pdf#page=18), not an opcode.
  - Deduplicate `RLDICL` in `lib/asm-docs/generated/asm-docs-power.ts`. IBM document this instruction both [here](https://www.ibm.com/docs/en/aix/7.3?topic=is-rldicl-rotate-left-double-word-immediate-then-clear-left-instruction) and [here](https://www.ibm.com/docs/en/aix/7.3?topic=is-rldicl-rotate-left-double-word-immediate-then-clear-left-instruction-1), and I picked the neater-looking one, which is also more similar to their [`RLDICR`](https://www.ibm.com/docs/en/aix/7.3?topic=is-rldicr-rotate-left-double-word-immediate-then-clear-right-instruction) documentation.