### PR TITLE
Tiniest possible step towards type safety for CompilationResult.asm

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2491,7 +2491,7 @@ export class BaseCompiler {
         return this.checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters);
     }
 
-    doTempfolderCleanup(buildResult: BuildResult) {
+    doTempfolderCleanup(buildResult: BuildResult | CompilationResult) {
         if (buildResult.dirPath && !this.delayCleanupTemp) {
             fs.remove(buildResult.dirPath);
         }
@@ -3025,7 +3025,7 @@ export class BaseCompiler {
     }
 
     async afterCompilation(
-        result,
+        result /*: CompilationResult*/,
         doExecute: boolean,
         key: CacheKey,
         executeOptions: ExecutableExecutionOptions,
@@ -3055,7 +3055,7 @@ export class BaseCompiler {
         const compilationInfo = this.getCompilationInfo(key, result, customBuildPath);
 
         result.tools = _.union(
-            result.tools,
+            result.tools || [],
             await Promise.all(this.runToolsOfType(tools, 'postcompilation', compilationInfo)),
         );
 
@@ -3115,7 +3115,7 @@ export class BaseCompiler {
         }
 
         if (doExecute && result.code === 0) {
-            result.execResult = await execPromise;
+            result.execResult = (await execPromise) as CompilationResult;
 
             if (result.execResult.buildResult) {
                 this.doTempfolderCleanup(result.execResult.buildResult);

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -37,6 +37,7 @@ import {SelectedLibraryVersion} from '../libraries/libraries.interfaces.js';
 import {ResultLine} from '../resultline/resultline.interfaces.js';
 import {Artifact, ToolResult} from '../tool.interfaces.js';
 
+import {PossibleArguments} from '../compiler-arguments.interfaces.js';
 import {CFGResult} from './cfg.interfaces.js';
 import {ClangirBackendOptions} from './clangir.interfaces.js';
 import {ConfiguredOverrides} from './compiler-overrides.interfaces.js';
@@ -229,6 +230,8 @@ export type CompilationResult = {
     source?: string; // todo: this is a crazy hack, we should get rid of it
 
     instructionSet?: InstructionSet;
+
+    popularArguments?: PossibleArguments;
 };
 
 export type ExecutionOptions = {

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -164,7 +164,7 @@ export type CompilationResult = {
     buildsteps?: BuildStep[];
     inputFilename?: string;
     // Temp hack until we get all code to agree on type of asm
-    asm?: ResultLine[] | string;
+    asm?: ParsedAsmResultLine[] | string;
     asmSize?: number;
     devices?: Record<string, CompilationResult>;
     stdout: ResultLine[];


### PR DESCRIPTION
This is a super conservative tweak towards trying to use types for processAsm, objdump, afterCompilation et al.