### PR TITLE
[swift]: add 6.0.3 compiler configuration that will cross-compile to aarch64

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -51,7 +51,7 @@ compiler.arm-swift603.options=-target aarch64-swift-linux-musl -sdk /opt/compile
 
 compiler.swift510.exe=/opt/compiler-explorer/swift-5.10/usr/bin/swiftc
 compiler.swift510.semver=5.10
-compiler.swift510.alias=switf510nightly
+compiler.swift510.alias=swift510nightly
 
 compiler.swift59.exe=/opt/compiler-explorer/swift-5.9/usr/bin/swiftc
 compiler.swift59.semver=5.9

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,11 +1,23 @@
-compilers=&swift
+compilers=&swift:&arm-swift
 demangler=/opt/compiler-explorer/swift-6.0.3/usr/bin/swift-demangle
 defaultCompiler=swift603
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
+#################################
+# Compiler Groups
+#################################
+
+# swift (x86_64)
 group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swift58:swift59:swift510:swift603:swiftdevsnapshot:swiftnightly
 group.swift.isSemVer=true
+group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc
+
+# arm-swift (aarch64)
+group.arm-swift.compilers=arm-swift603
+group.arm-swift.isSemVer=true
+group.arm-swift.groupName=swift (aarch64)
+group.arm-swift.baseName=aarch64 swiftc
 
 #################################
 # Development Compilers
@@ -24,10 +36,16 @@ compiler.swiftdevsnapshot.semver=devsnapshot
 # Release Compilers
 #################################
 
-# 6.x
+# 6.x (x86)
 
 compiler.swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
 compiler.swift603.semver=6.0.3
+
+# 6.x (arm)
+
+compiler.arm-swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
+compiler.arm-swift603.semver=6.0.3
+compiler.arm-swift603.options=-target aarch64-swift-linux-musl -sdk /opt/compiler-explorer/swift-6.0.3-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64 -resource-dir /opt/compiler-explorer/swift-6.0.3-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static
 
 # 5.x
 


### PR DESCRIPTION
- add a new compiler group for swift aarch64 cross-compilation
- add a new entry for the 6.0.3 swift compiler to this new group that uses the existing x86 toolchain
- add additional compilation options to the new compiler which will cross compile to arm via the static musl SDK added in https://github.com/compiler-explorer/infra/pull/1524
- [tangential cleanup]: fixes a typo in the swift 5.10 alias

note: this is my first attempt to add a new compiler group, so i'd appreciate any feedback as to whether i've overlooked or mis-configured any of the fields.