### PR TITLE
[swift]: fix typo in 5.10 backward compatibility alias

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -33,7 +33,7 @@ compiler.swift603.semver=6.0.3
 
 compiler.swift510.exe=/opt/compiler-explorer/swift-5.10/usr/bin/swiftc
 compiler.swift510.semver=5.10
-compiler.swift510.alias=switf510nightly
+compiler.swift510.alias=swift510nightly
 
 compiler.swift59.exe=/opt/compiler-explorer/swift-5.9/usr/bin/swiftc
 compiler.swift59.semver=5.9


### PR DESCRIPTION
fixes a minor typo in the alias for the 5.10 compiler that was intended to preserve shared links that used an older compiler name. typo was introduced in https://github.com/compiler-explorer/compiler-explorer/pull/6371 when the alias was originally made. i think that implies the attempt to support existing links with the old compiler name has not been working, but we might as well fix it now.