### PR TITLE
Use node:fs/promises where possible

### DIFF
--- a/lib/artifact-utils.ts
+++ b/lib/artifact-utils.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import {BufferOkFunc, BuildResult, CompilationResult} from '../types/compilation/compilation.interfaces.js';
 import {Artifact, ArtifactType} from '../types/tool.interfaces.js';

--- a/lib/compilation-env.ts
+++ b/lib/compilation-env.ts
@@ -24,7 +24,7 @@
 
 import child_process from 'node:child_process';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import _ from 'underscore';
 
 import type {CacheableValue} from '../types/cache.interfaces.js';
@@ -176,7 +176,7 @@ export class CompilationEnvironment {
     }
 
     async executablePut(key: string, filepath: string): Promise<void> {
-        await this.executableCache.put(key, fs.readFileSync(filepath));
+        await this.executableCache.put(key, await fs.readFile(filepath));
     }
 
     setCachingInProgress(key: string) {

--- a/lib/compiler-arguments.ts
+++ b/lib/compiler-arguments.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import _ from 'underscore';
 
 import type {ICompilerArguments, PossibleArguments} from '../types/compiler-arguments.interfaces.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -25,8 +25,8 @@
 import path from 'node:path';
 import process from 'node:process';
 
+import fs from 'node:fs/promises';
 import * as Sentry from '@sentry/node';
-import fs from 'fs-extra';
 import _ from 'underscore';
 
 import {splitArguments} from '../../shared/common-utils.js';

--- a/lib/compilers/beebasm.ts
+++ b/lib/compilers/beebasm.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import type {ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
@@ -77,7 +77,7 @@ export class BeebAsmCompiler extends BaseCompiler {
 
         if (compilerExecResult.stdout.length > 0) {
             const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase);
-            fs.writeFileSync(outputFilename, compilerExecResult.stdout);
+            await fs.writeFile(outputFilename, compilerExecResult.stdout);
             compilerExecResult.stdout = '';
         }
 

--- a/lib/compilers/carbon.ts
+++ b/lib/compilers/carbon.ts
@@ -30,7 +30,7 @@ import type {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import {unwrap} from '../assert.js';
 import {BaseParser} from './argument-parsers.js';
 

--- a/lib/compilers/cc65.ts
+++ b/lib/compilers/cc65.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import _ from 'underscore';
 
 import type {CompilationResult, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';

--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import _ from 'underscore';
 
 import type {ParsedAsmResult, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
@@ -382,7 +382,7 @@ export class Dex2OatCompiler extends BaseCompiler {
     // the build number.
     override async getVersion() {
         const versionFile = this.artArtifactDir + '/snapshot-creation-build-number.txt';
-        const version = fs.readFileSync(versionFile, {encoding: 'utf8'});
+        const version = await fs.readFile(versionFile, {encoding: 'utf8'});
         return {
             stdout: 'Android Build ' + version,
             stderr: '',
@@ -615,7 +615,7 @@ export class Dex2OatCompiler extends BaseCompiler {
             const classesCfg = path.join(this.cwd, 'classes.cfg');
             let methodsAndOffsetsToDexPcs: Record<string, Record<number, number>> = {};
             try {
-                const rawCfgText = fs.readFileSync(classesCfg, {encoding: 'utf8'});
+                const rawCfgText = await fs.readFile(classesCfg, {encoding: 'utf8'});
                 methodsAndOffsetsToDexPcs = this.passDumpParser.parsePassDumpsForDexPcs(rawCfgText.split(/\n/));
             } catch (e) {
                 // This is expected if this is running in a test. If this fails
@@ -628,7 +628,7 @@ export class Dex2OatCompiler extends BaseCompiler {
                 const files = await fs.readdir(this.cwd);
                 const smaliFiles = files.filter(f => f.endsWith('.smali'));
                 for (const smaliFile of smaliFiles) {
-                    const rawSmaliText = fs.readFileSync(path.join(this.cwd, smaliFile), {encoding: 'utf8'});
+                    const rawSmaliText = await fs.readFile(path.join(this.cwd, smaliFile), {encoding: 'utf8'});
                     this.parseSmaliForLineNumbers(dexPcsToLines, rawSmaliText.split(/\n/));
                 }
             } catch (e) {
@@ -770,7 +770,7 @@ export class Dex2OatCompiler extends BaseCompiler {
 
         try {
             const classesCfg = dirPath + '/classes.cfg';
-            const rawText = fs.readFileSync(classesCfg, {encoding: 'utf8'});
+            const rawText = await fs.readFile(classesCfg, {encoding: 'utf8'});
             const parseStart = performance.now();
             const optPipeline = this.passDumpParser.process(rawText);
             const parseEnd = performance.now();

--- a/lib/compilers/ispc.ts
+++ b/lib/compilers/ispc.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import Semver from 'semver';
 
 import {

--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import Semver from 'semver';
 import _ from 'underscore';
 

--- a/lib/compilers/ldc.ts
+++ b/lib/compilers/ldc.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import semverParser from 'semver';
 
 import type {CompilationResult} from '../../types/compilation/compilation.interfaces.js';

--- a/lib/compilers/madpascal.ts
+++ b/lib/compilers/madpascal.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import {CompilationResult, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
 import {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
@@ -174,8 +174,7 @@ export class MadPascalCompiler extends BaseCompiler {
             return result;
         }
 
-        const content = await fs.readFile(listingFilename);
-        result.asm = this.postProcessObjdumpOutput(content.toString('utf8'));
+        result.asm = this.postProcessObjdumpOutput(await fs.readFile(listingFilename, 'utf8'));
 
         return result;
     }

--- a/lib/compilers/pascal-win.ts
+++ b/lib/compilers/pascal-win.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import type {ExecutionOptions, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';

--- a/lib/compilers/pascal.ts
+++ b/lib/compilers/pascal.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import _ from 'underscore';
 
 import type {ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import type {
     CompilationResult,

--- a/lib/compilers/rga.ts
+++ b/lib/compilers/rga.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import type {
     CompilationResult,

--- a/lib/compilers/solidity.ts
+++ b/lib/compilers/solidity.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 import path from 'node:path';
 
 import Semver from 'semver';
@@ -74,7 +74,7 @@ export class SolidityCompiler extends BaseCompiler {
         // solc gives us a character range for each asm instruction,
         // so open the input file and figure out what line each
         // character is on
-        const inputFile = fs.readFileSync(result.inputFilename);
+        const inputFile = await fs.readFile(result.inputFilename);
         let currentLine = 1;
         const charToLine = inputFile.map(c => {
             const line = currentLine;

--- a/lib/execution/base-execution-env.ts
+++ b/lib/execution/base-execution-env.ts
@@ -25,7 +25,7 @@
 import os from 'node:os';
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import temp from 'temp';
 
 import {splitArguments} from '../../shared/common-utils.js';

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -24,9 +24,9 @@
 
 import path from 'node:path';
 
+import fs from 'node:fs/promises';
 import * as Sentry from '@sentry/node';
 import express from 'express';
-import fs from 'fs-extra';
 import Server from 'http-proxy';
 import PromClient, {Counter} from 'prom-client';
 import temp from 'temp';
@@ -247,7 +247,7 @@ export class CompileHandler implements ICompileHandler {
             // Try stat'ing the compiler to cache its mtime and only re-run it if it
             // has changed since the last time.
             try {
-                let modificationTime;
+                let modificationTime: Date;
                 if (isPrediscovered) {
                     modificationTime = compiler.mtime;
                 } else {

--- a/lib/tooling/clang-format-tool.ts
+++ b/lib/tooling/clang-format-tool.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../../types/tool.interfaces.js';

--- a/lib/tooling/clang-query-tool.ts
+++ b/lib/tooling/clang-query-tool.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../../types/tool.interfaces.js';

--- a/lib/tooling/clang-tidy-tool.ts
+++ b/lib/tooling/clang-tidy-tool.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import {splitArguments} from '../../shared/common-utils.js';
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
@@ -64,8 +64,7 @@ export class ClangTidyTool extends BaseTool {
         if (wantsFix) {
             args = args.filter(option => !option.includes('-header-filter='));
 
-            const data = await fs.readFile(sourcefile);
-            source = data.toString();
+            source = await fs.readFile(sourcefile, 'utf-8');
         }
 
         // order should be:

--- a/lib/tooling/llvm-mca-tool.ts
+++ b/lib/tooling/llvm-mca-tool.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 // import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';

--- a/lib/tooling/osaca-tool.ts
+++ b/lib/tooling/osaca-tool.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 // import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';

--- a/lib/tooling/pvs-studio-tool.ts
+++ b/lib/tooling/pvs-studio-tool.ts
@@ -24,7 +24,7 @@
 
 import path from 'node:path';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 
 import {splitArguments} from '../../shared/common-utils.js';
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,7 +28,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import fs from 'fs-extra';
+import fs from 'node:fs/promises';
 import {ComponentConfig, ItemConfigType} from 'golden-layout';
 import semverParser from 'semver';
 import _ from 'underscore';


### PR DESCRIPTION
- Updates a number of uses of `fs-extra` which were only for the promisified fs calls.
- Makes a few sync calls async.
- Makes a few `read` calls that didn't specify a text mode, but then parsed as a string...into the equivalent `readFile` call.