### PR TITLE
Fix #7296: `clearOptions` instead of `clear` for gcc pass selector

### DIFF
--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -317,7 +317,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         // trigger new compilation
         this.inhibitPassSelect = true;
 
-        selectize.clear(true);
+        selectize.clearOptions();
 
         for (const p of passes) {
             selectize.addOption(p);


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
