### PR TITLE
New temp directory tracker

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -22,12 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import os from 'node:os';
 import path from 'node:path';
 
 import fs from 'fs-extra';
 import * as PromClient from 'prom-client';
-import temp from 'temp';
 import _ from 'underscore';
 
 import {splitArguments, unique} from '../shared/common-utils.js';
@@ -125,6 +123,7 @@ import {HeaptrackWrapper} from './runtime-tools/heaptrack-wrapper.js';
 import {LibSegFaultHelper} from './runtime-tools/libsegfault-helper.js';
 import {SentryCapture} from './sentry.js';
 import * as StackUsage from './stack-usage-transformer.js';
+import * as temp from './temp.js';
 import {
     clang_style_sysroot_flag,
     getSpecificTargetBasedOnToolchainPath,
@@ -410,9 +409,7 @@ export class BaseCompiler {
     }
 
     async newTempDir(): Promise<string> {
-        // `temp` caches the os tmp dir on import (which we may change), so here we ensure we use the current os.tmpdir
-        // each time.
-        return await temp.mkdir({prefix: utils.ce_temp_prefix, dir: os.tmpdir()});
+        return await temp.mkdir(utils.ce_temp_prefix);
     }
 
     optOutputRequested(options: string[]) {

--- a/lib/execution/base-execution-env.ts
+++ b/lib/execution/base-execution-env.ts
@@ -22,11 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import os from 'node:os';
 import path from 'node:path';
 
 import fs from 'node:fs/promises';
-import temp from 'temp';
 
 import {splitArguments} from '../../shared/common-utils.js';
 import {
@@ -51,6 +49,7 @@ import {logger} from '../logger.js';
 import {Packager} from '../packager.js';
 import {propsFor} from '../properties.js';
 import {HeaptrackWrapper} from '../runtime-tools/heaptrack-wrapper.js';
+import * as temp from '../temp.js';
 import * as utils from '../utils.js';
 
 import {ExecutablePackageCacheMiss, IExecutionEnvironment} from './execution-env.interfaces.js';
@@ -129,7 +128,7 @@ export class LocalExecutionEnvironment implements IExecutionEnvironment {
     }
 
     async downloadExecutablePackage(hash: string): Promise<void> {
-        this.dirPath = await temp.mkdir({prefix: utils.ce_temp_prefix, dir: os.tmpdir()});
+        this.dirPath = await temp.mkdir(utils.ce_temp_prefix);
 
         this.buildResult = await this.loadPackageWithExecutable(hash, this.dirPath);
     }

--- a/lib/temp.ts
+++ b/lib/temp.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {logger} from './logger.js';
+
+const pendingRemoval: string[] = [];
+
+/**
+ * Create a temporary directory, always in the operating systems' temporary directory.
+ * @param prefix a prefix for the directory name
+ */
+export async function mkdir(prefix: string) {
+    const result = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+    pendingRemoval.push(result);
+    return result;
+}
+
+/**
+ * Synchronously create a temporary directory, always in the operating systems' temporary directory.
+ * @param prefix a prefix for the directory name
+ */
+export function mkdirSync(prefix: string) {
+    const result = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    pendingRemoval.push(result);
+    return result;
+}
+
+/**
+ * Remove all temporary directories created by this module.
+ */
+export async function cleanup() {
+    // "Atomically" take a copy of the things to remove and set it to an empty array.
+    const toRemove = pendingRemoval.splice(0, pendingRemoval.length);
+    let numRemoved = 0;
+    for (const dir of toRemove) {
+        try {
+            await fs.promises.rm(dir, {recursive: true, force: true});
+            ++numRemoved;
+        } catch (e) {
+            logger.error(`Failed to remove ${dir}: ${e}`);
+        }
+    }
+    logger.debug(`Removed ${numRemoved} of ${toRemove.length} temporary directories`);
+}
+
+process.on('exit', async () => {
+    await cleanup();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         "serve-favicon": "^2.5.0",
         "systemd-socket": "0.0.0",
         "tar-stream": "^3.1.7",
-        "temp": "^0.9.4",
         "tom-select": "^2.4.3",
         "tree-kill": "^1.2.2",
         "triple-beam": "^1.4.1",
@@ -5542,6 +5541,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -5745,16 +5745,6 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -6401,12 +6391,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/constantinople": {
@@ -8021,12 +8005,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8145,27 +8123,6 @@
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -8551,17 +8508,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -10041,18 +9987,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -10610,15 +10544,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -12009,19 +11934,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.34.8",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
@@ -13079,19 +12991,6 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
-      }
-    },
-    "node_modules/temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "serve-favicon": "^2.5.0",
     "systemd-socket": "0.0.0",
     "tar-stream": "^3.1.7",
-    "temp": "^0.9.4",
     "tom-select": "^2.4.3",
     "tree-kill": "^1.2.2",
     "triple-beam": "^1.4.1",

--- a/test/temp-tests.ts
+++ b/test/temp-tests.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, describe, expect, it} from 'vitest';
+import * as temp from '../lib/temp.js';
+import * as utils from '../lib/utils.js';
+
+describe('Creates and tracks temporary directories', () => {
+    const osTemp = os.tmpdir();
+    afterEach(async () => await temp.cleanup());
+
+    it('creates directories under $TMPDIR', async () => {
+        const newTemp = await temp.mkdir('prefix');
+        expect(newTemp).toContain(osTemp);
+        expect(await utils.dirExists(newTemp)).toBe(true);
+    });
+    it('creates directories with prefix', async () => {
+        const newTemp = await temp.mkdir('prefix');
+        expect(newTemp).toContain('prefix');
+    });
+    it('creates uniquely-named directories', async () => {
+        const temp1 = await temp.mkdir('prefix');
+        const temp2 = await temp.mkdir('prefix');
+        const temp3 = await temp.mkdir('prefix');
+        expect(temp1).not.toEqual(temp2);
+        expect(temp1).not.toEqual(temp3);
+        expect(temp2).not.toEqual(temp3);
+    });
+    it('cleans up directories even if not empty', async () => {
+        const newTemp1 = await temp.mkdir('prefix');
+        await utils.ensureFileExists(path.join(newTemp1, 'some', 'dirs', 'under', 'file'));
+        const newTemp2 = await temp.mkdir('prefix');
+        const newTemp3 = await temp.mkdir('prefix');
+        await temp.cleanup();
+        expect(await utils.dirExists(newTemp1)).toBe(false);
+        expect(await utils.dirExists(newTemp2)).toBe(false);
+        expect(await utils.dirExists(newTemp3)).toBe(false);
+    });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -22,12 +22,11 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import temp from 'temp';
 import {expect} from 'vitest';
+import * as temp from '../lib/temp.js';
 
 import {CompilationEnvironment} from '../lib/compilation-env.js';
 import {CompilationQueue} from '../lib/compilation-queue.js';
@@ -84,6 +83,5 @@ export function resolvePathFromTestRoot(...args: string[]): string {
 
 // Tracked temporary directories.
 export function newTempDir() {
-    temp.track(true);
-    return temp.mkdirSync({prefix: 'compiler-explorer-tests', dir: os.tmpdir()});
+    return temp.mkdirSync('compiler-explorer-tests');
 }


### PR DESCRIPTION
Replaces aging `temp` with a simple, bespoke solution. Reduces the number of deprecated/out-of-date dependencies we pick up.

Closes #7445.
