### PR TITLE
Don't cleanup build dirs until after processAsm

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3059,11 +3059,6 @@ export class BaseCompiler {
 
         result = await this.extractDeviceCode(result, filters, compilationInfo);
 
-        this.doTempfolderCleanup(result);
-        if (result.buildResult) {
-            this.doTempfolderCleanup(result.buildResult);
-        }
-
         if (backendOptions.skipAsm) {
             result.asm = [];
         } else {
@@ -3096,6 +3091,11 @@ export class BaseCompiler {
         }
 
         if (!backendOptions.skipPopArgs) result.popularArguments = this.possibleArguments.getPopularArguments(options);
+
+        this.doTempfolderCleanup(result);
+        if (result.buildResult) {
+            this.doTempfolderCleanup(result.buildResult);
+        }
 
         result = this.postCompilationPreCacheHook(result);
 


### PR DESCRIPTION
- `d8` and `r8`'s `processAsm` looks in the build output folder for `.smali` and `.cfg` files.
- it used to do this _synchronously_ and so worked (maybe accidentally)
- changes recently made that async, and so some of the time the files would be cleaned up before it read them (or even during...)
