### PR TITLE
[Spice] Short cli flag -obj was removed

### DIFF
--- a/lib/compilers/spice.ts
+++ b/lib/compilers/spice.ts
@@ -79,7 +79,7 @@ export class SpiceCompiler extends BaseCompiler {
         }
 
         if (filters.binary || filters.binaryObject) {
-            options.push('-obj');
+            options.push('--dump-object-file');
         }
 
         this.optLevelSuffix = '';


### PR DESCRIPTION
The short flag `-obj` was removed from the compiler cli.
The long version (`--dump-object-file`) was already available before and thus also works for older compiler versions.