### PR TITLE
Added new versions of Intel OneAPI C++ compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3,7 +3,7 @@ compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rv
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
 defaultCompiler=g142
-# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind 
+# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 needsMulti=false
@@ -1350,7 +1350,7 @@ compiler.icc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-12.2.0/bin/g++
 
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icx202410:icx202420:icx202500:icxlatest
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icx202410:icx202420:icx202421:icx202500:icx202501:icx202503:icx202504:icxlatest
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -1447,16 +1447,40 @@ compiler.icx202420.libPath=/opt/compiler-explorer/intel-cpp-2024.2.0.495/compile
 compiler.icx202420.semver=2024.2.0
 compiler.icx202420.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
+compiler.icx202421.exe=/opt/compiler-explorer/intel-cpp-2024.2.1.79/compiler/latest/bin/icpx
+compiler.icx202421.ldPath=/opt/compiler-explorer/intel-cpp-2024.2.1.79/compiler/latest/lib
+compiler.icx202421.libPath=/opt/compiler-explorer/intel-cpp-2024.2.1.79/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2024.2.1.79/tbb/latest/lib
+compiler.icx202421.semver=2024.2.1
+compiler.icx202421.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
+
 compiler.icx202500.exe=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/bin/icpx
 compiler.icx202500.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib
 compiler.icx202500.libPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.0.740/tbb/latest/lib
 compiler.icx202500.semver=2025.0.0
 compiler.icx202500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
-compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/bin/icpx
-compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib
-compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.0.740/tbb/latest/lib
-compiler.icxlatest.semver=2025.0.0
+compiler.icx202501.exe=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/bin/icpx
+compiler.icx202501.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/lib
+compiler.icx202501.libPath=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.1.46/tbb/latest/lib
+compiler.icx202501.semver=2025.0.1
+compiler.icx202501.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
+
+compiler.icx202503.exe=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/bin/icpx
+compiler.icx202503.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/lib
+compiler.icx202503.libPath=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.3.9/tbb/latest/lib
+compiler.icx202503.semver=2025.0.3
+compiler.icx202503.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
+
+compiler.icx202504.exe=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/bin/icpx
+compiler.icx202504.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib
+compiler.icx202504.libPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.4.20/tbb/latest/lib
+compiler.icx202504.semver=2025.0.4
+compiler.icx202504.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
+
+compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/bin/icpx
+compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.4.20/tbb/latest/lib
+compiler.icxlatest.semver=2025.0.4
 compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 ################################


### PR DESCRIPTION
Added new versions (and one old one) of the Intel OneAPI C++ compiler:
- 2024.2.1
- 2025.0.1
- 2025.0.3
- 2025.0.4

Refers to [this PR](https://github.com/compiler-explorer/infra/pull/1541).
