### PR TITLE
Initial support for c2rust

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac
+compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust
 defaultCompiler=cg142
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -3575,6 +3575,17 @@ compiler.orcac220.goldenGate=/opt/compiler-explorer/orca-c-2.2.0
 compiler.orcac220.semver=2.2.0
 compiler.orcac221.goldenGate=/opt/compiler-explorer/orca-c-2.2.1
 compiler.orcac221.semver=2.2.1
+
+# C2Rust transpiler
+
+group.c2rust.compilers=c2rust-master
+group.c2rust.compilerType=c2rust
+group.c2rust.supportsExecute=false
+group.c2rust.supportsBinary=false
+group.c2rust.supportsBinaryObject=false
+
+compiler.c2rust-master.exe=/opt/compiler-explorer/c2rust-master/c2rust
+compiler.c2rust-master.name=C2Rust (master)
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -27,6 +27,7 @@ export {AnalysisTool} from './analysis-tool.js';
 export {AssemblyCompiler} from './assembly.js';
 export {AvrGcc6502Compiler} from './avrgcc6502.js';
 export {BeebAsmCompiler} from './beebasm.js';
+export {C2RustCompiler} from './c2rust.js';
 export {C3Compiler} from './c3c.js';
 export {CIRCTCompiler} from './circt.js';
 export {CL430Compiler} from './cl430.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -956,7 +956,6 @@ export class MrustcParser extends BaseParser {
 
 export class C2RustParser extends BaseParser {
     static override async parse(compiler: BaseCompiler) {
-        // TODO: Do we need custom logic to parse our options?
         await C2RustParser.getOptions(compiler, '--help');
         return compiler;
     }

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -954,6 +954,14 @@ export class MrustcParser extends BaseParser {
     }
 }
 
+export class C2RustParser extends BaseParser {
+    static override async parse(compiler: BaseCompiler) {
+        // TODO: Do we need custom logic to parse our options?
+        await C2RustParser.getOptions(compiler, '--help');
+        return compiler;
+    }
+}
+
 export class NimParser extends BaseParser {
     static override async parse(compiler: BaseCompiler) {
         await NimParser.getOptions(compiler, '-help');

--- a/lib/compilers/c2rust.ts
+++ b/lib/compilers/c2rust.ts
@@ -11,7 +11,7 @@ export class C2RustCompiler extends BaseCompiler {
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
-        return [];
+        return ['transpile'];
     }
 
     override getOutputFilename(dirPath: string) {

--- a/lib/compilers/c2rust.ts
+++ b/lib/compilers/c2rust.ts
@@ -1,10 +1,16 @@
-import path from 'node:path';
-
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 
 import {C2RustParser} from './argument-parsers.js';
 
+// TODO: By default the comments filter is enable and seems to be stripping out
+// the first line of the Rust output, likely because it's seeing the `#` for the
+// attribute on the first line as a comment. I tried using `getDefaultFilters`
+// to set all the filters to false, but that doesn't seem to disable the
+// comments filter by default. There's probably a different way to address this
+// issue, e.g. fixing the output language such that the filter doesn't see `#`
+// as a comment, but it's already set to Rust so I'm not sure what else needs to
+// be done there.
 export class C2RustCompiler extends BaseCompiler {
     static get key() {
         return 'c2rust';
@@ -14,39 +20,11 @@ export class C2RustCompiler extends BaseCompiler {
         return ['transpile'];
     }
 
-    override getOutputFilename(dirPath: string) {
-        return path.join(dirPath, 'example.rs');
-    }
-
     override getArgumentParserClass() {
         return C2RustParser;
     }
 
     override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'rust';
-    }
-
-    // TODO: By default the comments filter is enable and seems to be stripping
-    // out the first line of the Rust output, likely because it's seeing the `#`
-    // for the attribute on the first line as a comment. This function is trying
-    // to disable that by setting all the filters to false, but that doesn't
-    // seem to disable the comments filter by default. There's probably a
-    // different way to address this issue, e.g. fixing the output language such
-    // that the filter doesn't see `#` as a comment.
-    override getDefaultFilters(): ParseFiltersAndOutputOptions {
-        return {
-            binary: false,
-            execute: false,
-            demangle: false,
-            intel: false,
-            commentOnly: false,
-            directives: false,
-            labels: false,
-            optOutput: false,
-            libraryCode: false,
-            trim: false,
-            binaryObject: false,
-            debugCalls: false,
-        };
     }
 }

--- a/lib/compilers/c2rust.ts
+++ b/lib/compilers/c2rust.ts
@@ -1,0 +1,52 @@
+import path from 'node:path';
+
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+
+import {C2RustParser} from './argument-parsers.js';
+
+export class C2RustCompiler extends BaseCompiler {
+    static get key() {
+        return 'c2rust';
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
+        return [];
+    }
+
+    override getOutputFilename(dirPath: string) {
+        return path.join(dirPath, 'example.rs');
+    }
+
+    override getArgumentParserClass() {
+        return C2RustParser;
+    }
+
+    override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
+        return 'rust';
+    }
+
+    // TODO: By default the comments filter is enable and seems to be stripping
+    // out the first line of the Rust output, likely because it's seeing the `#`
+    // for the attribute on the first line as a comment. This function is trying
+    // to disable that by setting all the filters to false, but that doesn't
+    // seem to disable the comments filter by default. There's probably a
+    // different way to address this issue, e.g. fixing the output language such
+    // that the filter doesn't see `#` as a comment.
+    override getDefaultFilters(): ParseFiltersAndOutputOptions {
+        return {
+            binary: false,
+            execute: false,
+            demangle: false,
+            intel: false,
+            commentOnly: false,
+            directives: false,
+            labels: false,
+            optOutput: false,
+            libraryCode: false,
+            trim: false,
+            binaryObject: false,
+            debugCalls: false,
+        };
+    }
+}

--- a/lib/compilers/c2rust.ts
+++ b/lib/compilers/c2rust.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 
@@ -26,5 +28,9 @@ export class C2RustCompiler extends BaseCompiler {
 
     override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'rust';
+    }
+
+    override getOutputFilename(dirPath: string) {
+        return path.join(dirPath, 'example.rs');
     }
 }


### PR DESCRIPTION
Adds new compiler base for c2rust, a transpiler that converts C code to Rust.

There's one outstanding TODO in the code about incorrect default filters for the c2rust output. I wasn't sure how to address it, so help would be appreciated.

Fixes https://github.com/compiler-explorer/compiler-explorer/issues/6888 and https://github.com/compiler-explorer/compiler-explorer/issues/5900 (there are duplicate feature requests).