### PR TITLE
Install Clang/LLVM 20

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -160,7 +160,7 @@ compiler.gnuasriscv32g1320.name=RISC-V binutils 2.38.0
 compiler.gnuasriscv32g1320.semver=2.38.0
 compiler.gnuasriscv32g1320.objdumper=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
-group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas1910:llvmas_trunk:llvmas_assertions_trunk
+group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas1910:llvmas2010:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version
 group.llvmas.options=-filetype=obj -o example.o
 group.llvmas.versionRe=LLVM version .*
@@ -237,6 +237,8 @@ compiler.llvmas1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llvm-mc
 compiler.llvmas1810.semver=18.1.0
 compiler.llvmas1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llvm-mc
 compiler.llvmas1910.semver=19.1.0
+compiler.llvmas2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/llvm-mc
+compiler.llvmas2010.semver=20.1.0
 compiler.llvmas_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mc
 compiler.llvmas_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llvmas_trunk.semver=(trunk)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3,7 +3,7 @@ compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rv
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
 defaultCompiler=g142
-# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind 
+# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 needsMulti=false
@@ -278,7 +278,7 @@ compiler.g142assert.semver=14.2 (assertions)
 
 ################################
 # Clang for x86
-group.clang.compilers=&clangx86assert:clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang502:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang1200:clang1201:clang1300:clang1301:clang1400:clang1500:clang1600:clang1701:clang1810:clang1910
+group.clang.compilers=&clangx86assert:clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang352:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang501:clang502:clang600:clang601:clang700:clang701:clang710:clang800:clang801:clang900:clang901:clang1000:clang1001:clang1100:clang1101:clang1200:clang1201:clang1300:clang1301:clang1400:clang1500:clang1600:clang1701:clang1810:clang1910:clang2010
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang.groupName=Clang x86-64
@@ -459,6 +459,11 @@ compiler.clang1910.semver=19.1.0
 compiler.clang1910.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
 compiler.clang1910.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 compiler.clang1910.debugPatched=true
+compiler.clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.clang2010.semver=20.1.0
+compiler.clang2010.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang2010.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang2010.debugPatched=true
 
 
 group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_bb_p2996:clang_p2998:clang_p3068:clang_p3309:clang_p3367:clang_p3372:clang_p3412:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_p1974:clang_chrisbazley
@@ -580,7 +585,7 @@ compiler.clang_p1974.exe=/opt/compiler-explorer/clang-p1974-trunk/bin/clang++
 compiler.clang_p1974.semver=(p1974)
 compiler.clang_p1974.notification=p1974; see <a href="https://github.com/je4d/llvm-project/tree/godbolt/propconst" target="_blank" rel="noopener noreferrer">je4d/llvm-project<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
-group.clangx86assert.compilers=clang26assert:clang27assert:clang28assert:clang29assert:clang30assert:clang31assert:clang32assert:clang33assert:clang34assert:clang35assert:clang36assert:clang37assert:clang38assert:clang39assert:clang40assert:clang50assert:clang60assert:clang70assert:clang80assert:clang90assert:clang100assert:clang110assert:clang120assert:clang130assert:clang140assert:clang150assert:clang160assert:clang170assert:clang181assert:clang191assert
+group.clangx86assert.compilers=clang26assert:clang27assert:clang28assert:clang29assert:clang30assert:clang31assert:clang32assert:clang33assert:clang34assert:clang35assert:clang36assert:clang37assert:clang38assert:clang39assert:clang40assert:clang50assert:clang60assert:clang70assert:clang80assert:clang90assert:clang100assert:clang110assert:clang120assert:clang130assert:clang140assert:clang150assert:clang160assert:clang170assert:clang181assert:clang191assert:clang201assert
 group.clangx86assert.options=
 group.clangx86assert.groupName=Clang x86-64 (assertions)
 group.clangx86assert.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -692,7 +697,10 @@ compiler.clang191assert.exe=/opt/compiler-explorer/clang-assertions-19.1.0/bin/c
 compiler.clang191assert.semver=19.1.0 (assertions)
 compiler.clang191assert.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
 compiler.clang191assert.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
-
+compiler.clang201assert.exe=/opt/compiler-explorer/clang-assertions-20.1.0/bin/clang++
+compiler.clang201assert.semver=20.1.0 (assertions)
+compiler.clang201assert.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang201assert.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
 group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102
 group.clang-rocm.intelAsm=-mllvm --x86-asm-syntax=intel
@@ -757,7 +765,7 @@ compiler.clang-rocm-60102.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unkn
 # Clang for Arm
 # Provides 32-bit menu items for release versions and trunk
 group.armclang32.groupName=Arm 32-bit clang
-group.armclang32.compilers=armv7-clang900:armv7-clang901:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang1101:armv7-clang1200:armv7-clang1201:armv7-clang1300:armv7-clang1301:armv7-clang1400:armv7-clang1500:armv7-clang1600:armv7-clang1701:armv7-clang1810:armv7-clang1910:armv7-clang-trunk
+group.armclang32.compilers=armv7-clang900:armv7-clang901:armv7-clang1000:armv7-clang1001:armv7-clang1100:armv7-clang1101:armv7-clang1200:armv7-clang1201:armv7-clang1300:armv7-clang1301:armv7-clang1400:armv7-clang1500:armv7-clang1600:armv7-clang1701:armv7-clang1810:armv7-clang1910:armv7-clang2010:armv7-clang-trunk
 group.armclang32.isSemVer=true
 group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
@@ -770,6 +778,9 @@ group.armclang32.licensePreamble=The LLVM Project is under the Apache License v2
 group.armclang32.compilerCategories=clang
 group.armclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
+compiler.armv7-clang2010.exe=/opt/compiler-explorer/clang-2-.1.0/bin/clang++
+compiler.armv7-clang2010.semver=20.1.0
+compiler.armv7-clang2010.options=-target arm-unknown-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 compiler.armv7-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.armv7-clang1910.semver=19.1.0
 compiler.armv7-clang1910.options=-target arm-unknown-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
@@ -834,7 +845,7 @@ compiler.armv7-clang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/
 # Clang for Arm
 # Provides 64- menu items for clang-9, clang-10 and trunk
 group.armclang64.groupName=Arm 64-bit clang
-group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang1200:armv8-clang1300:armv8-clang1400:armv8-clang1500:armv8-clang1600:armv8-clang1701:armv8-clang1810:armv8-clang1910:armv8-clang-trunk:armv8-full-clang-trunk
+group.armclang64.compilers=armv8-clang900:armv8-clang901:armv8-clang1000:armv8-clang1001:armv8-clang1100:armv8-clang1101:armv8-clang1200:armv8-clang1300:armv8-clang1400:armv8-clang1500:armv8-clang1600:armv8-clang1701:armv8-clang1810:armv8-clang1910:armv8-clang2010:armv8-clang-trunk:armv8-full-clang-trunk
 group.armclang64.isSemVer=true
 group.armclang64.baseName=armv8-a clang
 group.armclang64.compilerType=clang
@@ -848,6 +859,9 @@ group.armclang64.compilerCategories=clang
 group.armclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 group.armclang64.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 
+compiler.armv8-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.armv8-clang2010.semver=20.1.0
+compiler.armv8-clang2010.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 compiler.armv8-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.armv8-clang1910.semver=19.1.0
 compiler.armv8-clang1910.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
@@ -1042,7 +1056,7 @@ group.rvclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE
 group.rvclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.rvclang.debugPatched=true
 
-group.rv32clang.compilers=rv32-clang:rv32-clang1910:rv32-clang1810:rv32-clang1701:rv32-clang1600:rv32-clang1500:rv32-clang1400:rv32-clang1301:rv32-clang1300:rv32-clang1201:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
+group.rv32clang.compilers=rv32-clang:rv32-clang2010:rv32-clang1910:rv32-clang1810:rv32-clang1701:rv32-clang1600:rv32-clang1500:rv32-clang1400:rv32-clang1301:rv32-clang1300:rv32-clang1201:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
 group.rv32clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 group.rv32clang.baseName=RISC-V rv32gc clang
@@ -1091,6 +1105,9 @@ compiler.rv32-clang1810.semver=18.1.0
 compiler.rv32-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.rv32-clang1910.semver=19.1.0
 compiler.rv32-clang1910.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
+compiler.rv32-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.rv32-clang2010.semver=20.1.0
+compiler.rv32-clang2010.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
 compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv32-clang.semver=(trunk)
 compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
@@ -1098,7 +1115,7 @@ compiler.rv32-clang.isNightly=true
 compiler.rv32-clang.alias=rv32clang
 compiler.rv32-clang.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
 
-group.rv64clang.compilers=rv64-clang:rv64-clang1910:rv64-clang1810:rv64-clang1701:rv64-clang1600:rv64-clang1500:rv64-clang1400:rv64-clang1301:rv64-clang1300:rv64-clang1201:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
+group.rv64clang.compilers=rv64-clang:rv64-clang2010:rv64-clang1910:rv64-clang1810:rv64-clang1701:rv64-clang1600:rv64-clang1500:rv64-clang1400:rv64-clang1301:rv64-clang1300:rv64-clang1201:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
 group.rv64clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64clang.baseName=RISC-V rv64gc clang
@@ -1147,6 +1164,9 @@ compiler.rv64-clang1810.semver=18.1.0
 compiler.rv64-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.rv64-clang1910.semver=19.1.0
 compiler.rv64-clang1910.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
+compiler.rv64-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.rv64-clang2010.semver=20.1.0
+compiler.rv64-clang2010.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv64-clang.semver=(trunk)
 compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -1224,7 +1244,7 @@ group.loongarch-clang.licenseName=LLVM Apache 2
 group.loongarch-clang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.loongarch-clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.loongarch64clang.compilers=loongarch64-clangtrunk:loongarch64-clang1701:loongarch64-clang1810:loongarch64-clang1910
+group.loongarch64clang.compilers=loongarch64-clangtrunk:loongarch64-clang1701:loongarch64-clang1810:loongarch64-clang1910:loongarch64-clang2010
 group.loongarch64clang.options=-target loongarch64-unknown-linux-gnu --gcc-toolchain=/opt/compiler-explorer/loongarch64/gcc-13.3.0/loongarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/loongarch64/gcc-13.3.0/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot
 group.loongarch64clang.objdumper=/opt/compiler-explorer/loongarch64/gcc-13.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 group.loongarch64clang.baseName=LoongArch64 clang
@@ -1239,6 +1259,9 @@ compiler.loongarch64-clang1810.semver=18.1.0
 compiler.loongarch64-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.loongarch64-clang1910.semver=19.1.0
 compiler.loongarch64-clang1910.options=-target loongarch64-unknown-linux-gnu --gcc-toolchain=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot
+compiler.loongarch64-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.loongarch64-clang2010.semver=20.1.0
+compiler.loongarch64-clang2010.options=-target loongarch64-unknown-linux-gnu --gcc-toolchain=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/loongarch64/gcc-14.2.0/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot
 compiler.loongarch64-clangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.loongarch64-clangtrunk.semver=(trunk)
 compiler.loongarch64-clangtrunk.isNightly=true
@@ -1580,7 +1603,7 @@ group.bpf.compilers=&gccbpf:&clangbpf
 group.bpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 # Clang for BPF
-group.clangbpf.compilers=bpfclangtrunk:bpfclang1910:bpfclang1810:bpfclang1701:bpfclang1600:bpfclang1500:bpfclang1400:bpfclang1300
+group.clangbpf.compilers=bpfclangtrunk:bpfclang2010:bpfclang1910:bpfclang1810:bpfclang1701:bpfclang1600:bpfclang1500:bpfclang1400:bpfclang1300
 group.clangbpf.supportsBinary=false
 group.clangbpf.supportsExecute=false
 group.clangbpf.baseName=BPF clang
@@ -1595,6 +1618,9 @@ group.clangbpf.compilerCategories=clang
 compiler.bpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.bpfclangtrunk.semver=(trunk)
 compiler.bpfclangtrunk.isNightly=true
+
+compiler.bpfclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.bpfclang2010.semver=20.1.0
 
 compiler.bpfclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.bpfclang1910.semver=19.1.0
@@ -2847,7 +2873,7 @@ group.mipss.isSemVer=true
 # Clang for all MIPS
 
 ## MIPS
-group.mips-clang.compilers=mips-clang1910:mips-clang1810:mips-clang1701:mips-clang1600:mips-clang1500:mips-clang1400:mips-clang1300
+group.mips-clang.compilers=mips-clang2010:mips-clang1910:mips-clang1810:mips-clang1701:mips-clang1600:mips-clang1500:mips-clang1400:mips-clang1300
 group.mips-clang.groupName=MIPS clang
 group.mips-clang.baseName=mips clang
 group.mips-clang.supportsBinary=false
@@ -2857,6 +2883,10 @@ group.mips-clang.options=-target mips-elf
 group.mips-clang.compilerCategories=clang
 group.mips-clang.instructionSet=mips
 group.mips-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.mips-clang2010.semver=20.1.0
+compiler.mips-clang2010.options=-target mips-unknown-linux-gnu --gcc-toolchain=/opt/compiler-explorer/mips/gcc-14.2.0/mips-unknown-linux-gnu
 
 compiler.mips-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.mips-clang1910.semver=19.1.0
@@ -2881,7 +2911,7 @@ compiler.mips-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips-clang1300.semver=13.0.0
 
 ## MIPSEL
-group.mipsel-clang.compilers=mipsel-clang1910:mipsel-clang1810:mipsel-clang1701:mipsel-clang1600:mipsel-clang1500:mipsel-clang1400:mipsel-clang1300
+group.mipsel-clang.compilers=mipsel-clang2010:mipsel-clang1910:mipsel-clang1810:mipsel-clang1701:mipsel-clang1600:mipsel-clang1500:mipsel-clang1400:mipsel-clang1300
 group.mipsel-clang.instructionSet=mips
 group.mipsel-clang.groupName=MIPSEL clang
 group.mipsel-clang.baseName=mipsel clang
@@ -2891,6 +2921,10 @@ group.mipsel-clang.supportsExecute=false
 group.mipsel-clang.options=-target mipsel-elf
 group.mipsel-clang.compilerCategories=clang
 group.mipsel-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mipsel-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.mipsel-clang2010.semver=20.1.0
+compiler.mipsel-clang2010.options=-target mipsel-multilib-linux-gnu --gcc-toolchain=/opt/compiler-explorer/mipsel/gcc-14.2.0/mipsel-multilib-linux-gnu
 
 compiler.mipsel-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.mipsel-clang1910.semver=19.1.0
@@ -2915,7 +2949,7 @@ compiler.mipsel-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mipsel-clang1300.semver=13.0.0
 
 ## MIPS64
-group.mips64-clang.compilers=mips64-clang1910:mips64-clang1810:mips64-clang1701:mips64-clang1600:mips64-clang1500:mips64-clang1400:mips64-clang1300
+group.mips64-clang.compilers=mips64-clang2010:mips64-clang1910:mips64-clang1810:mips64-clang1701:mips64-clang1600:mips64-clang1500:mips64-clang1400:mips64-clang1300
 group.mips64-clang.instructionSet=mips
 group.mips64-clang.groupName=MIPS64 clang
 group.mips64-clang.baseName=mips64 clang
@@ -2925,6 +2959,9 @@ group.mips64-clang.supportsExecute=false
 group.mips64-clang.options=-target mips64-elf
 group.mips64-clang.compilerCategories=clang
 group.mips64-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips64-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.mips64-clang2010.semver=20.1.0
 
 compiler.mips64-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.mips64-clang1910.semver=19.1.0
@@ -2948,7 +2985,7 @@ compiler.mips64-clang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.mips64-clang1300.semver=13.0.0
 
 ## MIPS64EL
-group.mips64el-clang.compilers=mips64el-clang1910:mips64el-clang1810:mips64el-clang1701:mips64el-clang1600:mips64el-clang1500:mips64el-clang1400:mips64el-clang1300
+group.mips64el-clang.compilers=mips64el-clang2010:mips64el-clang1910:mips64el-clang1810:mips64el-clang1701:mips64el-clang1600:mips64el-clang1500:mips64el-clang1400:mips64el-clang1300
 group.mips64el-clang.instructionSet=mips
 group.mips64el-clang.groupName=MIPS64EL clang
 group.mips64el-clang.baseName=mips64el clang
@@ -2958,6 +2995,9 @@ group.mips64el-clang.supportsExecute=false
 group.mips64el-clang.options=-target mips64el-elf
 group.mips64el-clang.compilerCategories=clang
 group.mips64el-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips64el-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.mips64el-clang2010.semver=20.1.0
 
 compiler.mips64el-clang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.mips64el-clang1910.semver=19.1.0
@@ -4962,7 +5002,7 @@ libs.libuv.versions.1381.libpath=/opt/compiler-explorer/libs/libuv/v1.38.1/x86_6
 
 libs.llvm.name=LLVM
 libs.llvm.description=LLVM
-libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000:1001:1100:1200:1201:1300:1301:1400:1406:1500:1507:1600:1606:1701:1706:1810:1910
+libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000:1001:1100:1200:1201:1300:1301:1400:1406:1500:1507:1600:1606:1701:1706:1810:1910:2010
 libs.llvm.url=https://llvm.org/
 libs.llvm.versions.trunk.version=trunk
 libs.llvm.versions.trunk.path=/opt/compiler-explorer/libs/llvm/trunk/include
@@ -5024,6 +5064,10 @@ libs.llvm.versions.1910.version=19.1.0
 libs.llvm.versions.1910.path=/opt/compiler-explorer/libs/llvm/19.1.0/include
 libs.llvm.versions.1910.libpath=/opt/compiler-explorer/libs/llvm/19.1.0/lib
 libs.llvm.versions.1910.staticliblink=LLVMWindowsManifest:LLVMXRay:LLVMLibDriver:LLVMDlltoolDriver:LLVMTextAPIBinaryReader:LLVMCoverage:LLVMLineEditor:LLVMXCoreDisassembler:LLVMXCoreCodeGen:LLVMXCoreDesc:LLVMXCoreInfo:LLVMX86TargetMCA:LLVMX86Disassembler:LLVMX86AsmParser:LLVMX86CodeGen:LLVMX86Desc:LLVMX86Info:LLVMWebAssemblyDisassembler:LLVMWebAssemblyAsmParser:LLVMWebAssemblyCodeGen:LLVMWebAssemblyUtils:LLVMWebAssemblyDesc:LLVMWebAssemblyInfo:LLVMVEDisassembler:LLVMVEAsmParser:LLVMVECodeGen:LLVMVEDesc:LLVMVEInfo:LLVMSystemZDisassembler:LLVMSystemZAsmParser:LLVMSystemZCodeGen:LLVMSystemZDesc:LLVMSystemZInfo:LLVMSparcDisassembler:LLVMSparcAsmParser:LLVMSparcCodeGen:LLVMSparcDesc:LLVMSparcInfo:LLVMRISCVTargetMCA:LLVMRISCVDisassembler:LLVMRISCVAsmParser:LLVMRISCVCodeGen:LLVMRISCVDesc:LLVMRISCVInfo:LLVMPowerPCDisassembler:LLVMPowerPCAsmParser:LLVMPowerPCCodeGen:LLVMPowerPCDesc:LLVMPowerPCInfo:LLVMNVPTXCodeGen:LLVMNVPTXDesc:LLVMNVPTXInfo:LLVMMSP430Disassembler:LLVMMSP430AsmParser:LLVMMSP430CodeGen:LLVMMSP430Desc:LLVMMSP430Info:LLVMMipsDisassembler:LLVMMipsAsmParser:LLVMMipsCodeGen:LLVMMipsDesc:LLVMMipsInfo:LLVMLoongArchDisassembler:LLVMLoongArchAsmParser:LLVMLoongArchCodeGen:LLVMLoongArchDesc:LLVMLoongArchInfo:LLVMLanaiDisassembler:LLVMLanaiCodeGen:LLVMLanaiAsmParser:LLVMLanaiDesc:LLVMLanaiInfo:LLVMHexagonDisassembler:LLVMHexagonCodeGen:LLVMHexagonAsmParser:LLVMHexagonDesc:LLVMHexagonInfo:LLVMBPFDisassembler:LLVMBPFAsmParser:LLVMBPFCodeGen:LLVMBPFDesc:LLVMBPFInfo:LLVMAVRDisassembler:LLVMAVRAsmParser:LLVMAVRCodeGen:LLVMAVRDesc:LLVMAVRInfo:LLVMARMDisassembler:LLVMARMAsmParser:LLVMARMCodeGen:LLVMARMDesc:LLVMARMUtils:LLVMARMInfo:LLVMAMDGPUTargetMCA:LLVMAMDGPUDisassembler:LLVMAMDGPUAsmParser:LLVMAMDGPUCodeGen:LLVMAMDGPUDesc:LLVMAMDGPUUtils:LLVMAMDGPUInfo:LLVMAArch64Disassembler:LLVMAArch64AsmParser:LLVMAArch64CodeGen:LLVMAArch64Desc:LLVMAArch64Utils:LLVMAArch64Info:LLVMOrcDebugging:LLVMOrcJIT:LLVMWindowsDriver:LLVMMCJIT:LLVMJITLink:LLVMInterpreter:LLVMExecutionEngine:LLVMRuntimeDyld:LLVMOrcTargetProcess:LLVMOrcShared:LLVMDWP:LLVMDebugInfoLogicalView:LLVMDebugInfoGSYM:LLVMOption:LLVMObjectYAML:LLVMObjCopy:LLVMMCA:LLVMMCDisassembler:LLVMLTO:LLVMFrontendOpenACC:LLVMFrontendHLSL:LLVMFrontendDriver:LLVMExtensions:LLVMPasses:LLVMHipStdPar:LLVMCoroutines:LLVMCFGuard:LLVMipo:LLVMInstrumentation:LLVMVectorize:LLVMLinker:LLVMFrontendOpenMP:LLVMFrontendOffloading:LLVMDWARFLinkerParallel:LLVMDWARFLinkerClassic:LLVMDWARFLinker:LLVMGlobalISel:LLVMMIRParser:LLVMAsmPrinter:LLVMSelectionDAG:LLVMCodeGen:LLVMTarget:LLVMObjCARCOpts:LLVMCodeGenTypes:LLVMIRPrinter:LLVMInterfaceStub:LLVMFileCheck:LLVMFuzzMutate:LLVMScalarOpts:LLVMInstCombine:LLVMAggressiveInstCombine:LLVMTransformUtils:LLVMBitWriter:LLVMAnalysis:LLVMProfileData:LLVMSymbolize:LLVMDebugInfoBTF:LLVMDebugInfoPDB:LLVMDebugInfoMSF:LLVMDebugInfoDWARF:LLVMObject:LLVMTextAPI:LLVMMCParser:LLVMIRReader:LLVMAsmParser:LLVMMC:LLVMDebugInfoCodeView:LLVMBitReader:LLVMFuzzerCLI:LLVMCore:LLVMRemarks:LLVMBitstreamReader:LLVMBinaryFormat:LLVMTargetParser:LLVMTableGen:LLVMSupport:LLVMDemangle
+libs.llvm.versions.2010.version=20.1.0
+libs.llvm.versions.2010.path=/opt/compiler-explorer/libs/llvm/20.1.0/include
+libs.llvm.versions.2010.libpath=/opt/compiler-explorer/libs/llvm/20.1.0/lib
+libs.llvm.versions.2010.staticliblink=LLVMWindowsManifest:LLVMXRay:LLVMLibDriver:LLVMDlltoolDriver:LLVMTextAPIBinaryReader:LLVMCoverage:LLVMLineEditor:LLVMXCoreDisassembler:LLVMXCoreCodeGen:LLVMXCoreDesc:LLVMXCoreInfo:LLVMX86TargetMCA:LLVMX86Disassembler:LLVMX86AsmParser:LLVMX86CodeGen:LLVMX86Desc:LLVMX86Info:LLVMWebAssemblyDisassembler:LLVMWebAssemblyAsmParser:LLVMWebAssemblyCodeGen:LLVMWebAssemblyUtils:LLVMWebAssemblyDesc:LLVMWebAssemblyInfo:LLVMVEDisassembler:LLVMVEAsmParser:LLVMVECodeGen:LLVMVEDesc:LLVMVEInfo:LLVMSystemZDisassembler:LLVMSystemZAsmParser:LLVMSystemZCodeGen:LLVMSystemZDesc:LLVMSystemZInfo:LLVMSparcDisassembler:LLVMSparcAsmParser:LLVMSparcCodeGen:LLVMSparcDesc:LLVMSparcInfo:LLVMRISCVTargetMCA:LLVMRISCVDisassembler:LLVMRISCVAsmParser:LLVMRISCVCodeGen:LLVMRISCVDesc:LLVMRISCVInfo:LLVMPowerPCDisassembler:LLVMPowerPCAsmParser:LLVMPowerPCCodeGen:LLVMPowerPCDesc:LLVMPowerPCInfo:LLVMNVPTXCodeGen:LLVMNVPTXDesc:LLVMNVPTXInfo:LLVMMSP430Disassembler:LLVMMSP430AsmParser:LLVMMSP430CodeGen:LLVMMSP430Desc:LLVMMSP430Info:LLVMMipsDisassembler:LLVMMipsAsmParser:LLVMMipsCodeGen:LLVMMipsDesc:LLVMMipsInfo:LLVMLoongArchDisassembler:LLVMLoongArchAsmParser:LLVMLoongArchCodeGen:LLVMLoongArchDesc:LLVMLoongArchInfo:LLVMLanaiDisassembler:LLVMLanaiCodeGen:LLVMLanaiAsmParser:LLVMLanaiDesc:LLVMLanaiInfo:LLVMHexagonDisassembler:LLVMHexagonCodeGen:LLVMHexagonAsmParser:LLVMHexagonDesc:LLVMHexagonInfo:LLVMBPFDisassembler:LLVMBPFAsmParser:LLVMBPFCodeGen:LLVMBPFDesc:LLVMBPFInfo:LLVMAVRDisassembler:LLVMAVRAsmParser:LLVMAVRCodeGen:LLVMAVRDesc:LLVMAVRInfo:LLVMARMDisassembler:LLVMARMAsmParser:LLVMARMCodeGen:LLVMARMDesc:LLVMARMUtils:LLVMARMInfo:LLVMAMDGPUTargetMCA:LLVMAMDGPUDisassembler:LLVMAMDGPUAsmParser:LLVMAMDGPUCodeGen:LLVMAMDGPUDesc:LLVMAMDGPUUtils:LLVMAMDGPUInfo:LLVMAArch64Disassembler:LLVMAArch64AsmParser:LLVMAArch64CodeGen:LLVMAArch64Desc:LLVMAArch64Utils:LLVMAArch64Info:LLVMOrcDebugging:LLVMOrcJIT:LLVMWindowsDriver:LLVMMCJIT:LLVMJITLink:LLVMInterpreter:LLVMExecutionEngine:LLVMRuntimeDyld:LLVMOrcTargetProcess:LLVMOrcShared:LLVMDWP:LLVMDebugInfoLogicalView:LLVMDebugInfoGSYM:LLVMOption:LLVMObjectYAML:LLVMObjCopy:LLVMMCA:LLVMMCDisassembler:LLVMLTO:LLVMFrontendOpenACC:LLVMFrontendHLSL:LLVMFrontendDriver:LLVMExtensions:LLVMPasses:LLVMHipStdPar:LLVMCoroutines:LLVMCFGuard:LLVMipo:LLVMInstrumentation:LLVMVectorize:LLVMLinker:LLVMFrontendOpenMP:LLVMFrontendOffloading:LLVMDWARFLinkerParallel:LLVMDWARFLinkerClassic:LLVMDWARFLinker:LLVMGlobalISel:LLVMMIRParser:LLVMAsmPrinter:LLVMSelectionDAG:LLVMCodeGen:LLVMTarget:LLVMObjCARCOpts:LLVMCodeGenTypes:LLVMIRPrinter:LLVMInterfaceStub:LLVMFileCheck:LLVMFuzzMutate:LLVMScalarOpts:LLVMInstCombine:LLVMAggressiveInstCombine:LLVMTransformUtils:LLVMBitWriter:LLVMAnalysis:LLVMProfileData:LLVMSymbolize:LLVMDebugInfoBTF:LLVMDebugInfoPDB:LLVMDebugInfoMSF:LLVMDebugInfoDWARF:LLVMObject:LLVMTextAPI:LLVMMCParser:LLVMIRReader:LLVMAsmParser:LLVMMC:LLVMDebugInfoCodeView:LLVMBitReader:LLVMFuzzerCLI:LLVMCore:LLVMRemarks:LLVMBitstreamReader:LLVMBinaryFormat:LLVMTargetParser:LLVMTableGen:LLVMSupport:LLVMDemangle
 
 libs.llvmfs.name=Filesystem (LLVM)
 libs.llvmfs.versions=autodetect

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac
 defaultCompiler=cg142
-# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind 
+# We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 needsMulti=false
@@ -239,7 +239,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang1500:cclang1600:cclang1701:cclang1810:cclang1910:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_widberg
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang1500:cclang1600:cclang1701:cclang1810:cclang1910:cclang2010:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_widberg
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -372,6 +372,9 @@ compiler.cclang1810.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 compiler.cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.cclang1910.semver=19.1.0
 compiler.cclang1910.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
+compiler.cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.cclang2010.semver=20.1.0
+compiler.cclang2010.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
 
 compiler.cclang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cclang_trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -433,7 +436,7 @@ compiler.nvc_x86_25_1.semver=25.1
 # Clang for Arm
 # Provides 32- and 64-bit menu items for clang-9 and trunk
 group.armcclang32.groupName=Arm 32-bit clang
-group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang1200:armv7-cclang1201:armv7-cclang1300:armv7-cclang1301:armv7-cclang1400:armv7-cclang1500:armv7-cclang1600:armv7-cclang1701:armv7-cclang1810:armv7-cclang1910:armv7-cclang-trunk
+group.armcclang32.compilers=armv7-cclang900:armv7-cclang901:armv7-cclang1000:armv7-cclang1001:armv7-cclang1100:armv7-cclang1101:armv7-cclang1200:armv7-cclang1201:armv7-cclang1300:armv7-cclang1301:armv7-cclang1400:armv7-cclang1500:armv7-cclang1600:armv7-cclang1701:armv7-cclang1810:armv7-cclang1910:armv7-cclang2010:armv7-cclang-trunk
 group.armcclang32.isSemVer=true
 group.armcclang32.compilerType=clang
 group.armcclang32.supportsExecute=false
@@ -445,7 +448,7 @@ group.armcclang32.compilerCategories=clang
 group.armcclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 group.armcclang64.groupName=Arm 64-bit clang
-group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang1701:armv8-cclang1810:armv8-cclang1910:armv8-cclang-trunk:armv8-full-cclang-trunk
+group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang1701:armv8-cclang1810:armv8-cclang1910:armv8-cclang2010:armv8-cclang-trunk:armv8-full-cclang-trunk
 group.armcclang64.isSemVer=true
 group.armcclang64.compilerType=clang
 group.armcclang64.supportsExecute=false
@@ -455,6 +458,18 @@ group.armcclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LIC
 group.armcclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang64.compilerCategories=clang
 group.armcclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.armv7-cclang2010.name=armv7-a clang 20.1.0
+compiler.armv7-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.armv7-cclang2010.semver=20.1.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-cclang2010.options=-target arm-linux-gnueabi --gcc-toolchain=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-14.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+
+compiler.armv8-cclang2010.name=armv8-a clang 20.1.0
+compiler.armv8-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.armv8-cclang2010.semver=20.1.0
+# Arm v8-a
+compiler.armv8-cclang2010.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-14.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv7-cclang1910.name=armv7-a clang 19.1.0
 compiler.armv7-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
@@ -754,7 +769,7 @@ group.rvcclang.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENS
 group.rvcclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.rvcclang.compilerCategories=clang
 
-group.rv32cclang.compilers=rv32-cclang:rv32-cclang1910:rv32-cclang1810:rv32-cclang1701:rv32-cclang1600:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
+group.rv32cclang.compilers=rv32-cclang:rv32-cclang2010:rv32-cclang1910:rv32-cclang1810:rv32-cclang1701:rv32-cclang1600:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
 group.rv32cclang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
 group.rv32cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 group.rv32cclang.baseName=RISC-V rv32gc clang
@@ -805,12 +820,14 @@ compiler.rv32-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.rv32-cclang1810.semver=18.1.0
 compiler.rv32-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.rv32-cclang1910.semver=19.1.0
+compiler.rv32-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.rv32-cclang2010.semver=20.1.0
 compiler.rv32-cclang.alias=rv32cclang
 compiler.rv32-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv32-cclang.semver=(trunk)
 compiler.rv32-cclang.isNightly=true
 
-group.rv64cclang.compilers=rv64-cclang:rv64-cclang1910:rv64-cclang1810:rv64-cclang1701:rv64-cclang1600:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
+group.rv64cclang.compilers=rv64-cclang:rv64-cclang2010:rv64-cclang1910:rv64-cclang1810:rv64-cclang1701:rv64-cclang1600:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
 group.rv64cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 group.rv64cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64cclang.baseName=RISC-V rv64gc clang
@@ -858,6 +875,8 @@ compiler.rv64-cclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang
 compiler.rv64-cclang1810.semver=18.1.0
 compiler.rv64-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.rv64-cclang1910.semver=19.1.0
+compiler.rv64-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.rv64-cclang2010.semver=20.1.0
 compiler.rv64-cclang.alias=rv64cclang
 compiler.rv64-cclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.rv64-cclang.semver=(trunk)
@@ -1092,7 +1111,7 @@ group.cbpf.compilers=&cgccbpf:&cclangbpf
 group.cbpf.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 # Clang for BPF
-group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang1910:cbpfclang1810:cbpfclang1701:cbpfclang1600:cbpfclang1500:cbpfclang1400:cbpfclang1300
+group.cclangbpf.compilers=cbpfclangtrunk:cbpfclang2010:cbpfclang1910:cbpfclang1810:cbpfclang1701:cbpfclang1600:cbpfclang1500:cbpfclang1400:cbpfclang1300
 group.cclangbpf.supportsBinary=false
 group.cclangbpf.supportsExecute=false
 group.cclangbpf.baseName=BPF clang
@@ -1107,6 +1126,9 @@ group.cclangbpf.compilerCategories=clang
 compiler.cbpfclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cbpfclangtrunk.semver=(trunk)
 compiler.cbpfclangtrunk.isNightly=true
+
+compiler.cbpfclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.cbpfclang2010.semver=20.1.0
 
 compiler.cbpfclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.cbpfclang1910.semver=19.1.0
@@ -2450,7 +2472,7 @@ group.cmipss.supportsExecute=false
 # Clang for all MIPS
 
 ## MIPS
-group.mips-cclang.compilers=mips-cclang1910:mips-cclang1810:mips-cclang1701:mips-cclang1600:mips-cclang1500:mips-cclang1400:mips-cclang1300
+group.mips-cclang.compilers=mips-cclang2010:mips-cclang1910:mips-cclang1810:mips-cclang1701:mips-cclang1600:mips-cclang1500:mips-cclang1400:mips-cclang1300
 group.mips-cclang.instructionSet=mips
 group.mips-cclang.groupName=MIPS clang
 group.mips-cclang.baseName=mips clang
@@ -2460,6 +2482,9 @@ group.mips-cclang.supportsExecute=false
 group.mips-cclang.options=-target mips-elf
 group.mips-cclang.compilerCategories=clang
 group.mips-cclang.compilerCategories.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.mips-cclang2010.semver=20.1.0
 
 compiler.mips-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.mips-cclang1910.semver=19.1.0
@@ -2483,7 +2508,7 @@ compiler.mips-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mips-cclang1300.semver=13.0.0
 
 ## MIPSEL
-group.mipsel-cclang.compilers=mipsel-cclang1910:mipsel-cclang1810:mipsel-cclang1701:mipsel-cclang1600:mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
+group.mipsel-cclang.compilers=mipsel-cclang2010:mipsel-cclang1910:mipsel-cclang1810:mipsel-cclang1701:mipsel-cclang1600:mipsel-cclang1500:mipsel-cclang1400:mipsel-cclang1300
 group.mipsel-cclang.instructionSet=mips
 group.mipsel-cclang.groupName=MIPSEL clang
 group.mipsel-cclang.baseName=mipsel clang
@@ -2493,6 +2518,9 @@ group.mipsel-cclang.supportsExecute=false
 group.mipsel-cclang.options=-target mipsel-elf
 group.mipsel-cclang.compilerCategories=clang
 group.mipsel-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mipsel-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.mipsel-cclang2010.semver=20.1.0
 
 compiler.mipsel-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.mipsel-cclang1910.semver=19.1.0
@@ -2516,7 +2544,7 @@ compiler.mipsel-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mipsel-cclang1300.semver=13.0.0
 
 ## MIPS64
-group.mips64-cclang.compilers=mips64-cclang1910:mips64-cclang1810:mips64-cclang1701:mips64-cclang1600:mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
+group.mips64-cclang.compilers=mips64-cclang2010:mips64-cclang1910:mips64-cclang1810:mips64-cclang1701:mips64-cclang1600:mips64-cclang1500:mips64-cclang1400:mips64-cclang1300
 group.mips64-cclang.groupName=MIPS64 clang
 group.mips64-cclang.instructionSet=mips
 group.mips64-cclang.baseName=mips64 clang
@@ -2526,6 +2554,9 @@ group.mips64-cclang.supportsExecute=false
 group.mips64-cclang.options=-target mips64-elf
 group.mips64-cclang.compilerCategories=clang
 group.mips64-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips64-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.mips64-cclang2010.semver=20.1.0
 
 compiler.mips64-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.mips64-cclang1910.semver=19.1.0
@@ -2549,7 +2580,7 @@ compiler.mips64-cclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.mips64-cclang1300.semver=13.0.0
 
 ## MIPS64EL
-group.mips64el-cclang.compilers=mips64el-cclang1910:mips64el-cclang1810:mips64el-cclang1701:mips64el-cclang1600:mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
+group.mips64el-cclang.compilers=mips64el-cclang2010:mips64el-cclang1910:mips64el-cclang1810:mips64el-cclang1701:mips64el-cclang1600:mips64el-cclang1500:mips64el-cclang1400:mips64el-cclang1300
 group.mips64el-cclang.groupName=MIPS64EL clang
 group.mips64el-cclang.instructionSet=mips
 group.mips64el-cclang.baseName=mips64el clang
@@ -2559,6 +2590,9 @@ group.mips64el-cclang.supportsExecute=false
 group.mips64el-cclang.options=-target mips64el-elf
 group.mips64el-cclang.compilerCategories=clang
 group.mips64el-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+
+compiler.mips64el-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
+compiler.mips64el-cclang2010.semver=20.1.0
 
 compiler.mips64el-cclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.mips64el-cclang1910.semver=19.1.0

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -253,7 +253,7 @@ compiler.nvcc126u2.nvdisasm=/opt/compiler-explorer/cuda/12.6.2/bin/nvdisasm
 compiler.nvcc126u2.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 compiler.nvcc126u2.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 
-group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cuclang1600:cuclang1701:cuclang1810:cuclang1910:cltrunk
+group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cuclang1600:cuclang1701:cuclang1810:cuclang1910:cuclang2010:cltrunk
 group.cuclang.isSemVer=true
 group.cuclang.baseName=clang
 group.cuclang.compilerType=clang-cuda
@@ -309,6 +309,12 @@ compiler.cuclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.cuclang1910.semver=19.1.0
 compiler.cuclang1910.name=19.1.0 sm_90 CUDA-12.5.1
 compiler.cuclang1910.options=--cuda-path=/opt/compiler-explorer/cuda/12.5.1 --cuda-gpu-arch=sm_90 --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
+
+# We keep -D_ALLOW_UNSUPPORTED_LIBCPP so the user does not have to do that for -stdlib=libc++
+compiler.cuclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.cuclang2010.semver=20.1.0
+compiler.cuclang2010.name=20.1.0 sm_90 CUDA-12.5.1
+compiler.cuclang2010.options=--cuda-path=/opt/compiler-explorer/cuda/12.5.1 --cuda-gpu-arch=sm_90 --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
 
 compiler.cltrunk.semver=trunk
 compiler.cltrunk.name=trunk sm_90 CUDA-12.6.1

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -309,8 +309,6 @@ compiler.cuclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.cuclang1910.semver=19.1.0
 compiler.cuclang1910.name=19.1.0 sm_90 CUDA-12.5.1
 compiler.cuclang1910.options=--cuda-path=/opt/compiler-explorer/cuda/12.5.1 --cuda-gpu-arch=sm_90 --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
-
-# We keep -D_ALLOW_UNSUPPORTED_LIBCPP so the user does not have to do that for -stdlib=libc++
 compiler.cuclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
 compiler.cuclang2010.semver=20.1.0
 compiler.cuclang2010.name=20.1.0 sm_90 CUDA-12.5.1

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -8,7 +8,7 @@ licenseName=LLVM Apache 2
 licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.irclang.compilers=irclang401:irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclang1001:irclang1100:irclang1101:irclang1200:irclang1201:irclang1300:irclang1400:irclang1500:irclang1600:irclang1701:irclang1810:irclang1910:irclangtrunk:irclang-assertions-trunk
+group.irclang.compilers=irclang401:irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclang1001:irclang1100:irclang1101:irclang1200:irclang1201:irclang1300:irclang1400:irclang1500:irclang1600:irclang1701:irclang1810:irclang1910:irclang2010:irclangtrunk:irclang-assertions-trunk
 group.irclang.intelAsm=-masm=intel
 group.irclang.groupName=Clang x86-64
 group.irclang.options=-x ir
@@ -54,6 +54,8 @@ compiler.irclang1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/clang++
 compiler.irclang1810.semver=18.1.0
 compiler.irclang1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/clang++
 compiler.irclang1910.semver=19.1.0
+compiler.irclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
+compiler.irclang2010.semver=20.1.0
 compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.irclangtrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.irclangtrunk.semver=(trunk)
@@ -73,7 +75,7 @@ compiler.irhexagonclang1605.exe=/opt/compiler-explorer/clang+llvm-16.0.5-cross-h
 compiler.irhexagonclang1605.compilerType=clang-hexagon
 compiler.irhexagonclang1605.compilerCategories=clang-hexagon
 
-group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llc1600:llc1701:llc1810:llc1910:llctrunk:llc-assertions-trunk
+group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llc1001:llc1100:llc1101:llc1200:llc1201:llc1300:llc1400:llc1500:llc1600:llc1701:llc1810:llc1910:llc2010:llctrunk:llc-assertions-trunk
 group.llc.compilerType=llc
 group.llc.supportsExecute=false
 group.llc.intelAsm=-masm=intel
@@ -128,6 +130,8 @@ compiler.llc1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llc
 compiler.llc1810.semver=18.1.0
 compiler.llc1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llc
 compiler.llc1910.semver=19.1.0
+compiler.llc2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/llc
+compiler.llc2010.semver=20.1.0
 compiler.llctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.llctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llctrunk.semver=(trunk)
@@ -135,7 +139,7 @@ compiler.llc-assertions-trunk.exe=/opt/compiler-explorer/clang-assertions-trunk/
 compiler.llc-assertions-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.llc-assertions-trunk.semver=(assertions trunk)
 
-group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opt1001:opt1100:opt1101:opt1200:opt1201:opt1300:opt1400:opt1500:opt1600:opt1701:opt1810:opt1910:opttrunk:opt-assertions-trunk
+group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opt1001:opt1100:opt1101:opt1200:opt1201:opt1300:opt1400:opt1500:opt1600:opt1701:opt1810:opt1910:opt2010:opttrunk:opt-assertions-trunk
 group.opt.compilerType=opt
 group.opt.supportsBinary=false
 group.opt.supportsExecute=false
@@ -192,6 +196,8 @@ compiler.opt1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/opt
 compiler.opt1810.semver=18.1.0
 compiler.opt1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/opt
 compiler.opt1910.semver=19.1.0
+compiler.opt2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/opt
+compiler.opt2010.semver=20.1.0
 compiler.opttrunk.exe=/opt/compiler-explorer/clang-trunk/bin/opt
 compiler.opttrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.opttrunk.semver=(trunk)

--- a/etc/config/llvm_mir.amazon.properties
+++ b/etc/config/llvm_mir.amazon.properties
@@ -8,7 +8,7 @@ licenseName=LLVM Apache 2
 licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 
-group.mirllc.compilers=mirllc32:mirllc33:mirllc391:mirllc400:mirllc401:mirllc500:mirllc600:mirllc700:mirllc800:mirllc900:mirllc1000:mirllc1001:mirllc1100:mirllc1101:mirllc1200:mirllc1201:mirllc1300:mirllc1400:mirllc1500:mirllc1600:mirllc1701:mirllc1810:mirllc1910:mirllctrunk:mirllc-assertions-trunk
+group.mirllc.compilers=mirllc32:mirllc33:mirllc391:mirllc400:mirllc401:mirllc500:mirllc600:mirllc700:mirllc800:mirllc900:mirllc1000:mirllc1001:mirllc1100:mirllc1101:mirllc1200:mirllc1201:mirllc1300:mirllc1400:mirllc1500:mirllc1600:mirllc1701:mirllc1810:mirllc1910:mirllc2010:mirllctrunk:mirllc-assertions-trunk
 group.mirllc.compilerType=llc
 group.mirllc.supportsExecute=false
 group.mirllc.intelAsm=-masm=intel
@@ -63,6 +63,8 @@ compiler.mirllc1810.exe=/opt/compiler-explorer/clang-18.1.0/bin/llc
 compiler.mirllc1810.semver=18.1.0
 compiler.mirllc1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llc
 compiler.mirllc1910.semver=19.1.0
+compiler.mirllc2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/llc
+compiler.mirllc2010.semver=20.1.0
 compiler.mirllctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.mirllctrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.mirllctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump

--- a/etc/config/tablegen.amazon.properties
+++ b/etc/config/tablegen.amazon.properties
@@ -4,7 +4,7 @@ compilerType=tablegen
 supportsBinary=false
 supportsExecute=false
 
-group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701:llvmtblgen1810:llvmtblgen1910
+group.llvmtblgen.compilers=llvmtblgen_trunk:llvmtblgen1701:llvmtblgen1810:llvmtblgen1910:llvmtblgen2010
 group.llvmtblgen.groupName=LLVM TableGen
 group.llvmtblgen.baseName=LLVM TableGen
 group.llvmtblgen.isSemVer=true
@@ -32,3 +32,7 @@ compiler.llvmtblgen1810.includePath=/opt/compiler-explorer/clang-18.1.0/include/
 compiler.llvmtblgen1910.exe=/opt/compiler-explorer/clang-19.1.0/bin/llvm-tblgen
 compiler.llvmtblgen1910.semver=19.1.0
 compiler.llvmtblgen1910.includePath=/opt/compiler-explorer/clang-19.1.0/include/
+
+compiler.llvmtblgen2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/llvm-tblgen
+compiler.llvmtblgen2010.semver=20.1.0
+compiler.llvmtblgen2010.includePath=/opt/compiler-explorer/clang-20.1.0/include/


### PR DESCRIPTION
Should take care of the LLVM stuff mostly everywhere.

- Didn't touch cppx or cpp_for_opencl, these haven't been updated the last few times either
- MLIR untouched, because it's a different install. I can look into that later