### PR TITLE
Add clippy for Rust

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -19,6 +19,7 @@ group.rust.licenseName=Dual-licensed under Apache 2.0 and MIT terms
 group.rust.licensePreamble=Rust is licensed under the Apache License, Version 2.0 or the MIT license
 group.rust.supportsBinary=true
 group.rust.supportsBinaryObject=true
+group.rust.supportsClippy=true
 # Rust 1.83+ needs `libPath` for execution with dynamically linked standard library
 # see https://github.com/compiler-explorer/compiler-explorer/pull/7367
 compiler.r1850.exe=/opt/compiler-explorer/rust-1.85.0/bin/rustc
@@ -992,7 +993,18 @@ libs.zerocopy.versions.0732.path=libzerocopy.rlib
 #################################
 # Installed tools
 
-tools=ldd:llvm-mcatrunk:llvm-dwarfdumptrunk:osacatrunk:pahole:readelf:nm:strings:rustfmt1436:bloaty11
+tools=clippy:ldd:llvm-mcatrunk:llvm-dwarfdumptrunk:osacatrunk:pahole:readelf:nm:strings:rustfmt1436:bloaty11
+
+tools.clippy.name=Clippy
+# overridden by `runTool`
+tools.clippy.exe=/opt/compiler-explorer/rust-nightly/bin/clippy-driver
+tools.clippy.type=independent
+tools.clippy.class=clippy-tool
+tools.clippy.stdinHint=disabled
+tools.clippy.includeKey=supportsClippy
+# clippy is supported for Rust >= 1.29
+# https://github.com/compiler-explorer/compiler-explorer/pull/7477#pullrequestreview-2662514775
+tools.clippy.exclude=r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190:r180:r170:r160:r150:r140:r130:r120:r110:r100
 
 tools.ldd.name=ldd
 tools.ldd.exe=/usr/bin/ldd

--- a/etc/config/rust.defaults.properties
+++ b/etc/config/rust.defaults.properties
@@ -16,3 +16,12 @@ versionFlag=-vV
 #################################
 # Installed libs (See c++.amazon.properties for a scheme of libs group)
 libs=
+
+tools=clippy
+
+tools.clippy.name=Clippy
+# overridden by `runTool`
+tools.clippy.exe=/usr/bin/clippy-driver
+tools.clippy.type=independent
+tools.clippy.class=clippy-tool
+tools.clippy.stdinHint=disabled

--- a/lib/tooling/_all.ts
+++ b/lib/tooling/_all.ts
@@ -41,3 +41,4 @@ export {StringsTool} from './strings-tool.js';
 export {x86to6502Tool} from './x86to6502-tool.js';
 export {TestingTool} from './testing-tool.js';
 export {BloatyTool} from './bloaty-tool.js';
+export {ClippyTool} from './clippy-tool.js';

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -145,6 +145,14 @@ export class BaseTool implements ITool {
         });
     }
 
+    protected getToolExe(compilationInfo: CompilationInfo): string {
+        return this.tool.exe;
+    }
+
+    protected async getCustomCwd(inputFilepath: string): Promise<string> {
+        return path.dirname(inputFilepath);
+    }
+
     async runTool(
         compilationInfo: CompilationInfo,
         inputFilepath?: string,
@@ -159,17 +167,18 @@ export class BaseTool implements ITool {
             });
         }
         const execOptions = this.getDefaultExecOptions();
-        if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);
+        if (inputFilepath) execOptions.customCwd = await this.getCustomCwd(inputFilepath);
         execOptions.input = stdin;
 
         args = args || [];
         if (this.addOptionsToToolArgs) args = this.tool.options.concat(args);
         if (inputFilepath) args.push(inputFilepath);
 
-        const exeDir = path.dirname(this.tool.exe);
+        const toolExe = this.getToolExe(compilationInfo);
+        const exeDir = path.dirname(toolExe);
 
         try {
-            const result = await this.exec(this.tool.exe, args, execOptions);
+            const result = await this.exec(toolExe, args, execOptions);
             return this.convertResult(result, inputFilepath, exeDir);
         } catch (e) {
             logger.error('Error while running tool: ', e);

--- a/lib/tooling/clippy-tool.ts
+++ b/lib/tooling/clippy-tool.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'node:path';
+
+import type {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
+import type {ResultLine} from '../../types/resultline/resultline.interfaces.js';
+import type {OptionsHandlerLibrary} from '../options-handler.js';
+import * as temp from '../temp.js';
+import {ce_temp_prefix, parseRustOutput} from '../utils.js';
+
+import {BaseTool} from './base-tool.js';
+
+export class ClippyTool extends BaseTool {
+    static get key() {
+        return 'clippy-tool';
+    }
+
+    override getToolExe(compilationInfo: CompilationInfo): string {
+        return path.format({dir: path.dirname(compilationInfo.compiler.exe), base: 'clippy-driver'});
+    }
+
+    override async getCustomCwd(inputFilepath: string): Promise<string> {
+        return await temp.mkdir(ce_temp_prefix);
+    }
+
+    override async runTool(
+        compilationInfo: CompilationInfo,
+        inputFilepath?: string,
+        args?: string[],
+        stdin?: string,
+        supportedLibraries?: Record<string, OptionsHandlerLibrary>,
+    ) {
+        const clippyArgs = ['--color=always', ...(args || [])];
+        return await super.runTool(compilationInfo, inputFilepath, clippyArgs, stdin, supportedLibraries);
+    }
+
+    override parseOutput(lines: string, inputFilename?: string, pathPrefix?: string): ResultLine[] {
+        return parseRustOutput(lines, inputFilename, pathPrefix);
+    }
+}


### PR DESCRIPTION
This adds the [Clippy](https://github.com/rust-lang/rust-clippy) linter for all Rust compilers >= v1.29.

~~Clippy is already installed by default for recent-ish Rust versions, but I have not checked if it’s also installed for *really* old versions.~~

Resolves #2562.