### PR TITLE
Fix goldenlayout dropdowns z-index fight with Monaco's minimaps

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -1636,3 +1636,8 @@ span.lib-info {
 button.new-pane-button:disabled:after {
     content: ' [already open]';
 }
+
+// Ensure goldenlayout tabs are on top of the minimap
+.lm_header .lm_tabdropdown_list {
+    z-index: 6; // 5 by default, same as the minimap
+}


### PR DESCRIPTION
Fixes a z-index fight among goldenlayout's dropdowns and the editor's minimap, which both had a z-index of 5 - Let goldenlayout's win by 1 now

Closes https://github.com/compiler-explorer/compiler-explorer/issues/7473
