### PR TITLE
Add zig 0.14.0 and make it the default zig compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3662,7 +3662,7 @@ compiler.djggp494.semver=4.9.4
 
 #################################
 # Zig c++
-group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxx0130:zcxxtrunk
+group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxx0130:zcxx0140:zcxxtrunk
 group.zigcxx.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcxx.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcxx.options=
@@ -3696,6 +3696,8 @@ compiler.zcxx0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
 compiler.zcxx0121.semver=0.12.1
 compiler.zcxx0130.exe=/opt/compiler-explorer/zig-0.13.0/zig
 compiler.zcxx0130.semver=0.13.0
+compiler.zcxx0140.exe=/opt/compiler-explorer/zig-0.14.0/zig
+compiler.zcxx0140.semver=0.14.0
 compiler.zcxxtrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcxxtrunk.semver=trunk
 compiler.zcxxtrunk.isNightly=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3360,7 +3360,7 @@ compiler.tinycc0927.semver=0.9.27
 
 #################################
 # Zig cc
-group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcc0130:zcctrunk
+group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcc0130:zcc0140:zcctrunk
 group.zigcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcc.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcc.options=
@@ -3393,6 +3393,8 @@ compiler.zcc0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
 compiler.zcc0121.semver=0.12.1
 compiler.zcc0130.exe=/opt/compiler-explorer/zig-0.13.0/zig
 compiler.zcc0130.semver=0.13.0
+compiler.zcc0140.exe=/opt/compiler-explorer/zig-0.14.0/zig
+compiler.zcc0140.semver=0.14.0
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 compiler.zcctrunk.isNightly=true

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -1,8 +1,8 @@
 compilers=&zig
-defaultCompiler=z0130
+defaultCompiler=z0140
 
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
-group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130
+group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130:z0140
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
@@ -44,6 +44,8 @@ compiler.z0121.exe=/opt/compiler-explorer/zig-0.12.1/zig
 compiler.z0121.semver=0.12.1
 compiler.z0130.exe=/opt/compiler-explorer/zig-0.13.0/zig
 compiler.z0130.semver=0.13.0
+compiler.z0140.exe=/opt/compiler-explorer/zig-0.14.0/zig
+compiler.z0140.semver=0.14.0
 
 #################################
 #################################


### PR DESCRIPTION
zig `0.14.0` released on 2025-03-05.

Corresponding infra PR: https://github.com/compiler-explorer/infra/pull/1544