### PR TITLE
Put the carbon toolchain in the `carbon.defaults` properties

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -156,3 +156,4 @@ From oldest to newest contributor, we would like to thank:
 - [Niles Salter](https://github.com/Validark)
 - [Stephen Heumann](https://github.com/sheumann)
 - [Joshua Batty](https://github.com/joshuabatty)
+- [Dana Jansens](https://github.com/danakj)

--- a/etc/config/carbon.defaults.properties
+++ b/etc/config/carbon.defaults.properties
@@ -1,14 +1,21 @@
 # Default settings for carbon
-compilers=carbon-trunkdef
-defaultCompiler=carbon-trunkdef
+compilers=carbon-trunk:carbon-explorer-trunk
+defaultCompiler=carbon-trunk
 compilerType=carbon
 needsMulti=false
 supportsExecute=true
 supportsBinary=true
 supportsBinaryObject=true
 
-compiler.carbon-trunkdef.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon-explorer
-compiler.carbon-trunkdef.name=Explorer (trunk)
-compiler.carbon-trunkdef.alias=carbon-trunk
+compiler.carbon-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon
+compiler.carbon-trunk.name=Carbon (trunk)
+
+# Older deprecated explorer
+compiler.carbon-explorer-trunk.compilerType=carbon-explorer
+compiler.carbon-explorer-trunk.exe=/opt/compiler-explorer/carbon-explorer-trunk/bin/carbon-explorer
+compiler.carbon-explorer-trunk.name=Explorer (trunk)
+compiler.carbon-explorer-trunk.supportsExecute=true
+compiler.carbon-explorer-trunk.supportsBinary=false
+compiler.carbon-explorer-trunk.supportsBinaryObject=false
 
 libs=


### PR DESCRIPTION
This allows using the carbon toolchain as the default Carbon compiler when working in a local development environment.
