### PR TITLE
Correctly handle missing .dex file for R8

### DIFF
--- a/lib/compilers/d8.ts
+++ b/lib/compilers/d8.ts
@@ -224,6 +224,12 @@ export class D8Compiler extends BaseCompiler implements SimpleOutputFilenameComp
         // There is only one dex file for all classes.
         let files = await fs.readdir(dirPath);
         const dexFile = files.find(f => f.endsWith('.dex'));
+        if (!dexFile) {
+            return (
+                'No output .dex file was found, but this is expected if you are using R8 without any keep annotations.\n' +
+                'Please load R8Example.java for an example with keep annotations.'
+            );
+        }
         const baksmaliOptions = ['-jar', this.compiler.objdumper, 'd', `${dexFile}`, '--code-offsets', '-o', dirPath];
         const execResult = await this.exec(javaCompiler.javaRuntime, baksmaliOptions, {
             maxOutput: maxSize,


### PR DESCRIPTION
R8 will not produce a .dex file if there are no entry points into the .class file code. This change updates R8/D8 so that a missing .dex file returns a message to the user in the compiler output window, instead of logging a warning/error.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
