### PR TITLE
Update C3 default compiler and do some further fixes to C3-mode.

### DIFF
--- a/etc/config/c3.amazon.properties
+++ b/etc/config/c3.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&c3c
 compilerType=c3c
-defaultCompiler=c3c062
+defaultCompiler=c3c068
 supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
-group.c3c.compilers=c3c04:c3c050:c3c055:c3c060:c3c061:c3c062
+group.c3c.compilers=c3c04:c3c050:c3c055:c3c060:c3c061:c3c062:c3c064:c3c065:c3c066:c3c067:c3c068
 group.c3c.isSemVer=true
 group.c3c.baseName=c3
 
@@ -26,3 +26,21 @@ compiler.c3c061.exe=/opt/compiler-explorer/c3-0.6.1/c3c
 
 compiler.c3c062.semver=0.6.2
 compiler.c3c062.exe=/opt/compiler-explorer/c3-0.6.2/c3c
+
+compiler.c3c063.semver=0.6.3
+compiler.c3c063.exe=/opt/compiler-explorer/c3-0.6.3/c3c
+
+compiler.c3c064.semver=0.6.4
+compiler.c3c064.exe=/opt/compiler-explorer/c3-0.6.4/c3c
+
+compiler.c3c065.semver=0.6.5
+compiler.c3c065.exe=/opt/compiler-explorer/c3-0.6.5/c3c
+
+compiler.c3c066.semver=0.6.6
+compiler.c3c066.exe=/opt/compiler-explorer/c3-0.6.6/c3c
+
+compiler.c3c067.semver=0.6.7
+compiler.c3c067.exe=/opt/compiler-explorer/c3-0.6.7/c3c
+
+compiler.c3c068.semver=0.6.8
+compiler.c3c068.exe=/opt/compiler-explorer/c3-0.6.8/c3c

--- a/static/modes/c3-mode.ts
+++ b/static/modes/c3-mode.ts
@@ -63,6 +63,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             '$eval',
             '$evaltype',
             '$extnameof',
+            '$exec',
             '$for',
             '$foreach',
             '$if',
@@ -307,7 +308,7 @@ function definition(): monaco.languages.IMonarchLanguage {
             whitespace: [
                 [/[ \r\n]+/, 'white'],
                 [/\/\*/, 'comment', '@comment'],
-                [/\/\+/, 'comment', '@comment'],
+                [/<\*/, 'contract', '@contract'],
                 [/\/\/.*$/, 'comment'],
                 [/\t/, 'comment.invalid'],
             ],
@@ -316,7 +317,15 @@ function definition(): monaco.languages.IMonarchLanguage {
                 [/[^/*]+/, 'comment'],
                 [/\/\*/, 'comment', '@comment'],
                 [/\*\//, 'comment', '@pop'],
+                [/\*>/, 'comment', '@pop'],
                 [/[/*]/, 'comment'],
+            ],
+
+            contract: [
+                [/[^/*]+/, 'contract'],
+                [/\*>/, 'contract', '@pop'],
+                [/[/*]/, 'contract'],
+                [/\t/, 'contract.invalid'],
             ],
 
             string: [


### PR DESCRIPTION
This enables all C3 compiler versions submitted to infra up to the latest (0.6.8). It adds the missing `$exec` keyword and correctly renders the new contract syntax.