### PR TITLE
Update SPIR-V and Slang verisons

### DIFF
--- a/etc/config/slang.amazon.properties
+++ b/etc/config/slang.amazon.properties
@@ -1,16 +1,18 @@
 compilers=&defaultslangc
 
-defaultCompiler=slangc_2025_2_2
+defaultCompiler=slangc_2025_6_2
 supportsBinary=false
 compilerType=slang
 instructionSet=spirv
 
 disassemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-dis
 
-group.defaultslangc.compilers=slangc_2024_14_6:slangc_2025_2_2
+group.defaultslangc.compilers=slangc_2024_14_6:slangc_2025_2_2:slangc_2025_6_2
 group.defaultslangc.versionFlag=-version
 
 compiler.slangc_2024_14_6.exe=/opt/compiler-explorer/slang-2024.14.6/bin/slangc
 compiler.slangc_2024_14_6.name=slangc 2024.14.6
 compiler.slangc_2025_2_2.exe=/opt/compiler-explorer/slang-2025.2.2/bin/slangc
 compiler.slangc_2025_2_2.name=slangc 2025.2.2
+compiler.slangc_2025_6_2.exe=/opt/compiler-explorer/slang-2025.6.2/bin/slangc
+compiler.slangc_2025_6_2.name=slangc 2025.6.2

--- a/etc/config/spirv.amazon.properties
+++ b/etc/config/spirv.amazon.properties
@@ -17,12 +17,12 @@ group.spirv-val.compilerType=spirv-tools
 
 group.spirv-cross.groupName=Translate
 group.spirv-cross.baseName=SPIRV-Cross
-group.spirv-cross.compilers=spirv-cross-sdk-296:spirv-cross-sdk-304
+group.spirv-cross.compilers=spirv-cross-sdk-296:spirv-cross-sdk-304:spirv-cross-sdk-309
 group.spirv-cross.compilerType=spirv-tools
 
 group.spirv-reflect.groupName=Reflection
 group.spirv-reflect.baseName=SPIRV-Reflect
-group.spirv-reflect.compilers=spirv-reflect-sdk-304
+group.spirv-reflect.compilers=spirv-reflect-sdk-304:spirv-reflect-sdk-309
 group.spirv-reflect.compilerType=spirv-tools
 
 assemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-as
@@ -40,3 +40,8 @@ compiler.spirv-cross-sdk-304.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.304.0/x8
 compiler.spirv-cross-sdk-304.name=spirv-cross (sdk-304)
 compiler.spirv-reflect-sdk-304.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.304.0/x86_64/bin/spirv-reflect
 compiler.spirv-reflect-sdk-304.name=spirv-reflect (sdk-304)
+
+compiler.spirv-cross-sdk-309.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.309.0/x86_64/bin/spirv-cross
+compiler.spirv-cross-sdk-309.name=spirv-cross (sdk-309)
+compiler.spirv-reflect-sdk-309.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.309.0/x86_64/bin/spirv-reflect
+compiler.spirv-reflect-sdk-309.name=spirv-reflect (sdk-309)


### PR DESCRIPTION
Update the online version for SPIR-V and Slang compilers for the Vulkan 309 SDK to correspond with https://github.com/compiler-explorer/infra/pull/1550