### PR TITLE
c++: Add swift-clang to the list of compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&clad-clang
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&clad-clang:&swift-clang
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -760,6 +760,34 @@ compiler.clang-rocm-60102.exe=/opt/compiler-explorer/clang-rocm-6.1.2/bin/clang+
 compiler.clang-rocm-60102.semver=rocm-6.1.2
 compiler.clang-rocm-60102.options=--gcc-toolchain=/opt/compiler-explorer/gcc-12.2.0
 compiler.clang-rocm-60102.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+
+group.swift-clang.compilers=swift-nightly-clang:swift-devsnapshot-clang:swift603-clang
+group.swift-clang.intelAsm=-mllvm --x86-asm-syntax=intel
+group.swift-clang.options=-fuse-ld=lld
+group.swift-clang.groupName=Swift Clang x86-64
+group.swift-clang.instructionSet=amd64
+group.swift-clang.baseName=x86-64 clang swift
+group.swift-clang.isSemVer=true
+group.swift-clang.compilerType=clang
+group.swift-clang.unwiseOptions=-march=native
+group.swift-clang.supportsPVS-Studio=true
+group.swift-clang.supportsSonar=true
+group.swift-clang.supportsLlvmCov=true
+group.swift-clang.licenseName=LLVM Apache 2
+group.swift-clang.licenseLink=https://github.com/swiftlang/llvm-project/blob/main/LICENSE.TXT
+group.swift-clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.swift-clang.supportsBinaryObject=true
+group.swift-clang.compilerCategories=clang
+group.swift-clang.demangler=/opt/compiler-explorer/swift-nightly/usr/bin/llvm-cxxfilt
+group.swift-clang.objdumper=/opt/compiler-explorer/swift-nightly/usr/bin/llvm-objdump
+
+compiler.swift-nightly-clang.semVer=nightly
+compiler.swift-nightly-clang.isNightly=true
+compiler.swift-nightly-clang.exe=/opt/compiler-explorer/swift-nightly/usr/bin/clang++
+compiler.swift-devsnapshot-clang.semVer=devsnapshot
+compiler.swift-devsnapshot-clang.exe=/opt/compiler-explorer/swift-dev-snapshot/usr/bin/clang++
+compiler.swift603-clang.semVer=6.0.3
+compiler.swift603-clang.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/clang++
 
 ################################
 # Clang for Arm


### PR DESCRIPTION
Swift's distribution of clang is able to compile C++ and Objective-C++, while also allowing features like -fblocks and -fobjc-arc.

This should address https://github.com/compiler-explorer/compiler-explorer/issues/284
