### PR TITLE
fix: add build to sway options

### DIFF
--- a/etc/config/sway.amazon.properties
+++ b/etc/config/sway.amazon.properties
@@ -10,7 +10,7 @@ group.sway.irArg=--ir final
 group.sway.supportsBinary=true
 group.sway.supportsAsm=true
 group.sway.asmArg=--asm all
-group.sway.options=--offline
+group.sway.options=build --offline
 
 compiler.swayv0667.exe=/opt/compiler-explorer/sway-0.66.7/forc-binaries/forc
 compiler.swayv0667.semver=0.66.7


### PR DESCRIPTION
Add `build` command to Sway compiler options to ensure Compiler Explorer correctly executes `forc build --offline` when running Sway code.

This should resolve the error that was reported by @partouf [here](https://github.com/compiler-explorer/compiler-explorer/pull/7456#issuecomment-2721747677).

