### PR TITLE
Dont change original library versioninfo object

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -814,8 +814,9 @@ export class BaseCompiler {
 
         if (!result) return false;
 
-        result.name = foundLib.name;
-        return result;
+        const copiedResult = structuredClone(result);
+        copiedResult.name = foundLib.name;
+        return copiedResult;
     }
 
     protected optionsForDemangler(filters?: ParseFiltersAndOutputOptions): string[] {


### PR DESCRIPTION
Causes unwanted cache invalidation (of `client-options.js`) when libraries are selected by the user on GPU instances.
