### PR TITLE
use OSACA v0.7.0 as tool

### DIFF
--- a/etc/config/algol68.amazon.properties
+++ b/etc/config/algol68.amazon.properties
@@ -39,8 +39,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -22,7 +22,7 @@ group.osaca.supportsBinary=false
 group.osaca.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 group.osaca.compilerType=osaca
 
-compiler.osacatrunk.name=OSACA (0.6.1)
-compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+compiler.osacatrunk.name=OSACA (0.7.0)
+compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 # Intel syntax currently unsupported (WIP)
 # compiler.osacatrunk.intelAsm=--intel-syntax

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6015,8 +6015,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3767,8 +3767,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/clean.amazon.properties
+++ b/etc/config/clean.amazon.properties
@@ -49,8 +49,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=_32
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=_32

--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -40,8 +40,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_blue.amazon.properties
+++ b/etc/config/cppx_blue.amazon.properties
@@ -24,8 +24,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_gold.amazon.properties
+++ b/etc/config/cppx_gold.amazon.properties
@@ -24,8 +24,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -958,8 +958,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=dmd

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1422,8 +1422,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -1712,8 +1712,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -1206,8 +1206,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=gl:6g141
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=gl:6g141

--- a/etc/config/haskell.amazon.properties
+++ b/etc/config/haskell.amazon.properties
@@ -58,8 +58,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -93,8 +93,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -218,8 +218,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=opt
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=opt

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2204,8 +2204,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1103,8 +1103,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -68,8 +68,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 tools.llvm-mcatrunk.exclude=mptrunk
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1024,8 +1024,8 @@ tools.llvm-dwarfdumptrunk.type=postcompilation
 tools.llvm-dwarfdumptrunk.class=llvm-dwarfdump-tool
 tools.llvm-dwarfdumptrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/spice.amazon.properties
+++ b/etc/config/spice.amazon.properties
@@ -63,8 +63,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -133,8 +133,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -72,8 +72,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.6.1)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.6.1/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.0)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/lib/tooling/osaca-tool.ts
+++ b/lib/tooling/osaca-tool.ts
@@ -47,10 +47,6 @@ export class OSACATool extends BaseTool {
             return this.createErrorResponse('<cannot run analysis on binary>');
         }
 
-        if (compilationInfo.filters.intel) {
-            return this.createErrorResponse('<cannot run analysis on Intel assembly>');
-        }
-
         const rewrittenOutputFilename = compilationInfo.outputFilename + '.osaca';
         await this.writeAsmFile(
             compilationInfo.asmParser,


### PR DESCRIPTION
Updated OSACA to version 0.7.0 that finally includes support for Intel syntax assembly.
Therefore, I increased the version numbers in the `*.amazon.properties` files and removed the check and error message for Intel syntax in `osaca-tool.ts`.
Successfully tested with `make check` and manually with a local instance
