### PR TITLE
Enable binary support for Clang (assertions) 2.8 and 3.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -605,7 +605,6 @@ compiler.clang27assert.supportsBinary=false
 compiler.clang28assert.exe=/opt/compiler-explorer/clang-assertions-2.8.0/bin/clang++
 compiler.clang28assert.semver=2.8.0 (assertions)
 compiler.clang28assert.options=-I/opt/compiler-explorer/gcc-4.5.3/lib/gcc/x86_64-linux-gnu/4.5.3/include -I/opt/compiler-explorer/gcc-4.5.3/include/c++/4.5.3 -I/opt/compiler-explorer/gcc-4.5.3/include/c++/4.5.3/x86_64-linux-gnu/
-compiler.clang28assert.supportsBinary=false
 compiler.clang29assert.exe=/opt/compiler-explorer/clang-assertions-2.9.0/bin/clang++
 compiler.clang29assert.semver=2.9.0 (assertions)
 compiler.clang29assert.options=-I/opt/compiler-explorer/gcc-4.5.3/lib/gcc/x86_64-linux-gnu/4.5.3/include -I/opt/compiler-explorer/gcc-4.5.3/include/c++/4.5.3 -I/opt/compiler-explorer/gcc-4.5.3/include/c++/4.5.3/x86_64-linux-gnu/
@@ -613,7 +612,6 @@ compiler.clang29assert.supportsBinary=false
 compiler.clang30assert.exe=/opt/compiler-explorer/clang-assertions-3.0.0/bin/clang++
 compiler.clang30assert.semver=3.0.0 (assertions)
 compiler.clang30assert.options=-I/opt/compiler-explorer/gcc-4.6.4/lib/gcc/x86_64-linux-gnu/4.6.4/include -I/opt/compiler-explorer/gcc-4.6.4/include/c++/4.6.4 -I/opt/compiler-explorer/gcc-4.6.4/include/c++/4.6.4/x86_64-linux-gnu/
-compiler.clang30assert.supportsBinary=false
 # Clang 3.1 and above: let's try the latest stable GCC as of the time of build
 compiler.clang31assert.exe=/opt/compiler-explorer/clang-assertions-3.1.0/bin/clang++
 compiler.clang31assert.semver=3.1 (assertions)


### PR DESCRIPTION
This PR accompanies https://github.com/compiler-explorer/clang-builder/pull/84.
Those new build of Clang 2.8 and 3.0 should be capable of compiling a C++ hello world that can be successfully executed.
No other changes should be necessary, because new builds should be compatible with the old ones.