### PR TITLE
Configure packageManager field to enable corepack compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,5 +160,6 @@
     "ts-check": "tsc -p ./tsconfig.backend.json --noEmit && tsc -p ./tsconfig.frontend.json --noEmit && tsc -p ./tsconfig.tests.json --noEmit",
     "webpack": "node --no-warnings=ExperimentalWarning --import=tsx ./node_modules/webpack-cli/bin/cli.js --node-env=production --config webpack.config.esm.ts"
   },
-  "license": "BSD-2-Clause"
+  "license": "BSD-2-Clause",
+  "packageManager": "npm@11.2.0"
 }


### PR DESCRIPTION
Corepack (https://github.com/nodejs/corepack) is a shim for pnpm/yarn/npm that allows you to automatically use the right package manager for a project as long as it declares which packageManager it wants to use.

This patch adds registers npm 11.2.0 (latest) as the preferred version for corepack.

This has no effect on any project infrastructure as CE infra itself does not use corepack at the moment.