### PR TITLE
Add Bintuils 2.42 assemblers for x86, riscv32 and riscv64

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -25,7 +25,7 @@ compiler.nasm21601.semver=2.16.01
 compiler.nasm21601.exe=/opt/compiler-explorer/nasm-2.16.01/bin/nasm
 
 
-group.gnuas.compilers=gnuas72:gnuas73:gnuas92:gnuas103:gnuas112:gnuas121:gnuassnapshot
+group.gnuas.compilers=gnuas72:gnuas73:gnuas92:gnuas103:gnuas112:gnuas121:gnuas142:gnuassnapshot
 group.gnuas.versionFlag=--version
 group.gnuas.options=-g
 group.gnuas.isSemVer=true
@@ -43,6 +43,8 @@ compiler.gnuas112.exe=/opt/compiler-explorer/gcc-11.2.0/bin/as
 compiler.gnuas112.semver=2.36.1
 compiler.gnuas121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/as
 compiler.gnuas121.semver=2.38
+compiler.gnuas142.exe=/opt/compiler-explorer/gcc-14.2.0/bin/as
+compiler.gnuas142.semver=2.42
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)
@@ -111,7 +113,7 @@ group.gnuasriscv.supportsExecute=false
 group.gnuasriscv.versionFlag=--version
 
 ## GNU as for RISC-V 64-bits
-group.gnuasriscv64.compilers=gnuasriscv64g820:gnuasriscv64g1020:gnuasriscv64g1140:gnuasriscv64g1320
+group.gnuasriscv64.compilers=gnuasriscv64g820:gnuasriscv64g1020:gnuasriscv64g1140:gnuasriscv64g1320:gnuasriscv64g1420
 group.gnuasriscv64.groupName=RISC-V (64-bits) binutils
 group.gnuasriscv64.baseName=RISC-V (64-bits) binutils
 
@@ -135,8 +137,13 @@ compiler.gnuasriscv64g1320.name=RISC-V binutils 2.38.0
 compiler.gnuasriscv64g1320.semver=2.38.0
 compiler.gnuasriscv64g1320.objdumper=/opt/compiler-explorer/riscv64/gcc-13.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.gnuasriscv64g1420.exe=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
+compiler.gnuasriscv64g1420.name=RISC-V binutils 2.42.0
+compiler.gnuasriscv64g1420.semver=2.42.0
+compiler.gnuasriscv64g1420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
 ## GNU as for RISC-V 32-bits
-group.gnuasriscv32.compilers=gnuasriscv32g820:gnuasriscv32g1020:gnuasriscv32g1140:gnuasriscv32g1320
+group.gnuasriscv32.compilers=gnuasriscv32g820:gnuasriscv32g1020:gnuasriscv32g1140:gnuasriscv32g1320:gnuasriscv32g1420
 group.gnuasriscv32.groupName=RISC-V (32-bits) binutils
 group.gnuasriscv32.baseName=RISC-V (32-bits) binutils
 
@@ -159,6 +166,11 @@ compiler.gnuasriscv32g1320.exe=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32
 compiler.gnuasriscv32g1320.name=RISC-V binutils 2.38.0
 compiler.gnuasriscv32g1320.semver=2.38.0
 compiler.gnuasriscv32g1320.objdumper=/opt/compiler-explorer/riscv32/gcc-13.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv32g1420.exe=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
+compiler.gnuasriscv32g1420.name=RISC-V binutils 2.42.0
+compiler.gnuasriscv32g1420.semver=2.42.0
+compiler.gnuasriscv32g1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas1910:llvmas2010:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version


### PR DESCRIPTION
Relates to https://github.com/compiler-explorer/compiler-explorer/issues/7528.

I am not updating Arm and AArch64 because they are still using 2.38 in their GCC 14.2.0 builds.
