### PR TITLE
Update c++.amazon.properties: update repo URL after org renaming

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4085,7 +4085,7 @@ libs.belleviews.versions.trunk.path=/opt/compiler-explorer/libs/belleviews/trunk
 
 libs.beman_iterator_interface.name=beman.iterator_interface
 libs.beman_iterator_interface.versions=trunk
-libs.beman_iterator_interface.url=https://github.com/beman-project/iterator_interface
+libs.beman_iterator_interface.url=https://github.com/bemanproject/iterator_interface
 libs.beman_iterator_interface.packagedheaders=true
 libs.beman_iterator_interface.staticliblink=beman.iterator_interface
 libs.beman_iterator_interface.versions.trunk.version=trunk

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4093,7 +4093,7 @@ libs.beman_iterator_interface.versions.trunk.lookupversion=main
 
 libs.beman_optional.name=beman.optional
 libs.beman_optional.versions=trunk
-libs.beman_optional.url=https://github.com/beman-project/optional
+libs.beman_optional.url=https://github.com/bemanproject/optional
 libs.beman_optional.versions.trunk.version=trunk
 libs.beman_optional.versions.trunk.path=/opt/compiler-explorer/libs/beman_optional/main/include
 


### PR DESCRIPTION
Update c++.amazon.properties: update repo URL after org renaming: https://github.com/bemanproject/

The URL was updated in https://github.com/compiler-explorer/infra/blob/main/bin/yaml/libraries.yaml#L1140-L1163.

I know GitHub redirects for old links, but I would like to fix this leftover.

Note: we don't need to re-deploy for this issue.