### PR TITLE
[swift]: add 6.1 x86 release compiler

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&swift:&arm-swift
-demangler=/opt/compiler-explorer/swift-6.0.3/usr/bin/swift-demangle
-defaultCompiler=swift603
+demangler=/opt/compiler-explorer/swift-6.1/usr/bin/swift-demangle
+defaultCompiler=swift61
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
 #################################
@@ -8,7 +8,7 @@ objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 #################################
 
 # swift (x86_64)
-group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swift58:swift59:swift510:swift603:swiftdevsnapshot:swiftnightly
+group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swift58:swift59:swift510:swift603:swift61:swiftdevsnapshot:swiftnightly
 group.swift.isSemVer=true
 group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc
@@ -37,6 +37,9 @@ compiler.swiftdevsnapshot.semver=devsnapshot
 #################################
 
 # 6.x (x86)
+
+compiler.swift61.exe=/opt/compiler-explorer/swift-6.1/usr/bin/swiftc
+compiler.swift61.semver=6.1
 
 compiler.swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
 compiler.swift603.semver=6.0.3


### PR DESCRIPTION
infra change: https://github.com/compiler-explorer/infra/pull/1564. something may have changed with the Musl SDK used for cross compiling, so going to defer updating the UI to add that until someone can figure out what's going on there.