### PR TITLE
Add (e)z80-clang compilers.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -158,3 +158,4 @@ From oldest to newest contributor, we would like to thank:
 - [Joshua Batty](https://github.com/joshuabatty)
 - [Dana Jansens](https://github.com/danakj)
 - [Mathias Gredal](https://github.com/mathiasgredal)
+- [Adrien Bertrand](https://github.com/adriweb)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&clad-clang
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cl:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:&nvcxx_arm_cxx:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -4055,6 +4055,53 @@ compiler.qnx800.semver=8.0.0
 compiler.qnx800.qnxHost=/opt/compiler-explorer/qnx-800/host/linux/x86_64
 compiler.qnx800.qnxTarget=/opt/compiler-explorer/qnx-800/target/qnx
 compiler.qnx800.qnxLicense=/opt/qnx/licenses
+
+################################
+# Clang++ for eZ80,Z80,Z180
+group.z80-clang.compilers=ez80-clang-1500:ez80-clang-1507:z80-clang-1500:z80-clang-1507:z180-clang-1500:z180-clang-1507
+group.z80-clang.compilerType=clang
+group.z80-clang.groupName=(e)Z80-clang
+group.z80-clang.baseName=z80-clang
+group.z80-clang.supportsBinary=false
+group.z80-clang.supportsBinaryObject=false
+group.z80-clang.supportsExecute=false
+group.z80-clang.isSemVer=true
+group.z80-clang.isNightly=true
+group.z80-clang.licenseName=LLVM Apache 2
+group.z80-clang.licenseLink=https://github.com/CE-Programming/llvm-project/blob/z80/llvm/LICENSE.TXT
+group.z80-clang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.z80-clang.compilerCategories=clang
+group.z80-clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+compiler.ez80-clang-1500.exe=/opt/compiler-explorer/z80-clang-15.0.0/bin/clang++
+compiler.ez80-clang-1500.name=ez80-clang 15.0.0
+compiler.ez80-clang-1500.semver=15.0.0
+compiler.ez80-clang-1500.instructionSet=ez80
+compiler.ez80-clang-1500.options=-target ez80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.ez80-clang-1507.exe=/opt/compiler-explorer/z80-clang-15.0.7/bin/clang++
+compiler.ez80-clang-1507.name=ez80-clang 15.0.7
+compiler.ez80-clang-1507.semver=15.0.7
+compiler.ez80-clang-1507.instructionSet=ez80
+compiler.ez80-clang-1507.options=-target ez80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z80-clang-1500.exe=/opt/compiler-explorer/z80-clang-15.0.0/bin/clang++
+compiler.z80-clang-1500.name=z80-clang 15.0.0
+compiler.z80-clang-1500.semver=15.0.0
+compiler.z80-clang-1500.instructionSet=z80
+compiler.z80-clang-1500.options=-target z80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z80-clang-1507.exe=/opt/compiler-explorer/z80-clang-15.0.7/bin/clang++
+compiler.z80-clang-1507.name=z80-clang 15.0.7
+compiler.z80-clang-1507.semver=15.0.7
+compiler.z80-clang-1507.instructionSet=z80
+compiler.z80-clang-1507.options=-target z80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z180-clang-1500.exe=/opt/compiler-explorer/z80-clang-15.0.0/bin/clang++
+compiler.z180-clang-1500.name=z180-clang 15.0.0
+compiler.z180-clang-1500.semver=15.0.0
+compiler.z180-clang-1500.instructionSet=z180
+compiler.z180-clang-1500.options=-target z180 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z180-clang-1507.exe=/opt/compiler-explorer/z80-clang-15.0.7/bin/clang++
+compiler.z180-clang-1507.name=z180-clang 15.0.7
+compiler.z180-clang-1507.semver=15.0.7
+compiler.z180-clang-1507.instructionSet=z180
+compiler.z180-clang-1507.options=-target z180 -g0 -nostdinc -fno-threadsafe-statics
 
 #################################
 #################################

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust
+compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust
 defaultCompiler=cg142
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -3332,6 +3332,53 @@ compiler.sdcc440.exe=/opt/compiler-explorer/sdcc-4.4.0/bin/sdcc
 compiler.sdcc440.semver=4.4.0
 compiler.sdcc450.exe=/opt/compiler-explorer/sdcc-4.5.0/bin/sdcc
 compiler.sdcc450.semver=4.5.0
+
+################################
+# Clang for eZ80,Z80,Z180
+group.z80-cclang.compilers=ez80-cclang-1500:ez80-cclang-1507:z80-cclang-1500:z80-cclang-1507:z180-cclang-1500:z180-cclang-1507
+group.z80-cclang.compilerType=clang
+group.z80-cclang.groupName=(e)Z80-clang
+group.z80-cclang.baseName=z80-cclang
+group.z80-cclang.supportsBinary=false
+group.z80-cclang.supportsBinaryObject=false
+group.z80-cclang.supportsExecute=false
+group.z80-cclang.isSemVer=true
+group.z80-cclang.isNightly=true
+group.z80-cclang.licenseName=LLVM Apache 2
+group.z80-cclang.licenseLink=https://github.com/CE-Programming/llvm-project/blob/z80/llvm/LICENSE.TXT
+group.z80-cclang.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.z80-cclang.compilerCategories=clang
+group.z80-cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+compiler.ez80-cclang-1500.exe=/opt/compiler-explorer/z80-clang-15.0.0/bin/clang
+compiler.ez80-cclang-1500.name=ez80-clang 15.0.0
+compiler.ez80-cclang-1500.semver=15.0.0
+compiler.ez80-cclang-1500.instructionSet=ez80
+compiler.ez80-cclang-1500.options=-target ez80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.ez80-cclang-1507.exe=/opt/compiler-explorer/z80-clang-15.0.7/bin/clang
+compiler.ez80-cclang-1507.name=ez80-clang 15.0.7
+compiler.ez80-cclang-1507.semver=15.0.7
+compiler.ez80-cclang-1507.instructionSet=ez80
+compiler.ez80-cclang-1507.options=-target ez80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z80-cclang-1500.exe=/opt/compiler-explorer/z80-clang-15.0.0/bin/clang
+compiler.z80-cclang-1500.name=z80-clang 15.0.0
+compiler.z80-cclang-1500.semver=15.0.0
+compiler.z80-cclang-1500.instructionSet=z80
+compiler.z80-cclang-1500.options=-target z80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z80-cclang-1507.exe=/opt/compiler-explorer/z80-clang-15.0.7/bin/clang
+compiler.z80-cclang-1507.name=z80-clang 15.0.7
+compiler.z80-cclang-1507.semver=15.0.7
+compiler.z80-cclang-1507.instructionSet=z80
+compiler.z80-cclang-1507.options=-target z80 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z180-cclang-1500.exe=/opt/compiler-explorer/z80-clang-15.0.0/bin/clang
+compiler.z180-cclang-1500.name=z180-clang 15.0.0
+compiler.z180-cclang-1500.semver=15.0.0
+compiler.z180-cclang-1500.instructionSet=z180
+compiler.z180-cclang-1500.options=-target z180 -g0 -nostdinc -fno-threadsafe-statics
+compiler.z180-cclang-1507.exe=/opt/compiler-explorer/z80-clang-15.0.7/bin/clang
+compiler.z180-cclang-1507.name=z180-clang 15.0.7
+compiler.z180-cclang-1507.semver=15.0.7
+compiler.z180-cclang-1507.instructionSet=z180
+compiler.z180-cclang-1507.options=-target z180 -g0 -nostdinc -fno-threadsafe-statics
 
 #################################
 # z88dk

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -162,6 +162,7 @@ export {WineVcCompiler} from './wine-vc.js';
 export {WslVcCompiler} from './wsl-vc.js';
 export {WyrmCompiler} from './wyrm.js';
 export {YLCCompiler} from './ylc.js';
+export {Z80ClangCompiler} from './clang.js';
 export {ZigCC} from './zigcc.js';
 export {ZigCXX} from './zigcxx.js';
 export {ZigCompiler} from './zig.js';

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -440,3 +440,16 @@ export class ClangDxcCompiler extends ClangCompiler {
         return ['--driver-mode=dxc', '-Zi', '-Qembed_debug', '-Fc', this.filename(outputFilename)];
     }
 }
+
+export class Z80ClangCompiler extends ClangCompiler {
+    static override get key() {
+        return 'z80-clang';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(info, env);
+
+        this.compiler.supportsIntel = false;
+        this.compiler.irArg = ['-Xclang', '-emit-llvm'];
+    }
+}

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -59,6 +59,10 @@ export class InstructionSets {
                 target: ['bpf'],
                 path: ['/bpf-'],
             },
+            ez80: {
+                target: ['ez80'],
+                path: [],
+            },
             kvx: {
                 target: ['kvx'],
                 path: ['/kvx-', '/k1-'],
@@ -122,6 +126,10 @@ export class InstructionSets {
             xtensa: {
                 target: ['xtensa'],
                 path: ['/xtensa-'],
+            },
+            z180: {
+                target: ['z180'],
+                path: [],
             },
             z80: {
                 target: ['z80'],

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -35,6 +35,7 @@ export const InstructionSetsList = [
     'ebpf',
     'evm',
     'eravm',
+    'ez80',
     'hook',
     'core',
     'java',
@@ -61,6 +62,7 @@ export const InstructionSetsList = [
     'wasm64',
     'wdc65c816',
     'xtensa',
+    'z180',
     'z80',
 ] as const;
 


### PR DESCRIPTION
These clang + LLVM backends are not upstreamed but [a community effort](https://github.com/CE-Programming/llvm-project/), so it's a bit customized.

This requires https://github.com/compiler-explorer/infra/pull/1566

_Edit: tested locally, works fine._