### PR TITLE
Add spdlog also to c++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5607,6 +5607,12 @@ libs.spdlog.versions.1110.version=1.11.0
 libs.spdlog.versions.1110.path=/opt/compiler-explorer/libs/spdlog/1.11.0/include
 libs.spdlog.versions.1120.version=1.12.0
 libs.spdlog.versions.1120.path=/opt/compiler-explorer/libs/spdlog/1.12.0/include
+libs.spdlog.versions.1130.version=1.13.0
+libs.spdlog.versions.1130.path=/opt/compiler-explorer/libs/spdlog/1.13.0/include
+libs.spdlog.versions.1141.version=1.14.1
+libs.spdlog.versions.1141.path=/opt/compiler-explorer/libs/spdlog/1.14.1/include
+libs.spdlog.versions.1152.version=1.15.2
+libs.spdlog.versions.1152.path=/opt/compiler-explorer/libs/spdlog/1.15.2/include
 
 libs.spy.name=SPY
 libs.spy.description=C++17 constexpr settings detectors

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5586,7 +5586,7 @@ libs.sol2.versions.321.path=/opt/compiler-explorer/libs/sol2/v3.2.1/include
 
 libs.spdlog.name=spdlog
 libs.spdlog.url=https://github.com/gabime/spdlog
-libs.spdlog.versions=150:160:161:170:180:192:1100:1110:1120
+libs.spdlog.versions=150:160:161:170:180:192:1100:1110:1120:1130:1141:1152
 libs.spdlog.staticliblink=spdlogd
 libs.spdlog.options=-DSPDLOG_COMPILED_LIB
 libs.spdlog.versions.150.version=1.5.0


### PR DESCRIPTION
I'm so sorry for the follow-up PR. In #7532 I had just changed all files that refer to spdlog according to a [search](https://github.com/search?q=repo%3Acompiler-explorer%2Fcompiler-explorer%20spdlog&type=code), but it seems that doesn't return c++.amazon.properties. Weird... (GitHub probably only indexes the first 2000 lines or so).

In any case, this PR adds the same lines as in #7532 to `etc/config/c++.amazon.properties` as well. Again, apologies this didn't get included in a single PR.