### PR TITLE
[swift]: add 6.1 arm release compiler

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -14,7 +14,7 @@ group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc
 
 # arm-swift (aarch64)
-group.arm-swift.compilers=arm-swift603
+group.arm-swift.compilers=arm-swift603:arm-swift61
 group.arm-swift.isSemVer=true
 group.arm-swift.groupName=swift (aarch64)
 group.arm-swift.baseName=aarch64 swiftc
@@ -45,6 +45,10 @@ compiler.swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
 compiler.swift603.semver=6.0.3
 
 # 6.x (arm)
+
+compiler.arm-swift61.exe=/opt/compiler-explorer/swift-6.1/usr/bin/swiftc
+compiler.arm-swift61.semver=6.1
+compiler.arm-swift61.options=-target aarch64-swift-linux-musl -sdk /opt/compiler-explorer/swift-6.1-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64 -resource-dir /opt/compiler-explorer/swift-6.1-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static
 
 compiler.arm-swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
 compiler.arm-swift603.semver=6.0.3


### PR DESCRIPTION
adds a config entry for cross compiling to arm for the 6.1 release compiler. necessary infra changes added in https://github.com/compiler-explorer/infra/pull/1564. tested that the new config should work by manually adding the flags here: https://swift.godbolt.org/z/EPrsbKPf4.