### PR TITLE
Make default Rust code compatible with 2024 edition

### DIFF
--- a/examples/rust/default.rs
+++ b/examples/rust/default.rs
@@ -3,10 +3,10 @@
 // As of Rust 1.75, small functions are automatically
 // marked as `#[inline]` so they will not show up in
 // the output when compiling with optimisations. Use
-// `#[no_mangle]` or `#[inline(never)]` to work around
-// this issue.
+// `#[unsafe(no_mangle)]` or `#[inline(never)]` to
+// work around this issue.
 // See https://github.com/compiler-explorer/compiler-explorer/issues/5939
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn square(num: i32) -> i32 {
     num * num
 }


### PR DESCRIPTION
`no_mangle` is an `unsafe` attribute in the 2024 edition. All other editions still accept the old form without `unsafe`, but also optionally allow `#[unsafe(no_mangle)]`.

The new form was stabilised in Rust 1.82 (released 2024-10-17), so the default code is now incompatible with Rust <= 1.81.

Unsafe attributes RFC: https://rust-lang.github.io/rfcs/3325-unsafe-attributes.html

Example: https://godbolt.org/z/d3rE9r7ae