### PR TITLE
[c2rust]: allow passing arguments to `clang`

### DIFF
--- a/lib/compilers/c2rust.ts
+++ b/lib/compilers/c2rust.ts
@@ -58,4 +58,26 @@ export class C2RustCompiler extends BaseCompiler {
     override getOutputFilename(dirPath: string) {
         return path.join(dirPath, 'example.rs');
     }
+
+    override orderArguments(
+        options: string[],
+        inputFilename: string,
+        libIncludes: string[],
+        libOptions: string[],
+        libPaths: string[],
+        libLinks: string[],
+        userOptions: string[],
+        staticLibLinks: string[],
+    ): string[] {
+        return options.concat(
+            [this.filename(inputFilename)],
+            userOptions,
+            userOptions.includes('--') ? [] : ['--'],
+            libIncludes,
+            libOptions,
+            libPaths,
+            libLinks,
+            staticLibLinks,
+        );
+    }
 }


### PR DESCRIPTION
To pass arguments to `clang` (such as `-std=...`), `--` must be used to separate these arguments from the arguments to `c2rust`:

```console
$ ./c2rust-transpile --help
transpile 0.20.0
[...]
USAGE:
    c2rust-transpile [OPTIONS] [COMPILE_COMMANDS]... [-- <EXTRA_CLANG_ARGS>...]
```

However, when doing this, the input file must be passed *before* the `--`. Also, when libraries are enabled, the include and link flags must be passed to `clang` (but duplicate `--` are not allowed).

Example for passing command line arguments: https://godbolt.org/z/eqfa3T7WY
Example for activating a library: https://godbolt.org/z/srh55Y1hY