### PR TITLE
Execution fixes (when using architectures that cant run)

### DIFF
--- a/lib/binaries/binary-utils.ts
+++ b/lib/binaries/binary-utils.ts
@@ -123,11 +123,11 @@ export class BinaryInfoLinux {
         return undefined;
     }
 
-    static async readFile(filepath: string): Promise<BinaryInfo | undefined> {
+    static async readFile(filepath: string, instructionSetHint?: InstructionSet): Promise<BinaryInfo | undefined> {
         if (os.platform() === 'win32') {
             return {
                 os: OSType.windows,
-                instructionSet: 'amd64',
+                instructionSet: instructionSetHint || 'amd64',
             };
         }
         const info = await executeDirect('/usr/bin/file', ['-b', filepath], {});

--- a/lib/execution/execution-query.ts
+++ b/lib/execution/execution-query.ts
@@ -76,7 +76,7 @@ export class RemoteExecutionQuery {
         const triple = new BaseExecutionTriple();
 
         if (result.executableFilename) {
-            const info = await BinaryInfoLinux.readFile(result.executableFilename);
+            const info = await BinaryInfoLinux.readFile(result.executableFilename, result.instructionSet);
             if (info) {
                 triple.instructionSet = info.instructionSet;
                 triple.os = info.os;

--- a/static/panes/output.ts
+++ b/static/panes/output.ts
@@ -211,8 +211,11 @@ export class Output extends Pane<OutputState> {
             }
         }
 
-        if (result.execResult && (result.execResult.didExecute || result.didExecute)) {
-            this.add('Program returned: ' + result.execResult.code);
+        if (result.execResult) {
+            if (result.execResult.didExecute || result.didExecute) {
+                this.add('Program returned: ' + result.execResult.code);
+            }
+
             if (result.execResult.stderr.length || result.execResult.stdout.length) {
                 for (const obj of result.execResult.stderr) {
                     // Conserve empty lines as they are discarded by ansiToHtml


### PR DESCRIPTION
* Fixes bug where executables were always run on Windows even if aarch64 
* Fixes bug in output pane where error was not shown as to why execution did not work

(Windows still not properly fixed, will need to find `file` equivalent for Windows)