### PR TITLE
Update Qt 6.9.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5458,7 +5458,7 @@ libs.qt.url=https://www.qt.io
 libs.qt.packagedheaders=true
 libs.qt.liblink=Qt6Core
 libs.qt.options=-DQT_NO_VERSION_TAGGING
-libs.qt.versions=642:652:660:670:680
+libs.qt.versions=642:652:660:670:680:690
 libs.qt.versions.642.version=6.4.2
 libs.qt.versions.642.path=/app/qt/include/QtCore
 libs.qt.versions.652.version=6.5.2
@@ -5469,6 +5469,8 @@ libs.qt.versions.670.version=6.7.0
 libs.qt.versions.670.path=/app/qt/include/QtCore
 libs.qt.versions.680.version=6.8.0
 libs.qt.versions.680.path=/app/qt/include/QtCore
+libs.qt.versions.690.version=6.9.0
+libs.qt.versions.690.path=/app/qt/include/QtCore
 
 libs.quill.name=Quill
 libs.quill.description=C++ Low Latency Logging Library


### PR DESCRIPTION
Qt 6.9.0 release in c++.amazon.properties

infra PR here: https://github.com/compiler-explorer/infra/pull/1581

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
