### PR TITLE
Specifically allow OPTIONS for browser preflight CORS checks.

### DIFF
--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -75,7 +75,7 @@ export class ApiHandler {
                 'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept',
                 'Cache-Control': cacheHeader,
             });
-            if (req.method == 'OPTIONS') {
+            if (req.method === 'OPTIONS') {
                 res.sendStatus(200);
             } else {
                 next();

--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -43,7 +43,7 @@ import {StorageBase} from '../storage/index.js';
 import {CompileHandler} from './compile.js';
 
 function methodNotAllowed(req: express.Request, res: express.Response) {
-    res.status(405).send('Method Not Allowed').end();
+    res.status(405).send('Method Not Allowed');
 }
 
 export class ApiHandler {
@@ -75,7 +75,11 @@ export class ApiHandler {
                 'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept',
                 'Cache-Control': cacheHeader,
             });
-            next();
+            if (req.method == 'OPTIONS') {
+                res.sendStatus(200);
+            } else {
+                next();
+            }
         });
         this.handle.route('/compilers').get(this.handleCompilers.bind(this)).all(methodNotAllowed);
 


### PR DESCRIPTION
Google AI suggested too (independently, I did this first then searched and got:

---

1. Using Middleware
A middleware function can intercept OPTIONS requests and set the appropriate CORS headers.

```js
app.use(function(req, res, next) {
  res.header("Access-Control-Allow-Origin", "*");
  res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
  if (req.method === 'OPTIONS') {
    res.sendStatus(200);
  } else {
    next();
  }
});
```
---

Tested locally with curl on GET, OPTIONS, and POST and correctly lets OPTIONS return an empty CORS block, etc. And the site works too :)