### PR TITLE
Add extra PATH to Sail compiler so it can find Z3

### DIFF
--- a/etc/config/sail.amazon.properties
+++ b/etc/config/sail.amazon.properties
@@ -20,3 +20,4 @@ group.sail.compilerType=sail
 
 compiler.sail_0_18.semver=0.18
 compiler.sail_0_18.exe=/opt/compiler-explorer/sail-0.18/bin/sail
+compiler.sail_0_18.extraPath=/opt/compiler-explorer/sail-0.18/bin


### PR DESCRIPTION
The Sail compiler needs a copy of the Z3 SMT solver to compile Sail code, and it includes one in its `bin` directory, but it doesn't automatically look in the same directory for it; it needs to be on the `PATH`. This adds the `bin` directory to the `PATH` so it should be able to find it.
