### PR TITLE
Replace PascalUtils class with top-level functions (NFC)

### DIFF
--- a/lib/compilers/pascal-utils.ts
+++ b/lib/compilers/pascal-utils.ts
@@ -22,34 +22,32 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-export class PascalUtils {
-    isProgram(source: string) {
-        const re = /\s?program\s+([\w.-]*);/i;
-        return !!re.test(source);
+export function isProgram(source: string) {
+    const re = /\s?program\s+([\w.-]*);/i;
+    return !!re.test(source);
+}
+
+export function isUnit(source: string) {
+    const re = /\s?unit\s+([\w.-]*);/i;
+    return !!re.test(source);
+}
+
+export function getUnitname(source: string) {
+    const re = /\s?unit\s+([\w.-]*);/i;
+    const match = source.match(re);
+    if (match) {
+        return match[1];
     }
 
-    isUnit(source: string) {
-        const re = /\s?unit\s+([\w.-]*);/i;
-        return !!re.test(source);
+    return 'example';
+}
+
+export function getProgName(source: string) {
+    const re = /\s?program\s+([\w.-]*);/i;
+    const match = source.match(re);
+    if (match) {
+        return match[1];
     }
 
-    getUnitname(source: string) {
-        const re = /\s?unit\s+([\w.-]*);/i;
-        const match = source.match(re);
-        if (match) {
-            return match[1];
-        }
-
-        return 'example';
-    }
-
-    getProgName(source: string) {
-        const re = /\s?program\s+([\w.-]*);/i;
-        const match = source.match(re);
-        if (match) {
-            return match[1];
-        }
-
-        return 'prog';
-    }
+    return 'prog';
 }

--- a/lib/compilers/pascal-win.ts
+++ b/lib/compilers/pascal-win.ts
@@ -36,7 +36,7 @@ import {MapFileReaderDelphi} from '../mapfiles/map-file-delphi.js';
 import {PELabelReconstructor} from '../pe32-support.js';
 import * as utils from '../utils.js';
 
-import {getUnitname, isProgram} from './pascal-utils.js';
+import * as pascalUtils from './pascal-utils.js';
 
 export class PascalWinCompiler extends BaseCompiler {
     static get key() {
@@ -123,10 +123,10 @@ export class PascalWinCompiler extends BaseCompiler {
 
     override async writeAllFiles(dirPath: string, source: string, files: any[], filters: ParseFiltersAndOutputOptions) {
         let inputFilename: string;
-        if (isProgram(source)) {
+        if (pascalUtils.isProgram(source)) {
             inputFilename = path.join(dirPath, this.dprFilename);
         } else {
-            const unitName = getUnitname(source);
+            const unitName = pascalUtils.getUnitname(source);
             if (unitName) {
                 inputFilename = path.join(dirPath, unitName + '.pas');
             } else {

--- a/lib/compilers/pascal-win.ts
+++ b/lib/compilers/pascal-win.ts
@@ -36,7 +36,7 @@ import {MapFileReaderDelphi} from '../mapfiles/map-file-delphi.js';
 import {PELabelReconstructor} from '../pe32-support.js';
 import * as utils from '../utils.js';
 
-import {PascalUtils} from './pascal-utils.js';
+import {getUnitname, isProgram} from './pascal-utils.js';
 
 export class PascalWinCompiler extends BaseCompiler {
     static get key() {
@@ -45,7 +45,6 @@ export class PascalWinCompiler extends BaseCompiler {
 
     mapFilename: string | null;
     dprFilename: string;
-    pasUtils: PascalUtils;
 
     constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(info, env);
@@ -54,7 +53,6 @@ export class PascalWinCompiler extends BaseCompiler {
         this.mapFilename = null;
         this.compileFilename = 'output.pas';
         this.dprFilename = 'prog.dpr';
-        this.pasUtils = new PascalUtils();
     }
 
     override getSharedLibraryPathsAsArguments() {
@@ -117,18 +115,18 @@ export class PascalWinCompiler extends BaseCompiler {
         await fs.writeFile(
             filename,
             'program prog;\n' +
-            'uses ' + unitName + " in '" + unitPath + "';\n" +
+            'uses ' + unitName + ' in \'' + unitPath + '\';\n' +
             'begin\n' +
             'end.\n',
         );
     }
 
     override async writeAllFiles(dirPath: string, source: string, files: any[], filters: ParseFiltersAndOutputOptions) {
-        let inputFilename;
-        if (this.pasUtils.isProgram(source)) {
+        let inputFilename: string;
+        if (isProgram(source)) {
             inputFilename = path.join(dirPath, this.dprFilename);
         } else {
-            const unitName = this.pasUtils.getUnitname(source);
+            const unitName = getUnitname(source);
             if (unitName) {
                 inputFilename = path.join(dirPath, unitName + '.pas');
             } else {

--- a/lib/compilers/pascal.ts
+++ b/lib/compilers/pascal.ts
@@ -40,7 +40,7 @@ import {CompilationEnvironment} from '../compilation-env.js';
 import * as utils from '../utils.js';
 
 import {PascalParser} from './argument-parsers.js';
-import {getProgName, getUnitname, isProgram} from './pascal-utils.js';
+import * as pascalUtils from './pascal-utils.js';
 
 export class FPCCompiler extends BaseCompiler {
     static get key() {
@@ -133,8 +133,8 @@ export class FPCCompiler extends BaseCompiler {
 
     override getExecutableFilename(dirPath: string, outputFilebase: string, key?: CacheKey | CompilationCacheKey) {
         const source = (key && (key as CacheKey).source) || '';
-        if (key && this.pasUtils.isProgram(source)) {
-            return path.join(dirPath, this.pasUtils.getProgName(source));
+        if (key && pascalUtils.isProgram(source)) {
+            return path.join(dirPath, pascalUtils.getProgName(source));
         }
 
         return path.join(dirPath, 'prog');
@@ -217,10 +217,10 @@ export class FPCCompiler extends BaseCompiler {
 
     getMainSourceFilename(source: string) {
         let inputFilename: string;
-        if (isProgram(source)) {
-            inputFilename = getProgName(source) + '.dpr';
+        if (pascalUtils.isProgram(source)) {
+            inputFilename = pascalUtils.getProgName(source) + '.dpr';
         } else {
-            const unitName = getUnitname(source);
+            const unitName = pascalUtils.getUnitname(source);
             if (unitName) {
                 inputFilename = unitName + '.pas';
             } else {

--- a/lib/compilers/pascal.ts
+++ b/lib/compilers/pascal.ts
@@ -40,7 +40,7 @@ import {CompilationEnvironment} from '../compilation-env.js';
 import * as utils from '../utils.js';
 
 import {PascalParser} from './argument-parsers.js';
-import {PascalUtils} from './pascal-utils.js';
+import {getProgName, getUnitname, isProgram} from './pascal-utils.js';
 
 export class FPCCompiler extends BaseCompiler {
     static get key() {
@@ -50,7 +50,6 @@ export class FPCCompiler extends BaseCompiler {
     dprFilename: string;
     supportsOptOutput: boolean;
     nasmPath: string;
-    pasUtils: PascalUtils;
     demangler: any | null = null;
 
     constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
@@ -60,7 +59,6 @@ export class FPCCompiler extends BaseCompiler {
         this.dprFilename = 'prog.dpr';
         this.supportsOptOutput = false;
         this.nasmPath = this.compilerProps<string>('nasmpath');
-        this.pasUtils = new PascalUtils();
     }
 
     override getSharedLibraryPathsAsArguments() {
@@ -218,11 +216,11 @@ export class FPCCompiler extends BaseCompiler {
     }
 
     getMainSourceFilename(source: string) {
-        let inputFilename;
-        if (this.pasUtils.isProgram(source)) {
-            inputFilename = this.pasUtils.getProgName(source) + '.dpr';
+        let inputFilename: string;
+        if (isProgram(source)) {
+            inputFilename = getProgName(source) + '.dpr';
         } else {
-            const unitName = this.pasUtils.getUnitname(source);
+            const unitName = getUnitname(source);
             if (unitName) {
                 inputFilename = unitName + '.pas';
             } else {

--- a/test/pascal-tests.ts
+++ b/test/pascal-tests.ts
@@ -27,7 +27,7 @@ import path from 'node:path';
 
 import {beforeAll, describe, expect, it} from 'vitest';
 
-import {PascalUtils} from '../lib/compilers/pascal-utils.js';
+import {isProgram, isUnit} from '../lib/compilers/pascal-utils.js';
 import {PascalWinCompiler} from '../lib/compilers/pascal-win.js';
 import {FPCCompiler} from '../lib/compilers/pascal.js';
 import {PascalDemangler} from '../lib/demangler/index.js';
@@ -407,18 +407,17 @@ describe('Pascal', () => {
     });
 
     describe('Pascal filetype detection', async () => {
-        const pasUtils = new PascalUtils();
         const progSource = await fs.readFile('test/pascal/prog.dpr', 'utf-8');
         const unitSource = await fs.readFile('test/pascal/example.pas', 'utf-8');
 
         it('Should detect simple program', () => {
-            expect(pasUtils.isProgram(progSource)).toEqual(true);
-            expect(pasUtils.isProgram(unitSource)).toEqual(false);
+            expect(isProgram(progSource)).toEqual(true);
+            expect(isProgram(unitSource)).toEqual(false);
         });
 
         it('Should detect simple unit', () => {
-            expect(pasUtils.isUnit(progSource)).toEqual(false);
-            expect(pasUtils.isUnit(unitSource)).toEqual(true);
+            expect(isUnit(progSource)).toEqual(false);
+            expect(isUnit(unitSource)).toEqual(true);
         });
     });
 

--- a/test/pascal-tests.ts
+++ b/test/pascal-tests.ts
@@ -27,7 +27,7 @@ import path from 'node:path';
 
 import {beforeAll, describe, expect, it} from 'vitest';
 
-import {isProgram, isUnit} from '../lib/compilers/pascal-utils.js';
+import * as pascalUtils from '../lib/compilers/pascal-utils.js';
 import {PascalWinCompiler} from '../lib/compilers/pascal-win.js';
 import {FPCCompiler} from '../lib/compilers/pascal.js';
 import {PascalDemangler} from '../lib/demangler/index.js';
@@ -411,13 +411,13 @@ describe('Pascal', () => {
         const unitSource = await fs.readFile('test/pascal/example.pas', 'utf-8');
 
         it('Should detect simple program', () => {
-            expect(isProgram(progSource)).toEqual(true);
-            expect(isProgram(unitSource)).toEqual(false);
+            expect(pascalUtils.isProgram(progSource)).toEqual(true);
+            expect(pascalUtils.isProgram(unitSource)).toEqual(false);
         });
 
         it('Should detect simple unit', () => {
-            expect(isUnit(progSource)).toEqual(false);
-            expect(isUnit(unitSource)).toEqual(true);
+            expect(pascalUtils.isUnit(progSource)).toEqual(false);
+            expect(pascalUtils.isUnit(unitSource)).toEqual(true);
         });
     });
 


### PR DESCRIPTION
The class doesn't hold any state, and it's only ever instantiated to call these functions. We might as well export them as regular functions

Unfortunately the git diff looks pretty horrible, but it's simply replacing each method with `export function` and deleting the class.