### PR TITLE
Install more recent MS compilers

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -85,20 +85,20 @@ group.vcpp.licenseLink=https://visualstudio.microsoft.com/license-terms/vs2022-g
 group.vcpp.licensePreamble=The use of this compiler is only permitted for internal evaluation purposes and is otherwise governed by the MSVC License Agreement.
 group.vcpp.licenseInvasive=true
 
-group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86:vcpp_v19_32_VS17_2_x86:vcpp_v19_34_VS17_4_x86:vcpp_v19_36_VS17_6_x86:vcpp_v19_38_VS17_8_x86:vcpp_v19_39_VS17_9_x86:vcpp_v19_40_VS17_10_x86:vcpp_v19_latest_x86
+group.vcpp_x86.compilers=vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86:vcpp_v19_32_VS17_2_x86:vcpp_v19_34_VS17_4_x86:vcpp_v19_36_VS17_6_x86:vcpp_v19_38_VS17_8_x86:vcpp_v19_39_VS17_9_x86:vcpp_v19_40_VS17_10_x86:vcpp_v19_41_VS17_11_x86:vcpp_v19_42_VS17_12_x86:vcpp_v19_43_VS17_13_x86
 group.vcpp_x86.groupName=MSVC x86
 group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
 group.vcpp_x86.supportsExecute=true
 group.vcpp_x86.instructionSet=amd64
 
-group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64:vcpp_v19_32_VS17_2_x64:vcpp_v19_34_VS17_4_x64:vcpp_v19_36_VS17_6_x64:vcpp_v19_38_VS17_8_x64:vcpp_v19_39_VS17_9_x64:vcpp_v19_40_VS17_10_x64:vcpp_v19_latest_x64
+group.vcpp_x64.compilers=vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64:vcpp_v19_32_VS17_2_x64:vcpp_v19_34_VS17_4_x64:vcpp_v19_36_VS17_6_x64:vcpp_v19_38_VS17_8_x64:vcpp_v19_39_VS17_9_x64:vcpp_v19_40_VS17_10_x64:vcpp_v19_41_VS17_11_x64:vcpp_v19_42_VS17_12_x64:vcpp_v19_43_VS17_13_x64
 group.vcpp_x64.groupName=MSVC x64
 group.vcpp_x64.supportsBinary=true
 group.vcpp_x64.supportsExecute=true
 group.vcpp_x64.instructionSet=amd64
 
-group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64:vcpp_v19_32_VS17_2_arm64:vcpp_v19_34_VS17_4_arm64:vcpp_v19_36_VS17_6_arm64:vcpp_v19_38_VS17_8_arm64:vcpp_v19_39_VS17_9_arm64:vcpp_v19_40_VS17_10_arm64:vcpp_v19_latest_arm64
+group.vcpp_arm64.compilers=vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64:vcpp_v19_32_VS17_2_arm64:vcpp_v19_34_VS17_4_arm64:vcpp_v19_36_VS17_6_arm64:vcpp_v19_38_VS17_8_arm64:vcpp_v19_39_VS17_9_arm64:vcpp_v19_40_VS17_10_arm64:vcpp_v19_41_VS17_11_arm64:vcpp_v19_42_VS17_12_arm64:vcpp_v19_43_VS17_13_arm64
 group.vcpp_arm64.groupName=MSVC arm64
 group.vcpp_arm64.supportsBinary=false
 group.vcpp_arm64.supportsBinaryObject=false
@@ -554,14 +554,14 @@ compiler.vcpp_v19_40_VS17_10_x86.libPath=Z:/compilers/msvc/14.40.33807-14.40.338
 compiler.vcpp_v19_40_VS17_10_x86.includePath=Z:/compilers/msvc/14.40.33807-14.40.33811.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_40_VS17_10_x86.name=x86 msvc v19.40 VS17.10
 compiler.vcpp_v19_40_VS17_10_x86.semver=14.40.33811.0
-compiler.vcpp_v19_40_VS17_10_x86.alias=vcpp_v19_40_x86:vcpp_v19_latest_x86
+compiler.vcpp_v19_40_VS17_10_x86.alias=vcpp_v19_40_x86
 
 compiler.vcpp_v19_40_VS17_10_x64.exe=Z:/compilers/msvc/14.40.33807-14.40.33811.0/bin/Hostx64/x64/cl.exe
 compiler.vcpp_v19_40_VS17_10_x64.libPath=Z:/compilers/msvc/14.40.33807-14.40.33811.0/lib;Z:/compilers/msvc/14.40.33807-14.40.33811.0/lib/x64;Z:/compilers/msvc/14.40.33807-14.40.33811.0/atlmfc/lib/x64;Z:/compilers/msvc/14.40.33807-14.40.33811.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
 compiler.vcpp_v19_40_VS17_10_x64.includePath=Z:/compilers/msvc/14.40.33807-14.40.33811.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_40_VS17_10_x64.name=x64 msvc v19.40 VS17.10
 compiler.vcpp_v19_40_VS17_10_x64.semver=14.40.33811.0
-compiler.vcpp_v19_40_VS17_10_x64.alias=vcpp_v19_40_x64:vcpp_v19_latest_x64
+compiler.vcpp_v19_40_VS17_10_x64.alias=vcpp_v19_40_x64
 
 compiler.vcpp_v19_40_VS17_10_arm64.exe=Z:/compilers/msvc/14.40.33807-14.40.33811.0/bin/Hostx64/arm64/cl.exe
 compiler.vcpp_v19_40_VS17_10_arm64.libPath=Z:/compilers/msvc/14.40.33807-14.40.33811.0/lib;Z:/compilers/msvc/14.40.33807-14.40.33811.0/lib/arm64;Z:/compilers/msvc/14.40.33807-14.40.33811.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.40.33807-14.40.33811.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
@@ -570,24 +570,62 @@ compiler.vcpp_v19_40_VS17_10_arm64.name=arm64 msvc v19.40 VS17.10
 compiler.vcpp_v19_40_VS17_10_arm64.semver=14.40.33811.0
 compiler.vcpp_v19_40_VS17_10_arm64.alias=vcpp_v19_40_arm64
 
-# Manually synced "latest" version (until we can automate)
-compiler.vcpp_v19_latest_x86.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x86/cl.exe
-compiler.vcpp_v19_latest_x86.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
-compiler.vcpp_v19_latest_x86.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
-compiler.vcpp_v19_latest_x86.name=x86 msvc v19.latest
-compiler.vcpp_v19_latest_x86.semver=14.41.33923.0-Pre
+compiler.vcpp_v19_41_VS17_11_x86.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x86/cl.exe
+compiler.vcpp_v19_41_VS17_11_x86.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_41_VS17_11_x86.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_41_VS17_11_x86.name=x86 msvc v19.41 VS17.11
+compiler.vcpp_v19_41_VS17_11_x86.semver=14.41.33923.0
 
-compiler.vcpp_v19_latest_x64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_latest_x64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
-compiler.vcpp_v19_latest_x64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
-compiler.vcpp_v19_latest_x64.name=x64 msvc v19.latest
-compiler.vcpp_v19_latest_x64.semver=14.41.33923.0-Pre
+compiler.vcpp_v19_41_VS17_11_x64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_41_VS17_11_x64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_41_VS17_11_x64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_41_VS17_11_x64.name=x64 msvc v19.41 VS17.11
+compiler.vcpp_v19_41_VS17_11_x64.semver=14.41.33923.0
 
-compiler.vcpp_v19_latest_arm64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_latest_arm64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
-compiler.vcpp_v19_latest_arm64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
-compiler.vcpp_v19_latest_arm64.name=arm64 msvc v19.latest
-compiler.vcpp_v19_latest_arm64.semver=14.41.33923.0-Pre
+compiler.vcpp_v19_41_VS17_11_arm64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_41_VS17_11_arm64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_41_VS17_11_arm64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_41_VS17_11_arm64.name=arm64 msvc v19.41 VS17.11
+compiler.vcpp_v19_41_VS17_11_arm64.semver=14.41.33923.0
+
+compiler.vcpp_v19_42_VS17_12_x86.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/x86/cl.exe
+compiler.vcpp_v19_42_VS17_12_x86.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_42_VS17_12_x86.includePath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_42_VS17_12_x86.name=x86 msvc v19.42 VS17.12
+compiler.vcpp_v19_42_VS17_12_x86.semver=14.42.34441.0
+
+compiler.vcpp_v19_42_VS17_12_x64.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_42_VS17_12_x64.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/x64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/x64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_42_VS17_12_x64.includePath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_42_VS17_12_x64.name=x64 msvc v19.42 VS17.12
+compiler.vcpp_v19_42_VS17_12_x64.semver=14.42.34441.0
+
+compiler.vcpp_v19_42_VS17_12_arm64.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_42_VS17_12_arm64.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/arm64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_42_VS17_12_arm64.includePath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_42_VS17_12_arm64.name=arm64 msvc v19.42 VS17.12
+compiler.vcpp_v19_42_VS17_12_arm64.semver=14.42.34441.0
+
+compiler.vcpp_v19_43_VS17_13_x86.exe=Z:/compilers/msvc/14.43.34808-14.43.34810.0/bin/Hostx64/x86/cl.exe
+compiler.vcpp_v19_43_VS17_13_x86.libPath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib;Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib/x86;Z:/compilers/msvc/14.43.34808-14.43.34810.0/atlmfc/lib/x86;Z:/compilers/msvc/14.43.34808-14.43.34810.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_43_VS17_13_x86.includePath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_43_VS17_13_x86.name=x86 msvc v19.43 VS17.13
+compiler.vcpp_v19_43_VS17_13_x86.semver=14.43.34810.0
+compiler.vcpp_v19_43_VS17_13_x86.semver.alias=vcpp_v19_latest_x86
+
+compiler.vcpp_v19_43_VS17_13_x64.exe=Z:/compilers/msvc/14.43.34808-14.43.34810.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_43_VS17_13_x64.libPath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib;Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib/x64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/atlmfc/lib/x64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_43_VS17_13_x64.includePath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_43_VS17_13_x64.name=x64 msvc v19.43 VS17.13
+compiler.vcpp_v19_43_VS17_13_x64.semver=14.43.34810.0
+compiler.vcpp_v19_43_VS17_13_x64.semver.alias=vcpp_v19_latest_x64
+
+compiler.vcpp_v19_43_VS17_13_arm64.exe=Z:/compilers/msvc/14.43.34808-14.43.34810.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_43_VS17_13_arm64.libPath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib;Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib/arm64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_43_VS17_13_arm64.includePath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_43_VS17_13_arm64.name=arm64 msvc v19.43 VS17.13
+compiler.vcpp_v19_43_VS17_13_arm64.semver=14.43.34810.0
+compiler.vcpp_v19_43_VS17_13_arm64.semver.alias=vcpp_v19_latest_arm64
 
 libs=
 

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -66,17 +66,17 @@ group.vc.licenseLink=https://visualstudio.microsoft.com/license-terms/vs2022-ga-
 group.vc.licensePreamble=The use of this compiler is only permitted for internal evaluation purposes and is otherwise governed by the MSVC License Agreement.
 group.vc.licenseInvasive=true
 
-group.vc_x86.compilers=vc_v19_24_VS16_4_x86:vc_v19_25_VS16_5_x86:vc_v19_27_VS16_7_x86:vc_v19_28_VS16_8_x86:vc_v19_28_VS16_9_x86:vc_v19_29_VS16_10_x86:vc_v19_29_VS16_11_x86:vc_v19_20_VS16_0_x86:vc_v19_21_VS16_1_x86:vc_v19_22_VS16_2_x86:vc_v19_23_VS16_3_x86:vc_v19_26_VS16_6_x86:vc_v19_30_VS17_0_x86:vc_v19_31_VS17_1_x86:vc_v19_33_VS17_3_x86:vc_v19_35_VS17_5_x86:vc_v19_37_VS17_7_x86:vc_v19_32_VS17_2_x86:vc_v19_34_VS17_4_x86:vc_v19_36_VS17_6_x86:vc_v19_38_VS17_8_x86:vc_v19_39_VS17_9_x86:vc_v19_40_VS17_10_x86:vc_v19_latest_x86
+group.vc_x86.compilers=vc_v19_24_VS16_4_x86:vc_v19_25_VS16_5_x86:vc_v19_27_VS16_7_x86:vc_v19_28_VS16_8_x86:vc_v19_28_VS16_9_x86:vc_v19_29_VS16_10_x86:vc_v19_29_VS16_11_x86:vc_v19_20_VS16_0_x86:vc_v19_21_VS16_1_x86:vc_v19_22_VS16_2_x86:vc_v19_23_VS16_3_x86:vc_v19_26_VS16_6_x86:vc_v19_30_VS17_0_x86:vc_v19_31_VS17_1_x86:vc_v19_33_VS17_3_x86:vc_v19_35_VS17_5_x86:vc_v19_37_VS17_7_x86:vc_v19_32_VS17_2_x86:vc_v19_34_VS17_4_x86:vc_v19_36_VS17_6_x86:vc_v19_38_VS17_8_x86:vc_v19_39_VS17_9_x86:vc_v19_40_VS17_10_x86:vc_v19_41_VS17_11_x86:vc_v19_42_VS17_12_x86:vc_v19_43_VS17_13_x86
 group.vc_x86.groupName=MSVC x86
 group.vc_x86.supportsBinary=true
 group.vc_x86.supportsExecute=true
 
-group.vc_x64.compilers=vc_v19_24_VS16_4_x64:vc_v19_25_VS16_5_x64:vc_v19_27_VS16_7_x64:vc_v19_28_VS16_8_x64:vc_v19_28_VS16_9_x64:vc_v19_29_VS16_10_x64:vc_v19_29_VS16_11_x64:vc_v19_20_VS16_0_x64:vc_v19_21_VS16_1_x64:vc_v19_22_VS16_2_x64:vc_v19_23_VS16_3_x64:vc_v19_26_VS16_6_x64:vc_v19_30_VS17_0_x64:vc_v19_31_VS17_1_x64:vc_v19_33_VS17_3_x64:vc_v19_35_VS17_5_x64:vc_v19_37_VS17_7_x64:vc_v19_32_VS17_2_x64:vc_v19_34_VS17_4_x64:vc_v19_36_VS17_6_x64:vc_v19_38_VS17_8_x64:vc_v19_39_VS17_9_x64:vc_v19_40_VS17_10_x64:vc_v19_latest_x64
+group.vc_x64.compilers=vc_v19_24_VS16_4_x64:vc_v19_25_VS16_5_x64:vc_v19_27_VS16_7_x64:vc_v19_28_VS16_8_x64:vc_v19_28_VS16_9_x64:vc_v19_29_VS16_10_x64:vc_v19_29_VS16_11_x64:vc_v19_20_VS16_0_x64:vc_v19_21_VS16_1_x64:vc_v19_22_VS16_2_x64:vc_v19_23_VS16_3_x64:vc_v19_26_VS16_6_x64:vc_v19_30_VS17_0_x64:vc_v19_31_VS17_1_x64:vc_v19_33_VS17_3_x64:vc_v19_35_VS17_5_x64:vc_v19_37_VS17_7_x64:vc_v19_32_VS17_2_x64:vc_v19_34_VS17_4_x64:vc_v19_36_VS17_6_x64:vc_v19_38_VS17_8_x64:vc_v19_39_VS17_9_x64:vc_v19_40_VS17_10_x64:vc_v19_41_VS17_11_x64:vc_v19_42_VS17_12_x64:vc_v19_43_VS17_13_x64
 group.vc_x64.groupName=MSVC x64
 group.vc_x64.supportsBinary=true
 group.vc_x64.supportsExecute=true
 
-group.vc_arm64.compilers=vc_v19_28_VS16_9_arm64:vc_v19_29_VS16_10_arm64:vc_v19_29_VS16_11_arm64:vc_v19_25_VS16_5_arm64:vc_v19_27_VS16_7_arm64:vc_v19_24_VS16_4_arm64:vc_v19_28_VS16_8_arm64:vc_v19_20_VS16_0_arm64:vc_v19_21_VS16_1_arm64:vc_v19_22_VS16_2_arm64:vc_v19_23_VS16_3_arm64:vc_v19_26_VS16_6_arm64:vc_v19_30_VS17_0_arm64:vc_v19_31_VS17_1_arm64:vc_v19_33_VS17_3_arm64:vc_v19_35_VS17_5_arm64:vc_v19_37_VS17_7_arm64:vc_v19_32_VS17_2_arm64:vc_v19_34_VS17_4_arm64:vc_v19_36_VS17_6_arm64:vc_v19_38_VS17_8_arm64:vc_v19_39_VS17_9_arm64:vc_v19_40_VS17_10_arm64:vc_v19_latest_arm64
+group.vc_arm64.compilers=vc_v19_28_VS16_9_arm64:vc_v19_29_VS16_10_arm64:vc_v19_29_VS16_11_arm64:vc_v19_25_VS16_5_arm64:vc_v19_27_VS16_7_arm64:vc_v19_24_VS16_4_arm64:vc_v19_28_VS16_8_arm64:vc_v19_20_VS16_0_arm64:vc_v19_21_VS16_1_arm64:vc_v19_22_VS16_2_arm64:vc_v19_23_VS16_3_arm64:vc_v19_26_VS16_6_arm64:vc_v19_30_VS17_0_arm64:vc_v19_31_VS17_1_arm64:vc_v19_33_VS17_3_arm64:vc_v19_35_VS17_5_arm64:vc_v19_37_VS17_7_arm64:vc_v19_32_VS17_2_arm64:vc_v19_34_VS17_4_arm64:vc_v19_36_VS17_6_arm64:vc_v19_38_VS17_8_arm64:vc_v19_39_VS17_9_arm64:vc_v19_40_VS17_10_arm64:vc_v19_41_VS17_11_arm64:vc_v19_42_VS17_12_arm64:vc_v19_43_VS17_13_arm64
 group.vc_arm64.groupName=MSVC arm64
 group.vc_arm64.isSemVer=true
 group.vc_arm64.supportsBinary=false
@@ -535,24 +535,62 @@ compiler.vc_v19_40_VS17_10_arm64.includePath=Z:/compilers/msvc/14.40.33807-14.40
 compiler.vc_v19_40_VS17_10_arm64.name=arm64 msvc v19.40 VS17.10
 compiler.vc_v19_40_VS17_10_arm64.semver=14.40.33811.0
 
-# Manually synced "latest" version (until we can automate)
-compiler.vc_v19_latest_x86.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x86/cl.exe
-compiler.vc_v19_latest_x86.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
-compiler.vc_v19_latest_x86.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
-compiler.vc_v19_latest_x86.name=x86 msvc v19.latest
-compiler.vc_v19_latest_x86.semver=14.41.33923.0-Pre
+compiler.vc_v19_41_VS17_11_x86.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x86/cl.exe
+compiler.vc_v19_41_VS17_11_x86.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vc_v19_41_VS17_11_x86.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_41_VS17_11_x86.name=x86 msvc v19.41 VS17.11
+compiler.vc_v19_41_VS17_11_x86.semver=14.41.33923.0
 
-compiler.vc_v19_latest_x64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/cl.exe
-compiler.vc_v19_latest_x64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
-compiler.vc_v19_latest_x64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
-compiler.vc_v19_latest_x64.name=x64 msvc v19.latest
-compiler.vc_v19_latest_x64.semver=14.41.33923.0-Pre
+compiler.vc_v19_41_VS17_11_x64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/cl.exe
+compiler.vc_v19_41_VS17_11_x64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vc_v19_41_VS17_11_x64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_41_VS17_11_x64.name=x64 msvc v19.41 VS17.11
+compiler.vc_v19_41_VS17_11_x64.semver=14.41.33923.0
 
-compiler.vc_v19_latest_arm64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/arm64/cl.exe
-compiler.vc_v19_latest_arm64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
-compiler.vc_v19_latest_arm64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
-compiler.vc_v19_latest_arm64.name=arm64 msvc v19.latest
-compiler.vc_v19_latest_arm64.semver=14.41.33923.0-Pre
+compiler.vc_v19_41_VS17_11_arm64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/arm64/cl.exe
+compiler.vc_v19_41_VS17_11_arm64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vc_v19_41_VS17_11_arm64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_41_VS17_11_arm64.name=arm64 msvc v19.41 VS17.11
+compiler.vc_v19_41_VS17_11_arm64.semver=14.41.33923.0
+
+compiler.vc_v19_42_VS17_12_x86.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/x86/cl.exe
+compiler.vc_v19_42_VS17_12_x86.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vc_v19_42_VS17_12_x86.includePath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_42_VS17_12_x86.name=x86 msvc v19.42 VS17.12
+compiler.vc_v19_42_VS17_12_x86.semver=14.42.34441.0
+
+compiler.vc_v19_42_VS17_12_x64.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/x64/cl.exe
+compiler.vc_v19_42_VS17_12_x64.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/x64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/x64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vc_v19_42_VS17_12_x64.includePath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_42_VS17_12_x64.name=x64 msvc v19.42 VS17.12
+compiler.vc_v19_42_VS17_12_x64.semver=14.42.34441.0
+
+compiler.vc_v19_42_VS17_12_arm64.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/arm64/cl.exe
+compiler.vc_v19_42_VS17_12_arm64.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/arm64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vc_v19_42_VS17_12_arm64.includePath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_42_VS17_12_arm64.name=arm64 msvc v19.42 VS17.12
+compiler.vc_v19_42_VS17_12_arm64.semver=14.42.34441.0
+
+compiler.vc_v19_43_VS17_13_x86.exe=Z:/compilers/msvc/14.43.34808-14.43.34810.0/bin/Hostx64/x86/cl.exe
+compiler.vc_v19_43_VS17_13_x86.libPath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib;Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib/x86;Z:/compilers/msvc/14.43.34808-14.43.34810.0/atlmfc/lib/x86;Z:/compilers/msvc/14.43.34808-14.43.34810.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vc_v19_43_VS17_13_x86.includePath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_43_VS17_13_x86.name=x86 msvc v19.43 VS17.13
+compiler.vc_v19_43_VS17_13_x86.semver=14.43.34810.0
+compiler.vc_v19_43_VS17_13_x86.alias=vc_v19_latest_x86
+
+compiler.vc_v19_43_VS17_13_x64.exe=Z:/compilers/msvc/14.43.34808-14.43.34810.0/bin/Hostx64/x64/cl.exe
+compiler.vc_v19_43_VS17_13_x64.libPath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib;Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib/x64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/atlmfc/lib/x64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vc_v19_43_VS17_13_x64.includePath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_43_VS17_13_x64.name=x64 msvc v19.43 VS17.13
+compiler.vc_v19_43_VS17_13_x64.semver=14.43.34810.0
+compiler.vc_v19_43_VS17_13_x64.alias=vc_v19_latest_x64
+
+compiler.vc_v19_43_VS17_13_arm64.exe=Z:/compilers/msvc/14.43.34808-14.43.34810.0/bin/Hostx64/arm64/cl.exe
+compiler.vc_v19_43_VS17_13_arm64.libPath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib;Z:/compilers/msvc/14.43.34808-14.43.34810.0/lib/arm64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.43.34808-14.43.34810.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vc_v19_43_VS17_13_arm64.includePath=Z:/compilers/msvc/14.43.34808-14.43.34810.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_43_VS17_13_arm64.name=arm64 msvc v19.43 VS17.13
+compiler.vc_v19_43_VS17_13_arm64.semver=14.43.34810.0
+compiler.vc_v19_43_VS17_13_arm64.alias=vc_v19_latest_arm64
 
 libs=
 


### PR DESCRIPTION
Built using the instructions from https://github.com/compiler-explorer/infra/pull/1589

Fixes up the "latest" and assumes the "Pre" we used to have are no longer "pre" and instead makes the latest the latest released version.

Ulzii from MS has suggested there's new compilers coming, so I thought I'd blow the cobwebs off the process so I can add the new ones when they drop.

Will test in winstaging.