### PR TITLE
Add solx, new Solidity LLVM-based compiler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -357,6 +357,7 @@
       - any-glob-to-any-file:
           - 'lib/compilers/solidity.ts'
           - 'lib/compilers/solidity-zksync.ts'
+          - 'lib/compilers/solx.ts'
           - 'etc/config/solidity.*.properties'
 
 'lang-spice':

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -1,7 +1,7 @@
-compilers=&solc:&zksolc
-defaultCompiler=solc0821
+compilers=&solc:&zksolc:&solx
+defaultCompiler=solc0829
 
-group.solc.compilers=solc0426:solc0517:solc0612:solc076:solc0821
+group.solc.compilers=solc0426:solc0517:solc0612:solc076:solc0821:solc0829
 group.solc.compilerType=solidity
 group.solc.supportsBinary=false
 group.solc.instructionSet=evm
@@ -20,8 +20,11 @@ compiler.solc076.name=solc 0.7.6
 compiler.solc0821.exe=/opt/compiler-explorer/solc-0.8.21/solc
 compiler.solc0821.semver=0.8.21
 compiler.solc0821.name=solc 0.8.21
+compiler.solc0829.exe=/opt/compiler-explorer/solc-0.8.29/solc
+compiler.solc0829.semver=0.8.29
+compiler.solc0829.name=solc 0.8.29
 
-group.zksolc.compilers=zksolc141:zksolc150
+group.zksolc.compilers=zksolc141:zksolc150:zksolc1513
 group.zksolc.compilerType=solidity-eravm
 group.zksolc.supportsBinary=false
 group.zksolc.instructionSet=eravm
@@ -33,6 +36,18 @@ compiler.zksolc150.exe=/opt/compiler-explorer/zksolc-1.5.0/zksolc
 compiler.zksolc150.semver=1.5.0
 compiler.zksolc150.name=zksolc 1.5.0
 compiler.zksolc150.options=--solc /opt/compiler-explorer/zksync-solc-0.8.26-1.0.1/solc
+compiler.zksolc1513.exe=/opt/compiler-explorer/zksolc-1.5.13/zksolc
+compiler.zksolc1513.semver=1.5.13
+compiler.zksolc1513.name=zksolc 1.5.13
+compiler.zksolc1513.options=--solc /opt/compiler-explorer/zksync-solc-0.8.29-1.0.1/solc
+
+group.solx.compilers=solx010alpha2
+group.solx.compilerType=solx
+group.solx.supportsBinary=false
+group.solx.instructionSet=evm
+compiler.solx010alpha2.exe=/opt/compiler-explorer/solx-0.1.0-alpha.2/solx
+compiler.solx010alpha2.semver=0.1.0-alpha.2
+compiler.solx010alpha2.name=solx 0.1.0-alpha.2
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -1,4 +1,4 @@
-compilers=solc:zksolc
+compilers=solc:zksolc:solx
 compilerType=solidity
 defaultCompiler=solc
 
@@ -15,6 +15,13 @@ compiler.zksolc.name=zksolc 1.5.0
 compiler.zksolc.compilerType=solidity-eravm
 compiler.zksolc.instructionSet=eravm
 compiler.zksolc.isSemVer=true
+
+compiler.solx.exe=/usr/bin/solx
+compiler.solx.semver=0.1.0-alpha.2
+compiler.solx.name=solx 0.1.0-alpha.2
+compiler.solx.compilerType=solx
+compiler.solx.instructionSet=evm
+compiler.solx.isSemVer=true
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -139,6 +139,7 @@ export {SlangCompiler} from './slang.js';
 export {SnowballCompiler} from './snowball.js';
 export {SolidityCompiler} from './solidity.js';
 export {SolidityZKsyncCompiler} from './solidity-zksync.js';
+export {SolxCompiler} from './solx.js';
 export {SpiceCompiler} from './spice.js';
 export {SwayCompiler} from './sway.js';
 export {SwiftCompiler} from './swift.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -935,6 +935,14 @@ export class ZksolcParser extends RustParser {
     }
 }
 
+export class SolxParser extends RustParser {
+    static override async parse(compiler: BaseCompiler) {
+        const options = await this.getOptions(compiler, '--help');
+        await this.setCompilerSettingsFromOptions(compiler, options);
+        return compiler;
+    }
+}
+
 export class MrustcParser extends BaseParser {
     static override async parse(compiler: BaseCompiler) {
         await this.getOptions(compiler, '--help');

--- a/lib/compilers/solx.ts
+++ b/lib/compilers/solx.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Compiler Explorer Authors
+// Copyright (c) 2025, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/lib/compilers/solx.ts
+++ b/lib/compilers/solx.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {BaseCompiler} from '../base-compiler.js';
+
+import {SolxParser} from './argument-parsers.js';
+
+import {resultLinesToText} from '../utils.js';
+
+export class SolxCompiler extends BaseCompiler {
+    static get key() {
+        return 'solx';
+    }
+
+    override getSharedLibraryPathsAsArguments() {
+        return [];
+    }
+
+    override getArgumentParserClass() {
+        return SolxParser;
+    }
+
+    override optionsForFilter(): string[] {
+        return ['--asm'];
+    }
+
+    override isCfgCompiler() {
+        return false;
+    }
+
+    override async processAsm(result) {
+        return {
+            asm: [{text: resultLinesToText(result.stdout)}],
+        };
+    }
+}


### PR DESCRIPTION
## What?

* [x] Add new LLVM-based Solidity compiler `solx`
* [x] Add `zksolc` 1.5.13 version support
* [x] Add `solc` 0.8.29 support 

Related PR in infra: https://github.com/compiler-explorer/infra/pull/1602
