### PR TITLE
Reinstate and restyle load/save button

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -519,18 +519,6 @@ pre.content.wrap * {
     padding-right: 1em;
 }
 
-.local-file {
-    display: none;
-}
-
-.save-file {
-    display: none;
-}
-
-.save-btn {
-    margin-left: 5px;
-}
-
 label#vim-label {
     top: 3px;
 }

--- a/views/popups/load-save.pug
+++ b/views/popups/load-save.pug
@@ -30,7 +30,7 @@
                     | Delete
               .input-group.mb-3
                 input.form-control.save-name(type="text" placeholder="Set name of state")
-                button.btn.btn-light.save-button(type="button") Save to browser-local storage
+                button.btn.btn-outline-secondary.save-button(type="button") Save to browser-local storage
             #load-browser-local-history.tab-pane(role="tabpanel")
               h4.card-title Load from browser-local history:
               ul.local-history.small-v-scrollable
@@ -41,6 +41,6 @@
                 label.form-label Load from a local file
                 input.form-control.local-file(type="file")
               .mb-3
-                button.btn.btn-outline-secondary.save-btn(type="button") Save to file
+                button.btn.btn-outline-secondary.save-file(type="button") Save to file
       .modal-footer
         button.btn.btn-outline-primary(type="button" data-bs-dismiss="modal" aria-label="Close") Close


### PR DESCRIPTION
Not quite sure what happened here: the display: none came from change ef7db1af1d0ba3dce03dc9df33db346bb309d39f and we can't quite work out how it was working then.

Fixes #7641
