### PR TITLE
Make 2024 the default edition for Rust >= 1.85

### DIFF
--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -129,8 +129,6 @@ export class RustCompiler extends BaseCompiler {
                     defaultEdition = '2024';
                 } else if (compilerVersion.compare('1.56.0') >= 0) {
                     defaultEdition = '2021';
-                } else if (compilerVersion.compare('1.31.0') >= 0) {
-                    defaultEdition = '2018';
                 }
             }
 

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -122,11 +122,15 @@ export class RustCompiler extends BaseCompiler {
         if (possibleEditions.length > 0) {
             let defaultEdition: undefined | string;
             if (!this.compiler.semver || this.isNightly()) {
-                defaultEdition = '2021';
+                defaultEdition = '2024';
             } else {
                 const compilerVersion = new SemVer(this.compiler.semver);
-                if (compilerVersion.compare('1.56.0') >= 0) {
+                if (compilerVersion.compare('1.85.0') >= 0) {
+                    defaultEdition = '2024';
+                } else if (compilerVersion.compare('1.56.0') >= 0) {
                     defaultEdition = '2021';
+                } else if (compilerVersion.compare('1.31.0') >= 0) {
+                    defaultEdition = '2018';
                 }
             }
 


### PR DESCRIPTION
Resolves #7472.