### PR TITLE
Add `-march=native` warning for x86 GCC and clang for C

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -20,6 +20,7 @@ group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
 group.cgcc86.baseName=x86-64 gcc
+group.cgcc86.unwiseOptions=-march=native
 group.cgcc86.supportsPVS-Studio=true
 group.cgcc86.supportsSonar=true
 group.cgcc86.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
@@ -251,6 +252,7 @@ group.cclang.instructionSet=amd64
 group.cclang.isSemVer=true
 group.cclang.baseName=x86-64 clang
 group.cclang.compilerType=clang
+group.cclang.unwiseOptions=-march=native
 group.cclang.supportsPVS-Studio=true
 group.cclang.supportsSonar=true
 group.cclang.licenseName=LLVM Apache 2


### PR DESCRIPTION
Resolves #7489.