### PR TITLE
Fix conformance compiler output title not showing

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -1322,10 +1322,6 @@ html[data-theme='one-dark'] {
     cursor: help;
 }
 
-.compiler-selector-icon {
-    padding: 0 4px 0 4px !important;
-}
-
 .load-project-from-file {
     width: 400px;
 }

--- a/static/styles/themes/pink-theme.scss
+++ b/static/styles/themes/pink-theme.scss
@@ -179,14 +179,6 @@ textarea.form-control {
     }
 }
 
-.conformance-wrapper {
-    background-color: #1e1e1e !important;
-
-    .compiler-list .row {
-        border-bottom: 1px solid #3e3e3e;
-    }
-}
-
 .copy-link-btn:hover {
     background-color: $dark !important;
 }

--- a/views/templates/widgets/compiler-selector.pug
+++ b/views/templates/widgets/compiler-selector.pug
@@ -8,7 +8,8 @@
       button.btn.btn-sm.btn-light.input-group-text.prepend-options(tabindex="0" data-trigger="focus" style="cursor: pointer;" role="button" title="All compilation options")
         span.btn.btn-sm.btn-light.status-icon
       input.conformance-options.form-control(type="text" placeholder="Compiler options..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
-      button.btn.btn-sm.fas.fa-receipt.d-none.compiler-out.compiler-selector-icon(disabled=true style="cursor: help;" title="This compiler has generated some output. Open its associated pane to read it.")
+      div.badge.align-content-center.d-none.compiler-out.compiler-selector-icon
+        div.fas.fa-receipt(style="cursor: help;" title="This compiler has generated some output. Open its associated pane to read it.")
       button.btn.btn-sm.fas.fa-times.close-compiler.compiler-selector-icon(aria-label="Close" title="Close")
       button.btn.btn-sm.fas.fa-share.extract-compiler.compiler-selector-icon(aria-label="Pop compiler" title="Show compiler")
       button.btn.btn-sm.fas.fa-copy.copy-compiler.compiler-selector-icon(aria-label="Copy compiler" title="Copy compiler")

--- a/views/templates/widgets/compiler-selector.pug
+++ b/views/templates/widgets/compiler-selector.pug
@@ -8,8 +8,8 @@
       button.btn.btn-sm.btn-light.input-group-text.prepend-options(tabindex="0" data-trigger="focus" style="cursor: pointer;" role="button" title="All compilation options")
         span.btn.btn-sm.btn-light.status-icon
       input.conformance-options.form-control(type="text" placeholder="Compiler options..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
-      div.badge.align-content-center.d-none.compiler-out.compiler-selector-icon
-        div.fas.fa-receipt(style="cursor: help;" title="This compiler has generated some output. Open its associated pane to read it.")
+      div.badge.align-content-center.d-none.compiler-out.compiler-selector-icon(style="cursor: help;" title="This compiler has generated some output. Open its associated pane to read it.")
+        div.fas.fa-receipt
       button.btn.btn-sm.fas.fa-times.close-compiler.compiler-selector-icon(aria-label="Close" title="Close")
       button.btn.btn-sm.fas.fa-share.extract-compiler.compiler-selector-icon(aria-label="Pop compiler" title="Show compiler")
       button.btn.btn-sm.fas.fa-copy.copy-compiler.compiler-selector-icon(aria-label="Copy compiler" title="Copy compiler")


### PR DESCRIPTION
Closes https://github.com/compiler-explorer/compiler-explorer/issues/7648

In Boostrap 5, `disabled` buttons now have `pointer-events: none` ([Changelog here](https://getbootstrap.com/docs/5.0/migration/#buttons)) which disables the `title` contents popping up.

This PR fixes it by making it a default `badge`, which keeps the same layout as buttons, but is not clickable by default, much better than having a `disabled` button never meant to be clicked.

It also slightly changes the padding of the buttons to give them some breathing space, and fixes a dark background on the pink theme (Found while testing that all themes worked properly with the `badge`) 

![image](https://github.com/user-attachments/assets/a9cb3637-9540-414f-93bd-ef98b7145c7f)
