### PR TITLE
Fix Rust edition argument parser

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -845,7 +845,7 @@ export class RustParser extends BaseParser {
 
     static override async getPossibleEditions(compiler: BaseCompiler): Promise<string[]> {
         const result = await compiler.execCompilerCached(compiler.compiler.exe, ['--help']);
-        const re = /--edition ([\d|]*)/;
+        const re = /--edition <?([\w|]*)>?/;
 
         const match = result.stdout.match(re);
         if (match?.[1]) {

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -844,7 +844,7 @@ export class RustParser extends BaseParser {
     }
 
     static override async getPossibleEditions(compiler: BaseCompiler): Promise<string[]> {
-        const result = await compiler.execCompilerCached(compiler.compiler.exe, ['--help']);
+        const result = await compiler.execCompilerCached(compiler.compiler.exe, ['--help', '-v']);
         const re = /--edition <?([\w|]*)>?/;
 
         const match = result.stdout.match(re);

--- a/test/compilers/argument-parsers-tests.ts
+++ b/test/compilers/argument-parsers-tests.ts
@@ -31,6 +31,7 @@ import {
     GCCParser,
     ICCParser,
     PascalParser,
+    RustParser,
     TableGenParser,
     VCParser,
 } from '../../lib/compilers/argument-parsers.js';
@@ -260,5 +261,40 @@ describe('TableGen argument parser', () => {
             {name: 'print-detailed-records: Print full details...', value: '--print-detailed-records'},
             {name: 'gen-x86-mnemonic-tables: Generate X86...', value: '--gen-x86-mnemonic-tables'},
         ]);
+    });
+});
+
+describe('Rust editions parser', () => {
+    it('Should extract new format editions', async () => {
+        // From Rust nightly-2025-05-05 output
+        const lines = [
+            'USAGE: rustc [OPTIONS]',
+            '',
+            'OPTIONS:',
+            '',
+            '        --edition <2015|2018|2021|2024|future>',
+            '                        Specify which edition of the compiler to use when',
+            '                        compiling code. The default is 2015 and the latest',
+            '                        stable edition is 2024.',
+        ];
+        const compiler = makeCompiler(lines.join('\n'));
+        const editions = await RustParser.getPossibleEditions(compiler);
+        expect(editions).toEqual(['2015', '2018', '2021', '2024', 'future']);
+    });
+
+    it('Should extract old format editions', async () => {
+        // From Rust 1.31 with verbose output
+        const lines = [
+            'USAGE: rustc [OPTIONS]',
+            '',
+            'OPTIONS:',
+            '',
+            '        --edition 2015|2018',
+            '                        Specify which edition of the compiler to use when',
+            '                        compiling code.',
+        ];
+        const compiler = makeCompiler(lines.join('\n'));
+        const editions = await RustParser.getPossibleEditions(compiler);
+        expect(editions).toEqual(['2015', '2018']);
     });
 });


### PR DESCRIPTION
* For `nightly` Rust (and 1.88+), the output format of `--help` was changed in https://github.com/rust-lang/rust/pull/140152.
  This PR changes the parser to parse the new format, so that edition overrides are selectable for `nightly` Rust. Note the `<>`:
  ```
          --edition <2015|2018|2021|2024|future>
                          Specify which edition of the compiler to use when
                          compiling code. The default is 2015 and the latest
                          stable edition is 2024.
  ```
* Rust <= 1.34 (and >= 1.31) support the 2018 edition, but the help message only includes `--edition` in verbose mode.