### PR TITLE
Fix system light theme timing widget visibility

### DIFF
--- a/static/widgets/timing-info-widget.ts
+++ b/static/widgets/timing-info-widget.ts
@@ -157,8 +157,7 @@ function displayData(data: Data) {
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
             fontColour = '#ffffff';
         }
-    }
-    else if (settings.theme !== 'default' && settings.theme !== 'pink') {
+    } else if (settings.theme !== 'default' && settings.theme !== 'pink') {
         fontColour = '#ffffff';
     }
 

--- a/static/widgets/timing-info-widget.ts
+++ b/static/widgets/timing-info-widget.ts
@@ -153,7 +153,12 @@ function displayData(data: Data) {
 
     const settings = Settings.getStoredSettings();
     let fontColour = defaults.color.toString();
-    if (settings.theme !== 'default') {
+    if (settings.theme === 'system') {
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            fontColour = '#ffffff';
+        }
+    }
+    else if (settings.theme !== 'default' && settings.theme !== 'pink') {
         fontColour = '#ffffff';
     }
 


### PR DESCRIPTION
Closes https://github.com/compiler-explorer/compiler-explorer/issues/7647

Fixed timing widget for light system:
<img width="534" alt="Captura de pantalla 2025-05-04 a las 23 32 11" src="https://github.com/user-attachments/assets/23ea9e4c-160c-40ab-a1f7-aa3976ba4a0b" />

Also made the pink theme use the default chart.js colours, as I think they have more contrast than white-on-pink
