### PR TITLE
Add Porffor JS compiler

### DIFF
--- a/etc/config/javascript.amazon.properties
+++ b/etc/config/javascript.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&v8
+compilers=&v8:&porffor
 defaultCompiler=v8trunk
 
 group.v8.compilers=v8trunk:v8113
@@ -24,3 +24,23 @@ postProcess=
 options=
 supportsExecute=false
 stubText=
+
+group.porffor.compilers=porffor-nightly:porffor-05724
+group.porffor.baseName=Porffor
+group.porffor.groupName=Porffor
+group.porffor.compilerType=porffor
+group.porffor.objdumper=/opt/compiler-explorer/clang-18.1.0/bin/llvm-objdump
+group.porffor.objdumperType=llvm
+group.porffor.supportsBinary=true
+group.porffor.supportsExecute=true
+group.porffor.interpreted=true
+group.porffor.isSemVer=true
+
+compiler.porffor-nightly.exe=/opt/compiler-explorer/porffor-nightly/porf
+compiler.porffor-nightly.isNightly=true
+compiler.porffor-nightly.name=Porffor Nightly
+compiler.porffor-nightly.semver=nightly
+
+compiler.porffor-05724.exe=/opt/compiler-explorer/porffor-0.57.24/porf
+compiler.porffor-05724.name=Porffor v0.57.24
+compiler.porffor-05724.semver=0.57.24

--- a/etc/config/javascript.defaults.properties
+++ b/etc/config/javascript.defaults.properties
@@ -1,6 +1,6 @@
 # Default settings for v8
 
-compilers=&v8
+compilers=&v8:&porffor
 defaultCompiler=v8trunk
 
 group.v8.compilers=v8trunk:v8113
@@ -22,3 +22,23 @@ postProcess=
 options=
 supportsExecute=false
 stubText=
+
+group.porffor.compilers=porffor-nightly:porffor-05724
+group.porffor.baseName=Porffor
+group.porffor.groupName=Porffor
+group.porffor.compilerType=porffor
+group.porffor.objdumper=llvm-objdump
+group.porffor.objdumperType=llvm
+group.porffor.supportsBinary=true
+group.porffor.supportsExecute=true
+group.porffor.interpreted=true
+group.porffor.isSemVer=true
+
+compiler.porffor-nightly.exe=porf
+compiler.porffor-nightly.isNightly=true
+compiler.porffor-nightly.name=Porffor Nightly
+compiler.porffor-nightly.semver=nightly
+
+compiler.porffor-05724.exe=porf
+compiler.porffor-05724.name=Porffor v0.57.24
+compiler.porffor-05724.semver=0.57.24

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -120,6 +120,7 @@ export {OptCompiler} from './opt.js';
 export {PPCICompiler} from './ppci.js';
 export {PascalWinCompiler} from './pascal-win.js';
 export {PonyCompiler} from './pony.js';
+export {PorfforCompiler} from './porffor.js';
 export {PtxAssembler} from './ptxas.js';
 export {PythonCompiler} from './python.js';
 export {PythranCompiler} from './pythran.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -604,6 +604,13 @@ export class PascalParser extends BaseParser {
     }
 }
 
+export class PorfforParser extends BaseParser {
+    static override async parse(compiler: BaseCompiler) {
+        await this.getOptions(compiler, '--help');
+        return compiler;
+    }
+}
+
 export class ICCParser extends GCCParser {
     static override async setCompilerSettingsFromOptions(compiler: BaseCompiler, options: Record<string, Argument>) {
         const keys = _.keys(options);

--- a/lib/compilers/porffor.ts
+++ b/lib/compilers/porffor.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'node:path';
+import _ from 'underscore';
+
+import {CacheKey, CompilationResult, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import {ExecutableExecutionOptions} from '../../types/execution/execution.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
+import {unwrap} from '../assert.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {PorfforParser} from './argument-parsers.js';
+
+export class PorfforCompiler extends BaseCompiler {
+    target = 'wasm';
+
+    static get key(): string {
+        return 'porffor';
+    }
+
+    constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(compilerInfo, env);
+
+        this.compiler.supportsIntel = true;
+    }
+
+    override async handleInterpreting(
+        key: CacheKey,
+        executeParameters: ExecutableExecutionOptions,
+    ): Promise<CompilationResult> {
+        // Prevent the interpreter (which uses node) from inheriting our NODE_OPTIONS.
+        executeParameters.env.NODE_OPTIONS = '';
+
+        return super.handleInterpreting(key, executeParameters);
+    }
+
+    override getDefaultExecOptions(): ExecutionOptionsWithEnv {
+        const opts = super.getDefaultExecOptions();
+        opts.env.NODE_OPTIONS = '';
+
+        return opts;
+    }
+
+    getTargetFromOptions(options: string[]): string {
+        return options.find(o => o.startsWith('--target='))?.substring(9) ?? 'wasm';
+    }
+
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
+        const options = unwrap(userOptions);
+
+        this.target = this.getTargetFromOptions(options);
+        if (this.target === 'wasm' || this.target == 'native') filters.binary = true;
+
+        return ['-d', `-o=${this.filename(outputFilename)}`];
+    }
+
+    getOutputExtension(target: string): string {
+        switch (target) {
+            case 'c': {
+                return '.c';
+            }
+            case 'native': {
+                return '';
+            }
+            default: {
+                return '.wasm';
+            }
+        }
+    }
+
+    override getOutputFilename(dirPath: string, outputFilebase: string, key?: CacheKey): string {
+        return path.join(dirPath, `out${this.getOutputExtension(this.target)}`);
+    }
+
+    override isCfgCompiler(): boolean {
+        return true;
+    }
+
+    override getArgumentParserClass() {
+        return PorfforParser;
+    }
+
+    override getSharedLibraryPathsAsArguments(libraries: SelectedLibraryVersion[], libDownloadPath?: string): string[] {
+        return [];
+    }
+
+    override getSharedLibraryLinks(libraries: SelectedLibraryVersion[]): string[] {
+        return [];
+    }
+}


### PR DESCRIPTION
[Porffor](https://porffor.dev/) is a work in progress AOT JS compiler targeting WASM and native architectures.

Note: The example/default JS contains V8 intrinsics which aren't supported in Porffor, leading to an immediate compile error when switching the compiler to Porffor, until the user removes them. I'm unsure whether I should modify it, so deferring on that.