### PR TITLE
Added Intel OneAPI 2025.1.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1398,7 +1398,7 @@ compiler.icc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-12.2.0/bin/g++
 
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icx202410:icx202420:icx202421:icx202500:icx202501:icx202503:icx202504:icx202510:icxlatest
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icx202410:icx202420:icx202421:icx202500:icx202501:icx202503:icx202504:icx202510:icx202511:icxlatest
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -1531,10 +1531,16 @@ compiler.icx202510.libPath=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compile
 compiler.icx202510.semver=2025.1.0
 compiler.icx202510.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
-compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/bin/icpx
-compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/lib
-compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.0.573/tbb/latest/lib
-compiler.icxlatest.semver=2025.1.0
+compiler.icx202511.exe=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/bin/icpx
+compiler.icx202511.ldPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib
+compiler.icx202511.libPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/tbb/latest/lib
+compiler.icx202511.semver=2025.1.1
+compiler.icx202511.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
+
+compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/bin/icpx
+compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/tbb/latest/lib
+compiler.icxlatest.semver=2025.1.1
 compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 ################################


### PR DESCRIPTION
Adds latest Intel OneAPI C++ compiler version: 2025.1.1. Also changes the latest version to point to it.

A PR on `compiler-explorer/infra` will soon follow.
Edit: [here](https://github.com/compiler-explorer/infra/pull/1606) it is.