### PR TITLE
Arm: add missing objdumper settings and update to GNU objdump 15.1.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -791,7 +791,7 @@ group.armclang32.compilerType=clang
 group.armclang32.supportsExecute=false
 group.armclang32.instructionSet=arm32
 group.armclang32.baseName=armv7-a clang
-group.armclang32.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+group.armclang32.objdumper=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.armclang32.licenseName=LLVM Apache 2
 group.armclang32.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.armclang32.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
@@ -877,7 +877,7 @@ group.armclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICE
 group.armclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armclang64.compilerCategories=clang
 group.armclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
-group.armclang64.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
+group.armclang64.objdumper=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 
 compiler.armv8-clang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
 compiler.armv8-clang2010.semver=20.1.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -458,6 +458,7 @@ group.armcclang32.licenseLink=https://github.com/llvm/llvm-project/blob/main/LIC
 group.armcclang32.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang32.compilerCategories=clang
 group.armcclang32.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+group.armcclang32.objdumper=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 
 group.armcclang64.groupName=Arm 64-bit clang
 group.armcclang64.compilers=armv8-cclang900:armv8-cclang901:armv8-cclang1000:armv8-cclang1001:armv8-cclang1100:armv8-cclang1101:armv8-cclang1200:armv8-cclang1201:armv8-cclang1300:armv8-cclang1301:armv8-cclang1400:armv8-cclang1500:armv8-cclang1600:armv8-cclang1701:armv8-cclang1810:armv8-cclang1910:armv8-cclang2010:armv8-cclang-trunk:armv8-full-cclang-trunk
@@ -470,6 +471,7 @@ group.armcclang64.licenseLink=https://github.com/llvm/llvm-project/blob/main/LIC
 group.armcclang64.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.armcclang64.compilerCategories=clang
 group.armcclang64.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
+group.armcclang64.objdumper=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 
 compiler.armv7-cclang2010.name=armv7-a clang 20.1.0
 compiler.armv7-cclang2010.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang
@@ -699,7 +701,6 @@ compiler.armv8-cclang900.alias=armv8-cclang-9
 
 compiler.armv7-cclang-trunk.name=armv7-a clang (trunk)
 compiler.armv7-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv7-cclang-trunk.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armv7-cclang-trunk.semver=(trunk)
 compiler.armv7-cclang-trunk.isNightly=true
 # Arm v7-a with Neon and VFPv3
@@ -707,7 +708,6 @@ compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=
 
 compiler.armv8-cclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv8-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-cclang-trunk.semver=(trunk)
 compiler.armv8-cclang-trunk.isNightly=true
 # Arm v8-a
@@ -715,7 +715,6 @@ compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/o
 
 compiler.armv8-full-cclang-trunk.name=armv8-a clang (all architectural features, trunk)
 compiler.armv8-full-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
-compiler.armv8-full-cclang-trunk.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 compiler.armv8-full-cclang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features


### PR DESCRIPTION
Fixes #7635

Prior to this change the C++ compilers set objdumper on the Armv7/v8 category as a whole, pointing to some objdump from a gcc cross compiler. This works because that tool expects Arm objects, and you could use the "compile to binary object" option successfully.

For C, we only set objdumper for specific compilers. Those being the trunk and "all features" versions. So when "compile to binary object" was enabled it worked for trunk but never for any version before that.

The other versions were using the settings file's global objdumper which pointed to an objdump that only expects x86 object files.

/opt/compiler-explorer/gcc-14.2.0/bin/objdump: can't disassemble for architecture UNKNOWN!
/tmp/compiler-explorer-compiler4xFvjY/output.s:     file format elf64-little

To fix this I have copied the way that the C++ settings work, into the C settings. So all Armv7 and Armv8 clangs get their objdumper setting from the category of compilers, rather than setting it for each compiler.

While I'm doing this, we might as well update to the objdump from GCC 15.1.0, so that we can disassemble new instructions.

The worst that can happen is some unallocated encoding at the time of clang X.Y is now allocated, but compilers should be using the specific "udf" (always undefined) encodings or marking these values as data anyway. So I don't see the harm in always using a new objdump everywhere.