### PR TITLE
Fix: Compiler License button not working

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3097,7 +3097,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             this.compile(true);
         });
 
-        this.compilerLicenseButton.on('click', () => {
+        BootstrapUtils.setElementEventHandler(this.compilerLicenseButton, 'click', () => {
             const title = this.compiler ? 'License for ' + this.compiler.name : 'No compiler selected';
             this.alertSystem.alert(title, this.generateLicenseInfo());
         });


### PR DESCRIPTION
## Summary
* Fixes #7659 where the Compiler License button wasn't working after Bootstrap 5 migration
* Updates the event handler to use BootstrapUtils.setElementEventHandler instead of jQuery's on() method

## Test plan
1. Visit Compiler Explorer
2. Select any compiler
3. Click the "Compiler License" button at the bottom of the compiler pane
4. Verify that the license information appears in a modal

🤖 Generated with [Claude Code](https://claude.ai/code)