### PR TITLE
Add kotlinx.coroutines to Android Kotlin

### DIFF
--- a/etc/config/android-kotlin.amazon.properties
+++ b/etc/config/android-kotlin.amazon.properties
@@ -358,7 +358,7 @@ compiler.android-kotlinc-1400.runtime=/opt/compiler-explorer/jdk-15.0.2/bin/java
 
 defaultCompiler=kotlin-dex2oat-latest
 
-libs=android-api-stubs:r8-keepanno:androidx-annotation
+libs=android-api-stubs:r8-keepanno:androidx-annotation:kotlinx-coroutines-core-jvm
 
 libs.android-api-stubs.name=Android API stubs
 libs.android-api-stubs.versions=11662386
@@ -436,5 +436,22 @@ libs.androidx-annotation.versions.190.path=/opt/compiler-explorer/androidx-annot
 libs.androidx-annotation.versions.191.version=1.9.1
 libs.androidx-annotation.versions.191.path=/opt/compiler-explorer/androidx-annotation-1.9.1/annotation-jvm.jar
 
+libs.kotlinx-coroutines-core-jvm.name=kotlinx.coroutines
+libs.kotlinx-coroutines-core-jvm.versions=1102:190:181:173:164
+
+libs.kotlinx-coroutines-core-jvm.versions.1102.version=1.10.2
+libs.kotlinx-coroutines-core-jvm.versions.1102.path=/opt/compiler-explorer/kotlinx-coroutines-core-jvm-1.10.2/kotlinx-coroutines-core-jvm.jar
+
+libs.kotlinx-coroutines-core-jvm.versions.190.version=1.9.0
+libs.kotlinx-coroutines-core-jvm.versions.190.path=/opt/compiler-explorer/kotlinx-coroutines-core-jvm-1.9.0/kotlinx-coroutines-core-jvm.jar
+
+libs.kotlinx-coroutines-core-jvm.versions.181.version=1.8.1
+libs.kotlinx-coroutines-core-jvm.versions.181.path=/opt/compiler-explorer/kotlinx-coroutines-core-jvm-1.8.1/kotlinx-coroutines-core-jvm.jar
+
+libs.kotlinx-coroutines-core-jvm.versions.173.version=1.7.3
+libs.kotlinx-coroutines-core-jvm.versions.173.path=/opt/compiler-explorer/kotlinx-coroutines-core-jvm-1.7.3/kotlinx-coroutines-core-jvm.jar
+
+libs.kotlinx-coroutines-core-jvm.versions.164.version=1.6.4
+libs.kotlinx-coroutines-core-jvm.versions.164.path=/opt/compiler-explorer/kotlinx-coroutines-core-jvm-1.6.4/kotlinx-coroutines-core-jvm.jar
 
 defaultLibs=android-api-stubs.11662386:r8-keepanno.latest:androidx-annotation.versions.191


### PR DESCRIPTION
This covers library versions 1.10.2, 1.9.0, 1.8.1, 1.7.3, and 1.6.4, which are the latest releases for each major version. dex2oat uses Kotlin 1.9.20 under the hood, so 1.9.0 is the latest kotlinx.coroutines release supported. (1.10.2 can still be used for kotlinc).

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
