### PR TITLE
Treat `opt` output as LLVM IR

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3150,7 +3150,11 @@ export class BaseCompiler {
     }
 
     async processAsm(result, filters: ParseFiltersAndOutputOptions, options: string[]) {
-        if ((options && isOutputLikelyLllvmIr(options)) || this.llvmIr.isLlvmIr(result.asm)) {
+        if (
+            result.languageId === 'llvm-ir' ||
+            (options && isOutputLikelyLllvmIr(options)) ||
+            this.llvmIr.isLlvmIr(result.asm)
+        ) {
             return await this.llvmIr.processFromFilters(result.asm, filters);
         }
 


### PR DESCRIPTION
Resolves #7669.

`processAsm` didn’t recognise that `opt` generates LLVM IR, so it invoked the generic `AsmParser` instead.