### PR TITLE
Update SPIR-V and Slang version

### DIFF
--- a/etc/config/spirv.amazon.properties
+++ b/etc/config/spirv.amazon.properties
@@ -17,12 +17,12 @@ group.spirv-val.compilerType=spirv-tools
 
 group.spirv-cross.groupName=Translate
 group.spirv-cross.baseName=SPIRV-Cross
-group.spirv-cross.compilers=spirv-cross-sdk-296:spirv-cross-sdk-304:spirv-cross-sdk-309
+group.spirv-cross.compilers=spirv-cross-sdk-296:spirv-cross-sdk-304:spirv-cross-sdk-309:spirv-cross-sdk-313
 group.spirv-cross.compilerType=spirv-tools
 
 group.spirv-reflect.groupName=Reflection
 group.spirv-reflect.baseName=SPIRV-Reflect
-group.spirv-reflect.compilers=spirv-reflect-sdk-304:spirv-reflect-sdk-309
+group.spirv-reflect.compilers=spirv-reflect-sdk-304:spirv-reflect-sdk-309:spirv-reflect-sdk-313
 group.spirv-reflect.compilerType=spirv-tools
 
 assemblerPath=/opt/compiler-explorer/SPIRV-Tools-master/build/tools/spirv-as
@@ -45,3 +45,8 @@ compiler.spirv-cross-sdk-309.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.309.0/x8
 compiler.spirv-cross-sdk-309.name=spirv-cross (sdk-309)
 compiler.spirv-reflect-sdk-309.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.309.0/x86_64/bin/spirv-reflect
 compiler.spirv-reflect-sdk-309.name=spirv-reflect (sdk-309)
+
+compiler.spirv-cross-sdk-313.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.313.0/x86_64/bin/spirv-cross
+compiler.spirv-cross-sdk-313.name=spirv-cross (sdk-313)
+compiler.spirv-reflect-sdk-313.exe=/opt/compiler-explorer/vulkan-sdk/v1.4.313.0/x86_64/bin/spirv-reflect
+compiler.spirv-reflect-sdk-313.name=spirv-reflect (sdk-313)


### PR DESCRIPTION
Update the online version for SPIR-V and Slang compilers for the Vulkan 309 SDK to correspond with https://github.com/compiler-explorer/infra/pull/1611