### PR TITLE
Show source in stack usage view

### DIFF
--- a/static/panes/stack-usage-view.ts
+++ b/static/panes/stack-usage-view.ts
@@ -89,7 +89,7 @@ export class StackUsage extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
         if (this.compilerInfo.compilerId !== id || !this.isCompilerSupported) return;
         this.editor.setValue(unwrap(result.source));
         if (result.stackUsageOutput) {
-            this.showStackUsageResults(result.stackUsageOutput);
+            this.showStackUsageResults(result.stackUsageOutput, result.source);
         }
 
         // TODO: This is inelegant again. Previously took advantage of fourth argument for the compileResult event.

--- a/static/panes/stack-usage-view.ts
+++ b/static/panes/stack-usage-view.ts
@@ -87,9 +87,10 @@ export class StackUsage extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
 
     override onCompileResult(id: number, compiler: CompilerInfo, result: CompilationResult) {
         if (this.compilerInfo.compilerId !== id || !this.isCompilerSupported) return;
-        this.editor.setValue(unwrap(result.source));
+        const source = unwrap(result.source);
+        this.editor.setValue(source);
         if (result.stackUsageOutput) {
-            this.showStackUsageResults(result.stackUsageOutput, result.source);
+            this.showStackUsageResults(result.stackUsageOutput, source);
         }
 
         // TODO: This is inelegant again. Previously took advantage of fourth argument for the compileResult event.
@@ -121,7 +122,7 @@ export class StackUsage extends MonacoPane<monaco.editor.IStandaloneCodeEditor, 
         return '<Unimplemented>';
     }
 
-    showStackUsageResults(suEntries: suCodeEntry[], source?: string) {
+    showStackUsageResults(suEntries: suCodeEntry[], source: string) {
         const splitLines = (text: string): string[] => {
             if (!text) return [];
             const result = text.split(/\r?\n/);


### PR DESCRIPTION
The stack usage view does not show the source code, only the stack usage lines:

![stack_usage_view_before](https://github.com/user-attachments/assets/c4eb70ab-9fce-4d89-9bde-1b3469666631)

With this PR, the code is shown:

![stack_usage_view_after](https://github.com/user-attachments/assets/20e9efee-0567-41e0-8b35-493f7989a523)
