### PR TITLE
Set `ldPath` for c2rust to find the correct clang

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -3766,6 +3766,9 @@ group.c2rust.supportsBinaryObject=false
 
 compiler.c2rust-master.exe=/opt/compiler-explorer/c2rust-master/c2rust
 compiler.c2rust-master.name=C2Rust (master)
+# needs to be kept in sync with the clang version set in
+# https://github.com/compiler-explorer/misc-builder/blob/main/Dockerfile.c2rust
+compiler.c2rust-master.ldPath=/opt/compiler-explorer/clang-19.1.0/lib
 
 #################################
 #################################


### PR DESCRIPTION
Required for https://github.com/compiler-explorer/misc-builder/pull/110.