### PR TITLE
Assembly: Add new GNU AS versions for Arm and AArch64

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -50,7 +50,7 @@ compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)
 compiler.gnuassnapshot.isNightly=true
 
-group.gnuasarm.compilers=gnuasarmhfg54:gnuasarmg464:gnuasarmg630:gnuasarmg820:gnuasarm930:gnuasarm1020
+group.gnuasarm.compilers=gnuasarmhfg54:gnuasarmg464:gnuasarmg630:gnuasarmg820:gnuasarm930:gnuasarm1020:gnuasarm1320:gnuasarm1510
 group.gnuasarm.versionFlag=--version
 group.gnuasarm.options=-g
 group.gnuasarm.isSemVer=true
@@ -77,9 +77,15 @@ compiler.gnuasarm930.semver=ARM binutils 2.33.1
 compiler.gnuasarm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
 compiler.gnuasarm1020.name=ARM gcc 10.2 (linux)
 compiler.gnuasarm1020.semver=ARM binutils 2.35.1
+compiler.gnuasarm1320.exe=/opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
+compiler.gnuasarm1320.name=ARM gcc 13.2 (linux)
+compiler.gnuasarm1320.semver=ARM binutils 2.38
+compiler.gnuasarm1510.exe=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
+compiler.gnuasarm1510.name=ARM gcc 15.1 (linux)
+compiler.gnuasarm1510.semver=ARM binutils 2.44
 
 
-group.gnuasarm64.compilers=gnuasarm64g630:gnuasarm64g820:gnuasarm64g930:gnuasarm64g1020:gnuasarm64g1320
+group.gnuasarm64.compilers=gnuasarm64g630:gnuasarm64g820:gnuasarm64g930:gnuasarm64g1020:gnuasarm64g1320:gnuasarm64g1510
 group.gnuasarm64.versionFlag=--version
 group.gnuasarm64.options=-g
 group.gnuasarm64.isSemVer=true
@@ -103,6 +109,9 @@ compiler.gnuasarm64g1020.semver=2.35.1
 compiler.gnuasarm64g1320.exe=/opt/compiler-explorer/arm64/gcc-13.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
 compiler.gnuasarm64g1320.name=AArch64 binutils 2.38
 compiler.gnuasarm64g1320.semver=2.38
+compiler.gnuasarm64g1510.exe=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
+compiler.gnuasarm64g1510.name=AArch64 binutils 2.44
+compiler.gnuasarm64g1510.semver=2.44
 
 # GNU as for RISC-V
 group.gnuasriscv.compilers=&gnuasriscv64:&gnuasriscv32


### PR DESCRIPTION
Follow up to https://github.com/compiler-explorer/compiler-explorer/pull/7540.

Fixes #7528

Last time I tried this, the 14.2.0 GCC builds were still using 2.38 for Arm and AArch64, now there are 15.1.0 builds and those both use 2.44.

Which I have confirmed locally:
$ /opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as --version
GNU assembler (GNU Binutils) 2.44

$ /opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as --version
GNU assembler (GNU Binutils) 2.44

While I'm here, I added 2.38 to Arm since it was missing. From the GCC 13.2.0 build:
$ /opt/compiler-explorer/arm/gcc-13.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as --version
GNU assembler (GNU Binutils) 2.38