### PR TITLE
Add Game Boy emulator support using WasmBoy

### DIFF
--- a/docs/SupportedEmulators.md
+++ b/docs/SupportedEmulators.md
@@ -13,6 +13,7 @@ These are using Javascript and/or using external websites to facilitate emulatio
   with Z88DK (target `+sms`)
 - [Viciious](https://github.com/compiler-explorer/viciious) (https://static.ce-cdn.net/viciious/viciious.html) - for
   `.prg` files built with LLVM MOS C64 or CC65 (`--target c64`)
+- [WasmBoy](https://github.com/torch2424/wasmboy) (https://static.ce-cdn.net/wasmboy-ceweb/index.html) - for `.gb` ROM files built with z88dk (target `+gb`) [Note: Requires hosting wasmboy-ceweb fork]
 
 ## Examples
 

--- a/docs/SupportedEmulators.md
+++ b/docs/SupportedEmulators.md
@@ -13,7 +13,7 @@ These are using Javascript and/or using external websites to facilitate emulatio
   with Z88DK (target `+sms`)
 - [Viciious](https://github.com/compiler-explorer/viciious) (https://static.ce-cdn.net/viciious/viciious.html) - for
   `.prg` files built with LLVM MOS C64 or CC65 (`--target c64`)
-- [WasmBoy](https://github.com/torch2424/wasmboy) (https://static.ce-cdn.net/wasmboy-ceweb/index.html) - for `.gb` ROM files built with z88dk (target `+gb`) [Note: Requires hosting wasmboy-ceweb fork]
+- [WasmBoy](https://github.com/compiler-explorer/wasmboy) (https://static.ce-cdn.net/wasmboy/index.html) - for `.gb` ROM files built with z88dk (target `+gb`)
 
 ## Examples
 

--- a/lib/compilers/z88dk.ts
+++ b/lib/compilers/z88dk.ts
@@ -129,6 +129,10 @@ export class z88dkCompiler extends BaseCompiler {
         return `${this.outputFilebase}.sms`;
     }
 
+    getGbfilename() {
+        return `${this.outputFilebase}.gb`;
+    }
+
     override async objdump(
         outputFilename: string,
         result: any,
@@ -188,6 +192,11 @@ export class z88dkCompiler extends BaseCompiler {
             const smsFilepath = path.join(result.dirPath, this.getSmsfilename());
             if (await utils.fileExists(smsFilepath)) {
                 await addArtifactToResult(result, smsFilepath, ArtifactType.smsrom);
+            }
+
+            const gbFilepath = path.join(result.dirPath, this.getGbfilename());
+            if (await utils.fileExists(gbFilepath)) {
+                await addArtifactToResult(result, gbFilepath, ArtifactType.gbrom);
             }
         }
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1809,9 +1809,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             '?' +
                             tmstr +
                             '#customFilename=' +
-                            artifact.name +
+                            encodeURIComponent(artifact.name) +
                             '&b64data=' +
-                            artifact.content;
+                            encodeURIComponent(artifact.content);
                         window.open(speedscope_url);
                     });
                 },
@@ -1878,7 +1878,11 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                         if ('contentWindow' in miracleMenuFrame) {
                             const emuwindow = unwrap(miracleMenuFrame.contentWindow);
                             const tmstr = Date.now();
-                            emuwindow.location = 'https://xania.org/miracle/miracle.html?' + tmstr + '#b64sms=' + image;
+                            emuwindow.location =
+                                'https://xania.org/miracle/miracle.html?' +
+                                tmstr +
+                                '#b64sms=' +
+                                encodeURIComponent(image);
                         }
                     });
                 },
@@ -1907,7 +1911,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             const emuwindow = unwrap(speccyemuframe.contentWindow);
                             const tmstr = Date.now();
                             emuwindow.location =
-                                'https://static.ce-cdn.net/jsspeccy/index.html?' + tmstr + '#b64tape=' + image;
+                                'https://static.ce-cdn.net/jsspeccy/index.html?' +
+                                tmstr +
+                                '#b64tape=' +
+                                encodeURIComponent(image);
                         }
                     });
                 },
@@ -1934,7 +1941,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             const emuwindow = unwrap(jsbeebemuframe.contentWindow);
                             const tmstr = Date.now();
                             emuwindow.location =
-                                'https://bbc.godbolt.org/?' + tmstr + '#embed&autoboot&disc1=b64data:' + bbcdiskimage;
+                                'https://bbc.godbolt.org/?' +
+                                tmstr +
+                                '#embed&autoboot&disc1=b64data:' +
+                                encodeURIComponent(bbcdiskimage);
                         }
                     });
                 },
@@ -1961,7 +1971,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             const emuwindow = unwrap(jsnesemuframe.contentWindow);
                             const tmstr = Date.now();
                             emuwindow.location =
-                                'https://static.ce-cdn.net/jsnes-ceweb/index.html?' + tmstr + '#b64nes=' + nesrom;
+                                'https://static.ce-cdn.net/jsnes-ceweb/index.html?' +
+                                tmstr +
+                                '#b64nes=' +
+                                encodeURIComponent(nesrom);
                         }
                     });
                 },
@@ -1983,9 +1996,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             'https://static.ce-cdn.net/viciious/viciious.html?' +
                             tmstr +
                             '#filename=' +
-                            prg.title +
+                            encodeURIComponent(prg.title) +
                             '&b64c64=' +
-                            prg.content;
+                            encodeURIComponent(prg.content);
 
                         window.open(url, '_blank');
                     });
@@ -2011,9 +2024,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             'https://static.ce-cdn.net/wasmboy/index.html?' +
                             tmstr +
                             '#rom-name=' +
-                            prg.title +
+                            encodeURIComponent(prg.title) +
                             '&rom-data=' +
-                            prg.content;
+                            encodeURIComponent(prg.content);
                         window.open(url, '_blank');
                     });
 
@@ -2029,9 +2042,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                                 'https://static.ce-cdn.net/wasmboy/iframe/index.html?' +
                                 tmstr +
                                 '#rom-name=' +
-                                prg.title +
+                                encodeURIComponent(prg.title) +
                                 '&rom-data=' +
-                                prg.content;
+                                encodeURIComponent(prg.content);
                             emuwindow.location = url;
                         }
                     });

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1783,7 +1783,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 } else if (artifact.type === ArtifactType.heaptracktxt) {
                     this.offerViewInSpeedscope(artifact);
                 } else if (artifact.type === ArtifactType.gbrom) {
-                    this.emulateGameBoyROM(artifact.content);
+                    this.emulateGameBoyROM(artifact);
                 }
             }
         }
@@ -1994,17 +1994,30 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         );
     }
 
-    emulateGameBoyROM(gbrom: string): void {
+    emulateGameBoyROM(prg: Artifact): void {
         const dialog = $('#gbemu');
 
         this.alertSystem.notify(
-            'Click <a target="_blank" id="emulink" style="cursor:pointer;" click="javascript:;">here</a> to emulate',
+            'Click <a target="_blank" id="emulink" style="cursor:pointer;" click="javascript:;">here</a> to emulate with a debugger, ' +
+                'or <a target="_blank" id="emulink-play" style="cursor:pointer;" click="javascript:;">here</a> to emulate just to play.',
             {
                 group: 'emulation',
                 collapseSimilar: true,
                 dismissTime: 10000,
                 onBeforeShow: elem => {
                     elem.find('#emulink').on('click', () => {
+                        const tmstr = Date.now();
+                        const url =
+                            'https://static.ce-cdn.net/wasmboy/index.html?' +
+                            tmstr +
+                            '#rom-name=' +
+                            prg.title +
+                            '&rom-data=' +
+                            prg.content;
+                        window.open(url, '_blank');
+                    });
+
+                    elem.find('#emulink-play').on('click', () => {
                         BootstrapUtils.showModal(dialog);
 
                         const gbemuframe = dialog.find('#gbemuframe')[0];
@@ -2012,10 +2025,14 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                         if ('contentWindow' in gbemuframe) {
                             const emuwindow = unwrap(gbemuframe.contentWindow);
                             const tmstr = Date.now();
-                            // TODO: Update URL once wasmboy-ceweb is hosted on CE CDN
-                            // For now, this follows the same pattern as other emulators
-                            emuwindow.location =
-                                'https://static.ce-cdn.net/wasmboy-ceweb/index.html?' + tmstr + '#b64gb=' + gbrom;
+                            const url =
+                                'https://static.ce-cdn.net/wasmboy/iframe/index.html?' +
+                                tmstr +
+                                '#rom-name=' +
+                                prg.title +
+                                '&rom-data=' +
+                                prg.content;
+                            emuwindow.location = url;
                         }
                     });
                 },

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1782,6 +1782,8 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                     this.emulateC64Prg(artifact);
                 } else if (artifact.type === ArtifactType.heaptracktxt) {
                     this.offerViewInSpeedscope(artifact);
+                } else if (artifact.type === ArtifactType.gbrom) {
+                    this.emulateGameBoyROM(artifact.content);
                 }
             }
         }
@@ -1986,6 +1988,35 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                             prg.content;
 
                         window.open(url, '_blank');
+                    });
+                },
+            },
+        );
+    }
+
+    emulateGameBoyROM(gbrom: string): void {
+        const dialog = $('#gbemu');
+
+        this.alertSystem.notify(
+            'Click <a target="_blank" id="emulink" style="cursor:pointer;" click="javascript:;">here</a> to emulate',
+            {
+                group: 'emulation',
+                collapseSimilar: true,
+                dismissTime: 10000,
+                onBeforeShow: elem => {
+                    elem.find('#emulink').on('click', () => {
+                        BootstrapUtils.showModal(dialog);
+
+                        const gbemuframe = dialog.find('#gbemuframe')[0];
+                        assert(gbemuframe instanceof HTMLIFrameElement);
+                        if ('contentWindow' in gbemuframe) {
+                            const emuwindow = unwrap(gbemuframe.contentWindow);
+                            const tmstr = Date.now();
+                            // TODO: Update URL once wasmboy-ceweb is hosted on CE CDN
+                            // For now, this follows the same pattern as other emulators
+                            emuwindow.location =
+                                'https://static.ce-cdn.net/wasmboy-ceweb/index.html?' + tmstr + '#b64gb=' + gbrom;
+                        }
                     });
                 },
             },

--- a/types/tool.interfaces.ts
+++ b/types/tool.interfaces.ts
@@ -59,6 +59,7 @@ export enum ArtifactType {
     timetrace = 'timetracejson',
     c64prg = 'c64prg',
     heaptracktxt = 'heaptracktxt',
+    gbrom = 'gbrom',
 }
 
 export type Artifact = {

--- a/views/popups/_all.pug
+++ b/views/popups/_all.pug
@@ -36,3 +36,5 @@ include jsspeccyemu
 include miracleemu
 
 include jsnesemu
+
+include gbemu

--- a/views/popups/gbemu.pug
+++ b/views/popups/gbemu.pug
@@ -1,0 +1,5 @@
+#gbemu.modal.fade.gl_keep(tabindex="-1" role="dialog")
+  .modal-dialog.modal-xl
+    .modal-content
+      .modal-body
+        iframe#gbemuframe(src="about:blank" width="670" height="560")


### PR DESCRIPTION
## Summary
- Adds support for Game Boy ROM emulation using WasmBoy
- Enables z88dk compiler to produce Game Boy ROM artifacts that can be emulated in the browser

## Changes
- Added `ArtifactType.gbrom` to handle Game Boy ROM files
- Added `emulateGameBoyROM()` method in compiler pane to launch the emulator
- Updated z88dk compiler to detect and offer `.gb` ROM files for emulation
- Created modal dialog for the Game Boy emulator iframe
- Updated documentation to include WasmBoy in supported emulators

## Implementation Notes
This follows the same pattern as other emulators (JSNES, JSBeeb, JSSpeccy, etc.) where:
1. Compilers detect specific output files and mark them as artifacts
2. The compiler pane shows a notification to launch the emulator
3. The emulator runs in an iframe within a modal dialog
4. ROM data is passed as base64 in the URL fragment

## TODO
- [x] Create `wasmboy-ceweb` fork that accepts base64 ROM data via URL fragment (similar to `jsnes-ceweb`)
- [x] Host the fork at `https://static.ce-cdn.net/wasmboy-ceweb/index.html`
- [x] Test with z88dk Game Boy compilation (e.g., `zcc +gb -create-app example.c`)

## Testing
Once the wasmboy-ceweb fork is ready:
1. Write a simple Game Boy C program
2. Compile with z88dk using `+gb` target
3. Verify the "Click here to emulate" notification appears
4. Confirm the emulator launches with the compiled ROM

🤖 Generated with [Claude Code](https://claude.ai/code)