### PR TITLE
Add Rust crate ahash v0.8.12

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -307,7 +307,13 @@ compiler.mrustc-master.isNightly=true
 #################################
 # Installed libs, generated from ce_install generate-rust-crates
 # Don't modify directly
-libs=aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:bumpalo:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
+libs=ahash:aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:bumpalo:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
+
+libs.ahash.name=ahash
+libs.ahash.url=https://crates.io/crates/ahash
+libs.ahash.versions=0812
+libs.ahash.versions.0812.version=0.8.12
+libs.ahash.versions.0812.path=libahash.rlib
 
 libs.aho-corasick.name=aho-corasick
 libs.aho-corasick.url=https://crates.io/crates/aho-corasick


### PR DESCRIPTION
This PR adds the Rust crate **ahash** version 0.8.12 to Compiler Explorer.

Related PR: https://github.com/compiler-explorer/infra/pull/1633