### PR TITLE
Fix Vitest timeout deprecation warnings

### DIFF
--- a/test/filter-tests.ts
+++ b/test/filter-tests.ts
@@ -61,18 +61,13 @@ const stringifyKeysInOrder = (data: any): string => {
 
 function testFilter(filename: string, suffix: string, filters: ParseFiltersAndOutputOptions) {
     const testName = path.basename(filename + suffix);
-    it(
-        testName,
-        // Bump the timeout a bit so that we don't fail for slow cases
-        {timeout: 10000},
-        async () => {
-            const result = processAsm(filename, filters);
-            delete result.parsingTime;
-            delete result.filteredCount;
-            // TODO normalize line endings?
-            await expect(stringifyKeysInOrder(result)).toMatchFileSnapshot(path.join(casesRoot, testName + '.json'));
-        },
-    );
+    it(testName, async () => {
+        const result = processAsm(filename, filters);
+        delete result.parsingTime;
+        delete result.filteredCount;
+        // TODO normalize line endings?
+        await expect(stringifyKeysInOrder(result)).toMatchFileSnapshot(path.join(casesRoot, testName + '.json'));
+    }, 10000); // Bump the timeout a bit so that we don't fail for slow cases
 }
 
 describe('Filter test cases', () => {

--- a/test/packager-tests.ts
+++ b/test/packager-tests.ts
@@ -36,40 +36,32 @@ async function writeTestFile(filepath) {
 }
 
 describe('Packager', () => {
-    it(
-        'should be able to package 1 file',
-        async () => {
-            const pack = new Packager();
+    it('should be able to package 1 file', async () => {
+        const pack = new Packager();
 
-            const dirPath = newTempDir();
-            await writeTestFile(path.join(dirPath, 'hello.txt'));
+        const dirPath = newTempDir();
+        await writeTestFile(path.join(dirPath, 'hello.txt'));
 
-            const targzPath = path.join(dirPath, 'package.tgz');
-            await pack.package(dirPath, targzPath);
+        const targzPath = path.join(dirPath, 'package.tgz');
+        await pack.package(dirPath, targzPath);
 
-            await expect(fs.stat(targzPath)).resolves.toBeDefined();
-        },
-        {timeout: 5000},
-    );
+        await expect(fs.stat(targzPath)).resolves.toBeDefined();
+    }, 5000);
 
-    it(
-        'should be able to unpack',
-        async () => {
-            const pack = new Packager();
+    it('should be able to unpack', async () => {
+        const pack = new Packager();
 
-            const dirPath = newTempDir();
-            await writeTestFile(path.join(dirPath, 'hello.txt'));
+        const dirPath = newTempDir();
+        await writeTestFile(path.join(dirPath, 'hello.txt'));
 
-            const targzPath = path.join(dirPath, 'package.tgz');
-            await pack.package(dirPath, targzPath);
+        const targzPath = path.join(dirPath, 'package.tgz');
+        await pack.package(dirPath, targzPath);
 
-            const unpackPath = newTempDir();
-            const pack2 = new Packager();
-            await pack2.unpack(targzPath, unpackPath);
+        const unpackPath = newTempDir();
+        const pack2 = new Packager();
+        await pack2.unpack(targzPath, unpackPath);
 
-            const unpackedFilepath = path.join(unpackPath, 'hello.txt');
-            await expect(fs.stat(unpackedFilepath)).resolves.toBeDefined;
-        },
-        {timeout: 5000},
-    );
+        const unpackedFilepath = path.join(unpackPath, 'hello.txt');
+        await expect(fs.stat(unpackedFilepath)).resolves.toBeDefined;
+    }, 5000);
 });


### PR DESCRIPTION
## Summary
This PR updates test files to use the new Vitest timeout syntax, resolving deprecation warnings.

## Changes
- Updated `test/packager-tests.ts` to pass timeout as a number instead of `{timeout: 5000}`
- Updated `test/filter-tests.ts` to pass timeout as a number instead of `{timeout: 10000}`

## Details
Vitest now expects timeouts to be passed directly as a number as the third parameter to `it()`, rather than as an object. This change updates all occurrences to use the new syntax.

## Test plan
- [x] All existing tests continue to pass
- [x] No deprecation warnings are shown when running tests
- [x] Linter and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)