### PR TITLE
Refactor startup to catch exceptions where they're thrown. 

### DIFF
--- a/static/main.ts
+++ b/static/main.ts
@@ -613,11 +613,16 @@ function start() {
 
     let layout: GoldenLayout;
     let hub: Hub;
+    let themer: Themer;
+    let settings: SiteSettings;
     try {
         layout = new GoldenLayout(config, root);
         hub = new Hub(layout, subLangId, defaultLangId);
+        [themer, settings] = setupSettings(hub);
+        hub.initLayout();
     } catch (e) {
         SentryCapture(e, 'goldenlayout/hub setup');
+        console.log('Exception processing state, resetting layout to default', e);
 
         if (document.URL.includes('/z/')) {
             document.location = document.URL.replace('/z/', '/resetlayout/');
@@ -625,10 +630,9 @@ function start() {
 
         layout = new GoldenLayout(defaultConfig, root);
         hub = new Hub(layout, subLangId, defaultLangId);
+        [themer, settings] = setupSettings(hub);
+        hub.initLayout();
     }
-
-    const [themer, settings] = setupSettings(hub);
-    hub.initLayout();
 
     setSentryLayout(layout);
 

--- a/static/main.ts
+++ b/static/main.ts
@@ -634,10 +634,7 @@ function start() {
             document.location = document.URL.replace('/z/', '/resetlayout/');
         }
 
-        layout = new GoldenLayout(defaultConfig, root);
-        hub = new Hub(layout, subLangId, defaultLangId);
-        [themer, settings] = setupSettings(hub);
-        hub.initLayout();
+        [layout, hub, themer, settings] = initializeLayout(defaultConfig, root);
     }
 
     setSentryLayout(layout);

--- a/static/main.ts
+++ b/static/main.ts
@@ -615,11 +615,17 @@ function start() {
     let hub: Hub;
     let themer: Themer;
     let settings: SiteSettings;
-    try {
-        layout = new GoldenLayout(config, root);
-        hub = new Hub(layout, subLangId, defaultLangId);
-        [themer, settings] = setupSettings(hub);
+
+    function initializeLayout(config: any, root: JQuery<HTMLElement>): [GoldenLayout, Hub, Themer, SiteSettings] {
+        const layout = new GoldenLayout(config, root);
+        const hub = new Hub(layout, subLangId, defaultLangId);
+        const [themer, settings] = setupSettings(hub);
         hub.initLayout();
+        return [layout, hub, themer, settings];
+    }
+
+    try {
+        [layout, hub, themer, settings] = initializeLayout(config, root);
     } catch (e) {
         SentryCapture(e, 'goldenlayout/hub setup');
         console.log('Exception processing state, resetting layout to default', e);


### PR DESCRIPTION
Fixes issues with missing components (e.g. from beta, 'explain')

The issue was that the exceptions are thrown in `initLayout`, not in the constructor.
