### PR TITLE
Add bmpi3

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -161,3 +161,4 @@ From oldest to newest contributor, we would like to thank:
 - [RongDong Xu](https://github.com/arong)
 - [Adrien Bertrand](https://github.com/adriweb)
 - [Roberto Parolin](https://github.com/rparolin)
+- [Alfredo Correa](https://github.com/correaa)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4376,7 +4376,7 @@ compiler.z180-clang-1507.options=-target z180 -g0 -nostdinc -fno-threadsafe-stat
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan
+libs=abseil:array:async_simple:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan
 
 libs.abseil.name=Abseil
 libs.abseil.versions=202501270
@@ -4570,6 +4570,13 @@ libs.boost.versions.186.lookupname=boost_bin
 libs.boost.versions.187.version=1.87.0
 libs.boost.versions.187.packagedheaders=true
 libs.boost.versions.187.lookupname=boost_bin
+
+libs.bmpi3.name=B-MPI3
+libs.bmpi3.url=https://gitlab.com/correaa/boost-mpi3
+libs.bmpi3.versions=trunk
+libs.bmpi3.description=Modern C++ MPI-3 wrapper
+libs.bmpi3.versions.trunk.version=trunk
+libs.bmpi3.versions.trunk.path=/opt/compiler-explorer/libs/bmpi3/trunk/include
 
 libs.bmulti.name=B-Multi
 libs.bmulti.url=https://gitlab.com/correaa/boost-multi


### PR DESCRIPTION
Proposing to add the B-MPI3 library to the live site. https://gitlab.com/correaa/boost-mpi3

Followed the steps as best as I could in based on other gitlab type libraries (bmulti)

Feedback on improving the hooks and the organizations of files in the repository is welcome.
The goal is to include the library by doing #include<mpi3/communicator.hpp>.