### PR TITLE
Add C++ library jsoncons v0.177.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5258,10 +5258,12 @@ libs.immer.versions.trunk.path=/opt/compiler-explorer/libs/immer/trunk
 
 libs.jsoncons.name=jsoncons
 libs.jsoncons.description=jsoncons is a C++, header-only library for constructing JSON and JSON-like data formats such as CBOR.
-libs.jsoncons.versions=1683
+libs.jsoncons.versions=1683:01770
 libs.jsoncons.url=https://github.com/danielaparker/jsoncons
 libs.jsoncons.versions.1683.version=0.168.3
 libs.jsoncons.versions.1683.path=/opt/compiler-explorer/libs/jsoncons/v0.168.3/include
+libs.jsoncons.versions.01770.path=/opt/compiler-explorer/libs/jsoncons/v0.177.0/include
+libs.jsoncons.versions.01770.version=0.177.0
 
 libs.jsoncpp.name=JsonCpp
 libs.jsoncpp.description=JsonCpp is a C++ library that allows manipulating JSON values, including serialization and deserialization to and from strings


### PR DESCRIPTION
This PR adds the C++ library **jsoncons** version 0.177.0 to Compiler Explorer.

- GitHub URL: https://github.com/danielaparker/jsoncons
- Library Type: Unknown

Related PR: https://github.com/compiler-explorer/infra/pull/1641