### PR TITLE
Add C++ library json v3.12.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5601,7 +5601,7 @@ libs.nanorange.versions.trunk.version=trunk
 libs.nanorange.versions.trunk.path=/opt/compiler-explorer/libs/nanorange/include
 
 libs.nlohmann_json.name=nlohmann::json
-libs.nlohmann_json.versions=trunk:3111:3105:391:380:373:361:360:312:211
+libs.nlohmann_json.versions=trunk:211:312:360:361:373:380:391:3105:3111:3120
 libs.nlohmann_json.url=https://github.com/nlohmann/json
 libs.nlohmann_json.versions.trunk.version=trunk
 libs.nlohmann_json.versions.trunk.path=/opt/compiler-explorer/libs/nlohmann_json/trunk/single_include
@@ -5623,6 +5623,8 @@ libs.nlohmann_json.versions.312.version=3.1.2
 libs.nlohmann_json.versions.312.path=/opt/compiler-explorer/libs/nlohmann_json/v3.1.2/single_include
 libs.nlohmann_json.versions.211.version=2.1.1
 libs.nlohmann_json.versions.211.path=/opt/compiler-explorer/libs/nlohmann_json/v2.1.1/src
+libs.nlohmann_json.versions.3120.path=/opt/compiler-explorer/libs/nlohmann_json/v3.12.0/include
+libs.nlohmann_json.versions.3120.version=3.12.0
 
 libs.nsimd.name=NSIMD
 libs.nsimd.url=https://github.com/agenium-scale/nsimd/


### PR DESCRIPTION
This PR adds the C++ library **json** version 3.12.0 to Compiler Explorer.

- GitHub URL: https://github.com/nlohmann/json
- Library Type: Unknown

Related PR: https://github.com/compiler-explorer/infra/pull/1642