### PR TITLE
Add C++ library doctest v2.4.12

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4860,7 +4860,7 @@ libs.dlib.versions.1910.lookupversion=v19.10
 libs.doctest.name=Doctest
 libs.doctest.description=The fastest feature-rich C++11 single-header testing framework for unit tests and TDD
 libs.doctest.url=https://github.com/onqtam/doctest
-libs.doctest.versions=trunk:129:200:201:210:220:221:222:223:230:231:232:233:234:235:236:237:238
+libs.doctest.versions=trunk:129:200:201:210:220:221:222:223:230:231:232:233:234:235:236:237:238:2412
 libs.doctest.versions.trunk.version=trunk
 libs.doctest.versions.trunk.path=/opt/compiler-explorer/libs/doctest/trunk/doctest
 libs.doctest.versions.129.version=1.2.9
@@ -4897,6 +4897,8 @@ libs.doctest.versions.237.version=2.3.7
 libs.doctest.versions.237.path=/opt/compiler-explorer/libs/doctest/2.3.7/doctest
 libs.doctest.versions.238.version=2.3.8
 libs.doctest.versions.238.path=/opt/compiler-explorer/libs/doctest/2.3.8/doctest
+libs.doctest.versions.2412.path=/opt/compiler-explorer/libs/doctest/2.4.12/include
+libs.doctest.versions.2412.version=2.4.12
 
 libs.eastl.name=EASTL
 libs.eastl.description=The Electronic Arts Standard Template Library. It is an extensive and robust implementation that has an emphasis on high performance.


### PR DESCRIPTION
This PR adds the C++ library **doctest** version 2.4.12 to Compiler Explorer.

- GitHub URL: https://github.com/doctest/doctest
- Library Type: Unknown

Related PR: https://github.com/compiler-explorer/infra/pull/1643