### PR TITLE
Add C++ library magic_enum v0.9.7

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5500,13 +5500,15 @@ libs.lua.versions.540.path=/opt/compiler-explorer/libs/lua/v5.4.0/include
 libs.lua.versions.540.libpath=/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86_64:/opt/compiler-explorer/libs/lua/v5.4.0/lib/x86
 
 libs.magic_enum.name=magic_enum
-libs.magic_enum.versions=trunk:073
+libs.magic_enum.versions=trunk:073:097
 libs.magic_enum.url=https://github.com/Neargye/magic_enum
 libs.magic_enum.description=Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code
 libs.magic_enum.versions.trunk.version=trunk
 libs.magic_enum.versions.trunk.path=/opt/compiler-explorer/libs/magic_enum/trunk/include
 libs.magic_enum.versions.073.version=0.7.3
 libs.magic_enum.versions.073.path=/opt/compiler-explorer/libs/magic_enum/v0.7.3/include
+libs.magic_enum.versions.097.path=/opt/compiler-explorer/libs/magic_enum/v0.9.7/include
+libs.magic_enum.versions.097.version=0.9.7
 
 libs.mdspan.name=mdspan
 libs.mdspan.versions=06


### PR DESCRIPTION
This PR adds the C++ library **magic_enum** version 0.9.7 to Compiler Explorer.

- GitHub URL: https://github.com/Neargye/magic_enum
- Library Type: Unknown

Related PR: https://github.com/compiler-explorer/infra/pull/1644