### PR TITLE
Use an actual released compiler for vc 17.11

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -575,23 +575,23 @@ compiler.vcpp_v19_40_VS17_10_arm64.name=arm64 msvc v19.40 VS17.10
 compiler.vcpp_v19_40_VS17_10_arm64.semver=14.40.33811.0
 compiler.vcpp_v19_40_VS17_10_arm64.alias=vcpp_v19_40_arm64
 
-compiler.vcpp_v19_41_VS17_11_x86.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x86/cl.exe
-compiler.vcpp_v19_41_VS17_11_x86.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
-compiler.vcpp_v19_41_VS17_11_x86.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_41_VS17_11_x86.exe=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/x86/cl.exe
+compiler.vcpp_v19_41_VS17_11_x86.libPath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib;Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib/x86;Z:/compilers/msvc/14.41.34120-14.41.34123.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.34120-14.41.34123.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_41_VS17_11_x86.includePath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_41_VS17_11_x86.name=x86 msvc v19.41 VS17.11
-compiler.vcpp_v19_41_VS17_11_x86.semver=14.41.33923.0
+compiler.vcpp_v19_41_VS17_11_x86.semver=14.41.34123.0
 
-compiler.vcpp_v19_41_VS17_11_x64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_41_VS17_11_x64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
-compiler.vcpp_v19_41_VS17_11_x64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_41_VS17_11_x64.exe=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_41_VS17_11_x64.libPath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib;Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib/x64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_41_VS17_11_x64.includePath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_41_VS17_11_x64.name=x64 msvc v19.41 VS17.11
-compiler.vcpp_v19_41_VS17_11_x64.semver=14.41.33923.0
+compiler.vcpp_v19_41_VS17_11_x64.semver=14.41.34123.0
 
-compiler.vcpp_v19_41_VS17_11_arm64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_41_VS17_11_arm64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
-compiler.vcpp_v19_41_VS17_11_arm64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_41_VS17_11_arm64.exe=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_41_VS17_11_arm64.libPath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib;Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib/arm64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_41_VS17_11_arm64.includePath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_41_VS17_11_arm64.name=arm64 msvc v19.41 VS17.11
-compiler.vcpp_v19_41_VS17_11_arm64.semver=14.41.33923.0
+compiler.vcpp_v19_41_VS17_11_arm64.semver=14.41.34123.0
 
 compiler.vcpp_v19_42_VS17_12_x86.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/x86/cl.exe
 compiler.vcpp_v19_42_VS17_12_x86.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -535,23 +535,23 @@ compiler.vc_v19_40_VS17_10_arm64.includePath=Z:/compilers/msvc/14.40.33807-14.40
 compiler.vc_v19_40_VS17_10_arm64.name=arm64 msvc v19.40 VS17.10
 compiler.vc_v19_40_VS17_10_arm64.semver=14.40.33811.0
 
-compiler.vc_v19_41_VS17_11_x86.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x86/cl.exe
-compiler.vc_v19_41_VS17_11_x86.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
-compiler.vc_v19_41_VS17_11_x86.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_41_VS17_11_x86.exe=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/x86/cl.exe
+compiler.vc_v19_41_VS17_11_x86.libPath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib;Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib/x86;Z:/compilers/msvc/14.41.34120-14.41.34123.0/atlmfc/lib/x86;Z:/compilers/msvc/14.41.34120-14.41.34123.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vc_v19_41_VS17_11_x86.includePath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vc_v19_41_VS17_11_x86.name=x86 msvc v19.41 VS17.11
-compiler.vc_v19_41_VS17_11_x86.semver=14.41.33923.0
+compiler.vc_v19_41_VS17_11_x86.semver=14.41.34123.0
 
-compiler.vc_v19_41_VS17_11_x64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/cl.exe
-compiler.vc_v19_41_VS17_11_x64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
-compiler.vc_v19_41_VS17_11_x64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_41_VS17_11_x64.exe=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/x64/cl.exe
+compiler.vc_v19_41_VS17_11_x64.libPath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib;Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib/x64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/atlmfc/lib/x64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vc_v19_41_VS17_11_x64.includePath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vc_v19_41_VS17_11_x64.name=x64 msvc v19.41 VS17.11
-compiler.vc_v19_41_VS17_11_x64.semver=14.41.33923.0
+compiler.vc_v19_41_VS17_11_x64.semver=14.41.34123.0
 
-compiler.vc_v19_41_VS17_11_arm64.exe=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/arm64/cl.exe
-compiler.vc_v19_41_VS17_11_arm64.libPath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib;Z:/compilers/msvc/14.41.33923-14.41.33923.0/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.33923-14.41.33923.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
-compiler.vc_v19_41_VS17_11_arm64.includePath=Z:/compilers/msvc/14.41.33923-14.41.33923.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_41_VS17_11_arm64.exe=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/arm64/cl.exe
+compiler.vc_v19_41_VS17_11_arm64.libPath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib;Z:/compilers/msvc/14.41.34120-14.41.34123.0/lib/arm64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.41.34120-14.41.34123.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vc_v19_41_VS17_11_arm64.includePath=Z:/compilers/msvc/14.41.34120-14.41.34123.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vc_v19_41_VS17_11_arm64.name=arm64 msvc v19.41 VS17.11
-compiler.vc_v19_41_VS17_11_arm64.semver=14.41.33923.0
+compiler.vc_v19_41_VS17_11_arm64.semver=14.41.34123.0
 
 compiler.vc_v19_42_VS17_12_x86.exe=Z:/compilers/msvc/14.42.34433-14.42.34441.0/bin/Hostx64/x86/cl.exe
 compiler.vc_v19_42_VS17_12_x86.libPath=Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib;Z:/compilers/msvc/14.42.34433-14.42.34441.0/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/atlmfc/lib/x86;Z:/compilers/msvc/14.42.34433-14.42.34441.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;


### PR DESCRIPTION
Closes #7745. Hopefully

I followed https://github.com/compiler-explorer/infra/blob/main/docs/adding_msvc_compilers.md with an official 17.11.6 compiler