### PR TITLE
Add compiler categories to Fortran compilers

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -13,6 +13,7 @@ group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:g
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
+group.gfortran_86.compilerCategories=gfortran
 compiler.gfortran494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gfortran
 compiler.gfortran494.semver=4.9.4
 compiler.gfortran550.exe=/opt/compiler-explorer/gcc-5.5.0/bin/gfortran
@@ -93,6 +94,7 @@ compiler.gfortransnapshot.isNightly=true
 ## GFORTRAN x86 build with "assertions" (--enable-checking=XXX)
 group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert
 group.gfortranassert.groupName=GFORTRAN x86-64 (assertions)
+group.gfortranassert.compilerCategories=gfortran
 
 compiler.gfortran103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gfortran
 compiler.gfortran103assert.semver=10.3 (assertions)
@@ -138,6 +140,7 @@ group.ifort.intelAsm=-masm=intel
 group.ifort.groupName=IFORT x86-64
 group.ifort.isSemVer=true
 group.ifort.baseName=x86-64 ifort
+group.ifort.compilerCategories=ifort
 #compiler.ifort16.exe=/opt/compiler-explorer/intel/xe_2016_update3/bin/ifort
 #compiler.ifort16.semver=16.0.3
 #compiler.ifort17.exe=/opt/compiler-explorer/intel/2017/bin/ifort
@@ -228,6 +231,7 @@ group.ifx.groupName=IFX x86-64
 group.ifx.isSemVer=true
 group.ifx.baseName=x86-64 ifx
 group.ifx.options=
+group.ifx.compilerCategories=ifort
 
 compiler.ifx202112.exe=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/bin/ifx
 compiler.ifx202112.ldPath=/opt/compiler-explorer/intel-fortran-2021.1.2.62/compiler/latest/linux/compiler/lib/intel64_lin
@@ -353,6 +357,7 @@ group.cross.supportsExecute=false
 group.cross.supportsBinary=false
 group.cross.supportsBinaryObject=true
 group.cross.groupName=Cross GCC
+group.cross.compilerCategories=gfortran
 
 ###############################
 # GCC for Tricore
@@ -360,6 +365,7 @@ group.gcctricore.compilers=ftricoreg1130
 group.gcctricore.groupName=Tricore gfortran
 group.gcctricore.baseName=Tricore gfortran
 group.gcctricore.supportsBinary=true
+group.gcctricore.compilerCategories=gfortran
 
 compiler.ftricoreg1130.exe=/opt/compiler-explorer/tricore/gcc-11.3.0/tricore-none-elf/bin/tricore-none-elf-gfortran
 compiler.ftricoreg1130.semver=11.3.0 (EEESlab)
@@ -372,6 +378,7 @@ group.gcchppa.compilers=fhppag1420:fhppag1430:fhppag1510
 group.gcchppa.groupName=HPPA gfortran
 group.gcchppa.baseName=HPPA gfortran
 group.gcchppa.supportsBinary=true
+group.gcchppa.compilerCategories=gfortran
 
 compiler.fhppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gfortran
 compiler.fhppag1420.semver=14.2.0
@@ -393,6 +400,7 @@ compiler.fhppag1510.demangler=/opt/compiler-explorer/hppa/gcc-15.1.0/hppa-unknow
 group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1410:fsparcg1420:fsparcg1430:fsparcg1510
 group.gccsparc.groupName=SPARC gfortran
 group.gccsparc.baseName=SPARC gfortran
+group.gccsparc.compilerCategories=gfortran
 
 compiler.fsparcg1220.exe=/opt/compiler-explorer/sparc/gcc-12.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
 compiler.fsparcg1220.semver=12.2.0
@@ -449,6 +457,7 @@ compiler.fsparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-unk
 group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240:fsparc64g1420:fsparc64g1510:fsparc64g1430
 group.gccsparc64.groupName=SPARC64 gfortran
 group.gccsparc64.baseName=SPARC64 gfortran
+group.gccsparc64.compilerCategories=gfortran
 
 compiler.fsparc64g1220.exe=/opt/compiler-explorer/sparc64/gcc-12.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
 compiler.fsparc64g1220.semver=12.2.0
@@ -505,6 +514,7 @@ compiler.fsparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/sparc
 group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1410:fsparcleong1420:fsparcleong1430:fsparcleong1510
 group.gccsparcleon.groupName=SPARC LEON gfortran
 group.gccsparcleon.baseName=SPARC LEON gfortran
+group.gccsparcleon.compilerCategories=gfortran
 
 # this one was wrongly built using 'master', not 12.2.0 release.
 compiler.fsparcleong1220.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
@@ -568,6 +578,7 @@ compiler.fsparcleong1510.demangler=/opt/compiler-explorer/sparc-leon/gcc-15.1.0/
 group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240:floongarch64g1420:floongarch64g1510:floongarch64g1430
 group.gccloongarch64.groupName=LOONGARCH64 gfortran
 group.gccloongarch64.baseName=LOONGARCH64 gfortran
+group.gccloongarch64.compilerCategories=gfortran
 
 compiler.floongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
 compiler.floongarch64g1220.semver=12.2.0
@@ -624,6 +635,7 @@ compiler.floongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc-15.1
 group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240:friscv64g1420:friscv64g1510:friscv64g1430
 group.gccriscv64.groupName=RISCV64 gfortran
 group.gccriscv64.baseName=RISCV64 gfortran
+group.gccriscv64.compilerCategories=gfortran
 
 compiler.friscv64g1140.exe=/opt/compiler-explorer/riscv64/gcc-11.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
 compiler.friscv64g1140.semver=11.4.0
@@ -685,6 +697,7 @@ compiler.friscv64g1510.demangler=/opt/compiler-explorer/riscv64/gcc-15.1.0/riscv
 group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1310:friscvg1320:friscvg1330:friscvg1410:friscvg1420:friscvg1430:friscvg1510
 group.gccriscv.groupName=RISCV (32bit) gfortran
 group.gccriscv.baseName=RISCV (32bit) gfortran
+group.gccriscv.compilerCategories=gfortran
 
 compiler.friscvg1140.exe=/opt/compiler-explorer/riscv32/gcc-11.4.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gfortran
 compiler.friscvg1140.semver=11.4.0
@@ -746,6 +759,7 @@ compiler.friscvg1510.demangler=/opt/compiler-explorer/riscv32/gcc-15.1.0/riscv32
 group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1310:farmg1320:farmg1330:farmg1410:farmg1420:farmg1430:farmg1510
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
+group.gccarm.compilerCategories=gfortran
 
 compiler.farmg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gfortran
 compiler.farmg640.semver=6.4
@@ -824,6 +838,7 @@ compiler.farmg1510.demangler=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-l
 group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240:fs390xg1420:fs390xg1510:fs390xg1430
 group.gccs390x.groupName=s390x gfortran
 group.gccs390x.baseName=s390x gfortran
+group.gccs390x.compilerCategories=gfortran
 
 compiler.fs390xg1210.exe=/opt/compiler-explorer/s390x/gcc-12.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
 compiler.fs390xg1210.semver=12.1.0
@@ -884,6 +899,7 @@ compiler.fs390xg1510.demangler=/opt/compiler-explorer/s390x/gcc-15.1.0/s390x-ibm
 group.clang_llvmflang.compilers=flangtrunk:flangtrunk-fc
 group.clang_llvmflang.groupName=LLVM-FLANG x86-64
 group.clang_llvmflang.compilerType=flang
+group.clang_llvmflang.compilerCategories=flang
 
 compiler.flangtrunk.exe=/opt/compiler-explorer/clang-llvmflang-trunk/bin/flang
 compiler.flangtrunk.name=flang-trunk
@@ -910,6 +926,7 @@ group.lfortran.supportsBinaryObject=true
 group.lfortran.supportsExecute=true
 group.lfortran.compilerType=lfortran
 group.lfortran.isSemVer=true
+group.lfortran.compilerCategories=lfortran
 compiler.lfortran0420.exe=/opt/compiler-explorer/lfortran/v0.42.0/bin/lfortran
 compiler.lfortran0420.semver=0.42.0
 compiler.lfortran0420.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
@@ -919,6 +936,7 @@ compiler.lfortran0420.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240:farm64g1420:farm64g1510:farm64g1430
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 group.gccaarch64.baseName=AARCH64 gfortran
+group.gccaarch64.compilerCategories=gfortran
 
 compiler.farm64g494.exe=/opt/compiler-explorer/arm64/gcc-4.9.4/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g494.semver=4.9.4
@@ -1007,12 +1025,14 @@ compiler.farm64g1510.demangler=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-u
 group.ppcs.compilers=&ppc64:&ppc64le:&ppc
 group.ppcs.groupName=POWER Compilers
 group.ppcs.instructionSet=powerpc
+group.ppcs.compilerCategories=gfortran
 
 ###############################
 # GCC for PPC
 group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1310:fppcg1320:fppcg1330:fppcg1410:fppcg1420:fppcg1430:fppcg1510
 group.ppc.groupName=POWER gfortran
 group.ppc.baseName=POWER gfortran
+group.ppc.compilerCategories=gfortran
 
 compiler.fppcg1210.exe=/opt/compiler-explorer/powerpc/gcc-12.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
 compiler.fppcg1210.semver=12.1.0
@@ -1073,6 +1093,7 @@ compiler.fppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-u
 group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240:fppc64g1420:fppc64g1510:fppc64g1430
 group.ppc64.groupName=POWER64 gfortran
 group.ppc64.baseName=POWER64 gfortran
+group.ppc64.compilerCategories=gfortran
 
 compiler.fppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64g8.name=power64 AT12.0
@@ -1146,6 +1167,7 @@ compiler.fppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/power
 group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240:fppc64leg1420:fppc64leg1510:fppc64leg1430
 group.ppc64le.groupName=POWER64le gfortran
 group.ppc64le.baseName=POWER64le gfortran
+group.ppc64le.compilerCategories=gfortran
 
 compiler.fppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
 compiler.fppc64leg8.name=power64le AT12.0
@@ -1218,12 +1240,14 @@ compiler.fppc64legtrunk.demangler=/opt/compiler-explorer/powerpc64le/gcc-trunk/p
 ##  GCC For RISC-V 32 and 64
 
 group.gccrvs.compilers=&gccrv64:&gccrv32
+group.gccrvs.compilerCategories=gfortran
 
 ################################
 # GCC for RISC-V 32-bits
 group.gccrv32.compilers=frv32gtrunk:frv32g1210
 group.gccrv32.groupName=RISC-V 32-bits gfortran
 group.gccrv32.baseName=RISC-V 32-bits gfortran
+group.gccrv32.compilerCategories=gfortran
 
 compiler.frv32g1210.exe=/opt/compiler-explorer/riscv32/gcc-12.1.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-gfortran
 compiler.frv32g1210.semver=12.1.0
@@ -1238,6 +1262,7 @@ compiler.frv32gtrunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-
 group.gccrv64.compilers=frv64gtrunk:frv64g1210
 group.gccrv64.groupName=RISC-V 64-bits gfortran
 group.gccrv64.baseName=RISC-V 64-bits gfortran
+group.gccrv64.compilerCategories=gfortran
 
 compiler.frv64g1210.exe=/opt/compiler-explorer/riscv64/gcc-12.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
 compiler.frv64g1210.semver=12.1.0
@@ -1253,6 +1278,7 @@ compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-
 group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1410:fmipsg1420:fmipsg1430:fmipsg1510
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
+group.gccmips.compilerCategories=gfortran
 
 compiler.fmipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
 compiler.fmipsg494.semver=4.9.4
@@ -1328,6 +1354,7 @@ compiler.fmipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unknow
 group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240:fmips64g1420:fmips64g1510:fmips64g1430
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
+group.gccmips64.compilerCategories=gfortran
 
 compiler.fmips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
 compiler.fmips64g494.semver=4.9.4
@@ -1403,6 +1430,7 @@ compiler.fmips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips64-
 group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1410:fmipselg1420:fmipselg1430:fmipselg1510
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
+group.gccmipsel.compilerCategories=gfortran
 
 compiler.fmipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gfortran
 compiler.fmipselg494.semver=4.9.4
@@ -1478,6 +1506,7 @@ compiler.fmipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mipsel-
 group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240:fmips64elg1420:fmips64elg1510:fmips64elg1430
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
+group.gccmips64el.compilerCategories=gfortran
 
 compiler.fmips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gfortran
 compiler.fmips64elg494.semver=4.9.4

--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -9,6 +9,7 @@ compilerType=fortran
 # GCC for x86
 group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494def:gfortran48:gfortran4:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550def:gfortran5:gfortran62:gfortran63def:gfortran6:gfortran71def:gfortran72def:gfortran73def:gfortran7:gfortran8:gfortran81def:gfortran9:gfortran10:gfortran11:gfortran
 group.gfortran_86.groupName=GCC x86-64
+group.gfortran_86.compilerCategories=gfortran
 compiler.gfortran412.exe=/usr/bin/gfortran-4.1.2
 compiler.gfortran412.name=gfortran 4.1.2
 compiler.gfortran447.exe=/usr/bin/gfortran-4.4.7
@@ -100,6 +101,7 @@ compiler.gfortran.name=gfortran
 group.clang_llvmflang.compilers=flangtrunk
 group.clang_llvmflang.groupName=LLVM-FLANG
 group.clang_llvmflang.compilerType=flang
+group.clang_llvmflang.compilerCategories=flang
 
 compiler.flangtrunk.exe=/usr/local/bin/flang
 compiler.flangtrunk.name=flang-trunk


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Thanks for the wonderful tool! I noticed that the Fortran compilers were uncategorised, so I've attempted to add the relevant config metadata.

Following the C++ compiler categories, I've lumped `ifort` and `ifx` together under `ifort`