### PR TITLE
Fix null compiler error in diff pane

### DIFF
--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -91,7 +91,15 @@ class DiffStateObject {
 
     update(id: number | string, compiler: CompilerInfo, result: CompilationResult) {
         if (this.id !== id) return false;
-        this.compiler!.compiler = compiler;
+
+        // Handle the case where compiler hasn't been initialized yet
+        // In a race condition, we might receive results before the compiler is registered
+        if (this.compiler === null) {
+            // Ignore the update - the result will be requested again when the compiler is registered
+            return false;
+        }
+
+        this.compiler.compiler = compiler;
         this.result = result;
         this.refresh();
 

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -94,7 +94,7 @@ class DiffStateObject {
 
         // Handle the case where compiler hasn't been initialized yet
         // In a race condition, we might receive results before the compiler is registered
-        if (this.compiler === null) {
+        if (!this.compiler) {
             // Ignore the update - the result will be requested again when the compiler is registered
             return false;
         }


### PR DESCRIPTION
## Summary
- Fix TypeError when diff pane receives execution results before compiler is registered
- Add null check to prevent crash and gracefully handle race condition

## Description
This PR fixes issue #7761 where a `TypeError: Cannot set properties of null (setting 'compiler')` occurs in the diff pane.

### The Problem
A race condition can occur where:
1. An executor pane resends its results (e.g., during layout initialization)
2. The diff pane receives the `executeResult` event
3. The diff pane tries to update its state, but `this.compiler` is still null
4. The code crashes trying to set `this.compiler.compiler = compiler`

### The Solution
Add a null check in the `update` method of `DiffStateObject`. If `this.compiler` is null, we simply ignore the update and return false. This is safe because:
- When `onCompiler` is eventually called, it will properly initialize the compiler
- `onCompiler` calls `onDiffSelect()` which calls `requestResendResult()`
- This will re-request the compilation/execution results
- By then, the compiler will be properly initialized and the update will succeed

### Testing
- TypeScript checks pass
- Linting passes
- The fix prevents the crash while maintaining correct behavior

Fixes #7761

🤖 Generated with [Claude Code](https://claude.ai/code)