### PR TITLE
Fix null reference error in findConfig when URL parsing fails

### DIFF
--- a/static/main.ts
+++ b/static/main.ts
@@ -347,7 +347,7 @@ function findConfig(defaultConfig: ConfigType, options: CompilerExplorerOptions,
                 const savedState = sessionThenLocalStorage.get('gl', null);
                 if (savedState) config = JSON.parse(savedState);
             }
-            if (!config.content || config.content.length === 0) {
+            if (!config?.content || config.content?.length === 0) {
                 config = defaultConfig;
             }
         }


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'content')` in `findConfig()` when URL parsing fails and no saved state is available.

## Root Cause

This error occurs when:
1. `url.deserialiseState()` throws an exception due to malformed/corrupted URLs
2. No saved state exists in localStorage (`sessionThenLocalStorage.get('gl', null)` returns `null`)
3. Code attempts to access `config.content` when `config` is still `undefined`

The error happens legitimately from truncated URLs, corrupted bookmarks, or URL shortener issues.

## Changes

- Changed `if (!config.content || config.content.length === 0)` to use optional chaining: `if (!config?.content || config.content?.length === 0)`
- This gracefully handles the null/undefined case and falls back to default config as intended

## Impact

- Maintains existing user experience (fallback to default config when URL parsing fails)
- Prevents crash with 1430+ reported occurrences
- No behavioral changes for valid URLs

Fixes COMPILER-EXPLORER-DE3

🤖 Generated with [Claude Code](https://claude.ai/code)