### PR TITLE
Fix null reference errors in gccdump view selection handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Comments should provide additional context or explain "why" something is done, not just restate "what" is being done.
 - Only add function header comments when they provide meaningful information beyond what the function name and signature convey.
 - Use British English spellings for things like "initialise" and "colour", but only in new code. It's a preference not a hard requirement
+- Use modern Typescript features like optional chaining when updating existing code or adding new code
 
 ## Testing Guidelines
 - Use Vitest for unit tests (compatible with Jest syntax)

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -234,7 +234,8 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
             const activeOption = Object.entries(this.selectize.options).find(
                 op => op[1].filename_suffix === this.selectedPass,
             );
-            const selectedPassId = activeOption![0];
+            if (!activeOption) return;
+            const selectedPassId = activeOption[0];
             const option = this.selectize.getOption(selectedPassId);
             // Workaround for a TomSelect glitch: onFocus sets the active option to the first one
             // on the first re-open, so this setActiveOption call needs to be delayed.
@@ -302,6 +303,12 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
 
     onPassSelect(passId: string) {
         const selectedPass = this.selectize.options[passId] as unknown as GccDumpViewSelectedPass;
+
+        if (!selectedPass) {
+            // Pass option not found - happens when user deletes selection via TomSelect
+            // and the change event fires with a passId that no longer exists in options
+            return;
+        }
 
         if (this.inhibitPassSelect !== true) {
             this.eventHub.emit('gccDumpPassSelected', this.compilerInfo.compilerId, selectedPass, true);


### PR DESCRIPTION
## Summary

Fixes two related null reference errors in the GCC dump view's TomSelect dropdown handling that occur during user interactions.

## Root Cause Analysis

**COMPILER-EXPLORER-96P** (1067 occurrences):
- Error: `TypeError: undefined is not an object (evaluating 't.filename_suffix')`
- Location: `gccdump-view.ts:318` in `onPassSelect()`
- Trigger: User deletes a selection via TomSelect → `deleteSelection()` → `removeItem()` → `trigger('change')` → `onPassSelect()` called with passId that no longer exists in `this.selectize.options`

**COMPILER-EXPLORER-E44** (34 occurrences):
- Error: `TypeError: Cannot read properties of undefined (reading '0')`  
- Location: `gccdump-view.ts:237` in dropdown open handler
- Trigger: `find()` returns undefined when searching for pass by filename_suffix, but code uses non-null assertion `activeOption![0]`

Both errors occur due to timing issues when dropdown options are being updated while user interactions are happening.

## Changes

1. **Added null check in `onPassSelect()`**: Safely handle case where `this.selectize.options[passId]` returns undefined
2. **Removed unsafe non-null assertion**: Replace `activeOption![0]` with proper null check and early return
3. **Added CLAUDE.md guidance**: Include preference for modern TypeScript features like optional chaining

## Impact

- Prevents crashes with 1100+ reported occurrences combined
- Maintains existing user experience - dropdowns continue to work normally
- No behavioral changes for valid interactions

Fixes COMPILER-EXPLORER-96P
Fixes COMPILER-EXPLORER-E44

🤖 Generated with [Claude Code](https://claude.ai/code)