### PR TITLE
Fix null reference error in CFG view birds-eye zoom

### DIFF
--- a/static/panes/cfg-view.ts
+++ b/static/panes/cfg-view.ts
@@ -554,7 +554,7 @@ export class Cfg extends Pane<CfgState> {
     }
 
     birdsEyeView() {
-        if (!this.layout?.blocks || this.layout.blocks.length === 0) {
+        if (!this.layout?.blocks?.length) {
             // No layout loaded yet or empty layout - nothing to zoom to
             return;
         }

--- a/static/panes/cfg-view.ts
+++ b/static/panes/cfg-view.ts
@@ -554,17 +554,20 @@ export class Cfg extends Pane<CfgState> {
     }
 
     birdsEyeView() {
-        if (this.layout.blocks.length > 0) {
-            const fullW = this.layout.getWidth();
-            const fullH = this.layout.getHeight();
-            const container_size = this.graphContainer.getBoundingClientRect();
-            const zoom = Math.min(container_size.width / fullW, container_size.height / fullH);
-            this.setZoom(zoom);
-            this.setPan({
-                x: container_size.width / 2 - (fullW * zoom) / 2,
-                y: container_size.height / 2 - (fullH * zoom) / 2,
-            });
+        if (!this.layout?.blocks || this.layout.blocks.length === 0) {
+            // No layout loaded yet or empty layout - nothing to zoom to
+            return;
         }
+
+        const fullW = this.layout.getWidth();
+        const fullH = this.layout.getHeight();
+        const container_size = this.graphContainer.getBoundingClientRect();
+        const zoom = Math.min(container_size.width / fullW, container_size.height / fullH);
+        this.setZoom(zoom);
+        this.setPan({
+            x: container_size.width / 2 - (fullW * zoom) / 2,
+            y: container_size.height / 2 - (fullH * zoom) / 2,
+        });
     }
 
     setZoom(zoom: number, superficial?: boolean) {


### PR DESCRIPTION
## Summary

Fixes COMPILER-EXPLORER-BY7: TypeError accessing 'blocks' property of undefined layout when clicking zoom-out button before any CFG has been generated.

- Uses modern TypeScript optional chaining for null-safe access 
- Prevents crashes when users click zoom-out before compiling code

## Test plan

- [ ] Load CFG view pane
- [ ] Click zoom-out button before generating any CFG (should not crash)
- [ ] Generate a CFG and verify zoom-out still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)