### PR TITLE
Fix race condition in pane container closing

### DIFF
--- a/static/panes/pane.ts
+++ b/static/panes/pane.ts
@@ -227,7 +227,12 @@ export abstract class Pane<S> {
     /** Close the pane if the compiler this pane was attached to closes */
     protected onCompilerClose(compilerId: number) {
         if (this.compilerInfo.compilerId === compilerId) {
-            _.defer(() => this.container.close());
+            _.defer(() => {
+                // Check if container is still valid before attempting to close
+                if (this.container?.parent && this.container.layoutManager?.isInitialised) {
+                    this.container.close();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes COMPILER-EXPLORER-3W3: Prevents "Can't remove child item. Unknown content item" errors (4830 occurrences) when attempting to close containers that have already been destroyed or removed from the layout hierarchy.

- Uses modern TypeScript optional chaining to check container validity before close operations
- Prevents race conditions between compiler close events and GoldenLayout's destruction process
- Addresses issue where deferred `container.close()` calls were executing on already-destroyed containers

## Root Cause

The error occurred when:
1. A compiler close event triggers `onCompilerClose()` which defers `container.close()`
2. Meanwhile, GoldenLayout destroys the container through its own process
3. The deferred close attempt executes on an already-destroyed container, causing the GoldenLayout error

## Test plan

- [ ] Open multiple compiler panes with associated tool/output panes
- [ ] Quickly close compilers while panes are still loading/updating
- [ ] Verify no "Can't remove child item" errors appear in console
- [ ] Verify panes still close properly in normal scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)