### PR TITLE
Switch back to `rustfilt` for Rust demangling

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -3,8 +3,7 @@ objdumper=/opt/compiler-explorer/gcc-14.1.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-14.1.0/bin/gcc
 aarch64linker=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 defaultCompiler=r1870
-demangler=/opt/compiler-explorer/gcc-14.1.0/bin/c++filt
-demanglerArgs=--format=rust
+demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
 
 buildenvsetup=ceconan-rust
 buildenvsetup.host=https://conan.compiler-explorer.com


### PR DESCRIPTION
Needs https://github.com/compiler-explorer/tools/pull/14.

See https://github.com/compiler-explorer/compiler-explorer/issues/7772. This PR does not quite resolve that issue because C++ is also affected.