### PR TITLE
Add baseline functional tests for AsmParser subclasses

### DIFF
--- a/test/asm-parser-subclass-integration-tests.ts
+++ b/test/asm-parser-subclass-integration-tests.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+import {describe, expect, it} from 'vitest';
+
+import {AsmEWAVRParser} from '../lib/parsers/asm-parser-ewavr.js';
+import {SPIRVAsmParser} from '../lib/parsers/asm-parser-spirv.js';
+import {VcAsmParser} from '../lib/parsers/asm-parser-vc.js';
+import * as properties from '../lib/properties.js';
+
+describe('AsmParser subclass compatibility', () => {
+    describe('Integration with real test cases', () => {
+        it('should handle VC assembly files from filter tests', () => {
+            // Test with actual vc test files
+            const vcTestFiles = [
+                'test/filters-cases/vc-numbers.asm',
+                'test/filters-cases/vc-regex.asm',
+                'test/filters-cases/vc-threadlocalddef.asm',
+            ];
+
+            for (const testFile of vcTestFiles) {
+                try {
+                    const vcAsmContent = readFileSync(resolve(testFile), 'utf8');
+                    const parser = new VcAsmParser();
+
+                    const result = parser.processAsm(vcAsmContent, {
+                        directives: true,
+                        labels: true,
+                        commentOnly: false,
+                    });
+
+                    expect(result.asm.length).toBeGreaterThan(0);
+                    // VcAsmParser has custom processAsm that doesn't return labelDefinitions
+                    expect(result.labelDefinitions).toBeUndefined();
+                } catch (error) {
+                    // If file doesn't exist, skip this test
+                    if ((error as any).code !== 'ENOENT') {
+                        throw error;
+                    }
+                }
+            }
+        });
+
+        it('should handle EWAVR assembly files from filter tests', () => {
+            try {
+                const ewavrAsmContent = readFileSync(resolve('test/filters-cases/ewarm-1.asm'), 'utf8');
+                const parser = new AsmEWAVRParser(properties.fakeProps({}));
+
+                const result = parser.processAsm(ewavrAsmContent, {
+                    directives: true,
+                    labels: true,
+                    commentOnly: false,
+                });
+
+                expect(result.asm.length).toBeGreaterThan(0);
+                // AsmEWAVRParser has custom processAsm that doesn't return labelDefinitions
+                expect(result.labelDefinitions).toBeUndefined();
+            } catch (error) {
+                // If file doesn't exist, skip this test
+                if ((error as any).code !== 'ENOENT') {
+                    throw error;
+                }
+            }
+        });
+    });
+
+    describe('Method override interactions', () => {
+        it('should use VcAsmParser labelFindFor override in findUsedLabels', () => {
+            const parser = new VcAsmParser();
+            const asmLines = ['_start:', 'mov eax, OFFSET _data', 'call _function', 'jmp _start'];
+
+            const usedLabels = parser.findUsedLabels(asmLines, true);
+
+            // Should find all labels using VC-specific regex
+            expect(usedLabels.has('_data')).toBe(true);
+            expect(usedLabels.has('_function')).toBe(true);
+            expect(usedLabels.has('_start')).toBe(true);
+        });
+
+        it('should use SPIRVAsmParser getUsedLabelsInLine override in processAsm', () => {
+            const parser = new SPIRVAsmParser();
+            const spirvCode = `
+                %main = OpFunction %void None %1
+                %entry = OpLabel
+                OpFunctionCall %void %helper_func
+                OpBranch %exit_label
+                %exit_label = OpLabel
+                OpReturn
+                OpFunctionEnd
+            `;
+
+            const result = parser.processAsm(spirvCode, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should detect SPIR-V specific labels using custom override
+            const hasSpirVLabels = result.asm.some(line => line.labels?.some(label => label.name === '%helper_func'));
+            expect(hasSpirVLabels).toBe(true);
+        });
+
+        it('should use AsmEWAVRParser labelFindFor override in processing', () => {
+            const parser = new AsmEWAVRParser(properties.fakeProps({}));
+            const asmLines = ['main:', 'ldi r16, HIGH(data_table)', 'call subroutine', 'rjmp main'];
+
+            const usedLabels = parser.findUsedLabels(asmLines, true);
+
+            // Current behavior: EWAVR labelFindFor() is broken - finds no labels
+            expect(usedLabels.has('data_table')).toBe(false);
+            expect(usedLabels.has('subroutine')).toBe(false);
+            expect(usedLabels.has('main')).toBe(false);
+            expect(usedLabels.size).toBe(0);
+        });
+    });
+
+    describe('Regression prevention', () => {
+        it('should maintain consistent behavior across subclasses', async () => {
+            const testCode = `
+                start:
+                    mov r1, #value
+                    bl function
+                    b start
+            `;
+
+            // Test that different parsers can handle similar code
+            const {AsmParser} = await import('../lib/parsers/asm-parser.js');
+            const baseParser = new AsmParser();
+            const vcParser = new VcAsmParser();
+
+            const baseResult = baseParser.processAsm(testCode, {directives: true, labels: false});
+            const vcResult = vcParser.processAsm(testCode, {directives: true, labels: false});
+
+            // Both should successfully process the assembly
+            expect(baseResult.asm.length).toBeGreaterThan(0);
+            expect(vcResult.asm.length).toBeGreaterThan(0);
+        });
+
+        it('should preserve label detection accuracy', () => {
+            // Test that subclass overrides don't break label detection
+            const spirvParser = new SPIRVAsmParser();
+
+            const codeWithLabels = `
+                OpBranch %label1
+                %label1 = OpLabel
+                OpFunctionCall %void %func
+                OpBranch %label2
+                %label2 = OpLabel
+            `;
+
+            const result = spirvParser.processAsm(codeWithLabels, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should correctly identify both labels and function call
+            expect(result.labelDefinitions).toHaveProperty('%label1');
+            expect(result.labelDefinitions).toHaveProperty('%label2');
+
+            const hasFunc = result.asm.some(line => line.labels?.some(label => label.name === '%func'));
+            expect(hasFunc).toBe(true);
+        });
+    });
+});

--- a/test/ewavr-asm-parser-tests.ts
+++ b/test/ewavr-asm-parser-tests.ts
@@ -1,0 +1,214 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {AsmEWAVRParser} from '../lib/parsers/asm-parser-ewavr.js';
+import * as properties from '../lib/properties.js';
+
+describe('AsmEWAVRParser', () => {
+    let parser: AsmEWAVRParser;
+
+    beforeEach(() => {
+        parser = new AsmEWAVRParser(properties.fakeProps({}));
+    });
+
+    describe('EWAVR assembly processing functionality', () => {
+        it('should process EWAVR assembly with label structure', () => {
+            const ewavrAssembly = `
+// 1 "example.c"
+// 2 
+_main:
+                ldi r16, 0xFF
+                call _function
+                br _main
+                
+_function:
+                ldi r17, 255
+                ret
+            `;
+
+            const result = parser.processAsm(ewavrAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should successfully process EWAVR assembly format
+            expect(result).toHaveProperty('asm');
+            expect(Array.isArray(result.asm)).toBe(true);
+            expect(result.asm.length).toBeGreaterThan(0);
+
+            // Should preserve assembly instructions
+            const hasInstructions = result.asm.some(
+                line =>
+                    line.text && (line.text.includes('ldi') || line.text.includes('call') || line.text.includes('ret')),
+            );
+            expect(hasInstructions).toBe(true);
+        });
+
+        it('should handle EWAVR-specific directives and segments', () => {
+            const ewavrAssembly = `
+RSEG CODE
+PUBLIC _function
+EXTERN _external_var
+_function:
+                ldi r16, HIGH(_external_var)
+                ldi r17, LOW(_external_var)
+                ret
+                END
+            `;
+
+            const result = parser.processAsm(ewavrAssembly, {
+                directives: true,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should process EWAVR segments and directives
+            expect(result.asm.length).toBeGreaterThan(0);
+
+            // Should handle filtering of directives when requested
+            const resultWithoutDirectives = parser.processAsm(ewavrAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+            // Both should process successfully (directive filtering behavior may vary)
+            expect(resultWithoutDirectives.asm.length).toBeGreaterThanOrEqual(0);
+        });
+
+        it('should correctly handle EWAVR comment filtering', () => {
+            const ewavrAssembly = `
+// This is a comment
+_main:
+// Another comment
+                ldi r16, 42
+                ret
+            `;
+
+            const resultWithComments = parser.processAsm(ewavrAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            const resultWithoutComments = parser.processAsm(ewavrAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: true,
+            });
+
+            // Comment filtering should reduce output
+            expect(resultWithoutComments.asm.length).toBeLessThanOrEqual(resultWithComments.asm.length);
+
+            // Should still have the actual instruction
+            const hasInstruction = resultWithoutComments.asm.some(line => line.text?.includes('ldi'));
+            expect(hasInstruction).toBe(true);
+        });
+    });
+
+    describe('EWAVR assembly processing', () => {
+        it('should process real EWAVR assembly correctly', () => {
+            const ewavrAssembly = `
+// 1 "example.c"
+_main:
+                ldi r16, 0xFF
+                out PORTB, r16
+                call _delay
+                br _main
+                
+_delay:
+                ldi r17, 255
+delay_loop:
+                dec r17
+                brne delay_loop
+                ret
+            `.trim();
+
+            const result = parser.processAsm(ewavrAssembly, {
+                directives: true,
+                labels: false,
+                commentOnly: false,
+            });
+
+            expect(result.asm.length).toBeGreaterThan(0);
+            // AsmEWAVRParser doesn't return labelDefinitions - it has its own format
+            expect(result).toHaveProperty('asm');
+            expect(result.labelDefinitions).toBeUndefined();
+        });
+
+        it('should handle EWAVR-specific instructions and labels', () => {
+            const asmLines = ['ldi r16, HIGH(_data)', 'ldi r17, LOW(_data)', 'call _subroutine', 'rjmp _loop'];
+
+            const usedLabels = parser.findUsedLabels(asmLines, true);
+
+            // Current behavior: EWAVR labelFindFor() is broken - finds no labels
+            expect(usedLabels.has('_data')).toBe(false);
+            expect(usedLabels.has('_subroutine')).toBe(false);
+            expect(usedLabels.has('_loop')).toBe(false);
+            expect(usedLabels.size).toBe(0);
+        });
+
+        it('should process real EWAVR test case', () => {
+            // Use the actual test case content if available
+            const ewavrCode = `
+                CODE32 segment 'CODE'
+                public _main
+                extern ?relay:DATA16
+                
+                _main:
+                    ldi r16, 0xFF
+                    out DDRC, r16
+                    call _init
+                    br _main_loop
+                    
+                _main_loop:
+                    in r16, PINC
+                    call _process
+                    br _main_loop
+                    
+                _init:
+                    ldi r17, 0x00
+                    ret
+                    
+                _process:
+                    cpi r16, 0xFF
+                    ret
+                    
+                CODE32 ends
+            `;
+
+            const result = parser.processAsm(ewavrCode, {
+                directives: true,
+                labels: true,
+                commentOnly: false,
+            });
+
+            expect(result.asm.length).toBeGreaterThan(0);
+            // AsmEWAVRParser doesn't return labelDefinitions - it has its own format
+            expect(result.labelDefinitions).toBeUndefined();
+        });
+    });
+});

--- a/test/spirv-asm-parser-tests.ts
+++ b/test/spirv-asm-parser-tests.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {SPIRVAsmParser} from '../lib/parsers/asm-parser-spirv.js';
+
+describe('SPIRVAsmParser', () => {
+    let parser: SPIRVAsmParser;
+
+    beforeEach(() => {
+        parser = new SPIRVAsmParser();
+    });
+
+    describe('getUsedLabelsInLine override', () => {
+        it('should detect labels in OpFunctionCall', () => {
+            const line = 'OpFunctionCall %void %func_main';
+            const labels = parser.getUsedLabelsInLine(line);
+
+            expect(labels).toHaveLength(1);
+            expect(labels[0].name).toBe('%func_main');
+        });
+
+        it('should detect labels in OpBranch', () => {
+            const line = 'OpBranch %label_endif';
+            const labels = parser.getUsedLabelsInLine(line);
+
+            expect(labels).toHaveLength(1);
+            expect(labels[0].name).toBe('%label_endif');
+        });
+
+        it('should detect multiple labels in OpBranchConditional', () => {
+            const line = 'OpBranchConditional %cond %true_label %false_label';
+            const labels = parser.getUsedLabelsInLine(line);
+
+            expect(labels).toHaveLength(2);
+            expect(labels[0].name).toBe('%true_label');
+            expect(labels[1].name).toBe('%false_label');
+        });
+
+        it('should detect labels in OpSelectionMerge', () => {
+            const line = 'OpSelectionMerge %merge_label None';
+            const labels = parser.getUsedLabelsInLine(line);
+
+            expect(labels).toHaveLength(1);
+            expect(labels[0].name).toBe('%merge_label');
+        });
+
+        it('should detect labels in OpLoopMerge', () => {
+            const line = 'OpLoopMerge %merge_label %continue_label None';
+            const labels = parser.getUsedLabelsInLine(line);
+
+            expect(labels).toHaveLength(2);
+            expect(labels[0].name).toBe('%merge_label');
+            expect(labels[1].name).toBe('%continue_label');
+        });
+
+        it('should detect labels in OpSwitch', () => {
+            const line = 'OpSwitch %selector %default 1 %case1 2 %case2';
+            const labels = parser.getUsedLabelsInLine(line);
+
+            expect(labels).toHaveLength(3);
+            expect(labels[0].name).toBe('%default');
+            expect(labels[1].name).toBe('%case1');
+            expect(labels[2].name).toBe('%case2');
+        });
+
+        it('should be called during assembly processing', () => {
+            const spy = vi.spyOn(parser, 'getUsedLabelsInLine');
+
+            const spirvCode = `
+                OpBranch %exit_label
+                %exit_label = OpLabel
+            `;
+
+            parser.processAsm(spirvCode, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+
+    describe('SPIR-V assembly processing', () => {
+        it('should process complete SPIR-V function correctly', () => {
+            const spirvCode = `
+                OpCapability Shader
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint Fragment %main "main"
+                OpExecutionMode %main OriginUpperLeft
+                
+                %void = OpTypeVoid
+                %1 = OpTypeFunction %void
+                
+                %main = OpFunction %void None %1
+                %entry = OpLabel
+                OpBranch %exit
+                %exit = OpLabel
+                OpReturn
+                OpFunctionEnd
+            `;
+
+            const result = parser.processAsm(spirvCode, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            expect(result.asm.length).toBeGreaterThan(0);
+
+            // Should detect SPIR-V specific labels in assembly
+            const hasSpirVLabels = result.asm.some(line => line.labels?.some(label => label.name.startsWith('%')));
+            expect(hasSpirVLabels).toBe(true);
+        });
+
+        it('should handle complex control flow with multiple labels', () => {
+            const spirvCode = `
+                %condition = OpLoad %bool %condition_var
+                OpSelectionMerge %merge None
+                OpBranchConditional %condition %true_block %false_block
+                %true_block = OpLabel
+                OpBranch %merge
+                %false_block = OpLabel
+                OpBranch %merge
+                %merge = OpLabel
+            `;
+
+            const result = parser.processAsm(spirvCode, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should properly identify all the control flow labels
+            expect(result.labelDefinitions).toHaveProperty('%true_block');
+            expect(result.labelDefinitions).toHaveProperty('%false_block');
+            expect(result.labelDefinitions).toHaveProperty('%merge');
+        });
+    });
+});

--- a/test/vc-asm-parser-tests.ts
+++ b/test/vc-asm-parser-tests.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {VcAsmParser} from '../lib/parsers/asm-parser-vc.js';
+
+describe('VcAsmParser', () => {
+    let parser: VcAsmParser;
+
+    beforeEach(() => {
+        parser = new VcAsmParser();
+    });
+
+    describe('VC assembly processing functionality', () => {
+        it('should process VC assembly with function structure', () => {
+            const vcAssembly = `
+; Function compile flags: /Ogtp
+; File example.cpp
+; Line 1
+_main	PROC
+	mov	eax, OFFSET _variable
+	call	_function
+	ret	0
+_main	ENDP
+            `;
+
+            const result = parser.processAsm(vcAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should successfully process VC assembly format
+            expect(result).toHaveProperty('asm');
+            expect(Array.isArray(result.asm)).toBe(true);
+            expect(result.asm.length).toBeGreaterThan(0);
+
+            // Should preserve assembly instructions
+            const hasInstructions = result.asm.some(
+                line =>
+                    line.text && (line.text.includes('mov') || line.text.includes('call') || line.text.includes('ret')),
+            );
+            expect(hasInstructions).toBe(true);
+        });
+
+        it('should handle VC-specific directives and comments', () => {
+            const vcAssembly = `
+; Function compile flags: /Ogtp
+PUBLIC _function
+_data	SEGMENT
+_variable	DD	42
+_data	ENDS
+_text	SEGMENT
+_function	PROC
+	mov	eax, _variable
+	ret
+_function	ENDP
+_text	ENDS
+            `;
+
+            const result = parser.processAsm(vcAssembly, {
+                directives: true,
+                labels: false,
+                commentOnly: false,
+            });
+
+            // Should process VC segments and procedures
+            expect(result.asm.length).toBeGreaterThan(0);
+
+            // Should handle filtering of directives when requested
+            const resultWithoutDirectives = parser.processAsm(vcAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+            // Both should process successfully (directive filtering behavior may vary)
+            expect(resultWithoutDirectives.asm.length).toBeGreaterThanOrEqual(0);
+        });
+
+        it('should correctly handle VC comment filtering', () => {
+            const vcAssembly = `
+; Function compile flags: /Ogtp
+; File example.cpp
+; Line 1
+_main	PROC
+; Another comment
+	mov	eax, 42
+	ret	0
+_main	ENDP
+            `;
+
+            const resultWithComments = parser.processAsm(vcAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: false,
+            });
+
+            const resultWithoutComments = parser.processAsm(vcAssembly, {
+                directives: false,
+                labels: false,
+                commentOnly: true,
+            });
+
+            // Both should process successfully
+            expect(resultWithComments.asm.length).toBeGreaterThan(0);
+            expect(resultWithoutComments.asm.length).toBeGreaterThan(0);
+
+            // Should have the actual instruction in both cases
+            const hasInstruction = resultWithoutComments.asm.some(line => line.text?.includes('mov'));
+            expect(hasInstruction).toBe(true);
+        });
+    });
+
+    describe('VC assembly processing', () => {
+        it('should process real VC assembly correctly', () => {
+            const vcAssembly = `
+; Function compile flags: /Ogtp /arch:SSE2
+_main	PROC
+	mov	eax, OFFSET _string
+	push	eax
+	call	_printf
+	add	esp, 4
+	xor	eax, eax
+	ret	0
+_main	ENDP
+            `.trim();
+
+            const result = parser.processAsm(vcAssembly, {
+                directives: true,
+                labels: false,
+                commentOnly: false,
+            });
+
+            expect(result.asm.length).toBeGreaterThan(0);
+            // VcAsmParser doesn't return labelDefinitions - it has its own format
+            expect(result).toHaveProperty('asm');
+            expect(result.labelDefinitions).toBeUndefined();
+        });
+
+        it('should handle VC-specific syntax', () => {
+            const asmLines = ['OFFSET _data', 'DWORD PTR _variable', 'call _function'];
+
+            const usedLabels = parser.findUsedLabels(asmLines, true);
+
+            expect(usedLabels.has('_data')).toBe(true);
+            expect(usedLabels.has('_variable')).toBe(true);
+            expect(usedLabels.has('_function')).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

These tests document the expected functional behavior of AsmParser subclasses before refactoring work begins, focusing on public API behavior rather than implementation details.

## Changes

**Test Coverage Added:**
- **VcAsmParser**: Tests VC assembly format with PROC/ENDP structure, directive handling, comment filtering
- **AsmEWAVRParser**: Tests EWAVR assembly format with label structure, RSEG/PUBLIC/EXTERN directives  
- **SPIRVAsmParser**: Tests SPIR-V assembly with OpFunction/OpLabel structure, custom %label syntax detection
- **Integration tests**: Cross-parser compatibility and real test case handling

**Key Insights Documented:**
- VcAsmParser & AsmEWAVRParser have completely custom `processAsm()` implementations that don't use base class methods
- SPIRVAsmParser uses base class `processAsm()` but overrides `getUsedLabelsInLine()` for custom label detection
- Different return formats: VC/EWAVR return `{asm: [...]}`, SPIRV returns full `ParsedAsmResult` with `labelDefinitions`

## Test Plan

```bash
npm run test -- --run vc-asm-parser-tests.ts ewavr-asm-parser-tests.ts spirv-asm-parser-tests.ts asm-parser-subclass-integration-tests.ts
```

These tests establish the baseline behavior that must be preserved during the upcoming AsmParser refactoring work to ensure subclass compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)