### PR TITLE
Add recent LFortran versions

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -946,7 +946,7 @@ compiler.flangtrunk-fc.alias=flangtrunknew-fc
 
 #################################
 # LFortran
-group.lfortran.compilers=lfortran0420
+group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520
 group.lfortran.groupName=LFortran
 group.lfortran.baseName=LFortran
 group.lfortran.supportsBinary=true
@@ -957,6 +957,36 @@ group.lfortran.isSemVer=true
 compiler.lfortran0420.exe=/opt/compiler-explorer/lfortran/v0.42.0/bin/lfortran
 compiler.lfortran0420.semver=0.42.0
 compiler.lfortran0420.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0430.exe=/opt/compiler-explorer/lfortran/v0.43.0/bin/lfortran
+compiler.lfortran0430.semver=0.43.0
+compiler.lfortran0430.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0440.exe=/opt/compiler-explorer/lfortran/v0.44.0/bin/lfortran
+compiler.lfortran0440.semver=0.44.0
+compiler.lfortran0440.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0450.exe=/opt/compiler-explorer/lfortran/v0.45.0/bin/lfortran
+compiler.lfortran0450.semver=0.45.0
+compiler.lfortran0450.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0460.exe=/opt/compiler-explorer/lfortran/v0.46.0/bin/lfortran
+compiler.lfortran0460.semver=0.46.0
+compiler.lfortran0460.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0470.exe=/opt/compiler-explorer/lfortran/v0.47.0/bin/lfortran
+compiler.lfortran0470.semver=0.47.0
+compiler.lfortran0470.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0480.exe=/opt/compiler-explorer/lfortran/v0.48.0/bin/lfortran
+compiler.lfortran0480.semver=0.48.0
+compiler.lfortran0480.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0490.exe=/opt/compiler-explorer/lfortran/v0.49.0/bin/lfortran
+compiler.lfortran0490.semver=0.49.0
+compiler.lfortran0490.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0500.exe=/opt/compiler-explorer/lfortran/v0.50.0/bin/lfortran
+compiler.lfortran0500.semver=0.50.0
+compiler.lfortran0500.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0510.exe=/opt/compiler-explorer/lfortran/v0.51.0/bin/lfortran
+compiler.lfortran0510.semver=0.51.0
+compiler.lfortran0510.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0520.exe=/opt/compiler-explorer/lfortran/v0.52.0/bin/lfortran
+compiler.lfortran0520.semver=0.52.0
+compiler.lfortran0520.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 
 ###############################
 # GCC for ARM 64bit


### PR DESCRIPTION
Following from https://github.com/compiler-explorer/infra/pull/1650, add the recent lfortran versions to the front end.

Not quite sure if the `clang` version needs to change for any of them, I've guessed not!