### PR TITLE
Sort rakudo versions newest-first

### DIFF
--- a/etc/config/raku.amazon.properties
+++ b/etc/config/raku.amazon.properties
@@ -3,8 +3,10 @@ defaultCompiler=rakudo-moar-2025-05-01
 compilerType=raku
 
 group.rakudo-moar.compilers=rakudo-moar-2025-05-01:rakudo-moar-2025-04-01:rakudo-moar-2025-03-01:rakudo-moar-2025-02-01:rakudo-moar-2025-01-01:rakudo-moar-2024-12-01:rakudo-moar-2024-10-01:rakudo-moar-2024-09-01:rakudo-moar-2024-08-01:rakudo-moar-2024-07-01:rakudo-moar-2024-06-01:rakudo-moar-2024-05-01:rakudo-moar-2024-04-01:rakudo-moar-2024-03-01:rakudo-moar-2024-02-01:rakudo-moar-2024-01-01:rakudo-moar-2023-12-01:rakudo-moar-2023-11-01:rakudo-moar-2023-10-01:rakudo-moar-2023-10-02:rakudo-moar-2023-09-01:rakudo-moar-2023-08-01:rakudo-moar-2023-06-01:rakudo-moar-2023-04-01:rakudo-moar-2023-02-01:rakudo-moar-2022-12-01:rakudo-moar-2022-07-01:rakudo-moar-2022-06-01:rakudo-moar-2022-04-01:rakudo-moar-2022-03-01:rakudo-moar-2022-02-01:rakudo-moar-2021-12-01:rakudo-moar-2021-10-01:rakudo-moar-2021-09-01:rakudo-moar-2021-08-01:rakudo-moar-2021-07-01:rakudo-moar-2021-06-01:rakudo-moar-2021-05-01:rakudo-moar-2021-04-01:rakudo-moar-2021-03-01:rakudo-moar-2021-02-1-01:rakudo-moar-2021-02-01:rakudo-moar-2020-12-01:rakudo-moar-2020-11-01
-group.rakudo-moar.isSemVer=false
 group.rakudo-moar.baseName=Rakudo MoarVM
+
+## strictly speaking, the versions are not SemVer, but this makes sorting do the right thing
+group.rakudo-moar.isSemVer=true
 
 interpreted=true
 supportsBinary=false
@@ -115,3 +117,49 @@ compiler.rakudo-moar-2020-12-01.name=Rakudo 2020.12 MoarVM
 compiler.rakudo-moar-2020-11-01.name=Rakudo 2020.11 MoarVM
 
 compiler.rakudo-moar-2021-02-1-01.name=Rakudo 2021.02.1 MoarVM
+
+compiler.rakudo-moar-2025-05-01.semVer=2025.05.01
+compiler.rakudo-moar-2025-04-01.semVer=2025.04.01
+compiler.rakudo-moar-2025-03-01.semVer=2025.03.01
+compiler.rakudo-moar-2025-02-01.semVer=2025.02.01
+compiler.rakudo-moar-2025-01-01.semVer=2025.01.01
+compiler.rakudo-moar-2024-12-01.semVer=2024.12.01
+compiler.rakudo-moar-2024-10-01.semVer=2024.10.01
+compiler.rakudo-moar-2024-09-01.semVer=2024.09.01
+compiler.rakudo-moar-2024-08-01.semVer=2024.08.01
+compiler.rakudo-moar-2024-07-01.semVer=2024.07.01
+compiler.rakudo-moar-2024-06-01.semVer=2024.06.01
+compiler.rakudo-moar-2024-05-01.semVer=2024.05.01
+compiler.rakudo-moar-2024-04-01.semVer=2024.04.01
+compiler.rakudo-moar-2024-03-01.semVer=2024.03.01
+compiler.rakudo-moar-2024-02-01.semVer=2024.02.01
+compiler.rakudo-moar-2024-01-01.semVer=2024.01.01
+compiler.rakudo-moar-2023-12-01.semVer=2023.12.01
+compiler.rakudo-moar-2023-11-01.semVer=2023.11.01
+compiler.rakudo-moar-2023-10-01.semVer=2023.10.01
+compiler.rakudo-moar-2023-10-02.semVer=2023.10.02
+compiler.rakudo-moar-2023-09-01.semVer=2023.09.01
+compiler.rakudo-moar-2023-08-01.semVer=2023.08.01
+compiler.rakudo-moar-2023-06-01.semVer=2023.06.01
+compiler.rakudo-moar-2023-04-01.semVer=2023.04.01
+compiler.rakudo-moar-2023-02-01.semVer=2023.02.01
+compiler.rakudo-moar-2022-12-01.semVer=2022.12.01
+compiler.rakudo-moar-2022-07-01.semVer=2022.07.01
+compiler.rakudo-moar-2022-06-01.semVer=2022.06.01
+compiler.rakudo-moar-2022-04-01.semVer=2022.04.01
+compiler.rakudo-moar-2022-03-01.semVer=2022.03.01
+compiler.rakudo-moar-2022-02-01.semVer=2022.02.01
+compiler.rakudo-moar-2021-12-01.semVer=2021.12.01
+compiler.rakudo-moar-2021-10-01.semVer=2021.10.01
+compiler.rakudo-moar-2021-09-01.semVer=2021.09.01
+compiler.rakudo-moar-2021-08-01.semVer=2021.08.01
+compiler.rakudo-moar-2021-07-01.semVer=2021.07.01
+compiler.rakudo-moar-2021-06-01.semVer=2021.06.01
+compiler.rakudo-moar-2021-05-01.semVer=2021.05.01
+compiler.rakudo-moar-2021-04-01.semVer=2021.04.01
+compiler.rakudo-moar-2021-03-01.semVer=2021.03.01
+compiler.rakudo-moar-2021-02-01.semVer=2021.02.01
+compiler.rakudo-moar-2020-12-01.semVer=2020.12.01
+compiler.rakudo-moar-2020-11-01.semVer=2020.11.01
+
+compiler.rakudo-moar-2021-02-1-01.semVer=2021.02.1.01


### PR DESCRIPTION
by adding a (strictly speaking wrong) isSemVer=true and setting a SemVer prop based on the year.month.patch versioning that the releases have.

The decision to keep the "name" property instead of relying on baseName + SemVer is to keep the naming scheme as
Rakudo $version $backend instead of having the backend in the middle.