### PR TITLE
Add more recent LFortran linker flag

### DIFF
--- a/lib/compilers/lfortran.ts
+++ b/lib/compilers/lfortran.ts
@@ -64,6 +64,7 @@ export class LFortranCompiler extends FortranCompiler {
             execOptions = this.getDefaultExecOptions();
         }
         execOptions.env.LFORTRAN_CC = this.clang;
+        execOptions.env.LFORTRAN_LINKER = this.clang;
         return super.runCompiler(compiler, options, inputFilename, execOptions);
     }
 }


### PR DESCRIPTION
More recent versions of LFortran use `LFORTRAN_LINKER` env var for linking, rather than `LFORTRAN_CC`.

Tested locally with 0.42 and 0.51