### PR TITLE
Add padding in tool output pane

### DIFF
--- a/views/templates/panes/tool-output.pug
+++ b/views/templates/panes/tool-output.pug
@@ -22,5 +22,5 @@
     input.options.form-control(type="text" placeholder="Tool arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
   .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
     textarea.tool-stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: vertical")
-  pre.content
+  pre.content.output-content
   .monaco-placeholder


### PR DESCRIPTION
The tool output pane does not currently have any left padding like the compiler output pane. This makes selecting text hard because the selection changes as soon as the cursor touches the left border of the pane. Also, the inconsistency with the compiler output pane looks a bit weird.