### PR TITLE
Set correct tool type for local `clippy`

### DIFF
--- a/etc/config/rust.defaults.properties
+++ b/etc/config/rust.defaults.properties
@@ -22,6 +22,6 @@ tools=clippy
 tools.clippy.name=Clippy
 # overridden by `runTool`
 tools.clippy.exe=/usr/bin/clippy-driver
-tools.clippy.type=independent
+tools.clippy.type=postcompilation
 tools.clippy.class=clippy-tool
 tools.clippy.stdinHint=disabled


### PR DESCRIPTION
The `clippy` configured in `rust.defaults.properties` is currently broken since `clippy-tool.ts` requires a `postcompilation` tool (https://github.com/compiler-explorer/compiler-explorer/commit/61715be49a88c5fb3d2bb25e05974049fe26c441).