### PR TITLE
Fix argument parser for Rust >= 1.88

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -871,9 +871,9 @@ export class RustParser extends BaseParser {
         let previousOption: false | string = false;
         const options: Record<string, Argument> = {};
 
-        const doubleOptionFinder = /^\s{4}(-\w, --\w*\s?[\w:=[\]]*)\s*(.*)/i;
-        const singleOptionFinder = /^\s{8}(--[\w-]*\s?[\w:=[\]|-]*)\s*(.*)/i;
-        const singleComplexOptionFinder = /^\s{4}(-\w*\s?[\w:=[\]]*)\s*(.*)/i;
+        const doubleOptionFinder = /^\s{4}(-\w, --\w*\s?[\w:=[\]<>]*)\s*(.*)/i;
+        const singleOptionFinder = /^\s{8}(--[\w-]*\s?[\w:=[\]|<>-]*)\s*(.*)/i;
+        const singleComplexOptionFinder = /^\s{4}(-\w*\s?[\w:=[\]<>]*)\s*(.*)/i;
 
         utils.eachLine(stdout, line => {
             let description = '';

--- a/test/compilers/argument-parsers-tests.ts
+++ b/test/compilers/argument-parsers-tests.ts
@@ -298,3 +298,68 @@ describe('Rust editions parser', () => {
         expect(editions).toEqual(['2015', '2018']);
     });
 });
+
+describe('Rust help message parser', () => {
+    it('Should parse <= 1.87 help message', async () => {
+        const lines = [
+            'Usage: rustc [OPTIONS] INPUT',
+            '',
+            'Options:',
+            '    -l [KIND[:MODIFIERS]=]NAME[:RENAME]',
+            '                        Link the generated crate(s) to the specified native',
+            '                        library NAME. The optional KIND can be one of',
+            '        --target TARGET Target triple for which the code is compiled',
+            '    -W, --warn OPT      Set lint warnings',
+        ];
+        const compiler = makeCompiler(lines.join('\n'));
+        await RustParser.parse(compiler);
+        expect(compiler.compiler.supportsTarget).toBe(true);
+        expect(RustParser.getOptions(compiler, '--help')).resolves.toEqual({
+            '-l [KIND[:MODIFIERS]=]NAME[:RENAME]': {
+                description:
+                    'Link the generated crate(s) to the specified native library NAME. The optional KIND can be one of',
+                timesused: 0,
+            },
+            '--target TARGET': {
+                description: 'Target triple for which the code is compiled',
+                timesused: 0,
+            },
+            '-W, --warn OPT': {
+                description: 'Set lint warnings',
+                timesused: 0,
+            },
+        });
+    });
+
+    it('Should parse >= 1.88 help message', async () => {
+        const lines = [
+            'Usage: rustc [OPTIONS] INPUT',
+            '',
+            'Options:',
+            '    -l [<KIND>[:<MODIFIERS>]=]<NAME>[:<RENAME>]',
+            '                        Link the generated crate(s) to the specified native',
+            '                        library NAME. The optional KIND can be one of',
+            '        --target <TARGET>',
+            '                        Target triple for which the code is compiled',
+            '    -W, --warn <LINT>   Set lint warnings',
+        ];
+        const compiler = makeCompiler(lines.join('\n'));
+        await RustParser.parse(compiler);
+        expect(compiler.compiler.supportsTarget).toBe(true);
+        expect(RustParser.getOptions(compiler, '--help')).resolves.toEqual({
+            '-l [<KIND>[:<MODIFIERS>]=]<NAME>[:<RENAME>]': {
+                description:
+                    'Link the generated crate(s) to the specified native library NAME. The optional KIND can be one of',
+                timesused: 0,
+            },
+            '--target <TARGET>': {
+                description: 'Target triple for which the code is compiled',
+                timesused: 0,
+            },
+            '-W, --warn <LINT>': {
+                description: 'Set lint warnings',
+                timesused: 0,
+            },
+        });
+    });
+});


### PR DESCRIPTION
Resolves #7780.

Basically a follow-up to #7652; the output format of `rustc --help` was changed to include angle brackets `<` and `>`. This PR updates the regexes used to parse the help output and adds some tests.