### PR TITLE
Fix EBADF error in HeaptrackWrapper

### DIFF
--- a/lib/runtime-tools/heaptrack-wrapper.ts
+++ b/lib/runtime-tools/heaptrack-wrapper.ts
@@ -130,7 +130,7 @@ export class HeaptrackWrapper extends BaseRuntimeTool {
             });
         });
 
-        return new Promise(resolve => oldfs.close(fd, () => resolve(true)));
+        // Don't manually close fd - the socket owns it and closes it during cleanup
     }
 
     private async interpretAndSave(execOptions: ExecutionOptions, result: UnprocessedExecResult) {

--- a/lib/runtime-tools/heaptrack-wrapper.ts
+++ b/lib/runtime-tools/heaptrack-wrapper.ts
@@ -43,7 +43,7 @@ import {PropertyGetter} from '../properties.interfaces.js';
 
 import {BaseRuntimeTool} from './base-runtime-tool.js';
 
-const O_NONBLOCK = 2048;
+const O_NONBLOCK = fsConstants.O_NONBLOCK;
 
 export class HeaptrackWrapper extends BaseRuntimeTool {
     private rawOutput: string;
@@ -112,7 +112,7 @@ export class HeaptrackWrapper extends BaseRuntimeTool {
         return this.execFunc(this.interpreter, [this.rawOutput], execOptions);
     }
 
-    private async finishPipesAndStreams(fd: number, file: WriteStream, socket: net.Socket) {
+    private async finishPipesAndStreams(fd: number, file: WriteStream, socket: net.Socket): Promise<void> {
         socket.push(null);
         await new Promise(resolve => socket.end(() => resolve(true)));
 
@@ -120,6 +120,7 @@ export class HeaptrackWrapper extends BaseRuntimeTool {
 
         file.write(Buffer.from([0]));
 
+        // Don't manually close fd - the socket owns it and closes it during cleanup
         if (socket.resetAndDestroy) socket.resetAndDestroy();
         socket.unref();
 
@@ -129,8 +130,6 @@ export class HeaptrackWrapper extends BaseRuntimeTool {
                 resolve(true);
             });
         });
-
-        // Don't manually close fd - the socket owns it and closes it during cleanup
     }
 
     private async interpretAndSave(execOptions: ExecutionOptions, result: UnprocessedExecResult) {

--- a/test/runtime-tools/heaptrack-wrapper-tests.ts
+++ b/test/runtime-tools/heaptrack-wrapper-tests.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {execSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+describe('HeaptrackWrapper FD behavior tests', () => {
+    it('should verify that net.Socket takes ownership of file descriptors', async () => {
+        // Skip on Windows as pipes work differently there
+        if (process.platform === 'win32') {
+            return;
+        }
+
+        const tmpDir = os.tmpdir();
+        const pipePath = path.join(tmpDir, `test_pipe_${process.pid}_${Date.now()}`);
+
+        try {
+            // Create a named pipe
+            execSync(`mkfifo "${pipePath}"`);
+
+            // Open the pipe with O_NONBLOCK (like HeaptrackWrapper does)
+            const O_NONBLOCK = 0x800; // Linux O_NONBLOCK
+            const O_RDWR = fs.constants.O_RDWR;
+
+            const fd = fs.openSync(pipePath, O_RDWR | O_NONBLOCK);
+
+            // Verify FD is valid before creating socket
+            expect(() => fs.fstatSync(fd)).not.toThrow();
+
+            // Create a net.Socket with the pipe FD (like HeaptrackWrapper)
+            const socket = new net.Socket({fd: fd, readable: true, writable: true});
+
+            // Set up a promise to wait for socket close
+            const socketClosed = new Promise<void>(resolve => {
+                socket.on('close', resolve);
+            });
+
+            // Destroy the socket
+            socket.destroy();
+
+            // Wait for socket to close
+            await socketClosed;
+
+            // Verify that the FD has been closed by the socket
+            // Attempting to use the FD should throw EBADF
+            expect(() => fs.fstatSync(fd)).toThrow(/EBADF/);
+
+            // Attempting to manually close should also fail with EBADF
+            // This confirms the socket already closed it
+            await expect(
+                new Promise((resolve, reject) => {
+                    fs.close(fd, err => {
+                        if (err) reject(err);
+                        else resolve(true);
+                    });
+                }),
+            ).rejects.toThrow(/EBADF/);
+        } finally {
+            // Clean up the pipe
+            try {
+                fs.unlinkSync(pipePath);
+            } catch {
+                // Ignore cleanup errors
+            }
+        }
+    });
+
+    it('should verify net.Socket closes FDs on destroy - critical for HeaptrackWrapper', async () => {
+        // Skip on Windows as pipes work differently there
+        if (process.platform === 'win32') {
+            return;
+        }
+
+        // This test verifies the critical assumption that HeaptrackWrapper relies on:
+        // When a net.Socket is created with an FD and then destroyed, it closes that FD.
+        // If this behavior changes in future Node.js versions, HeaptrackWrapper will break.
+
+        return new Promise<void>((resolve, reject) => {
+            // Create a pair of connected sockets
+            const server = net.createServer(socket => {
+                // Get the raw FD from the socket
+                const fd = (socket as any)._handle?.fd;
+
+                if (!fd) {
+                    // If we can't get the FD, skip the test but log a warning
+                    console.warn('Could not access socket._handle.fd - Node.js internals may have changed');
+                    server.close();
+                    resolve();
+                    return;
+                }
+
+                // Verify FD is valid before destroying the socket
+                try {
+                    fs.fstatSync(fd);
+                } catch (err) {
+                    reject(new Error('FD should be valid before socket destroy'));
+                    return;
+                }
+
+                // Now destroy the socket - this is what HeaptrackWrapper does
+                socket.on('close', () => {
+                    // After destroy, the FD should be closed
+                    try {
+                        fs.fstatSync(fd);
+                        reject(
+                            new Error(
+                                'FD should be closed after socket.destroy() - HeaptrackWrapper assumption violated!',
+                            ),
+                        );
+                    } catch (err: any) {
+                        if (err.code === 'EBADF') {
+                            // Good! The FD was closed as expected
+                            server.close();
+                            resolve();
+                        } else {
+                            reject(err);
+                        }
+                    }
+                });
+
+                socket.destroy();
+            });
+
+            server.on('error', reject);
+
+            server.listen(0, () => {
+                const client = net.connect((server.address() as net.AddressInfo).port);
+                client.on('error', () => {
+                    // Ignore client errors - we're destroying the socket anyway
+                });
+            });
+        });
+    });
+});

--- a/test/runtime-tools/heaptrack-wrapper-tests.ts
+++ b/test/runtime-tools/heaptrack-wrapper-tests.ts
@@ -46,7 +46,7 @@ describe('HeaptrackWrapper FD behavior tests', () => {
             execSync(`mkfifo "${pipePath}"`);
 
             // Open the pipe with O_NONBLOCK (like HeaptrackWrapper does)
-            const O_NONBLOCK = 0x800; // Linux O_NONBLOCK
+            const O_NONBLOCK = fs.constants.O_NONBLOCK; // Use fs.constants for portability
             const O_RDWR = fs.constants.O_RDWR;
             const fd = fs.openSync(pipePath, O_RDWR | O_NONBLOCK);
 


### PR DESCRIPTION
## Summary
- Fixes EBADF error in HeaptrackWrapper by removing redundant file descriptor close operation
- The net.Socket takes ownership of the FD and closes it during cleanup, making manual close unnecessary and dangerous

## Root Cause Analysis
The issue occurred in `lib/runtime-tools/heaptrack-wrapper.ts:133` where the code attempted to manually close a file descriptor that was already owned by a `net.Socket`. When creating a socket with `new net.Socket({fd: fd})`, the socket takes ownership of the file descriptor and closes it during cleanup operations like `resetAndDestroy()`.

Attempting to close the FD again results in:
1. EBADF errors when the FD hasn't been recycled
2. Potentially closing a different resource if the FD has been recycled by the OS

## Solution
Removed the manual `oldfs.close(fd)` call since the socket handles FD cleanup automatically. This prevents both the EBADF error and the more dangerous scenario of closing recycled file descriptors.

## Verification
Created tests to verify that `net.Socket` takes ownership of file descriptors:
```javascript
// Test confirms that after socket.destroy(), the FD is no longer valid
const fd = fs.openSync(pipePath, O_RDWR | O_NONBLOCK);
const socket = new net.Socket({ fd: fd, readable: true, writable: true });
socket.destroy();
// fs.fstatSync(fd) throws EBADF - confirming FD was closed by socket
```

## Test Plan
- [x] TypeScript compilation passes
- [x] Minimal test suite passes
- [x] Pre-commit hooks pass
- [x] Created unit test to verify net.Socket FD ownership behavior

Fixes COMPILER-EXPLORER-EA7

🤖 Generated with [Claude Code](https://claude.ai/code)