### PR TITLE
Re-enable Monaco autoformatting for Rust

### DIFF
--- a/static/formatter-registry.ts
+++ b/static/formatter-registry.ts
@@ -102,6 +102,6 @@ const register = (lang: string, formatter: string, isOneTrueStyle: boolean) => {
 register('cppp', 'clangformat', false);
 register('nc', 'clangformat', false);
 register('go', 'gofmt', true);
-register('rust', 'rustfmt', true);
+register('rustp', 'rustfmt', true);
 register('dart', 'dartformat', true);
 register('v', 'vfmt', true);

--- a/static/modes/rust-mode.ts
+++ b/static/modes/rust-mode.ts
@@ -53,7 +53,7 @@ function definition(): monaco.languages.IMonarchLanguage {
 
     if (!patternFound) {
         throw new Error(
-            'Monaco Rust hex pattern not found - check if upstream fixed the issue (https://github.com/microsoft/monaco-editor/issues/4917) and remove this patch',
+            'Monaco Rust hex pattern not found - check if upstream fixed the issue (https://github.com/microsoft/monaco-editor/issues/4917), remove this patch and revert #7819',
         );
     }
 


### PR DESCRIPTION
#7766 changed the Monaco language identifier for Rust, but missed a spot in `formatter-registry.ts`, so now Monaco can’t autoformat (right click → “Format Document”) Rust code any more.