### PR TITLE
Add CopperSpice GUI support with automatic Xcb plugin deployment

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6446,8 +6446,8 @@ libs.curl.versions.7831.path=/opt/compiler-explorer/libs/curl/7.83.1/include
 
 libs.copperspice.name=CopperSpice
 libs.copperspice.url=https://www.copperspice.com/
-libs.copperspice.description=CopperSpice is a set of individual libraries which can be used to develop cross platform software applications in C++. Note that on CE we only include: CsCore, CsXml, CsXmlPatterns, CsNetwork and CsScript.
-libs.copperspice.liblink=CsScript1.8:CsXmlPatterns1.8:CsNetwork1.8:CsXml1.8:CsCore1.8
+libs.copperspice.description=CopperSpice is a set of individual libraries which can be used to develop cross platform software applications in C++. Note that on CE we only include: CsCore, CsXml, CsXmlPatterns, CsNetwork, CsScript and CsGui.
+libs.copperspice.liblink=CsGui1.8:CsScript1.8:CsXmlPatterns1.8:CsNetwork1.8:CsXml1.8:CsCore1.8
 libs.copperspice.versions=180
 libs.copperspice.versions.180.version=1.8.0
 libs.copperspice.versions.180.path=/opt/compiler-explorer/libs/copperspice/1.8.0/include:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtCore:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXml:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXmlPatterns:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtNetwork:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtScript:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtGui

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2359,8 +2359,8 @@ libs.curl.versions.7831.path=/opt/compiler-explorer/libs/curl/7.83.1/include
 
 libs.copperspice.name=CopperSpice
 libs.copperspice.url=https://www.copperspice.com/
-libs.copperspice.description=CopperSpice is a set of individual libraries which can be used to develop cross platform software applications in C++. Note that on CE we only include: CsCore, CsXml, CsXmlPatterns, CsNetwork and CsScript.
-libs.copperspice.liblink=CsScript1.8:CsXmlPatterns1.8:CsNetwork1.8:CsXml1.8:CsCore1.8
+libs.copperspice.description=CopperSpice is a set of individual libraries which can be used to develop cross platform software applications in C++. Note that on CE we only include: CsCore, CsXml, CsXmlPatterns, CsNetwork, CsScript and CsGui.
+libs.copperspice.liblink=CsGui1.8:CsScript1.8:CsXmlPatterns1.8:CsNetwork1.8:CsXml1.8:CsCore1.8
 libs.copperspice.versions=180
 libs.copperspice.versions.180.version=1.8.0
 libs.copperspice.versions.180.path=/opt/compiler-explorer/libs/copperspice/1.8.0/include:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtCore:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXml:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXmlPatterns:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtNetwork:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtScript

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2363,7 +2363,7 @@ libs.copperspice.description=CopperSpice is a set of individual libraries which 
 libs.copperspice.liblink=CsGui1.8:CsScript1.8:CsXmlPatterns1.8:CsNetwork1.8:CsXml1.8:CsCore1.8
 libs.copperspice.versions=180
 libs.copperspice.versions.180.version=1.8.0
-libs.copperspice.versions.180.path=/opt/compiler-explorer/libs/copperspice/1.8.0/include:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtCore:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXml:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXmlPatterns:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtNetwork:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtScript
+libs.copperspice.versions.180.path=/opt/compiler-explorer/libs/copperspice/1.8.0/include:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtCore:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXml:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtXmlPatterns:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtNetwork:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtScript:/opt/compiler-explorer/libs/copperspice/1.8.0/include/QtGui
 libs.copperspice.versions.180.libpath=/opt/compiler-explorer/libs/copperspice/1.8.0/lib
 
 

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import os from 'node:os';
 import path from 'node:path';
 
 import fs from 'node:fs/promises';
@@ -80,6 +81,7 @@ import {type ToolResult, type ToolTypeKey} from '../types/tool.interfaces.js';
 
 import {moveArtifactsIntoResult} from './artifact-utils.js';
 import {assert, unwrap} from './assert.js';
+import {copyCopperSpicePlugins} from './binaries/copperspice-utils.js';
 import type {BuildEnvDownloadInfo} from './buildenvsetup/buildenv.interfaces.js';
 import {BuildEnvSetupBase, getBuildEnvTypeByKey} from './buildenvsetup/index.js';
 import {BaseCache} from './cache/base.js';
@@ -1969,6 +1971,11 @@ export class BaseCompiler {
     }
 
     async afterBuild(key: CacheKey, dirPath: string, buildResult: BuildResult): Promise<BuildResult> {
+        if (os.platform() === 'linux' && buildResult.code === 0 && buildResult.executableFilename) {
+            const libraryPaths = this.getSharedLibraryPaths(key.libraries, dirPath);
+            await copyCopperSpicePlugins(dirPath, buildResult.executableFilename, key.libraries, libraryPaths);
+        }
+
         return buildResult;
     }
 

--- a/lib/binaries/copperspice-utils.ts
+++ b/lib/binaries/copperspice-utils.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2024, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
+import {logger} from '../logger.js';
+
+function hasCopperSpiceGui(libraries: SelectedLibraryVersion[]): boolean {
+    return libraries.some(lib => lib.id === 'copperspice');
+}
+
+async function findCopperSpicePlugins(libraryPaths: string[]): Promise<string[]> {
+    const pluginFiles: string[] = [];
+
+    for (const libPath of libraryPaths) {
+        try {
+            const files = await fs.readdir(libPath);
+            for (const file of files) {
+                if (file.startsWith('CsGuiXcb') && file.endsWith('.so')) {
+                    const fullPath = path.join(libPath, file);
+                    pluginFiles.push(fullPath);
+                    logger.debug(`Found CopperSpice plugin: ${fullPath}`);
+                }
+                if (file.startsWith('CsXcbSupport') && file.endsWith('.so')) {
+                    const fullPath = path.join(libPath, file);
+                    pluginFiles.push(fullPath);
+                    logger.debug(`Found CopperSpice support plugin: ${fullPath}`);
+                }
+            }
+        } catch (e) {
+            logger.debug(`Could not read directory ${libPath}: ${e}`);
+        }
+    }
+
+    return pluginFiles;
+}
+
+export async function copyCopperSpicePlugins(
+    dirPath: string,
+    executableFilename: string,
+    libraries: SelectedLibraryVersion[],
+    libraryPaths: string[] = [],
+): Promise<void> {
+    if (!hasCopperSpiceGui(libraries)) {
+        return;
+    }
+
+    logger.debug(`CopperSpice GUI detected, setting up Xcb plugins for ${executableFilename}`);
+
+    try {
+        // Default CopperSpice library path if none provided
+        if (libraryPaths.length === 0) {
+            libraryPaths = ['/opt/compiler-explorer/libs/copperspice/1.8.0/lib'];
+        }
+
+        const pluginFiles = await findCopperSpicePlugins(libraryPaths);
+
+        if (pluginFiles.length === 0) {
+            logger.debug('No CopperSpice Xcb plugins found in library paths');
+            return;
+        }
+
+        // Create platforms directory for Qt-style plugin discovery
+        const platformsDir = path.join(dirPath, 'platforms');
+        await fs.mkdir(platformsDir, {recursive: true});
+
+        // Copy plugin files to platforms directory
+        for (const pluginFile of pluginFiles) {
+            const targetPath = path.join(platformsDir, path.basename(pluginFile));
+            await fs.copyFile(pluginFile, targetPath);
+            logger.debug(`Copied ${path.basename(pluginFile)} to platforms directory`);
+        }
+
+        logger.debug(`Successfully set up CopperSpice plugins in ${platformsDir}`);
+    } catch (e) {
+        logger.error(`Error while setting up CopperSpice plugins for ${executableFilename}: ${e}`);
+    }
+}

--- a/lib/binaries/copperspice-utils.ts
+++ b/lib/binaries/copperspice-utils.ts
@@ -71,7 +71,6 @@ export async function copyCopperSpicePlugins(
     logger.debug(`CopperSpice GUI detected, setting up Xcb plugins for ${executableFilename}`);
 
     try {
-        // Default CopperSpice library path if none provided
         if (libraryPaths.length === 0) {
             libraryPaths = ['/opt/compiler-explorer/libs/copperspice/1.8.0/lib'];
         }
@@ -83,11 +82,9 @@ export async function copyCopperSpicePlugins(
             return;
         }
 
-        // Create platforms directory for Qt-style plugin discovery
         const platformsDir = path.join(dirPath, 'platforms');
         await fs.mkdir(platformsDir, {recursive: true});
 
-        // Copy plugin files to platforms directory
         for (const pluginFile of pluginFiles) {
             const targetPath = path.join(platformsDir, path.basename(pluginFile));
             await fs.copyFile(pluginFile, targetPath);


### PR DESCRIPTION
## Summary

This PR implements automatic CopperSpice GUI support to resolve Qt platform plugin discovery issues (fixes #5221).

### Changes

- **Library Configuration**: Include `CsGui1.8` in default CopperSpice library linking across all property files
- **Plugin Auto-deployment**: Automatically copy CopperSpice Xcb plugins (`CsGuiXcb*.so`, `CsXcbSupport*.so`) to `platforms/` directory for GUI applications
- **Platform Safety**: Linux-only implementation with `os.platform()` check to avoid conflicts with Windows builds
- **Centralized Logic**: Integrated into `BaseCompiler.afterBuild()` for consistent behavior across all compilers

### Implementation Details

- Created `lib/binaries/copperspice-utils.ts` with plugin detection and copying logic
- Updated CopperSpice library configuration in `c++.amazon.properties` and `objc++.amazon.properties`
- Added platform-aware integration to `base-compiler.ts` 
- Follows Qt's standard plugin discovery mechanism (no environment variables needed)

### Test Plan

- [x] TypeScript compilation passes
- [x] Linting passes  
- [x] Pre-commit hooks pass
- [x] Test with CopperSpice GUI example (e.g., https://cppcoach.godbolt.org/z/jecoed4hh)
- [x] Verify plugin files are copied to platforms/ directory on successful GUI compilation
- [ ] Confirm Windows builds are unaffected

This resolves the "platform plugin was not found" error for CopperSpice GUI applications while maintaining compatibility with existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)