### PR TITLE
Ban unused imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -31,7 +31,8 @@
         "useTemplate": "off"
       },
       "correctness": {
-        "noUnsafeOptionalChaining": "off"
+        "noUnsafeOptionalChaining": "off",
+        "noUnusedImports": "error"
       },
       "performance": {
         "noAccumulatingSpread": "off",

--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -22,8 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import _ from 'underscore';
-
 import {isString} from '../../shared/common-utils.js';
 import {
     AsmResultLabel,


### PR DESCRIPTION
Enables non-default linter rule to ban unused imports