### PR TITLE
Filter Monaco Editor hit testing errors in Sentry

### DIFF
--- a/static/sentry.ts
+++ b/static/sentry.ts
@@ -71,7 +71,7 @@ export function SetupSentry() {
                 /Illegal value for lineNumber/,
                 'SlowRequest',
             ],
-            beforeSend(event: Sentry.Event, hint: Sentry.EventHint) {
+            beforeSend(event, hint) {
                 // Filter Monaco Editor hit testing errors
                 // See: https://github.com/microsoft/monaco-editor/issues/4527
                 if (event.exception?.values?.[0]?.stacktrace?.frames) {

--- a/static/sentry.ts
+++ b/static/sentry.ts
@@ -71,7 +71,7 @@ export function SetupSentry() {
                 /Illegal value for lineNumber/,
                 'SlowRequest',
             ],
-            beforeSend(event, hint) {
+            beforeSend(event: Sentry.Event, hint: Sentry.EventHint) {
                 // Filter Monaco Editor hit testing errors
                 // See: https://github.com/microsoft/monaco-editor/issues/4527
                 if (event.exception?.values?.[0]?.stacktrace?.frames) {


### PR DESCRIPTION
## Summary
- Replace broken regex filter with proper `beforeSend` handler for Monaco Editor errors
- Fixes noise from Monaco Editor hit testing bug in Firefox (190K+ occurrences)
- Uses structured stack frame checking instead of string parsing

## Root Cause
COMPILER-EXPLORER-AXA was caused by a known Monaco Editor bug in Firefox where hit testing fails with null reference errors during mouse operations. The existing regex filter `/i is null _doHitTestWithCaretPositionFromPoint/` was ineffective because Sentry's `ignoreErrors` only matches error messages, not stack traces.

## Solution
Added a `beforeSend` callback that:
- Checks if the top stack frame function is `_doHitTestWithCaretPositionFromPoint`
- Filters out any error thrown directly from this Monaco Editor function
- Uses Sentry's structured stack frames for reliable detection

## References
- Fixes Sentry issue: COMPILER-EXPLORER-AXA (190K+ occurrences)
- Related Monaco Editor bug: https://github.com/microsoft/monaco-editor/issues/4527

## Test plan
- [x] TypeScript checks pass
- [x] Test suite passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)