### PR TITLE
Fix unhandled promise rejections causing Sentry noise

### DIFF
--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -201,10 +201,10 @@ export class CompilerService {
                     break;
             }
         }
-        reject({
-            request: request,
-            error: error,
-        });
+        const requestError = new Error(error);
+        // Attach request context to the error for debugging
+        (requestError as any).request = request;
+        reject(requestError);
     }
 
     private getBaseUrl() {

--- a/static/multifile-service.ts
+++ b/static/multifile-service.ts
@@ -422,7 +422,7 @@ export class MultifileService {
         if (file) {
             return this.includeByFileId(file.fileId);
         }
-        return Promise.reject('File not found');
+        return Promise.reject(new Error('File not found'));
     }
 
     public forEachOpenFile(callback: (File) => void) {
@@ -497,7 +497,7 @@ export class MultifileService {
 
     public async renameFile(fileId: number): Promise<boolean> {
         const file = this.getFileByFileId(fileId);
-        if (!file) return Promise.reject('File could not be found');
+        if (!file) return Promise.reject(new Error('File could not be found'));
 
         let editor: any = null;
         if (file.isOpen && file.editorId > 0) {
@@ -546,6 +546,6 @@ export class MultifileService {
         if (file) {
             return this.renameFile(file.fileId);
         }
-        return Promise.reject('File not found');
+        return Promise.reject(new Error('File not found'));
     }
 }

--- a/static/panes/cfg-view.ts
+++ b/static/panes/cfg-view.ts
@@ -670,7 +670,7 @@ export class Cfg extends Pane<CfgState> {
                 if (blob) {
                     resolve(blob);
                 } else {
-                    reject(blob);
+                    reject(new Error('Failed to create blob from canvas'));
                 }
             }, 'image/png');
         });

--- a/static/panes/tree.ts
+++ b/static/panes/tree.ts
@@ -608,10 +608,10 @@ export class Tree {
                         resolve();
                     },
                     no: () => {
-                        reject();
+                        reject(new Error('User cancelled file overwrite'));
                     },
                     onClose: () => {
-                        reject();
+                        reject(new Error('User cancelled file overwrite'));
                     },
                     yesClass: 'btn-danger',
                     yesHtml: 'Yes',

--- a/static/sentry.ts
+++ b/static/sentry.ts
@@ -84,7 +84,17 @@ export function SetupSentry() {
             },
         });
         window.addEventListener('unhandledrejection', event => {
-            SentryCapture(event.reason, 'Unhandled Promise Rejection');
+            // Convert non-Error rejection reasons to Error objects
+            let reason = event.reason;
+            if (!(reason instanceof Error)) {
+                const errorMessage =
+                    typeof reason === 'string' ? reason : `Non-Error rejection: ${JSON.stringify(reason)}`;
+                reason = new Error(errorMessage);
+
+                // Preserve original reason for debugging
+                (reason as any).originalReason = event.reason;
+            }
+            SentryCapture(reason, 'Unhandled Promise Rejection');
         });
     }
 }

--- a/static/sharing.ts
+++ b/static/sharing.ts
@@ -293,7 +293,13 @@ export class Sharing {
                 if (error || !newUrl) {
                     this.displayTooltip(this.shareTooltipTarget, 'Oops, something went wrong');
                     SentryCapture(error, 'Getting short link failed');
-                    reject();
+                    reject(
+                        new Error(
+                            error
+                                ? `Getting short link failed: ${error}`
+                                : 'Getting short link failed: no URL returned',
+                        ),
+                    );
                 } else {
                     if (updateState) {
                         Sharing.storeCurrentConfig(config, extra);


### PR DESCRIPTION
## Summary
- Fixes unhandled promise rejections being logged as "Non-Error capture" in Sentry issue COMPILER-EXPLORER-BT9
- Converts all promise rejections to use proper Error objects instead of plain objects/strings/undefined
- Adds defensive handling in Sentry's unhandled rejection listener

## Root Cause
The Sentry issue was caused by services rejecting promises with non-Error objects:
- `CompilerService.handleRequestError()` rejected with `{request, error}` plain objects
- Various other services rejected with strings or undefined values
- These triggered the global unhandled rejection handler, which logged them as "Non-Error capture"

## Changes Made
1. **CompilerService**: Modified `handleRequestError()` to reject with Error objects while preserving request context
2. **Sentry**: Enhanced unhandled rejection handler to defensively convert non-Error reasons to Error objects
3. **MultifileService**: Changed string rejections to Error objects
4. **SharingService**: Added descriptive Error objects for link failures
5. **TreePane**: Used Error objects for user cancellation scenarios
6. **CfgView**: Used Error objects for canvas blob creation failures

## Test Plan
- [x] TypeScript compilation passes
- [x] All tests pass (npm run test-min)
- [x] Linter passes
- [x] Pre-commit hooks validated

## Impact
- Reduces Sentry noise from "Non-Error capture" events
- Provides better stack traces for debugging
- Maintains backwards compatibility (consuming code handles both Error objects and other types)
- More robust error handling throughout the application

🤖 Generated with [Claude Code](https://claude.ai/code)