### PR TITLE
Fix clipboard cancellation filter to use startsWith - Fixes COMPILER-EXPLORER-CGQ

### DIFF
--- a/static/sentry.ts
+++ b/static/sentry.ts
@@ -93,8 +93,8 @@ export function SetupSentry() {
                     const hasClipboardFrame = frames.some(frame =>
                         frame.filename?.includes('monaco-editor/esm/vs/platform/clipboard/browser/clipboardService.js'),
                     );
-                    // NOTE: Error value is just "Canceled", not "Canceled: Canceled" (UI combines type + value)
-                    const isCancellationError = event.exception.values[0].value === 'Canceled';
+                    // NOTE: Error value may be "Canceled" or "Canceled\nSentryCapture Context: ..." due to context addition
+                    const isCancellationError = event.exception.values[0].value?.startsWith('Canceled');
 
                     if (hasClipboardFrame && isCancellationError) {
                         return null; // Don't send to Sentry


### PR DESCRIPTION
## Summary

Fixed the clipboard cancellation filter that was deployed but not working due to `SentryCapture` context modification.

## Root Cause

The filter was checking for exact equality:
```typescript
event.exception.values[0].value === 'Canceled'
```

But `SentryCapture()` modifies error messages by adding context:
- Original: `"Canceled"`
- Modified: `"Canceled\nSentryCapture Context: Unhandled Promise Rejection"`

## Solution

Changed to use `startsWith('Canceled')` which:
- ✅ Catches original error: `"Canceled"`
- ✅ Catches modified error: `"Canceled\nSentryCapture Context: ..."`
- ✅ More precise than `includes()` - reduces false positives
- ✅ Still combined with specific stack trace check for safety

## Test Plan

- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass
- [ ] Deploy and verify clipboard cancellation errors are filtered

This should finally stop the 20k+ COMPILER-EXPLORER-CGQ occurrences.

🤖 Generated with [Claude Code](https://claude.ai/code)