### PR TITLE
Fix unhandled promise rejections in compiler and executor panes - Fixes COMPILER-EXPLORER-BY1

### DIFF
--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -322,21 +322,36 @@ export class Executor extends Pane<ExecutorState> {
             });
             return;
         }
-        this.hub.compilerService.expandToFiles(this.source).then((sourceAndFiles: SourceAndFiles) => {
-            const request: CompilationRequest = {
-                source: sourceAndFiles.source || '',
-                compiler: this.compiler ? this.compiler.id : '',
-                options: options,
-                lang: this.currentLangId,
-                files: sourceAndFiles.files,
-            };
-            if (bypassCache) request.bypassCache = bypassCache;
-            if (!this.compiler) {
-                this.onCompileResponse(request, this.errorResult('<Please select a compiler>'), false);
-            } else {
-                this.sendCompile(request);
-            }
-        });
+        this.hub.compilerService
+            .expandToFiles(this.source)
+            .then((sourceAndFiles: SourceAndFiles) => {
+                const request: CompilationRequest = {
+                    source: sourceAndFiles.source || '',
+                    compiler: this.compiler ? this.compiler.id : '',
+                    options: options,
+                    lang: this.currentLangId,
+                    files: sourceAndFiles.files,
+                };
+                if (bypassCache) request.bypassCache = bypassCache;
+                if (!this.compiler) {
+                    this.onCompileResponse(request, this.errorResult('<Please select a compiler>'), false);
+                } else {
+                    this.sendCompile(request);
+                }
+            })
+            .catch(error => {
+                this.onCompileResponse(
+                    {
+                        source: this.source,
+                        compiler: this.compiler?.id || '',
+                        options: options,
+                        lang: this.currentLangId,
+                        files: [],
+                    },
+                    this.errorResult('Failed to expand includes: ' + error.message),
+                    false,
+                );
+            });
     }
 
     compileFromTree(options: CompilationRequestOptions, bypassCache?: BypassCache): void {
@@ -374,26 +389,34 @@ export class Executor extends Pane<ExecutorState> {
             );
         }
 
-        Promise.all(fetches).then(() => {
-            const treeState = tree.currentState();
-            const cmakeProject = tree.multifileService.isACMakeProject();
-            request.files.push(...moreFiles);
+        Promise.all(fetches)
+            .then(() => {
+                const treeState = tree.currentState();
+                const cmakeProject = tree.multifileService.isACMakeProject();
+                request.files.push(...moreFiles);
 
-            if (bypassCache) request.bypassCache = bypassCache;
-            if (!this.compiler) {
-                this.onCompileResponse(request, this.errorResult('<Please select a compiler>'), false);
-            } else if (cmakeProject && request.source === '') {
-                this.onCompileResponse(request, this.errorResult('<Please supply a CMakeLists.txt>'), false);
-            } else {
-                if (cmakeProject) {
-                    request.options.compilerOptions.cmakeArgs = treeState.cmakeArgs;
-                    request.options.compilerOptions.customOutputFilename = treeState.customOutputFilename;
-                    this.sendCMakeCompile(request);
+                if (bypassCache) request.bypassCache = bypassCache;
+                if (!this.compiler) {
+                    this.onCompileResponse(request, this.errorResult('<Please select a compiler>'), false);
+                } else if (cmakeProject && request.source === '') {
+                    this.onCompileResponse(request, this.errorResult('<Please supply a CMakeLists.txt>'), false);
                 } else {
-                    this.sendCompile(request);
+                    if (cmakeProject) {
+                        request.options.compilerOptions.cmakeArgs = treeState.cmakeArgs;
+                        request.options.compilerOptions.customOutputFilename = treeState.customOutputFilename;
+                        this.sendCMakeCompile(request);
+                    } else {
+                        this.sendCompile(request);
+                    }
                 }
-            }
-        });
+            })
+            .catch(error => {
+                this.onCompileResponse(
+                    request,
+                    this.errorResult('Failed to expand includes in files: ' + error.message),
+                    false,
+                );
+            });
     }
 
     sendCMakeCompile(request: CompilationRequest): void {

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -413,7 +413,7 @@ export class Executor extends Pane<ExecutorState> {
             .catch(error => {
                 this.onCompileResponse(
                     request,
-                    this.errorResult('Failed to expand includes in files: ' + error.message),
+                    this.errorResult('Failed to expand includes in files: ' + (error instanceof Error ? error.message : String(error))),
                     false,
                 );
             });

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -348,7 +348,7 @@ export class Executor extends Pane<ExecutorState> {
                         lang: this.currentLangId,
                         files: [],
                     },
-                    this.errorResult('Failed to expand includes: ' + error.message),
+                    this.errorResult('Failed to expand includes: ' + (error instanceof Error ? error.message : String(error))),
                     false,
                 );
             });

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -348,7 +348,9 @@ export class Executor extends Pane<ExecutorState> {
                         lang: this.currentLangId,
                         files: [],
                     },
-                    this.errorResult('Failed to expand includes: ' + (error instanceof Error ? error.message : String(error))),
+                    this.errorResult(
+                        'Failed to expand includes: ' + (error instanceof Error ? error.message : String(error)),
+                    ),
                     false,
                 );
             });
@@ -413,7 +415,10 @@ export class Executor extends Pane<ExecutorState> {
             .catch(error => {
                 this.onCompileResponse(
                     request,
-                    this.errorResult('Failed to expand includes in files: ' + (error instanceof Error ? error.message : String(error))),
+                    this.errorResult(
+                        'Failed to expand includes in files: ' +
+                            (error instanceof Error ? error.message : String(error)),
+                    ),
                     false,
                 );
             });


### PR DESCRIPTION
## Summary
- Added missing `.catch()` handlers for `expandToFiles()` calls in compiler.ts and executor.ts
- Added error handling for `requestPopularArguments()` calls (with console.warn since they're optional)
- Fixed `Promise.all()` for file expansion operations to properly handle rejections

## Background
Sentry issue COMPILER-EXPLORER-BY1 was tracking unhandled promise rejections with the error:
```
UnhandledRejection: Object captured as promise rejection with keys: error, request
```

## Root Cause
Several promise chains were missing `.catch()` handlers:
1. `expandToFiles()` calls that could fail due to network issues or invalid includes
2. `requestPopularArguments()` calls that could fail but are optional features
3. `Promise.all()` aggregating multiple `expandToFiles()` operations

## Solution
- **Critical errors**: `expandToFiles()` failures now show proper error messages to users via `this.onCompileResponse()`
- **Optional features**: `requestPopularArguments()` failures are logged to console but don't disrupt workflow
- **Defensive programming**: All promise chains now have proper error handling

## Test Plan
- [x] `npm run ts-check` passes
- [x] `npm run lint` passes  
- [x] `npm run test-min` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)