### PR TITLE
Fix MSVC library naming for debug/release modes

### DIFF
--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -74,8 +74,8 @@ export class Win32Compiler extends BaseCompiler {
             }
         }
 
-        // If fullLibName is a full path (not just a filename), try it directly
-        if (path.isAbsolute(fullLibName) || fullLibName.includes(path.sep)) {
+        // If fullLibName is an absolute path (not just a filename), try it directly
+        if (path.isAbsolute(fullLibName)) {
             if (fs.existsSync(fullLibName)) {
                 return libName;
             }


### PR DESCRIPTION
## Summary
- Add file existence check for .lib files in Windows MSVC compiler
- Try release version (without 'd' suffix) if debug version doesn't exist  
- Applies to both static and shared library linking
- Maintains backward compatibility by falling back to original behavior

## Problem
When switching to Release mode libraries for MSVC compilers, library names sometimes change. For example, fmt uses `fmtd.lib` in debug mode but `fmt.lib` in release mode. This inconsistency causes linking failures when the expected library file doesn't exist.

## Solution
Enhanced the Win32 compiler to:
1. Check if the requested library file exists in the configured library paths
2. If not found and the library name ends with 'd' (debug suffix), try the release version by removing the 'd'
3. Only check absolute paths directly (not relative paths or plain filenames in current directory)
4. Fall back to original behavior if no suitable library is found

## Test plan
- [x] TypeScript compilation passes
- [x] Linting passes  
- [x] Minimal test suite passes
- [x] Test with MSVC compiler using libraries that have debug/release naming differences
- [x] Verify fallback behavior works correctly
- [ ] Ensure no regression in existing library linking

🤖 Generated with [Claude Code](https://claude.ai/code)