### PR TITLE
Aarch64 config fixes

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1122,9 +1122,11 @@ compiler.cicxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.2.0
 ###############################
 # Cross Compilers (mostly GCC & Clang)
 group.ccross.compilers=&cppcs:&cmipss:&cnanomips:&cmrisc32:&cmsp:&cgccarm:&cavr:&rvcgcc:&cxtensaesp32:&cxtensaesp32s2:&cxtensaesp32s3:&cplatspec:&ckalray:&cs390x:&csh:&cloongarch64:&cc6x:&csparc:&csparc64:&csparcleon:&cbpf:&cvax:&cm68k:&chppa:&ctricore
-group.ccross.supportsBinary=false
 group.ccross.supportsBinaryObject=true
+group.ccross.supportsBinary=true
 group.ccross.groupName=Cross GCC
+group.ccross.supportsExecute=false
+
 group.ccross.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.ccross.licenseName=GNU General Public License
 group.ccross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>

--- a/etc/config/execution.aarch64prod.properties
+++ b/etc/config/execution.aarch64prod.properties
@@ -2,4 +2,4 @@ sandboxType=nsjail
 executionType=nsjail
 wine=
 wineServer=
-firejail=/usr/local/firejail-0.9.70/bin/firejail
+firejail=

--- a/etc/config/execution.aarch64staging.properties
+++ b/etc/config/execution.aarch64staging.properties
@@ -1,0 +1,5 @@
+sandboxType=nsjail
+executionType=nsjail
+wine=
+wineServer=
+firejail=


### PR DESCRIPTION
- removes config for firejail (unused, and doesn't exist on aarch64)
- copies execution config to aarch64prod, aarch64staging (as that's the path that is looked for by the environment)
- unifies c and c++ aarch64 config to "supportBinary" for aarch64 compilers
