### PR TITLE
Add support for demangling quoted labels

### DIFF
--- a/lib/demangler/base.ts
+++ b/lib/demangler/base.ts
@@ -44,18 +44,18 @@ export class BaseDemangler extends AsmRegex {
     readonly includeMetadata: boolean;
     readonly compiler: BaseCompiler;
 
-    readonly jumpDef = /(j\w+|b|bl|blx)\s+([$_a-z][\w$@]*)/i;
-    readonly callDef = /callq?\s+([$._a-z][\w$.@]*)/i;
-    readonly callPtrDef1 = /callq?.*ptr\s\[[a-z]*\s\+\s([$._a-z][\w$.@]*)]/i;
-    readonly callPtrDef2 = /callq?\s+([$*._a-z][\w$.@]*)/i;
-    readonly callPtrDef3 = /callq?.*\[qword ptr\s([$._a-z][\w$.@]*).*]/i;
-    readonly callPtrDef4 = /callq?.*qword\sptr\s\[[a-z]*\s\+\s([$._a-z][\w$.@]*)\+?\d?]/i;
+    readonly jumpDef = /(j\w+|b|bl|blx)\s+([$_a-z][\w$@]*|"[$_a-z][\w$@]*")/i;
+    readonly callDef = /callq?\s+([$._a-z][\w$.@]*|"[$._a-z][\w$.@]*")/i;
+    readonly callPtrDef1 = /callq?.*ptr\s\[[a-z]*\s\+\s([$._a-z][\w$.@]*|"[$._a-z][\w$.@]*")]/i;
+    readonly callPtrDef2 = /callq?\s+([$*._a-z][\w$.@]*|"[$*._a-z][\w$.@]*")/i;
+    readonly callPtrDef3 = /callq?.*\[qword ptr\s([$._a-z][\w$.@]*|"[$._a-z][\w$.@]*").*]/i;
+    readonly callPtrDef4 = /callq?.*qword\sptr\s\[[a-z]*\s\+\s([$._a-z][\w$.@]*|"[$._a-z][\w$.@]*")\+?\d?]/i;
 
     // symbols in a mov or lea command starting with an underscore
-    readonly movUnderscoreDef = /mov.*[\s:](_[\w$.@]*)/i;
+    readonly movUnderscoreDef = /mov.*[\s:](_[\w$.@]*|"[\w$.@]*")/i;
     readonly leaUnderscoreDef = /lea.*[\s:](_[\w$.@]*)/i;
-    readonly quadUnderscoreDef = /\.quad\s*(_[\w$.@]*)/i;
-    readonly ptrOffset = /\bptr\s*\[.+\b(_[\w$.@]*)\s*]/i;
+    readonly quadUnderscoreDef = /\.quad\s*(_[\w$.@]*|"[\w$.@]*")/i;
+    readonly ptrOffset = /\bptr\s*\[.+\b(_[\w$.@]*|"[\w$.@]*")\s*]/i;
 
     // E.g., ".entry _Z6squarePii("
     // E.g., ".func  (.param .b32 func_retval0) bar("

--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -320,9 +320,9 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.labelProcessor = new LabelProcessor();
         this.parsingState = new ParsingState({}, null, '', false, false, []);
 
-        this.labelFindNonMips = /[.A-Z_a-z][\w$.]*/g;
+        this.labelFindNonMips = /[.A-Z_a-z][\w$.]*|"[.A-Z_a-z][\w$.]*"/g;
         // MIPS labels can start with a $ sign, but other assemblers use $ to mean literal.
-        this.labelFindMips = /[$.A-Z_a-z][\w$.]*/g;
+        this.labelFindMips = /[$.A-Z_a-z][\w$.]*|"[$.A-Z_a-z][\w$.]*"/g;
         this.mipsLabelDefinition = /^\$[\w$.]+:/;
         this.dataDefn =
             /^\s*\.(ascii|asciz|base64|[1248]?byte|dc(?:\.[abdlswx])?|dcb(?:\.[bdlswx])?|ds(?:\.[bdlpswx])?|double|dword|fill|float|half|hword|int|long|octa|quad|short|single|skip|space|string(?:8|16|32|64)?|value|word|xword|zero)/;
@@ -333,10 +333,10 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.identifierFindRe = /([$.@A-Z_a-z]\w*)(?:@\w+)*/g;
         this.hasNvccOpcodeRe = /^\s*[@A-Za-z|]/;
         this.definesFunction = /^\s*\.(type.*,\s*[#%@]function|proc\s+[.A-Z_a-z][\w$.]*:.*)$/;
-        this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*)/;
-        this.definesWeak = /^\s*\.(?:weakext|weak)\s*([.A-Z_a-z][\w$.]*)/;
-        this.definesAlias = /^\s*\.set\s*([.A-Z_a-z][\w$.]*\s*),\s*\.\s*(\+\s*0)?$/;
-        this.indentedLabelDef = /^\s*([$.A-Z_a-z][\w$.]*):/;
+        this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*|"[.A-Z_a-z][\w$.]*")/;
+        this.definesWeak = /^\s*\.(?:weakext|weak)\s*([.A-Z_a-z][\w$.]*|"[.A-Z_a-z][\w$.]*")/;
+        this.definesAlias = /^\s*\.set\s*((?:[.A-Z_a-z][\w$.]*|"[.A-Z_a-z][\w$.]*")\s*),\s*\.\s*(\+\s*0)?$/;
+        this.indentedLabelDef = /^\s*([$.A-Z_a-z][\w$.]*|"[$.A-Z_a-z][\w$.]*"):/;
         this.assignmentDef = /^\s*([$.A-Z_a-z][\w$.]*)\s*=\s*(.*)/;
         this.directive = /^\s*\..*$/;
         // These four regexes when phrased as /\s*#APP.*/ etc exhibit costly polynomial backtracking. Instead use ^$ and
@@ -713,6 +713,8 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         this.removeLabelsWithoutDefinition(asm, labelDefinitions);
 
         const endTime = process.hrtime.bigint();
+
+        console.log(labelDefinitions);
 
         return {
             asm: asm,

--- a/lib/parsers/asmregex.ts
+++ b/lib/parsers/asmregex.ts
@@ -31,7 +31,7 @@ export class AsmRegex {
     protected labelDef: RegExp;
 
     constructor() {
-        this.labelDef = /^(?:.proc\s+)?([\w$.@]+):/i;
+        this.labelDef = /^(?:.proc\s+)?([\w$.@]+|"[\w$.@]+"):/i;
     }
 
     static squashHorizontalWhitespace(line: string, atStart: boolean): string {


### PR DESCRIPTION
This PR updates a dozen regular expressions related to labels and demangling to allow quoted names which gcc trunk is now emitting:

![image](https://github.com/user-attachments/assets/efc727d1-a056-4544-8196-4276bb14fc02)


Resolves #7729