### PR TITLE
Add option for how parents are placed in control flow layout

### DIFF
--- a/static/graph-layout-core.ts
+++ b/static/graph-layout-core.ts
@@ -160,7 +160,10 @@ export class GraphLayoutCore {
     edgeRows: (RowDescriptor & EdgeRowMetadata)[];
     readonly layoutTime: number;
 
-    constructor(cfg: AnnotatedCfgDescriptor) {
+    constructor(
+        cfg: AnnotatedCfgDescriptor,
+        readonly centerParents: boolean,
+    ) {
         this.populate_graph(cfg);
 
         const start = performance.now();
@@ -358,9 +361,14 @@ export class GraphLayoutCore {
             boundingBox.rows++;
             block.boundingBox = boundingBox;
             block.row = 0;
-            // between immediate children
-            const [left, right] = [this.blocks[block.treeEdges[0]], this.blocks[block.treeEdges[1]]];
-            block.col = Math.floor((left.col + right.col) / 2); // TODO
+            if (this.centerParents) {
+                // center of bounding box
+                block.col = Math.floor(Math.max(boundingBox.cols - 2, 0) / 2);
+            } else {
+                // center between immediate children
+                const [left, right] = [this.blocks[block.treeEdges[0]], this.blocks[block.treeEdges[1]]];
+                block.col = Math.floor((left.col + right.col) / 2);
+            }
         }
     }
 

--- a/static/panes/cfg-view.interfaces.ts
+++ b/static/panes/cfg-view.interfaces.ts
@@ -25,6 +25,7 @@
 export interface CfgState {
     selectedFunction: string | null;
     isircfg?: boolean;
+    centerparents?: boolean;
 }
 
 /*

--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -504,6 +504,10 @@ pre.content.wrap * {
         font-size: x-small;
         font-style: italic;
     }
+
+    .options button {
+        height: 100%;
+    }
 }
 
 .change-language {

--- a/views/templates/panes/cfg.pug
+++ b/views/templates/panes/cfg.pug
@@ -2,6 +2,15 @@
   .top-bar.btn-toolbar.bg-light.cfg-toolbar(role="toolbar")
     .btn-group.btn-group-sm(role="group")
       select.function-selector
+    .btn-group.btn-group-sm.filters(role="group")
+      button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Control flow graph options" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the control flow graph is rendered")
+        span.fas.fa-cog
+        span.hideable Layout Options
+      .dropdown-menu.options
+        .button-checkbox
+          button.dropdown-item.btn.btn-sm.btn-light.center-parents(type="button" title="Center Parents" data-bind="centerparents" aria-pressed="false" aria-label="Center Parents")
+            span Center Parents
+          input.d-none(type="checkbox" checked=false)
     .btn-group.btn-group-sm(role="group" aria-label="CFG Export")
       button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="LLVM Opt Pass Options" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Set output options")
         span.fas.fa-arrow-down


### PR DESCRIPTION
This PR implements this part of the cutter graph layout algorithm:
![image](https://github.com/user-attachments/assets/134e1717-ba24-4e22-bd83-b64b5333fb96)

![image](https://github.com/user-attachments/assets/27c35f4f-73c8-487d-bb2c-cf9ac57787e8)

![image](https://github.com/user-attachments/assets/661a1afe-4e1e-42fd-8b9d-5ca38a2e8a18)
