### PR TITLE
Add `cursor: pointer` to some clickable texts

### DIFF
--- a/static/panes/tool.ts
+++ b/static/panes/tool.ts
@@ -519,8 +519,7 @@ export class Tool extends MonacoPane<monaco.editor.IStandaloneCodeEditor, ToolSt
         if (lineNum && this.compilerInfo.editorId) {
             elem.empty();
             const editorId = unwrap(this.compilerInfo.editorId);
-            $('<a></a>')
-                .addClass('link-primary')
+            $('<span class="linked-compiler-output-line"></span>')
                 .html(msg)
                 .on('click', e => {
                     this.eventHub.emit('editorSetDecoration', editorId, lineNum, true, column);

--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -1685,3 +1685,7 @@ button.new-pane-button:disabled:after {
 .lm_header .lm_tabdropdown_list {
     z-index: 6; // 5 by default, same as the minimap
 }
+
+.link-primary {
+    cursor: pointer;
+}

--- a/views/index.pug
+++ b/views/index.pug
@@ -80,17 +80,17 @@ block prepend content
               // use `data-bs-toggle="modal"` on the `<a>` itself, as that would prevent the clipboard button from working.
               // Bootstrap's default blanket event handler beats out any event handler we manually attach to the button.
               if storageSolution !== "null"
-                a.dropdown-item#shareShort(data-bs-target="#sharelinkdialog" data-bind="Short")
+                a.dropdown-item#shareShort(data-bs-target="#sharelinkdialog" data-bind="Short" role="button")
                   span.dropdown-icon.fas.fa-cloud.d-inline
                   | Short Link
                   button.btn.btn-sm.copy-link-btn.clip-icon.float-end(data-bs-target="" data-bs-toggle="none")
                     span.dropdown-icon.fa.fa-clipboard
-              a.dropdown-item#shareFull(data-bs-target="#sharelinkdialog" data-bind="Full")
+              a.dropdown-item#shareFull(data-bs-target="#sharelinkdialog" data-bind="Full" role="button")
                 span.dropdown-icon.fas.fa-store-slash.d-inline
                 | Full Link
                 button.btn.btn-sm.copy-link-btn.clip-icon.float-end(data-bs-toggle="none")
                   span.dropdown-icon.fa.fa-clipboard
-              a.dropdown-item#shareEmbed(data-bs-target="#sharelinkdialog" data-bind="Embed")
+              a.dropdown-item#shareEmbed(data-bs-target="#sharelinkdialog" data-bind="Embed" role="button")
                 span.dropdown-icon.fas.fa-window-restore.d-inline
                 | Embed in iframe
                 // This is not an oversight, there is in fact a .float-end missing here that's there in the other 2


### PR DESCRIPTION
Before #7797, elements such as “Toggle full version output” in the compiler version popup or the share buttons (“Short Link” etc.) would change the cursor to a pointer on hover (like normal links do), but this was lost when they were switched to use `link-primary`.

This PR restores the previous behaviour.