### PR TITLE
Fix SYCL code not finding CPU on Intel OneAPI >= 2025.0.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1511,43 +1511,43 @@ compiler.icx202421.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202500.exe=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/bin/icpx
 compiler.icx202500.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib
-compiler.icx202500.libPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.0.740/tbb/latest/lib
+compiler.icx202500.libPath=/opt/compiler-explorer/intel-cpp-2025.0.0.740/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.0.740/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.0.740/umf/latest/lib
 compiler.icx202500.semver=2025.0.0
 compiler.icx202500.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202501.exe=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/bin/icpx
 compiler.icx202501.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/lib
-compiler.icx202501.libPath=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.1.46/tbb/latest/lib
+compiler.icx202501.libPath=/opt/compiler-explorer/intel-cpp-2025.0.1.46/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.1.46/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.1.46/umf/latest/lib
 compiler.icx202501.semver=2025.0.1
 compiler.icx202501.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202503.exe=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/bin/icpx
 compiler.icx202503.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/lib
-compiler.icx202503.libPath=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.3.9/tbb/latest/lib
+compiler.icx202503.libPath=/opt/compiler-explorer/intel-cpp-2025.0.3.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.3.9/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.3.9/umf/latest/lib
 compiler.icx202503.semver=2025.0.3
 compiler.icx202503.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202504.exe=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/bin/icpx
 compiler.icx202504.ldPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib
-compiler.icx202504.libPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.4.20/tbb/latest/lib
+compiler.icx202504.libPath=/opt/compiler-explorer/intel-cpp-2025.0.4.20/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.4.20/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.0.4.20/umf/latest/lib
 compiler.icx202504.semver=2025.0.4
 compiler.icx202504.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202510.exe=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/bin/icpx
 compiler.icx202510.ldPath=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/lib
-compiler.icx202510.libPath=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.0.573/tbb/latest/lib
+compiler.icx202510.libPath=/opt/compiler-explorer/intel-cpp-2025.1.0.573/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.0.573/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.0.573/umf/latest/lib
 compiler.icx202510.semver=2025.1.0
 compiler.icx202510.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icx202511.exe=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/bin/icpx
 compiler.icx202511.ldPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib
-compiler.icx202511.libPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/tbb/latest/lib
+compiler.icx202511.libPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/umf/latest/lib
 compiler.icx202511.semver=2025.1.1
 compiler.icx202511.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/bin/icpx
 compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib
-compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/tbb/latest/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.1.1.9/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.1.1.9/umf/latest/lib
 compiler.icxlatest.semver=2025.1.1
 compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 


### PR DESCRIPTION
When running a simple example like [this one](https://godbolt.org/z/os3q4a4dc) with Intel OneAPI < 2025.0.0, it runs just fine but the same code with any version of the same compiler >=2025.0.0 will not be able to find the CPU as a SYCL device. This happens because, starting from OneAPI 2025.0.0, the installation directory of OneAPI contains a new subdirectory `umf` for the Unified Memory Interface which is linked by default to all SYCL executables and is responsible for finding SYCL devices.

This PR fixes #7739.

Note: [this PR] is also related. Depending on which is merged first, the other will need to be modified.