### PR TITLE
Conditionally render img tags for language logos

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -83,6 +83,7 @@ import {ICompilerShared} from '../compiler-shared.interfaces.js';
 import {CompilerShared} from '../compiler-shared.js';
 import {SourceAndFiles} from '../download-service.js';
 import {SentryCapture} from '../sentry.js';
+import {getStaticImage} from '../utils.js';
 import {CompilerVersionInfo, setCompilerVersionPopoverForPane} from '../widgets/compiler-version-info.js';
 
 type CachedOpcode = {
@@ -2482,18 +2483,18 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         const addTool = (toolName: string, title: string, toolIcon?: string, toolIconDark?: string) => {
             const btn = $("<button class='dropdown-item btn btn-light btn-sm'>");
             btn.addClass('view-' + toolName);
-            btn.data('toolname', toolName);
             if (toolIcon) {
-                const toolIconFull = `${window.staticRoot}logos/${toolIcon}`;
-                const toolIconDarkFull = toolIconDark ? `${window.staticRoot}logos/${toolIconDark}` : '';
+                const toolIconFull = getStaticImage(toolIcon, 'logos');
+                // If there is a dark icon, we use it, otherwise we use the light icon
+                const toolIconDarkFull =
+                    toolIconDark !== undefined ? getStaticImage(toolIconDark, 'logos') : toolIconFull;
                 btn.append(
-                    '<span class="dropdown-icon fas">' +
-                        '<img src="' +
-                        toolIconFull +
-                        '" class="theme-light-only" width="16px" style="max-height: 16px"/>' +
-                        '<img src="' +
-                        toolIconDarkFull ||
-                        toolIconFull + '" class="theme-dark-only" width="16px" style="max-height: 16px"/>' + '</span>',
+                    `
+                    <span class="dropdown-icon fas">
+                      <img src="${toolIconFull}" class="theme-light-only" width="16px" style="max-height: 16px"/>
+                      <img src="${toolIconDarkFull}" class="theme-dark-only" width="16px" style="max-height: 16px"/>
+                    </span>
+                    `,
                 );
             } else {
                 btn.append("<span class='dropdown-icon fas fa-cog'></span>");

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -57,6 +57,7 @@ import {EditorState} from './editor.interfaces.js';
 import {MonacoPaneState, PaneState} from './pane.interfaces.js';
 import {MonacoPane} from './pane.js';
 import IModelDeltaDecoration = editor.IModelDeltaDecoration;
+import {getStaticImage} from '../utils';
 
 const loadSave = new loadSaveLib.LoadSave();
 const languages = options.languages;
@@ -1916,28 +1917,31 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     }
 
     getSelectizeRenderHtml(language: Language, escapeHtml: typeof escape_html, width: number, height: number): string {
-        const logoFilename = language.logoFilename !== null ? `${window.staticRoot}logos/${language.logoFilename}` : '';
-        const logoFilenameDark =
-            language.logoFilenameDark !== null ? `${window.staticRoot}logos/${language.logoFilenameDark}` : '';
         return `
         <div class='d-flex' style='align-items: center'>
-          <div class='me-1 d-flex' style='align-items: center'>
-             <img src='${logoFilename}'
-                  alt='Logo for ${escapeHtml(language.name)}'
-                  class='${language.logoFilenameDark ? 'theme-light-only' : ''}'
-                  width='${width}px'
-                  height='${height}px' />
-             <!-- Dark mode logo, if it exists -->
-             ${
-                 language.logoFilenameDark
-                     ? `<img src='${logoFilenameDark}'
+          <div class='me-1 d-flex' style='align-items: center; width: ${width}px; height: ${height}px'>
+            ${
+                language.logoFilename !== null
+                    ? `
+                <img src='${getStaticImage(language.logoFilename, 'logos')}'
+                     alt='Logo for ${escapeHtml(language.name)}'
+                     class='${language.logoFilenameDark ? 'theme-light-only' : ''}'
+                     width='${width}px'
+                     height='${height}px' />
+                `
+                    : ''
+            }
+            ${
+                language.logoFilenameDark !== null
+                    ? `
+                <img src='${getStaticImage(language.logoFilenameDark, 'logos')}'
                      alt='Logo for ${escapeHtml(language.name)}'
                      class='theme-dark-only'
                      width='${width}px'
                      height='${height}px' />
                `
-                     : ''
-             }
+                    : ''
+            }
           </div>
           <div title='${language.tooltip ?? ''}'>
             ${escapeHtml(language.name)}

--- a/static/utils.ts
+++ b/static/utils.ts
@@ -25,6 +25,17 @@
 import bigInt from 'big-integer';
 import {addDigitSeparator} from '../shared/common-utils.js';
 
+/**
+ * Get an image relative to `/public` in the source root.
+ */
+export function getStaticImage(filename: string, parent?: string) {
+    const root = window.staticRoot;
+    if (parent) {
+        return `${root}${parent}/${filename}`;
+    }
+    return `${root}${filename}`;
+}
+
 export function updateAndCalcTopBarHeight(domRoot: JQuery, topBar: JQuery, hideable: JQuery): number {
     let topBarHeight = 0;
     if (!topBar.hasClass('d-none')) {

--- a/static/widgets/site-templates-widget.ts
+++ b/static/widgets/site-templates-widget.ts
@@ -32,6 +32,7 @@ import * as BootstrapUtils from '../bootstrap-utils.js';
 import {localStorage} from '../local.js';
 import {Settings} from '../settings.js';
 import * as url from '../url.js';
+import {getStaticImage} from '../utils';
 import {Alert} from './alert.js';
 
 class SiteTemplatesWidget {
@@ -94,7 +95,7 @@ class SiteTemplatesWidget {
         return theme;
     }
     getAsset(name: string) {
-        return `${window.staticRoot}template_screenshots/${name}.${this.getCurrentTheme()}.png`;
+        return getStaticImage(`${name}.${this.getCurrentTheme()}.png`, 'template_screenshots');
     }
     getDefaultAsset() {
         return 'https://placehold.jp/30/4b4b4b/ffffff/1000x800.png?text=we%27ll+support+screenshot+generation+for+user+templates+some+day';


### PR DESCRIPTION
Don't render the img tag if there's no image.

Also adds a helper for resolving image paths, optionally with a folder from the root
