### PR TITLE
Infer pane state from pane constructor

### DIFF
--- a/static/components.interfaces.ts
+++ b/static/components.interfaces.ts
@@ -32,7 +32,8 @@ import {ClangirState} from './panes/clangir-view.interfaces.js';
 import {GccDumpViewState} from './panes/gccdump-view.interfaces.js';
 import {IrState} from './panes/ir-view.interfaces.js';
 import {OptPipelineViewState} from './panes/opt-pipeline.interfaces.js';
-import {MonacoPaneState} from './panes/pane.interfaces.js';
+import {MonacoPane, Pane} from './panes/pane';
+import {MonacoPaneState, PaneState} from './panes/pane.interfaces.js';
 
 /**
  * Component name constants with 'as const' assertions.
@@ -468,3 +469,9 @@ export interface SerializedLayoutState {
  * Type for drag source factory functions
  */
 export type DragSourceFactory<K extends keyof ComponentStateMap> = () => ComponentConfig<K>;
+
+export type InferComponentState<T> = T extends MonacoPane<infer E, infer S>
+    ? S & MonacoPaneState
+    : T extends Pane<infer S>
+      ? S & PaneState
+      : never;

--- a/static/hub.ts
+++ b/static/hub.ts
@@ -23,8 +23,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import GoldenLayout, {ContentItem} from 'golden-layout';
-type GLC = GoldenLayout.Container;
-
 import _ from 'underscore';
 import {LanguageKey} from '../types/languages.interfaces.js';
 import {CompilerService} from './compiler-service.js';
@@ -46,6 +44,7 @@ import {
     HASKELL_CORE_VIEW_COMPONENT_NAME,
     HASKELL_STG_VIEW_COMPONENT_NAME,
     IR_VIEW_COMPONENT_NAME,
+    InferComponentState,
     LLVM_OPT_PIPELINE_VIEW_COMPONENT_NAME,
     OPT_PIPELINE_VIEW_COMPONENT_NAME,
     OPT_VIEW_COMPONENT_NAME,
@@ -89,7 +88,9 @@ import {RustMir as RustMirView} from './panes/rustmir-view.js';
 import {StackUsage as StackUsageView} from './panes/stack-usage-view.js';
 import {ToolInputView} from './panes/tool-input-view.js';
 import {Tool} from './panes/tool.js';
-import {Tree} from './panes/tree.js';
+import {Tree, TreeState} from './panes/tree.js';
+
+type GLC = GoldenLayout.Container;
 
 type EventDescriptorMap = {
     [E in keyof EventMap]: [E, ...Parameters<EventMap[E]>];
@@ -429,7 +430,7 @@ export class Hub {
 
     // Component Factories
 
-    private codeEditorFactory(container: GoldenLayout.Container, state: any): Editor {
+    private codeEditorFactory(container: GoldenLayout.Container, state: InferComponentState<Editor>): Editor {
         // Ensure editors are closable: some older versions had 'isClosable' false.
         // NB there doesn't seem to be a better way to do this than reach into the config and rely on the fact nothing
         // has used it yet.
@@ -442,157 +443,142 @@ export class Hub {
         return editor;
     }
 
-    private treeFactory(container: GoldenLayout.Container, state: ConstructorParameters<typeof Tree>[2]): Tree {
+    private treeFactory(container: GoldenLayout.Container, state: TreeState): Tree {
         const tree = new Tree(this, container, state);
         this.trees.push(tree);
         return tree;
     }
 
-    public compilerFactory(container: GoldenLayout.Container, state: any): any /* typeof Compiler */ {
+    public compilerFactory(container: GoldenLayout.Container, state: InferComponentState<Compiler>): Compiler {
         return new Compiler(this, container, state);
     }
 
-    public executorFactory(container: GoldenLayout.Container, state: any): any /*typeof Executor */ {
+    public executorFactory(container: GoldenLayout.Container, state: InferComponentState<Executor>): Executor {
         return new Executor(this, container, state);
     }
 
-    public outputFactory(container: GoldenLayout.Container, state: ConstructorParameters<typeof Output>[2]): Output {
+    public outputFactory(container: GoldenLayout.Container, state: InferComponentState<Output>): Output {
         return new Output(this, container, state);
     }
 
-    public toolFactory(container: GoldenLayout.Container, state: any): any /* typeof Tool */ {
+    public toolFactory(container: GoldenLayout.Container, state: InferComponentState<Tool>): Tool {
         return new Tool(this, container, state);
     }
 
-    public diffFactory(container: GoldenLayout.Container, state: any): any /* typeof Diff */ {
+    public diffFactory(container: GoldenLayout.Container, state: InferComponentState<Diff>): Diff {
         return new Diff(this, container, state);
     }
 
     public toolInputViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof ToolInputView>[2],
+        state: InferComponentState<ToolInputView>,
     ): ToolInputView {
         return new ToolInputView(this, container, state);
     }
 
-    public optViewFactory(container: GoldenLayout.Container, state: ConstructorParameters<typeof OptView>[2]): OptView {
+    public optViewFactory(container: GoldenLayout.Container, state: InferComponentState<OptView>): OptView {
         return new OptView(this, container, state);
     }
 
     public stackUsageViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof StackUsageView>[2],
+        state: InferComponentState<StackUsageView>,
     ): StackUsageView {
         return new StackUsageView(this, container, state);
     }
 
-    public flagsViewFactory(
-        container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof FlagsView>[2],
-    ): FlagsView {
+    public flagsViewFactory(container: GoldenLayout.Container, state: InferComponentState<FlagsView>): FlagsView {
         return new FlagsView(this, container, state);
     }
 
     public ppViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof PreProcessorView>[2],
+        state: InferComponentState<PreProcessorView>,
     ): PreProcessorView {
         return new PreProcessorView(this, container, state);
     }
 
-    public astViewFactory(container: GoldenLayout.Container, state: ConstructorParameters<typeof AstView>[2]): AstView {
+    public astViewFactory(container: GoldenLayout.Container, state: InferComponentState<AstView>): AstView {
         return new AstView(this, container, state);
     }
 
-    public irViewFactory(container: GoldenLayout.Container, state: ConstructorParameters<typeof IrView>[2]): IrView {
+    public irViewFactory(container: GoldenLayout.Container, state: InferComponentState<IrView>): IrView {
         return new IrView(this, container, state);
     }
 
-    public clangirViewFactory(
-        container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof ClangirView>[2],
-    ): ClangirView {
+    public clangirViewFactory(container: GoldenLayout.Container, state: InferComponentState<ClangirView>): ClangirView {
         return new ClangirView(this, container, state);
     }
 
-    public optPipelineFactory(
-        container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof OptPipeline>[2],
-    ): OptPipeline {
+    public optPipelineFactory(container: GoldenLayout.Container, state: InferComponentState<OptPipeline>): OptPipeline {
         return new OptPipeline(this, container, state);
     }
 
-    public deviceViewFactory(
-        container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof DeviceView>[2],
-    ): DeviceView {
+    public deviceViewFactory(container: GoldenLayout.Container, state: InferComponentState<DeviceView>): DeviceView {
         return new DeviceView(this, container, state);
     }
 
     public gnatDebugTreeViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof GnatDebugTreeView>[2],
+        state: InferComponentState<GnatDebugTreeView>,
     ): GnatDebugTreeView {
         return new GnatDebugTreeView(this, container, state);
     }
 
     public gnatDebugViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof GnatDebugView>[2],
+        state: InferComponentState<GnatDebugView>,
     ): GnatDebugView {
         return new GnatDebugView(this, container, state);
     }
 
-    public rustMirViewFactory(
-        container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof RustMirView>[2],
-    ): RustMirView {
+    public rustMirViewFactory(container: GoldenLayout.Container, state: InferComponentState<RustMirView>): RustMirView {
         return new RustMirView(this, container, state);
     }
 
     public rustMacroExpViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof RustMacroExpView>[2],
+        state: InferComponentState<RustMacroExpView>,
     ): RustMacroExpView {
         return new RustMacroExpView(this, container, state);
     }
 
-    public rustHirViewFactory(
-        container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof RustHirView>[2],
-    ): RustHirView {
+    public rustHirViewFactory(container: GoldenLayout.Container, state: InferComponentState<RustHirView>): RustHirView {
         return new RustHirView(this, container, state);
     }
 
     public haskellCoreViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof HaskellCoreView>[2],
+        state: InferComponentState<HaskellCoreView>,
     ): HaskellCoreView {
         return new HaskellCoreView(this, container, state);
     }
 
     public haskellStgViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof HaskellStgView>[2],
+        state: InferComponentState<HaskellStgView>,
     ): HaskellStgView {
         return new HaskellStgView(this, container, state);
     }
     public haskellCmmViewFactory(
         container: GoldenLayout.Container,
-        state: ConstructorParameters<typeof HaskellCmmView>[2],
+        state: InferComponentState<HaskellCmmView>,
     ): HaskellCmmView {
         return new HaskellCmmView(this, container, state);
     }
 
-    public gccDumpViewFactory(container: GoldenLayout.Container, state: any): any /* typeof GccDumpView */ {
+    public gccDumpViewFactory(container: GoldenLayout.Container, state: InferComponentState<GCCDumpView>): GCCDumpView {
         return new GCCDumpView(this, container, state);
     }
 
-    public cfgViewFactory(container: GoldenLayout.Container, state: ConstructorParameters<typeof CfgView>[2]): CfgView {
+    public cfgViewFactory(container: GoldenLayout.Container, state: InferComponentState<CfgView>): CfgView {
         return new CfgView(this, container, state);
     }
 
-    public conformanceViewFactory(container: GoldenLayout.Container, state: any): any /* typeof ConformanceView */ {
+    public conformanceViewFactory(
+        container: GoldenLayout.Container,
+        state: InferComponentState<ConformanceView>,
+    ): ConformanceView {
         return new ConformanceView(this, container, state);
     }
 }


### PR DESCRIPTION
Removes all `any` return types from the factories, and infers the state type from the pane itself (except for tree which isn't a traditional pane)