### PR TITLE
Add Fortran library roots_fortran v1.5.0

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1743,6 +1743,14 @@ libs.libfpm.versions=0101
 libs.libfpm.packagedheaders=true
 libs.libfpm.versions.0101.version=0.10.1
 
+libs.roots_fortran.name=roots_fortran
+libs.roots_fortran.url=https://github.com/jacobwilliams/roots-fortran
+libs.roots_fortran.staticliblink=roots_fortran
+libs.roots_fortran.versions=150
+libs.roots_fortran.packagedheaders=true
+libs.roots_fortran.versions.150.version=1.5.0
+
+
 #################################
 #################################
 # Installed tools


### PR DESCRIPTION
This PR adds the Fortran library **roots_fortran** version 1.5.0 to Compiler Explorer.

- GitHub URL: https://github.com/jacobwilliams/roots-fortran
- Package Manager: FPM (Fortran Package Manager)

Related PR: https://github.com/compiler-explorer/infra/pull/1683

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-lib-wizard)_