### PR TITLE
Add top 100 Rust crates to Compiler Explorer

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -315,7 +315,7 @@ compiler.mrustc-master.isNightly=true
 #################################
 # Installed libs, generated from ce_install generate-rust-crates
 # Don't modify directly
-libs=ahash:aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:bumpalo:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fnv:futures:futures-channel:futures-core:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-syntax:rustc_version:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:slab:smallvec:socket2:strsim:subtle:syn:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:toml:typenum:unicode-bidi:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:vec_map:version_check:wide:winapi:zerocopy
+libs=ahash:aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:bumpalo:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fastrand:fnv:futures:futures-channel:futures-core:futures-io:futures-sink:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:http-body:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:linux-raw-sys:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pin-utils:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-automata:regex-syntax:rustc_version:rustix:rustls:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:sha2:slab:smallvec:socket2:strsim:subtle:syn:tempfile:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:tokio-util:toml:tracing:tracing-core:typenum:unicode-bidi:unicode-ident:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:uuid:vec_map:version_check:wide:winapi:windows-sys:windows_aarch64_msvc:windows_i686_gnu:windows_i686_msvc:windows_x86_64_gnu:windows_x86_64_msvc:zerocopy
 
 libs.ahash.name=ahash
 libs.ahash.url=https://crates.io/crates/ahash
@@ -325,9 +325,11 @@ libs.ahash.versions.0812.path=libahash.rlib
 
 libs.aho-corasick.name=aho-corasick
 libs.aho-corasick.url=https://crates.io/crates/aho-corasick
-libs.aho-corasick.versions=0718
+libs.aho-corasick.versions=0718:113
 libs.aho-corasick.versions.0718.version=0.7.18
 libs.aho-corasick.versions.0718.path=libaho_corasick.rlib
+libs.aho-corasick.versions.113.version=1.1.3
+libs.aho-corasick.versions.113.path=libaho_corasick.rlib
 
 libs.ansi_term.name=ansi_term
 libs.ansi_term.url=https://crates.io/crates/ansi_term
@@ -337,9 +339,11 @@ libs.ansi_term.versions.0121.path=libansi_term.rlib
 
 libs.anyhow.name=anyhow
 libs.anyhow.url=https://crates.io/crates/anyhow
-libs.anyhow.versions=1057
+libs.anyhow.versions=1057:1098
 libs.anyhow.versions.1057.version=1.0.57
 libs.anyhow.versions.1057.path=libanyhow.rlib
+libs.anyhow.versions.1098.version=1.0.98
+libs.anyhow.versions.1098.path=libanyhow.rlib
 
 libs.arrayvec.name=arrayvec
 libs.arrayvec.url=https://crates.io/crates/arrayvec
@@ -355,9 +359,11 @@ libs.atty.versions.0214.path=libatty.rlib
 
 libs.autocfg.name=autocfg
 libs.autocfg.url=https://crates.io/crates/autocfg
-libs.autocfg.versions=110
+libs.autocfg.versions=110:150
 libs.autocfg.versions.110.version=1.1.0
 libs.autocfg.versions.110.path=libautocfg.rlib
+libs.autocfg.versions.150.version=1.5.0
+libs.autocfg.versions.150.path=libautocfg.rlib
 
 libs.backtrace.name=backtrace
 libs.backtrace.url=https://crates.io/crates/backtrace
@@ -367,9 +373,11 @@ libs.backtrace.versions.0365.path=libbacktrace.rlib
 
 libs.base64.name=base64
 libs.base64.url=https://crates.io/crates/base64
-libs.base64.versions=0130
+libs.base64.versions=0130:0221
 libs.base64.versions.0130.version=0.13.0
 libs.base64.versions.0130.path=libbase64.rlib
+libs.base64.versions.0221.version=0.22.1
+libs.base64.versions.0221.path=libbase64.rlib
 
 libs.bincode.name=bincode
 libs.bincode.url=https://crates.io/crates/bincode
@@ -379,15 +387,19 @@ libs.bincode.versions.133.path=libbincode.rlib
 
 libs.bitflags.name=bitflags
 libs.bitflags.url=https://crates.io/crates/bitflags
-libs.bitflags.versions=132
+libs.bitflags.versions=132:291
 libs.bitflags.versions.132.version=1.3.2
 libs.bitflags.versions.132.path=libbitflags.rlib
+libs.bitflags.versions.291.version=2.9.1
+libs.bitflags.versions.291.path=libbitflags.rlib
 
 libs.block-buffer.name=block-buffer
 libs.block-buffer.url=https://crates.io/crates/block-buffer
-libs.block-buffer.versions=0102
+libs.block-buffer.versions=0102:0104
 libs.block-buffer.versions.0102.version=0.10.2
 libs.block-buffer.versions.0102.path=libblock_buffer.rlib
+libs.block-buffer.versions.0104.version=0.10.4
+libs.block-buffer.versions.0104.path=libblock_buffer.rlib
 
 libs.bumpalo.name=bumpalo
 libs.bumpalo.url=https://crates.io/crates/bumpalo
@@ -397,41 +409,53 @@ libs.bumpalo.versions.3160.path=libbumpalo.rlib
 
 libs.byteorder.name=byteorder
 libs.byteorder.url=https://crates.io/crates/byteorder
-libs.byteorder.versions=143
+libs.byteorder.versions=143:150
 libs.byteorder.versions.143.version=1.4.3
 libs.byteorder.versions.143.path=libbyteorder.rlib
+libs.byteorder.versions.150.version=1.5.0
+libs.byteorder.versions.150.path=libbyteorder.rlib
 
 libs.bytes.name=bytes
 libs.bytes.url=https://crates.io/crates/bytes
-libs.bytes.versions=110
+libs.bytes.versions=110:1101
 libs.bytes.versions.110.version=1.1.0
 libs.bytes.versions.110.path=libbytes.rlib
+libs.bytes.versions.1101.version=1.10.1
+libs.bytes.versions.1101.path=libbytes.rlib
 
 libs.cc.name=cc
 libs.cc.url=https://crates.io/crates/cc
-libs.cc.versions=1073
+libs.cc.versions=1073:1227
 libs.cc.versions.1073.version=1.0.73
 libs.cc.versions.1073.path=libcc.rlib
+libs.cc.versions.1227.version=1.2.27
+libs.cc.versions.1227.path=libcc.rlib
 
 libs.cfg-if.name=cfg-if
 libs.cfg-if.url=https://crates.io/crates/cfg-if
-libs.cfg-if.versions=100
+libs.cfg-if.versions=100:101
 libs.cfg-if.versions.100.version=1.0.0
 libs.cfg-if.versions.100.path=libcfg_if.rlib
+libs.cfg-if.versions.101.version=1.0.1
+libs.cfg-if.versions.101.path=libcfg_if.rlib
 
 libs.chrono.name=chrono
 libs.chrono.url=https://crates.io/crates/chrono
-libs.chrono.versions=0419
+libs.chrono.versions=0419:0441
 libs.chrono.versions.0419.version=0.4.19
 libs.chrono.versions.0419.path=libchrono.rlib
+libs.chrono.versions.0441.version=0.4.41
+libs.chrono.versions.0441.path=libchrono.rlib
 
 libs.clap.name=clap
 libs.clap.url=https://crates.io/crates/clap
-libs.clap.versions=3118:4520
+libs.clap.versions=3118:4520:4540
 libs.clap.versions.3118.version=3.1.18
 libs.clap.versions.3118.path=libclap.rlib
 libs.clap.versions.4520.version=4.5.20
 libs.clap.versions.4520.path=libclap.rlib
+libs.clap.versions.4540.version=4.5.40
+libs.clap.versions.4540.path=libclap.rlib
 
 libs.color-eyre.name=color-eyre
 libs.color-eyre.url=https://crates.io/crates/color-eyre
@@ -465,9 +489,11 @@ libs.crossbeam-epoch.versions.098.path=libcrossbeam_epoch.rlib
 
 libs.crossbeam-utils.name=crossbeam-utils
 libs.crossbeam-utils.url=https://crates.io/crates/crossbeam-utils
-libs.crossbeam-utils.versions=088
+libs.crossbeam-utils.versions=088:0821
 libs.crossbeam-utils.versions.088.version=0.8.8
 libs.crossbeam-utils.versions.088.path=libcrossbeam_utils.rlib
+libs.crossbeam-utils.versions.0821.version=0.8.21
+libs.crossbeam-utils.versions.0821.path=libcrossbeam_utils.rlib
 
 libs.dashmap.name=dashmap
 libs.dashmap.url=https://crates.io/crates/dashmap
@@ -477,15 +503,19 @@ libs.dashmap.versions.540.path=libdashmap.rlib
 
 libs.digest.name=digest
 libs.digest.url=https://crates.io/crates/digest
-libs.digest.versions=0103
+libs.digest.versions=0103:0107
 libs.digest.versions.0103.version=0.10.3
 libs.digest.versions.0103.path=libdigest.rlib
+libs.digest.versions.0107.version=0.10.7
+libs.digest.versions.0107.path=libdigest.rlib
 
 libs.either.name=either
 libs.either.url=https://crates.io/crates/either
-libs.either.versions=161
+libs.either.versions=161:1150
 libs.either.versions.161.version=1.6.1
 libs.either.versions.161.path=libeither.rlib
+libs.either.versions.1150.version=1.15.0
+libs.either.versions.1150.path=libeither.rlib
 
 libs.env_logger.name=env_logger
 libs.env_logger.url=https://crates.io/crates/env_logger
@@ -499,6 +529,12 @@ libs.eyre.versions=068
 libs.eyre.versions.068.version=0.6.8
 libs.eyre.versions.068.path=libeyre.rlib
 
+libs.fastrand.name=fastrand
+libs.fastrand.url=https://crates.io/crates/fastrand
+libs.fastrand.versions=230
+libs.fastrand.versions.230.version=2.3.0
+libs.fastrand.versions.230.path=libfastrand.rlib
+
 libs.fnv.name=fnv
 libs.fnv.url=https://crates.io/crates/fnv
 libs.fnv.versions=107
@@ -507,69 +543,109 @@ libs.fnv.versions.107.path=libfnv.rlib
 
 libs.futures.name=futures
 libs.futures.url=https://crates.io/crates/futures
-libs.futures.versions=0321
+libs.futures.versions=0321:0331
 libs.futures.versions.0321.version=0.3.21
 libs.futures.versions.0321.path=libfutures.rlib
+libs.futures.versions.0331.version=0.3.31
+libs.futures.versions.0331.path=libfutures.rlib
 
 libs.futures-channel.name=futures-channel
 libs.futures-channel.url=https://crates.io/crates/futures-channel
-libs.futures-channel.versions=0321
+libs.futures-channel.versions=0321:0331
 libs.futures-channel.versions.0321.version=0.3.21
 libs.futures-channel.versions.0321.path=libfutures_channel.rlib
+libs.futures-channel.versions.0331.version=0.3.31
+libs.futures-channel.versions.0331.path=libfutures_channel.rlib
 
 libs.futures-core.name=futures-core
 libs.futures-core.url=https://crates.io/crates/futures-core
-libs.futures-core.versions=0321
+libs.futures-core.versions=0321:0331
 libs.futures-core.versions.0321.version=0.3.21
 libs.futures-core.versions.0321.path=libfutures_core.rlib
+libs.futures-core.versions.0331.version=0.3.31
+libs.futures-core.versions.0331.path=libfutures_core.rlib
+
+libs.futures-io.name=futures-io
+libs.futures-io.url=https://crates.io/crates/futures-io
+libs.futures-io.versions=0331
+libs.futures-io.versions.0331.version=0.3.31
+libs.futures-io.versions.0331.path=libfutures_io.rlib
+
+libs.futures-sink.name=futures-sink
+libs.futures-sink.url=https://crates.io/crates/futures-sink
+libs.futures-sink.versions=0331
+libs.futures-sink.versions.0331.version=0.3.31
+libs.futures-sink.versions.0331.path=libfutures_sink.rlib
 
 libs.futures-task.name=futures-task
 libs.futures-task.url=https://crates.io/crates/futures-task
-libs.futures-task.versions=0321
+libs.futures-task.versions=0321:0331
 libs.futures-task.versions.0321.version=0.3.21
 libs.futures-task.versions.0321.path=libfutures_task.rlib
+libs.futures-task.versions.0331.version=0.3.31
+libs.futures-task.versions.0331.path=libfutures_task.rlib
 
 libs.futures-util.name=futures-util
 libs.futures-util.url=https://crates.io/crates/futures-util
-libs.futures-util.versions=0321
+libs.futures-util.versions=0321:0331
 libs.futures-util.versions.0321.version=0.3.21
 libs.futures-util.versions.0321.path=libfutures_util.rlib
+libs.futures-util.versions.0331.version=0.3.31
+libs.futures-util.versions.0331.path=libfutures_util.rlib
 
 libs.generic-array.name=generic-array
 libs.generic-array.url=https://crates.io/crates/generic-array
-libs.generic-array.versions=0145
+libs.generic-array.versions=0145:120
 libs.generic-array.versions.0145.version=0.14.5
 libs.generic-array.versions.0145.path=libgeneric_array.rlib
+libs.generic-array.versions.120.version=1.2.0
+libs.generic-array.versions.120.path=libgeneric_array.rlib
 
 libs.getrandom.name=getrandom
 libs.getrandom.url=https://crates.io/crates/getrandom
-libs.getrandom.versions=026
+libs.getrandom.versions=026:033
 libs.getrandom.versions.026.version=0.2.6
 libs.getrandom.versions.026.path=libgetrandom.rlib
+libs.getrandom.versions.033.version=0.3.3
+libs.getrandom.versions.033.path=libgetrandom.rlib
 
 libs.h2.name=h2
 libs.h2.url=https://crates.io/crates/h2
-libs.h2.versions=0313
+libs.h2.versions=0313:0411
 libs.h2.versions.0313.version=0.3.13
 libs.h2.versions.0313.path=libh2.rlib
+libs.h2.versions.0411.version=0.4.11
+libs.h2.versions.0411.path=libh2.rlib
 
 libs.hashbrown.name=hashbrown
 libs.hashbrown.url=https://crates.io/crates/hashbrown
-libs.hashbrown.versions=0121
+libs.hashbrown.versions=0121:0154
 libs.hashbrown.versions.0121.version=0.12.1
 libs.hashbrown.versions.0121.path=libhashbrown.rlib
+libs.hashbrown.versions.0154.version=0.15.4
+libs.hashbrown.versions.0154.path=libhashbrown.rlib
 
 libs.heck.name=heck
 libs.heck.url=https://crates.io/crates/heck
-libs.heck.versions=040
+libs.heck.versions=040:050
 libs.heck.versions.040.version=0.4.0
 libs.heck.versions.040.path=libheck.rlib
+libs.heck.versions.050.version=0.5.0
+libs.heck.versions.050.path=libheck.rlib
 
 libs.http.name=http
 libs.http.url=https://crates.io/crates/http
-libs.http.versions=028
+libs.http.versions=028:131
 libs.http.versions.028.version=0.2.8
 libs.http.versions.028.path=libhttp.rlib
+libs.http.versions.131.version=1.3.1
+libs.http.versions.131.path=libhttp.rlib
+
+libs.http-body.name=http-body
+libs.http-body.url=https://crates.io/crates/http-body
+libs.http-body.versions=101
+libs.http-body.versions.101.version=1.0.1
+libs.http-body.versions.101.path=libhttp_body.rlib
 
 libs.httparse.name=httparse
 libs.httparse.url=https://crates.io/crates/httparse
@@ -579,57 +655,81 @@ libs.httparse.versions.171.path=libhttparse.rlib
 
 libs.hyper.name=hyper
 libs.hyper.url=https://crates.io/crates/hyper
-libs.hyper.versions=01419
+libs.hyper.versions=01419:160
 libs.hyper.versions.01419.version=0.14.19
 libs.hyper.versions.01419.path=libhyper.rlib
+libs.hyper.versions.160.version=1.6.0
+libs.hyper.versions.160.path=libhyper.rlib
 
 libs.idna.name=idna
 libs.idna.url=https://crates.io/crates/idna
-libs.idna.versions=023
+libs.idna.versions=023:103
 libs.idna.versions.023.version=0.2.3
 libs.idna.versions.023.path=libidna.rlib
+libs.idna.versions.103.version=1.0.3
+libs.idna.versions.103.path=libidna.rlib
 
 libs.indexmap.name=indexmap
 libs.indexmap.url=https://crates.io/crates/indexmap
-libs.indexmap.versions=182
+libs.indexmap.versions=182:2100
 libs.indexmap.versions.182.version=1.8.2
 libs.indexmap.versions.182.path=libindexmap.rlib
+libs.indexmap.versions.2100.version=2.10.0
+libs.indexmap.versions.2100.path=libindexmap.rlib
 
 libs.itertools.name=itertools
 libs.itertools.url=https://crates.io/crates/itertools
-libs.itertools.versions=0103
+libs.itertools.versions=0103:0140
 libs.itertools.versions.0103.version=0.10.3
 libs.itertools.versions.0103.path=libitertools.rlib
+libs.itertools.versions.0140.version=0.14.0
+libs.itertools.versions.0140.path=libitertools.rlib
 
 libs.itoa.name=itoa
 libs.itoa.url=https://crates.io/crates/itoa
-libs.itoa.versions=102
+libs.itoa.versions=102:1015
 libs.itoa.versions.102.version=1.0.2
 libs.itoa.versions.102.path=libitoa.rlib
+libs.itoa.versions.1015.version=1.0.15
+libs.itoa.versions.1015.path=libitoa.rlib
 
 libs.lazy_static.name=lazy_static
 libs.lazy_static.url=https://crates.io/crates/lazy_static
-libs.lazy_static.versions=140
+libs.lazy_static.versions=140:150
 libs.lazy_static.versions.140.version=1.4.0
 libs.lazy_static.versions.140.path=liblazy_static.rlib
+libs.lazy_static.versions.150.version=1.5.0
+libs.lazy_static.versions.150.path=liblazy_static.rlib
 
 libs.libc.name=libc
 libs.libc.url=https://crates.io/crates/libc
-libs.libc.versions=02126
+libs.libc.versions=02126:02174
 libs.libc.versions.02126.version=0.2.126
 libs.libc.versions.02126.path=liblibc.rlib
+libs.libc.versions.02174.version=0.2.174
+libs.libc.versions.02174.path=liblibc.rlib
+
+libs.linux-raw-sys.name=linux-raw-sys
+libs.linux-raw-sys.url=https://crates.io/crates/linux-raw-sys
+libs.linux-raw-sys.versions=0100
+libs.linux-raw-sys.versions.0100.version=0.10.0
+libs.linux-raw-sys.versions.0100.path=liblinux_raw_sys.rlib
 
 libs.lock_api.name=lock_api
 libs.lock_api.url=https://crates.io/crates/lock_api
-libs.lock_api.versions=047
+libs.lock_api.versions=047:0413
 libs.lock_api.versions.047.version=0.4.7
 libs.lock_api.versions.047.path=liblock_api.rlib
+libs.lock_api.versions.0413.version=0.4.13
+libs.lock_api.versions.0413.path=liblock_api.rlib
 
 libs.log.name=log
 libs.log.url=https://crates.io/crates/log
-libs.log.versions=0417
+libs.log.versions=0417:0427
 libs.log.versions.0417.version=0.4.17
 libs.log.versions.0417.path=liblog.rlib
+libs.log.versions.0427.version=0.4.27
+libs.log.versions.0427.path=liblog.rlib
 
 libs.matches.name=matches
 libs.matches.url=https://crates.io/crates/matches
@@ -639,27 +739,35 @@ libs.matches.versions.019.path=libmatches.rlib
 
 libs.memchr.name=memchr
 libs.memchr.url=https://crates.io/crates/memchr
-libs.memchr.versions=250
+libs.memchr.versions=250:275
 libs.memchr.versions.250.version=2.5.0
 libs.memchr.versions.250.path=libmemchr.rlib
+libs.memchr.versions.275.version=2.7.5
+libs.memchr.versions.275.path=libmemchr.rlib
 
 libs.memoffset.name=memoffset
 libs.memoffset.url=https://crates.io/crates/memoffset
-libs.memoffset.versions=065
+libs.memoffset.versions=065:091
 libs.memoffset.versions.065.version=0.6.5
 libs.memoffset.versions.065.path=libmemoffset.rlib
+libs.memoffset.versions.091.version=0.9.1
+libs.memoffset.versions.091.path=libmemoffset.rlib
 
 libs.miniz_oxide.name=miniz_oxide
 libs.miniz_oxide.url=https://crates.io/crates/miniz_oxide
-libs.miniz_oxide.versions=053
+libs.miniz_oxide.versions=053:089
 libs.miniz_oxide.versions.053.version=0.5.3
 libs.miniz_oxide.versions.053.path=libminiz_oxide.rlib
+libs.miniz_oxide.versions.089.version=0.8.9
+libs.miniz_oxide.versions.089.path=libminiz_oxide.rlib
 
 libs.mio.name=mio
 libs.mio.url=https://crates.io/crates/mio
-libs.mio.versions=083
+libs.mio.versions=083:104
 libs.mio.versions.083.version=0.8.3
 libs.mio.versions.083.path=libmio.rlib
+libs.mio.versions.104.version=1.0.4
+libs.mio.versions.104.path=libmio.rlib
 
 libs.ndarray.name=ndarray
 libs.ndarray.url=https://crates.io/crates/ndarray
@@ -681,21 +789,27 @@ libs.num.versions.040.path=libnum.rlib
 
 libs.num-integer.name=num-integer
 libs.num-integer.url=https://crates.io/crates/num-integer
-libs.num-integer.versions=0145
+libs.num-integer.versions=0145:0146
 libs.num-integer.versions.0145.version=0.1.45
 libs.num-integer.versions.0145.path=libnum_integer.rlib
+libs.num-integer.versions.0146.version=0.1.46
+libs.num-integer.versions.0146.path=libnum_integer.rlib
 
 libs.num-traits.name=num-traits
 libs.num-traits.url=https://crates.io/crates/num-traits
-libs.num-traits.versions=0215
+libs.num-traits.versions=0215:0219
 libs.num-traits.versions.0215.version=0.2.15
 libs.num-traits.versions.0215.path=libnum_traits.rlib
+libs.num-traits.versions.0219.version=0.2.19
+libs.num-traits.versions.0219.path=libnum_traits.rlib
 
 libs.num_cpus.name=num_cpus
 libs.num_cpus.url=https://crates.io/crates/num_cpus
-libs.num_cpus.versions=1131
+libs.num_cpus.versions=1131:1170
 libs.num_cpus.versions.1131.version=1.13.1
 libs.num_cpus.versions.1131.path=libnum_cpus.rlib
+libs.num_cpus.versions.1170.version=1.17.0
+libs.num_cpus.versions.1170.path=libnum_cpus.rlib
 
 libs.num_traits.name=num_traits
 libs.num_traits.url=https://crates.io/crates/num_traits
@@ -705,9 +819,11 @@ libs.num_traits.versions.0215.path=libnum_traits.rlib
 
 libs.once_cell.name=once_cell
 libs.once_cell.url=https://crates.io/crates/once_cell
-libs.once_cell.versions=1120
+libs.once_cell.versions=1120:1213
 libs.once_cell.versions.1120.version=1.12.0
 libs.once_cell.versions.1120.path=libonce_cell.rlib
+libs.once_cell.versions.1213.version=1.21.3
+libs.once_cell.versions.1213.path=libonce_cell.rlib
 
 libs.opaque-debug.name=opaque-debug
 libs.opaque-debug.url=https://crates.io/crates/opaque-debug
@@ -717,21 +833,27 @@ libs.opaque-debug.versions.030.path=libopaque_debug.rlib
 
 libs.parking_lot.name=parking_lot
 libs.parking_lot.url=https://crates.io/crates/parking_lot
-libs.parking_lot.versions=0121
+libs.parking_lot.versions=0121:0124
 libs.parking_lot.versions.0121.version=0.12.1
 libs.parking_lot.versions.0121.path=libparking_lot.rlib
+libs.parking_lot.versions.0124.version=0.12.4
+libs.parking_lot.versions.0124.path=libparking_lot.rlib
 
 libs.parking_lot_core.name=parking_lot_core
 libs.parking_lot_core.url=https://crates.io/crates/parking_lot_core
-libs.parking_lot_core.versions=093
+libs.parking_lot_core.versions=093:0911
 libs.parking_lot_core.versions.093.version=0.9.3
 libs.parking_lot_core.versions.093.path=libparking_lot_core.rlib
+libs.parking_lot_core.versions.0911.version=0.9.11
+libs.parking_lot_core.versions.0911.path=libparking_lot_core.rlib
 
 libs.percent-encoding.name=percent-encoding
 libs.percent-encoding.url=https://crates.io/crates/percent-encoding
-libs.percent-encoding.versions=210
+libs.percent-encoding.versions=210:231
 libs.percent-encoding.versions.210.version=2.1.0
 libs.percent-encoding.versions.210.path=libpercent_encoding.rlib
+libs.percent-encoding.versions.231.version=2.3.1
+libs.percent-encoding.versions.231.path=libpercent_encoding.rlib
 
 libs.phf.name=phf
 libs.phf.url=https://crates.io/crates/phf
@@ -741,21 +863,33 @@ libs.phf.versions.0112.path=libphf.rlib
 
 libs.pin-project-lite.name=pin-project-lite
 libs.pin-project-lite.url=https://crates.io/crates/pin-project-lite
-libs.pin-project-lite.versions=029
+libs.pin-project-lite.versions=029:0216
 libs.pin-project-lite.versions.029.version=0.2.9
 libs.pin-project-lite.versions.029.path=libpin_project_lite.rlib
+libs.pin-project-lite.versions.0216.version=0.2.16
+libs.pin-project-lite.versions.0216.path=libpin_project_lite.rlib
+
+libs.pin-utils.name=pin-utils
+libs.pin-utils.url=https://crates.io/crates/pin-utils
+libs.pin-utils.versions=010
+libs.pin-utils.versions.010.version=0.1.0
+libs.pin-utils.versions.010.path=libpin_utils.rlib
 
 libs.pkg-config.name=pkg-config
 libs.pkg-config.url=https://crates.io/crates/pkg-config
-libs.pkg-config.versions=0325
+libs.pkg-config.versions=0325:0332
 libs.pkg-config.versions.0325.version=0.3.25
 libs.pkg-config.versions.0325.path=libpkg_config.rlib
+libs.pkg-config.versions.0332.version=0.3.32
+libs.pkg-config.versions.0332.path=libpkg_config.rlib
 
 libs.ppv-lite86.name=ppv-lite86
 libs.ppv-lite86.url=https://crates.io/crates/ppv-lite86
-libs.ppv-lite86.versions=0216
+libs.ppv-lite86.versions=0216:0221
 libs.ppv-lite86.versions.0216.version=0.2.16
 libs.ppv-lite86.versions.0216.path=libppv_lite86.rlib
+libs.ppv-lite86.versions.0221.version=0.2.21
+libs.ppv-lite86.versions.0221.path=libppv_lite86.rlib
 
 libs.proc-macro-hack.name=proc-macro-hack
 libs.proc-macro-hack.url=https://crates.io/crates/proc-macro-hack
@@ -765,33 +899,43 @@ libs.proc-macro-hack.versions.0519.path=libproc_macro_hack.rlib
 
 libs.proc-macro2.name=proc-macro2
 libs.proc-macro2.url=https://crates.io/crates/proc-macro2
-libs.proc-macro2.versions=1039
+libs.proc-macro2.versions=1039:1095
 libs.proc-macro2.versions.1039.version=1.0.39
 libs.proc-macro2.versions.1039.path=libproc_macro2.rlib
+libs.proc-macro2.versions.1095.version=1.0.95
+libs.proc-macro2.versions.1095.path=libproc_macro2.rlib
 
 libs.quote.name=quote
 libs.quote.url=https://crates.io/crates/quote
-libs.quote.versions=1018
+libs.quote.versions=1018:1040
 libs.quote.versions.1018.version=1.0.18
 libs.quote.versions.1018.path=libquote.rlib
+libs.quote.versions.1040.version=1.0.40
+libs.quote.versions.1040.path=libquote.rlib
 
 libs.rand.name=rand
 libs.rand.url=https://crates.io/crates/rand
-libs.rand.versions=085
+libs.rand.versions=085:091
 libs.rand.versions.085.version=0.8.5
 libs.rand.versions.085.path=librand.rlib
+libs.rand.versions.091.version=0.9.1
+libs.rand.versions.091.path=librand.rlib
 
 libs.rand_chacha.name=rand_chacha
 libs.rand_chacha.url=https://crates.io/crates/rand_chacha
-libs.rand_chacha.versions=031
+libs.rand_chacha.versions=031:090
 libs.rand_chacha.versions.031.version=0.3.1
 libs.rand_chacha.versions.031.path=librand_chacha.rlib
+libs.rand_chacha.versions.090.version=0.9.0
+libs.rand_chacha.versions.090.path=librand_chacha.rlib
 
 libs.rand_core.name=rand_core
 libs.rand_core.url=https://crates.io/crates/rand_core
-libs.rand_core.versions=063
+libs.rand_core.versions=063:093
 libs.rand_core.versions.063.version=0.6.3
 libs.rand_core.versions.063.path=librand_core.rlib
+libs.rand_core.versions.093.version=0.9.3
+libs.rand_core.versions.093.path=librand_core.rlib
 
 libs.rayon.name=rayon
 libs.rayon.url=https://crates.io/crates/rayon
@@ -801,15 +945,25 @@ libs.rayon.versions.161.path=librayon.rlib
 
 libs.regex.name=regex
 libs.regex.url=https://crates.io/crates/regex
-libs.regex.versions=156
+libs.regex.versions=156:1111
 libs.regex.versions.156.version=1.5.6
 libs.regex.versions.156.path=libregex.rlib
+libs.regex.versions.1111.version=1.11.1
+libs.regex.versions.1111.path=libregex.rlib
+
+libs.regex-automata.name=regex-automata
+libs.regex-automata.url=https://crates.io/crates/regex-automata
+libs.regex-automata.versions=049
+libs.regex-automata.versions.049.version=0.4.9
+libs.regex-automata.versions.049.path=libregex_automata.rlib
 
 libs.regex-syntax.name=regex-syntax
 libs.regex-syntax.url=https://crates.io/crates/regex-syntax
-libs.regex-syntax.versions=0626
+libs.regex-syntax.versions=0626:085
 libs.regex-syntax.versions.0626.version=0.6.26
 libs.regex-syntax.versions.0626.path=libregex_syntax.rlib
+libs.regex-syntax.versions.085.version=0.8.5
+libs.regex-syntax.versions.085.path=libregex_syntax.rlib
 
 libs.rustc_version.name=rustc_version
 libs.rustc_version.url=https://crates.io/crates/rustc_version
@@ -817,23 +971,41 @@ libs.rustc_version.versions=040
 libs.rustc_version.versions.040.version=0.4.0
 libs.rustc_version.versions.040.path=librustc_version.rlib
 
+libs.rustix.name=rustix
+libs.rustix.url=https://crates.io/crates/rustix
+libs.rustix.versions=107
+libs.rustix.versions.107.version=1.0.7
+libs.rustix.versions.107.path=librustix.rlib
+
+libs.rustls.name=rustls
+libs.rustls.url=https://crates.io/crates/rustls
+libs.rustls.versions=02328
+libs.rustls.versions.02328.version=0.23.28
+libs.rustls.versions.02328.path=librustls.rlib
+
 libs.ryu.name=ryu
 libs.ryu.url=https://crates.io/crates/ryu
-libs.ryu.versions=1010
+libs.ryu.versions=1010:1020
 libs.ryu.versions.1010.version=1.0.10
 libs.ryu.versions.1010.path=libryu.rlib
+libs.ryu.versions.1020.version=1.0.20
+libs.ryu.versions.1020.path=libryu.rlib
 
 libs.scopeguard.name=scopeguard
 libs.scopeguard.url=https://crates.io/crates/scopeguard
-libs.scopeguard.versions=110
+libs.scopeguard.versions=110:120
 libs.scopeguard.versions.110.version=1.1.0
 libs.scopeguard.versions.110.path=libscopeguard.rlib
+libs.scopeguard.versions.120.version=1.2.0
+libs.scopeguard.versions.120.path=libscopeguard.rlib
 
 libs.semver.name=semver
 libs.semver.url=https://crates.io/crates/semver
-libs.semver.versions=109
+libs.semver.versions=109:1026
 libs.semver.versions.109.version=1.0.9
 libs.semver.versions.109.path=libsemver.rlib
+libs.semver.versions.1026.version=1.0.26
+libs.semver.versions.1026.path=libsemver.rlib
 
 libs.semver-parser.name=semver-parser
 libs.semver-parser.url=https://crates.io/crates/semver-parser
@@ -843,45 +1015,65 @@ libs.semver-parser.versions.0102.path=libsemver_parser.rlib
 
 libs.serde.name=serde
 libs.serde.url=https://crates.io/crates/serde
-libs.serde.versions=10137
+libs.serde.versions=10137:10219
 libs.serde.versions.10137.version=1.0.137
 libs.serde.versions.10137.path=libserde.rlib
+libs.serde.versions.10219.version=1.0.219
+libs.serde.versions.10219.path=libserde.rlib
 
 libs.serde_derive.name=serde_derive
 libs.serde_derive.url=https://crates.io/crates/serde_derive
-libs.serde_derive.versions=10137
+libs.serde_derive.versions=10137:10219
 libs.serde_derive.versions.10137.version=1.0.137
 libs.serde_derive.versions.10137.path=libserde_derive.rlib
+libs.serde_derive.versions.10219.version=1.0.219
+libs.serde_derive.versions.10219.path=libserde_derive.rlib
 
 libs.serde_json.name=serde_json
 libs.serde_json.url=https://crates.io/crates/serde_json
-libs.serde_json.versions=1081
+libs.serde_json.versions=1081:10140
 libs.serde_json.versions.1081.version=1.0.81
 libs.serde_json.versions.1081.path=libserde_json.rlib
+libs.serde_json.versions.10140.version=1.0.140
+libs.serde_json.versions.10140.path=libserde_json.rlib
+
+libs.sha2.name=sha2
+libs.sha2.url=https://crates.io/crates/sha2
+libs.sha2.versions=0109
+libs.sha2.versions.0109.version=0.10.9
+libs.sha2.versions.0109.path=libsha2.rlib
 
 libs.slab.name=slab
 libs.slab.url=https://crates.io/crates/slab
-libs.slab.versions=046
+libs.slab.versions=046:0410
 libs.slab.versions.046.version=0.4.6
 libs.slab.versions.046.path=libslab.rlib
+libs.slab.versions.0410.version=0.4.10
+libs.slab.versions.0410.path=libslab.rlib
 
 libs.smallvec.name=smallvec
 libs.smallvec.url=https://crates.io/crates/smallvec
-libs.smallvec.versions=180
+libs.smallvec.versions=180:1151
 libs.smallvec.versions.180.version=1.8.0
 libs.smallvec.versions.180.path=libsmallvec.rlib
+libs.smallvec.versions.1151.version=1.15.1
+libs.smallvec.versions.1151.path=libsmallvec.rlib
 
 libs.socket2.name=socket2
 libs.socket2.url=https://crates.io/crates/socket2
-libs.socket2.versions=044
+libs.socket2.versions=044:0510
 libs.socket2.versions.044.version=0.4.4
 libs.socket2.versions.044.path=libsocket2.rlib
+libs.socket2.versions.0510.version=0.5.10
+libs.socket2.versions.0510.path=libsocket2.rlib
 
 libs.strsim.name=strsim
 libs.strsim.url=https://crates.io/crates/strsim
-libs.strsim.versions=0100
+libs.strsim.versions=0100:0111
 libs.strsim.versions.0100.version=0.10.0
 libs.strsim.versions.0100.path=libstrsim.rlib
+libs.strsim.versions.0111.version=0.11.1
+libs.strsim.versions.0111.path=libstrsim.rlib
 
 libs.subtle.name=subtle
 libs.subtle.url=https://crates.io/crates/subtle
@@ -891,9 +1083,17 @@ libs.subtle.versions.241.path=libsubtle.rlib
 
 libs.syn.name=syn
 libs.syn.url=https://crates.io/crates/syn
-libs.syn.versions=1096
+libs.syn.versions=1096:20104
 libs.syn.versions.1096.version=1.0.96
 libs.syn.versions.1096.path=libsyn.rlib
+libs.syn.versions.20104.version=2.0.104
+libs.syn.versions.20104.path=libsyn.rlib
+
+libs.tempfile.name=tempfile
+libs.tempfile.url=https://crates.io/crates/tempfile
+libs.tempfile.versions=3200
+libs.tempfile.versions.3200.version=3.20.0
+libs.tempfile.versions.3200.path=libtempfile.rlib
 
 libs.termcolor.name=termcolor
 libs.termcolor.url=https://crates.io/crates/termcolor
@@ -909,15 +1109,19 @@ libs.textwrap.versions.0150.path=libtextwrap.rlib
 
 libs.thiserror.name=thiserror
 libs.thiserror.url=https://crates.io/crates/thiserror
-libs.thiserror.versions=1031
+libs.thiserror.versions=1031:2012
 libs.thiserror.versions.1031.version=1.0.31
 libs.thiserror.versions.1031.path=libthiserror.rlib
+libs.thiserror.versions.2012.version=2.0.12
+libs.thiserror.versions.2012.path=libthiserror.rlib
 
 libs.thiserror-impl.name=thiserror-impl
 libs.thiserror-impl.url=https://crates.io/crates/thiserror-impl
-libs.thiserror-impl.versions=1031
+libs.thiserror-impl.versions=1031:2012
 libs.thiserror-impl.versions.1031.version=1.0.31
 libs.thiserror-impl.versions.1031.path=libthiserror_impl.rlib
+libs.thiserror-impl.versions.2012.version=2.0.12
+libs.thiserror-impl.versions.2012.path=libthiserror_impl.rlib
 
 libs.thread_local.name=thread_local
 libs.thread_local.url=https://crates.io/crates/thread_local
@@ -927,33 +1131,65 @@ libs.thread_local.versions.114.path=libthread_local.rlib
 
 libs.time.name=time
 libs.time.url=https://crates.io/crates/time
-libs.time.versions=039
+libs.time.versions=039:0341
 libs.time.versions.039.version=0.3.9
 libs.time.versions.039.path=libtime.rlib
+libs.time.versions.0341.version=0.3.41
+libs.time.versions.0341.path=libtime.rlib
 
 libs.tokio.name=tokio
 libs.tokio.url=https://crates.io/crates/tokio
-libs.tokio.versions=1192
+libs.tokio.versions=1192:1460
 libs.tokio.versions.1192.version=1.19.2
 libs.tokio.versions.1192.path=libtokio.rlib
+libs.tokio.versions.1460.version=1.46.0
+libs.tokio.versions.1460.path=libtokio.rlib
+
+libs.tokio-util.name=tokio-util
+libs.tokio-util.url=https://crates.io/crates/tokio-util
+libs.tokio-util.versions=0715
+libs.tokio-util.versions.0715.version=0.7.15
+libs.tokio-util.versions.0715.path=libtokio_util.rlib
 
 libs.toml.name=toml
 libs.toml.url=https://crates.io/crates/toml
-libs.toml.versions=059
+libs.toml.versions=059:0823
 libs.toml.versions.059.version=0.5.9
 libs.toml.versions.059.path=libtoml.rlib
+libs.toml.versions.0823.version=0.8.23
+libs.toml.versions.0823.path=libtoml.rlib
+
+libs.tracing.name=tracing
+libs.tracing.url=https://crates.io/crates/tracing
+libs.tracing.versions=0141
+libs.tracing.versions.0141.version=0.1.41
+libs.tracing.versions.0141.path=libtracing.rlib
+
+libs.tracing-core.name=tracing-core
+libs.tracing-core.url=https://crates.io/crates/tracing-core
+libs.tracing-core.versions=0134
+libs.tracing-core.versions.0134.version=0.1.34
+libs.tracing-core.versions.0134.path=libtracing_core.rlib
 
 libs.typenum.name=typenum
 libs.typenum.url=https://crates.io/crates/typenum
-libs.typenum.versions=1150
+libs.typenum.versions=1150:1180
 libs.typenum.versions.1150.version=1.15.0
 libs.typenum.versions.1150.path=libtypenum.rlib
+libs.typenum.versions.1180.version=1.18.0
+libs.typenum.versions.1180.path=libtypenum.rlib
 
 libs.unicode-bidi.name=unicode-bidi
 libs.unicode-bidi.url=https://crates.io/crates/unicode-bidi
 libs.unicode-bidi.versions=038
 libs.unicode-bidi.versions.038.version=0.3.8
 libs.unicode-bidi.versions.038.path=libunicode_bidi.rlib
+
+libs.unicode-ident.name=unicode-ident
+libs.unicode-ident.url=https://crates.io/crates/unicode-ident
+libs.unicode-ident.versions=1018
+libs.unicode-ident.versions.1018.version=1.0.18
+libs.unicode-ident.versions.1018.path=libunicode_ident.rlib
 
 libs.unicode-normalization.name=unicode-normalization
 libs.unicode-normalization.url=https://crates.io/crates/unicode-normalization
@@ -969,9 +1205,11 @@ libs.unicode-segmentation.versions.190.path=libunicode_segmentation.rlib
 
 libs.unicode-width.name=unicode-width
 libs.unicode-width.url=https://crates.io/crates/unicode-width
-libs.unicode-width.versions=019
+libs.unicode-width.versions=019:021
 libs.unicode-width.versions.019.version=0.1.9
 libs.unicode-width.versions.019.path=libunicode_width.rlib
+libs.unicode-width.versions.021.version=0.2.1
+libs.unicode-width.versions.021.path=libunicode_width.rlib
 
 libs.unicode-xid.name=unicode-xid
 libs.unicode-xid.url=https://crates.io/crates/unicode-xid
@@ -981,9 +1219,17 @@ libs.unicode-xid.versions.023.path=libunicode_xid.rlib
 
 libs.url.name=url
 libs.url.url=https://crates.io/crates/url
-libs.url.versions=222
+libs.url.versions=222:254
 libs.url.versions.222.version=2.2.2
 libs.url.versions.222.path=liburl.rlib
+libs.url.versions.254.version=2.5.4
+libs.url.versions.254.path=liburl.rlib
+
+libs.uuid.name=uuid
+libs.uuid.url=https://crates.io/crates/uuid
+libs.uuid.versions=1170
+libs.uuid.versions.1170.version=1.17.0
+libs.uuid.versions.1170.path=libuuid.rlib
 
 libs.vec_map.name=vec_map
 libs.vec_map.url=https://crates.io/crates/vec_map
@@ -993,9 +1239,11 @@ libs.vec_map.versions.082.path=libvec_map.rlib
 
 libs.version_check.name=version_check
 libs.version_check.url=https://crates.io/crates/version_check
-libs.version_check.versions=094
+libs.version_check.versions=094:095
 libs.version_check.versions.094.version=0.9.4
 libs.version_check.versions.094.path=libversion_check.rlib
+libs.version_check.versions.095.version=0.9.5
+libs.version_check.versions.095.path=libversion_check.rlib
 
 libs.wide.name=wide
 libs.wide.url=https://crates.io/crates/wide
@@ -1008,6 +1256,42 @@ libs.winapi.url=https://crates.io/crates/winapi
 libs.winapi.versions=039
 libs.winapi.versions.039.version=0.3.9
 libs.winapi.versions.039.path=libwinapi.rlib
+
+libs.windows-sys.name=windows-sys
+libs.windows-sys.url=https://crates.io/crates/windows-sys
+libs.windows-sys.versions=0602
+libs.windows-sys.versions.0602.version=0.60.2
+libs.windows-sys.versions.0602.path=libwindows_sys.rlib
+
+libs.windows_aarch64_msvc.name=windows_aarch64_msvc
+libs.windows_aarch64_msvc.url=https://crates.io/crates/windows_aarch64_msvc
+libs.windows_aarch64_msvc.versions=0530
+libs.windows_aarch64_msvc.versions.0530.version=0.53.0
+libs.windows_aarch64_msvc.versions.0530.path=libwindows_aarch64_msvc.rlib
+
+libs.windows_i686_gnu.name=windows_i686_gnu
+libs.windows_i686_gnu.url=https://crates.io/crates/windows_i686_gnu
+libs.windows_i686_gnu.versions=0530
+libs.windows_i686_gnu.versions.0530.version=0.53.0
+libs.windows_i686_gnu.versions.0530.path=libwindows_i686_gnu.rlib
+
+libs.windows_i686_msvc.name=windows_i686_msvc
+libs.windows_i686_msvc.url=https://crates.io/crates/windows_i686_msvc
+libs.windows_i686_msvc.versions=0530
+libs.windows_i686_msvc.versions.0530.version=0.53.0
+libs.windows_i686_msvc.versions.0530.path=libwindows_i686_msvc.rlib
+
+libs.windows_x86_64_gnu.name=windows_x86_64_gnu
+libs.windows_x86_64_gnu.url=https://crates.io/crates/windows_x86_64_gnu
+libs.windows_x86_64_gnu.versions=0530
+libs.windows_x86_64_gnu.versions.0530.version=0.53.0
+libs.windows_x86_64_gnu.versions.0530.path=libwindows_x86_64_gnu.rlib
+
+libs.windows_x86_64_msvc.name=windows_x86_64_msvc
+libs.windows_x86_64_msvc.url=https://crates.io/crates/windows_x86_64_msvc
+libs.windows_x86_64_msvc.versions=0530
+libs.windows_x86_64_msvc.versions.0530.version=0.53.0
+libs.windows_x86_64_msvc.versions.0530.path=libwindows_x86_64_msvc.rlib
 
 libs.zerocopy.name=zerocopy
 libs.zerocopy.url=https://crates.io/crates/zerocopy


### PR DESCRIPTION
This PR adds the **top 100 Rust crates** to Compiler Explorer.

This bulk addition includes the most popular crates from crates.io to provide better library support for Rust users.

Related PR: https://github.com/compiler-explorer/infra/pull/1687

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_