### PR TITLE
Add Fortran library roots_fortran v1.5.0

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1695,7 +1695,7 @@ compiler.fmips64elg1510.demangler=/opt/compiler-explorer/mips64el/gcc-15.1.0/mip
 #################################
 # Libraries
 
-libs=curl:http_client:json_fortran:forcompile:stdlib_fortran:libfpm
+libs=curl:http_client:json_fortran:forcompile:stdlib_fortran:libfpm:roots_fortran
 
 libs.curl.name=curl
 libs.curl.liblink=curl-d
@@ -1742,6 +1742,14 @@ libs.libfpm.staticliblink=fpm
 libs.libfpm.versions=0101
 libs.libfpm.packagedheaders=true
 libs.libfpm.versions.0101.version=0.10.1
+
+libs.roots_fortran.name=roots_fortran
+libs.roots_fortran.url=https://github.com/jacobwilliams/roots-fortran
+libs.roots_fortran.staticliblink=roots_fortran
+libs.roots_fortran.versions=150
+libs.roots_fortran.packagedheaders=true
+libs.roots_fortran.versions.150.version=1.5.0
+
 
 #################################
 #################################


### PR DESCRIPTION
This PR adds the Fortran library **roots_fortran** version 1.5.0 to Compiler Explorer.

- GitHub URL: https://github.com/jacobwilliams/roots-fortran
- Package Manager: FPM (Fortran Package Manager)

Related PR: https://github.com/compiler-explorer/infra/pull/1688

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_