### PR TITLE
Add C++ library glaze vv5.5.2

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5247,7 +5247,7 @@ libs.gemmlowp.versions.trunk.path=/opt/compiler-explorer/libs/gemmlowp/trunk
 
 libs.glaze.name=glaze
 libs.glaze.description=JSON, reflection, and interface library
-libs.glaze.versions=trunk:198:203:500
+libs.glaze.versions=trunk:198:203:500:v552
 libs.glaze.url=https://github.com/stephenberry/glaze
 libs.glaze.versions.trunk.version=trunk
 libs.glaze.versions.trunk.path=/opt/compiler-explorer/libs/glaze/trunk/include
@@ -5257,6 +5257,8 @@ libs.glaze.versions.203.version=2.0.3
 libs.glaze.versions.203.path=/opt/compiler-explorer/libs/glaze/v2.0.3/include
 libs.glaze.versions.500.version=5.0.0
 libs.glaze.versions.500.path=/opt/compiler-explorer/libs/glaze/v5.0.0/include
+libs.glaze.versions.v552.path=/opt/compiler-explorer/libs/glaze/vv5.5.2/include
+libs.glaze.versions.v552.version=v5.5.2
 
 libs.glm.name=GLM
 libs.glm.description=OpenGL Mathematics


### PR DESCRIPTION
This PR adds the C++ library **glaze** version v5.5.2 to Compiler Explorer.

- GitHub URL: https://github.com/stephenberry/glaze
- Library Type: header-only

Related PR: https://github.com/compiler-explorer/infra/pull/1689

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_