### PR TITLE
Add C++ library graaf v1.1.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4499,7 +4499,7 @@ compiler.z180-clang-1507.options=-target z180 -g0 -nostdinc -fno-threadsafe-stat
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:ppdt:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan
+libs=abseil:array:async_simple:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:ppdt:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan:graaf
 
 libs.abseil.name=Abseil
 libs.abseil.versions=202501270
@@ -6646,3 +6646,6 @@ tools.bloaty11.type=postcompilation
 tools.bloaty11.class=bloaty-tool
 tools.bloaty11.exclude=djggp
 tools.bloaty11.stdinHint=disabled
+
+libs.graaf.versions.111.path=/opt/compiler-explorer/libs/graaf/1.1.1/include
+libs.graaf.versions.111.version=1.1.1


### PR DESCRIPTION
This PR adds the C++ library **graaf** version 1.1.1 to Compiler Explorer.

- GitHub URL: https://github.com/bobluppes/graaf
- Library Type: header-only

Related PR: https://github.com/compiler-explorer/infra/pull/1691

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_