### PR TITLE
Add C++ library HPX v1.11.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5491,13 +5491,14 @@ libs.hotels-template-library.versions.trunk.version=trunk
 libs.hotels-template-library.versions.trunk.path=/opt/compiler-explorer/libs/hotels-template-library/trunk/
 
 libs.hpx.name=HPX
-libs.hpx.versions=v1.11.0
+libs.hpx.versions=v1110
 libs.hpx.url=https://github.com/STEllAR-GROUP/hpx
 libs.hpx.description=The C++ Standard Library for Concurrency and Parallelism
-libs.hpx.versions.v1.11.0.version=1.11.0
-libs.hpx.versions.v1.11.0.path=/opt/compiler-explorer/libs/hpx/v1.11.0/include:/opt/compiler-explorer/libs/hpx/v1.11.0/hwloc_installed/include:/opt/compiler-explorer/libs/boost_1_84_0
-libs.hpx.versions.v1.11.0.libpath=/opt/compiler-explorer/libs/hpx/v1.11.0/lib:/opt/compiler-explorer/libs/hpx/v1.11.0/hwloc_installed/lib
-libs.hpx.versions.v1.11.0.liblink=hpx_wrap:hpx_init:hpx:hpx_core:hwloc:dl:rt
+libs.hpx.packagedheaders=true
+libs.hpx.versions.v1110.version=1.11.0
+libs.hpx.versions.v1110.path=/opt/compiler-explorer/libs/hpx/v1.11.0/include:/opt/compiler-explorer/libs/hpx/v1.11.0/hwloc_installed/include:/opt/compiler-explorer/libs/boost_1_84_0
+libs.hpx.versions.v1110.libpath=/opt/compiler-explorer/libs/hpx/v1.11.0/lib:/opt/compiler-explorer/libs/hpx/v1.11.0/hwloc_installed/lib
+libs.hpx.versions.v1110.liblink=hpx_wrap:hpx_init:hpx:hpx_core:hwloc:dl:rt
 
 libs.immer.name=immer
 libs.immer.url=https://github.com/arximboldi/immer


### PR DESCRIPTION
Add's C++ library HPX v1.11.0. 
Corresponding **infra** PR's : [1679](https://github.com/compiler-explorer/infra/pull/1679) [1529](https://github.com/compiler-explorer/infra/pull/1529)
