### PR TITLE
Add GCC 12.5 for native and cross (+minor fix for 12.4)

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -7,7 +7,7 @@ compilerType=ada
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=&gnatassert:gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat124:gnat131:gnat132:gnat133:gnat134:gnat141:gnat142:gnat143:gnat151:gnatsnapshot
+group.gnat.compilers=&gnatassert:gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat124:gnat125:gnat131:gnat132:gnat133:gnat134:gnat141:gnat142:gnat143:gnat151:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=X86-64 GNAT
 group.gnat.baseName=x86-64 gnat
@@ -49,6 +49,8 @@ compiler.gnat123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gnatmake
 compiler.gnat123.semver=12.3
 compiler.gnat124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gnatmake
 compiler.gnat124.semver=12.4
+compiler.gnat125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gnatmake
+compiler.gnat125.semver=12.5
 compiler.gnat131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gnatmake
 compiler.gnat131.semver=13.1
 compiler.gnat132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gnatmake
@@ -73,7 +75,7 @@ compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnatsnapshot.semver=(trunk)
 
 ## GNAT x86 build with "assertions" (--enable-checking=XXX)
-group.gnatassert.compilers=gnat104assert:gnat105assert:gnat111assert:gnat112assert:gnat113assert:gnat114assert:gnat121assert:gnat122assert:gnat123assert:gnat124assert:gnat131assert:gnat132assert:gnat133assert:gnat134assert:gnat141assert:gnat142assert:gnat143assert:gnat151assert
+group.gnatassert.compilers=gnat104assert:gnat105assert:gnat111assert:gnat112assert:gnat113assert:gnat114assert:gnat121assert:gnat122assert:gnat123assert:gnat124assert:gnat125assert:gnat131assert:gnat132assert:gnat133assert:gnat134assert:gnat141assert:gnat142assert:gnat143assert:gnat151assert
 group.gnatassert.groupName=GCC x86-64 (assertions)
 
 compiler.gnat104assert.exe=/opt/compiler-explorer/gcc-assertions-10.4.0/bin/gnatmake
@@ -96,6 +98,8 @@ compiler.gnat123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/gnat
 compiler.gnat123assert.semver=12.3 (assertions)
 compiler.gnat124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gnatmake
 compiler.gnat124assert.semver=12.4 (assertions)
+compiler.gnat125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gnatmake
+compiler.gnat125assert.semver=12.5 (assertions)
 compiler.gnat131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gnatmake
 compiler.gnat131assert.semver=13.1 (assertions)
 compiler.gnat132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/gnatmake

--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -194,7 +194,7 @@ compiler.gnatsparcleon1430.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.3.
 
 ################################
 # GNAT for sparc
-group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1240:gnatsparc1310:gnatsparc1320:gnatsparc1330:gnatsparc1340:gnatsparc1410:gnatsparc1420:gnatsparc1430:gnatsparc1510
+group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1240:gnatsparc1250:gnatsparc1310:gnatsparc1320:gnatsparc1330:gnatsparc1340:gnatsparc1410:gnatsparc1420:gnatsparc1430:gnatsparc1510
 group.gnatsparcs.groupName=SPARC GNAT
 group.gnatsparcs.baseName=sparc gnat
 
@@ -212,6 +212,11 @@ compiler.gnatsparc1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown
 compiler.gnatsparc1240.semver=12.4.0
 compiler.gnatsparc1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gnatsparc1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gnatsparc1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
+compiler.gnatsparc1250.semver=12.5.0
+compiler.gnatsparc1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gnatsparc1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.gnatsparc1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
 compiler.gnatsparc1310.semver=13.1.0
@@ -255,7 +260,7 @@ compiler.gnatsparc1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-u
 
 ################################
 # GNAT for sparc64
-group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641240:gnatsparc641310:gnatsparc641320:gnatsparc641330:gnatsparc641340:gnatsparc641410:gnatsparc641420:gnatsparc641430:gnatsparc641510
+group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641240:gnatsparc641250:gnatsparc641310:gnatsparc641320:gnatsparc641330:gnatsparc641340:gnatsparc641410:gnatsparc641420:gnatsparc641430:gnatsparc641510
 group.gnatsparc64s.groupName=SPARC64 GNAT
 group.gnatsparc64s.baseName=sparc64 gnat
 
@@ -273,6 +278,11 @@ compiler.gnatsparc641240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-m
 compiler.gnatsparc641240.semver=12.4.0
 compiler.gnatsparc641240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gnatsparc641240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gnatsparc641250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
+compiler.gnatsparc641250.semver=12.5.0
+compiler.gnatsparc641250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gnatsparc641250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.gnatsparc641310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
 compiler.gnatsparc641310.semver=13.1.0
@@ -316,7 +326,7 @@ compiler.gnatsparc641510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/spa
 
 ################################
 # GNAT for riscv64
-group.gnatriscv64.compilers=gnatriscv64103:gnatriscv64112:gnatriscv641230:gnatriscv641240:gnatriscv641310:gnatriscv641320:gnatriscv641330:gnatriscv641340:gnatriscv641410:gnatriscv641420:gnatriscv641430:gnatriscv641510
+group.gnatriscv64.compilers=gnatriscv64103:gnatriscv64112:gnatriscv641230:gnatriscv641240:gnatriscv641250:gnatriscv641310:gnatriscv641320:gnatriscv641330:gnatriscv641340:gnatriscv641410:gnatriscv641420:gnatriscv641430:gnatriscv641510
 group.gnatriscv64.groupName=RISCV64 GNAT
 group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.instructionSet=riscv64
@@ -340,6 +350,11 @@ compiler.gnatriscv641240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-u
 compiler.gnatriscv641240.semver=12.4.0
 compiler.gnatriscv641240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gnatriscv641240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.gnatriscv641250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
+compiler.gnatriscv641250.semver=12.5.0
+compiler.gnatriscv641250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gnatriscv641250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.gnatriscv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
 compiler.gnatriscv641310.semver=13.1.0
@@ -383,7 +398,7 @@ compiler.gnatriscv641510.demangler=/opt/compiler-explorer/riscv64/gcc-15.1.0/ris
 
 ################################
 # GNAT for s390x
-group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1240:gnats390x1310:gnats390x1320:gnats390x1330:gnats390x1410:gnats390x1420:gnats390x1510:gnats390x1430:gnats390x1340
+group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1240:gnats390x1310:gnats390x1320:gnats390x1330:gnats390x1410:gnats390x1420:gnats390x1510:gnats390x1430:gnats390x1340:gnats390x1250
 group.gnats390x.groupName=S390X GNAT
 group.gnats390x.baseName=S390X GNAT
 
@@ -408,6 +423,11 @@ compiler.gnats390x1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-lin
 compiler.gnats390x1240.semver=12.4.0
 compiler.gnats390x1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gnats390x1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gnats390x1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1250.semver=12.5.0
+compiler.gnats390x1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gnats390x1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.gnats390x1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
 compiler.gnats390x1310.semver=13.1.0
@@ -456,7 +476,7 @@ group.gnatppcs.instructionSet=powerpc
 
 ## POWER
 group.gnatppc.groupName=POWERPC GNAT
-group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1240:gnatppc1310:gnatppc1320:gnatppc1330:gnatppc1340:gnatppc1410:gnatppc1420:gnatppc1430:gnatppc1510
+group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1240:gnatppc1250:gnatppc1310:gnatppc1320:gnatppc1330:gnatppc1340:gnatppc1410:gnatppc1420:gnatppc1430:gnatppc1510
 group.gnatppc.baseName=powerpc gnat
 
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
@@ -481,6 +501,11 @@ compiler.gnatppc1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unkno
 compiler.gnatppc1240.semver=12.4.0
 compiler.gnatppc1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gnatppc1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gnatppc1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1250.semver=12.5.0
+compiler.gnatppc1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gnatppc1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.gnatppc1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
 compiler.gnatppc1310.semver=13.1.0
@@ -525,7 +550,7 @@ compiler.gnatppc1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc
 ## POWER64
 group.gnatppc64.groupName=POWER64 GNAT
 group.gnatppc64.baseName=powerpc64 gnat
-group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641340:gnatppc641410:gnatppc641420:gnatppc641430:gnatppc641510
+group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641250:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641340:gnatppc641410:gnatppc641420:gnatppc641430:gnatppc641510
 
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
@@ -549,6 +574,11 @@ compiler.gnatppc641240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64
 compiler.gnatppc641240.semver=12.4.0
 compiler.gnatppc641240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gnatppc641240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gnatppc641250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641250.semver=12.5.0
+compiler.gnatppc641250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gnatppc641250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gnatppc641310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641310.semver=13.1.0
@@ -598,7 +628,7 @@ compiler.gnatppc64trunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/pow
 ## POWER64LE
 group.gnatppc64le.groupName=POWER64LE GNAT
 group.gnatppc64le.baseName=powerpc64le gnat
-group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310:gnatppc64le1320:gnatppc64letrunk:gnatppc64le1410:gnatppc64le1330:gnatppc64le1240:gnatppc64le1420:gnatppc64le1510:gnatppc64le1430:gnatppc64le1340
+group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310:gnatppc64le1320:gnatppc64letrunk:gnatppc64le1410:gnatppc64le1330:gnatppc64le1240:gnatppc64le1420:gnatppc64le1510:gnatppc64le1430:gnatppc64le1340:gnatppc64le1250
 
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1120.demangler=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
@@ -622,6 +652,11 @@ compiler.gnatppc64le1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/power
 compiler.gnatppc64le1240.semver=12.4.0
 compiler.gnatppc64le1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gnatppc64le1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gnatppc64le1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1250.semver=12.5.0
+compiler.gnatppc64le1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gnatppc64le1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gnatppc64le1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1310.semver=13.1.0
@@ -676,7 +711,7 @@ group.gnatmipss.compilers=&gnatmips:&gnatmips64
 ## MIPS
 group.gnatmips.groupName=MIPS GNAT
 group.gnatmips.baseName=mips gnat
-group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1240:gnatmips1310:gnatmips1320:gnatmips1330:gnatmips1340:gnatmips1410:gnatmips1420:gnatmips1430:gnatmips1510
+group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1240:gnatmips1250:gnatmips1310:gnatmips1320:gnatmips1330:gnatmips1340:gnatmips1410:gnatmips1420:gnatmips1430:gnatmips1510
 
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1120.demangler=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
@@ -700,6 +735,11 @@ compiler.gnatmips1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-li
 compiler.gnatmips1240.semver=12.4.0
 compiler.gnatmips1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gnatmips1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gnatmips1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1250.semver=12.5.0
+compiler.gnatmips1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gnatmips1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.gnatmips1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1310.semver=13.1.0
@@ -744,7 +784,7 @@ compiler.gnatmips1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unkn
 ## MIPS64
 group.gnatmips64.groupName=MIPS64 GNAT
 group.gnatmips64.baseName=mips64 gnat
-group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641240:gnatmips641310:gnatmips641320:gnatmips641330:gnatmips641340:gnatmips641410:gnatmips641420:gnatmips641430:gnatmips641510
+group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641240:gnatmips641250:gnatmips641310:gnatmips641320:gnatmips641330:gnatmips641340:gnatmips641410:gnatmips641420:gnatmips641430:gnatmips641510
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641120.demangler=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
@@ -768,6 +808,11 @@ compiler.gnatmips641240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unkn
 compiler.gnatmips641240.semver=12.4.0
 compiler.gnatmips641240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gnatmips641240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gnatmips641250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641250.semver=12.5.0
+compiler.gnatmips641250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gnatmips641250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.gnatmips641310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641310.semver=13.1.0
@@ -811,7 +856,7 @@ compiler.gnatmips641510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips6
 
 ################################
 # GNAT for arm64
-group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641240:gnatarm641310:gnatarm641320:gnatarm641330:gnatarm641340:gnatarm641410:gnatarm641420:gnatarm641430:gnatarm641510
+group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641240:gnatarm641250:gnatarm641310:gnatarm641320:gnatarm641330:gnatarm641340:gnatarm641410:gnatarm641420:gnatarm641430:gnatarm641510
 group.gnatarm64.groupName=ARM64 GNAT
 group.gnatarm64.baseName=arm64 gnat
 group.gnatarm64.instructionSet=aarch64
@@ -834,6 +879,11 @@ compiler.gnatarm641240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unkno
 compiler.gnatarm641240.semver=12.4.0
 compiler.gnatarm641240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gnatarm641240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.gnatarm641250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
+compiler.gnatarm641250.semver=12.5.0
+compiler.gnatarm641250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gnatarm641250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.gnatarm641310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
 compiler.gnatarm641310.semver=13.1.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g124:g131:g132:g133:g134:g141:g142:g143:g151:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -169,6 +169,8 @@ compiler.g123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/g++
 compiler.g123.semver=12.3
 compiler.g124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/g++
 compiler.g124.semver=12.4
+compiler.g125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/g++
+compiler.g125.semver=12.5
 compiler.g131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 compiler.g131.semver=13.1
 compiler.g132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/g++
@@ -246,7 +248,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g151assert
+group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g151assert
 group.gcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.g103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/g++
@@ -271,6 +273,8 @@ compiler.g123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/g++
 compiler.g123assert.semver=12.3 (assertions)
 compiler.g124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/g++
 compiler.g124assert.semver=12.4 (assertions)
+compiler.g125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/g++
+compiler.g125assert.semver=12.5 (assertions)
 compiler.g131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/g++
 compiler.g131assert.semver=13.1 (assertions)
 compiler.g132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/g++

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1792,7 +1792,7 @@ compiler.bpfgtrunk.isNightly=true
 group.sparc.compilers=&gccsparc
 
 # GCC for SPARC
-group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1240:sparcg1310:sparcg1320:sparcg1330:sparcg1340:sparcg1410:sparcg1420:sparcg1430:sparcg1510
+group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1240:sparcg1250:sparcg1310:sparcg1320:sparcg1330:sparcg1340:sparcg1410:sparcg1420:sparcg1430:sparcg1510
 group.gccsparc.baseName=SPARC gcc
 group.gccsparc.groupName=SPARC GCC
 group.gccsparc.isSemVer=true
@@ -1811,6 +1811,11 @@ compiler.sparcg1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-li
 compiler.sparcg1240.semver=12.4.0
 compiler.sparcg1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.sparcg1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.sparcg1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
+compiler.sparcg1250.semver=12.5.0
+compiler.sparcg1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.sparcg1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.sparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
 compiler.sparcg1310.semver=13.1.0
@@ -1857,7 +1862,7 @@ compiler.sparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-unkn
 group.sparc64.compilers=&gccsparc64
 
 # GCC for SPARC64
-group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310:sparc64g1320:sparc64g1410:sparc64g1330:sparc64g1240:sparc64g1420:sparc64g1510:sparc64g1430:sparc64g1340
+group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310:sparc64g1320:sparc64g1410:sparc64g1330:sparc64g1240:sparc64g1420:sparc64g1510:sparc64g1430:sparc64g1340:sparc64g1250
 group.gccsparc64.baseName=SPARC64 gcc
 group.gccsparc64.groupName=SPARC64 GCC
 group.gccsparc64.isSemVer=true
@@ -1876,6 +1881,11 @@ compiler.sparc64g1240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-mult
 compiler.sparc64g1240.semver=12.4.0
 compiler.sparc64g1240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.sparc64g1240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.sparc64g1250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
+compiler.sparc64g1250.semver=12.5.0
+compiler.sparc64g1250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.sparc64g1250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.sparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
 compiler.sparc64g1310.semver=13.1.0
@@ -1922,7 +1932,7 @@ compiler.sparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/sparc6
 group.sparcleon.compilers=&gccsparcleon
 
 # GCC for SPARC-LEON
-group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1240:sparcleong1310:sparcleong1320:sparcleong1330:sparcleong1340:sparcleong1410:sparcleong1420:sparcleong1430:sparcleong1510
+group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1240:sparcleong1250:sparcleong1310:sparcleong1320:sparcleong1330:sparcleong1340:sparcleong1410:sparcleong1420:sparcleong1430:sparcleong1510
 group.gccsparcleon.baseName=SPARC LEON gcc
 group.gccsparcleon.groupName=SPARC LEON GCC
 group.gccsparcleon.isSemVer=true
@@ -1943,6 +1953,11 @@ compiler.sparcleong1240.exe=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-l
 compiler.sparcleong1240.semver=12.4.0
 compiler.sparcleong1240.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1240.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.sparcleong1250.exe=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1250.semver=12.5.0
+compiler.sparcleong1250.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.sparcleong1250.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.sparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
 compiler.sparcleong1310.semver=13.1.0
@@ -1994,7 +2009,7 @@ compiler.sparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0
 group.c6x.compilers=&gccc6x
 
 # GCC for TI C6x
-group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310:c6xg1320:c6xg1410:c6xg1330:c6xg1240:c6xg1420:c6xg1510:c6xg1430:c6xg1340
+group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310:c6xg1320:c6xg1410:c6xg1330:c6xg1240:c6xg1420:c6xg1510:c6xg1430:c6xg1340:c6xg1250
 group.gccc6x.baseName=TI C6x gcc
 group.gccc6x.groupName=TI C6x GCC
 group.gccc6x.isSemVer=true
@@ -2013,6 +2028,11 @@ compiler.c6xg1240.exe=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-
 compiler.c6xg1240.semver=12.4.0
 compiler.c6xg1240.objdumper=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.c6xg1240.demangler=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.c6xg1250.exe=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-g++
+compiler.c6xg1250.semver=12.5.0
+compiler.c6xg1250.objdumper=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.c6xg1250.demangler=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-c++filt
 
 compiler.c6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-g++
 compiler.c6xg1310.semver=13.1.0
@@ -2061,7 +2081,7 @@ group.loongarch64.compilers=&gccloongarch64
 # GCC for loongarch64
 group.gccloongarch64.baseName=loongarch64 gcc
 group.gccloongarch64.groupName=loongarch64 gcc
-group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310:loongarch64g1320:loongarch64g1410:loongarch64g1330:loongarch64g1240:loongarch64g1420:loongarch64g1510:loongarch64g1430:loongarch64g1340
+group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310:loongarch64g1320:loongarch64g1410:loongarch64g1330:loongarch64g1240:loongarch64g1420:loongarch64g1510:loongarch64g1430:loongarch64g1340:loongarch64g1250
 group.gccloongarch64.isSemVer=true
 
 compiler.loongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
@@ -2078,6 +2098,11 @@ compiler.loongarch64g1240.exe=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loon
 compiler.loongarch64g1240.semver=12.4.0
 compiler.loongarch64g1240.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.loongarch64g1240.demangler=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.loongarch64g1250.exe=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
+compiler.loongarch64g1250.semver=12.5.0
+compiler.loongarch64g1250.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.loongarch64g1250.demangler=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.loongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
 compiler.loongarch64g1310.semver=13.1.0
@@ -2126,7 +2151,7 @@ group.sh.compilers=&gccsh
 # GCC for sh
 group.gccsh.baseName=sh gcc
 group.gccsh.groupName=sh gcc
-group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1240:shg1310:shg1320:shg1330:shg1340:shg1410:shg1420:shg1430:shg1510
+group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1240:shg1250:shg1310:shg1320:shg1330:shg1340:shg1410:shg1420:shg1430:shg1510
 group.gccsh.isSemVer=true
 
 compiler.shg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-g++
@@ -2153,6 +2178,11 @@ compiler.shg1240.exe=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-
 compiler.shg1240.semver=12.4.0
 compiler.shg1240.objdumper=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.shg1240.demangler=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.shg1250.exe=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-g++
+compiler.shg1250.semver=12.5.0
+compiler.shg1250.objdumper=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg1250.demangler=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
 compiler.shg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-g++
 compiler.shg1310.semver=13.1.0
@@ -2201,7 +2231,7 @@ group.s390x.compilers=&gccs390x
 # GCC for s390x
 group.gccs390x.baseName=s390x gcc
 group.gccs390x.groupName=s390x gcc
-group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310:s390xg1320:s390xg1410:s390xg1330:s390xg1240:s390xg1420:s390xg1510:s390xg1430:s390xg1340
+group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310:s390xg1320:s390xg1410:s390xg1330:s390xg1240:s390xg1420:s390xg1510:s390xg1430:s390xg1340:s390xg1250
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
@@ -2227,6 +2257,11 @@ compiler.s390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-
 compiler.s390xg1240.semver=12.4.0
 compiler.s390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.s390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.s390xg1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.s390xg1250.semver=12.5.0
+compiler.s390xg1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.s390xg1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.s390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
 compiler.s390xg1310.semver=13.1.0
@@ -2275,7 +2310,7 @@ group.ppcs.isSemVer=true
 group.ppcs.instructionSet=powerpc
 
 ## POWER
-group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1240:ppcg1310:ppcg1320:ppcg1330:ppcg1340:ppcg1410:ppcg1420:ppcg1430:ppcg1510
+group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1240:ppcg1250:ppcg1310:ppcg1320:ppcg1330:ppcg1340:ppcg1410:ppcg1420:ppcg1430:ppcg1510
 group.ppc.groupName=POWER GCC
 group.ppc.baseName=power gcc
 
@@ -2305,6 +2340,11 @@ compiler.ppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-
 compiler.ppcg1240.semver=12.4.0
 compiler.ppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.ppcg1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1250.semver=12.5.0
+compiler.ppcg1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.ppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
 compiler.ppcg1310.semver=13.1.0
@@ -2349,7 +2389,7 @@ compiler.ppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-un
 ## POWER64
 group.ppc64.groupName=POWER64 GCC
 group.ppc64.baseName=power64 gcc
-group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310:ppc64g1320:ppc64gtrunk:ppc64g1410:ppc64g1330:ppc64g1240:ppc64g1420:ppc64g1510:ppc64g1430:ppc64g1340
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310:ppc64g1320:ppc64gtrunk:ppc64g1410:ppc64g1330:ppc64g1240:ppc64g1420:ppc64g1510:ppc64g1430:ppc64g1340:ppc64g1250
 
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -2383,6 +2423,11 @@ compiler.ppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-un
 compiler.ppc64g1240.semver=12.4.0
 compiler.ppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.ppc64g1250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1250.semver=12.5.0
+compiler.ppc64g1250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.ppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g1310.semver=13.1.0
@@ -2443,7 +2488,7 @@ compiler.ppc64clang.compilerCategories=clang
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE GCC
-group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310:ppc64leg1320:ppc64legtrunk:ppc64leg1410:ppc64leg1330:ppc64leg1240:ppc64leg1420:ppc64leg1510:ppc64leg1430:ppc64leg1340
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310:ppc64leg1320:ppc64legtrunk:ppc64leg1410:ppc64leg1330:ppc64leg1240:ppc64leg1420:ppc64leg1510:ppc64leg1430:ppc64leg1340:ppc64leg1250
 group.ppc64le.baseName=power64le gcc
 
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
@@ -2482,6 +2527,11 @@ compiler.ppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc6
 compiler.ppc64leg1240.semver=12.4.0
 compiler.ppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.ppc64leg1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1250.semver=12.5.0
+compiler.ppc64leg1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.ppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg1310.semver=13.1.0
@@ -2550,7 +2600,7 @@ group.gccarm.includeFlag=-I
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
 group.gcc32arm.baseName=ARM GCC
-group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1310:armg1320:armug1320:armg1330:armug1330:armg1340:armug1340:armg1410:armug1410:armg1420:armug1420:armg1430:armug1430:armg1510:armgtrunk
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1250:armg1310:armg1320:armug1320:armg1330:armug1330:armg1340:armug1340:armg1410:armug1410:armg1420:armug1420:armg1430:armug1430:armg1510:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -2619,6 +2669,11 @@ compiler.armg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gn
 compiler.armg1240.semver=12.4.0
 compiler.armg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.armg1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1250.semver=12.5.0
+compiler.armg1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.armg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armg1310.semver=13.1.0
@@ -2762,7 +2817,7 @@ compiler.armgtrunk.isNightly=true
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g494:arm64g550:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050:arm64g1320:arm64g1410:arm64g1330:arm64g1240:arm64g1420:arm64g1510:arm64g1430:arm64g1340
+group.gcc64arm.compilers=aarchg54:arm64g494:arm64g550:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050:arm64g1320:arm64g1410:arm64g1330:arm64g1240:arm64g1420:arm64g1510:arm64g1430:arm64g1340:arm64g1250
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -2841,6 +2896,11 @@ compiler.arm64g1240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-
 compiler.arm64g1240.semver=12.4.0
 compiler.arm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.arm64g1250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1250.semver=12.5.0
+compiler.arm64g1250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.arm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g1310.semver=13.1.0
@@ -3091,7 +3151,7 @@ compiler.cl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1310:avrg1320:avrg1330:avrg1340:avrg1410:avrg1420:avrg1430:avrg1510
+group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1250:avrg1310:avrg1320:avrg1330:avrg1340:avrg1410:avrg1420:avrg1430:avrg1510
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -3143,6 +3203,11 @@ compiler.avrg1240.exe=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-g++
 compiler.avrg1240.semver=12.4.0
 compiler.avrg1240.objdumper=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-objdump
 compiler.avrg1240.demangler=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-c++filt
+
+compiler.avrg1250.exe=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-g++
+compiler.avrg1250.semver=12.5.0
+compiler.avrg1250.objdumper=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-objdump
+compiler.avrg1250.demangler=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-c++filt
 
 compiler.avrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-g++
 compiler.avrg1310.semver=13.1.0
@@ -3342,7 +3407,7 @@ compiler.mips64el-clang1300.semver=13.0.0
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1240:mipsg1310:mipsg1320:mipsg1330:mipsg1340:mipsg1410:mipsg1420:mipsg1430:mipsg1510
+group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1240:mipsg1250:mipsg1310:mipsg1320:mipsg1330:mipsg1340:mipsg1410:mipsg1420:mipsg1430:mipsg1510
 group.mips.baseName=mips gcc
 
 compiler.mipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
@@ -3392,6 +3457,11 @@ compiler.mipsg1240.semver=12.4.0
 compiler.mipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.mipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.mipsg1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg1250.semver=12.5.0
+compiler.mipsg1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.mipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mipsg1310.semver=13.1.0
 compiler.mipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -3434,7 +3504,7 @@ compiler.mipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unknown
 
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips64g1410:mips64g1330:mips64g1240:mips64g1420:mips64g1510:mips64g1430:mips64g1340:mips564:mips112064
+group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips64g1410:mips64g1330:mips64g1240:mips64g1420:mips64g1510:mips64g1430:mips64g1340:mips64g1250:mips564:mips112064
 group.mips64.baseName=mips64 gcc
 
 compiler.mips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
@@ -3479,6 +3549,11 @@ compiler.mips64g1240.semver=12.4.0
 compiler.mips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.mips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.mips64g1250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g1250.semver=12.5.0
+compiler.mips64g1250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g1250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.mips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips64g1310.semver=13.1.0
 compiler.mips64g1310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -3521,7 +3596,7 @@ compiler.mips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips64-u
 
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el:mipselg494:mipselg550:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1240:mipselg1310:mipselg1320:mipselg1330:mipselg1340:mipselg1410:mipselg1420:mipselg1430:mipselg1510
+group.mipsel.compilers=mips5el:mipselg494:mipselg550:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1240:mipselg1250:mipselg1310:mipselg1320:mipselg1330:mipselg1340:mipselg1410:mipselg1420:mipselg1430:mipselg1510
 group.mipsel.baseName=mipsel gcc
 
 compiler.mipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
@@ -3561,6 +3636,11 @@ compiler.mipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multili
 compiler.mipselg1240.semver=12.4.0
 compiler.mipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.mipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.mipselg1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.mipselg1250.semver=12.5.0
+compiler.mipselg1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.mipselg1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.mipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
 compiler.mipselg1310.semver=13.1.0
@@ -3604,7 +3684,7 @@ compiler.mipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mipsel-m
 
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips64elg1410:mips64elg1330:mips64elg1240:mips64elg1420:mips64elg1510:mips64elg1430:mips64elg1340:mips564el
+group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips64elg1410:mips64elg1330:mips64elg1240:mips64elg1420:mips64elg1510:mips64elg1430:mips64elg1340:mips64elg1250:mips564el
 group.mips64el.baseName=mips64 (el) gcc
 group.mips64el.compilerCategories=gcc
 
@@ -3645,6 +3725,11 @@ compiler.mips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-m
 compiler.mips64elg1240.semver=12.4.0
 compiler.mips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.mips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.mips64elg1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.mips64elg1250.semver=12.5.0
+compiler.mips64elg1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.mips64elg1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.mips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
 compiler.mips64elg1310.semver=13.1.0
@@ -3720,7 +3805,7 @@ group.rvgcc.supportsBinary=true
 group.rvgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 32-bits
-group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310:rv64-gcc1320:rv64-gcc1410:rv64-gcc1330:rv64-gcc1240:rv64-gcc1420:rv64-gcc1510:rv64-gcc1430:rv64-gcc1340
+group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310:rv64-gcc1320:rv64-gcc1410:rv64-gcc1330:rv64-gcc1240:rv64-gcc1420:rv64-gcc1510:rv64-gcc1430:rv64-gcc1340:rv64-gcc1250
 group.rv64gcc.groupName=RISC-V (64-bits) gcc
 group.rv64gcc.baseName=RISC-V (64-bits) gcc
 
@@ -3777,6 +3862,11 @@ compiler.rv64-gcc1240.semver=12.4.0
 compiler.rv64-gcc1240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gcc1240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.rv64-gcc1250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1250.semver=12.5.0
+compiler.rv64-gcc1250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc1250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.rv64-gcc1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcc1310.semver=13.1.0
 compiler.rv64-gcc1310.objdumper=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -3824,7 +3914,7 @@ compiler.rv64-gcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv6
 compiler.rv64-gcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ## GCC for RISC-V 32-bits
-group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310:rv32-gcc1320:rv32-gcc1410:rv32-gcc1330:rv32-gcc1240:rv32-gcc1420:rv32-gcc1510:rv32-gcc1430:rv32-gcc1340
+group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310:rv32-gcc1320:rv32-gcc1410:rv32-gcc1330:rv32-gcc1240:rv32-gcc1420:rv32-gcc1510:rv32-gcc1430:rv32-gcc1340:rv32-gcc1250
 group.rv32gcc.groupName=RISC-V (32-bits) gcc
 group.rv32gcc.baseName=RISC-V (32-bits) gcc
 
@@ -3879,6 +3969,11 @@ compiler.rv32-gcc1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unkn
 compiler.rv32-gcc1240.semver=12.4.0
 compiler.rv32-gcc1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gcc1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-gcc1250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1250.semver=12.5.0
+compiler.rv32-gcc1250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-gcc1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.rv32-gcc1310.semver=13.1.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1352,7 +1352,7 @@ compiler.cm68kg1510.demangler=/opt/compiler-explorer/m68k/gcc-15.1.0/m68k-unknow
 group.csparc.compilers=&cgccsparc
 
 # GCC for SPARC
-group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1240:csparcg1310:csparcg1320:csparcg1330:csparcg1340:csparcg1410:csparcg1420:csparcg1430:csparcg1510
+group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1240:csparcg1250:csparcg1310:csparcg1320:csparcg1330:csparcg1340:csparcg1410:csparcg1420:csparcg1430:csparcg1510
 group.cgccsparc.baseName=SPARC gcc
 group.cgccsparc.groupName=SPARC GCC
 group.cgccsparc.isSemVer=true
@@ -1371,6 +1371,11 @@ compiler.csparcg1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-l
 compiler.csparcg1240.semver=12.4.0
 compiler.csparcg1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.csparcg1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.csparcg1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.csparcg1250.semver=12.5.0
+compiler.csparcg1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.csparcg1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.csparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
 compiler.csparcg1310.semver=13.1.0
@@ -1417,7 +1422,7 @@ compiler.csparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-unk
 group.csparc64.compilers=&cgccsparc64
 
 # GCC for SPARC64
-group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310:csparc64g1320:csparc64g1410:csparc64g1330:csparc64g1240:csparc64g1420:csparc64g1510:csparc64g1430:csparc64g1340
+group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310:csparc64g1320:csparc64g1410:csparc64g1330:csparc64g1240:csparc64g1420:csparc64g1510:csparc64g1430:csparc64g1340:csparc64g1250
 group.cgccsparc64.baseName=SPARC64 gcc
 group.cgccsparc64.groupName=SPARC64 GCC
 group.cgccsparc64.isSemVer=true
@@ -1436,6 +1441,11 @@ compiler.csparc64g1240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-mul
 compiler.csparc64g1240.semver=12.4.0
 compiler.csparc64g1240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.csparc64g1240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.csparc64g1250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.csparc64g1250.semver=12.5.0
+compiler.csparc64g1250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.csparc64g1250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.csparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
 compiler.csparc64g1310.semver=13.1.0
@@ -1482,7 +1492,7 @@ compiler.csparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/sparc
 group.csparcleon.compilers=&cgccsparcleon
 
 # GCC for SPARC-LEON
-group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1240:csparcleong1310:csparcleong1320:csparcleong1330:csparcleong1340:csparcleong1410:csparcleong1420:csparcleong1430:csparcleong1510
+group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1240:csparcleong1250:csparcleong1310:csparcleong1320:csparcleong1330:csparcleong1340:csparcleong1410:csparcleong1420:csparcleong1430:csparcleong1510
 group.cgccsparcleon.baseName=SPARC LEON gcc
 group.cgccsparcleon.groupName=SPARC LEON GCC
 group.cgccsparcleon.isSemVer=true
@@ -1503,6 +1513,11 @@ compiler.csparcleong1240.exe=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-
 compiler.csparcleong1240.semver=12.4.0
 compiler.csparcleong1240.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.csparcleong1240.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.csparcleong1250.exe=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.csparcleong1250.semver=12.5.0
+compiler.csparcleong1250.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.csparcleong1250.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.csparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.csparcleong1310.semver=13.1.0
@@ -1554,7 +1569,7 @@ compiler.csparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.
 group.cc6x.compilers=&cgccc6x
 
 # GCC for TI C6x
-group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310:cc6xg1320:cc6xg1410:cc6xg1330:cc6xg1240:cc6xg1420:cc6xg1510:cc6xg1430:cc6xg1340
+group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310:cc6xg1320:cc6xg1410:cc6xg1330:cc6xg1240:cc6xg1420:cc6xg1510:cc6xg1430:cc6xg1340:cc6xg1250
 group.cgccc6x.baseName=TI C6x gcc
 group.cgccc6x.groupName=TI C6x GCC
 group.cgccc6x.isSemVer=true
@@ -1573,6 +1588,11 @@ compiler.cc6xg1240.exe=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x
 compiler.cc6xg1240.semver=12.4.0
 compiler.cc6xg1240.objdumper=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.cc6xg1240.demangler=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.cc6xg1250.exe=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.cc6xg1250.semver=12.5.0
+compiler.cc6xg1250.objdumper=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.cc6xg1250.demangler=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-c++filt
 
 compiler.cc6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-gcc
 compiler.cc6xg1310.semver=13.1.0
@@ -1619,7 +1639,7 @@ compiler.cc6xg1510.demangler=/opt/compiler-explorer/c6x/gcc-15.1.0/tic6x-elf/bin
 group.cloongarch64.compilers=&cgccloongarch64
 
 # GCC for loongarch64
-group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310:cloongarch64g1320:cloongarch64g1410:cloongarch64g1330:cloongarch64g1240:cloongarch64g1420:cloongarch64g1510:cloongarch64g1430:cloongarch64g1340
+group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310:cloongarch64g1320:cloongarch64g1410:cloongarch64g1330:cloongarch64g1240:cloongarch64g1420:cloongarch64g1510:cloongarch64g1430:cloongarch64g1340:cloongarch64g1250
 group.cgccloongarch64.baseName=loongarch64 gcc
 group.cgccloongarch64.groupName=loongarch64 GCC
 group.cgccloongarch64.isSemVer=true
@@ -1638,6 +1658,11 @@ compiler.cloongarch64g1240.exe=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loo
 compiler.cloongarch64g1240.semver=12.4.0
 compiler.cloongarch64g1240.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.cloongarch64g1240.demangler=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.cloongarch64g1250.exe=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.cloongarch64g1250.semver=12.5.0
+compiler.cloongarch64g1250.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.cloongarch64g1250.demangler=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.cloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
 compiler.cloongarch64g1310.semver=13.1.0
@@ -1684,7 +1709,7 @@ compiler.cloongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc-15.1
 group.csh.compilers=&cgccsh
 
 # GCC for sh
-group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1240:cshg1310:cshg1320:cshg1330:cshg1340:cshg1410:cshg1420:cshg1430:cshg1510
+group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1240:cshg1250:cshg1310:cshg1320:cshg1330:cshg1340:cshg1410:cshg1420:cshg1430:cshg1510
 group.cgccsh.baseName=sh gcc
 group.cgccsh.groupName=sh GCC
 group.cgccsh.isSemVer=true
@@ -1713,6 +1738,11 @@ compiler.cshg1240.exe=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh
 compiler.cshg1240.semver=12.4.0
 compiler.cshg1240.objdumper=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.cshg1240.demangler=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.cshg1250.exe=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.cshg1250.semver=12.5.0
+compiler.cshg1250.objdumper=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg1250.demangler=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
 compiler.cshg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
 compiler.cshg1310.semver=13.1.0
@@ -1759,7 +1789,7 @@ compiler.cshg1510.demangler=/opt/compiler-explorer/sh/gcc-15.1.0/sh-unknown-elf/
 group.cs390x.compilers=&cgccs390x
 
 # GCC for s390x
-group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310:cs390xg1320:cs390xg1410:cs390xg1330:cs390xg1240:cs390xg1420:cs390xg1510:cs390xg1430:cs390xg1340
+group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310:cs390xg1320:cs390xg1410:cs390xg1330:cs390xg1240:cs390xg1420:cs390xg1510:cs390xg1430:cs390xg1340:cs390xg1250
 group.cgccs390x.baseName=s390x gcc
 group.cgccs390x.groupName=s390x GCC
 group.cgccs390x.isSemVer=true
@@ -1786,6 +1816,11 @@ compiler.cs390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux
 compiler.cs390xg1240.semver=12.4.0
 compiler.cs390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.cs390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.cs390xg1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cs390xg1250.semver=12.5.0
+compiler.cs390xg1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.cs390xg1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.cs390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
 compiler.cs390xg1310.semver=13.1.0
@@ -1833,7 +1868,7 @@ group.cppcs.compilers=&cppc:&cppc64:&cppc64le
 group.cppcs.isSemVer=true
 group.cppcs.instructionSet=powerpc
 
-group.cppc.compilers=cppcg48:cppcg1120:cppcg1210:cppcg1220:cppcg1230:cppcg1240:cppcg1310:cppcg1320:cppcg1330:cppcg1340:cppcg1410:cppcg1420:cppcg1430:cppcg1510
+group.cppc.compilers=cppcg48:cppcg1120:cppcg1210:cppcg1220:cppcg1230:cppcg1240:cppcg1250:cppcg1310:cppcg1320:cppcg1330:cppcg1340:cppcg1410:cppcg1420:cppcg1430:cppcg1510
 group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
@@ -1863,6 +1898,11 @@ compiler.cppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown
 compiler.cppcg1240.semver=12.4.0
 compiler.cppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.cppcg1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1250.semver=12.5.0
+compiler.cppcg1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.cppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.cppcg1310.semver=13.1.0
@@ -1904,7 +1944,7 @@ compiler.cppcg1510.semver=15.1.0
 compiler.cppcg1510.objdumper=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310:cppc64g1320:cppc64gtrunk:cppc64g1410:cppc64g1330:cppc64g1240:cppc64g1420:cppc64g1510:cppc64g1430:cppc64g1340
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310:cppc64g1320:cppc64gtrunk:cppc64g1410:cppc64g1330:cppc64g1240:cppc64g1420:cppc64g1510:cppc64g1430:cppc64g1340:cppc64g1250
 group.cppc64.groupName=POWER64
 group.cppc64.baseName=POWER64 gcc
 
@@ -1940,6 +1980,11 @@ compiler.cppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-u
 compiler.cppc64g1240.semver=12.4.0
 compiler.cppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.cppc64g1250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1250.semver=12.5.0
+compiler.cppc64g1250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.cppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64g1310.semver=13.1.0
@@ -1995,7 +2040,7 @@ compiler.cppc64clang.semver=(snapshot)
 compiler.cppc64clang.isNightly=true
 compiler.cppc64clang.compilerCategories=clang
 
-group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310:cppc64leg1320:cppc64legtrunk:cppc64leg1410:cppc64leg1330:cppc64leg1240:cppc64leg1420:cppc64leg1510:cppc64leg1430:cppc64leg1340
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310:cppc64leg1320:cppc64legtrunk:cppc64leg1410:cppc64leg1330:cppc64leg1240:cppc64leg1420:cppc64leg1510:cppc64leg1430:cppc64leg1340:cppc64leg1250
 group.cppc64le.groupName=POWER64LE GCC
 group.cppc64le.baseName=power64le gcc
 
@@ -2035,6 +2080,11 @@ compiler.cppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc
 compiler.cppc64leg1240.semver=12.4.0
 compiler.cppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.cppc64leg1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1250.semver=12.5.0
+compiler.cppc64leg1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.cppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64leg1310.semver=13.1.0
@@ -2102,7 +2152,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1340:carmug1340:carmg1410:carmug1410:carmg1420:carmug1420:carmg1430:carmug1430:carmg1510:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1250:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1340:carmug1340:carmg1410:carmug1410:carmg1420:carmug1420:carmg1430:carmug1430:carmg1510:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -2158,6 +2208,11 @@ compiler.carmg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-g
 compiler.carmg1240.semver=12.4.0
 compiler.carmg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.carmg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.carmg1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1250.semver=12.5.0
+compiler.carmg1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.carmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carmg1310.semver=13.1.0 (linux)
@@ -2282,7 +2337,7 @@ compiler.carmgtrunk.isNightly=true
 # 64 bit
 group.cgcc64arm.groupName=ARM64 gcc
 group.cgcc64arm.baseName=ARM64 GCC
-group.cgcc64arm.compilers=caarchg54:carm64g494:carm64g550:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050:carm64g1320:carm64g1410:carm64g1330:carm64g1240:carm64g1420:carm64g1510:carm64g1430:carm64g1340
+group.cgcc64arm.compilers=caarchg54:carm64g494:carm64g550:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050:carm64g1320:carm64g1410:carm64g1330:carm64g1240:carm64g1420:carm64g1510:carm64g1430:carm64g1340:carm64g1250
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -2359,6 +2414,11 @@ compiler.carm64g1240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown
 compiler.carm64g1240.semver=12.4.0
 compiler.carm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.carm64g1250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1250.semver=12.5.0
+compiler.carm64g1250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.carm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g1310.semver=13.1.0
@@ -2574,7 +2634,7 @@ compiler.carduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hard
 
 ################################
 # GCC for MSP
-group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220:cmsp430g1230:cmsp430g1310:cmsp430g1320:cmsp430g1410:cmsp430g1330:cmsp430g1240:cmsp430g1420:cmsp430g1510:cmsp430g1430:cmsp430g1340
+group.cmsp.compilers=cmsp430g453:cmsp430g530:cmsp430g621:cmsp430g1210:cmsp430g1220:cmsp430g1230:cmsp430g1310:cmsp430g1320:cmsp430g1410:cmsp430g1330:cmsp430g1240:cmsp430g1420:cmsp430g1510:cmsp430g1430:cmsp430g1340:cmsp430g1250
 group.cmsp.groupName=MSP GCC
 group.cmsp.baseName=MSP430 gcc
 group.cmsp.isSemVer=true
@@ -2607,6 +2667,11 @@ compiler.cmsp430g1240.exe=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknow
 compiler.cmsp430g1240.semver=12.4.0
 compiler.cmsp430g1240.objdumper=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
 compiler.cmsp430g1240.demangler=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.cmsp430g1250.exe=/opt/compiler-explorer/msp430/gcc-12.5.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.cmsp430g1250.semver=12.5.0
+compiler.cmsp430g1250.objdumper=/opt/compiler-explorer/msp430/gcc-12.5.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.cmsp430g1250.demangler=/opt/compiler-explorer/msp430/gcc-12.5.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
 
 compiler.cmsp430g1310.exe=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
 compiler.cmsp430g1310.semver=13.1.0
@@ -2666,7 +2731,7 @@ compiler.ccl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1310:cavrg1320:cavrg1330:cavrg1340:cavrg1410:cavrg1420:cavrg1430:cavrg1510
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1250:cavrg1310:cavrg1320:cavrg1330:cavrg1340:cavrg1410:cavrg1420:cavrg1430:cavrg1510
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -2716,6 +2781,11 @@ compiler.cavrg1240.exe=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-gcc
 compiler.cavrg1240.semver=12.4.0
 compiler.cavrg1240.objdumper=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-objdump
 compiler.cavrg1240.demangler=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-c++filt
+
+compiler.cavrg1250.exe=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-gcc
+compiler.cavrg1250.semver=12.5.0
+compiler.cavrg1250.objdumper=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-objdump
+compiler.cavrg1250.demangler=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-c++filt
 
 compiler.cavrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-gcc
 compiler.cavrg1310.semver=13.1.0
@@ -2913,7 +2983,7 @@ compiler.mips64el-cclang1300.semver=13.0.0
 
 # GCC for all MIPS
 ## MIPS
-group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1240:cmipsg1310:cmipsg1320:cmipsg1330:cmipsg1340:cmipsg1410:cmipsg1420:cmipsg1430:cmipsg1510
+group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1240:cmipsg1250:cmipsg1310:cmipsg1320:cmipsg1330:cmipsg1340:cmipsg1410:cmipsg1420:cmipsg1430:cmipsg1510
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
 
@@ -2964,6 +3034,11 @@ compiler.cmipsg1240.semver=12.4.0
 compiler.cmipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.cmipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
+compiler.cmipsg1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg1250.semver=12.5.0
+compiler.cmipsg1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 compiler.cmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.cmipsg1310.semver=13.1.0
 compiler.cmipsg1310.objdumper=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
@@ -3006,7 +3081,7 @@ compiler.cmipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unknow
 
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips64g1410:cmips64g1330:cmips64g1240:cmips64g1420:cmips64g1510:cmips64g1430:cmips64g1340:cmips564:cmips112064
+group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips64g1410:cmips64g1330:cmips64g1240:cmips64g1420:cmips64g1510:cmips64g1430:cmips64g1340:cmips64g1250:cmips564:cmips112064
 group.cmips64.baseName=mips64 gcc
 
 compiler.cmips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -3051,6 +3126,11 @@ compiler.cmips64g1240.semver=12.4.0
 compiler.cmips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.cmips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
+compiler.cmips64g1250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g1250.semver=12.5.0
+compiler.cmips64g1250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g1250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 compiler.cmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.cmips64g1310.semver=13.1.0
 compiler.cmips64g1310.objdumper=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
@@ -3093,7 +3173,7 @@ compiler.cmips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips64-
 
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el:cmipselg494:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1240:cmipselg1310:cmipselg1320:cmipselg1330:cmipselg1340:cmipselg1410:cmipselg1420:cmipselg1430:cmipselg1510
+group.cmipsel.compilers=cmips5el:cmipselg494:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1240:cmipselg1250:cmipselg1310:cmipselg1320:cmipselg1330:cmipselg1340:cmipselg1410:cmipselg1420:cmipselg1430:cmipselg1510
 group.cmipsel.baseName=mips (el) gcc
 
 compiler.cmipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
@@ -3133,6 +3213,11 @@ compiler.cmipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multil
 compiler.cmipselg1240.semver=12.4.0
 compiler.cmipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.cmipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.cmipselg1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.cmipselg1250.semver=12.5.0
+compiler.cmipselg1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.cmipselg1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.cmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.cmipselg1310.semver=13.1.0
@@ -3176,7 +3261,7 @@ compiler.cmipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mipsel-
 
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips64elg1410:cmips64elg1330:cmips64elg1240:cmips64elg1420:cmips64elg1510:cmips64elg1430:cmips64elg1340:cmips564el
+group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips64elg1410:cmips64elg1330:cmips64elg1240:cmips64elg1420:cmips64elg1510:cmips64elg1430:cmips64elg1340:cmips64elg1250:cmips564el
 group.cmips64el.baseName=mips64 (el) gcc
 
 compiler.cmips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
@@ -3216,6 +3301,11 @@ compiler.cmips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-
 compiler.cmips64elg1240.semver=12.4.0
 compiler.cmips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.cmips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.cmips64elg1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.cmips64elg1250.semver=12.5.0
+compiler.cmips64elg1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.cmips64elg1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.cmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.cmips64elg1310.semver=13.1.0
@@ -3292,7 +3382,7 @@ group.rvcgcc.supportsBinary=true
 group.rvcgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 64-bits
-group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310:rv64-cgcc1320:rv64-cgcc1410:rv64-cgcc1330:rv64-cgcc1240:rv64-cgcc1420:rv64-cgcc1510:rv64-cgcc1430:rv64-cgcc1340
+group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310:rv64-cgcc1320:rv64-cgcc1410:rv64-cgcc1330:rv64-cgcc1240:rv64-cgcc1420:rv64-cgcc1510:rv64-cgcc1430:rv64-cgcc1340:rv64-cgcc1250
 group.rv64-cgccs.groupName=RISC-V (64-bits) gcc
 group.rv64-cgccs.baseName=RISC-V (64-bits) gcc
 
@@ -3349,6 +3439,11 @@ compiler.rv64-cgcc1240.semver=12.4.0
 compiler.rv64-cgcc1240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
+compiler.rv64-cgcc1250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1250.semver=12.5.0
+compiler.rv64-cgcc1250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 compiler.rv64-cgcc1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcc1310.semver=13.1.0
 compiler.rv64-cgcc1310.objdumper=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
@@ -3396,7 +3491,7 @@ compiler.rv64-cgcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv
 compiler.rv64-cgcctrunk.isNightly=true
 
 ## GCC for RISC-V 32-bits
-group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230:rv32-cgcc1320:rv32-cgcc1410:rv32-cgcc1330:rv32-cgcc1240:rv32-cgcc1420:rv32-cgcc1510:rv32-cgcc1430:rv32-cgcc1340
+group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230:rv32-cgcc1320:rv32-cgcc1410:rv32-cgcc1330:rv32-cgcc1240:rv32-cgcc1420:rv32-cgcc1510:rv32-cgcc1430:rv32-cgcc1340:rv32-cgcc1250
 group.rv32-cgccs.groupName=RISC-V (32-bits) gcc
 group.rv32-cgccs.baseName=RISC-V (32-bits) gcc
 
@@ -3452,6 +3547,11 @@ compiler.rv32-cgcc1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unk
 compiler.rv32-cgcc1240.semver=12.4.0
 compiler.rv32-cgcc1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-cgcc1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-cgcc1250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1250.semver=12.5.0
+compiler.rv32-cgcc1250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-cgcc1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.rv32-cgcc1310.semver=13.1.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -15,7 +15,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg124:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -157,6 +157,8 @@ compiler.cg123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gcc
 compiler.cg123.semver=12.3
 compiler.cg124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gcc
 compiler.cg124.semver=12.4
+compiler.cg125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gcc
+compiler.cg125.semver=12.5
 compiler.cg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gcc
 compiler.cg131.semver=13.1
 compiler.cg132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gcc
@@ -194,7 +196,7 @@ compiler.cg71.needsMulti=true
 compiler.cg72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg151assert
+group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg151assert
 group.cgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.cg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -219,6 +221,8 @@ compiler.cg123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/gcc
 compiler.cg123assert.semver=12.3 (assertions)
 compiler.cg124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gcc
 compiler.cg124assert.semver=12.4 (assertions)
+compiler.cg125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gcc
+compiler.cg125assert.semver=12.5 (assertions)
 compiler.cg131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gcc
 compiler.cg131assert.semver=13.1 (assertions)
 compiler.cg132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/gcc

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gdc:&ldc:&dmd:&gdccross
 defaultCompiler=ldc1_40
 
-group.gdc.compilers=&gdcassert:gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc124:gdc131:gdc132:gdc133:gdc134:gdc141:gdc142:gdc143:gdc151:gdctrunk
+group.gdc.compilers=&gdcassert:gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc124:gdc125:gdc131:gdc132:gdc133:gdc134:gdc141:gdc142:gdc143:gdc151:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
@@ -46,6 +46,8 @@ compiler.gdc123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gdc
 compiler.gdc123.semver=12.3
 compiler.gdc124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gdc
 compiler.gdc124.semver=12.4
+compiler.gdc125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gdc
+compiler.gdc125.semver=12.5
 compiler.gdc131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gdc
 compiler.gdc131.semver=13.1
 compiler.gdc132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gdc
@@ -69,7 +71,7 @@ compiler.gdctrunk.semver=(trunk)
 compiler.gdctrunk.isNightly=true
 
 ## GDC x86 build with "assertions" (--enable-checking=XXX)
-group.gdcassert.compilers=gdc105assert:gdc111assert:gdc113assert:gdc114assert:gdc121assert:gdc122assert:gdc123assert:gdc124assert:gdc131assert:gdc132assert:gdc133assert:gdc134assert:gdc141assert:gdc142assert:gdc143assert:gdc151assert
+group.gdcassert.compilers=gdc105assert:gdc111assert:gdc113assert:gdc114assert:gdc121assert:gdc122assert:gdc123assert:gdc124assert:gdc125assert:gdc131assert:gdc132assert:gdc133assert:gdc134assert:gdc141assert:gdc142assert:gdc143assert:gdc151assert
 group.gdcassert.groupName=GDC x86-64 (assertions)
 
 compiler.gdc105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gdc
@@ -88,6 +90,8 @@ compiler.gdc123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/gdc
 compiler.gdc123assert.semver=12.3 (assertions)
 compiler.gdc124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gdc
 compiler.gdc124assert.semver=12.4 (assertions)
+compiler.gdc125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gdc
+compiler.gdc125assert.semver=12.5 (assertions)
 compiler.gdc131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gdc
 compiler.gdc131assert.semver=13.1 (assertions)
 compiler.gdc132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/gdc

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -139,7 +139,7 @@ compiler.gdcloongarch641510.objdumper=/opt/compiler-explorer/loongarch64/gcc-15.
 compiler.gdcloongarch641510.demangler=/opt/compiler-explorer/loongarch64/gcc-15.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 ### GDC for RISCV32
-group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220:gdcriscv1230:gdcriscv1240:gdcriscv1310:gdcriscv1320:gdcriscv1330:gdcriscv1340:gdcriscv1410:gdcriscv1420:gdcriscv1430:gdcriscv1510
+group.gdcriscv.compilers=gdcriscv32trunk:gdcriscv1220:gdcriscv1230:gdcriscv1240:gdcriscv1250:gdcriscv1310:gdcriscv1320:gdcriscv1330:gdcriscv1340:gdcriscv1410:gdcriscv1420:gdcriscv1430:gdcriscv1510
 group.gdcriscv.groupName=GDC riscv
 group.gdcriscv.includeFlag=-isystem
 group.gdcriscv.isSemVer=true
@@ -159,6 +159,11 @@ compiler.gdcriscv1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unkn
 compiler.gdcriscv1240.semver=12.4.0
 compiler.gdcriscv1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.gdcriscv1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.gdcriscv1250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
+compiler.gdcriscv1250.semver=12.5.0
+compiler.gdcriscv1250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.gdcriscv1250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.gdcriscv1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gdc
 compiler.gdcriscv1310.semver=13.1.0
@@ -206,7 +211,7 @@ compiler.gdcriscv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/risc
 compiler.gdcriscv32trunk.demangler=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 ### GDC for RISCV64
-group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220:gdcriscv641230:gdcriscv641240:gdcriscv641310:gdcriscv641320:gdcriscv641330:gdcriscv641340:gdcriscv641410:gdcriscv641420:gdcriscv641430:gdcriscv641510
+group.gdcriscv64.compilers=gdcriscv64trunk:gdcriscv641220:gdcriscv641230:gdcriscv641240:gdcriscv641250:gdcriscv641310:gdcriscv641320:gdcriscv641330:gdcriscv641340:gdcriscv641410:gdcriscv641420:gdcriscv641430:gdcriscv641510
 group.gdcriscv64.groupName=GDC riscv64
 group.gdcriscv64.includeFlag=-isystem
 group.gdcriscv64.isSemVer=true
@@ -226,6 +231,11 @@ compiler.gdcriscv641240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-un
 compiler.gdcriscv641240.semver=12.4.0
 compiler.gdcriscv641240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gdcriscv641240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.gdcriscv641250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
+compiler.gdcriscv641250.semver=12.5.0
+compiler.gdcriscv641250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gdcriscv641250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.gdcriscv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gdc
 compiler.gdcriscv641310.semver=13.1.0
@@ -274,7 +284,7 @@ compiler.gdcriscv64trunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/risc
 compiler.gdcriscv64trunk.isNightly=true
 
 ### GDC for ARM64
-group.gdcarm64.compilers=gdcarm641220:gdcarm641230:gdcarm641240:gdcarm641310:gdcarm641320:gdcarm641330:gdcarm641340:gdcarm641410:gdcarm641420:gdcarm641430:gdcarm641510
+group.gdcarm64.compilers=gdcarm641220:gdcarm641230:gdcarm641240:gdcarm641250:gdcarm641310:gdcarm641320:gdcarm641330:gdcarm641340:gdcarm641410:gdcarm641420:gdcarm641430:gdcarm641510
 group.gdcarm64.groupName=GDC arm64
 group.gdcarm64.includeFlag=-isystem
 group.gdcarm64.isSemVer=true
@@ -294,6 +304,11 @@ compiler.gdcarm641240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknow
 compiler.gdcarm641240.semver=12.4.0
 compiler.gdcarm641240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gdcarm641240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.gdcarm641250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gdc
+compiler.gdcarm641250.semver=12.5.0
+compiler.gdcarm641250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gdcarm641250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.gdcarm641310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gdc
 compiler.gdcarm641310.semver=13.1.0
@@ -336,7 +351,7 @@ compiler.gdcarm641510.objdumper=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-
 compiler.gdcarm641510.demangler=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 ### GDC for ARM 32-bits
-group.gdcarm.compilers=gdcarm1220:gdcarm1230:gdcarm1240:gdcarm1310:gdcarm1320:gdcarm1330:gdcarm1340:gdcarm1410:gdcarm1420:gdcarm1430:gdcarm1510
+group.gdcarm.compilers=gdcarm1220:gdcarm1230:gdcarm1240:gdcarm1250:gdcarm1310:gdcarm1320:gdcarm1330:gdcarm1340:gdcarm1410:gdcarm1420:gdcarm1430:gdcarm1510
 group.gdcarm.groupName=GDC arm
 group.gdcarm.includeFlag=-isystem
 group.gdcarm.isSemVer=true
@@ -356,6 +371,11 @@ compiler.gdcarm1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-
 compiler.gdcarm1240.semver=12.4.0
 compiler.gdcarm1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gdcarm1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.gdcarm1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gdc
+compiler.gdcarm1250.semver=12.5.0
+compiler.gdcarm1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gdcarm1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.gdcarm1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gdc
 compiler.gdcarm1310.semver=13.1.0
@@ -398,7 +418,7 @@ compiler.gdcarm1510.objdumper=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-
 compiler.gdcarm1510.demangler=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 ### GDC for s390x
-group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220:gdcs390x1230:gdcs390x1310:gdcs390x1320:gdcs390x1410:gdcs390x1330:gdcs390x1240:gdcs390x1420:gdcs390x1510:gdcs390x1430:gdcs390x1340
+group.gdcs390x.compilers=gdcs390x1210:gdcs390x1220:gdcs390x1230:gdcs390x1310:gdcs390x1320:gdcs390x1410:gdcs390x1330:gdcs390x1240:gdcs390x1420:gdcs390x1510:gdcs390x1430:gdcs390x1340:gdcs390x1250
 group.gdcs390x.groupName=GDC s390x
 group.gdcs390x.includeFlag=-isystem
 group.gdcs390x.isSemVer=true
@@ -422,6 +442,11 @@ compiler.gdcs390x1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linu
 compiler.gdcs390x1240.semver=12.4.0
 compiler.gdcs390x1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gdcs390x1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gdcs390x1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
+compiler.gdcs390x1250.semver=12.5.0
+compiler.gdcs390x1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gdcs390x1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.gdcs390x1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gdc
 compiler.gdcs390x1310.semver=13.1.0
@@ -464,7 +489,7 @@ compiler.gdcs390x1510.objdumper=/opt/compiler-explorer/s390x/gcc-15.1.0/s390x-ib
 compiler.gdcs390x1510.demangler=/opt/compiler-explorer/s390x/gcc-15.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 ### GDC for powerpc
-group.gdcppc.compilers=gdcppc1210:gdcppc1220:gdcppc1230:gdcppc1240:gdcppc1310:gdcppc1320:gdcppc1330:gdcppc1340:gdcppc1410:gdcppc1420:gdcppc1430:gdcppc1510
+group.gdcppc.compilers=gdcppc1210:gdcppc1220:gdcppc1230:gdcppc1240:gdcppc1250:gdcppc1310:gdcppc1320:gdcppc1330:gdcppc1340:gdcppc1410:gdcppc1420:gdcppc1430:gdcppc1510
 group.gdcppc.groupName=GDC powerpc
 group.gdcppc.includeFlag=-isystem
 group.gdcppc.isSemVer=true
@@ -489,6 +514,11 @@ compiler.gdcppc1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknow
 compiler.gdcppc1240.semver=12.4.0
 compiler.gdcppc1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gdcppc1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gdcppc1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
+compiler.gdcppc1250.semver=12.5.0
+compiler.gdcppc1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gdcppc1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.gdcppc1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gdc
 compiler.gdcppc1310.semver=13.1.0
@@ -531,7 +561,7 @@ compiler.gdcppc1510.objdumper=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-
 compiler.gdcppc1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 ### GDC for powerpc64
-group.gdcppc64.compilers=gdcppc64trunk:gdcppc641210:gdcppc641220:gdcppc641230:gdcppc641240:gdcppc641310:gdcppc641320:gdcppc641330:gdcppc641340:gdcppc641410:gdcppc641420:gdcppc641430:gdcppc641510
+group.gdcppc64.compilers=gdcppc64trunk:gdcppc641210:gdcppc641220:gdcppc641230:gdcppc641240:gdcppc641250:gdcppc641310:gdcppc641320:gdcppc641330:gdcppc641340:gdcppc641410:gdcppc641420:gdcppc641430:gdcppc641510
 group.gdcppc64.groupName=GDC powerpc64
 group.gdcppc64.includeFlag=-isystem
 group.gdcppc64.isSemVer=true
@@ -555,6 +585,11 @@ compiler.gdcppc641240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-
 compiler.gdcppc641240.semver=12.4.0
 compiler.gdcppc641240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gdcppc641240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gdcppc641250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
+compiler.gdcppc641250.semver=12.5.0
+compiler.gdcppc641250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gdcppc641250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gdcppc641310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gdc
 compiler.gdcppc641310.semver=13.1.0
@@ -602,7 +637,7 @@ compiler.gdcppc64trunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powe
 compiler.gdcppc64trunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 ### GDC for powerpc64le
-group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220:gdcppc64le1230:gdcppc64le1310:gdcppc64le1320:gdcppc64letrunk:gdcppc64le1410:gdcppc64le1330:gdcppc64le1240:gdcppc64le1420:gdcppc64le1510:gdcppc64le1430:gdcppc64le1340
+group.gdcppc64le.compilers=gdcppc64le1210:gdcppc64le1220:gdcppc64le1230:gdcppc64le1310:gdcppc64le1320:gdcppc64letrunk:gdcppc64le1410:gdcppc64le1330:gdcppc64le1240:gdcppc64le1420:gdcppc64le1510:gdcppc64le1430:gdcppc64le1340:gdcppc64le1250
 group.gdcppc64le.groupName=GDC powerpc64le
 group.gdcppc64le.includeFlag=-isystem
 group.gdcppc64le.isSemVer=true
@@ -626,6 +661,11 @@ compiler.gdcppc64le1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerp
 compiler.gdcppc64le1240.semver=12.4.0
 compiler.gdcppc64le1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gdcppc64le1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gdcppc64le1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
+compiler.gdcppc64le1250.semver=12.5.0
+compiler.gdcppc64le1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gdcppc64le1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gdcppc64le1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gdc
 compiler.gdcppc64le1310.semver=13.1.0
@@ -673,7 +713,7 @@ compiler.gdcppc64letrunk.objdumper=/opt/compiler-explorer/powerpc64le/gcc-trunk/
 compiler.gdcppc64letrunk.demangler=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 ### GDC for mips64
-group.gdcmips64.compilers=gdcmips641210:gdcmips641220:gdcmips641230:gdcmips641240:gdcmips641310:gdcmips641320:gdcmips641330:gdcmips641340:gdcmips641410:gdcmips641420:gdcmips641430:gdcmips641510
+group.gdcmips64.compilers=gdcmips641210:gdcmips641220:gdcmips641230:gdcmips641240:gdcmips641250:gdcmips641310:gdcmips641320:gdcmips641330:gdcmips641340:gdcmips641410:gdcmips641420:gdcmips641430:gdcmips641510
 group.gdcmips64.groupName=GDC mips64
 group.gdcmips64.includeFlag=-isystem
 group.gdcmips64.isSemVer=true
@@ -697,6 +737,11 @@ compiler.gdcmips641240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unkno
 compiler.gdcmips641240.semver=12.4.0
 compiler.gdcmips641240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gdcmips641240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gdcmips641250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
+compiler.gdcmips641250.semver=12.5.0
+compiler.gdcmips641250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gdcmips641250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.gdcmips641310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gdc
 compiler.gdcmips641310.semver=13.1.0
@@ -739,7 +784,7 @@ compiler.gdcmips641510.objdumper=/opt/compiler-explorer/mips64/gcc-15.1.0/mips64
 compiler.gdcmips641510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 ### GDC for mips
-group.gdcmips.compilers=gdcmips1210:gdcmips1220:gdcmips1230:gdcmips1240:gdcmips1310:gdcmips1320:gdcmips1330:gdcmips1340:gdcmips1410:gdcmips1420:gdcmips1430:gdcmips1510
+group.gdcmips.compilers=gdcmips1210:gdcmips1220:gdcmips1230:gdcmips1240:gdcmips1250:gdcmips1310:gdcmips1320:gdcmips1330:gdcmips1340:gdcmips1410:gdcmips1420:gdcmips1430:gdcmips1510
 group.gdcmips.groupName=GDC mips
 group.gdcmips.includeFlag=-isystem
 group.gdcmips.isSemVer=true
@@ -763,6 +808,11 @@ compiler.gdcmips1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-lin
 compiler.gdcmips1240.semver=12.4.0
 compiler.gdcmips1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gdcmips1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gdcmips1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
+compiler.gdcmips1250.semver=12.5.0
+compiler.gdcmips1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gdcmips1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.gdcmips1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gdc
 compiler.gdcmips1310.semver=13.1.0
@@ -805,7 +855,7 @@ compiler.gdcmips1510.objdumper=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unkno
 compiler.gdcmips1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 ### GDC for mipsel
-group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220:gdcmipsel1230:gdcmipsel1240:gdcmipsel1310:gdcmipsel1320:gdcmipsel1330:gdcmipsel1340:gdcmipsel1410:gdcmipsel1420:gdcmipsel1430:gdcmipsel1510
+group.gdcmipsel.compilers=gdcmipsel1210:gdcmipsel1220:gdcmipsel1230:gdcmipsel1240:gdcmipsel1250:gdcmipsel1310:gdcmipsel1320:gdcmipsel1330:gdcmipsel1340:gdcmipsel1410:gdcmipsel1420:gdcmipsel1430:gdcmipsel1510
 group.gdcmipsel.groupName=GDC mipsel
 group.gdcmipsel.includeFlag=-isystem
 group.gdcmipsel.isSemVer=true
@@ -829,6 +879,11 @@ compiler.gdcmipsel1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multi
 compiler.gdcmipsel1240.semver=12.4.0
 compiler.gdcmipsel1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gdcmipsel1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gdcmipsel1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
+compiler.gdcmipsel1250.semver=12.5.0
+compiler.gdcmipsel1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gdcmipsel1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.gdcmipsel1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gdc
 compiler.gdcmipsel1310.semver=13.1.0

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran124:gfortran131:gfortran132:gfortran133:gfortran134:gfortran141:gfortran142:gfortran143:gfortran151:gfortransnapshot
+group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran124:gfortran125:gfortran131:gfortran132:gfortran133:gfortran134:gfortran141:gfortran142:gfortran143:gfortran151:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -70,6 +70,8 @@ compiler.gfortran123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gfortran
 compiler.gfortran123.semver=12.3
 compiler.gfortran124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gfortran
 compiler.gfortran124.semver=12.4
+compiler.gfortran125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gfortran
+compiler.gfortran125.semver=12.5
 compiler.gfortran131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gfortran
 compiler.gfortran131.semver=13.1
 compiler.gfortran132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gfortran
@@ -94,7 +96,7 @@ compiler.gfortransnapshot.semver=(trunk)
 compiler.gfortransnapshot.isNightly=true
 
 ## GFORTRAN x86 build with "assertions" (--enable-checking=XXX)
-group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran134assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert
+group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran125assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran134assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert
 group.gfortranassert.groupName=GFORTRAN x86-64 (assertions)
 group.gfortranassert.compilerCategories=gfortran
 
@@ -120,6 +122,8 @@ compiler.gfortran123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/
 compiler.gfortran123assert.semver=12.3 (assertions)
 compiler.gfortran124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gfortran
 compiler.gfortran124assert.semver=12.4 (assertions)
+compiler.gfortran125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gfortran
+compiler.gfortran125assert.semver=12.5 (assertions)
 compiler.gfortran131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gfortran
 compiler.gfortran131assert.semver=13.1 (assertions)
 compiler.gfortran132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/gfortran

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -401,7 +401,7 @@ compiler.fhppag1510.demangler=/opt/compiler-explorer/hppa/gcc-15.1.0/hppa-unknow
 
 ###############################
 # GCC for SPARC
-group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1340:fsparcg1410:fsparcg1420:fsparcg1430:fsparcg1510
+group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1250:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1340:fsparcg1410:fsparcg1420:fsparcg1430:fsparcg1510
 group.gccsparc.groupName=SPARC gfortran
 group.gccsparc.baseName=SPARC gfortran
 group.gccsparc.compilerCategories=gfortran
@@ -420,6 +420,11 @@ compiler.fsparcg1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-l
 compiler.fsparcg1240.semver=12.4.0
 compiler.fsparcg1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.fsparcg1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.fsparcg1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
+compiler.fsparcg1250.semver=12.5.0
+compiler.fsparcg1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.fsparcg1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.fsparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
 compiler.fsparcg1310.semver=13.1.0
@@ -463,7 +468,7 @@ compiler.fsparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-unk
 
 ###############################
 # GCC for SPARC64
-group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240:fsparc64g1420:fsparc64g1510:fsparc64g1430:fsparc64g1340
+group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240:fsparc64g1420:fsparc64g1510:fsparc64g1430:fsparc64g1340:fsparc64g1250
 group.gccsparc64.groupName=SPARC64 gfortran
 group.gccsparc64.baseName=SPARC64 gfortran
 group.gccsparc64.compilerCategories=gfortran
@@ -482,6 +487,11 @@ compiler.fsparc64g1240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-mul
 compiler.fsparc64g1240.semver=12.4.0
 compiler.fsparc64g1240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.fsparc64g1240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.fsparc64g1250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
+compiler.fsparc64g1250.semver=12.5.0
+compiler.fsparc64g1250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.fsparc64g1250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.fsparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
 compiler.fsparc64g1310.semver=13.1.0
@@ -525,7 +535,7 @@ compiler.fsparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/sparc
 
 ###############################
 # GCC for SPARC LEON
-group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1340:fsparcleong1410:fsparcleong1420:fsparcleong1430:fsparcleong1510
+group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1250:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1340:fsparcleong1410:fsparcleong1420:fsparcleong1430:fsparcleong1510
 group.gccsparcleon.groupName=SPARC LEON gfortran
 group.gccsparcleon.baseName=SPARC LEON gfortran
 group.gccsparcleon.compilerCategories=gfortran
@@ -546,6 +556,11 @@ compiler.fsparcleong1240.exe=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-
 compiler.fsparcleong1240.semver=12.4.0
 compiler.fsparcleong1240.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.fsparcleong1240.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.fsparcleong1250.exe=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
+compiler.fsparcleong1250.semver=12.5.0
+compiler.fsparcleong1250.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.fsparcleong1250.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.fsparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
 compiler.fsparcleong1220-1.semver=12.2.0
@@ -594,7 +609,7 @@ compiler.fsparcleong1510.demangler=/opt/compiler-explorer/sparc-leon/gcc-15.1.0/
 
 ###############################
 # GCC for LOONGARCH64
-group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240:floongarch64g1420:floongarch64g1510:floongarch64g1430:floongarch64g1340
+group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240:floongarch64g1420:floongarch64g1510:floongarch64g1430:floongarch64g1340:floongarch64g1250
 group.gccloongarch64.groupName=LOONGARCH64 gfortran
 group.gccloongarch64.baseName=LOONGARCH64 gfortran
 group.gccloongarch64.compilerCategories=gfortran
@@ -613,6 +628,11 @@ compiler.floongarch64g1240.exe=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loo
 compiler.floongarch64g1240.semver=12.4.0
 compiler.floongarch64g1240.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.floongarch64g1240.demangler=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.floongarch64g1250.exe=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
+compiler.floongarch64g1250.semver=12.5.0
+compiler.floongarch64g1250.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.floongarch64g1250.demangler=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.floongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
 compiler.floongarch64g1310.semver=13.1.0
@@ -656,7 +676,7 @@ compiler.floongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc-15.1
 
 ###############################
 # GCC for RISCV64
-group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240:friscv64g1420:friscv64g1510:friscv64g1430:friscv64g1340
+group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240:friscv64g1420:friscv64g1510:friscv64g1430:friscv64g1340:friscv64g1250
 group.gccriscv64.groupName=RISCV64 gfortran
 group.gccriscv64.baseName=RISCV64 gfortran
 group.gccriscv64.compilerCategories=gfortran
@@ -680,6 +700,11 @@ compiler.friscv64g1240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unk
 compiler.friscv64g1240.semver=12.4.0
 compiler.friscv64g1240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.friscv64g1240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.friscv64g1250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.friscv64g1250.semver=12.5.0
+compiler.friscv64g1250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.friscv64g1250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.friscv64g1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
 compiler.friscv64g1310.semver=13.1.0
@@ -723,7 +748,7 @@ compiler.friscv64g1510.demangler=/opt/compiler-explorer/riscv64/gcc-15.1.0/riscv
 
 ###############################
 # GCC for RISCV
-group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1310:friscvg1320:friscvg1330:friscvg1340:friscvg1410:friscvg1420:friscvg1430:friscvg1510
+group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1250:friscvg1310:friscvg1320:friscvg1330:friscvg1340:friscvg1410:friscvg1420:friscvg1430:friscvg1510
 group.gccriscv.groupName=RISCV (32bit) gfortran
 group.gccriscv.baseName=RISCV (32bit) gfortran
 group.gccriscv.compilerCategories=gfortran
@@ -747,6 +772,11 @@ compiler.friscvg1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unkno
 compiler.friscvg1240.semver=12.4.0
 compiler.friscvg1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.friscvg1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.friscvg1250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
+compiler.friscvg1250.semver=12.5.0
+compiler.friscvg1250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.friscvg1250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.friscvg1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
 compiler.friscvg1310.semver=13.1.0
@@ -790,7 +820,7 @@ compiler.friscvg1510.demangler=/opt/compiler-explorer/riscv32/gcc-15.1.0/riscv32
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1310:farmg1320:farmg1330:farmg1340:farmg1410:farmg1420:farmg1430:farmg1510
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1250:farmg1310:farmg1320:farmg1330:farmg1340:farmg1410:farmg1420:farmg1430:farmg1510
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
 group.gccarm.compilerCategories=gfortran
@@ -831,6 +861,11 @@ compiler.farmg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-g
 compiler.farmg1240.semver=12.4.0
 compiler.farmg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.farmg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.farmg1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1250.semver=12.5.0
+compiler.farmg1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.farmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
 compiler.farmg1310.semver=13.1.0
@@ -874,7 +909,7 @@ compiler.farmg1510.demangler=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-l
 
 ###############################
 ## GCC for s390x
-group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240:fs390xg1420:fs390xg1510:fs390xg1430:fs390xg1340
+group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240:fs390xg1420:fs390xg1510:fs390xg1430:fs390xg1340:fs390xg1250
 group.gccs390x.groupName=s390x gfortran
 group.gccs390x.baseName=s390x gfortran
 group.gccs390x.compilerCategories=gfortran
@@ -897,6 +932,11 @@ compiler.fs390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux
 compiler.fs390xg1240.semver=12.4.0
 compiler.fs390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.fs390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.fs390xg1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
+compiler.fs390xg1250.semver=12.5.0
+compiler.fs390xg1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.fs390xg1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.fs390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
 compiler.fs390xg1310.semver=13.1.0
@@ -1007,7 +1047,7 @@ compiler.lfortran0520.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240:farm64g1420:farm64g1510:farm64g1430:farm64g1340
+group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240:farm64g1420:farm64g1510:farm64g1430:farm64g1340:farm64g1250
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 group.gccaarch64.baseName=AARCH64 gfortran
 group.gccaarch64.compilerCategories=gfortran
@@ -1059,6 +1099,11 @@ compiler.farm64g1240.semver=12.4.0
 compiler.farm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.farm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
+compiler.farm64g1250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1250.semver=12.5.0
+compiler.farm64g1250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 compiler.farm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
 compiler.farm64g1310.semver=13.1.0
 compiler.farm64g1310.objdumper=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
@@ -1108,7 +1153,7 @@ group.ppcs.compilerCategories=gfortran
 
 ###############################
 # GCC for PPC
-group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1310:fppcg1320:fppcg1330:fppcg1340:fppcg1410:fppcg1420:fppcg1430:fppcg1510
+group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1250:fppcg1310:fppcg1320:fppcg1330:fppcg1340:fppcg1410:fppcg1420:fppcg1430:fppcg1510
 group.ppc.groupName=POWER gfortran
 group.ppc.baseName=POWER gfortran
 group.ppc.compilerCategories=gfortran
@@ -1131,6 +1176,11 @@ compiler.fppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown
 compiler.fppcg1240.semver=12.4.0
 compiler.fppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.fppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.fppcg1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
+compiler.fppcg1250.semver=12.5.0
+compiler.fppcg1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.fppcg1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.fppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
 compiler.fppcg1310.semver=13.1.0
@@ -1174,7 +1224,7 @@ compiler.fppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-u
 
 ###############################
 # GCC for PPC64
-group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240:fppc64g1420:fppc64g1510:fppc64g1430:fppc64g1340
+group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240:fppc64g1420:fppc64g1510:fppc64g1430:fppc64g1340:fppc64g1250
 group.ppc64.groupName=POWER64 gfortran
 group.ppc64.baseName=POWER64 gfortran
 group.ppc64.compilerCategories=gfortran
@@ -1205,6 +1255,11 @@ compiler.fppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-u
 compiler.fppc64g1240.semver=12.4.0
 compiler.fppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.fppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.fppc64g1250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.fppc64g1250.semver=12.5.0
+compiler.fppc64g1250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.fppc64g1250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.fppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64g1310.semver=13.1.0
@@ -1253,7 +1308,7 @@ compiler.fppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/power
 
 ###############################
 # GCC for PPC64LE
-group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240:fppc64leg1420:fppc64leg1510:fppc64leg1430:fppc64leg1340
+group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240:fppc64leg1420:fppc64leg1510:fppc64leg1430:fppc64leg1340:fppc64leg1250
 group.ppc64le.groupName=POWER64le gfortran
 group.ppc64le.baseName=POWER64le gfortran
 group.ppc64le.compilerCategories=gfortran
@@ -1284,6 +1339,11 @@ compiler.fppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc
 compiler.fppc64leg1240.semver=12.4.0
 compiler.fppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.fppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.fppc64leg1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg1250.semver=12.5.0
+compiler.fppc64leg1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.fppc64leg1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.fppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
 compiler.fppc64leg1310.semver=13.1.0
@@ -1369,7 +1429,7 @@ compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-
 
 ################################
 # GCC for MIPS
-group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1340:fmipsg1410:fmipsg1420:fmipsg1430:fmipsg1510
+group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1250:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1340:fmipsg1410:fmipsg1420:fmipsg1430:fmipsg1510
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
 group.gccmips.compilerCategories=gfortran
@@ -1407,6 +1467,11 @@ compiler.fmipsg1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linu
 compiler.fmipsg1240.semver=12.4.0
 compiler.fmipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.fmipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.fmipsg1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg1250.semver=12.5.0
+compiler.fmipsg1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.fmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
 compiler.fmipsg1310.semver=13.1.0
@@ -1450,7 +1515,7 @@ compiler.fmipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unknow
 
 ################################
 # GCC for MIPS64
-group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240:fmips64g1420:fmips64g1510:fmips64g1430:fmips64g1340
+group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240:fmips64g1420:fmips64g1510:fmips64g1430:fmips64g1340:fmips64g1250
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
 group.gccmips64.compilerCategories=gfortran
@@ -1488,6 +1553,11 @@ compiler.fmips64g1240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknow
 compiler.fmips64g1240.semver=12.4.0
 compiler.fmips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.fmips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.fmips64g1250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g1250.semver=12.5.0
+compiler.fmips64g1250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g1250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.fmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
 compiler.fmips64g1310.semver=13.1.0
@@ -1531,7 +1601,7 @@ compiler.fmips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips64-
 
 ################################
 # GCC for MIPSEL
-group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1340:fmipselg1410:fmipselg1420:fmipselg1430:fmipselg1510
+group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1250:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1340:fmipselg1410:fmipselg1420:fmipselg1430:fmipselg1510
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
 group.gccmipsel.compilerCategories=gfortran
@@ -1569,6 +1639,11 @@ compiler.fmipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multil
 compiler.fmipselg1240.semver=12.4.0
 compiler.fmipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.fmipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.fmipselg1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
+compiler.fmipselg1250.semver=12.5.0
+compiler.fmipselg1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.fmipselg1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.fmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
 compiler.fmipselg1310.semver=13.1.0
@@ -1612,7 +1687,7 @@ compiler.fmipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mipsel-
 
 ################################
 # GCC for MIPS64el
-group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240:fmips64elg1420:fmips64elg1510:fmips64elg1430:fmips64elg1340
+group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240:fmips64elg1420:fmips64elg1510:fmips64elg1430:fmips64elg1340:fmips64elg1250
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
 group.gccmips64el.compilerCategories=gfortran
@@ -1650,6 +1725,11 @@ compiler.fmips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-
 compiler.fmips64elg1240.semver=12.4.0
 compiler.fmips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.fmips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.fmips64elg1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
+compiler.fmips64elg1250.semver=12.5.0
+compiler.fmips64elg1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.fmips64elg1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.fmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
 compiler.fmips64elg1310.semver=13.1.0

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -12,7 +12,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.gimplegcc86.compilers=&gimplegcc86assert:gimpleg91:gimpleg92:gimpleg93:gimpleg94:gimpleg95:gimpleg101:gimpleg102:gimpleg103:gimpleg104:gimpleg105:gimpleg111:gimpleg112:gimpleg113:gimpleg114:gimpleg121:gimpleg122:gimpleg123:gimpleg124:gimpleg131:gimpleg132:gimpleg133:gimpleg134:gimpleg141:gimpleg142:gimpleg143:gimpleg151:gimplegsnapshot:gimplegstatic-analysis
+group.gimplegcc86.compilers=&gimplegcc86assert:gimpleg91:gimpleg92:gimpleg93:gimpleg94:gimpleg95:gimpleg101:gimpleg102:gimpleg103:gimpleg104:gimpleg105:gimpleg111:gimpleg112:gimpleg113:gimpleg114:gimpleg121:gimpleg122:gimpleg123:gimpleg124:gimpleg125:gimpleg131:gimpleg132:gimpleg133:gimpleg134:gimpleg141:gimpleg142:gimpleg143:gimpleg151:gimplegsnapshot:gimplegstatic-analysis
 group.gimplegcc86.groupName=GCC x86-64
 group.gimplegcc86.instructionSet=amd64
 group.gimplegcc86.isSemVer=true
@@ -58,6 +58,8 @@ compiler.gimpleg123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gcc
 compiler.gimpleg123.semver=12.3
 compiler.gimpleg124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gcc
 compiler.gimpleg124.semver=12.4
+compiler.gimpleg125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gcc
+compiler.gimpleg125.semver=12.5
 compiler.gimpleg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gcc
 compiler.gimpleg131.semver=13.1
 compiler.gimpleg132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gcc
@@ -90,7 +92,7 @@ compiler.gimplegstatic-analysis.options=-fanalyzer -fdiagnostics-urls=never -fdi
 compiler.gimplegstatic-analysis.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 ## GCC build with "assertions" (--enable-checking=XXX)
-group.gimplegcc86assert.compilers=gimpleg103assert:gimpleg104assert:gimpleg105assert:gimpleg111assert:gimpleg112assert:gimpleg113assert:gimpleg114assert:gimpleg121assert:gimpleg122assert:gimpleg123assert:gimpleg124assert:gimpleg131assert:gimpleg132assert:gimpleg133assert:gimpleg134assert:gimpleg141assert:gimpleg142assert:gimpleg143assert:gimpleg151assert
+group.gimplegcc86assert.compilers=gimpleg103assert:gimpleg104assert:gimpleg105assert:gimpleg111assert:gimpleg112assert:gimpleg113assert:gimpleg114assert:gimpleg121assert:gimpleg122assert:gimpleg123assert:gimpleg124assert:gimpleg125assert:gimpleg131assert:gimpleg132assert:gimpleg133assert:gimpleg134assert:gimpleg141assert:gimpleg142assert:gimpleg143assert:gimpleg151assert
 group.gimplegcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.gimpleg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -115,6 +117,8 @@ compiler.gimpleg123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/g
 compiler.gimpleg123assert.semver=12.3 (assertions)
 compiler.gimpleg124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gcc
 compiler.gimpleg124assert.semver=12.4 (assertions)
+compiler.gimpleg125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gcc
+compiler.gimpleg125assert.semver=12.5 (assertions)
 compiler.gimpleg131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gcc
 compiler.gimpleg131assert.semver=13.1 (assertions)
 compiler.gimpleg132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/gcc

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -138,7 +138,7 @@ compiler.gimpleg151assert.semver=15.1 (assertions)
 
 ################################
 # GCC for AVR
-group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1310:gimpleavrg1320:gimpleavrg1330:gimpleavrg1340:gimpleavrg1410:gimpleavrg1420:gimpleavrg1430:gimpleavrg1510
+group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1240:gimpleavrg1310:gimpleavrg1320:gimpleavrg1330:gimpleavrg1340:gimpleavrg1410:gimpleavrg1420:gimpleavrg1430:gimpleavrg1510
 group.gimpleavr.groupName=AVR GCC
 group.gimpleavr.baseName=AVR gcc
 group.gimpleavr.isSemVer=true
@@ -172,6 +172,11 @@ compiler.gimpleavrg1230.exe=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-gc
 compiler.gimpleavrg1230.semver=12.3.0
 compiler.gimpleavrg1230.objdumper=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-objdump
 compiler.gimpleavrg1230.demangler=/opt/compiler-explorer/avr/gcc-12.3.0/avr/bin/avr-c++filt
+
+compiler.gimpleavrg1240.exe=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-gcc
+compiler.gimpleavrg1240.semver=12.4.0
+compiler.gimpleavrg1240.objdumper=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-objdump
+compiler.gimpleavrg1240.demangler=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-c++filt
 
 compiler.gimpleavrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-gcc
 compiler.gimpleavrg1310.semver=13.1.0
@@ -349,7 +354,7 @@ group.gimplemipss.supportsExecute=false
 
 # GCC for all MIPS
 ## MIPS
-group.gimplemips.compilers=gimplemips930:gimplemips1120:gimplemipsg1210:gimplemipsg1220:gimplemipsg1230:gimplemipsg1310:gimplemipsg1320:gimplemipsg1330:gimplemipsg1340:gimplemipsg1410:gimplemipsg1420:gimplemipsg1430:gimplemipsg1510
+group.gimplemips.compilers=gimplemips930:gimplemips1120:gimplemipsg1210:gimplemipsg1220:gimplemipsg1230:gimplemipsg1240:gimplemipsg1310:gimplemipsg1320:gimplemipsg1330:gimplemipsg1340:gimplemipsg1410:gimplemipsg1420:gimplemipsg1430:gimplemipsg1510
 group.gimplemips.groupName=MIPS GCC
 group.gimplemips.baseName=mips gcc
 
@@ -375,6 +380,11 @@ compiler.gimplemipsg1230.exe=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown
 compiler.gimplemipsg1230.semver=12.3.0
 compiler.gimplemipsg1230.objdumper=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gimplemipsg1230.demangler=/opt/compiler-explorer/mips/gcc-12.3.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gimplemipsg1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1240.semver=12.4.0
+compiler.gimplemipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gimplemipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.gimplemipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.gimplemipsg1310.semver=13.1.0
@@ -418,7 +428,7 @@ compiler.gimplemipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-u
 
 ## MIPS64
 group.gimplemips64.groupName=MIPS64 GCC
-group.gimplemips64.compilers=gimplemips64g1210:gimplemips64g1220:gimplemips64g1230:gimplemips64g1310:gimplemips64g1320:gimplemips64g1330:gimplemips64g1410:gimplemips64g1420:gimplemips64g1510:gimplemips64g1430:gimplemips64g1340:gimplemips112064
+group.gimplemips64.compilers=gimplemips64g1210:gimplemips64g1220:gimplemips64g1230:gimplemips64g1240:gimplemips64g1310:gimplemips64g1320:gimplemips64g1330:gimplemips64g1410:gimplemips64g1420:gimplemips64g1510:gimplemips64g1430:gimplemips64g1340:gimplemips112064
 group.gimplemips64.baseName=mips64 gcc
 
 
@@ -439,6 +449,11 @@ compiler.gimplemips64g1230.exe=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-u
 compiler.gimplemips64g1230.semver=12.3.0
 compiler.gimplemips64g1230.objdumper=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gimplemips64g1230.demangler=/opt/compiler-explorer/mips64/gcc-12.3.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gimplemips64g1240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1240.semver=12.4.0
+compiler.gimplemips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gimplemips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.gimplemips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.gimplemips64g1310.semver=13.1.0
@@ -482,7 +497,7 @@ compiler.gimplemips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mi
 
 ## MIPS EL
 group.gimplemipsel.groupName=MIPSEL GCC
-group.gimplemipsel.compilers=gimplemipselg1210:gimplemipselg1220:gimplemipselg1230:gimplemipselg1310:gimplemipselg1320:gimplemipselg1330:gimplemipselg1340:gimplemipselg1410:gimplemipselg1420:gimplemipselg1430:gimplemipselg1510
+group.gimplemipsel.compilers=gimplemipselg1210:gimplemipselg1220:gimplemipselg1230:gimplemipselg1240:gimplemipselg1310:gimplemipselg1320:gimplemipselg1330:gimplemipselg1340:gimplemipselg1410:gimplemipselg1420:gimplemipselg1430:gimplemipselg1510
 group.gimplemipsel.baseName=mips (el) gcc
 
 compiler.gimplemipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
@@ -498,6 +513,11 @@ compiler.gimplemipselg1230.exe=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-m
 compiler.gimplemipselg1230.semver=12.3.0
 compiler.gimplemipselg1230.objdumper=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gimplemipselg1230.demangler=/opt/compiler-explorer/mipsel/gcc-12.3.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gimplemipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1240.semver=12.4.0
+compiler.gimplemipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gimplemipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.gimplemipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.gimplemipselg1310.semver=13.1.0
@@ -541,7 +561,7 @@ compiler.gimplemipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mi
 
 ## MIPS64 EL
 group.gimplemips64el.groupName=MIPS64EL GCC
-group.gimplemips64el.compilers=gimplemips64elg1210:gimplemips64elg1220:gimplemips64elg1230:gimplemips64elg1310:gimplemips64elg1320:gimplemips64elg1330:gimplemips64elg1410:gimplemips64elg1420:gimplemips64elg1510:gimplemips64elg1430:gimplemips64elg1340
+group.gimplemips64el.compilers=gimplemips64elg1210:gimplemips64elg1220:gimplemips64elg1230:gimplemips64elg1240:gimplemips64elg1310:gimplemips64elg1320:gimplemips64elg1330:gimplemips64elg1410:gimplemips64elg1420:gimplemips64elg1510:gimplemips64elg1430:gimplemips64elg1340
 group.gimplemips64el.baseName=mips64 (el) gcc
 
 compiler.gimplemips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
@@ -557,6 +577,11 @@ compiler.gimplemips64elg1230.exe=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips
 compiler.gimplemips64elg1230.semver=12.3.0
 compiler.gimplemips64elg1230.objdumper=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.gimplemips64elg1230.demangler=/opt/compiler-explorer/mips64el/gcc-12.3.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.gimplemips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1240.semver=12.4.0
+compiler.gimplemips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gimplemips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.gimplemips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.gimplemips64elg1310.semver=13.1.0
@@ -762,7 +787,7 @@ compiler.gimplem68kg1510.demangler=/opt/compiler-explorer/m68k/gcc-15.1.0/m68k-u
 group.gimplesparc.compilers=&gimplegccsparc
 
 # GCC for SPARC
-group.gimplegccsparc.compilers=gimplesparcg1220:gimplesparcg1230:gimplesparcg1310:gimplesparcg1320:gimplesparcg1330:gimplesparcg1340:gimplesparcg1410:gimplesparcg1420:gimplesparcg1430:gimplesparcg1510
+group.gimplegccsparc.compilers=gimplesparcg1220:gimplesparcg1230:gimplesparcg1240:gimplesparcg1310:gimplesparcg1320:gimplesparcg1330:gimplesparcg1340:gimplesparcg1410:gimplesparcg1420:gimplesparcg1430:gimplesparcg1510
 group.gimplegccsparc.baseName=SPARC gcc
 group.gimplegccsparc.groupName=SPARC GCC
 group.gimplegccsparc.isSemVer=true
@@ -776,6 +801,11 @@ compiler.gimplesparcg1230.exe=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unkn
 compiler.gimplesparcg1230.semver=12.3.0
 compiler.gimplesparcg1230.objdumper=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gimplesparcg1230.demangler=/opt/compiler-explorer/sparc/gcc-12.3.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gimplesparcg1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.gimplesparcg1240.semver=12.4.0
+compiler.gimplesparcg1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gimplesparcg1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.gimplesparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
 compiler.gimplesparcg1310.semver=13.1.0
@@ -822,7 +852,7 @@ compiler.gimplesparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/spar
 group.gimplesparc64.compilers=&gimplegccsparc64
 
 # GCC for SPARC64
-group.gimplegccsparc64.compilers=gimplesparc64g1220:gimplesparc64g1230:gimplesparc64g1310:gimplesparc64g1320:gimplesparc64g1330:gimplesparc64g1410:gimplesparc64g1420:gimplesparc64g1510:gimplesparc64g1430:gimplesparc64g1340
+group.gimplegccsparc64.compilers=gimplesparc64g1220:gimplesparc64g1230:gimplesparc64g1240:gimplesparc64g1310:gimplesparc64g1320:gimplesparc64g1330:gimplesparc64g1410:gimplesparc64g1420:gimplesparc64g1510:gimplesparc64g1430:gimplesparc64g1340
 group.gimplegccsparc64.baseName=SPARC64 gcc
 group.gimplegccsparc64.groupName=SPARC64 GCC
 group.gimplegccsparc64.isSemVer=true
@@ -836,6 +866,11 @@ compiler.gimplesparc64g1230.exe=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc6
 compiler.gimplesparc64g1230.semver=12.3.0
 compiler.gimplesparc64g1230.objdumper=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gimplesparc64g1230.demangler=/opt/compiler-explorer/sparc64/gcc-12.3.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gimplesparc64g1240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.gimplesparc64g1240.semver=12.4.0
+compiler.gimplesparc64g1240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gimplesparc64g1240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.gimplesparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
 compiler.gimplesparc64g1310.semver=13.1.0
@@ -882,7 +917,7 @@ compiler.gimplesparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/
 group.gimplesparcleon.compilers=&gimplegccsparcleon
 
 # GCC for SPARC-LEON
-group.gimplegccsparcleon.compilers=gimplesparcleong1220:gimplesparcleong1220-1:gimplesparcleong1230:gimplesparcleong1310:gimplesparcleong1320:gimplesparcleong1330:gimplesparcleong1340:gimplesparcleong1410:gimplesparcleong1420:gimplesparcleong1430:gimplesparcleong1510
+group.gimplegccsparcleon.compilers=gimplesparcleong1220:gimplesparcleong1220-1:gimplesparcleong1230:gimplesparcleong1240:gimplesparcleong1310:gimplesparcleong1320:gimplesparcleong1330:gimplesparcleong1340:gimplesparcleong1410:gimplesparcleong1420:gimplesparcleong1430:gimplesparcleong1510
 group.gimplegccsparcleon.baseName=SPARC LEON gcc
 group.gimplegccsparcleon.groupName=SPARC LEON GCC
 group.gimplegccsparcleon.isSemVer=true
@@ -898,6 +933,11 @@ compiler.gimplesparcleong1230.exe=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/s
 compiler.gimplesparcleong1230.semver=12.3.0
 compiler.gimplesparcleong1230.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.gimplesparcleong1230.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.3.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.gimplesparcleong1240.exe=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1240.semver=12.4.0
+compiler.gimplesparcleong1240.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1240.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.gimplesparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.gimplesparcleong1310.semver=13.1.0
@@ -949,7 +989,7 @@ compiler.gimplesparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-
 group.gimplec6x.compilers=&gimplegccc6x
 
 # GCC for TI C6x
-group.gimplegccc6x.compilers=gimplec6xg1220:gimplec6xg1230:gimplec6xg1310:gimplec6xg1320:gimplec6xg1330:gimplec6xg1410:gimplec6xg1420:gimplec6xg1510:gimplec6xg1430:gimplec6xg1340
+group.gimplegccc6x.compilers=gimplec6xg1220:gimplec6xg1230:gimplec6xg1240:gimplec6xg1310:gimplec6xg1320:gimplec6xg1330:gimplec6xg1410:gimplec6xg1420:gimplec6xg1510:gimplec6xg1430:gimplec6xg1340
 group.gimplegccc6x.baseName=TI C6x gcc
 group.gimplegccc6x.groupName=TI C6x GCC
 group.gimplegccc6x.isSemVer=true
@@ -963,6 +1003,11 @@ compiler.gimplec6xg1230.exe=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/
 compiler.gimplec6xg1230.semver=12.3.0
 compiler.gimplec6xg1230.objdumper=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.gimplec6xg1230.demangler=/opt/compiler-explorer/c6x/gcc-12.3.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.gimplec6xg1240.exe=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.gimplec6xg1240.semver=12.4.0
+compiler.gimplec6xg1240.objdumper=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.gimplec6xg1240.demangler=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-c++filt
 
 compiler.gimplec6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-gcc
 compiler.gimplec6xg1310.semver=13.1.0
@@ -1009,7 +1054,7 @@ compiler.gimplec6xg1510.demangler=/opt/compiler-explorer/c6x/gcc-15.1.0/tic6x-el
 group.gimpleloongarch64.compilers=&gimplegccloongarch64
 
 # GCC for loongarch64
-group.gimplegccloongarch64.compilers=gimpleloongarch64g1220:gimpleloongarch64g1230:gimpleloongarch64g1310:gimpleloongarch64g1320:gimpleloongarch64g1330:gimpleloongarch64g1410:gimpleloongarch64g1420:gimpleloongarch64g1510:gimpleloongarch64g1430:gimpleloongarch64g1340
+group.gimplegccloongarch64.compilers=gimpleloongarch64g1220:gimpleloongarch64g1230:gimpleloongarch64g1240:gimpleloongarch64g1310:gimpleloongarch64g1320:gimpleloongarch64g1330:gimpleloongarch64g1410:gimpleloongarch64g1420:gimpleloongarch64g1510:gimpleloongarch64g1430:gimpleloongarch64g1340
 group.gimplegccloongarch64.baseName=loongarch64 gcc
 group.gimplegccloongarch64.groupName=loongarch64 GCC
 group.gimplegccloongarch64.isSemVer=true
@@ -1023,6 +1068,11 @@ compiler.gimpleloongarch64g1230.exe=/opt/compiler-explorer/loongarch64/gcc-12.3.
 compiler.gimpleloongarch64g1230.semver=12.3.0
 compiler.gimpleloongarch64g1230.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.gimpleloongarch64g1230.demangler=/opt/compiler-explorer/loongarch64/gcc-12.3.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.gimpleloongarch64g1240.exe=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.gimpleloongarch64g1240.semver=12.4.0
+compiler.gimpleloongarch64g1240.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gimpleloongarch64g1240.demangler=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.gimpleloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
 compiler.gimpleloongarch64g1310.semver=13.1.0
@@ -1069,7 +1119,7 @@ compiler.gimpleloongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc
 group.gimplesh.compilers=&gimplegccsh
 
 # GCC for sh
-group.gimplegccsh.compilers=gimpleshg950:gimpleshg1220:gimpleshg1230:gimpleshg1310:gimpleshg1320:gimpleshg1330:gimpleshg1340:gimpleshg1410:gimpleshg1420:gimpleshg1430:gimpleshg1510
+group.gimplegccsh.compilers=gimpleshg950:gimpleshg1220:gimpleshg1230:gimpleshg1240:gimpleshg1310:gimpleshg1320:gimpleshg1330:gimpleshg1340:gimpleshg1410:gimpleshg1420:gimpleshg1430:gimpleshg1510
 group.gimplegccsh.baseName=sh gcc
 group.gimplegccsh.groupName=sh GCC
 group.gimplegccsh.isSemVer=true
@@ -1088,6 +1138,11 @@ compiler.gimpleshg1230.exe=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/b
 compiler.gimpleshg1230.semver=12.3.0
 compiler.gimpleshg1230.objdumper=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.gimpleshg1230.demangler=/opt/compiler-explorer/sh/gcc-12.3.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.gimpleshg1240.exe=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg1240.semver=12.4.0
+compiler.gimpleshg1240.objdumper=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg1240.demangler=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
 compiler.gimpleshg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
 compiler.gimpleshg1310.semver=13.1.0
@@ -1134,7 +1189,7 @@ compiler.gimpleshg1510.demangler=/opt/compiler-explorer/sh/gcc-15.1.0/sh-unknown
 group.gimples390x.compilers=&gimplegccs390x
 
 # GCC for s390x
-group.gimplegccs390x.compilers=gimplegccs390x112:gimples390xg1210:gimples390xg1220:gimples390xg1230:gimples390xg1310:gimples390xg1320:gimples390xg1330:gimples390xg1410:gimples390xg1420:gimples390xg1510:gimples390xg1430:gimples390xg1340
+group.gimplegccs390x.compilers=gimplegccs390x112:gimples390xg1210:gimples390xg1220:gimples390xg1230:gimples390xg1240:gimples390xg1310:gimples390xg1320:gimples390xg1330:gimples390xg1410:gimples390xg1420:gimples390xg1510:gimples390xg1430:gimples390xg1340
 group.gimplegccs390x.baseName=s390x gcc
 group.gimplegccs390x.groupName=s390x GCC
 group.gimplegccs390x.isSemVer=true
@@ -1156,6 +1211,11 @@ compiler.gimples390xg1230.exe=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-
 compiler.gimples390xg1230.semver=12.3.0
 compiler.gimples390xg1230.objdumper=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gimples390xg1230.demangler=/opt/compiler-explorer/s390x/gcc-12.3.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gimples390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1240.semver=12.4.0
+compiler.gimples390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gimples390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.gimples390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
 compiler.gimples390xg1310.semver=13.1.0
@@ -1203,7 +1263,7 @@ group.gimpleppcs.compilers=&gimpleppc:&gimpleppc64:&gimpleppc64le
 group.gimpleppcs.isSemVer=true
 group.gimpleppcs.instructionSet=powerpc
 
-group.gimpleppc.compilers=gimpleppcg1120:gimpleppcg1210:gimpleppcg1220:gimpleppcg1230:gimpleppcg1310:gimpleppcg1320:gimpleppcg1330:gimpleppcg1340:gimpleppcg1410:gimpleppcg1420:gimpleppcg1430:gimpleppcg1510
+group.gimpleppc.compilers=gimpleppcg1120:gimpleppcg1210:gimpleppcg1220:gimpleppcg1230:gimpleppcg1240:gimpleppcg1310:gimpleppcg1320:gimpleppcg1330:gimpleppcg1340:gimpleppcg1410:gimpleppcg1420:gimpleppcg1430:gimpleppcg1510
 group.gimpleppc.groupName=POWER
 group.gimpleppc.baseName=power gcc
 
@@ -1224,6 +1284,11 @@ compiler.gimpleppcg1230.exe=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-un
 compiler.gimpleppcg1230.semver=12.3.0
 compiler.gimpleppcg1230.objdumper=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gimpleppcg1230.demangler=/opt/compiler-explorer/powerpc/gcc-12.3.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gimpleppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1240.semver=12.4.0
+compiler.gimpleppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.gimpleppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.gimpleppcg1310.semver=13.1.0
@@ -1265,7 +1330,7 @@ compiler.gimpleppcg1510.semver=15.1.0
 compiler.gimpleppcg1510.objdumper=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gimpleppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.gimpleppc64.compilers=gimpleppc64g9:gimpleppc64g1120:gimpleppc64g1210:gimpleppc64g1220:gimpleppc64g1230:gimpleppc64g1310:gimpleppc64g1320:gimpleppc64g1330:gimpleppc64g1410:gimpleppc64g1420:gimpleppc64g1510:gimpleppc64g1430:gimpleppc64g1340
+group.gimpleppc64.compilers=gimpleppc64g9:gimpleppc64g1120:gimpleppc64g1210:gimpleppc64g1220:gimpleppc64g1230:gimpleppc64g1240:gimpleppc64g1310:gimpleppc64g1320:gimpleppc64g1330:gimpleppc64g1410:gimpleppc64g1420:gimpleppc64g1510:gimpleppc64g1430:gimpleppc64g1340
 group.gimpleppc64.groupName=POWER64
 group.gimpleppc64.baseName=POWER64 gcc
 
@@ -1291,6 +1356,11 @@ compiler.gimpleppc64g1230.exe=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerp
 compiler.gimpleppc64g1230.semver=12.3.0
 compiler.gimpleppc64g1230.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gimpleppc64g1230.demangler=/opt/compiler-explorer/powerpc64/gcc-12.3.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1240.semver=12.4.0
+compiler.gimpleppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gimpleppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.gimpleppc64g1310.semver=13.1.0
@@ -1332,7 +1402,7 @@ compiler.gimpleppc64g1510.semver=15.1.0
 compiler.gimpleppc64g1510.objdumper=/opt/compiler-explorer/powerpc64/gcc-15.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gimpleppc64g1510.demangler=/opt/compiler-explorer/powerpc64/gcc-15.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
-group.gimpleppc64le.compilers=gimpleppc64leg9:gimpleppc64leg1120:gimpleppc64leg1210:gimpleppc64leg1220:gimpleppc64leg1230:gimpleppc64leg1310:gimpleppc64leg1320:gimpleppc64leg1330:gimpleppc64leg1410:gimpleppc64leg1420:gimpleppc64leg1510:gimpleppc64leg1430:gimpleppc64leg1340
+group.gimpleppc64le.compilers=gimpleppc64leg9:gimpleppc64leg1120:gimpleppc64leg1210:gimpleppc64leg1220:gimpleppc64leg1230:gimpleppc64leg1240:gimpleppc64leg1310:gimpleppc64leg1320:gimpleppc64leg1330:gimpleppc64leg1410:gimpleppc64leg1420:gimpleppc64leg1510:gimpleppc64leg1430:gimpleppc64leg1340
 group.gimpleppc64le.groupName=POWER64LE GCC
 group.gimpleppc64le.baseName=power64le gcc
 
@@ -1358,6 +1428,11 @@ compiler.gimpleppc64leg1230.exe=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/po
 compiler.gimpleppc64leg1230.semver=12.3.0
 compiler.gimpleppc64leg1230.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gimpleppc64leg1230.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1240.semver=12.4.0
+compiler.gimpleppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gimpleppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.gimpleppc64leg1310.semver=13.1.0
@@ -1402,7 +1477,7 @@ compiler.gimpleppc64leg1510.demangler=/opt/compiler-explorer/powerpc64le/gcc-15.
 
 ################################
 # GCC for MSP
-group.gimplemsp.compilers=gimplemsp430g1210:gimplemsp430g1220:gimplemsp430g1230:gimplemsp430g1310:gimplemsp430g1320:gimplemsp430g1330:gimplemsp430g1410:gimplemsp430g1420:gimplemsp430g1510:gimplemsp430g1430:gimplemsp430g1340
+group.gimplemsp.compilers=gimplemsp430g1210:gimplemsp430g1220:gimplemsp430g1230:gimplemsp430g1240:gimplemsp430g1310:gimplemsp430g1320:gimplemsp430g1330:gimplemsp430g1410:gimplemsp430g1420:gimplemsp430g1510:gimplemsp430g1430:gimplemsp430g1340
 group.gimplemsp.groupName=MSP GCC
 group.gimplemsp.baseName=MSP430 gcc
 group.gimplemsp.isSemVer=true
@@ -1421,6 +1496,11 @@ compiler.gimplemsp430g1230.exe=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-u
 compiler.gimplemsp430g1230.semver=12.3.0
 compiler.gimplemsp430g1230.objdumper=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
 compiler.gimplemsp430g1230.demangler=/opt/compiler-explorer/msp430/gcc-12.3.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.gimplemsp430g1240.exe=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1240.semver=12.4.0
+compiler.gimplemsp430g1240.objdumper=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1240.demangler=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
 
 compiler.gimplemsp430g1310.exe=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
 compiler.gimplemsp430g1310.semver=13.1.0
@@ -1475,7 +1555,7 @@ group.gimplegccarm.includeFlag=-I
 # 32 bit
 group.gimplegcc32arm.groupName=Arm 32-bit GCC
 group.gimplegcc32arm.baseName=ARM GCC
-group.gimplegcc32arm.compilers=gimplearm921:gimplearm930:gimplearm1020:gimplearm1021:gimplearm1030:gimplearm1031_07:gimplearm1031_10:gimplearmg1050:gimplearm1100:gimplearm1120:gimplearm1121:gimplearm1130:gimplearmg1140:gimplearm1210:gimplearmg1220:gimplearmg1230:gimplearmg1310:gimplearmg1320:gimplearmug1320:gimplearmg1330:gimplearmug1330:gimplearmg1340:gimplearmug1340:gimplearmg1410:gimplearmug1410:gimplearmg1420:gimplearmug1420:gimplearmg1430:gimplearmug1430:gimplearmg1510:gimplearmgtrunk
+group.gimplegcc32arm.compilers=gimplearm921:gimplearm930:gimplearm1020:gimplearm1021:gimplearm1030:gimplearm1031_07:gimplearm1031_10:gimplearmg1050:gimplearm1100:gimplearm1120:gimplearm1121:gimplearm1130:gimplearmg1140:gimplearm1210:gimplearmg1220:gimplearmg1230:gimplearmg1240:gimplearmg1310:gimplearmg1320:gimplearmug1320:gimplearmg1330:gimplearmug1330:gimplearmg1340:gimplearmug1340:gimplearmg1410:gimplearmug1410:gimplearmg1420:gimplearmug1420:gimplearmg1430:gimplearmug1430:gimplearmg1510:gimplearmgtrunk
 group.gimplegcc32arm.isSemVer=true
 group.gimplegcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gimplegcc32arm.instructionSet=arm32
@@ -1499,6 +1579,11 @@ compiler.gimplearmg1230.exe=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-li
 compiler.gimplearmg1230.semver=12.3.0
 compiler.gimplearmg1230.objdumper=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gimplearmg1230.demangler=/opt/compiler-explorer/arm/gcc-12.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.gimplearmg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.gimplearmg1240.semver=12.4.0
+compiler.gimplearmg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gimplearmg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.gimplearmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.gimplearmg1310.semver=13.1.0 (linux)
@@ -1615,7 +1700,7 @@ compiler.gimplearmgtrunk.isNightly=true
 # 64 bit
 group.gimplegcc64arm.groupName=ARM64 gcc
 group.gimplegcc64arm.baseName=ARM64 GCC
-group.gimplegcc64arm.compilers=gimplearm64g930:gimplearm64g940:gimplearm64g950:gimplearm64g1020:gimplearm64g1030:gimplearm64g1040:gimplearm64g1100:gimplearm64g1120:gimplearm64g1130:gimplearm64g1140:gimplearm64g1210:gimplearm64gtrunk:gimplearm64g1220:gimplearm64g1230:gimplearm64g1310:gimplearm64g1050:gimplearm64g1320:gimplearm64g1330:gimplearm64g1410:gimplearm64g1420:gimplearm64g1510:gimplearm64g1430:gimplearm64g1340
+group.gimplegcc64arm.compilers=gimplearm64g930:gimplearm64g940:gimplearm64g950:gimplearm64g1020:gimplearm64g1030:gimplearm64g1040:gimplearm64g1100:gimplearm64g1120:gimplearm64g1130:gimplearm64g1140:gimplearm64g1210:gimplearm64gtrunk:gimplearm64g1220:gimplearm64g1230:gimplearm64g1240:gimplearm64g1310:gimplearm64g1050:gimplearm64g1320:gimplearm64g1330:gimplearm64g1410:gimplearm64g1420:gimplearm64g1510:gimplearm64g1430:gimplearm64g1340
 group.gimplegcc64arm.isSemVer=true
 group.gimplegcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gimplegcc64arm.instructionSet=aarch64
@@ -1662,6 +1747,11 @@ compiler.gimplearm64g1230.exe=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-un
 compiler.gimplearm64g1230.semver=12.3.0
 compiler.gimplearm64g1230.objdumper=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gimplearm64g1230.demangler=/opt/compiler-explorer/arm64/gcc-12.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.gimplearm64g1240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.gimplearm64g1240.semver=12.4.0
+compiler.gimplearm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gimplearm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.gimplearm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.gimplearm64g1310.semver=13.1.0
@@ -1730,7 +1820,7 @@ group.gimplervgcc.supportsBinary=true
 group.gimplervgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 64-bits
-group.rv64-gimplegccs.compilers=rv64-gimplegcctrunk:rv64-gimplegcc1230:rv64-gimplegcc1210:rv64-gimplegcc1140:rv64-gimplegcc1130:rv64-gimplegcc1220:rv64-gimplegcc1120:rv64-gimplegcc1030:rv64-gimplegcc1020:rv64-gimplegcc940:rv64-gimplegcc1310:rv64-gimplegcc1320:rv64-gimplegcc1330:rv64-gimplegcc1410:rv64-gimplegcc1420:rv64-gimplegcc1510:rv64-gimplegcc1430:rv64-gimplegcc1340
+group.rv64-gimplegccs.compilers=rv64-gimplegcctrunk:rv64-gimplegcc1230:rv64-gimplegcc1240:rv64-gimplegcc1210:rv64-gimplegcc1140:rv64-gimplegcc1130:rv64-gimplegcc1220:rv64-gimplegcc1120:rv64-gimplegcc1030:rv64-gimplegcc1020:rv64-gimplegcc940:rv64-gimplegcc1310:rv64-gimplegcc1320:rv64-gimplegcc1330:rv64-gimplegcc1410:rv64-gimplegcc1420:rv64-gimplegcc1510:rv64-gimplegcc1430:rv64-gimplegcc1340
 group.rv64-gimplegccs.groupName=RISC-V (64-bits) gcc
 group.rv64-gimplegccs.baseName=RISC-V (64-bits) gcc
 
@@ -1772,6 +1862,11 @@ compiler.rv64-gimplegcc1230.exe=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv6
 compiler.rv64-gimplegcc1230.semver=12.3.0
 compiler.rv64-gimplegcc1230.objdumper=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gimplegcc1230.demangler=/opt/compiler-explorer/riscv64/gcc-12.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.rv64-gimplegcc1240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-gimplegcc1240.semver=12.4.0
+compiler.rv64-gimplegcc1240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gimplegcc1240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.rv64-gimplegcc1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-gimplegcc1310.semver=13.1.0
@@ -1820,7 +1915,7 @@ compiler.rv64-gimplegcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/
 compiler.rv64-gimplegcctrunk.isNightly=true
 
 ## GCC for RISC-V 32-bits
-group.rv32-gimplegccs.compilers=rv32-gimplegcctrunk:rv32-gimplegcc1220:rv32-gimplegcc1210:rv32-gimplegcc1140:rv32-gimplegcc1130:rv32-gimplegcc1120:rv32-gimplegcc1030:rv32-gimplegcc1020:rv32-gimplegcc940:rv32-gimplegcc1310:rv32-gimplegcc1230:rv32-gimplegcc1320:rv32-gimplegcc1330:rv32-gimplegcc1410:rv32-gimplegcc1420:rv32-gimplegcc1510:rv32-gimplegcc1430:rv32-gimplegcc1340
+group.rv32-gimplegccs.compilers=rv32-gimplegcctrunk:rv32-gimplegcc1220:rv32-gimplegcc1210:rv32-gimplegcc1140:rv32-gimplegcc1130:rv32-gimplegcc1120:rv32-gimplegcc1030:rv32-gimplegcc1020:rv32-gimplegcc940:rv32-gimplegcc1310:rv32-gimplegcc1230:rv32-gimplegcc1240:rv32-gimplegcc1320:rv32-gimplegcc1330:rv32-gimplegcc1410:rv32-gimplegcc1420:rv32-gimplegcc1510:rv32-gimplegcc1430:rv32-gimplegcc1340
 group.rv32-gimplegccs.groupName=RISC-V (32-bits) gcc
 group.rv32-gimplegccs.baseName=RISC-V (32-bits) gcc
 
@@ -1862,6 +1957,11 @@ compiler.rv32-gimplegcc1230.exe=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv3
 compiler.rv32-gimplegcc1230.semver=12.3.0
 compiler.rv32-gimplegcc1230.objdumper=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gimplegcc1230.demangler=/opt/compiler-explorer/riscv32/gcc-12.3.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-gimplegcc1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-gimplegcc1240.semver=12.4.0
+compiler.rv32-gimplegcc1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gimplegcc1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-gimplegcc1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.rv32-gimplegcc1310.semver=13.1.0

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -138,7 +138,7 @@ compiler.gimpleg151assert.semver=15.1 (assertions)
 
 ################################
 # GCC for AVR
-group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1240:gimpleavrg1310:gimpleavrg1320:gimpleavrg1330:gimpleavrg1340:gimpleavrg1410:gimpleavrg1420:gimpleavrg1430:gimpleavrg1510
+group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1240:gimpleavrg1250:gimpleavrg1310:gimpleavrg1320:gimpleavrg1330:gimpleavrg1340:gimpleavrg1410:gimpleavrg1420:gimpleavrg1430:gimpleavrg1510
 group.gimpleavr.groupName=AVR GCC
 group.gimpleavr.baseName=AVR gcc
 group.gimpleavr.isSemVer=true
@@ -177,6 +177,11 @@ compiler.gimpleavrg1240.exe=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-gc
 compiler.gimpleavrg1240.semver=12.4.0
 compiler.gimpleavrg1240.objdumper=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-objdump
 compiler.gimpleavrg1240.demangler=/opt/compiler-explorer/avr/gcc-12.4.0/avr/bin/avr-c++filt
+
+compiler.gimpleavrg1250.exe=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-gcc
+compiler.gimpleavrg1250.semver=12.5.0
+compiler.gimpleavrg1250.objdumper=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-objdump
+compiler.gimpleavrg1250.demangler=/opt/compiler-explorer/avr/gcc-12.5.0/avr/bin/avr-c++filt
 
 compiler.gimpleavrg1310.exe=/opt/compiler-explorer/avr/gcc-13.1.0/avr/bin/avr-gcc
 compiler.gimpleavrg1310.semver=13.1.0
@@ -354,7 +359,7 @@ group.gimplemipss.supportsExecute=false
 
 # GCC for all MIPS
 ## MIPS
-group.gimplemips.compilers=gimplemips930:gimplemips1120:gimplemipsg1210:gimplemipsg1220:gimplemipsg1230:gimplemipsg1240:gimplemipsg1310:gimplemipsg1320:gimplemipsg1330:gimplemipsg1340:gimplemipsg1410:gimplemipsg1420:gimplemipsg1430:gimplemipsg1510
+group.gimplemips.compilers=gimplemips930:gimplemips1120:gimplemipsg1210:gimplemipsg1220:gimplemipsg1230:gimplemipsg1240:gimplemipsg1250:gimplemipsg1310:gimplemipsg1320:gimplemipsg1330:gimplemipsg1340:gimplemipsg1410:gimplemipsg1420:gimplemipsg1430:gimplemipsg1510
 group.gimplemips.groupName=MIPS GCC
 group.gimplemips.baseName=mips gcc
 
@@ -385,6 +390,11 @@ compiler.gimplemipsg1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown
 compiler.gimplemipsg1240.semver=12.4.0
 compiler.gimplemipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gimplemipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gimplemipsg1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.gimplemipsg1250.semver=12.5.0
+compiler.gimplemipsg1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gimplemipsg1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.gimplemipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.gimplemipsg1310.semver=13.1.0
@@ -428,7 +438,7 @@ compiler.gimplemipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-u
 
 ## MIPS64
 group.gimplemips64.groupName=MIPS64 GCC
-group.gimplemips64.compilers=gimplemips64g1210:gimplemips64g1220:gimplemips64g1230:gimplemips64g1240:gimplemips64g1310:gimplemips64g1320:gimplemips64g1330:gimplemips64g1410:gimplemips64g1420:gimplemips64g1510:gimplemips64g1430:gimplemips64g1340:gimplemips112064
+group.gimplemips64.compilers=gimplemips64g1210:gimplemips64g1220:gimplemips64g1230:gimplemips64g1240:gimplemips64g1310:gimplemips64g1320:gimplemips64g1330:gimplemips64g1410:gimplemips64g1420:gimplemips64g1510:gimplemips64g1430:gimplemips64g1340:gimplemips64g1250:gimplemips112064
 group.gimplemips64.baseName=mips64 gcc
 
 
@@ -454,6 +464,11 @@ compiler.gimplemips64g1240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-u
 compiler.gimplemips64g1240.semver=12.4.0
 compiler.gimplemips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gimplemips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gimplemips64g1250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.gimplemips64g1250.semver=12.5.0
+compiler.gimplemips64g1250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gimplemips64g1250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.gimplemips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.gimplemips64g1310.semver=13.1.0
@@ -497,7 +512,7 @@ compiler.gimplemips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mi
 
 ## MIPS EL
 group.gimplemipsel.groupName=MIPSEL GCC
-group.gimplemipsel.compilers=gimplemipselg1210:gimplemipselg1220:gimplemipselg1230:gimplemipselg1240:gimplemipselg1310:gimplemipselg1320:gimplemipselg1330:gimplemipselg1340:gimplemipselg1410:gimplemipselg1420:gimplemipselg1430:gimplemipselg1510
+group.gimplemipsel.compilers=gimplemipselg1210:gimplemipselg1220:gimplemipselg1230:gimplemipselg1240:gimplemipselg1250:gimplemipselg1310:gimplemipselg1320:gimplemipselg1330:gimplemipselg1340:gimplemipselg1410:gimplemipselg1420:gimplemipselg1430:gimplemipselg1510
 group.gimplemipsel.baseName=mips (el) gcc
 
 compiler.gimplemipselg1210.exe=/opt/compiler-explorer/mipsel/gcc-12.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
@@ -518,6 +533,11 @@ compiler.gimplemipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-m
 compiler.gimplemipselg1240.semver=12.4.0
 compiler.gimplemipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gimplemipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gimplemipselg1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.gimplemipselg1250.semver=12.5.0
+compiler.gimplemipselg1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gimplemipselg1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.gimplemipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.gimplemipselg1310.semver=13.1.0
@@ -561,7 +581,7 @@ compiler.gimplemipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mi
 
 ## MIPS64 EL
 group.gimplemips64el.groupName=MIPS64EL GCC
-group.gimplemips64el.compilers=gimplemips64elg1210:gimplemips64elg1220:gimplemips64elg1230:gimplemips64elg1240:gimplemips64elg1310:gimplemips64elg1320:gimplemips64elg1330:gimplemips64elg1410:gimplemips64elg1420:gimplemips64elg1510:gimplemips64elg1430:gimplemips64elg1340
+group.gimplemips64el.compilers=gimplemips64elg1210:gimplemips64elg1220:gimplemips64elg1230:gimplemips64elg1240:gimplemips64elg1310:gimplemips64elg1320:gimplemips64elg1330:gimplemips64elg1410:gimplemips64elg1420:gimplemips64elg1510:gimplemips64elg1430:gimplemips64elg1340:gimplemips64elg1250
 group.gimplemips64el.baseName=mips64 (el) gcc
 
 compiler.gimplemips64elg1210.exe=/opt/compiler-explorer/mips64el/gcc-12.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
@@ -582,6 +602,11 @@ compiler.gimplemips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips
 compiler.gimplemips64elg1240.semver=12.4.0
 compiler.gimplemips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.gimplemips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.gimplemips64elg1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.gimplemips64elg1250.semver=12.5.0
+compiler.gimplemips64elg1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gimplemips64elg1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.gimplemips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.gimplemips64elg1310.semver=13.1.0
@@ -787,7 +812,7 @@ compiler.gimplem68kg1510.demangler=/opt/compiler-explorer/m68k/gcc-15.1.0/m68k-u
 group.gimplesparc.compilers=&gimplegccsparc
 
 # GCC for SPARC
-group.gimplegccsparc.compilers=gimplesparcg1220:gimplesparcg1230:gimplesparcg1240:gimplesparcg1310:gimplesparcg1320:gimplesparcg1330:gimplesparcg1340:gimplesparcg1410:gimplesparcg1420:gimplesparcg1430:gimplesparcg1510
+group.gimplegccsparc.compilers=gimplesparcg1220:gimplesparcg1230:gimplesparcg1240:gimplesparcg1250:gimplesparcg1310:gimplesparcg1320:gimplesparcg1330:gimplesparcg1340:gimplesparcg1410:gimplesparcg1420:gimplesparcg1430:gimplesparcg1510
 group.gimplegccsparc.baseName=SPARC gcc
 group.gimplegccsparc.groupName=SPARC GCC
 group.gimplegccsparc.isSemVer=true
@@ -806,6 +831,11 @@ compiler.gimplesparcg1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unkn
 compiler.gimplesparcg1240.semver=12.4.0
 compiler.gimplesparcg1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gimplesparcg1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gimplesparcg1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.gimplesparcg1250.semver=12.5.0
+compiler.gimplesparcg1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gimplesparcg1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.gimplesparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
 compiler.gimplesparcg1310.semver=13.1.0
@@ -852,7 +882,7 @@ compiler.gimplesparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/spar
 group.gimplesparc64.compilers=&gimplegccsparc64
 
 # GCC for SPARC64
-group.gimplegccsparc64.compilers=gimplesparc64g1220:gimplesparc64g1230:gimplesparc64g1240:gimplesparc64g1310:gimplesparc64g1320:gimplesparc64g1330:gimplesparc64g1410:gimplesparc64g1420:gimplesparc64g1510:gimplesparc64g1430:gimplesparc64g1340
+group.gimplegccsparc64.compilers=gimplesparc64g1220:gimplesparc64g1230:gimplesparc64g1240:gimplesparc64g1310:gimplesparc64g1320:gimplesparc64g1330:gimplesparc64g1410:gimplesparc64g1420:gimplesparc64g1510:gimplesparc64g1430:gimplesparc64g1340:gimplesparc64g1250
 group.gimplegccsparc64.baseName=SPARC64 gcc
 group.gimplegccsparc64.groupName=SPARC64 GCC
 group.gimplegccsparc64.isSemVer=true
@@ -871,6 +901,11 @@ compiler.gimplesparc64g1240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc6
 compiler.gimplesparc64g1240.semver=12.4.0
 compiler.gimplesparc64g1240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gimplesparc64g1240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gimplesparc64g1250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.gimplesparc64g1250.semver=12.5.0
+compiler.gimplesparc64g1250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gimplesparc64g1250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.gimplesparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
 compiler.gimplesparc64g1310.semver=13.1.0
@@ -917,7 +952,7 @@ compiler.gimplesparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/
 group.gimplesparcleon.compilers=&gimplegccsparcleon
 
 # GCC for SPARC-LEON
-group.gimplegccsparcleon.compilers=gimplesparcleong1220:gimplesparcleong1220-1:gimplesparcleong1230:gimplesparcleong1240:gimplesparcleong1310:gimplesparcleong1320:gimplesparcleong1330:gimplesparcleong1340:gimplesparcleong1410:gimplesparcleong1420:gimplesparcleong1430:gimplesparcleong1510
+group.gimplegccsparcleon.compilers=gimplesparcleong1220:gimplesparcleong1220-1:gimplesparcleong1230:gimplesparcleong1240:gimplesparcleong1250:gimplesparcleong1310:gimplesparcleong1320:gimplesparcleong1330:gimplesparcleong1340:gimplesparcleong1410:gimplesparcleong1420:gimplesparcleong1430:gimplesparcleong1510
 group.gimplegccsparcleon.baseName=SPARC LEON gcc
 group.gimplegccsparcleon.groupName=SPARC LEON GCC
 group.gimplegccsparcleon.isSemVer=true
@@ -938,6 +973,11 @@ compiler.gimplesparcleong1240.exe=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/s
 compiler.gimplesparcleong1240.semver=12.4.0
 compiler.gimplesparcleong1240.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.gimplesparcleong1240.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.gimplesparcleong1250.exe=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.gimplesparcleong1250.semver=12.5.0
+compiler.gimplesparcleong1250.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.gimplesparcleong1250.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.gimplesparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.gimplesparcleong1310.semver=13.1.0
@@ -989,7 +1029,7 @@ compiler.gimplesparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-
 group.gimplec6x.compilers=&gimplegccc6x
 
 # GCC for TI C6x
-group.gimplegccc6x.compilers=gimplec6xg1220:gimplec6xg1230:gimplec6xg1240:gimplec6xg1310:gimplec6xg1320:gimplec6xg1330:gimplec6xg1410:gimplec6xg1420:gimplec6xg1510:gimplec6xg1430:gimplec6xg1340
+group.gimplegccc6x.compilers=gimplec6xg1220:gimplec6xg1230:gimplec6xg1240:gimplec6xg1310:gimplec6xg1320:gimplec6xg1330:gimplec6xg1410:gimplec6xg1420:gimplec6xg1510:gimplec6xg1430:gimplec6xg1340:gimplec6xg1250
 group.gimplegccc6x.baseName=TI C6x gcc
 group.gimplegccc6x.groupName=TI C6x GCC
 group.gimplegccc6x.isSemVer=true
@@ -1008,6 +1048,11 @@ compiler.gimplec6xg1240.exe=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/
 compiler.gimplec6xg1240.semver=12.4.0
 compiler.gimplec6xg1240.objdumper=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.gimplec6xg1240.demangler=/opt/compiler-explorer/c6x/gcc-12.4.0/tic6x-elf/bin/tic6x-elf-c++filt
+
+compiler.gimplec6xg1250.exe=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.gimplec6xg1250.semver=12.5.0
+compiler.gimplec6xg1250.objdumper=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.gimplec6xg1250.demangler=/opt/compiler-explorer/c6x/gcc-12.5.0/tic6x-elf/bin/tic6x-elf-c++filt
 
 compiler.gimplec6xg1310.exe=/opt/compiler-explorer/c6x/gcc-13.1.0/tic6x-elf/bin/tic6x-elf-gcc
 compiler.gimplec6xg1310.semver=13.1.0
@@ -1054,7 +1099,7 @@ compiler.gimplec6xg1510.demangler=/opt/compiler-explorer/c6x/gcc-15.1.0/tic6x-el
 group.gimpleloongarch64.compilers=&gimplegccloongarch64
 
 # GCC for loongarch64
-group.gimplegccloongarch64.compilers=gimpleloongarch64g1220:gimpleloongarch64g1230:gimpleloongarch64g1240:gimpleloongarch64g1310:gimpleloongarch64g1320:gimpleloongarch64g1330:gimpleloongarch64g1410:gimpleloongarch64g1420:gimpleloongarch64g1510:gimpleloongarch64g1430:gimpleloongarch64g1340
+group.gimplegccloongarch64.compilers=gimpleloongarch64g1220:gimpleloongarch64g1230:gimpleloongarch64g1240:gimpleloongarch64g1310:gimpleloongarch64g1320:gimpleloongarch64g1330:gimpleloongarch64g1410:gimpleloongarch64g1420:gimpleloongarch64g1510:gimpleloongarch64g1430:gimpleloongarch64g1340:gimpleloongarch64g1250
 group.gimplegccloongarch64.baseName=loongarch64 gcc
 group.gimplegccloongarch64.groupName=loongarch64 GCC
 group.gimplegccloongarch64.isSemVer=true
@@ -1073,6 +1118,11 @@ compiler.gimpleloongarch64g1240.exe=/opt/compiler-explorer/loongarch64/gcc-12.4.
 compiler.gimpleloongarch64g1240.semver=12.4.0
 compiler.gimpleloongarch64g1240.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.gimpleloongarch64g1240.demangler=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.gimpleloongarch64g1250.exe=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.gimpleloongarch64g1250.semver=12.5.0
+compiler.gimpleloongarch64g1250.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gimpleloongarch64g1250.demangler=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.gimpleloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
 compiler.gimpleloongarch64g1310.semver=13.1.0
@@ -1119,7 +1169,7 @@ compiler.gimpleloongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc
 group.gimplesh.compilers=&gimplegccsh
 
 # GCC for sh
-group.gimplegccsh.compilers=gimpleshg950:gimpleshg1220:gimpleshg1230:gimpleshg1240:gimpleshg1310:gimpleshg1320:gimpleshg1330:gimpleshg1340:gimpleshg1410:gimpleshg1420:gimpleshg1430:gimpleshg1510
+group.gimplegccsh.compilers=gimpleshg950:gimpleshg1220:gimpleshg1230:gimpleshg1240:gimpleshg1250:gimpleshg1310:gimpleshg1320:gimpleshg1330:gimpleshg1340:gimpleshg1410:gimpleshg1420:gimpleshg1430:gimpleshg1510
 group.gimplegccsh.baseName=sh gcc
 group.gimplegccsh.groupName=sh GCC
 group.gimplegccsh.isSemVer=true
@@ -1143,6 +1193,11 @@ compiler.gimpleshg1240.exe=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/b
 compiler.gimpleshg1240.semver=12.4.0
 compiler.gimpleshg1240.objdumper=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.gimpleshg1240.demangler=/opt/compiler-explorer/sh/gcc-12.4.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
+compiler.gimpleshg1250.exe=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.gimpleshg1250.semver=12.5.0
+compiler.gimpleshg1250.objdumper=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.gimpleshg1250.demangler=/opt/compiler-explorer/sh/gcc-12.5.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
 
 compiler.gimpleshg1310.exe=/opt/compiler-explorer/sh/gcc-13.1.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
 compiler.gimpleshg1310.semver=13.1.0
@@ -1189,7 +1244,7 @@ compiler.gimpleshg1510.demangler=/opt/compiler-explorer/sh/gcc-15.1.0/sh-unknown
 group.gimples390x.compilers=&gimplegccs390x
 
 # GCC for s390x
-group.gimplegccs390x.compilers=gimplegccs390x112:gimples390xg1210:gimples390xg1220:gimples390xg1230:gimples390xg1240:gimples390xg1310:gimples390xg1320:gimples390xg1330:gimples390xg1410:gimples390xg1420:gimples390xg1510:gimples390xg1430:gimples390xg1340
+group.gimplegccs390x.compilers=gimplegccs390x112:gimples390xg1210:gimples390xg1220:gimples390xg1230:gimples390xg1240:gimples390xg1310:gimples390xg1320:gimples390xg1330:gimples390xg1410:gimples390xg1420:gimples390xg1510:gimples390xg1430:gimples390xg1340:gimples390xg1250
 group.gimplegccs390x.baseName=s390x gcc
 group.gimplegccs390x.groupName=s390x GCC
 group.gimplegccs390x.isSemVer=true
@@ -1216,6 +1271,11 @@ compiler.gimples390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-
 compiler.gimples390xg1240.semver=12.4.0
 compiler.gimples390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gimples390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gimples390xg1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.gimples390xg1250.semver=12.5.0
+compiler.gimples390xg1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gimples390xg1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.gimples390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
 compiler.gimples390xg1310.semver=13.1.0
@@ -1263,7 +1323,7 @@ group.gimpleppcs.compilers=&gimpleppc:&gimpleppc64:&gimpleppc64le
 group.gimpleppcs.isSemVer=true
 group.gimpleppcs.instructionSet=powerpc
 
-group.gimpleppc.compilers=gimpleppcg1120:gimpleppcg1210:gimpleppcg1220:gimpleppcg1230:gimpleppcg1240:gimpleppcg1310:gimpleppcg1320:gimpleppcg1330:gimpleppcg1340:gimpleppcg1410:gimpleppcg1420:gimpleppcg1430:gimpleppcg1510
+group.gimpleppc.compilers=gimpleppcg1120:gimpleppcg1210:gimpleppcg1220:gimpleppcg1230:gimpleppcg1240:gimpleppcg1250:gimpleppcg1310:gimpleppcg1320:gimpleppcg1330:gimpleppcg1340:gimpleppcg1410:gimpleppcg1420:gimpleppcg1430:gimpleppcg1510
 group.gimpleppc.groupName=POWER
 group.gimpleppc.baseName=power gcc
 
@@ -1289,6 +1349,11 @@ compiler.gimpleppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-un
 compiler.gimpleppcg1240.semver=12.4.0
 compiler.gimpleppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gimpleppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gimpleppcg1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.gimpleppcg1250.semver=12.5.0
+compiler.gimpleppcg1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gimpleppcg1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.gimpleppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.gimpleppcg1310.semver=13.1.0
@@ -1330,7 +1395,7 @@ compiler.gimpleppcg1510.semver=15.1.0
 compiler.gimpleppcg1510.objdumper=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gimpleppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.gimpleppc64.compilers=gimpleppc64g9:gimpleppc64g1120:gimpleppc64g1210:gimpleppc64g1220:gimpleppc64g1230:gimpleppc64g1240:gimpleppc64g1310:gimpleppc64g1320:gimpleppc64g1330:gimpleppc64g1410:gimpleppc64g1420:gimpleppc64g1510:gimpleppc64g1430:gimpleppc64g1340
+group.gimpleppc64.compilers=gimpleppc64g9:gimpleppc64g1120:gimpleppc64g1210:gimpleppc64g1220:gimpleppc64g1230:gimpleppc64g1240:gimpleppc64g1310:gimpleppc64g1320:gimpleppc64g1330:gimpleppc64g1410:gimpleppc64g1420:gimpleppc64g1510:gimpleppc64g1430:gimpleppc64g1340:gimpleppc64g1250
 group.gimpleppc64.groupName=POWER64
 group.gimpleppc64.baseName=POWER64 gcc
 
@@ -1361,6 +1426,11 @@ compiler.gimpleppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerp
 compiler.gimpleppc64g1240.semver=12.4.0
 compiler.gimpleppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gimpleppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64g1250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.gimpleppc64g1250.semver=12.5.0
+compiler.gimpleppc64g1250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gimpleppc64g1250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gimpleppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.gimpleppc64g1310.semver=13.1.0
@@ -1402,7 +1472,7 @@ compiler.gimpleppc64g1510.semver=15.1.0
 compiler.gimpleppc64g1510.objdumper=/opt/compiler-explorer/powerpc64/gcc-15.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gimpleppc64g1510.demangler=/opt/compiler-explorer/powerpc64/gcc-15.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
-group.gimpleppc64le.compilers=gimpleppc64leg9:gimpleppc64leg1120:gimpleppc64leg1210:gimpleppc64leg1220:gimpleppc64leg1230:gimpleppc64leg1240:gimpleppc64leg1310:gimpleppc64leg1320:gimpleppc64leg1330:gimpleppc64leg1410:gimpleppc64leg1420:gimpleppc64leg1510:gimpleppc64leg1430:gimpleppc64leg1340
+group.gimpleppc64le.compilers=gimpleppc64leg9:gimpleppc64leg1120:gimpleppc64leg1210:gimpleppc64leg1220:gimpleppc64leg1230:gimpleppc64leg1240:gimpleppc64leg1310:gimpleppc64leg1320:gimpleppc64leg1330:gimpleppc64leg1410:gimpleppc64leg1420:gimpleppc64leg1510:gimpleppc64leg1430:gimpleppc64leg1340:gimpleppc64leg1250
 group.gimpleppc64le.groupName=POWER64LE GCC
 group.gimpleppc64le.baseName=power64le gcc
 
@@ -1433,6 +1503,11 @@ compiler.gimpleppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/po
 compiler.gimpleppc64leg1240.semver=12.4.0
 compiler.gimpleppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gimpleppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gimpleppc64leg1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.gimpleppc64leg1250.semver=12.5.0
+compiler.gimpleppc64leg1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gimpleppc64leg1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gimpleppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.gimpleppc64leg1310.semver=13.1.0
@@ -1477,7 +1552,7 @@ compiler.gimpleppc64leg1510.demangler=/opt/compiler-explorer/powerpc64le/gcc-15.
 
 ################################
 # GCC for MSP
-group.gimplemsp.compilers=gimplemsp430g1210:gimplemsp430g1220:gimplemsp430g1230:gimplemsp430g1240:gimplemsp430g1310:gimplemsp430g1320:gimplemsp430g1330:gimplemsp430g1410:gimplemsp430g1420:gimplemsp430g1510:gimplemsp430g1430:gimplemsp430g1340
+group.gimplemsp.compilers=gimplemsp430g1210:gimplemsp430g1220:gimplemsp430g1230:gimplemsp430g1240:gimplemsp430g1310:gimplemsp430g1320:gimplemsp430g1330:gimplemsp430g1410:gimplemsp430g1420:gimplemsp430g1510:gimplemsp430g1430:gimplemsp430g1340:gimplemsp430g1250
 group.gimplemsp.groupName=MSP GCC
 group.gimplemsp.baseName=MSP430 gcc
 group.gimplemsp.isSemVer=true
@@ -1501,6 +1576,11 @@ compiler.gimplemsp430g1240.exe=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-u
 compiler.gimplemsp430g1240.semver=12.4.0
 compiler.gimplemsp430g1240.objdumper=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
 compiler.gimplemsp430g1240.demangler=/opt/compiler-explorer/msp430/gcc-12.4.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
+
+compiler.gimplemsp430g1250.exe=/opt/compiler-explorer/msp430/gcc-12.5.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
+compiler.gimplemsp430g1250.semver=12.5.0
+compiler.gimplemsp430g1250.objdumper=/opt/compiler-explorer/msp430/gcc-12.5.0/msp430-unknown-elf/bin/msp430-unknown-elf-objdump
+compiler.gimplemsp430g1250.demangler=/opt/compiler-explorer/msp430/gcc-12.5.0/msp430-unknown-elf/bin/msp430-unknown-elf-c++filt
 
 compiler.gimplemsp430g1310.exe=/opt/compiler-explorer/msp430/gcc-13.1.0/msp430-unknown-elf/bin/msp430-unknown-elf-gcc
 compiler.gimplemsp430g1310.semver=13.1.0
@@ -1555,7 +1635,7 @@ group.gimplegccarm.includeFlag=-I
 # 32 bit
 group.gimplegcc32arm.groupName=Arm 32-bit GCC
 group.gimplegcc32arm.baseName=ARM GCC
-group.gimplegcc32arm.compilers=gimplearm921:gimplearm930:gimplearm1020:gimplearm1021:gimplearm1030:gimplearm1031_07:gimplearm1031_10:gimplearmg1050:gimplearm1100:gimplearm1120:gimplearm1121:gimplearm1130:gimplearmg1140:gimplearm1210:gimplearmg1220:gimplearmg1230:gimplearmg1240:gimplearmg1310:gimplearmg1320:gimplearmug1320:gimplearmg1330:gimplearmug1330:gimplearmg1340:gimplearmug1340:gimplearmg1410:gimplearmug1410:gimplearmg1420:gimplearmug1420:gimplearmg1430:gimplearmug1430:gimplearmg1510:gimplearmgtrunk
+group.gimplegcc32arm.compilers=gimplearm921:gimplearm930:gimplearm1020:gimplearm1021:gimplearm1030:gimplearm1031_07:gimplearm1031_10:gimplearmg1050:gimplearm1100:gimplearm1120:gimplearm1121:gimplearm1130:gimplearmg1140:gimplearm1210:gimplearmg1220:gimplearmg1230:gimplearmg1240:gimplearmg1250:gimplearmg1310:gimplearmg1320:gimplearmug1320:gimplearmg1330:gimplearmug1330:gimplearmg1340:gimplearmug1340:gimplearmg1410:gimplearmug1410:gimplearmg1420:gimplearmug1420:gimplearmg1430:gimplearmug1430:gimplearmg1510:gimplearmgtrunk
 group.gimplegcc32arm.isSemVer=true
 group.gimplegcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gimplegcc32arm.instructionSet=arm32
@@ -1584,6 +1664,11 @@ compiler.gimplearmg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-li
 compiler.gimplearmg1240.semver=12.4.0
 compiler.gimplearmg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gimplearmg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.gimplearmg1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.gimplearmg1250.semver=12.5.0
+compiler.gimplearmg1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gimplearmg1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.gimplearmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.gimplearmg1310.semver=13.1.0 (linux)
@@ -1700,7 +1785,7 @@ compiler.gimplearmgtrunk.isNightly=true
 # 64 bit
 group.gimplegcc64arm.groupName=ARM64 gcc
 group.gimplegcc64arm.baseName=ARM64 GCC
-group.gimplegcc64arm.compilers=gimplearm64g930:gimplearm64g940:gimplearm64g950:gimplearm64g1020:gimplearm64g1030:gimplearm64g1040:gimplearm64g1100:gimplearm64g1120:gimplearm64g1130:gimplearm64g1140:gimplearm64g1210:gimplearm64gtrunk:gimplearm64g1220:gimplearm64g1230:gimplearm64g1240:gimplearm64g1310:gimplearm64g1050:gimplearm64g1320:gimplearm64g1330:gimplearm64g1410:gimplearm64g1420:gimplearm64g1510:gimplearm64g1430:gimplearm64g1340
+group.gimplegcc64arm.compilers=gimplearm64g930:gimplearm64g940:gimplearm64g950:gimplearm64g1020:gimplearm64g1030:gimplearm64g1040:gimplearm64g1100:gimplearm64g1120:gimplearm64g1130:gimplearm64g1140:gimplearm64g1210:gimplearm64gtrunk:gimplearm64g1220:gimplearm64g1230:gimplearm64g1240:gimplearm64g1310:gimplearm64g1050:gimplearm64g1320:gimplearm64g1330:gimplearm64g1410:gimplearm64g1420:gimplearm64g1510:gimplearm64g1430:gimplearm64g1340:gimplearm64g1250
 group.gimplegcc64arm.isSemVer=true
 group.gimplegcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gimplegcc64arm.instructionSet=aarch64
@@ -1752,6 +1837,11 @@ compiler.gimplearm64g1240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-un
 compiler.gimplearm64g1240.semver=12.4.0
 compiler.gimplearm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gimplearm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.gimplearm64g1250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.gimplearm64g1250.semver=12.5.0
+compiler.gimplearm64g1250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gimplearm64g1250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.gimplearm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.gimplearm64g1310.semver=13.1.0
@@ -1820,7 +1910,7 @@ group.gimplervgcc.supportsBinary=true
 group.gimplervgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 64-bits
-group.rv64-gimplegccs.compilers=rv64-gimplegcctrunk:rv64-gimplegcc1230:rv64-gimplegcc1240:rv64-gimplegcc1210:rv64-gimplegcc1140:rv64-gimplegcc1130:rv64-gimplegcc1220:rv64-gimplegcc1120:rv64-gimplegcc1030:rv64-gimplegcc1020:rv64-gimplegcc940:rv64-gimplegcc1310:rv64-gimplegcc1320:rv64-gimplegcc1330:rv64-gimplegcc1410:rv64-gimplegcc1420:rv64-gimplegcc1510:rv64-gimplegcc1430:rv64-gimplegcc1340
+group.rv64-gimplegccs.compilers=rv64-gimplegcctrunk:rv64-gimplegcc1230:rv64-gimplegcc1240:rv64-gimplegcc1210:rv64-gimplegcc1140:rv64-gimplegcc1130:rv64-gimplegcc1220:rv64-gimplegcc1120:rv64-gimplegcc1030:rv64-gimplegcc1020:rv64-gimplegcc940:rv64-gimplegcc1310:rv64-gimplegcc1320:rv64-gimplegcc1330:rv64-gimplegcc1410:rv64-gimplegcc1420:rv64-gimplegcc1510:rv64-gimplegcc1430:rv64-gimplegcc1340:rv64-gimplegcc1250
 group.rv64-gimplegccs.groupName=RISC-V (64-bits) gcc
 group.rv64-gimplegccs.baseName=RISC-V (64-bits) gcc
 
@@ -1867,6 +1957,11 @@ compiler.rv64-gimplegcc1240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv6
 compiler.rv64-gimplegcc1240.semver=12.4.0
 compiler.rv64-gimplegcc1240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gimplegcc1240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.rv64-gimplegcc1250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-gimplegcc1250.semver=12.5.0
+compiler.rv64-gimplegcc1250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gimplegcc1250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.rv64-gimplegcc1310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-gimplegcc1310.semver=13.1.0
@@ -1915,7 +2010,7 @@ compiler.rv64-gimplegcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/
 compiler.rv64-gimplegcctrunk.isNightly=true
 
 ## GCC for RISC-V 32-bits
-group.rv32-gimplegccs.compilers=rv32-gimplegcctrunk:rv32-gimplegcc1220:rv32-gimplegcc1210:rv32-gimplegcc1140:rv32-gimplegcc1130:rv32-gimplegcc1120:rv32-gimplegcc1030:rv32-gimplegcc1020:rv32-gimplegcc940:rv32-gimplegcc1310:rv32-gimplegcc1230:rv32-gimplegcc1240:rv32-gimplegcc1320:rv32-gimplegcc1330:rv32-gimplegcc1410:rv32-gimplegcc1420:rv32-gimplegcc1510:rv32-gimplegcc1430:rv32-gimplegcc1340
+group.rv32-gimplegccs.compilers=rv32-gimplegcctrunk:rv32-gimplegcc1220:rv32-gimplegcc1210:rv32-gimplegcc1140:rv32-gimplegcc1130:rv32-gimplegcc1120:rv32-gimplegcc1030:rv32-gimplegcc1020:rv32-gimplegcc940:rv32-gimplegcc1310:rv32-gimplegcc1230:rv32-gimplegcc1240:rv32-gimplegcc1320:rv32-gimplegcc1330:rv32-gimplegcc1410:rv32-gimplegcc1420:rv32-gimplegcc1510:rv32-gimplegcc1430:rv32-gimplegcc1340:rv32-gimplegcc1250
 group.rv32-gimplegccs.groupName=RISC-V (32-bits) gcc
 group.rv32-gimplegccs.baseName=RISC-V (32-bits) gcc
 
@@ -1962,6 +2057,11 @@ compiler.rv32-gimplegcc1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv3
 compiler.rv32-gimplegcc1240.semver=12.4.0
 compiler.rv32-gimplegcc1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gimplegcc1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.rv32-gimplegcc1250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-gimplegcc1250.semver=12.5.0
+compiler.rv32-gimplegcc1250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gimplegcc1250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.rv32-gimplegcc1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.rv32-gimplegcc1310.semver=13.1.0

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -596,7 +596,7 @@ group.cross.groupName=Cross Go
 
 ###############################
 # GCC for sparc
-group.gccgosparc.compilers=gccgosparc1220:gccgosparc1230:gccgosparc1240:gccgosparc1310:gccgosparc1320:gccgosparc1330:gccgosparc1340:gccgosparc1410:gccgosparc1420:gccgosparc1430:gccgosparc1510
+group.gccgosparc.compilers=gccgosparc1220:gccgosparc1230:gccgosparc1240:gccgosparc1250:gccgosparc1310:gccgosparc1320:gccgosparc1330:gccgosparc1340:gccgosparc1410:gccgosparc1420:gccgosparc1430:gccgosparc1510
 group.gccgosparc.groupName=SPARC GCCGO
 group.gccgosparc.baseName=SPARC gccgo
 group.gccgosparc.isSemVer=true
@@ -615,6 +615,11 @@ compiler.gccgosparc1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknow
 compiler.gccgosparc1240.semver=12.4.0
 compiler.gccgosparc1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gccgosparc1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.gccgosparc1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
+compiler.gccgosparc1250.semver=12.5.0
+compiler.gccgosparc1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gccgosparc1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.gccgosparc1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gccgo
 compiler.gccgosparc1310.semver=13.1.0
@@ -658,7 +663,7 @@ compiler.gccgosparc1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-
 
 ###############################
 # GCC for sparc64
-group.gccgosparc64.compilers=gccgosparc641220:gccgosparc641230:gccgosparc641240:gccgosparc641310:gccgosparc641320:gccgosparc641330:gccgosparc641340:gccgosparc641410:gccgosparc641420:gccgosparc641430:gccgosparc641510
+group.gccgosparc64.compilers=gccgosparc641220:gccgosparc641230:gccgosparc641240:gccgosparc641250:gccgosparc641310:gccgosparc641320:gccgosparc641330:gccgosparc641340:gccgosparc641410:gccgosparc641420:gccgosparc641430:gccgosparc641510
 group.gccgosparc64.groupName=SPARC64 GCCGO
 group.gccgosparc64.baseName=SPARC64 gccgo
 group.gccgosparc64.isSemVer=true
@@ -678,6 +683,11 @@ compiler.gccgosparc641240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-
 compiler.gccgosparc641240.semver=12.4.0
 compiler.gccgosparc641240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gccgosparc641240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.gccgosparc641250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
+compiler.gccgosparc641250.semver=12.5.0
+compiler.gccgosparc641250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gccgosparc641250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.gccgosparc641310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gccgo
 compiler.gccgosparc641310.semver=13.1.0
@@ -721,7 +731,7 @@ compiler.gccgosparc641510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/sp
 
 ###############################
 # GCC for mips64el
-group.gccgomips64el.compilers=gccgomips64el1220:gccgomips64el1230:gccgomips64el1310:gccgomips64el1320:gccgomips64el1410:gccgomips64el1330:gccgomips64el1240:gccgomips64el1420:gccgomips64el1510:gccgomips64el1430:gccgomips64el1340
+group.gccgomips64el.compilers=gccgomips64el1220:gccgomips64el1230:gccgomips64el1310:gccgomips64el1320:gccgomips64el1410:gccgomips64el1330:gccgomips64el1240:gccgomips64el1420:gccgomips64el1510:gccgomips64el1430:gccgomips64el1340:gccgomips64el1250
 group.gccgomips64el.groupName=MIPS64EL GCCGO
 group.gccgomips64el.baseName=MIPS64EL gccgo
 group.gccgomips64el.isSemVer=true
@@ -740,6 +750,11 @@ compiler.gccgomips64el1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64
 compiler.gccgomips64el1240.semver=12.4.0
 compiler.gccgomips64el1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.gccgomips64el1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.gccgomips64el1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
+compiler.gccgomips64el1250.semver=12.5.0
+compiler.gccgomips64el1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.gccgomips64el1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.gccgomips64el1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gccgo
 compiler.gccgomips64el1310.semver=13.1.0
@@ -783,7 +798,7 @@ compiler.gccgomips64el1510.demangler=/opt/compiler-explorer/mips64el/gcc-15.1.0/
 
 ###############################
 # GCC for mipsel
-group.gccgomipsel.compilers=gccgomipsel1220:gccgomipsel1230:gccgomipsel1240:gccgomipsel1310:gccgomipsel1320:gccgomipsel1330:gccgomipsel1340:gccgomipsel1410:gccgomipsel1420:gccgomipsel1430:gccgomipsel1510
+group.gccgomipsel.compilers=gccgomipsel1220:gccgomipsel1230:gccgomipsel1240:gccgomipsel1250:gccgomipsel1310:gccgomipsel1320:gccgomipsel1330:gccgomipsel1340:gccgomipsel1410:gccgomipsel1420:gccgomipsel1430:gccgomipsel1510
 group.gccgomipsel.groupName=MIPSEL GCCGO
 group.gccgomipsel.baseName=MIPSEL gccgo
 group.gccgomipsel.isSemVer=true
@@ -802,6 +817,11 @@ compiler.gccgomipsel1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-mul
 compiler.gccgomipsel1240.semver=12.4.0
 compiler.gccgomipsel1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.gccgomipsel1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.gccgomipsel1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
+compiler.gccgomipsel1250.semver=12.5.0
+compiler.gccgomipsel1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.gccgomipsel1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.gccgomipsel1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gccgo
 compiler.gccgomipsel1310.semver=13.1.0
@@ -845,7 +865,7 @@ compiler.gccgomipsel1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mips
 
 ###############################
 # GCC for riscv64
-group.gccgoriscv64.compilers=gccgoriscv641220:gccgoriscv641230:gccgoriscv641240:gccgoriscv641310:gccgoriscv641320:gccgoriscv641330:gccgoriscv641340:gccgoriscv641410:gccgoriscv641420:gccgoriscv641430:gccgoriscv641510
+group.gccgoriscv64.compilers=gccgoriscv641220:gccgoriscv641230:gccgoriscv641240:gccgoriscv641250:gccgoriscv641310:gccgoriscv641320:gccgoriscv641330:gccgoriscv641340:gccgoriscv641410:gccgoriscv641420:gccgoriscv641430:gccgoriscv641510
 group.gccgoriscv64.groupName=RISC-V 64 GCCGO
 group.gccgoriscv64.baseName=RISC-V 64 gccgo
 group.gccgoriscv64.isSemVer=true
@@ -864,6 +884,11 @@ compiler.gccgoriscv641240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-
 compiler.gccgoriscv641240.semver=12.4.0
 compiler.gccgoriscv641240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gccgoriscv641240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.gccgoriscv641250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
+compiler.gccgoriscv641250.semver=12.5.0
+compiler.gccgoriscv641250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gccgoriscv641250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.gccgoriscv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gccgo
 compiler.gccgoriscv641310.semver=13.1.0
@@ -907,7 +932,7 @@ compiler.gccgoriscv641510.demangler=/opt/compiler-explorer/riscv64/gcc-15.1.0/ri
 
 ###############################
 # GCC for s390x
-group.gccgos390x.compilers=gccgos390x1220:gccgos390x1230:gccgos390x1310:gccgos390x1320:gccgos390x1410:gccgos390x1330:gccgos390x1240:gccgos390x1420:gccgos390x1510:gccgos390x1430:gccgos390x1340
+group.gccgos390x.compilers=gccgos390x1220:gccgos390x1230:gccgos390x1310:gccgos390x1320:gccgos390x1410:gccgos390x1330:gccgos390x1240:gccgos390x1420:gccgos390x1510:gccgos390x1430:gccgos390x1340:gccgos390x1250
 group.gccgos390x.groupName=S390X GCCGO
 group.gccgos390x.baseName=S390X gccgo
 group.gccgos390x.isSemVer=true
@@ -926,6 +951,11 @@ compiler.gccgos390x1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-li
 compiler.gccgos390x1240.semver=12.4.0
 compiler.gccgos390x1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gccgos390x1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.gccgos390x1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
+compiler.gccgos390x1250.semver=12.5.0
+compiler.gccgos390x1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gccgos390x1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.gccgos390x1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gccgo
 compiler.gccgos390x1310.semver=13.1.0
@@ -969,7 +999,7 @@ compiler.gccgos390x1510.demangler=/opt/compiler-explorer/s390x/gcc-15.1.0/s390x-
 
 ###############################
 # GCC for MIPS
-group.gccgomips.compilers=gccgomips1220:gccgomips1230:gccgomips1240:gccgomips1310:gccgomips1320:gccgomips1330:gccgomips1340:gccgomips1410:gccgomips1420:gccgomips1430:gccgomips1510
+group.gccgomips.compilers=gccgomips1220:gccgomips1230:gccgomips1240:gccgomips1250:gccgomips1310:gccgomips1320:gccgomips1330:gccgomips1340:gccgomips1410:gccgomips1420:gccgomips1430:gccgomips1510
 group.gccgomips.groupName=MIPS GCCGO
 group.gccgomips.baseName=MIPS gccgo
 group.gccgomips.isSemVer=true
@@ -988,6 +1018,11 @@ compiler.gccgomips1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-l
 compiler.gccgomips1240.semver=12.4.0
 compiler.gccgomips1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gccgomips1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.gccgomips1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
+compiler.gccgomips1250.semver=12.5.0
+compiler.gccgomips1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gccgomips1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.gccgomips1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gccgo
 compiler.gccgomips1310.semver=13.1.0
@@ -1031,7 +1066,7 @@ compiler.gccgomips1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unk
 
 ###############################
 # GCC for MIPS64
-group.gccgomips64.compilers=gccgomips641220:gccgomips641230:gccgomips641240:gccgomips641310:gccgomips641320:gccgomips641330:gccgomips641340:gccgomips641410:gccgomips641420:gccgomips641430:gccgomips641510
+group.gccgomips64.compilers=gccgomips641220:gccgomips641230:gccgomips641240:gccgomips641250:gccgomips641310:gccgomips641320:gccgomips641330:gccgomips641340:gccgomips641410:gccgomips641420:gccgomips641430:gccgomips641510
 group.gccgomips64.groupName=MIPS64 GCCGO
 group.gccgomips64.baseName=MIPS64 gccgo
 group.gccgomips64.isSemVer=true
@@ -1050,6 +1085,11 @@ compiler.gccgomips641240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unk
 compiler.gccgomips641240.semver=12.4.0
 compiler.gccgomips641240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gccgomips641240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.gccgomips641250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
+compiler.gccgomips641250.semver=12.5.0
+compiler.gccgomips641250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gccgomips641250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.gccgomips641310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gccgo
 compiler.gccgomips641310.semver=13.1.0
@@ -1093,7 +1133,7 @@ compiler.gccgomips641510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips
 
 ###############################
 # GCC for ARM64
-group.gccgoarm64.compilers=gccgoarm641220:gccgoarm641230:gccgoarm641240:gccgoarm641310:gccgoarm641320:gccgoarm641330:gccgoarm641340:gccgoarm641410:gccgoarm641420:gccgoarm641430:gccgoarm641510
+group.gccgoarm64.compilers=gccgoarm641220:gccgoarm641230:gccgoarm641240:gccgoarm641250:gccgoarm641310:gccgoarm641320:gccgoarm641330:gccgoarm641340:gccgoarm641410:gccgoarm641420:gccgoarm641430:gccgoarm641510
 group.gccgoarm64.groupName=ARM64 GCCGO
 group.gccgoarm64.baseName=ARM64 gccgo
 group.gccgoarm64.isSemVer=true
@@ -1112,6 +1152,11 @@ compiler.gccgoarm641240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unkn
 compiler.gccgoarm641240.semver=12.4.0
 compiler.gccgoarm641240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gccgoarm641240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.gccgoarm641250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
+compiler.gccgoarm641250.semver=12.5.0
+compiler.gccgoarm641250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gccgoarm641250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.gccgoarm641310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gccgo
 compiler.gccgoarm641310.semver=13.1.0
@@ -1155,7 +1200,7 @@ compiler.gccgoarm641510.demangler=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch6
 
 ###############################
 # GCC for ARM
-group.gccgoarm.compilers=gccgoarm1220:gccgoarm1230:gccgoarm1240:gccgoarm1310:gccgoarm1320:gccgoarm1330:gccgoarm1340:gccgoarm1410:gccgoarm1420:gccgoarm1430:gccgoarm1510
+group.gccgoarm.compilers=gccgoarm1220:gccgoarm1230:gccgoarm1240:gccgoarm1250:gccgoarm1310:gccgoarm1320:gccgoarm1330:gccgoarm1340:gccgoarm1410:gccgoarm1420:gccgoarm1430:gccgoarm1510
 group.gccgoarm.groupName=ARM GCCGO
 group.gccgoarm.baseName=ARM gccgo
 group.gccgoarm.isSemVer=true
@@ -1174,6 +1219,11 @@ compiler.gccgoarm1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linu
 compiler.gccgoarm1240.semver=12.4.0
 compiler.gccgoarm1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gccgoarm1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.gccgoarm1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
+compiler.gccgoarm1250.semver=12.5.0
+compiler.gccgoarm1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gccgoarm1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.gccgoarm1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gccgo
 compiler.gccgoarm1310.semver=13.1.0
@@ -1217,7 +1267,7 @@ compiler.gccgoarm1510.demangler=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknow
 
 ###############################
 # GCC for PPC
-group.gccgoppc.compilers=gccgoppc1220:gccgoppc1230:gccgoppc1240:gccgoppc1310:gccgoppc1320:gccgoppc1330:gccgoppc1340:gccgoppc1410:gccgoppc1420:gccgoppc1430:gccgoppc1510
+group.gccgoppc.compilers=gccgoppc1220:gccgoppc1230:gccgoppc1240:gccgoppc1250:gccgoppc1310:gccgoppc1320:gccgoppc1330:gccgoppc1340:gccgoppc1410:gccgoppc1420:gccgoppc1430:gccgoppc1510
 group.gccgoppc.groupName=POWER GCCGO
 group.gccgoppc.baseName=POWER gccgo
 group.gccgoppc.isSemVer=true
@@ -1236,6 +1286,11 @@ compiler.gccgoppc1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unkn
 compiler.gccgoppc1240.semver=12.4.0
 compiler.gccgoppc1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gccgoppc1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.gccgoppc1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
+compiler.gccgoppc1250.semver=12.5.0
+compiler.gccgoppc1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gccgoppc1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.gccgoppc1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gccgo
 compiler.gccgoppc1310.semver=13.1.0
@@ -1279,7 +1334,7 @@ compiler.gccgoppc1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerp
 
 ###############################
 # GCC for PPC64LE
-group.gccgoppc64le.compilers=gccgoppc64le1220:gccgoppc64le1230:gppc64leg9:gppc64leg8:gccgoppc64le1310:gccgoppc64le1320:gccgoppc64letrunk:gccgoppc64le1410:gccgoppc64le1330:gccgoppc64le1240:gccgoppc64le1420:gccgoppc64le1510:gccgoppc64le1430:gccgoppc64le1340
+group.gccgoppc64le.compilers=gccgoppc64le1220:gccgoppc64le1230:gppc64leg9:gppc64leg8:gccgoppc64le1310:gccgoppc64le1320:gccgoppc64letrunk:gccgoppc64le1410:gccgoppc64le1330:gccgoppc64le1240:gccgoppc64le1420:gccgoppc64le1510:gccgoppc64le1430:gccgoppc64le1340:gccgoppc64le1250
 group.gccgoppc64le.groupName=POWER64LE GCCGO
 group.gccgoppc64le.baseName=POWER64LE gccgo
 group.gccgoppc64le.isSemVer=true
@@ -1298,6 +1353,11 @@ compiler.gccgoppc64le1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powe
 compiler.gccgoppc64le1240.semver=12.4.0
 compiler.gccgoppc64le1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gccgoppc64le1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.gccgoppc64le1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
+compiler.gccgoppc64le1250.semver=12.5.0
+compiler.gccgoppc64le1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gccgoppc64le1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gccgoppc64le1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gccgo
 compiler.gccgoppc64le1310.semver=13.1.0
@@ -1352,7 +1412,7 @@ compiler.gppc64leg8.semver=AT12.0
 
 ###############################
 # GCC for PPC64
-group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc64trunk:gccgoppc641220:gccgoppc641230:gccgoppc641240:gccgoppc641310:gccgoppc641320:gccgoppc641330:gccgoppc641340:gccgoppc641410:gccgoppc641420:gccgoppc641430:gccgoppc641510
+group.gccgoppc64.compilers=gppc64g8:gppc64g9:gccgoppc64trunk:gccgoppc641220:gccgoppc641230:gccgoppc641240:gccgoppc641250:gccgoppc641310:gccgoppc641320:gccgoppc641330:gccgoppc641340:gccgoppc641410:gccgoppc641420:gccgoppc641430:gccgoppc641510
 group.gccgoppc64.groupName=POWER64 GCCGO
 group.gccgoppc64.baseName=POWER64 gccgo
 group.gccgoppc64.isSemVer=true
@@ -1371,6 +1431,11 @@ compiler.gccgoppc641240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc6
 compiler.gccgoppc641240.semver=12.4.0
 compiler.gccgoppc641240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gccgoppc641240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.gccgoppc641250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
+compiler.gccgoppc641250.semver=12.5.0
+compiler.gccgoppc641250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gccgoppc641250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gccgoppc641310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gccgo
 compiler.gccgoppc641310.semver=13.1.0

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gccgo:&gl:&cross
 defaultCompiler=gl1242
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 
-group.gccgo.compilers=&gccgoassert:gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo124:gccgo131:gccgo132:gccgo133:gccgo134:gccgo141:gccgo142:gccgo143:gccgo151
+group.gccgo.compilers=&gccgoassert:gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo124:gccgo125:gccgo131:gccgo132:gccgo133:gccgo134:gccgo141:gccgo142:gccgo143:gccgo151
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -39,6 +39,8 @@ compiler.gccgo123.exe=/opt/compiler-explorer/gcc-12.3.0/bin/gccgo
 compiler.gccgo123.semver=12.3.0
 compiler.gccgo124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gccgo
 compiler.gccgo124.semver=12.4.0
+compiler.gccgo125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gccgo
+compiler.gccgo125.semver=12.5.0
 compiler.gccgo131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gccgo
 compiler.gccgo131.semver=13.1
 compiler.gccgo132.exe=/opt/compiler-explorer/gcc-13.2.0/bin/gccgo
@@ -57,7 +59,7 @@ compiler.gccgo151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gccgo
 compiler.gccgo151.semver=15.1
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gccgoassert.compilers=gccgo105assert:gccgo111assert:gccgo112assert:gccgo113assert:gccgo114assert:gccgo121assert:gccgo122assert:gccgo123assert:gccgo124assert:gccgo131assert:gccgo132assert:gccgo133assert:gccgo134assert:gccgo141assert:gccgo142assert:gccgo143assert:gccgo151assert
+group.gccgoassert.compilers=gccgo105assert:gccgo111assert:gccgo112assert:gccgo113assert:gccgo114assert:gccgo121assert:gccgo122assert:gccgo123assert:gccgo124assert:gccgo125assert:gccgo131assert:gccgo132assert:gccgo133assert:gccgo134assert:gccgo141assert:gccgo142assert:gccgo143assert:gccgo151assert
 group.gccgoassert.groupName=x86 gccgo (assertions)
 
 compiler.gccgo105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gccgo
@@ -78,6 +80,8 @@ compiler.gccgo123assert.exe=/opt/compiler-explorer/gcc-assertions-12.3.0/bin/gcc
 compiler.gccgo123assert.semver=12.3.0 (assertions)
 compiler.gccgo124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gccgo
 compiler.gccgo124assert.semver=12.4.0 (assertions)
+compiler.gccgo125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gccgo
+compiler.gccgo125assert.semver=12.5.0 (assertions)
 compiler.gccgo131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gccgo
 compiler.gccgo131assert.semver=13.1 (assertions)
 compiler.gccgo132assert.exe=/opt/compiler-explorer/gcc-assertions-13.2.0/bin/gccgo

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -173,7 +173,7 @@ compiler.objcpploongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc
 
 ###############################
 # GCC for POWERPC64LE
-group.objcppgccpowerpc64le.compilers=objcppppc64leg1230:objcppppc64leg1310:objcppppc64leg1320:objcppppc64legtrunk:objcppppc64leg1410:objcppppc64leg1330:objcppppc64leg1240:objcppppc64leg1420:objcppppc64leg1510:objcppppc64leg1430:objcppppc64leg1340
+group.objcppgccpowerpc64le.compilers=objcppppc64leg1230:objcppppc64leg1310:objcppppc64leg1320:objcppppc64legtrunk:objcppppc64leg1410:objcppppc64leg1330:objcppppc64leg1240:objcppppc64leg1420:objcppppc64leg1510:objcppppc64leg1430:objcppppc64leg1340:objcppppc64leg1250
 group.objcppgccpowerpc64le.groupName=POWERPC64LE GCC
 group.objcppgccpowerpc64le.baseName=POWERPC64LE GCC
 group.objcppgccpowerpc64le.instructionSet=powerpc
@@ -187,6 +187,11 @@ compiler.objcppppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/po
 compiler.objcppppc64leg1240.semver=12.4.0
 compiler.objcppppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.objcppppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.objcppppc64leg1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.objcppppc64leg1250.semver=12.5.0
+compiler.objcppppc64leg1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.objcppppc64leg1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.objcppppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.objcppppc64leg1310.semver=13.1.0
@@ -235,7 +240,7 @@ compiler.objcppppc64legtrunk.demangler=/opt/compiler-explorer/powerpc64le/gcc-tr
 
 ###############################
 # GCC for POWERPC64
-group.objcppgccpowerpc64.compilers=objcppppc64g1230:objcppppc64g1310:objcppppc64g1320:objcppppc64gtrunk:objcppppc64g1410:objcppppc64g1330:objcppppc64g1240:objcppppc64g1420:objcppppc64g1510:objcppppc64g1430:objcppppc64g1340
+group.objcppgccpowerpc64.compilers=objcppppc64g1230:objcppppc64g1310:objcppppc64g1320:objcppppc64gtrunk:objcppppc64g1410:objcppppc64g1330:objcppppc64g1240:objcppppc64g1420:objcppppc64g1510:objcppppc64g1430:objcppppc64g1340:objcppppc64g1250
 group.objcppgccpowerpc64.groupName=POWERPC64 GCC
 group.objcppgccpowerpc64.baseName=POWERPC64 GCC
 group.objcppgccpowerpc64.instructionSet=powerpc
@@ -249,6 +254,11 @@ compiler.objcppppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerp
 compiler.objcppppc64g1240.semver=12.4.0
 compiler.objcppppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.objcppppc64g1250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.objcppppc64g1250.semver=12.5.0
+compiler.objcppppc64g1250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.objcppppc64g1250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.objcppppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.objcppppc64g1310.semver=13.1.0
@@ -297,7 +307,7 @@ compiler.objcppppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/
 
 ###############################
 # GCC for POWERPC
-group.objcppgccpowerpc.compilers=objcppppcg1230:objcppppcg1240:objcppppcg1310:objcppppcg1320:objcppppcg1330:objcppppcg1340:objcppppcg1410:objcppppcg1420:objcppppcg1430:objcppppcg1510
+group.objcppgccpowerpc.compilers=objcppppcg1230:objcppppcg1240:objcppppcg1250:objcppppcg1310:objcppppcg1320:objcppppcg1330:objcppppcg1340:objcppppcg1410:objcppppcg1420:objcppppcg1430:objcppppcg1510
 group.objcppgccpowerpc.groupName=POWERPC GCC
 group.objcppgccpowerpc.baseName=POWERPC GCC
 group.objcppgccpowerpc.instructionSet=powerpc
@@ -311,6 +321,11 @@ compiler.objcppppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-un
 compiler.objcppppcg1240.semver=12.4.0
 compiler.objcppppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.objcppppcg1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.objcppppcg1250.semver=12.5.0
+compiler.objcppppcg1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.objcppppcg1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.objcppppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
 compiler.objcppppcg1310.semver=13.1.0
@@ -354,7 +369,7 @@ compiler.objcppppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powe
 
 ###############################
 # GCC for MIPSEL
-group.objcppgccmipsel.compilers=objcppmipselg1230:objcppmipselg1240:objcppmipselg1310:objcppmipselg1320:objcppmipselg1330:objcppmipselg1340:objcppmipselg1410:objcppmipselg1420:objcppmipselg1430:objcppmipselg1510
+group.objcppgccmipsel.compilers=objcppmipselg1230:objcppmipselg1240:objcppmipselg1250:objcppmipselg1310:objcppmipselg1320:objcppmipselg1330:objcppmipselg1340:objcppmipselg1410:objcppmipselg1420:objcppmipselg1430:objcppmipselg1510
 group.objcppgccmipsel.groupName=MIPS (EL) GCC
 group.objcppgccmipsel.baseName=MIPS (EL) GCC
 
@@ -367,6 +382,11 @@ compiler.objcppmipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-m
 compiler.objcppmipselg1240.semver=12.4.0
 compiler.objcppmipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.objcppmipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.objcppmipselg1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.objcppmipselg1250.semver=12.5.0
+compiler.objcppmipselg1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.objcppmipselg1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.objcppmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
 compiler.objcppmipselg1310.semver=13.1.0
@@ -410,7 +430,7 @@ compiler.objcppmipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mi
 
 ###############################
 # GCC for MIPS64EL
-group.objcppgccmips64el.compilers=objcppmips64elg1230:objcppmips64elg1310:objcppmips64elg1320:objcppmips64elg1410:objcppmips64elg1330:objcppmips64elg1240:objcppmips64elg1420:objcppmips64elg1510:objcppmips64elg1430:objcppmips64elg1340
+group.objcppgccmips64el.compilers=objcppmips64elg1230:objcppmips64elg1310:objcppmips64elg1320:objcppmips64elg1410:objcppmips64elg1330:objcppmips64elg1240:objcppmips64elg1420:objcppmips64elg1510:objcppmips64elg1430:objcppmips64elg1340:objcppmips64elg1250
 group.objcppgccmips64el.groupName=MIPS64 (EL) GCC
 group.objcppgccmips64el.baseName=MIPS64 (EL) GCC
 
@@ -423,6 +443,11 @@ compiler.objcppmips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips
 compiler.objcppmips64elg1240.semver=12.4.0
 compiler.objcppmips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.objcppmips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.objcppmips64elg1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.objcppmips64elg1250.semver=12.5.0
+compiler.objcppmips64elg1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.objcppmips64elg1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.objcppmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
 compiler.objcppmips64elg1310.semver=13.1.0
@@ -466,7 +491,7 @@ compiler.objcppmips64elg1510.demangler=/opt/compiler-explorer/mips64el/gcc-15.1.
 
 ###############################
 # GCC for MIPS64
-group.objcppgccmips64.compilers=objcppmips64g1230:objcppmips64g1310:objcppmips64g1320:objcppmips64g1410:objcppmips64g1330:objcppmips64g1240:objcppmips64g1420:objcppmips64g1510:objcppmips64g1430:objcppmips64g1340
+group.objcppgccmips64.compilers=objcppmips64g1230:objcppmips64g1310:objcppmips64g1320:objcppmips64g1410:objcppmips64g1330:objcppmips64g1240:objcppmips64g1420:objcppmips64g1510:objcppmips64g1430:objcppmips64g1340:objcppmips64g1250
 group.objcppgccmips64.groupName=MIPS64 GCC
 group.objcppgccmips64.baseName=MIPS64 GCC
 
@@ -479,6 +504,11 @@ compiler.objcppmips64g1240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-u
 compiler.objcppmips64g1240.semver=12.4.0
 compiler.objcppmips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.objcppmips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.objcppmips64g1250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.objcppmips64g1250.semver=12.5.0
+compiler.objcppmips64g1250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.objcppmips64g1250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.objcppmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.objcppmips64g1310.semver=13.1.0
@@ -523,7 +553,7 @@ compiler.objcppmips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mi
 
 ###############################
 # GCC for MIPS
-group.objcppgccmips.compilers=objcppmipsg1230:objcppmipsg1240:objcppmipsg1310:objcppmipsg1320:objcppmipsg1330:objcppmipsg1340:objcppmipsg1410:objcppmipsg1420:objcppmipsg1430:objcppmipsg1510
+group.objcppgccmips.compilers=objcppmipsg1230:objcppmipsg1240:objcppmipsg1250:objcppmipsg1310:objcppmipsg1320:objcppmipsg1330:objcppmipsg1340:objcppmipsg1410:objcppmipsg1420:objcppmipsg1430:objcppmipsg1510
 group.objcppgccmips.groupName=MIPS GCC
 group.objcppgccmips.baseName=MIPS GCC
 
@@ -536,6 +566,11 @@ compiler.objcppmipsg1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown
 compiler.objcppmipsg1240.semver=12.4.0
 compiler.objcppmipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.objcppmipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.objcppmipsg1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.objcppmipsg1250.semver=12.5.0
+compiler.objcppmipsg1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.objcppmipsg1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.objcppmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.objcppmipsg1310.semver=13.1.0
@@ -579,7 +614,7 @@ compiler.objcppmipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-u
 
 ###############################
 # GCC for s390
-group.objcppgccs390x.compilers=objcpps390xg1230:objcpps390xg1310:objcpps390xg1320:objcpps390xg1410:objcpps390xg1330:objcpps390xg1240:objcpps390xg1420:objcpps390xg1510:objcpps390xg1430:objcpps390xg1340
+group.objcppgccs390x.compilers=objcpps390xg1230:objcpps390xg1310:objcpps390xg1320:objcpps390xg1410:objcpps390xg1330:objcpps390xg1240:objcpps390xg1420:objcpps390xg1510:objcpps390xg1430:objcpps390xg1340:objcpps390xg1250
 group.objcppgccs390x.groupName=S390X GCC
 group.objcppgccs390x.baseName=S390X GCC
 
@@ -592,6 +627,11 @@ compiler.objcpps390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-
 compiler.objcpps390xg1240.semver=12.4.0
 compiler.objcpps390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.objcpps390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.objcpps390xg1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.objcpps390xg1250.semver=12.5.0
+compiler.objcpps390xg1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.objcpps390xg1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.objcpps390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
 compiler.objcpps390xg1310.semver=13.1.0
@@ -635,7 +675,7 @@ compiler.objcpps390xg1510.demangler=/opt/compiler-explorer/s390x/gcc-15.1.0/s390
 
 ###############################
 # GCC for ARM
-group.objcppgccarm.compilers=objcpparmg1230:objcpparmg1240:objcpparmg1310:objcpparmg1320:objcpparmg1330:objcpparmg1340:objcpparmg1410:objcpparmg1420:objcpparmg1430:objcpparmg1510
+group.objcppgccarm.compilers=objcpparmg1230:objcpparmg1240:objcpparmg1250:objcpparmg1310:objcpparmg1320:objcpparmg1330:objcpparmg1340:objcpparmg1410:objcpparmg1420:objcpparmg1430:objcpparmg1510
 group.objcppgccarm.groupName=ARM GCC
 group.objcppgccarm.baseName=ARM GCC
 
@@ -648,6 +688,11 @@ compiler.objcpparmg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-li
 compiler.objcpparmg1240.semver=12.4.0
 compiler.objcpparmg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.objcpparmg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.objcpparmg1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.objcpparmg1250.semver=12.5.0
+compiler.objcpparmg1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.objcpparmg1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.objcpparmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.objcpparmg1310.semver=13.1.0
@@ -692,7 +737,7 @@ compiler.objcpparmg1510.demangler=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unkn
 ###############################
 # GCC for ARM64
 
-group.objcppgccarm64.compilers=objcpparm64g1230:objcpparm64g1310:objcpparm64g1320:objcpparm64g1410:objcpparm64g1330:objcpparm64g1240:objcpparm64g1420:objcpparm64g1510:objcpparm64g1430:objcpparm64g1340
+group.objcppgccarm64.compilers=objcpparm64g1230:objcpparm64g1310:objcpparm64g1320:objcpparm64g1410:objcpparm64g1330:objcpparm64g1240:objcpparm64g1420:objcpparm64g1510:objcpparm64g1430:objcpparm64g1340:objcpparm64g1250
 group.objcppgccarm64.groupName=ARM64 GCC
 group.objcppgccarm64.baseName=ARM64 GCC
 
@@ -705,6 +750,11 @@ compiler.objcpparm64g1240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-un
 compiler.objcpparm64g1240.semver=12.4.0
 compiler.objcpparm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.objcpparm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.objcpparm64g1250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.objcpparm64g1250.semver=12.5.0
+compiler.objcpparm64g1250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.objcpparm64g1250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.objcpparm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.objcpparm64g1310.semver=13.1.0
@@ -753,7 +803,7 @@ group.objcppgccrvs.compilers=&objcppgccrv32:&objcppgccrv64
 group.objcppgccrvs.groupName=RISC-V GCC
 
 ## Subgroup for riscv32
-group.objcppgccrv32.compilers=objcppgccrv32trunk:objcppgccrv321230:objcppgccrv321240:objcppgccrv321310:objcppgccrv321320:objcppgccrv321330:objcppgccrv321340:objcppgccrv321410:objcppgccrv321420:objcppgccrv321430:objcppgccrv321510
+group.objcppgccrv32.compilers=objcppgccrv32trunk:objcppgccrv321230:objcppgccrv321240:objcppgccrv321250:objcppgccrv321310:objcppgccrv321320:objcppgccrv321330:objcppgccrv321340:objcppgccrv321410:objcppgccrv321420:objcppgccrv321430:objcppgccrv321510
 group.objcppgccrv32.groupName=RISC-V 32-bits
 group.objcppgccrv32.baseName=RISC-V 32 GCC
 
@@ -766,6 +816,11 @@ compiler.objcppgccrv321240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32
 compiler.objcppgccrv321240.semver=12.4.0
 compiler.objcppgccrv321240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.objcppgccrv321240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.objcppgccrv321250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.objcppgccrv321250.semver=12.5.0
+compiler.objcppgccrv321250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.objcppgccrv321250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.objcppgccrv321310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.objcppgccrv321310.semver=13.1.0
@@ -814,7 +869,7 @@ compiler.objcppgccrv32trunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/r
 compiler.objcppgccrv32trunk.isNightly=true
 
 ## Subgroup for riscv64
-group.objcppgccrv64.compilers=objcppgccrv64trunk:objcppgccrv641230:objcppgccrv641240:objcppgccrv641310:objcppgccrv641320:objcppgccrv641330:objcppgccrv641340:objcppgccrv641410:objcppgccrv641420:objcppgccrv641430:objcppgccrv641510
+group.objcppgccrv64.compilers=objcppgccrv64trunk:objcppgccrv641230:objcppgccrv641240:objcppgccrv641250:objcppgccrv641310:objcppgccrv641320:objcppgccrv641330:objcppgccrv641340:objcppgccrv641410:objcppgccrv641420:objcppgccrv641430:objcppgccrv641510
 group.objcppgccrv64.groupName=RISC-V 64-bits
 group.objcppgccrv64.baseName=RISC-V 64 GCC
 
@@ -827,6 +882,11 @@ compiler.objcppgccrv641240.exe=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64
 compiler.objcppgccrv641240.semver=12.4.0
 compiler.objcppgccrv641240.objdumper=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.objcppgccrv641240.demangler=/opt/compiler-explorer/riscv64/gcc-12.4.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
+compiler.objcppgccrv641250.exe=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.objcppgccrv641250.semver=12.5.0
+compiler.objcppgccrv641250.objdumper=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.objcppgccrv641250.demangler=/opt/compiler-explorer/riscv64/gcc-12.5.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 compiler.objcppgccrv641310.exe=/opt/compiler-explorer/riscv64/gcc-13.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.objcppgccrv641310.semver=13.1.0

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.objcppgcc86.compilers=&objcppgcc86assert:objcppg105:objcppg114:objcppg122:objcppg123:objcppg124:objcppg131:objcppg132:objcppg133:objcppg134:objcppg141:objcppg142:objcppg143:objcppg151:objcppgsnapshot
+group.objcppgcc86.compilers=&objcppgcc86assert:objcppg105:objcppg114:objcppg122:objcppg123:objcppg124:objcppg125:objcppg131:objcppg132:objcppg133:objcppg134:objcppg141:objcppg142:objcppg143:objcppg151:objcppgsnapshot
 group.objcppgcc86.groupName=GCC x86-64
 group.objcppgcc86.instructionSet=amd64
 group.objcppgcc86.baseName=x86-64 gcc
@@ -40,6 +40,9 @@ compiler.objcppg123.semver=12.3
 
 compiler.objcppg124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/g++
 compiler.objcppg124.semver=12.4
+
+compiler.objcppg125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/g++
+compiler.objcppg125.semver=12.5
 
 compiler.objcppg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/g++
 compiler.objcppg131.semver=13.1
@@ -73,7 +76,7 @@ compiler.objcppgsnapshot.isNightly=true
 
 ## OBJC++ GCC x86 build with "assertions" (--enable-checking=XXX)
 group.objcppgcc86assert.groupName=GCC x86-64 (assertions)
-group.objcppgcc86assert.compilers=objcppg105assert:objcppg114assert:objcppg122assert:objcppg123assert:objcppg124assert:objcppg131assert:objcppg132assert:objcppg133assert:objcppg134assert:objcppg141assert:objcppg142assert:objcppg143assert:objcppg151assert
+group.objcppgcc86assert.compilers=objcppg105assert:objcppg114assert:objcppg122assert:objcppg123assert:objcppg124assert:objcppg125assert:objcppg131assert:objcppg132assert:objcppg133assert:objcppg134assert:objcppg141assert:objcppg142assert:objcppg143assert:objcppg151assert
 
 compiler.objcppg105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/g++
 compiler.objcppg105assert.semver=10.5 (assertions)
@@ -89,6 +92,9 @@ compiler.objcppg123assert.semver=12.3 (assertions)
 
 compiler.objcppg124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/g++
 compiler.objcppg124assert.semver=12.4 (assertions)
+
+compiler.objcppg125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/g++
+compiler.objcppg125assert.semver=12.5 (assertions)
 
 compiler.objcppg131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/g++
 compiler.objcppg131assert.semver=13.1 (assertions)

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -131,7 +131,7 @@ group.objccross.licensePreamble=Copyright (c) 2007 Free Software Foundation, Inc
 group.objcsparc.compilers=&objcgccsparc
 
 # GCC for SPARC
-group.objcgccsparc.compilers=objcsparcg1220:objcsparcg1230:objcsparcg1240:objcsparcg1310:objcsparcg1320:objcsparcg1330:objcsparcg1340:objcsparcg1410:objcsparcg1420:objcsparcg1430:objcsparcg1510
+group.objcgccsparc.compilers=objcsparcg1220:objcsparcg1230:objcsparcg1240:objcsparcg1250:objcsparcg1310:objcsparcg1320:objcsparcg1330:objcsparcg1340:objcsparcg1410:objcsparcg1420:objcsparcg1430:objcsparcg1510
 group.objcgccsparc.supportsBinary=true
 group.objcgccsparc.supportsExecute=false
 group.objcgccsparc.baseName=SPARC gcc
@@ -152,6 +152,11 @@ compiler.objcsparcg1240.exe=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknow
 compiler.objcsparcg1240.semver=12.4.0
 compiler.objcsparcg1240.objdumper=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.objcsparcg1240.demangler=/opt/compiler-explorer/sparc/gcc-12.4.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
+compiler.objcsparcg1250.exe=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.objcsparcg1250.semver=12.5.0
+compiler.objcsparcg1250.objdumper=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.objcsparcg1250.demangler=/opt/compiler-explorer/sparc/gcc-12.5.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 compiler.objcsparcg1310.exe=/opt/compiler-explorer/sparc/gcc-13.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
 compiler.objcsparcg1310.semver=13.1.0
@@ -198,7 +203,7 @@ compiler.objcsparcg1510.demangler=/opt/compiler-explorer/sparc/gcc-15.1.0/sparc-
 group.objcsparc64.compilers=&objcgccsparc64
 
 # GCC for SPARC64
-group.objcgccsparc64.compilers=objcsparc64g1220:objcsparc64g1230:objcsparc64g1310:objcsparc64g1320:objcsparc64g1410:objcsparc64g1330:objcsparc64g1240:objcsparc64g1420:objcsparc64g1510:objcsparc64g1430:objcsparc64g1340
+group.objcgccsparc64.compilers=objcsparc64g1220:objcsparc64g1230:objcsparc64g1310:objcsparc64g1320:objcsparc64g1410:objcsparc64g1330:objcsparc64g1240:objcsparc64g1420:objcsparc64g1510:objcsparc64g1430:objcsparc64g1340:objcsparc64g1250
 group.objcgccsparc64.supportsBinary=true
 group.objcgccsparc64.supportsExecute=false
 group.objcgccsparc64.baseName=SPARC64 gcc
@@ -219,6 +224,11 @@ compiler.objcsparc64g1240.exe=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-
 compiler.objcsparc64g1240.semver=12.4.0
 compiler.objcsparc64g1240.objdumper=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.objcsparc64g1240.demangler=/opt/compiler-explorer/sparc64/gcc-12.4.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
+compiler.objcsparc64g1250.exe=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.objcsparc64g1250.semver=12.5.0
+compiler.objcsparc64g1250.objdumper=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.objcsparc64g1250.demangler=/opt/compiler-explorer/sparc64/gcc-12.5.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 compiler.objcsparc64g1310.exe=/opt/compiler-explorer/sparc64/gcc-13.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
 compiler.objcsparc64g1310.semver=13.1.0
@@ -265,7 +275,7 @@ compiler.objcsparc64g1510.demangler=/opt/compiler-explorer/sparc64/gcc-15.1.0/sp
 group.objcsparcleon.compilers=&objcgccsparcleon
 
 # GCC for SPARC-LEON
-group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1:objcsparcleong1230:objcsparcleong1240:objcsparcleong1310:objcsparcleong1320:objcsparcleong1330:objcsparcleong1340:objcsparcleong1410:objcsparcleong1420:objcsparcleong1430:objcsparcleong1510
+group.objcgccsparcleon.compilers=objcsparcleong1220:objcsparcleong1220-1:objcsparcleong1230:objcsparcleong1240:objcsparcleong1250:objcsparcleong1310:objcsparcleong1320:objcsparcleong1330:objcsparcleong1340:objcsparcleong1410:objcsparcleong1420:objcsparcleong1430:objcsparcleong1510
 group.objcgccsparcleon.supportsBinary=true
 group.objcgccsparcleon.supportsExecute=false
 group.objcgccsparcleon.baseName=SPARC LEON gcc
@@ -288,6 +298,11 @@ compiler.objcsparcleong1240.exe=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/spa
 compiler.objcsparcleong1240.semver=12.4.0
 compiler.objcsparcleong1240.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.objcsparcleong1240.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.4.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
+compiler.objcsparcleong1250.exe=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.objcsparcleong1250.semver=12.5.0
+compiler.objcsparcleong1250.objdumper=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.objcsparcleong1250.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.5.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 compiler.objcsparcleong1310.exe=/opt/compiler-explorer/sparc-leon/gcc-13.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.objcsparcleong1310.semver=13.1.0
@@ -339,7 +354,7 @@ compiler.objcsparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12
 group.objcloongarch64.compilers=&objcgccloongarch64
 
 # GCC for loongarch64
-group.objcgccloongarch64.compilers=objcloongarch64g1220:objcloongarch64g1230:objcloongarch64g1310:objcloongarch64g1320:objcloongarch64g1410:objcloongarch64g1330:objcloongarch64g1240:objcloongarch64g1420:objcloongarch64g1510:objcloongarch64g1430:objcloongarch64g1340
+group.objcgccloongarch64.compilers=objcloongarch64g1220:objcloongarch64g1230:objcloongarch64g1310:objcloongarch64g1320:objcloongarch64g1410:objcloongarch64g1330:objcloongarch64g1240:objcloongarch64g1420:objcloongarch64g1510:objcloongarch64g1430:objcloongarch64g1340:objcloongarch64g1250
 group.objcgccloongarch64.supportsBinary=true
 group.objcgccloongarch64.supportsExecute=false
 group.objcgccloongarch64.baseName=loongarch64 gcc
@@ -360,6 +375,11 @@ compiler.objcloongarch64g1240.exe=/opt/compiler-explorer/loongarch64/gcc-12.4.0/
 compiler.objcloongarch64g1240.semver=12.4.0
 compiler.objcloongarch64g1240.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.objcloongarch64g1240.demangler=/opt/compiler-explorer/loongarch64/gcc-12.4.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
+compiler.objcloongarch64g1250.exe=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.objcloongarch64g1250.semver=12.5.0
+compiler.objcloongarch64g1250.objdumper=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.objcloongarch64g1250.demangler=/opt/compiler-explorer/loongarch64/gcc-12.5.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 compiler.objcloongarch64g1310.exe=/opt/compiler-explorer/loongarch64/gcc-13.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
 compiler.objcloongarch64g1310.semver=13.1.0
@@ -407,7 +427,7 @@ compiler.objcloongarch64g1510.demangler=/opt/compiler-explorer/loongarch64/gcc-1
 group.objcs390x.compilers=&objcgccs390x
 
 # GCC for s390x
-group.objcgccs390x.compilers=objcs390xg1220:objcs390xg1230:objcs390xg1310:objcs390xg1320:objcs390xg1410:objcs390xg1330:objcs390xg1240:objcs390xg1420:objcs390xg1510:objcs390xg1430:objcs390xg1340
+group.objcgccs390x.compilers=objcs390xg1220:objcs390xg1230:objcs390xg1310:objcs390xg1320:objcs390xg1410:objcs390xg1330:objcs390xg1240:objcs390xg1420:objcs390xg1510:objcs390xg1430:objcs390xg1340:objcs390xg1250
 group.objcgccs390x.supportsBinary=true
 group.objcgccs390x.supportsExecute=false
 group.objcgccs390x.baseName=s390x gcc
@@ -428,6 +448,11 @@ compiler.objcs390xg1240.exe=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-li
 compiler.objcs390xg1240.semver=12.4.0
 compiler.objcs390xg1240.objdumper=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.objcs390xg1240.demangler=/opt/compiler-explorer/s390x/gcc-12.4.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
+compiler.objcs390xg1250.exe=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.objcs390xg1250.semver=12.5.0
+compiler.objcs390xg1250.objdumper=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.objcs390xg1250.demangler=/opt/compiler-explorer/s390x/gcc-12.5.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 compiler.objcs390xg1310.exe=/opt/compiler-explorer/s390x/gcc-13.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
 compiler.objcs390xg1310.semver=13.1.0
@@ -477,7 +502,7 @@ group.objcppcs.supportsBinary=true
 group.objcppcs.supportsExecute=false
 group.objcppcs.instructionSet=powerpc
 
-group.objcppc.compilers=objcppcg1220:objcppcg1230:objcppcg1240:objcppcg1310:objcppcg1320:objcppcg1330:objcppcg1340:objcppcg1410:objcppcg1420:objcppcg1430:objcppcg1510
+group.objcppc.compilers=objcppcg1220:objcppcg1230:objcppcg1240:objcppcg1250:objcppcg1310:objcppcg1320:objcppcg1330:objcppcg1340:objcppcg1410:objcppcg1420:objcppcg1430:objcppcg1510
 group.objcppc.groupName=POWER
 group.objcppc.baseName=POWER GCC
 
@@ -495,6 +520,11 @@ compiler.objcppcg1240.exe=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unkn
 compiler.objcppcg1240.semver=12.4.0
 compiler.objcppcg1240.objdumper=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppcg1240.demangler=/opt/compiler-explorer/powerpc/gcc-12.4.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
+compiler.objcppcg1250.exe=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.objcppcg1250.semver=12.5.0
+compiler.objcppcg1250.objdumper=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.objcppcg1250.demangler=/opt/compiler-explorer/powerpc/gcc-12.5.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 compiler.objcppcg1310.exe=/opt/compiler-explorer/powerpc/gcc-13.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
 compiler.objcppcg1310.semver=13.1.0
@@ -536,7 +566,7 @@ compiler.objcppcg1510.semver=15.1.0
 compiler.objcppcg1510.objdumper=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.objcppcg1510.demangler=/opt/compiler-explorer/powerpc/gcc-15.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.objcppc64.compilers=objcppc64g1220:objcppc64g1230:objcppc64g1310:objcppc64g1320:objcppc64gtrunk:objcppc64g1410:objcppc64g1330:objcppc64g1240:objcppc64g1420:objcppc64g1510:objcppc64g1430:objcppc64g1340
+group.objcppc64.compilers=objcppc64g1220:objcppc64g1230:objcppc64g1310:objcppc64g1320:objcppc64gtrunk:objcppc64g1410:objcppc64g1330:objcppc64g1240:objcppc64g1420:objcppc64g1510:objcppc64g1430:objcppc64g1340:objcppc64g1250
 group.objcppc64.groupName=POWER64
 group.objcppc64.baseName=POWER64 GCC
 
@@ -554,6 +584,11 @@ compiler.objcppc64g1240.exe=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc6
 compiler.objcppc64g1240.semver=12.4.0
 compiler.objcppc64g1240.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppc64g1240.demangler=/opt/compiler-explorer/powerpc64/gcc-12.4.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
+compiler.objcppc64g1250.exe=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.objcppc64g1250.semver=12.5.0
+compiler.objcppc64g1250.objdumper=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.objcppc64g1250.demangler=/opt/compiler-explorer/powerpc64/gcc-12.5.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.objcppc64g1310.exe=/opt/compiler-explorer/powerpc64/gcc-13.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.objcppc64g1310.semver=13.1.0
@@ -600,7 +635,7 @@ compiler.objcppc64gtrunk.semver=trunk
 compiler.objcppc64gtrunk.objdumper=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.objcppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
-group.objcppc64le.compilers=objcppc64leg1220:objcppc64leg1230:objcppc64leg1310:objcppc64leg1320:objcppc64legtrunk:objcppc64leg1410:objcppc64leg1330:objcppc64leg1240:objcppc64leg1420:objcppc64leg1510:objcppc64leg1430:objcppc64leg1340
+group.objcppc64le.compilers=objcppc64leg1220:objcppc64leg1230:objcppc64leg1310:objcppc64leg1320:objcppc64legtrunk:objcppc64leg1410:objcppc64leg1330:objcppc64leg1240:objcppc64leg1420:objcppc64leg1510:objcppc64leg1430:objcppc64leg1340:objcppc64leg1250
 group.objcppc64le.groupName=POWER64LE
 group.objcppc64le.baseName=POWER64LE GCC
 
@@ -618,6 +653,11 @@ compiler.objcppc64leg1240.exe=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powe
 compiler.objcppc64leg1240.semver=12.4.0
 compiler.objcppc64leg1240.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.objcppc64leg1240.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.4.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
+compiler.objcppc64leg1250.exe=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.objcppc64leg1250.semver=12.5.0
+compiler.objcppc64leg1250.objdumper=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.objcppc64leg1250.demangler=/opt/compiler-explorer/powerpc64le/gcc-12.5.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.objcppc64leg1310.exe=/opt/compiler-explorer/powerpc64le/gcc-13.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.objcppc64leg1310.semver=13.1.0
@@ -675,7 +715,7 @@ group.objcgccarm.includeFlag=-I
 
 # 32 bit
 group.objcgcc32arm.groupName=Arm 32-bit GCC
-group.objcgcc32arm.compilers=objcarmg1220:objcarmg1230:objcarmg1240:objcarmg1310:objcarmg1320:objcarmg1330:objcarmg1340:objcarmg1410:objcarmg1420:objcarmg1430:objcarmg1510:objcarmgtrunk
+group.objcgcc32arm.compilers=objcarmg1220:objcarmg1230:objcarmg1240:objcarmg1250:objcarmg1310:objcarmg1320:objcarmg1330:objcarmg1340:objcarmg1410:objcarmg1420:objcarmg1430:objcarmg1510:objcarmgtrunk
 group.objcgcc32arm.isSemVer=true
 group.objcgcc32arm.instructionSet=arm32
 group.objcgcc32arm.baseName=ARM gcc
@@ -694,6 +734,11 @@ compiler.objcarmg1240.exe=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linu
 compiler.objcarmg1240.semver=12.4.0
 compiler.objcarmg1240.objdumper=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.objcarmg1240.demangler=/opt/compiler-explorer/arm/gcc-12.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
+compiler.objcarmg1250.exe=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.objcarmg1250.semver=12.5.0
+compiler.objcarmg1250.objdumper=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.objcarmg1250.demangler=/opt/compiler-explorer/arm/gcc-12.5.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 compiler.objcarmg1310.exe=/opt/compiler-explorer/arm/gcc-13.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.objcarmg1310.semver=13.1.0
@@ -744,7 +789,7 @@ compiler.objcarmgtrunk.isNightly=true
 # 64 bit
 group.objcgcc64arm.groupName=Arm 64-bit GCC
 group.objcgcc64arm.baseName=ARM64 GCC
-group.objcgcc64arm.compilers=objcarm64gtrunk:objcarm64g1220:objcarm64g1230:objcarm64g1310:objcarm64g1320:objcarm64g1410:objcarm64g1330:objcarm64g1240:objcarm64g1420:objcarm64g1510:objcarm64g1430:objcarm64g1340
+group.objcgcc64arm.compilers=objcarm64gtrunk:objcarm64g1220:objcarm64g1230:objcarm64g1310:objcarm64g1320:objcarm64g1410:objcarm64g1330:objcarm64g1240:objcarm64g1420:objcarm64g1510:objcarm64g1430:objcarm64g1340:objcarm64g1250
 group.objcgcc64arm.isSemVer=true
 group.objcgcc64arm.instructionSet=aarch64
 
@@ -762,6 +807,11 @@ compiler.objcarm64g1240.exe=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unkn
 compiler.objcarm64g1240.semver=12.4.0
 compiler.objcarm64g1240.objdumper=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.objcarm64g1240.demangler=/opt/compiler-explorer/arm64/gcc-12.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
+compiler.objcarm64g1250.exe=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.objcarm64g1250.semver=12.5.0
+compiler.objcarm64g1250.objdumper=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.objcarm64g1250.demangler=/opt/compiler-explorer/arm64/gcc-12.5.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 compiler.objcarm64g1310.exe=/opt/compiler-explorer/arm64/gcc-13.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.objcarm64g1310.semver=13.1.0
@@ -818,7 +868,7 @@ group.objcmipss.supportsBinary=true
 group.objcmipss.supportsExecute=false
 
 ## MIPS
-group.objcmips.compilers=objcmipsg1220:objcmipsg1230:objcmipsg1240:objcmipsg1310:objcmipsg1320:objcmipsg1330:objcmipsg1340:objcmipsg1410:objcmipsg1420:objcmipsg1430:objcmipsg1510
+group.objcmips.compilers=objcmipsg1220:objcmipsg1230:objcmipsg1240:objcmipsg1250:objcmipsg1310:objcmipsg1320:objcmipsg1330:objcmipsg1340:objcmipsg1410:objcmipsg1420:objcmipsg1430:objcmipsg1510
 group.objcmips.groupName=MIPS GCC
 group.objcmips.baseName=mips gcc
 
@@ -836,6 +886,11 @@ compiler.objcmipsg1240.exe=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-l
 compiler.objcmipsg1240.semver=12.4.0
 compiler.objcmipsg1240.objdumper=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.objcmipsg1240.demangler=/opt/compiler-explorer/mips/gcc-12.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
+compiler.objcmipsg1250.exe=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.objcmipsg1250.semver=12.5.0
+compiler.objcmipsg1250.objdumper=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.objcmipsg1250.demangler=/opt/compiler-explorer/mips/gcc-12.5.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 compiler.objcmipsg1310.exe=/opt/compiler-explorer/mips/gcc-13.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
 compiler.objcmipsg1310.semver=13.1.0
@@ -879,7 +934,7 @@ compiler.objcmipsg1510.demangler=/opt/compiler-explorer/mips/gcc-15.1.0/mips-unk
 
 ## MIPS64
 group.objcmips64.groupName=MIPS64 GCC
-group.objcmips64.compilers=objcmips64g1220:objcmips64g1230:objcmips64g1310:objcmips64g1320:objcmips64g1410:objcmips64g1330:objcmips64g1240:objcmips64g1420:objcmips64g1510:objcmips64g1430:objcmips64g1340
+group.objcmips64.compilers=objcmips64g1220:objcmips64g1230:objcmips64g1310:objcmips64g1320:objcmips64g1410:objcmips64g1330:objcmips64g1240:objcmips64g1420:objcmips64g1510:objcmips64g1430:objcmips64g1340:objcmips64g1250
 group.objcmips64.baseName=MIPS64 gcc
 
 compiler.objcmips64g1220.exe=/opt/compiler-explorer/mips64/gcc-12.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -896,6 +951,11 @@ compiler.objcmips64g1240.exe=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unk
 compiler.objcmips64g1240.semver=12.4.0
 compiler.objcmips64g1240.objdumper=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.objcmips64g1240.demangler=/opt/compiler-explorer/mips64/gcc-12.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
+compiler.objcmips64g1250.exe=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.objcmips64g1250.semver=12.5.0
+compiler.objcmips64g1250.objdumper=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.objcmips64g1250.demangler=/opt/compiler-explorer/mips64/gcc-12.5.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 compiler.objcmips64g1310.exe=/opt/compiler-explorer/mips64/gcc-13.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
 compiler.objcmips64g1310.semver=13.1.0
@@ -939,7 +999,7 @@ compiler.objcmips64g1510.demangler=/opt/compiler-explorer/mips64/gcc-15.1.0/mips
 
 ## MIPS EL
 group.objcmipsel.groupName=MIPSEL GCC
-group.objcmipsel.compilers=objcmipselg1220:objcmipselg1230:objcmipselg1240:objcmipselg1310:objcmipselg1320:objcmipselg1330:objcmipselg1340:objcmipselg1410:objcmipselg1420:objcmipselg1430:objcmipselg1510
+group.objcmipsel.compilers=objcmipselg1220:objcmipselg1230:objcmipselg1240:objcmipselg1250:objcmipselg1310:objcmipselg1320:objcmipselg1330:objcmipselg1340:objcmipselg1410:objcmipselg1420:objcmipselg1430:objcmipselg1510
 group.objcmipsel.baseName=mips (el) gcc
 
 compiler.objcmipselg1220.exe=/opt/compiler-explorer/mipsel/gcc-12.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
@@ -956,6 +1016,11 @@ compiler.objcmipselg1240.exe=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-mul
 compiler.objcmipselg1240.semver=12.4.0
 compiler.objcmipselg1240.objdumper=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.objcmipselg1240.demangler=/opt/compiler-explorer/mipsel/gcc-12.4.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
+compiler.objcmipselg1250.exe=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.objcmipselg1250.semver=12.5.0
+compiler.objcmipselg1250.objdumper=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.objcmipselg1250.demangler=/opt/compiler-explorer/mipsel/gcc-12.5.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 compiler.objcmipselg1310.exe=/opt/compiler-explorer/mipsel/gcc-13.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
 compiler.objcmipselg1310.semver=13.1.0
@@ -999,7 +1064,7 @@ compiler.objcmipselg1510.demangler=/opt/compiler-explorer/mipsel/gcc-15.1.0/mips
 
 ## MIPS64 EL
 group.objcmips64el.groupName=MIPS64EL GCC
-group.objcmips64el.compilers=objcmips64elg1220:objcmips64elg1230:objcmips64elg1310:objcmips64elg1320:objcmips64elg1410:objcmips64elg1330:objcmips64elg1240:objcmips64elg1420:objcmips64elg1510:objcmips64elg1430:objcmips64elg1340
+group.objcmips64el.compilers=objcmips64elg1220:objcmips64elg1230:objcmips64elg1310:objcmips64elg1320:objcmips64elg1410:objcmips64elg1330:objcmips64elg1240:objcmips64elg1420:objcmips64elg1510:objcmips64elg1430:objcmips64elg1340:objcmips64elg1250
 group.objcmips64el.baseName=mips64 (el) gcc
 
 compiler.objcmips64elg1220.exe=/opt/compiler-explorer/mips64el/gcc-12.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
@@ -1016,6 +1081,11 @@ compiler.objcmips64elg1240.exe=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64
 compiler.objcmips64elg1240.semver=12.4.0
 compiler.objcmips64elg1240.objdumper=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.objcmips64elg1240.demangler=/opt/compiler-explorer/mips64el/gcc-12.4.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
+compiler.objcmips64elg1250.exe=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.objcmips64elg1250.semver=12.5.0
+compiler.objcmips64elg1250.objdumper=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.objcmips64elg1250.demangler=/opt/compiler-explorer/mips64el/gcc-12.5.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 compiler.objcmips64elg1310.exe=/opt/compiler-explorer/mips64el/gcc-13.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
 compiler.objcmips64elg1310.semver=13.1.0
@@ -1070,7 +1140,7 @@ group.objcrv.supportsBinaryObject=true
 ## Subgroup for riscv32
 group.objcrv32.groupName=RISC-V 32-bits
 group.objcrv32.baseName=RISC-V 32 GCC
-group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220:objcrv32g1230:objcrv32g1310:objcrv32g1320:objcrv32g1410:objcrv32g1330:objcrv32g1240:objcrv32g1420:objcrv32g1510:objcrv32g1430:objcrv32g1340
+group.objcrv32.compilers=objcrv32gtrunk:objcrv32g1220:objcrv32g1230:objcrv32g1310:objcrv32g1320:objcrv32g1410:objcrv32g1330:objcrv32g1240:objcrv32g1420:objcrv32g1510:objcrv32g1430:objcrv32g1340:objcrv32g1250
 
 compiler.objcrv32g1220.exe=/opt/compiler-explorer/riscv32/gcc-12.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32g1220.semver=12.2.0
@@ -1086,6 +1156,11 @@ compiler.objcrv32g1240.exe=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unk
 compiler.objcrv32g1240.semver=12.4.0
 compiler.objcrv32g1240.objdumper=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.objcrv32g1240.demangler=/opt/compiler-explorer/riscv32/gcc-12.4.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
+compiler.objcrv32g1250.exe=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.objcrv32g1250.semver=12.5.0
+compiler.objcrv32g1250.objdumper=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.objcrv32g1250.demangler=/opt/compiler-explorer/riscv32/gcc-12.5.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 compiler.objcrv32g1310.exe=/opt/compiler-explorer/riscv32/gcc-13.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.objcrv32g1310.semver=13.1.0

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -9,7 +9,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.objcgcc86.compilers=&objcgcc86assert:objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg124:objcg131:objcg132:objcg133:objcg134:objcg141:objcg142:objcg143:objcg151:objcgsnapshot
+group.objcgcc86.compilers=&objcgcc86assert:objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg124:objcg125:objcg131:objcg132:objcg133:objcg134:objcg141:objcg142:objcg143:objcg151:objcgsnapshot
 group.objcgcc86.groupName=GCC x86-64
 group.objcgcc86.instructionSet=amd64
 group.objcgcc86.isSemVer=true
@@ -43,6 +43,9 @@ compiler.objcg123.semver=12.3
 compiler.objcg124.exe=/opt/compiler-explorer/gcc-12.4.0/bin/gcc
 compiler.objcg124.semver=12.4
 
+compiler.objcg125.exe=/opt/compiler-explorer/gcc-12.5.0/bin/gcc
+compiler.objcg125.semver=12.5
+
 compiler.objcg131.exe=/opt/compiler-explorer/gcc-13.1.0/bin/gcc
 compiler.objcg131.semver=13.1
 
@@ -74,7 +77,7 @@ compiler.objcgsnapshot.semver=(trunk)
 compiler.objcgsnapshot.isNightly=true
 
 ## OBJC GCC x86 build with "assertions" (--enable-checking=XXX)
-group.objcgcc86assert.compilers=objcg105assert:objcg114assert:objcg122assert:objcg123assert:objcg124assert:objcg131assert:objcg132assert:objcg133assert:objcg134assert:objcg141assert:objcg142assert:objcg143assert:objcg151assert
+group.objcgcc86assert.compilers=objcg105assert:objcg114assert:objcg122assert:objcg123assert:objcg124assert:objcg125assert:objcg131assert:objcg132assert:objcg133assert:objcg134assert:objcg141assert:objcg142assert:objcg143assert:objcg151assert
 group.objcgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.objcg105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gcc
@@ -91,6 +94,9 @@ compiler.objcg123assert.semver=12.3 (assertions)
 
 compiler.objcg124assert.exe=/opt/compiler-explorer/gcc-assertions-12.4.0/bin/gcc
 compiler.objcg124assert.semver=12.4 (assertions)
+
+compiler.objcg125assert.exe=/opt/compiler-explorer/gcc-assertions-12.5.0/bin/gcc
+compiler.objcg125assert.semver=12.5 (assertions)
 
 compiler.objcg131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gcc
 compiler.objcg131assert.semver=13.1 (assertions)


### PR DESCRIPTION
Add 20 cross + intel native for GCC 12.5

+ minor fix for missing all 12.4 cross for gimple.

fixes https://github.com/compiler-explorer/compiler-explorer/issues/7886