### PR TITLE
[HLSL] Add DXC 1.8.2505 releases

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&dxc:&rga:&clang
 
-group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502:dxc_1_8_2505:dxc_1_8_2505_1
 group.dxc.groupName=DXC
 group.dxc.isSemVer=true
 group.dxc.baseName=DXC
@@ -30,6 +30,10 @@ compiler.dxc_1_8_2407.exe=/opt/compiler-explorer/dxc-1.8.2407/bin/dxc
 compiler.dxc_1_8_2407.semver=1.8.2407
 compiler.dxc_1_8_2502.exe=/opt/compiler-explorer/dxc-1.8.2502/bin/dxc
 compiler.dxc_1_8_2502.semver=1.8.2502
+compiler.dxc_1_8_2505.exe=/opt/compiler-explorer/dxc-1.8.2505/bin/dxc
+compiler.dxc_1_8_2505.semver=1.8.2505
+compiler.dxc_1_8_2505_1.exe=/opt/compiler-explorer/dxc-1.8.2505.1/bin/dxc
+compiler.dxc_1_8_2505_1.semver=1.8.2505.1
 
 group.rga.compilers=rga262_dxctrunk:rga262_dxc172207:rga262_dxc162112:rga261_dxc172207:rga261_dxc162112:rga290_dxctrunk
 group.rga.groupName=RGA


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This change adds the new DXC 1.8.2405 releases. This PR depends on the infra PR below being merged and compilers built:

https://github.com/compiler-explorer/infra/pull/1713
