### PR TITLE
Fix to ensure labels are not mistaken for comments

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -261,6 +261,9 @@ export class AsmParser extends AsmRegex implements IAsmParser {
     }
 
     private shouldSkipCommentOnlyLine(filters: ParseFiltersAndOutputOptions, line: string): boolean {
+        if (this.labelDef.test(line)) {
+            return false;
+        }
         return Boolean(
             filters.commentOnly &&
                 ((this.commentOnly.test(line) && !this.parsingState.inNvccCode) ||

--- a/test/asm-parser-tests.ts
+++ b/test/asm-parser-tests.ts
@@ -43,6 +43,17 @@ describe('AsmParser tests', () => {
     });
 });
 
+describe('AsmParser comment filtering', () => {
+    const parser = new AsmParser();
+    it('should keep label lines starting with @ when filtering comments', () => {
+        const input = '@cube@4:\n    ret';
+        const result = parser.processAsm(input, {commentOnly: true});
+        const lines = result.asm.map(line => line.text);
+        expect(lines[0]).toBe('@cube@4:');
+        expect(lines[1]).toBe('    ret');
+    });
+});
+
 describe('PTXAsmParser tests', () => {
     const parser = new PTXAsmParser();
 


### PR DESCRIPTION
Ensured labels are not mistaken for comments by skipping comment filtering when the line matches a label definition

Added a regression test verifying that labels starting with “@” remain visible even when comment filtering is enabled

Fixes #7889 

Tested with 
npm run lint
npm run ts-check
npm run test-min
npm run check-frontend-imports
make check
