### PR TITLE
Fix CUDA binary architecture detection and improve parsing robustness

### DIFF
--- a/lib/binaries/binary-utils.ts
+++ b/lib/binaries/binary-utils.ts
@@ -41,7 +41,10 @@ export type BinaryInfo = {
 
 export class BinaryInfoLinux {
     static getInstructionSetForArchText(value: string): InstructionSet {
-        switch (value) {
+        // Clean up the architecture string by removing trailing punctuation
+        const cleanValue = value.replace(/[,;.]+$/, '').trim();
+
+        switch (cleanValue) {
             case 'x86-64': {
                 return 'amd64';
             }
@@ -80,6 +83,13 @@ export class BinaryInfoLinux {
             }
             case 'loongarch': {
                 return 'loongarch';
+            }
+            case 'nvidia cuda architecture': {
+                // Handle CUDA binaries as reported by the `file` command.
+                // This string appears when analyzing CUDA binaries compiled with nvcc/nvc++.
+                // Maps to PTX (Parallel Thread Execution) instruction set.
+                // See: https://github.com/compiler-explorer/compiler-explorer/issues/7936
+                return 'ptx';
             }
             default: {
                 logger.error(`Unknown architecture text: ${value}`);

--- a/test/execution-triple-tests.ts
+++ b/test/execution-triple-tests.ts
@@ -75,4 +75,26 @@ describe('Execution triple utils', () => {
         expect(info?.instructionSet).toEqual('avr');
         expect(info?.os).toEqual('linux');
     });
+    it('recognizes nvidia cuda architecture', () => {
+        const info = BinaryInfoLinux.parseFileInfo(
+            'ELF 64-bit LSB executable, NVIDIA CUDA architecture, version 1 (SYSV), statically linked, with debug_info, not stripped',
+        );
+        expect(info?.instructionSet).toEqual('ptx');
+        expect(info?.os).toEqual('linux');
+    });
+    it('handles trailing punctuation in architecture strings', () => {
+        // Test the general trailing punctuation cleaning for various architectures
+        const testCases = [
+            {input: 'ELF 64-bit LSB executable, nvidia cuda architecture,, version 1 (SYSV)', expected: 'ptx'},
+            {input: 'ELF 64-bit LSB executable, x86-64., version 1 (SYSV)', expected: 'amd64'},
+            {input: 'ELF 64-bit LSB executable, aarch64;, version 1 (SYSV)', expected: 'aarch64'},
+            {input: 'ELF 64-bit LSB executable, mips,;., version 1 (SYSV)', expected: 'mips'},
+        ];
+
+        testCases.forEach(({input, expected}) => {
+            const info = BinaryInfoLinux.parseFileInfo(input);
+            expect(info?.instructionSet).toEqual(expected);
+            expect(info?.os).toEqual('linux');
+        });
+    });
 });


### PR DESCRIPTION
Fix CUDA binary architecture detection and improve parsing robustness

- Add trailing punctuation cleanup for all architecture strings  
- Add support for 'nvidia cuda architecture' mapping to PTX instruction set
- Add comprehensive tests for both changes

## Before (Bugged State):
Test 1: "ELF 64-bit LSB executable, nvidia cuda architecture, version 1 (SYSV), statically linked"
error: Unknown architecture text: nvidia cuda architecture
   Result: {"os":"linux","instructionSet":"amd64"}

Test 2: "ELF 64-bit LSB executable, nvidia cuda architecture,, version 1 (SYSV), statically linked"
error: Unknown architecture text: nvidia cuda architecture,
   Result: {"os":"linux","instructionSet":"amd64"}

## After (Fixed State):
Test 1: "ELF 64-bit LSB executable, nvidia cuda architecture, version 1 (SYSV), statically linked"
   Result: {"os":"linux","instructionSet":"ptx"}

Test 2: "ELF 64-bit LSB executable, nvidia cuda architecture,, version 1 (SYSV), statically linked"
   Result: {"os":"linux","instructionSet":"ptx"}

Fixes #7936