### PR TITLE
Add RGA compiler support for HLSL

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&dxc:&rga:&clang
+compilers=&dxc:&amd_rga:&rga:&clang
 
 group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502:dxc_1_8_2505:dxc_1_8_2505_1
 group.dxc.groupName=DXC
@@ -34,6 +34,31 @@ compiler.dxc_1_8_2505.exe=/opt/compiler-explorer/dxc-1.8.2505/bin/dxc
 compiler.dxc_1_8_2505.semver=1.8.2505
 compiler.dxc_1_8_2505_1.exe=/opt/compiler-explorer/dxc-1.8.2505.1/bin/dxc
 compiler.dxc_1_8_2505_1.semver=1.8.2505.1
+
+group.amd_rga.compilers=rga_2_9_1:rga_2_10:rga_2_11:rga_2_12:rga_2_13
+group.amd_rga.groupName=AMD Radeon GPU Analyzer
+group.amd_rga.isSemVer=true
+group.amd_rga.compilerType=amd_rga
+
+compiler.rga_2_9_1.exe=Z:/compilers/amd-rga-2.9.1/rga.exe
+compiler.rga_2_9_1.semver=2.9.1
+compiler.rga_2_9_1.name=AMD RGA 2.9.1
+
+compiler.rga_2_10.exe=Z:/compilers/amd-rga-2.10/rga.exe
+compiler.rga_2_10.semver=2.10
+compiler.rga_2_10.name=AMD RGA 2.10
+
+compiler.rga_2_11.exe=Z:/compilers/amd-rga-2.11/rga.exe
+compiler.rga_2_11.semver=2.11
+compiler.rga_2_11.name=AMD RGA 2.11
+
+compiler.rga_2_12.exe=Z:/compilers/amd-rga-2.12/rga.exe
+compiler.rga_2_12.semver=2.12
+compiler.rga_2_12.name=AMD RGA 2.12
+
+compiler.rga_2_13.exe=Z:/compilers/amd-rga-2.13/rga.exe
+compiler.rga_2_13.semver=2.13
+compiler.rga_2_13.name=AMD RGA 2.13
 
 group.rga.compilers=rga262_dxctrunk:rga262_dxc172207:rga262_dxc162112:rga261_dxc172207:rga261_dxc162112:rga290_dxctrunk
 group.rga.groupName=RGA

--- a/etc/config/hlsl.defaults.properties
+++ b/etc/config/hlsl.defaults.properties
@@ -1,4 +1,4 @@
-compilers=&dxc:&rga:&clang
+compilers=&dxc:&amd_rga:&rga:&clang
 
 defaultCompiler=dxc_default
 supportsBinary=false
@@ -8,6 +8,12 @@ instructionSet=llvm
 group.dxc.compilers=dxc_default
 compiler.dxc_default.exe=/usr/dxc-artifacts/bin/dxc
 compiler.dxc_default.name=DXC
+
+group.amd_rga.compilers=amd_rga_default
+group.amd_rga.compilerType=amd_rga
+
+compiler.amd_rga_default.exe=Z:/compilers/amd-rga-2.13/rga.exe
+compiler.hlsl_clang_default.name=AMD Radeon GPU Analyzer
 
 group.rga.compilers=rga_default
 group.rga.compilerType=rga

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 export {AdaCompiler} from './ada.js';
+export {AMDRGACompiler} from './amd-rga.js';
 export {AnalysisTool} from './analysis-tool.js';
 export {AssemblyCompiler} from './assembly.js';
 export {AvrGcc6502Compiler} from './avrgcc6502.js';

--- a/lib/compilers/amd-rga.ts
+++ b/lib/compilers/amd-rga.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2022, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'node:path';
+
+import fs from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+
+import type {
+    CompilationResult,
+    ExecutionOptions,
+    ExecutionOptionsWithEnv,
+} from '../../types/compilation/compilation.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+import * as exec from '../exec.js';
+import {logger} from '../logger.js';
+import * as utils from '../utils.js';
+
+// AMD RGA := AMD's Radeon GPU Analyzer (https://gpuopen.com/rga/)
+export class AMDRGACompiler extends BaseCompiler {
+
+    static get key() {
+        return 'amd_rga';
+    }
+
+    constructor(info: any, env: any) {
+        super(info, env);
+        this.compiler.supportsIntel = false;
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: any, userOptions?: any): any[] {
+        return [outputFilename];
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+    ): Promise<CompilationResult> {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+
+        if (!execOptions.customCwd) {
+            execOptions.customCwd = path.dirname(inputFilename);
+        }
+
+        const result = await this.execRGA(compiler, options, execOptions);
+        return this.transformToCompilationResult(result, inputFilename);
+    }
+
+    async execRGA(filepath: string, args: string[], execOptions: ExecutionOptions): Promise<any> {
+        
+        // Track the total time spent instead of relying on executeDirect's internal timing facility
+        const startTime = process.hrtime.bigint();
+
+        // If help flag is requested, skip all extra options
+        if (args.includes('-h') || args.includes('--help')) {
+            logger.debug(`RGA help mode. Args: ${args.join(' ')}`);
+            return await exec.execute(filepath, args, execOptions);
+        }
+
+        const outputIsaFile = args[0];
+        const outputDir = path.dirname(outputIsaFile);
+
+        const rgaArgs = ['--isa', outputIsaFile, ...args.slice(1)];
+
+        // Pop the last argument assuming it's the HLSL input file
+        const inputHlslFile = rgaArgs.pop()!;
+
+        // Determine which flag to use based on shader stage
+        if (args.includes('-s') && args[args.indexOf('-s') + 1] === 'dxr') {
+            rgaArgs.push('--hlsl');
+        } else if (args.includes('-s') && args[args.indexOf('-s') + 1] === 'dx12') {
+            rgaArgs.push('--all-hlsl');
+        }
+
+        rgaArgs.push(inputHlslFile, '--offline');
+        logger.debug(`RGA args: ${rgaArgs}`);
+
+        const rgaResult = await exec.execute(filepath, rgaArgs, execOptions);
+        if (rgaResult.code !== 0) {
+            // Failed to compile AMD ISA
+            const endTime = process.hrtime.bigint();
+            rgaResult.execTime = utils.deltaTimeNanoToMili(startTime, endTime);
+            return rgaResult;
+        }
+
+        // RGA doesn't emit the exact file requested. Append all files with the same extension 
+        // as outputIsaFile into a new file outputIsaFile in outputDir.
+        const files = await fs.readdir(outputDir, {encoding: 'utf8'});
+        const outputIsaFileExt = path.extname(outputIsaFile);
+        const outputIsaFileBase = path.basename(outputIsaFile, outputIsaFileExt);
+        const writeStream = createWriteStream(outputIsaFile);
+
+        for (const file of files) {
+            if (file.endsWith(outputIsaFileExt) && file.includes(outputIsaFileBase)) {
+                const filePath = path.join(outputDir, file);
+                const content = await fs.readFile(filePath, 'utf8');
+                writeStream.write(content);
+                writeStream.write('\n\n');
+            }
+        }
+        writeStream.end();
+
+        const endTime = process.hrtime.bigint();
+        rgaResult.execTime = utils.deltaTimeNanoToMili(startTime, endTime);
+        return rgaResult;
+    }
+}


### PR DESCRIPTION
Add AMD Radeon GPU Analyzer (RGA) as a compiler target for HLSL in Compiler Explorer

This PR adds support for using AMD Radeon GPU Analyzer (RGA) as a compiler backend for HLSL shaders in Compiler Explorer.

Previously, an external contributor had integrated RGA into CE by using the vk-offline-spv-txt mode, which required compiling HLSL to SPIR-V via DXC before passing it to RGA. This workaround was based on RGA v2.6.2 and was suboptimal due to the added dependency on the Vulkan toolchain and indirect compilation path. (https://github.com/compiler-explorer/compiler-explorer/pull/3961)

Starting with RGA v2.9.1, DX12 Single Shader mode was introduced, which allows standalone compilation of individual HLSL shaders to AMD GPU ISA for DirectX 12 targets, without requiring Vulkan or actual AMD hardware. Internally, RGA uses DXC (bundled in the package), and leverages amdxc64.dll, also bundled, to perform the ISA generation. 

This update enables a much cleaner and more direct integration of RGA into Compiler Explorer, relying only on the RGA package itself and a Windows environment.

This PR relies on https://github.com/compiler-explorer/infra/pull/1717
