### PR TITLE
Add new /api/tools/<language> API endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,19 @@ You can use the given include paths to supply in the userArguments for compilati
 You will need the library id's, and the version id's to supply to **compile** if you want to include libraries during
 compilation.
 
+### `GET /api/tools/<language-id>` - return a list of tools available for a language
+
+Returns a list of tools available for the provided language id. This request only returns data in JSON.
+
+The response contains an array of tool objects, each with:
+- `id`: Tool identifier
+- `name`: Human-readable tool name  
+- `type`: Tool type (e.g., "postprocessor")
+- `languageId`: Language the tool supports
+- `allowStdin`: Boolean indicating if the tool accepts stdin input
+
+You can use the tool id's in the `tools` array when making compilation requests.
+
 ### `GET /api/shortlinkinfo/<linkid>` - return information about a given link
 
 Returns information like Sourcecode, Compiler settings and libraries for a given link id. This request only returns data


### PR DESCRIPTION
## Summary
- Add new `/api/tools/<language>` API endpoint that returns available tools for a specific language
- Follows the same pattern as the existing `/api/libraries/<language>` endpoint
- Returns essential tool information: id, name, type, languageId, and allowStdin

## Changes Made
- **Route registration**: Added new route `/api/tools/:language` in `lib/handlers/api.ts`
- **Handler method**: Implemented `handleLangTools()` method following same pattern as `handleLangLibraries()`
- **Helper method**: Created `getToolsAsArray()` method to format tool data for API response
- **Documentation**: Updated `docs/API.md` with new endpoint details

## API Response Format
```json
[
  {
    "id": "clangtidy",
    "name": "Clang-Tidy",
    "type": "postprocessor", 
    "languageId": "c++",
    "allowStdin": true
  }
]
```

## Implementation Details
- `allowStdin` field is `false` only when `stdinHint` is explicitly set to "disabled", `true` otherwise
- Returns simplified tool metadata without exposing internal implementation details
- Consistent error handling for missing language parameter and internal errors

## Test Plan
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] Existing API tests pass
- [x] Pre-commit hooks pass
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)