### PR TITLE
Fix PTX parsing with predicate

### DIFF
--- a/lib/parsers/asm-parser-ptx.ts
+++ b/lib/parsers/asm-parser-ptx.ts
@@ -80,6 +80,8 @@ export class PTXAsmParser extends AsmParser {
         this.functionCallEnd = /^\s*\)\s*;\s*$/;
 
         this.labelLine = /^\s*\$?[a-zA-Z_][a-zA-Z0-9_]*:.*$/;
+
+        this.hasOpcodeRe = /^\s*(@!?%\w+\s+)?(%[$.A-Z_a-z][\w$.]*\s*=\s*)?[A-Za-z]/;
     }
 
     override processAsm(asmResult: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {

--- a/test/asm-parser-tests.ts
+++ b/test/asm-parser-tests.ts
@@ -56,6 +56,19 @@ describe('AsmParser comment filtering', () => {
 describe('PTXAsmParser tests', () => {
     const parser = new PTXAsmParser();
 
+    describe('Identifying opcodes', () => {
+        it('should identify regular PTX opcodes', () => {
+            expect(parser.hasOpcode('  mov.u32 	%r25, %ctaid.x;')).toBe(true);
+            expect(parser.hasOpcode('  ld.global.v4.b32 { %r1, %r2, %r3, %r4 }, [ %rd1 + 0 ];')).toBe(true);
+            expect(parser.hasOpcode('  mul.wide.s32 	%rd10, %r31, 4;')).toBe(true);
+        });
+        it('should identify PTX opcodes with predicate', () => {
+            expect(parser.hasOpcode('  @%p1 ld.global.v4.b32 { %r1, %r2, %r3, %r4 }, [ %rd1 + 0 ];')).toBe(true);
+            expect(parser.hasOpcode('  @!%p1 bra LBB6_2;')).toBe(true);
+            expect(parser.hasOpcode('  @%r789 bra LBB6_2;')).toBe(true);
+        });
+    });
+
     describe('Nested brace indentation', () => {
         it('should indent content inside callseq blocks', () => {
             const input = `{ // callseq 0, 0

--- a/test/filters-cases/ptx-example-more-complicated.asm.binary.directives.labels.comments.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.binary.directives.labels.comments.json
@@ -117,7 +117,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -162,7 +167,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -212,7 +222,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -322,7 +337,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -362,7 +382,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -377,7 +402,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -442,7 +472,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -562,7 +597,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -662,7 +702,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -702,7 +747,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -717,7 +767,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -872,7 +927,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -902,7 +962,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -917,7 +982,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1022,7 +1092,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1042,7 +1117,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1082,7 +1162,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1097,7 +1182,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1242,7 +1332,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1282,7 +1377,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1297,7 +1397,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1312,7 +1417,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1327,7 +1437,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1377,7 +1492,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1432,7 +1552,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1447,7 +1572,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1462,7 +1592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1592,7 +1727,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.comments.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.comments.json
@@ -117,7 +117,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -162,7 +167,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -212,7 +222,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -322,7 +337,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -362,7 +382,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -377,7 +402,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -442,7 +472,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -562,7 +597,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -662,7 +702,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -702,7 +747,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -717,7 +767,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -872,7 +927,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -902,7 +962,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -917,7 +982,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1022,7 +1092,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1042,7 +1117,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1082,7 +1162,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1097,7 +1182,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1242,7 +1332,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1282,7 +1377,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1297,7 +1397,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1312,7 +1417,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1327,7 +1437,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1377,7 +1492,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1432,7 +1552,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1447,7 +1572,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1462,7 +1592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1592,7 +1727,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.json
@@ -182,7 +182,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -232,7 +237,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -292,7 +302,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -412,7 +427,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -462,7 +482,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -482,7 +507,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -562,7 +592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -692,7 +727,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -802,7 +842,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -852,7 +897,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -872,7 +922,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -1042,7 +1097,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -1082,7 +1142,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -1102,7 +1167,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1222,7 +1292,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1247,7 +1322,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1297,7 +1377,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1317,7 +1402,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1477,7 +1567,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1527,7 +1622,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1547,7 +1647,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1567,7 +1672,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1587,7 +1697,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1642,7 +1757,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1707,7 +1827,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1727,7 +1852,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1747,7 +1877,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1897,7 +2032,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.comments.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.comments.json
@@ -117,7 +117,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -162,7 +167,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -212,7 +222,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -322,7 +337,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -362,7 +382,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -377,7 +402,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -442,7 +472,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -562,7 +597,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -662,7 +702,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -702,7 +747,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -717,7 +767,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -872,7 +927,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -902,7 +962,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -917,7 +982,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1022,7 +1092,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1042,7 +1117,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1082,7 +1162,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1097,7 +1182,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1242,7 +1332,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1282,7 +1377,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1297,7 +1397,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1312,7 +1417,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1327,7 +1437,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1377,7 +1492,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1432,7 +1552,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1447,7 +1572,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1462,7 +1592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1592,7 +1727,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -87,7 +87,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -132,7 +137,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -182,7 +192,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -292,7 +307,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -332,7 +352,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -347,7 +372,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -412,7 +442,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -532,7 +567,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -632,7 +672,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -672,7 +717,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -687,7 +737,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -842,7 +897,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -872,7 +932,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -887,7 +952,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -992,7 +1062,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1012,7 +1087,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1052,7 +1132,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1067,7 +1152,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1212,7 +1302,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1252,7 +1347,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1267,7 +1367,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1282,7 +1387,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1297,7 +1407,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1347,7 +1462,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1402,7 +1522,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1417,7 +1542,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1432,7 +1562,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1562,7 +1697,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.comments.library.json
@@ -87,7 +87,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -132,7 +137,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -182,7 +192,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -292,7 +307,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -332,7 +352,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -347,7 +372,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -412,7 +442,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -532,7 +567,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -632,7 +672,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -672,7 +717,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -687,7 +737,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -842,7 +897,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -872,7 +932,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -887,7 +952,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -992,7 +1062,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1012,7 +1087,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1052,7 +1132,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1067,7 +1152,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1212,7 +1302,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1252,7 +1347,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1267,7 +1367,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1282,7 +1387,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1297,7 +1407,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1347,7 +1462,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1402,7 +1522,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1417,7 +1542,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1432,7 +1562,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1562,7 +1697,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.labels.json
@@ -182,7 +182,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -232,7 +237,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -292,7 +302,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -412,7 +427,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -462,7 +482,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -482,7 +507,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -562,7 +592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -692,7 +727,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -802,7 +842,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -852,7 +897,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -872,7 +922,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -1042,7 +1097,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -1082,7 +1142,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -1102,7 +1167,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1222,7 +1292,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1247,7 +1322,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1297,7 +1377,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1317,7 +1402,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1477,7 +1567,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1527,7 +1622,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1547,7 +1647,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1567,7 +1672,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1587,7 +1697,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1642,7 +1757,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1707,7 +1827,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1727,7 +1852,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1747,7 +1877,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1897,7 +2032,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.directives.library.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.directives.library.json
@@ -152,7 +152,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -202,7 +207,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -262,7 +272,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -382,7 +397,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -432,7 +452,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -452,7 +477,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -532,7 +562,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -662,7 +697,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -772,7 +812,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -822,7 +867,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -842,7 +892,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -1012,7 +1067,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -1052,7 +1112,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -1072,7 +1137,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1192,7 +1262,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1217,7 +1292,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1267,7 +1347,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1287,7 +1372,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1447,7 +1537,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1497,7 +1592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1517,7 +1617,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1537,7 +1642,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1557,7 +1667,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1612,7 +1727,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1677,7 +1797,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1697,7 +1822,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1717,7 +1847,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -1867,7 +2002,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {

--- a/test/filters-cases/ptx-example-more-complicated.asm.none.json
+++ b/test/filters-cases/ptx-example-more-complicated.asm.none.json
@@ -242,7 +242,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p1 bra \t$L__BB0_49;"
     },
     {
@@ -297,7 +302,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p2 bra \t$L__BB0_28;"
     },
     {
@@ -367,7 +377,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_5;"
     },
     {
@@ -502,7 +517,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p7 bra \t$L__BB0_7;"
     },
     {
@@ -557,7 +577,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p8 bra \t$L__BB0_10;"
     },
     {
@@ -577,7 +602,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p9 bra \t$L__BB0_11;"
     },
     {
@@ -672,7 +702,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p3 bra \t$L__BB0_13;"
     },
     {
@@ -812,7 +847,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p14 bra \t$L__BB0_15;"
     },
     {
@@ -922,7 +962,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p18 bra \t$L__BB0_17;"
     },
     {
@@ -977,7 +1022,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_20;"
     },
     {
@@ -997,7 +1047,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p20 bra \t$L__BB0_21;"
     },
     {
@@ -1182,7 +1237,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p24 bra \t$L__BB0_23;"
     },
     {
@@ -1227,7 +1287,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p19 bra \t$L__BB0_26;"
     },
     {
@@ -1247,7 +1312,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p26 bra \t$L__BB0_27;"
     },
     {
@@ -1392,7 +1462,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p27 bra \t$L__BB0_3;"
     },
     {
@@ -1422,7 +1497,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p28 bra \t$L__BB0_49;"
     },
     {
@@ -1487,7 +1567,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p29 bra \t$L__BB0_33;"
     },
     {
@@ -1507,7 +1592,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 9,
+        "mainsource": true
+      },
       "text": "\t@%p30 bra \t$L__BB0_34;"
     },
     {
@@ -1692,7 +1782,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 11,
+        "mainsource": true
+      },
       "text": "\t@%p34 bra \t$L__BB0_36;"
     },
     {
@@ -1747,7 +1842,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p35 bra \t$L__BB0_42;"
     },
     {
@@ -1767,7 +1867,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p39 bra \t$L__BB0_40;"
     },
     {
@@ -1787,7 +1892,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p40 bra \t$L__BB0_41;"
     },
     {
@@ -1807,7 +1917,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p41 bra \t$L__BB0_40;"
     },
     {
@@ -1867,7 +1982,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 13,
+        "mainsource": true
+      },
       "text": "\t@%p42 bra \t$L__BB0_48;"
     },
     {
@@ -1937,7 +2057,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p36 bra \t$L__BB0_47;"
     },
     {
@@ -1957,7 +2082,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p37 bra \t$L__BB0_46;"
     },
     {
@@ -1977,7 +2107,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 9,
+        "file": "example.cu",
+        "line": 12,
+        "mainsource": true
+      },
       "text": "\t@%p38 bra \t$L__BB0_48;"
     },
     {
@@ -2147,7 +2282,12 @@
     },
     {
       "labels": [],
-      "source": null,
+      "source": {
+        "column": 5,
+        "file": "example.cu",
+        "line": 8,
+        "mainsource": true
+      },
       "text": "\t@%p43 bra \t$L__BB0_30;"
     },
     {


### PR DESCRIPTION
Recogonize lines with predicate (e.g., `@%p1`, `@!%p1`) as instructions:
- `@%p1 ld.global.v4.b32 { %r9, %r10, %r11, %r12 }, [ %rd3 + 0 ];`
- `@%p2 bra $L__BB0_28;`
- `@!%p2 bra $L__BB0_28;`

| Before | After | 
| --- | --- |
| <img width="580" height="320" alt="image" src="https://github.com/user-attachments/assets/c3913b09-ce04-44c5-a4c0-fa69805cf1d7" /> | <img width="566" height="323" alt="image" src="https://github.com/user-attachments/assets/08308b3d-df00-4cf1-8321-203c374c27c3" /> |



From https://docs.nvidia.com/cuda/parallel-thread-execution/#instruction-statements: 

> Instructions have an optional guard predicate which controls conditional execution. The guard predicate follows the optional label and precedes the opcode, and is written as @p, where p is a predicate register. The guard predicate may be optionally negated, written as @!p.

Implementation-wise, added `(@!?%\w+\s+)?` to existing default `hasOpcodeRe` (`/^\s*(%[$.A-Z_a-z][\w$.]*\s*=\s*)?[A-Za-z]/`)
