### PR TITLE
Remove dangling empty braces in PTX

### DIFF
--- a/lib/parsers/asm-parser-ptx.ts
+++ b/lib/parsers/asm-parser-ptx.ts
@@ -100,6 +100,8 @@ export class PTXAsmParser extends AsmParser {
         let inFunctionCall = false;
         let callBaseIndent = '';
         let braceDepth = 0;
+        let lineNumber = 0;
+        let openBraceLineNumber = 0;
 
         for (let line of asmLines) {
             const newSource = this.processSourceLine(line, files);
@@ -181,8 +183,14 @@ export class PTXAsmParser extends AsmParser {
 
             if (this.functionStart.test(line)) {
                 braceDepth++;
+                openBraceLineNumber = lineNumber;
             } else if (this.functionEnd.test(line)) {
                 braceDepth--;
+                // Remove paired braces with no content
+                if (openBraceLineNumber + 1 === lineNumber) {
+                    asm.pop();
+                    continue;
+                }
             }
 
             if (filters.trim) {
@@ -194,6 +202,7 @@ export class PTXAsmParser extends AsmParser {
                 source: this.hasOpcode(line) ? currentSource : null,
                 labels: [],
             });
+            lineNumber++;
         }
 
         const endTime = process.hrtime.bigint();

--- a/test/asm-parser-tests.ts
+++ b/test/asm-parser-tests.ts
@@ -195,4 +195,26 @@ vprintf,
             expect(lines[7]).toBe('}');
         });
     });
+
+    describe('Directive filter', () => {
+        it('should remove directives when directive filter is enabled', () => {
+            const input = `
+ 	.file	1 "/tmp/compiler-explorer-compilerk2brih/example.py"
+    .section	.debug_abbrev
+    {
+	.b8 1
+	}
+    .section	.debug_info
+    {
+    .b32 70
+    .b32 .debug_abbrev
+    }
+    .section	.debug_macinfo	{	}
+`;
+            const result = parser.processAsm(input, {directives: true});
+            const lines = result.asm.map(line => line.text);
+            expect(lines.length).toBe(1);
+            expect(lines[0]).toBe('');
+        });
+    });
 });


### PR DESCRIPTION
After directive filtering, there will be dangling `{}` spanning two lines. This PR attempts to remove them. 

For example, 
```
.section    .debug_abbrev
{
.b8 1
}
.section    .debug_info
{
.b32 70
.b32 .debug_abbrev
}
```

The above assembly used to become the following text after filtering directive

```
{
}
{
}
```