### PR TITLE
Configure Nix compiler for production environment

### DIFF
--- a/etc/config/nix.amazon.properties
+++ b/etc/config/nix.amazon.properties
@@ -1,0 +1,21 @@
+compilers=&nix
+defaultCompiler=nix2290
+
+group.nix.groupName=Nix
+group.nix.compilers=nix2263:nix2271:nix2283:nix2290
+group.nix.isSemVer=true
+group.nix.baseName=Nix
+group.nix.licenseName=LGPL v2.1
+group.nix.licenseLink=https://github.com/NixOS/nix/blob/master/COPYING
+
+compiler.nix2263.semver=2.26.3
+compiler.nix2263.exe=/opt/compiler-explorer/nix-2.26.3/nix
+
+compiler.nix2271.semver=2.27.1
+compiler.nix2271.exe=/opt/compiler-explorer/nix-2.27.1/nix
+
+compiler.nix2283.semver=2.28.3
+compiler.nix2283.exe=/opt/compiler-explorer/nix-2.28.3/nix
+
+compiler.nix2290.semver=2.29.0
+compiler.nix2290.exe=/opt/compiler-explorer/nix-2.29.0/nix


### PR DESCRIPTION
- Add nix.amazon.properties with proper executable paths
- Define 4 Nix versions: 2.26.3, 2.27.1, 2.28.3, 2.29.0
- Set 2.29.0 as default version

Fixes #7811

🤖 Generated with [Claude Code](https://claude.ai/code)
