### PR TITLE
Simplify default.go

### DIFF
--- a/examples/go/default.go
+++ b/examples/go/default.go
@@ -1,9 +1,6 @@
 // Type your code here, or load an example.
-// Your function name should start with a capital letter.
-package main
+package p
 
-func Square(x int) int {
+func square(x int) int {
     return x * x
 }
-
-func main() {}


### PR DESCRIPTION
A while ago compiler explorer would only see exported functions of the main package (and the main function).
I don't know when but at someone improved the flags passed to the go compiler and it now sees all functions, even if you use the oldest go compiler still supported.

Remove noise from the example and make it more like the C one.
