### PR TITLE
Fix llvm-mca tool preprocessing of debug directives

### DIFF
--- a/lib/tooling/llvm-mca-tool.ts
+++ b/lib/tooling/llvm-mca-tool.ts
@@ -36,12 +36,13 @@ export class LLVMMcaTool extends BaseTool {
         return 'llvm-mca-tool';
     }
 
-    rewriteAsm(asm: string) {
+    public rewriteAsm(asm: string) {
         return asm
             .replaceAll(/.hword\s/gim, '.short ')
             .replaceAll(/offset flat:/gim, '')
             .replaceAll(/ptr\s%fs/gim, 'PTR fs')
-            .replaceAll(/^\s*\.(fnstart|eabi_attribute|fpu).*/gim, ''); // https://github.com/compiler-explorer/compiler-explorer/issues/1270
+            .replaceAll(/^\s*\.(fnstart|eabi_attribute|fpu).*/gim, '') // https://github.com/compiler-explorer/compiler-explorer/issues/1270
+            .replaceAll(/^\s*\.(loc|file).*/gim, ''); // Remove debug directives that can cause "unassigned file number" errors
     }
 
     writeAsmFile(data: string, destination: string) {


### PR DESCRIPTION
This PR fixes the "unassigned file number" error in llvm-mca when processing GCC-generated assembly with debug information #6795 .

**Problem**: GCC with `-g` flag generates `.loc` and `.file` debug directives that cause llvm-mca to fail with "unassigned file number" errors.

**Solution**: Filter out `.loc` and `.file` directives during assembly preprocessing, similar to how other problematic directives are already handled.

**Changes**:
- Add regex filtering for `.loc` and `.file` directives in `rewriteAsm()`
- Make `rewriteAsm()` method public for testability
- Add comprehensive test coverage for debug directive removal

The fix is minimal, targeted, and follows the existing pattern of directive filtering.