### PR TITLE
Filter out network-level jQuery failures from Sentry reports

### DIFF
--- a/static/main.ts
+++ b/static/main.ts
@@ -196,7 +196,17 @@ function setupButtons(options: CompilerExplorerOptions, hub: Hub) {
             $('#ces .ces-icons').html(data);
         })
         .fail(err => {
-            SentryCapture(err, '$.get failed');
+            // Filter out network-level failures that aren't actionable bugs
+            // readyState 0 with status 0 typically indicates network issues, ad blockers, or aborted requests
+            if (err.readyState === 0 && err.status === 0) {
+                console.debug('Icons request failed due to network/browser policy:', err.statusText);
+                return;
+            }
+
+            // Only capture server errors or other potentially actionable failures
+            if (err.status >= 400) {
+                SentryCapture(err, '$.get failed loading icons');
+            }
         });
 
     $('#ces').on('click', () => {
@@ -205,11 +215,25 @@ function setupButtons(options: CompilerExplorerOptions, hub: Hub) {
                 alertSystem.alert('Compiler Explorer Sponsors', data);
             })
             .fail(err => {
-                const result = err.responseText || JSON.stringify(err);
-                alertSystem.alert(
-                    'Compiler Explorer Sponsors',
-                    '<div>Unable to fetch sponsors:</div><div>' + result + '</div>',
-                );
+                // Filter out network-level failures that aren't actionable bugs
+                if (err.readyState === 0 && err.status === 0) {
+                    console.debug('Sponsors request failed due to network/browser policy:', err.statusText);
+                    return;
+                }
+
+                // Only capture server errors for Sentry - silently fail for network issues
+                if (err.status >= 400) {
+                    SentryCapture(err, '$.get failed loading sponsors');
+                }
+
+                // Still show user-facing error for actual server problems
+                if (err.status >= 400) {
+                    const result = err.responseText || JSON.stringify(err);
+                    alertSystem.alert(
+                        'Compiler Explorer Sponsors',
+                        '<div>Unable to fetch sponsors:</div><div>' + result + '</div>',
+                    );
+                }
             });
     });
 

--- a/static/main.ts
+++ b/static/main.ts
@@ -221,13 +221,9 @@ function setupButtons(options: CompilerExplorerOptions, hub: Hub) {
                     return;
                 }
 
-                // Only capture server errors for Sentry - silently fail for network issues
                 if (err.status >= 400) {
+                    // Capture server errors for Sentry, and show to the user
                     SentryCapture(err, '$.get failed loading sponsors');
-                }
-
-                // Still show user-facing error for actual server problems
-                if (err.status >= 400) {
                     const result = err.responseText || JSON.stringify(err);
                     alertSystem.alert(
                         'Compiler Explorer Sponsors',


### PR DESCRIPTION
## Summary

This PR fixes Sentry issue COMPILER-EXPLORER-BFA which has generated over 33,000 occurrences of non-actionable error reports.

## Problem

The issue occurs when jQuery `.get()` requests fail with `readyState: 0` and `status: 0`, which typically indicates:
- Ad blockers blocking requests to static assets (icons.html, sponsors.html)
- Network connectivity issues
- Browser security policies 
- User navigating away during request

These network-level failures are not application bugs and create noise in Sentry monitoring.

## Solution

- Filter out network failures (`readyState === 0 && status === 0`) before sending to Sentry
- Only capture actual server errors (`status >= 400`) for debugging
- Log network failures to console for debugging instead
- For sponsors.html specifically, silently fail on network issues per request

## Test Plan

- [x] TypeScript compilation passes
- [x] All tests pass
- [x] Pre-commit hooks complete successfully
- Verified logic handles both network failures and real server errors appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)