### PR TITLE
[Triton] Fix AMD lld issue

### DIFF
--- a/etc/scripts/triton_wrapper.py
+++ b/etc/scripts/triton_wrapper.py
@@ -181,6 +181,19 @@ def setup_triton(
     except ImportError:
         pass
 
+    # Triton used to depends on the ld.lld binary, and search for the following paths:
+    #   - TRITON_HIP_LLD_PATH (see https://github.com/triton-lang/triton/pull/3917)
+    #   - third_party/amd/backend/llvm/bin/ld.lld (see https://github.com/triton-lang/triton/pull/3662)
+    #   - /opt/rocm/llvm/bin/ld.lld
+    #   - /usr/bin/ld.lld (see https://github.com/triton-lang/triton/pull/3197)
+    # However, none of them are available in the production environment, which causes
+    #     Exception: ROCm linker /opt/rocm/llvm/bin/ld.lld not found. Set 'TRITON_HIP_LLD_PATH' to its path.
+    # Since the linker is only used to generate the binary .hsaco file (from the .amdgcn assembly),
+    # we don't really need it. We can just mock it to be a no-op.
+    # Note: Triton no longer depends on the ld.lld binary after v3.4.0 (exclusive) with commit:
+    #     https://github.com/triton-lang/triton/pull/7548
+    os.environ["TRITON_HIP_LLD_PATH"] = "/bin/true"
+
 
 def main(
     input_file: Path,


### PR DESCRIPTION
Fix issue with AMD by removing the dependency on lld (tested locally by moving `/usr/bin/ld.lld` and `/opt/rocm/llvm/bin/ld.lld`)

```
  File "/opt/compiler-explorer/triton/v3.3.1/lib/python3.12/site-packages/triton/runtime/jit.py", line 347, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/compiler-explorer/triton/v3.3.1/lib/python3.12/site-packages/triton/runtime/jit.py", line 569, in run
    kernel = self.compile(src, target=target, options=options.__dict__)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/compiler-explorer/triton/v3.3.1/lib/python3.12/site-packages/triton/compiler/compiler.py", line 230, in compile
    key = f"{triton_key()}-{src.hash()}-{backend.hash()}-{options.hash()}-{str(sorted(env_vars.items()))}"
                                         ^^^^^^^^^^^^^^
  File "/opt/compiler-explorer/triton/v3.3.1/lib/python3.12/site-packages/triton/backends/amd/compiler.py", line 418, in hash
    version = subprocess.check_output([HIPBackend.path_to_rocm_lld(), "--version"], encoding='utf-8')
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/compiler-explorer/triton/v3.3.1/lib/python3.12/site-packages/triton/backends/amd/compiler.py", line 197, in path_to_rocm_lld
    raise Exception("ROCm linker /opt/rocm/llvm/bin/ld.lld not found. Set 'TRITON_HIP_LLD_PATH' to its path.")
Exception: ROCm linker /opt/rocm/llvm/bin/ld.lld not found. Set 'TRITON_HIP_LLD_PATH' to its path.
```