### PR TITLE
Fix tzdata missing for <date> #6729

### DIFF
--- a/etc/nsjail/compilers-and-tools.cfg
+++ b/etc/nsjail/compilers-and-tools.cfg
@@ -70,6 +70,14 @@ mount {
     dst: "/etc/localtime"
     is_bind: true
 }
+
+# To allow timezone-aware libraries like Howard Hinnant's date library to work
+mount {
+    src: "/usr/share/zoneinfo"
+    dst: "/usr/share/zoneinfo"
+    is_bind: true
+}
+
 mount {
     src_content: "nobody:x:65534:65534:Not root:/root:/none\nce:x:10240:10240:Not a real account:/app:/bin/bash"
     dst: "/etc/passwd"

--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -52,7 +52,7 @@ mount {
     is_bind: true
 }
 
-# To allow cctz to work
+# To allow timezone-aware libraries like Howard Hinnant's date library and cctz to work
 mount {
     src: "/usr/share/zoneinfo"
     dst: "/usr/share/zoneinfo"


### PR DESCRIPTION
As shown in bug #6729, sandbox was missing the tzdata file when using Howard Hinnant's date library via `#include <date/tz.h>`, where the timezone database location would default to "/app/Downloads/tzdata", and then seg fault.

This fix includes the correct path mounted in compilers-and-tools.cfg to allow for the library to work correctly.

