### PR TITLE
Add alias option for gcc tree/rtl viewer (#7985)

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -715,6 +715,9 @@ export class BaseCompiler {
         if (gccDumpOptions.dumpFlags.address !== false) {
             flags += '-address';
         }
+        if (gccDumpOptions.dumpFlags.alias !== false) {
+            flags += '-alias';
+        }
         if (gccDumpOptions.dumpFlags.slim !== false) {
             flags += '-slim';
         }

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2173,6 +2173,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             this.dumpFlags = {
                 gimpleFe: dumpOpts.gimpleFeOption,
                 address: dumpOpts.addressOption,
+                alias: dumpOpts.aliasOption,
                 slim: dumpOpts.slimOption,
                 raw: dumpOpts.rawOption,
                 details: dumpOpts.detailsOption,

--- a/static/panes/gccdump-view.interfaces.ts
+++ b/static/panes/gccdump-view.interfaces.ts
@@ -47,6 +47,7 @@ export type GccDumpFiltersState = {
 
     gimpleFeOption: boolean;
     addressOption: boolean;
+    aliasOption: boolean;
     blocksOption: boolean;
     linenoOption: boolean;
     detailsOption: boolean;

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -53,6 +53,8 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
     optionGimpleFeTitle: string;
     optionAddressButton: JQuery<HTMLElement>;
     optionAddressTitle: string;
+    optionAliasButton: JQuery<HTMLElement>;
+    optionAliasTitle: string;
     optionSlimButton: JQuery<HTMLElement>;
     optionSlimTitle: string;
     optionRawButton: JQuery<HTMLElement>;
@@ -190,6 +192,9 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         this.optionAddressButton = this.domRoot.find("[data-bind='addressOption']");
         this.optionAddressTitle = this.optionAddressButton.prop('title');
 
+        this.optionAliasButton = this.domRoot.find("[data-bind='aliasOption']");
+        this.optionAliasTitle = this.optionAliasButton.prop('title');
+
         this.optionSlimButton = this.domRoot.find("[data-bind='slimOption']");
         this.optionSlimTitle = this.optionSlimButton.prop('title');
 
@@ -270,6 +275,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         formatButtonTitle(this.dumpIpaButton, this.dumpIpaTitle);
         formatButtonTitle(this.optionGimpleFeButton, this.optionGimpleFeTitle);
         formatButtonTitle(this.optionAddressButton, this.optionAddressTitle);
+        formatButtonTitle(this.optionAliasButton, this.optionAliasTitle);
         formatButtonTitle(this.optionSlimButton, this.optionSlimTitle);
         formatButtonTitle(this.optionRawButton, this.optionRawTitle);
         formatButtonTitle(this.optionDetailsButton, this.optionDetailsTitle);

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -72,6 +72,7 @@ export type LibsAndOptions = {
 export type GccDumpFlags = {
     gimpleFe: boolean;
     address: boolean;
+    alias: boolean;
     slim: boolean;
     raw: boolean;
     details: boolean;

--- a/views/templates/panes/gccdump.pug
+++ b/views/templates/panes/gccdump.pug
@@ -29,6 +29,7 @@ mixin optionButton(bind, isActive, text, title)
         // This addresses one was marked as aria-pressed=true, but not checked. What should its default state be then? Set to false for now
         +optionButton("gimpleFeOption", false, "GIMPLE Frontend Syntax", "Dump syntax that the GIMPLE frontend can accept")
         +optionButton("addressOption", false, "Addresses", "Print the address of each tree node")
+        +optionButton("aliasOption", false, "Alias", "Display alias information")
         +optionButton("blocksOption", false, "Basic Blocks", "Show the basic block boundaries (disabled in raw dumps)")
         +optionButton("linenoOption", false, "Line Numbers", "Show line numbers")
         +optionButton("detailsOption", false, "Pass Details", "Enable more detailed dumps (not honored by every dump option)")


### PR DESCRIPTION
This option is undocumented, but has been around since 2010 for GCC 4.6.0

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
