### PR TITLE
Bump Binutils version into 2.45 when using GCC 15.1.

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -46,7 +46,7 @@ compiler.gnuas121.semver=2.38
 compiler.gnuas142.exe=/opt/compiler-explorer/gcc-14.2.0/bin/as
 compiler.gnuas142.semver=2.42
 compiler.gnuas151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/as
-compiler.gnuas151.semver=2.44
+compiler.gnuas151.semver=2.45
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnuassnapshot.semver=(trunk)
@@ -84,7 +84,7 @@ compiler.gnuasarm1320.name=ARM gcc 13.2 (linux)
 compiler.gnuasarm1320.semver=ARM binutils 2.38
 compiler.gnuasarm1510.exe=/opt/compiler-explorer/arm/gcc-15.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-as
 compiler.gnuasarm1510.name=ARM gcc 15.1 (linux)
-compiler.gnuasarm1510.semver=ARM binutils 2.44
+compiler.gnuasarm1510.semver=ARM binutils 2.45
 
 
 group.gnuasarm64.compilers=gnuasarm64g630:gnuasarm64g820:gnuasarm64g930:gnuasarm64g1020:gnuasarm64g1320:gnuasarm64g1510
@@ -112,8 +112,8 @@ compiler.gnuasarm64g1320.exe=/opt/compiler-explorer/arm64/gcc-13.2.0/aarch64-unk
 compiler.gnuasarm64g1320.name=AArch64 binutils 2.38
 compiler.gnuasarm64g1320.semver=2.38
 compiler.gnuasarm64g1510.exe=/opt/compiler-explorer/arm64/gcc-15.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-as
-compiler.gnuasarm64g1510.name=AArch64 binutils 2.44
-compiler.gnuasarm64g1510.semver=2.44
+compiler.gnuasarm64g1510.name=AArch64 binutils 2.45
+compiler.gnuasarm64g1510.semver=2.45
 
 # GNU as for RISC-V
 group.gnuasriscv.compilers=&gnuasriscv64:&gnuasriscv32
@@ -154,8 +154,8 @@ compiler.gnuasriscv64g1420.semver=2.42.0
 compiler.gnuasriscv64g1420.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 compiler.gnuasriscv64g1510.exe=/opt/compiler-explorer/riscv64/gcc-15.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
-compiler.gnuasriscv64g1510.name=RISC-V binutils 2.44.0
-compiler.gnuasriscv64g1510.semver=2.44.0
+compiler.gnuasriscv64g1510.name=RISC-V binutils 2.45.0
+compiler.gnuasriscv64g1510.semver=2.45.0
 compiler.gnuasriscv64g1510.objdumper=/opt/compiler-explorer/riscv64/gcc-15.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 ## GNU as for RISC-V 32-bits
@@ -189,8 +189,8 @@ compiler.gnuasriscv32g1420.semver=2.42.0
 compiler.gnuasriscv32g1420.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 compiler.gnuasriscv32g1510.exe=/opt/compiler-explorer/riscv32/gcc-15.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
-compiler.gnuasriscv32g1510.name=RISC-V binutils 2.44.0
-compiler.gnuasriscv32g1510.semver=2.44.0
+compiler.gnuasriscv32g1510.name=RISC-V binutils 2.45.0
+compiler.gnuasriscv32g1510.semver=2.45.0
 compiler.gnuasriscv32g1510.objdumper=/opt/compiler-explorer/riscv32/gcc-15.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas1910:llvmas2010:llvmas_trunk:llvmas_assertions_trunk


### PR DESCRIPTION
Bump Binutils version into 2.45 when using GCC 15.1.

The change form 2.44 into 2.45 includes some new assembler features, the details please check 

https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gas/NEWS;h=2e9538bd2736b4108cc5a383802c75f5feacfbc4;hb=2bc7af1ff7732451b6a7b09462a815c3284f9613