### PR TITLE
Fix #8009: Allow quotes as part of labels

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -333,7 +333,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         // Opcode expression here matches LLVM-style opcodes of the form `%blah = opcode`
         this.hasOpcodeRe = /^\s*(%[$.A-Z_a-z][\w$.]*\s*=\s*)?[A-Za-z]/;
         this.instructionRe = /^\s*[A-Za-z]+/;
-        this.identifierFindRe = /([$.@A-Z_a-z]\w*)(?:@\w+)*/g;
+        this.identifierFindRe = /([$.@A-Z_a-z"]\w*"?)(?:@\w+)*/g;
         this.hasNvccOpcodeRe = /^\s*[@A-Za-z|]/;
         this.definesFunction = /^\s*\.(type.*,\s*[#%@]function|proc\s+[.A-Z_a-z][\w$.]*:.*)$/;
         this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*|"[.A-Z_a-z][\w$.]*")/;

--- a/test/demangle-cases/bug-660.asm.json
+++ b/test/demangle-cases/bug-660.asm.json
@@ -4290,15 +4290,7 @@
       "text": "$LASF54:",
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 22,
-            "startCol": 18,
-          },
-        },
-      ],
+      "labels": [],
       "source": null,
       "text": "        .ascii  "main\000"",
     },

--- a/test/demangle-cases/bug-713.asm.json
+++ b/test/demangle-cases/bug-713.asm.json
@@ -7589,15 +7589,7 @@
       "text": ".LASF21:",
     },
     {
-      "labels": [
-        {
-          "name": "caller1()",
-          "range": {
-            "endCol": 27,
-            "startCol": 18,
-          },
-        },
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string "caller1()"",
     },
@@ -7777,15 +7769,7 @@
       "text": ".LASF7:",
     },
     {
-      "labels": [
-        {
-          "name": "Normal::~Normal() [deleting destructor]",
-          "range": {
-            "endCol": 57,
-            "startCol": 18,
-          },
-        },
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string "Normal::~Normal() [deleting destructor]"",
     },
@@ -7795,15 +7779,7 @@
       "text": ".LASF19:",
     },
     {
-      "labels": [
-        {
-          "name": "caller2(Normal*)",
-          "range": {
-            "endCol": 34,
-            "startCol": 18,
-          },
-        },
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string "caller2(Normal*)"",
     },
@@ -7833,15 +7809,7 @@
       "text": ".LASF8:",
     },
     {
-      "labels": [
-        {
-          "name": "Normal::~Normal() [base object destructor]",
-          "range": {
-            "endCol": 60,
-            "startCol": 18,
-          },
-        },
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string "Normal::~Normal() [base object destructor]"",
     },

--- a/test/filters-cases/6502-square.asm.none.json
+++ b/test/filters-cases/6502-square.asm.none.json
@@ -124,15 +124,7 @@
       "text": ""
     },
     {
-      "labels": [
-        {
-          "name": "_square",
-          "range": {
-            "endCol": 55,
-            "startCol": 48
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .dbg    func, \"square\", \"00\", extern, \"_square\""
     },

--- a/test/filters-cases/arm-hellow.asm.none.json
+++ b/test/filters-cases/arm-hellow.asm.none.json
@@ -5323,15 +5323,7 @@
       "text": ".LASF55:"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 22,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .ascii  \"main\\000\""
     },

--- a/test/filters-cases/bug-1229.asm.none.json
+++ b/test/filters-cases/bug-1229.asm.none.json
@@ -8374,15 +8374,7 @@
       "text": ".Linfo_string573:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z6myfuncv",
-          "range": {
-            "endCol": 28,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"_Z6myfuncv\"            # string offset=14532"
     },
@@ -8402,15 +8394,7 @@
       "text": ".Linfo_string575:"
     },
     {
-      "labels": [
-        {
-          "name": "_ZN4ctre18evaluate_recursiveINS_13regex_resultsIPKcJEEES3_S3_Lm0ELm0EJNS_3anyEEJNS_10assert_endENS_8end_markENS_6acceptEEEET_mT0_SA_T1_S9_N4ctll4listIJNS_6repeatIXT2_EXT3_EJDpT4_EEEDpT5_EEE",
-          "range": {
-            "endCol": 207,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"_ZN4ctre18evaluate_recursiveINS_13regex_resultsIPKcJEEES3_S3_Lm0ELm0EJNS_3anyEEJNS_10assert_endENS_8end_markENS_6acceptEEEET_mT0_SA_T1_S9_N4ctll4listIJNS_6repeatIXT2_EXT3_EJDpT4_EEEDpT5_EEE\" # string offset=14550"
     },

--- a/test/filters-cases/bug-1285c.asm.none.json
+++ b/test/filters-cases/bug-1285c.asm.none.json
@@ -2808,15 +2808,7 @@
       "text": ".LASF1:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z3bazv",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z3bazv\""
     },
@@ -2826,15 +2818,7 @@
       "text": ".LASF2:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z3foov",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z3foov\""
     },
@@ -2884,15 +2868,7 @@
       "text": ".LASF11:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z3barv",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z3barv\""
     },

--- a/test/filters-cases/bug-1307.asm.none.json
+++ b/test/filters-cases/bug-1307.asm.none.json
@@ -49195,15 +49195,7 @@
       "text": ".LASF730:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z8testfuncf",
-          "range": {
-            "endCol": 30,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z8testfuncf\""
     },

--- a/test/filters-cases/bug-192.asm.none.json
+++ b/test/filters-cases/bug-192.asm.none.json
@@ -484,15 +484,7 @@
       "text": ".Linfo_string8:"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 22,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"main\"                  # string offset=175"
     },
@@ -512,15 +504,7 @@
       "text": ".Linfo_string10:"
     },
     {
-      "labels": [
-        {
-          "name": "__cxx_global_var_init",
-          "range": {
-            "endCol": 39,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"__cxx_global_var_init\" # string offset=184"
     },
@@ -1818,15 +1802,7 @@
       "text": "        .long   99                      # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 22,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"main\"                  # External Name"
     },
@@ -1836,15 +1812,7 @@
       "text": "        .long   124                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "__cxx_global_var_init",
-          "range": {
-            "endCol": 39,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"__cxx_global_var_init\" # External Name"
     },

--- a/test/filters-cases/bug-2164.asm.none.json
+++ b/test/filters-cases/bug-2164.asm.none.json
@@ -81,15 +81,7 @@
       "text": "        .eabi_attribute 14, 0"
     },
     {
-      "labels": [
-        {
-          "name": "example",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .file   \"example.3a1fbbbh-cgu.0\""
     },
@@ -939,15 +931,7 @@
       "text": ".Linfo_string3:"
     },
     {
-      "labels": [
-        {
-          "name": "example",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"example\""
     },
@@ -957,15 +941,7 @@
       "text": ".Linfo_string4:"
     },
     {
-      "labels": [
-        {
-          "name": "example",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"example::abort\""
     },
@@ -1048,15 +1024,7 @@
       "text": "        .long   38"
     },
     {
-      "labels": [
-        {
-          "name": "example",
-          "range": {
-            "endCol": 25,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"example\""
     },

--- a/test/filters-cases/bug-2164b.asm.none.json
+++ b/test/filters-cases/bug-2164b.asm.none.json
@@ -419,15 +419,7 @@
       "text": ".Linfo_string3:"
     },
     {
-      "labels": [
-        {
-          "name": "trap_arm",
-          "range": {
-            "endCol": 26,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"trap_arm\"              @ string offset=124"
     },
@@ -437,15 +429,7 @@
       "text": ".Linfo_string4:"
     },
     {
-      "labels": [
-        {
-          "name": "trap_thumb",
-          "range": {
-            "endCol": 28,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"trap_thumb\"            @ string offset=133"
     },

--- a/test/filters-cases/bug-5020.asm.none.json
+++ b/test/filters-cases/bug-5020.asm.none.json
@@ -5660,15 +5660,7 @@
       "text": "        .uleb128 0x4d"
     },
     {
-      "labels": [
-        {
-          "name": "std",
-          "range": {
-            "endCol": 21,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"std\""
     },
@@ -42953,15 +42945,7 @@
       "text": ".LASF263:"
     },
     {
-      "labels": [
-        {
-          "name": "std",
-          "range": {
-            "endCol": 21,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"std::_Function_base::~_Function_base() [base object destructor]\""
     },
@@ -43251,15 +43235,7 @@
       "text": ".LASF260:"
     },
     {
-      "labels": [
-        {
-          "name": "std",
-          "range": {
-            "endCol": 21,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"std::__throw_bad_function_call()\""
     },
@@ -43879,15 +43855,7 @@
       "text": ".LASF236:"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 22,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"main\""
     },

--- a/test/filters-cases/bug-5050.asm.none.json
+++ b/test/filters-cases/bug-5050.asm.none.json
@@ -14816,15 +14816,7 @@
       "text": ".Linfo_string126:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z1fSt7variantIJPiPlPcEE",
-          "range": {
-            "endCol": 42,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"_Z1fSt7variantIJPiPlPcEE\"      # string offset=4068"
     },

--- a/test/filters-cases/bug-577_clang.asm.none.json
+++ b/test/filters-cases/bug-577_clang.asm.none.json
@@ -269,15 +269,7 @@
       "text": ".Linfo_string3:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z6squarei",
-          "range": {
-            "endCol": 28,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"_Z6squarei\"            # string offset=154"
     },

--- a/test/filters-cases/bug-577_gcc.asm.none.json
+++ b/test/filters-cases/bug-577_gcc.asm.none.json
@@ -993,15 +993,7 @@
       "text": ".LASF3:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z6squarei",
-          "range": {
-            "endCol": 28,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z6squarei\""
     },

--- a/test/filters-cases/bug-629.asm.none.json
+++ b/test/filters-cases/bug-629.asm.none.json
@@ -739,15 +739,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "y",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"y\""
     },
@@ -815,15 +807,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "d",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"d\""
     },
@@ -871,15 +855,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "f",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"f\""
     },
@@ -955,15 +931,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "v",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"v\""
     },
@@ -1039,15 +1007,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "dd",
-          "range": {
-            "endCol": 20,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"dd\""
     },
@@ -1123,15 +1083,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "yuu",
-          "range": {
-            "endCol": 21,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"yuu\""
     },
@@ -1179,15 +1131,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "jj",
-          "range": {
-            "endCol": 20,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"jj\""
     },
@@ -1263,15 +1207,7 @@
       "text": "        .uleb128 0x2"
     },
     {
-      "labels": [
-        {
-          "name": "q",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"q\""
     },

--- a/test/filters-cases/bug-660.asm.none.json
+++ b/test/filters-cases/bug-660.asm.none.json
@@ -4290,15 +4290,7 @@
       "text": "$LASF54:"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 15,
-            "startCol": 11
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "  .ascii \"main\\000\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.comments.json
+++ b/test/filters-cases/bug-7280.asm.directives.comments.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.json
+++ b/test/filters-cases/bug-7280.asm.directives.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.labels.comments.json
+++ b/test/filters-cases/bug-7280.asm.directives.labels.comments.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/bug-7280.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/bug-7280.asm.directives.labels.comments.library.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.labels.json
+++ b/test/filters-cases/bug-7280.asm.directives.labels.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.directives.library.json
+++ b/test/filters-cases/bug-7280.asm.directives.library.json
@@ -6,15 +6,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/bug-7280.asm.none.json
+++ b/test/filters-cases/bug-7280.asm.none.json
@@ -52,15 +52,7 @@
       "text": ".LC0:"
     },
     {
-      "labels": [
-        {
-          "name": "a",
-          "range": {
-            "endCol": 19,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"a\""
     },

--- a/test/filters-cases/cc65-square.asm.none.json
+++ b/test/filters-cases/cc65-square.asm.none.json
@@ -124,15 +124,7 @@
       "text": ""
     },
     {
-      "labels": [
-        {
-          "name": "_square",
-          "range": {
-            "endCol": 55,
-            "startCol": 48
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .dbg    func, \"square\", \"00\", extern, \"_square\""
     },

--- a/test/filters-cases/clang-hellow.asm.directives.comments.json
+++ b/test/filters-cases/clang-hellow.asm.directives.comments.json
@@ -295,15 +295,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.directives.json
+++ b/test/filters-cases/clang-hellow.asm.directives.json
@@ -300,15 +300,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.directives.labels.comments.json
+++ b/test/filters-cases/clang-hellow.asm.directives.labels.comments.json
@@ -155,15 +155,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/clang-hellow.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -165,15 +165,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/clang-hellow.asm.directives.labels.comments.library.json
@@ -155,15 +155,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.directives.labels.json
+++ b/test/filters-cases/clang-hellow.asm.directives.labels.json
@@ -160,15 +160,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.directives.library.json
+++ b/test/filters-cases/clang-hellow.asm.directives.library.json
@@ -300,15 +300,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clang-hellow.asm.none.json
+++ b/test/filters-cases/clang-hellow.asm.none.json
@@ -579,15 +579,7 @@
       "text": "        .byte   2                       # Abbrev [2] 0x8b:0x20 DW_TAG_subprogram"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .ascii   \"main\"                 # DW_AT_name"
     },
@@ -1047,15 +1039,7 @@
       "text": "        .long   139                     # DIE offset"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 23,
-            "startCol": 19
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz   \"main\"                 # External Name"
     },

--- a/test/filters-cases/clanglib-bug2898-b.asm.none.json
+++ b/test/filters-cases/clanglib-bug2898-b.asm.none.json
@@ -23455,15 +23455,7 @@
       "text": ".Linfo_string277:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z3fooRKSt17basic_string_viewIcSt11char_traitsIcEE",
-          "range": {
-            "endCol": 68,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"_Z3fooRKSt17basic_string_viewIcSt11char_traitsIcEE\" # string offset=6257"
     },

--- a/test/filters-cases/clanglib-bug2898.asm.none.json
+++ b/test/filters-cases/clanglib-bug2898.asm.none.json
@@ -52878,15 +52878,7 @@
       "text": ".Linfo_string597:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z3cvtN3eve7logicalINS_10avx_abi_v04wideIsNS_5fixedILl8EEEEEEE",
-          "range": {
-            "endCol": 80,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .asciz  \"_Z3cvtN3eve7logicalINS_10avx_abi_v04wideIsNS_5fixedILl8EEEEEEE\" # string offset=10275"
     },

--- a/test/filters-cases/diab.asm.none.json
+++ b/test/filters-cases/diab.asm.none.json
@@ -7597,15 +7597,7 @@
       "text": "        .4byte      .L167-.L2"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 28,
-            "startCol": 24
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .byte         \"main\""
     },
@@ -8715,15 +8707,7 @@
       "text": "        .wrcm.nelem \"functions\""
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 26,
-            "startCol": 22
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .wrcm.nelem \"main\""
     },

--- a/test/filters-cases/gcc-arm-sum.asm.none.json
+++ b/test/filters-cases/gcc-arm-sum.asm.none.json
@@ -1554,15 +1554,7 @@
       "text": ".LASF5:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z12testFunctionPii",
-          "range": {
-            "endCol": 37,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z12testFunctionPii\""
     },

--- a/test/filters-cases/gcc-avr-sum.asm.none.json
+++ b/test/filters-cases/gcc-avr-sum.asm.none.json
@@ -216,13 +216,6 @@
         {
           "name": "_Z12testFunctionPii",
           "range": {
-            "endCol": 37,
-            "startCol": 18
-          }
-        },
-        {
-          "name": "_Z12testFunctionPii",
-          "range": {
             "endCol": 72,
             "startCol": 53
           }

--- a/test/filters-cases/gcc-sum.asm.none.json
+++ b/test/filters-cases/gcc-sum.asm.none.json
@@ -1520,15 +1520,7 @@
       "text": ".LASF5:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z12testFunctionPii",
-          "range": {
-            "endCol": 37,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z12testFunctionPii\""
     },

--- a/test/filters-cases/gcc-x86-vector.asm.none.json
+++ b/test/filters-cases/gcc-x86-vector.asm.none.json
@@ -22452,15 +22452,7 @@
       "text": ".LASF296:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z3sumRKSt6vectorIiSaIiEE",
-          "range": {
-            "endCol": 43,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"_Z3sumRKSt6vectorIiSaIiEE\""
     },

--- a/test/filters-cases/gcc4.6-hellow.asm.none.json
+++ b/test/filters-cases/gcc4.6-hellow.asm.none.json
@@ -5154,15 +5154,7 @@
       "text": ".LASF52:"
     },
     {
-      "labels": [
-        {
-          "name": "main",
-          "range": {
-            "endCol": 22,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"main\""
     },

--- a/test/filters-cases/intsize.asm.none.json
+++ b/test/filters-cases/intsize.asm.none.json
@@ -619,15 +619,7 @@
       "text": ".LASF3:"
     },
     {
-      "labels": [
-        {
-          "name": "size",
-          "range": {
-            "endCol": 22,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .string \"size\""
     },

--- a/test/filters-cases/mips5-square.asm.none.json
+++ b/test/filters-cases/mips5-square.asm.none.json
@@ -1114,15 +1114,7 @@
       "text": "$LASF3:"
     },
     {
-      "labels": [
-        {
-          "name": "_Z6squarei",
-          "range": {
-            "endCol": 28,
-            "startCol": 18
-          }
-        }
-      ],
+      "labels": [],
       "source": null,
       "text": "        .ascii  \"_Z6squarei\\000\""
     },


### PR DESCRIPTION
As reported in issue #8009, gcc trunk started to quote labels in assembly.
This fix allows quotes as part of labels in the relevant regex which fixes the issue, but has some side-effects -
Once quoting changes the identifier, many string directives that were previously treated as labels no longer are.  A line like
```
        .ascii  \"main\\000\"
```
is no longer treated as containing a label. 
I think this is an improvement - these really are not labels, although often there *is* a label of the same name. But awaiting more opinions before pushing.
