### PR TITLE
Remove unused method `AsmParser.labelFindFor`

### DIFF
--- a/lib/parsers/asm-parser-ewavr.ts
+++ b/lib/parsers/asm-parser-ewavr.ts
@@ -92,10 +92,6 @@ export class AsmEWAVRParser extends AsmParser {
         return this.hasOpcodeRe.test(line);
     }
 
-    override labelFindFor() {
-        return this.labelDef;
-    }
-
     override processAsm(asm: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
         // NOTE: EWAVR assembly seems to be closest to visual studio
         const getFilenameFromComment = (line: string) => {

--- a/lib/parsers/asm-parser-vc.ts
+++ b/lib/parsers/asm-parser-vc.ts
@@ -100,10 +100,6 @@ export class VcAsmParser extends AsmParser {
         return this.hasOpcodeRe.test(line);
     }
 
-    override labelFindFor() {
-        return this.labelFind;
-    }
-
     override processAsm(asm: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
         if (filters.binary || filters.binaryObject) {
             return this.asmBinaryParser.processAsm(asm, filters);

--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -441,10 +441,6 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         };
     }
 
-    labelFindFor(asmLines: string[]) {
-        return this.labelProcessor.getLabelFind(asmLines, this.createLabelContext());
-    }
-
     findUsedLabels(asmLines: string[], filterDirectives?: boolean): Set<string> {
         return this.labelProcessor.findUsedLabels(asmLines, filterDirectives || false, this.createLabelContext());
     }

--- a/test/asm-parser-subclass-integration-tests.ts
+++ b/test/asm-parser-subclass-integration-tests.ts
@@ -50,17 +50,7 @@ function processAsmWithParser<T extends AsmParser>(
 }
 
 describe('AsmParser subclass compatibility', () => {
-    describe('labelFindFor method behavior', () => {
-        it('should use VcAsmParser labelFindFor override to find specific VC labels', () => {
-            const asmLines = ['_start:', 'mov eax, OFFSET _data', 'call _function', 'jmp _start'];
-            const usedLabels = initializeParserAndFindLabels(VcAsmParser, [], asmLines);
-
-            // VC-specific label detection should find these labels
-            expect(usedLabels.has('_data')).toBe(true);
-            expect(usedLabels.has('_function')).toBe(true);
-            expect(usedLabels.has('_start')).toBe(true);
-        });
-
+    describe('findUsedLabels method behavior', () => {
         it('should show EWAVR label finding now works correctly after refactoring', () => {
             const asmLines = [
                 '_data:     .word 0x1234',
@@ -78,10 +68,6 @@ describe('AsmParser subclass compatibility', () => {
             expect(usedLabels.has('_main')).toBe(true);
             expect(usedLabels.has('HIGH')).toBe(true);
             expect(usedLabels.has('LOW')).toBe(true);
-            // Verify that specific expected labels are found rather than checking exact count
-
-            // The refactoring fixed the issue where EWAVR's labelFindFor returned definition regex
-            // Now it uses the base class identifierFindRe for finding label references
         });
 
         it('should show base class finds all identifier-like tokens as potential labels', () => {
@@ -96,9 +82,6 @@ describe('AsmParser subclass compatibility', () => {
             expect(usedLabels.has('value')).toBe(true); // Actual label reference
             expect(usedLabels.has('jmp')).toBe(true); // Instruction (not a label)
             expect(usedLabels.has('_start')).toBe(true); // Actual label reference
-
-            // This over-matching is why subclasses override labelFindFor
-            // to be more specific about what constitutes a label in their syntax
         });
     });
 

--- a/test/ewavr-asm-parser-tests.ts
+++ b/test/ewavr-asm-parser-tests.ts
@@ -163,11 +163,6 @@ describe('AsmEWAVRParser', () => {
             expect(usedLabels.has('HIGH')).toBe(true); // Ensure HIGH is included
             expect(usedLabels.has('LOW')).toBe(true); // Ensure LOW is included
             // Verify we found the expected labels rather than checking exact count
-
-            // The labelFindFor regex is still for definitions (with colons)
-            const labelFindRegex = parser.labelFindFor();
-            expect(labelFindRegex.test('_data:')).toBe(true); // Matches definitions
-            expect(labelFindRegex.test('_data')).toBe(false); // Doesn't match usage
         });
 
         it('should handle EWAVR segment syntax and register operations', () => {


### PR DESCRIPTION
`AsmParser.labelFindFor` was only called in tests.