### PR TITLE
Add C++ library fusedkernellibrary vBeta-0.1.9

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6714,7 +6714,7 @@ libs.graaf.versions.110.version=1.1.0
 libs.fusedkernellibrary.name=fusedkernellibrary
 libs.fusedkernellibrary.url=https://github.com/Libraries-Openly-Fused/FusedKernelLibrary
 libs.fusedkernellibrary.versions=Beta-019
-libs.fusedkernellibrary.versions.Beta-019.path=/opt/compiler-explorer/libs/fusedkernellibrary/vBeta-0.1.9/include
+libs.fusedkernellibrary.versions.Beta-019.path=/opt/compiler-explorer/libs/fusedkernellibrary/Beta-0.1.9/include
 libs.fusedkernellibrary.versions.Beta-019.version=Beta-0.1.9
 
 #################################


### PR DESCRIPTION
This PR adds the C++ library **fusedkernellibrary** version Beta-0.1.9 to Compiler Explorer.

- GitHub URL: https://github.com/Libraries-Openly-Fused/FusedKernelLibrary


Related PR: https://github.com/compiler-explorer/infra/pull/1755

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_