### PR TITLE
Fix demangling for symbols with dots in jump instructions

### DIFF
--- a/lib/demangler/base.ts
+++ b/lib/demangler/base.ts
@@ -44,7 +44,7 @@ export class BaseDemangler extends AsmRegex {
     readonly includeMetadata: boolean;
     readonly compiler: BaseCompiler;
 
-    readonly jumpDef = /(j\w+|b|bl|blx)\s+([$_a-z][\w$@]*|"[$_a-z][\w$@]*")/i;
+    readonly jumpDef = /(j\w+|b|bl|blx)\s+([$_a-z][\w$.@]*|"[$_a-z][\w$.@]*")/i;
     readonly callDef = /callq?\s+([$._a-z][\w$.@]*|"[$._a-z][\w$.@]*")/i;
     readonly callPtrDef1 = /callq?.*ptr\s\[[a-z]*\s\+\s([$._a-z][\w$.@]*|"[$._a-z][\w$.@]*")]/i;
     readonly callPtrDef2 = /callq?\s+([$*._a-z][\w$.@]*|"[$*._a-z][\w$.@]*")/i;


### PR DESCRIPTION
For example Rust on AArch64: https://godbolt.org/z/e3q9Wv7zj