### PR TITLE
Mount cefs into the jails

### DIFF
--- a/etc/nsjail/compilers-and-tools.cfg
+++ b/etc/nsjail/compilers-and-tools.cfg
@@ -231,6 +231,12 @@ mount {
     is_bind: true
 }
 
+mount {
+    src: "/cefs"
+    dst: "/cefs"
+    is_bind: true
+}
+
 # Needed for icc
 mount {
     src: "/opt/intel"

--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -209,6 +209,12 @@ mount {
     is_bind: true
 }
 
+mount {
+    src: "/cefs"
+    dst: "/cefs"
+    is_bind: true
+}
+
 # Remove some sensitive stuff from execution
 mount {
     dst: "/opt/compiler-explorer/sonar"


### PR DESCRIPTION
This _maybe_ shows an issue - users could find _anything_ in cefs so we need to make sure we don't ever put privileged stuff in cefs.
