### PR TITLE
Mg/cefs mount prop

### DIFF
--- a/etc/nsjail/compilers-and-tools.cfg
+++ b/etc/nsjail/compilers-and-tools.cfg
@@ -235,6 +235,10 @@ mount {
     src: "/cefs"
     dst: "/cefs"
     is_bind: true
+    # needed for cefs to see new mounts.
+    # needs ce's patched nsjail to work
+    # http://github.com/compiler-explorer/nsjail
+    needs_mount_propagation: true
 }
 
 # Needed for icc

--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -213,6 +213,10 @@ mount {
     src: "/cefs"
     dst: "/cefs"
     is_bind: true
+    # needed for cefs to see new mounts.
+    # needs ce's patched nsjail to work
+    # http://github.com/compiler-explorer/nsjail
+    needs_mount_propagation: true
 }
 
 # Remove some sensitive stuff from execution


### PR DESCRIPTION
makes the root bindmount a "slave" which means it gets all host mount point change notifications, needed for cefs automounting. Security tradeoffs mentioned in compiler-explorer/nsjail#2