### PR TITLE
Fix #8037: avoid duplicate `compile` call

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -263,6 +263,9 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         const source = this.getSource();
         if (!force && source === this.lastChangeEmitted) return;
 
+        if (this.settings.formatOnCompile) {
+            this.runFormatDocumentAction();
+        }
         this.updateExtraDecorations();
 
         this.lastChangeEmitted = source ?? null;

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -341,8 +341,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.container.layoutManager.on('initialised', () => {
             // Once initialized, let everyone know what text we have.
             this.maybeEmitChange();
-            // And maybe ask for a compilation (Will hit the cache most of the time)
-            this.requestCompilation();
         });
 
         this.eventHub.on('treeCompilerEditorIncludeChange', this.onTreeCompilerEditorIncludeChange, this);
@@ -901,19 +899,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         }
     }
 
-    requestCompilation(): void {
-        this.eventHub.emit('requestCompilation', this.id, false);
-        if (this.settings.formatOnCompile) {
-            this.runFormatDocumentAction();
-        }
-
-        this.hub.trees.forEach(tree => {
-            if (tree.multifileService.isEditorPartOfProject(this.id)) {
-                this.eventHub.emit('requestCompilation', this.id, tree.id);
-            }
-        });
-    }
-
     override registerEditorActions(): void {
         this.editor.addAction({
             id: 'compile',
@@ -923,9 +908,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             contextMenuGroupId: 'navigation',
             contextMenuOrder: 1.5,
             run: () => {
-                // This change request is mostly superfluous
                 this.maybeEmitChange();
-                this.requestCompilation();
             },
         });
 
@@ -1831,7 +1814,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                         this.setFilename(filename);
                         this.updateState();
                         this.maybeEmitChange(true);
-                        this.requestCompilation();
                     },
                     this.getSource(),
                     this.currentLanguage,
@@ -1863,7 +1845,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                 this.decorations = {};
                 if (!firstTime) {
                     this.maybeEmitChange(true);
-                    this.requestCompilation();
                 }
             }
             this.waitingForLanguage = false;


### PR DESCRIPTION
Trying to solve the root cause:

`Editor.maybeEmitChange` calls `this.eventHub.emit('editorChange')`, and then `Compiler.onEditorChange` calls `this.compile()` .
So the idiom
```ts
  this.maybeEmitChange();
  this.requestCompilation();
```
repeated a few times in editor.ts, causes two rapid (and redundant) invocations of `compile`, which in turn cause the race.  This PR removes all calls to `Editor.requestCompilation` and in fact removes the function entirely.

@jeremy-rifkin  I'm guessing this is *not* the race you encountered mentioned in the source? (but might be wrong of course).

I'm guessing `maybeEmitChange` is a late addition to solve some other problems, and this race was an unintended side effect, but please correct me if you have better understanding of the code and its history.