### PR TITLE
Changing clang reflection labels

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -528,7 +528,7 @@ compiler.clang_lifetime.semver=(experimental -Wlifetime)
 compiler.clang_lifetime.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 -Wlifetime
 compiler.clang_lifetime.notification=Lifetime profile checker based on Herb Sutter's paper; see <a href="https://herbsutter.com/2018/09/20/lifetime-profile-v1-0-posted/" target="_blank" rel="noopener noreferrer">this blog post <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for more information
 compiler.clang_bb_p2996.exe=/opt/compiler-explorer/clang-bb-p2996-trunk/bin/clang++
-compiler.clang_bb_p2996.semver=(experimental P2996)
+compiler.clang_bb_p2996.semver=(reflection - C++26)
 compiler.clang_bb_p2996.notification=Experimental Reflection Support; see <a href="https://github.com/bloomberg/clang-p2996/blob/p2996/P2996.md" target="_blank" rel="noopener noreferrer">P2996<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_bb_p2996.options=-std=c++26 -freflection -stdlib=libc++
 compiler.clang_p2998.exe=/opt/compiler-explorer/clang-p2998-trunk/bin/clang++
@@ -588,7 +588,7 @@ compiler.clang_resugar.semver=(resugar)
 compiler.clang_resugar.options=-std=c++20 -stdlib=libc++
 compiler.clang_resugar.notification=Experimental support for resugaring template specializations; see <a href="https://reviews.llvm.org/D127695" target="_blank" rel="noopener noreferrer">D127695<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_reflection.exe=/opt/compiler-explorer/clang-reflection-trunk/bin/clang++
-compiler.clang_reflection.semver=(reflection)
+compiler.clang_reflection.semver=(reflection - TS)
 compiler.clang_reflection.options=-std=c++20 -freflection-ts -stdlib=libc++
 compiler.clang_reflection.notification=Experimental Reflection Support; see <a href="https://github.com/cplusplus/reflection-ts" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_variadic_friends.exe=/opt/compiler-explorer/clang-variadic-friends-trunk/bin/clang++


### PR DESCRIPTION
There are two clang reflection implementations:

* The one from Matúš that implements the Reflection TS
* The one from Dan that implements p2996

The latter is what will be in C++26, but that's hard to tell from the labels since the former is labeled "reflection" while the latter is labeled "experimental p2996". This changes the labels to "reflection - TS" and "relfection - C++26", respectively, to make it clearer as to which is which. 