### PR TITLE
Add Mojo 25.5

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -162,3 +162,4 @@ From oldest to newest contributor, we would like to thank:
 - [Adrien Bertrand](https://github.com/adriweb)
 - [Roberto Parolin](https://github.com/rparolin)
 - [Alfredo Correa](https://github.com/correaa)
+- [Alex Trotta](https://github.com/Ahajha)

--- a/etc/config/mojo.amazon.properties
+++ b/etc/config/mojo.amazon.properties
@@ -2,9 +2,12 @@ compilers=&mojo
 defaultCompiler=mojo_nightly
 compilerType=mojo
 
-group.mojo.compilers=mojo_nightly
+group.mojo.compilers=mojo_25_5_0:mojo_nightly
 group.mojo.isSemVer=true
 group.mojo.baseName=Mojo
+
+compiler.mojo_25_5_0.exe=/opt/compiler-explorer/mojo-25.5.0/bin/mojo
+compiler.mojo_25_5_0.semver=25.5.0
 
 compiler.mojo_nightly.exe=/opt/compiler-explorer/mojo-nightly/bin/mojo
 compiler.mojo_nightly.semver=nightly


### PR DESCRIPTION
Adding the latest stable version here. I'm also invoking Cunningham's law, I'm not exactly sure the process here. I ran `make` locally, but the new compiler doesn't show up. What else needs to be done to update a version?