### PR TITLE
Fix jump to label with symbols containing `$`

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -350,7 +350,7 @@ export class AsmParser extends AsmRegex implements IAsmParser {
         // Opcode expression here matches LLVM-style opcodes of the form `%blah = opcode`
         this.hasOpcodeRe = /^\s*(%[$.A-Z_a-z][\w$.]*\s*=\s*)?[A-Za-z]/;
         this.instructionRe = /^\s*[A-Za-z]+/;
-        this.identifierFindRe = /((?!\$\.)[$.@A-Z_a-z"][\w.]*"?)(?:@\w+)*/g;
+        this.identifierFindRe = /((?!\$\.)[$.@A-Z_a-z"][\w$.]*"?)(?:@\w+)*/g;
         this.hasNvccOpcodeRe = /^\s*[@A-Za-z|]/;
         this.definesFunction = /^\s*\.(type.*,\s*[#%@]function|proc\s+[.A-Z_a-z][\w$.]*:.*)$/;
         this.definesGlobal = /^\s*\.(?:globa?l|GLB|export)\s*([.A-Z_a-z][\w$.]*|"[.A-Z_a-z][\w$.]*")/;

--- a/test/filters-cases/bug-725_rust.asm.none.json
+++ b/test/filters-cases/bug-725_rust.asm.none.json
@@ -16,7 +16,15 @@
       "text": "        .section        \".text._ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E\",\"ax\",@progbits"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "_ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E",
+          "range": {
+            "endCol": 142,
+            "startCol": 17
+          }
+        }
+      ],
       "source": null,
       "text": "        .globl  _ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E"
     },
@@ -26,7 +34,15 @@
       "text": "        .p2align        4, 0x90"
     },
     {
-      "labels": [],
+      "labels": [
+        {
+          "name": "_ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E",
+          "range": {
+            "endCol": 142,
+            "startCol": 17
+          }
+        }
+      ],
       "source": null,
       "text": "        .type   _ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E,@function"
     },
@@ -73,10 +89,24 @@
     {
       "labels": [
         {
+          "name": "_ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E",
+          "range": {
+            "endCol": 142,
+            "startCol": 17
+          }
+        },
+        {
           "name": ".Lfunc_end0",
           "range": {
             "endCol": 155,
             "startCol": 144
+          }
+        },
+        {
+          "name": "_ZN95_$LT$example..Bla$LT$$u27$a$GT$$u20$as$u20$core..convert..Into$LT$alloc..string..String$GT$$GT$4into17h38301ffbb2e8fb47E",
+          "range": {
+            "endCol": 281,
+            "startCol": 156
           }
         }
       ],


### PR DESCRIPTION
For example Rust will mangle `<` to `$LT$`: https://godbolt.org/z/86n9M6P3f