### PR TITLE
Adding monaco langauge configuration for zig

### DIFF
--- a/static/modes/zig-mode.ts
+++ b/static/modes/zig-mode.ts
@@ -228,5 +228,31 @@ function definition(): monaco.languages.IMonarchLanguage {
     };
 }
 
+const config: monaco.languages.LanguageConfiguration = {
+    comments: {
+        lineComment: '//',
+    },
+    brackets: [
+        ['{', '}'],
+        ['[', ']'],
+        ['(', ')'],
+    ],
+    autoClosingPairs: [
+        {open: '{', close: '}'},
+        {open: '[', close: ']'},
+        {open: '(', close: ')'},
+        {open: '"', close: '"'},
+        {open: "'", close: "'"},
+    ],
+    surroundingPairs: [
+        {open: '{', close: '}'},
+        {open: '[', close: ']'},
+        {open: '(', close: ')'},
+        {open: '"', close: '"'},
+        {open: "'", close: "'"},
+    ],
+};
+
 monaco.languages.register({id: 'zig'});
 monaco.languages.setMonarchTokensProvider('zig', definition());
+monaco.languages.setLanguageConfiguration('zig', config);


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Resolves #8041

Adds a monaco language configuration for zig. 

Letting you comment lines in the editor with `Ctrl/Cmd K + C`.
Auto closing braces/curly brackets/parentheses/single quote/double quote.