### PR TITLE
Send a "request compile" if compile on demand isn't set

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -926,6 +926,10 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             contextMenuOrder: 1.5,
             run: () => {
                 this.maybeEmitChange();
+                // If compileOnChange is disabled, we need to request compilation manually.
+                if (!this.settings.compileOnChange) {
+                    this.eventHub.emit('requestCompilation', this.id, false);
+                }
             },
         });
 


### PR DESCRIPTION
This fixes #8064 - hitting ctrl-enter worked _if compile on demand was set_. Otherwise the compiler ignored the editor change.

We still need to emit the change (else the compiler window and tools may not notice any changed text), but then if compile on demand is not on, we manually trigger a request.
