### PR TITLE
Added nvcc 13.0.0 and nvrtc 13.0.0

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -9,7 +9,7 @@ supportsExecute=false
 # Details of GPUs/features supported by CUDA compilers can be found here:
 # gist.github.com/ax3l/9489132#clang--x-cuda
 
-group.nvcc.compilers=nvcc129u1:nvcc129:nvcc128u1:nvcc126u2:nvcc126u1:nvcc125u1:nvcc124u1:nvcc123u1:nvcc122u1:nvcc121:nvcc120u1:nvcc120:nvcc118:nvcc117u1:nvcc117:nvcc116u2:nvcc116u1:nvcc116:nvcc115u2:nvcc115u1:nvcc115:nvcc114u4:nvcc114u3:nvcc114u2:nvcc114u1:nvcc114:nvcc113u1:nvcc113:nvcc112u2:nvcc112u1:nvcc112:nvcc111u1:nvcc111:nvcc11u1:nvcc11:nvcc102:nvcc101u2:nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
+group.nvcc.compilers=nvcc130:nvcc129u1:nvcc129:nvcc128u1:nvcc126u2:nvcc126u1:nvcc125u1:nvcc124u1:nvcc123u1:nvcc122u1:nvcc121:nvcc120u1:nvcc120:nvcc118:nvcc117u1:nvcc117:nvcc116u2:nvcc116u1:nvcc116:nvcc115u2:nvcc115u1:nvcc115:nvcc114u4:nvcc114u3:nvcc114u2:nvcc114u1:nvcc114:nvcc113u1:nvcc113:nvcc112u2:nvcc112u1:nvcc112:nvcc111u1:nvcc111:nvcc11u1:nvcc11:nvcc102:nvcc101u2:nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
 group.nvcc.versionRe=^Cuda.*
 group.nvcc.compilerType=nvcc
 group.nvcc.isSemVer=true
@@ -272,6 +272,13 @@ compiler.nvcc129u1.options=--compiler-bindir /opt/compiler-explorer/gcc-10.2.0/b
 compiler.nvcc129u1.nvdisasm=/opt/compiler-explorer/cuda/12.9.1/bin/nvdisasm
 compiler.nvcc129u1.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 compiler.nvcc129u1.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
+compiler.nvcc130.semver=13.0.0
+compiler.nvcc130.exe=/opt/compiler-explorer/cuda/13.0.0/bin/nvcc
+compiler.nvcc130.ldPath=/opt/compiler-explorer/gcc-14.1.0/lib64
+compiler.nvcc130.options=--compiler-bindir /opt/compiler-explorer/gcc-14.1.0/bin
+compiler.nvcc130.nvdisasm=/opt/compiler-explorer/cuda/13.0.0/bin/nvdisasm
+compiler.nvcc130.demangler=/opt/compiler-explorer/gcc-14.1.0/bin/c++filt
+compiler.nvcc130.objdumper=/opt/compiler-explorer/gcc-14.1.0/bin/objdump
 
 group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cuclang1600:cuclang1701:cuclang1810:cuclang1910:cuclang2010-1251:cuclang2010-1261:cuclang2010-1262:cltrunk
 group.cuclang.isSemVer=true
@@ -478,7 +485,7 @@ compiler.hipclang-staging-rocm-60400.nvdisasm=/opt/compiler-explorer/clang-rocm-
 compiler.hipclang-staging-rocm-60400.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-60400.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/6.4.0 -include hip/hip_runtime.h
 
-group.nvrtc.compilers=nvrtc129u1:nvrtc129:nvrtc128u1:nvrtc126u2:nvrtc126u1:nvrtc125u1:nvrtc124u1:nvrtc123u1:nvrtc122u1:nvrtc121:nvrtc120u1:nvrtc120:nvrtc118:nvrtc117u1:nvrtc117:nvrtc116u2:nvrtc116u1:nvrtc116:nvrtc115u2:nvrtc115u1:nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11
+group.nvrtc.compilers=nvrtc130:nvrtc129u1:nvrtc129:nvrtc128u1:nvrtc126u2:nvrtc126u1:nvrtc125u1:nvrtc124u1:nvrtc123u1:nvrtc122u1:nvrtc121:nvrtc120u1:nvrtc120:nvrtc118:nvrtc117u1:nvrtc117:nvrtc116u2:nvrtc116u1:nvrtc116:nvrtc115u2:nvrtc115u1:nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11
 group.nvrtc.compilerType=nvrtc
 group.nvrtc.isSemVer=true
 group.nvrtc.baseName=NVRTC
@@ -554,6 +561,9 @@ compiler.nvrtc129.ldPath=/opt/compiler-explorer/gcc-14.1.0/lib64
 compiler.nvrtc129u1.semver=12.9.1
 compiler.nvrtc129u1.exe=/opt/compiler-explorer/cuda/12.9.1/bin/nvrtc_cli
 compiler.nvrtc129u1.ldPath=/opt/compiler-explorer/gcc-14.1.0/lib64
+compiler.nvrtc130.semver=13.0.0
+compiler.nvrtc130.exe=/opt/compiler-explorer/cuda/13.0.0/bin/nvrtc_cli
+compiler.nvrtc130.ldPath=/opt/compiler-explorer/gcc-14.1.0/lib64
 
 libs=boost:bmulti:cueigen:cccl:thrustcub:cucub:cudacxx:matx:nvtx:nsimd:cuco:hip-amd
 libs.boost.name=Boost


### PR DESCRIPTION
Added nvcc and nvrtc for CUDA 13.0.0. Also fixed host compiler to gcc 14.1.0 on newest nvcc.

Depends on https://github.com/compiler-explorer/infra/pull/1797
