### PR TITLE
Fixing OCaml and other compilers Intel asm syntax option

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -163,3 +163,4 @@ From oldest to newest contributor, we would like to thank:
 - [Roberto Parolin](https://github.com/rparolin)
 - [Alfredo Correa](https://github.com/correaa)
 - [Florian Freitag](https://github.com/flofriday)
+- [Jacob Panov](https://github.com/jacobpanov)

--- a/lib/compilers/ocaml.ts
+++ b/lib/compilers/ocaml.ts
@@ -41,6 +41,9 @@ export class OCamlCompiler extends BaseCompiler {
         // with this override and optionsForFilter override, that pecularity..
         // ..is bypassed entirely.
         this.outputFilebase = 'example';
+
+        // OCaml produces AT&T syntax assembly, not Intel syntax
+        this.compiler.supportsIntel = false;
     }
 
     override getSharedLibraryPathsAsArguments() {

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2598,7 +2598,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                     (button.prop('disabled') ? ' [LOCKED]' : ''),
             );
         };
-        const isIntelFilterDisabled = !this.compiler.supportsIntel && !filters.binary && !filters.binaryObject;
+        const shouldShowIntelFilter = this.compiler.supportsIntel || filters.binary || filters.binaryObject;
+        this.filterIntelButton.toggle(shouldShowIntelFilter);
+        const isIntelFilterDisabled = !shouldShowIntelFilter;
         this.filterIntelButton.prop('disabled', isIntelFilterDisabled);
         formatFilterTitle(this.filterIntelButton, this.filterIntelTitle);
 


### PR DESCRIPTION
Previously, as explained in issue #6178, the OCaml compiler displayed the "Intel asm syntax" option with the last known state (enabled or disabled). Even though this option was "greyed out", the fact that it was being displayed at all when it should be disabled and unchecked could lead to user confusion.

As is with the OCaml case, the "Intel asm syntax" would be displayed as enabled (albeit greyed out) when Ocaml was producing AT&T syntax.

Changing the default compiler options for OCaml did not seem to fix the issue, as the default values were ignored if the option was "greyed out" to begin with, leading the option to maintain its previously known value.

Therefore, the solution was to hide the "Intel asm syntax" option for OCaml and languages that do not support Intel syntax via `.toggle()` until the option to linking to binary or compiling to binary object is enabled (since objdump can display Intel syntax regardless of compiler support)

- **`lib/compilers/ocaml.ts`**: Set `supportsIntel = false` in OCaml compiler constructor to indicate that OCaml does not support Intel assembly syntax

- **`static/panes/compiler.ts`**: Modified Intel filter visibility logic to hide the "Intel asm syntax" option entirely when:
  - The compiler doesn't support Intel syntax AND
  - Neither "Link to binary" nor "Compile to binary object" options are selected

- I also appended my name to the contributors list finally!

Of course, this fixes #6178.
