### PR TITLE
Add new C++ library med

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5907,7 +5907,7 @@ libs.med.name=med
 libs.med.versions=trunk
 libs.med.url=https://github.com/cppden/med
 libs.med.versions.trunk.version=trunk
-libs.med.versions.trunk.path=/opt/compiler-explorer/libs/med/master
+libs.med.versions.trunk.path=/opt/compiler-explorer/libs/med/trunk
 
 libs.mfem.name=mfem
 libs.mfem.versions=47

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4733,7 +4733,7 @@ compiler.z180-clang-1507.options=-target z180 -g0 -nostdinc -fno-threadsafe-stat
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:hpx:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:ppdt:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:re2:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan:graaf:fusedkernellibrary
+libs=abseil:array:async_simple:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:hpx:immer:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:pipes:ppdt:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:re2:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan:graaf:fusedkernellibrary:med
 
 libs.abseil.name=Abseil
 libs.abseil.versions=202501270
@@ -5902,6 +5902,12 @@ libs.mdspan.url=https://github.com/kokkos/mdspan
 libs.mdspan.description=Reference Implementation of MDSpan (c++23)
 libs.mdspan.versions.06.version=0.6
 libs.mdspan.versions.06.path=/opt/compiler-explorer/libs/mdspan-0.6.0/include
+
+libs.med.name=med
+libs.med.versions=trunk
+libs.med.url=https://github.com/cppden/med
+libs.med.versions.trunk.version=trunk
+libs.med.versions.trunk.path=/opt/compiler-explorer/libs/med/master
 
 libs.mfem.name=mfem
 libs.mfem.versions=47


### PR DESCRIPTION
Hello. I would like to add new C++ library to CE. Meta-Encoder/Decoder (med) is a header only library with no dependencies and MIT license. Only requirement is compiler with C++ 20 support. https://github.com/cppden/med

Infra pull request: https://github.com/compiler-explorer/infra/pull/1808

I run "make", "make check" and tested the changes locally and it seems that everything is fine. By locally i mean using `c++.local.properties`. Screenshot as a proof:

<img width="1310" height="843" alt="image" src="https://github.com/user-attachments/assets/b4ca06c4-532d-4a98-90e5-3bfa290705c8" />

I'm new to contributing, so please tell me if i did something wrong. Thank you for the CE!