### PR TITLE
updated OSACA to v0.7.1

### DIFF
--- a/etc/config/algol68.amazon.properties
+++ b/etc/config/algol68.amazon.properties
@@ -39,8 +39,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -22,7 +22,7 @@ group.osaca.supportsBinary=false
 group.osaca.demangler=/opt/compiler-explorer/gcc-10.2.0/bin/c++filt
 group.osaca.compilerType=osaca
 
-compiler.osacatrunk.name=OSACA (0.7.0)
-compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+compiler.osacatrunk.name=OSACA (0.7.1)
+compiler.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 # Intel syntax currently unsupported (WIP)
 # compiler.osacatrunk.intelAsm=--intel-syntax

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6860,8 +6860,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4442,8 +4442,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/clean.amazon.properties
+++ b/etc/config/clean.amazon.properties
@@ -49,8 +49,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=_32
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=_32

--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -40,8 +40,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_blue.amazon.properties
+++ b/etc/config/cppx_blue.amazon.properties
@@ -24,8 +24,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/cppx_gold.amazon.properties
+++ b/etc/config/cppx_gold.amazon.properties
@@ -24,8 +24,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1286,8 +1286,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=dmd
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=dmd

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1942,8 +1942,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -2418,8 +2418,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -1577,8 +1577,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=gl:6g141
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=gl:6g141

--- a/etc/config/haskell.amazon.properties
+++ b/etc/config/haskell.amazon.properties
@@ -64,8 +64,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/ispc.amazon.properties
+++ b/etc/config/ispc.amazon.properties
@@ -102,8 +102,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -224,8 +224,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=opt
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=opt

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2569,8 +2569,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=avr:rv32:armv7:mips:msp:ppc:cl19:cl_new:djggp:kvx:k1c:armhf:armg:arm5

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1530,8 +1530,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.exclude=cavr:carm:cmips:cmsp:cppc:ppci:armv7:ckvx:ck1c:carduino:carmh:carm5:carmg:carmce:cfr:rv6

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -68,8 +68,8 @@ tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 tools.llvm-mcatrunk.exclude=mptrunk
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1350,8 +1350,8 @@ tools.llvm-dwarfdumptrunk.type=postcompilation
 tools.llvm-dwarfdumptrunk.class=llvm-dwarfdump-tool
 tools.llvm-dwarfdumptrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/spice.amazon.properties
+++ b/etc/config/spice.amazon.properties
@@ -69,8 +69,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -140,8 +140,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -76,8 +76,8 @@ tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.stdinHint=disabled
 
-tools.osacatrunk.name=OSACA (0.7.0)
-tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.0/bin/osaca
+tools.osacatrunk.name=OSACA (0.7.1)
+tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.7.1/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

Updated OSACA to version 0.7.1 that includes bugfixes for Intel syntax support and support for a few more instruction.
See also corresponding PR in https://github.com/compiler-explorer/infra/pull/1810