### PR TITLE
Add S3 overflow support for compilation workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Shared Parsing**: Common request parsing logic is shared between web handlers and SQS workers for consistency
 - **Remote Compiler Support**: Workers automatically detect and proxy requests to remote compilers using HTTP, maintaining compatibility with existing remote compiler infrastructure
 - **S3 Storage Integration**: Compilation results include an `s3Key` property containing the cache key hash for S3 storage reference. Large results (>31KiB) can be stored in S3 and referenced by this key. The s3Key is removed from API responses before sending to users.
+- **Metrics & Statistics**: SQS workers track separate Prometheus metrics (`ce_sqs_compilations_total`, `ce_sqs_executions_total`, `ce_sqs_cmake_compilations_total`, `ce_sqs_cmake_executions_total`) and record compilation statistics via `statsNoter.noteCompilation` for Grafana monitoring, mirroring the regular API route behavior.
 
 ## Testing Guidelines
 - Use Vitest for unit tests (compatible with Jest syntax)


### PR DESCRIPTION
## Summary
Implements S3 overflow support in compilation workers to handle large compilation requests that exceed SQS message size limits (256KB).

When ce-router stores oversized messages in S3 (as implemented in compiler-explorer/ce-router#1), compilation workers now automatically detect and fetch them from S3.

## Related PRs
- **ce-router**: https://github.com/compiler-explorer/ce-router/pull/1 - Adds S3 overflow support on the message producer side
- **infra**: https://github.com/compiler-explorer/infra/pull/1822 - Terraform configuration for S3 overflow bucket and IAM permissions

## Changes
- Added S3 client initialization in `SqsCompilationQueueBase`
- Added `S3OverflowMessage` type to handle overflow reference messages
- Implemented `isS3OverflowMessage()` method to detect overflow messages
- Added `fetchFromS3()` method to retrieve full compilation requests from S3
- Modified `pop()` method to handle both regular and S3 overflow messages
- Updated CLAUDE.md documentation with S3 overflow configuration details

## How it works
1. When a compilation request exceeds SQS size limits, ce-router stores it in S3
2. ce-router sends a lightweight reference message to SQS with type `s3-overflow`
3. Compilation worker detects the overflow message
4. Worker fetches the full request from S3 using the provided bucket and key
5. Request is processed normally with proper error handling

## Test plan
- [x] TypeScript type checking passes (`npm run ts-check`)
- [x] Linting passes (`npm run lint`)
- [x] Pre-commit hooks pass
- [x] Test with normal-sized messages (should work unchanged)
- [x] Test with oversized messages (should fetch from S3)
- [ ] Verify S3 fetch error handling
- [ ] Confirm backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)