### PR TITLE
[Spice] Add version 0.22.4

### DIFF
--- a/etc/config/spice.amazon.properties
+++ b/etc/config/spice.amazon.properties
@@ -1,9 +1,9 @@
 compilers=&spice
-defaultCompiler=spice02203
+defaultCompiler=spice02204
 
-group.spice.compilers=spice01902:spice01903:spice01904:spice01905:spice01906:spice02000:spice02001:spice02002:spice02003:spice02004:spice02005:spice02006:spice02100:spice02101:spice02200:spice02201:spice02202:spice02203
-group.spice.demangler=/opt/compiler-explorer/gcc-14.2.0/bin/c++filt
-group.spice.objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
+group.spice.compilers=spice01902:spice01903:spice01904:spice01905:spice01906:spice02000:spice02001:spice02002:spice02003:spice02004:spice02005:spice02006:spice02100:spice02101:spice02200:spice02201:spice02202:spice02203:spice02204
+group.spice.demangler=/opt/compiler-explorer/gcc-15.2.0/bin/c++filt
+group.spice.objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
 group.spice.isSemVer=true
 group.spice.baseName=spice
 group.spice.compilerType=spice
@@ -13,7 +13,7 @@ group.spice.licenseName=The MIT License
 group.spice.licensePreamble=Copyright (c) 2021-2025 Marc Auberer
 
 # spice needs to be able to find clang for linking
-group.spice.extraPath=/opt/compiler-explorer/clang-19.1.0/bin
+group.spice.extraPath=/opt/compiler-explorer/clang-21.1.0/bin
 
 compiler.spice01902.exe=/opt/compiler-explorer/spice-0.19.2/spice
 compiler.spice01902.semver=0.19.2
@@ -51,6 +51,8 @@ compiler.spice02202.exe=/opt/compiler-explorer/spice-0.22.2/spice
 compiler.spice02202.semver=0.22.2
 compiler.spice02203.exe=/opt/compiler-explorer/spice-0.22.3/spice
 compiler.spice02203.semver=0.22.3
+compiler.spice02204.exe=/opt/compiler-explorer/spice-0.22.4/spice
+compiler.spice02204.semver=0.22.4
 
 #################################
 #################################


### PR DESCRIPTION
Infra PR: https://github.com/compiler-explorer/infra/pull/1823

- Add Spice compiler version 0.22.4
- Use GCC 15.2.0 for demangling
- Use Clang 21.1.0 for linking