### PR TITLE
Major package updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "^11.2.1",
         "lz-string": "^1.5.0",
-        "marked": "^15.0.12",
+        "marked": "^16.2.1",
         "monaco-editor": "^0.49.0",
         "monaco-vim": "^0.4.2",
         "morgan": "^1.10.1",
@@ -11221,15 +11221,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.2.1.tgz",
+      "integrity": "sha512-r3UrXED9lMlHF97jJByry90cwrZBBvZmjG1L68oYfuPMW+uDTnuMbyJDymCWwbTE+f+3LhpNDKfpR3a3saFyjA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "^11.2.1",
     "lz-string": "^1.5.0",
-    "marked": "^15.0.12",
+    "marked": "^16.2.1",
     "monaco-editor": "^0.49.0",
     "monaco-vim": "^0.4.2",
     "morgan": "^1.10.1",


### PR DESCRIPTION
* Update sentry from 9.x to 10.x
* Upgrade Cypress
* Update marked to latest; was a node version drop only

Sentry: Nothing breaking in the limited functionality we use. Mostly an OpenTelemetry upgrade. See https://docs.sentry.io/platforms/javascript/migration/v9-to-v10/

Cypress: 14->15; nothing big that affects us: https://docs.cypress.io/app/references/migration-guide

Marked: was a node version drop only
