### PR TITLE
Allow selecting different versions of clang-tidy

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6821,7 +6821,7 @@ tools.clangquerytrunk.stdinHint=Query commands
 tools.clangquerytrunk.monacoStdin=true
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.exclude=cl19:cl_new

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4422,7 +4422,7 @@ tools.clangquerytrunk.class=clang-query-tool
 tools.clangquerytrunk.stdinHint=Query commands
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -252,7 +252,7 @@ compiler.cpp4oclclvk.isNightly=true
 tools=clangtidytrunk:clangformattrunk:clangquerytrunk
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -2398,7 +2398,7 @@ tools.clangquerytrunk.class=clang-query-tool
 tools.clangquerytrunk.stdinHint=Query commands
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2535,7 +2535,7 @@ tools.clangquerytrunk.stdinHint=Query commands
 tools.clangquerytrunk.monacoStdin=true
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.exclude=cl19:cl_new

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1510,7 +1510,7 @@ tools.clangquerytrunk.class=clang-query-tool
 tools.clangquerytrunk.stdinHint=Query commands
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -264,7 +264,7 @@ compiler.clvk.options=-cl-single-precision-constant -cl-kernel-arg-info -fp64=0 
 tools=clangtidytrunk:clangformattrunk:clangquerytrunk
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
-tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.name=clang-tidy
 tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0

--- a/lib/tooling/clang-tidy-tool.ts
+++ b/lib/tooling/clang-tidy-tool.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -36,6 +37,16 @@ import {BaseTool} from './base-tool.js';
 export class ClangTidyTool extends BaseTool {
     static get key() {
         return 'clang-tidy-tool';
+    }
+
+    override getToolExe(compilationInfo: CompilationInfo): string {
+        const exe = path.format({dir: path.dirname(compilationInfo.compiler.exe), base: 'clang-tidy'});
+        try {
+            fsSync.accessSync(exe);
+            return exe;
+        } catch {
+            return this.tool.exe;
+        }
     }
 
     constructor(toolInfo: ToolInfo, env: ToolEnv) {


### PR DESCRIPTION
Fixes #7335.

The logic works like this: we look in the directory where the current compiler lives, and if there's a `clang-tidy` in there, we use it, otherwise we use the trunk version. So, if Clang 17 is the current compiler, users get clang-tidy 17. If GCC is the current compiler, users get clang-tidy trunk.

Note: I'm familiar with neither Compiler Explorer internals nor Typescript; sorry if I'm overlooking something obvious!
