### PR TITLE
[swift]: add 6.2 release compilers

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&swift:&arm-swift
-demangler=/opt/compiler-explorer/swift-6.1/usr/bin/swift-demangle
-defaultCompiler=swift61
+demangler=/opt/compiler-explorer/swift-6.2/usr/bin/swift-demangle
+defaultCompiler=swift62
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
 #################################
@@ -8,13 +8,13 @@ objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 #################################
 
 # swift (x86_64)
-group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swift58:swift59:swift510:swift603:swift61:swiftdevsnapshot:swiftnightly
+group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swift58:swift59:swift510:swift603:swift61:swift62:swiftdevsnapshot:swiftnightly
 group.swift.isSemVer=true
 group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc
 
 # arm-swift (aarch64)
-group.arm-swift.compilers=arm-swift603:arm-swift61
+group.arm-swift.compilers=arm-swift62:arm-swift61:arm-swift603
 group.arm-swift.isSemVer=true
 group.arm-swift.groupName=swift (aarch64)
 group.arm-swift.baseName=aarch64 swiftc
@@ -38,6 +38,9 @@ compiler.swiftdevsnapshot.semver=devsnapshot
 
 # 6.x (x86)
 
+compiler.swift62.exe=/opt/compiler-explorer/swift-6.2/usr/bin/swiftc
+compiler.swift62.semver=6.2
+
 compiler.swift61.exe=/opt/compiler-explorer/swift-6.1/usr/bin/swiftc
 compiler.swift61.semver=6.1
 
@@ -45,6 +48,10 @@ compiler.swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
 compiler.swift603.semver=6.0.3
 
 # 6.x (arm)
+
+compiler.arm-swift62.exe=/opt/compiler-explorer/swift-6.2/usr/bin/swiftc
+compiler.arm-swift62.semver=6.2
+compiler.arm-swift62.options=-target aarch64-swift-linux-musl -sdk /opt/compiler-explorer/swift-6.2-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64 -resource-dir /opt/compiler-explorer/swift-6.2-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static
 
 compiler.arm-swift61.exe=/opt/compiler-explorer/swift-6.1/usr/bin/swiftc
 compiler.arm-swift61.semver=6.1


### PR DESCRIPTION
- adds support for the Swift 6.2 release compilers (x86 & cross-compiled arm)
- bumps the default Swift compiler to 6.2

depends on infra change: https://github.com/compiler-explorer/infra/pull/1834