### PR TITLE
[swift][refactor]: sort compilers config entry in descending order

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -8,7 +8,7 @@ objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 #################################
 
 # swift (x86_64)
-group.swift.compilers=swift311:swift402:swift403:swift41:swift411:swift412:swift42:swift50:swift51:swift52:swift53:swift54:swift55:swift56:swift57:swift58:swift59:swift510:swift603:swift61:swift62:swiftdevsnapshot:swiftnightly
+group.swift.compilers=swift62:swift61:swift603:swift510:swift59:swift58:swift57:swift56:swift55:swift54:swift53:swift52:swift51:swift50:swift42:swift412:swift411:swift41:swift403:swift402:swift311:swiftdevsnapshot:swiftnightly
 group.swift.isSemVer=true
 group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc


### PR DESCRIPTION
seems marginally easier to update with new versions this way