### PR TITLE
Make `Toggles` callbacks statically typechecked

### DIFF
--- a/static/panes/clangir-view.ts
+++ b/static/panes/clangir-view.ts
@@ -77,7 +77,7 @@ export class Clangir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Cla
     override registerButtons(state: ClangirState): void {
         super.registerButtons(state);
         this.options = new Toggles(this.domRoot.find('.options'), state as unknown as Record<string, boolean>);
-        this.options.on('change', this.onOptionsChange.bind(this));
+        this.options.on('change', () => this.onOptionsChange());
     }
 
     override registerCallbacks(): void {

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -112,9 +112,9 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
     override registerButtons(state: IrState) {
         super.registerButtons(state);
         this.options = new Toggles(this.domRoot.find('.options'), state as unknown as Record<string, boolean>);
-        this.options.on('change', this.onOptionsChange.bind(this));
+        this.options.on('change', () => this.onOptionsChange());
         this.filters = new Toggles(this.domRoot.find('.filters'), state as unknown as Record<string, boolean>);
-        this.filters.on('change', this.onOptionsChange.bind(this));
+        this.filters.on('change', () => this.onOptionsChange());
 
         this.cfgButton = this.domRoot.find('.cfg');
         const createCfgView = () => {

--- a/static/widgets/toggles.ts
+++ b/static/widgets/toggles.ts
@@ -119,4 +119,15 @@ export class Toggles extends EventEmitter {
             }
         }
     }
+
+    override emit(type: string, oldState: Record<string, boolean>, newState: Record<string, boolean>): boolean {
+        return super.emit(type, oldState, newState);
+    }
+
+    override on(
+        type: string,
+        listener: (oldState: Record<string, boolean>, newState: Record<string, boolean>) => void,
+    ): this {
+        return super.on(type, listener);
+    }
 }


### PR DESCRIPTION
As a followup to #8115, this overrides two methods in `Toggles` so that callbacks can be typechecked.

The three callbacks that were changed had the same problem as `showOptRemarks` in #8115 (the old state was passed in place of the optional `boolean` parameter `force`), however I don’t think there was a bug because in all cases, the wrong parameter was only used in `if (changed || force)` where `changed` was always true when called via the `Toggles` event.

This change is mostly to prevent bugs like #8109 in the future.