### PR TITLE
Fix quadratic runtime in execution output reading

### DIFF
--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -151,9 +151,9 @@ export async function executeDirect(
 
     function setupStream(stream: Stream, name: 'stdout' | 'stderr') {
         if (stream === undefined) return;
+        let currentLength = 0;
         stream.on('data', (data: Buffer) => {
             if (streams.truncated) return;
-            const currentLength = Buffer.concat(streams[name]).toString('utf8').length;
             const newLength = currentLength + data.length;
             if (maxOutput > 0 && newLength > maxOutput) {
                 const truncatedMsg = '\n[Truncated]';
@@ -165,6 +165,7 @@ export async function executeDirect(
                 return;
             }
             streams[name].push(Buffer.from(data));
+            currentLength = newLength;
         });
         setupOnError(stream, name);
     }


### PR DESCRIPTION
Calling `Buffer.concat` on each `data` event has quadratic runtime.

The only place where I could find a significant slowdown was the opt pipeline viewer in a local CE instance (not sure why it doesn’t happen on the live site): Even for short source code, this produces a *lot* of output and for some reason each `data` event yields only a small chunk of output. For example the `maxArray` example (https://godbolt.org/z/oTcKn7hWM) produces 46k lines (2 MB) of output with `-O3` and running the opt pipeline viewer takes 10x longer without this change.