### PR TITLE
Update Solidity solc and solx compiler versions

### DIFF
--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&solc:&zksolc:&solx
-defaultCompiler=solc0829
+defaultCompiler=solc0830
 
-group.solc.compilers=solc0426:solc0517:solc0612:solc076:solc0821:solc0829
+group.solc.compilers=solc0426:solc0517:solc0612:solc076:solc0821:solc0829:solc0830
 group.solc.compilerType=solidity
 group.solc.supportsBinary=false
 group.solc.instructionSet=evm
@@ -23,6 +23,9 @@ compiler.solc0821.name=solc 0.8.21
 compiler.solc0829.exe=/opt/compiler-explorer/solc-0.8.29/solc
 compiler.solc0829.semver=0.8.29
 compiler.solc0829.name=solc 0.8.29
+compiler.solc0830.exe=/opt/compiler-explorer/solc-0.8.30/solc
+compiler.solc0830.semver=0.8.30
+compiler.solc0830.name=solc 0.8.30
 
 group.zksolc.compilers=zksolc141:zksolc150:zksolc1513
 group.zksolc.compilerType=solidity-eravm
@@ -41,13 +44,19 @@ compiler.zksolc1513.semver=1.5.13
 compiler.zksolc1513.name=zksolc 1.5.13
 compiler.zksolc1513.options=--solc /opt/compiler-explorer/zksync-solc-0.8.29-1.0.1/solc
 
-group.solx.compilers=solx010alpha2
+group.solx.compilers=solx010:solx011:solx012
 group.solx.compilerType=solx
 group.solx.supportsBinary=false
 group.solx.instructionSet=evm
-compiler.solx010alpha2.exe=/opt/compiler-explorer/solx-0.1.0-alpha.2/solx
-compiler.solx010alpha2.semver=0.1.0-alpha.2
-compiler.solx010alpha2.name=solx 0.1.0-alpha.2
+compiler.solx010.exe=/opt/compiler-explorer/solx-0.1.0/solx
+compiler.solx010.semver=0.1.0
+compiler.solx010.name=solx 0.1.0
+compiler.solx011.exe=/opt/compiler-explorer/solx-0.1.1/solx
+compiler.solx011.semver=0.1.1
+compiler.solx011.name=solx 0.1.1
+compiler.solx012.exe=/opt/compiler-explorer/solx-0.1.2/solx
+compiler.solx012.semver=0.1.2
+compiler.solx012.name=solx 0.1.2
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -17,8 +17,8 @@ compiler.zksolc.instructionSet=eravm
 compiler.zksolc.isSemVer=true
 
 compiler.solx.exe=/usr/bin/solx
-compiler.solx.semver=0.1.0-alpha.2
-compiler.solx.name=solx 0.1.0-alpha.2
+compiler.solx.semver=0.1.2
+compiler.solx.name=solx 0.1.2
 compiler.solx.compilerType=solx
 compiler.solx.instructionSet=evm
 compiler.solx.isSemVer=true


### PR DESCRIPTION
## What?

Update Solidity compilers:
* [x] Add `solx` 0.1.0, 0.1.1 and 0.1.2 versions support
* [x] Add `solc` 0.8.30 version support

Related PR in infra: https://github.com/compiler-explorer/infra/pull/1837
