### PR TITLE
Add Kotlin 2.2.20

### DIFF
--- a/etc/config/kotlin.amazon.properties
+++ b/etc/config/kotlin.amazon.properties
@@ -3,7 +3,7 @@ compilerType=kotlin
 versionFlag=-version
 objdumper=/opt/compiler-explorer/jdk-23.0.1/bin/javap
 instructionSet=java
-defaultCompiler=kotlinc2210
+defaultCompiler=kotlinc2220
 demangler=
 postProcess=
 options=
@@ -12,7 +12,7 @@ needsMulti=false
 supportsExecute=true
 interpreted=true
 
-group.kotlin.compilers=kotlinc1400:kotlinc1410:kotlinc1420:kotlinc1421:kotlinc1430:kotlinc1431:kotlinc1432:kotlinc1500:kotlinc1510:kotlinc1520:kotlinc1521:kotlinc1530:kotlinc1531:kotlinc1600:kotlinc1610:kotlinc1620:kotlinc1700:kotlinc1800:kotlinc1810:kotlinc1820:kotlinc1900:kotlinc1910:kotlinc1920:kotlinc2000:kotlinc2010:kotlinc2020:kotlinc2021:kotlinc2100:kotlinc2110:kotlinc2120:kotlinc2121:kotlinc2200:kotlinc2210
+group.kotlin.compilers=kotlinc1400:kotlinc1410:kotlinc1420:kotlinc1421:kotlinc1430:kotlinc1431:kotlinc1432:kotlinc1500:kotlinc1510:kotlinc1520:kotlinc1521:kotlinc1530:kotlinc1531:kotlinc1600:kotlinc1610:kotlinc1620:kotlinc1700:kotlinc1800:kotlinc1810:kotlinc1820:kotlinc1900:kotlinc1910:kotlinc1920:kotlinc2000:kotlinc2010:kotlinc2020:kotlinc2021:kotlinc2100:kotlinc2110:kotlinc2120:kotlinc2121:kotlinc2200:kotlinc2210:kotlinc2220
 group.kotlin.groupName=Kotlin
 group.kotlin.baseName=kotlinc
 group.kotlin.isSemVer=true
@@ -151,6 +151,10 @@ compiler.kotlinc2210.exe=/opt/compiler-explorer/kotlin-jvm-2.2.10/bin/kotlinc-jv
 compiler.kotlinc2210.semver=2.2.10
 compiler.kotlinc2210.java_home=/opt/compiler-explorer/jdk-23.0.1
 compiler.kotlinc2210.runtime=/opt/compiler-explorer/jdk-23.0.1/bin/java
+compiler.kotlinc2220.exe=/opt/compiler-explorer/kotlin-jvm-2.2.20/bin/kotlinc-jvm
+compiler.kotlinc2220.semver=2.2.20
+compiler.kotlinc2220.java_home=/opt/compiler-explorer/jdk-23.0.1
+compiler.kotlinc2220.runtime=/opt/compiler-explorer/jdk-23.0.1/bin/java
 
 libs=kotlinx-coroutines-core-jvm
 


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
This PR adds support for the latest [Kotlin 2.2.20](https://kotlinlang.org/docs/whatsnew2220.html) and sets it as the default.

Depends on [infra/1840](https://github.com/compiler-explorer/infra/pull/1840).

