### PR TITLE
Fix comment syntax highlighting for Haskell

### DIFF
--- a/static/modes/haskell-mode.ts
+++ b/static/modes/haskell-mode.ts
@@ -77,20 +77,30 @@ function definition(): monaco.languages.IMonarchLanguage {
             ],
 
             comment: [
-                [/[^/*]+/, 'comment'],
-                [/\*\//, 'comment', '@pop'],
-                [/[/*]/, 'comment'],
+                [/[^{-]+/, 'comment'],
+                [/{-/, 'comment', '@push'],
+                [/-}/, 'comment', '@pop'],
+                [/[{-]/, 'comment'],
             ],
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
-                [/\/\*/, 'comment', '@comment'],
-                [/\/\/.*$/, 'comment'],
+                [/{-/, 'comment', '@comment'],
                 [/--.*$/, 'comment'],
             ],
         },
     };
 }
 
+function configuration(): monaco.languages.LanguageConfiguration {
+    return {
+        comments: {
+            lineComment: '--',
+            blockComment: ['{-', '-}'],
+        },
+    };
+}
+
 monaco.languages.register({id: 'haskell'});
 monaco.languages.setMonarchTokensProvider('haskell', definition());
+monaco.languages.setLanguageConfiguration('haskell', configuration());


### PR DESCRIPTION
This adds syntax highlighting for block comments `{- ... -}` and configuration to support the “add comment” and “remove comment” keyboard shortcuts.