### PR TITLE
Add C++ library fmt v12.0.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5332,7 +5332,7 @@ libs.flux.versions.trunk.path=/opt/compiler-explorer/libs/flux/trunk/include
 libs.flux.versions.040.version=0.4.0
 libs.flux.versions.040.path=/opt/compiler-explorer/libs/flux/v0.4.0/include
 
-libs.fmt.name=fmt
+libs.fmt.name={fmt}
 libs.fmt.description=A modern formatting library
 libs.fmt.versions=trunk:400:410:500:510:520:530:600:610:611:612:620:621:700:713:801:811:900:910:1000:1011:1021:1100:1200
 libs.fmt.url=https://fmt.dev/


### PR DESCRIPTION
This PR adds the C++ library **fmt** version 12.0.0 to Compiler Explorer.

- GitHub URL: https://github.com/fmtlib/fmt
- Library Type: static

Related PR: https://github.com/compiler-explorer/infra/pull/1850

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_