### PR TITLE
Change Mojo version to include leading `0.`

### DIFF
--- a/etc/config/mojo.amazon.properties
+++ b/etc/config/mojo.amazon.properties
@@ -2,12 +2,12 @@ compilers=&mojo
 defaultCompiler=mojo_nightly
 compilerType=mojo
 
-group.mojo.compilers=mojo_25_6_0:mojo_nightly
+group.mojo.compilers=mojo_0_25_6_0:mojo_nightly
 group.mojo.isSemVer=true
 group.mojo.baseName=Mojo
 
-compiler.mojo_25_6_0.exe=/opt/compiler-explorer/mojo-0.25.6.0/bin/mojo
-compiler.mojo_25_6_0.semver=25.6.0
+compiler.mojo_0_25_6_0.exe=/opt/compiler-explorer/mojo-0.25.6.0/bin/mojo
+compiler.mojo_0_25_6_0.semver=0.25.6.0
 
 compiler.mojo_nightly.exe=/opt/compiler-explorer/mojo-nightly/bin/mojo
 compiler.mojo_nightly.semver=nightly


### PR DESCRIPTION
We changed version strategies ~2 months ago to include this leading zero (in preparation for a future 1.0), reflecting that change here so it doesn't confuse people.
