### PR TITLE
Add Resolc 0.4.0 compiler for Solidity and Yul

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -371,6 +371,7 @@
           - 'lib/compilers/solidity.ts'
           - 'lib/compilers/solidity-zksync.ts'
           - 'lib/compilers/solx.ts'
+          - 'lib/compilers/resolc.ts'
           - 'etc/config/solidity.*.properties'
 
 'lang-spice':
@@ -446,6 +447,13 @@
           - 'lib/compilers/wasmtime.ts'
           - 'etc/config/wasm.*.properties'
           - 'static/modes/wat-mode.ts'
+
+'lang-yul':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/resolc.ts'
+          - 'etc/config/yul.*.properties'
+          - 'static/modes/yul-mode.ts'
 
 'lang-zig':
   - changed-files:

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -58,17 +58,24 @@ compiler.solx012.exe=/opt/compiler-explorer/solx-0.1.2/solx
 compiler.solx012.semver=0.1.2
 compiler.solx012.name=solx 0.1.2
 
-group.resolc.compilers=resolc030
+# The Resolc compiler supports compiling both Solidity and Yul (Solidity IR), thus
+# the same compiler is used for both languages. The compiler config IDs will clash
+# if they are not unique, therefore the IDs contain either '_yul' or '_sol'.
+group.resolc.compilers=resolc030_sol_pvm:resolc030_sol_riscv
 group.resolc.compilerType=resolc
 group.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
 group.resolc.objdumperType=llvm
 group.resolc.supportsBinaryObject=true
-group.resolc.instructionSet=riscv64
 group.resolc.isSemver=true
 group.resolc.versionFlag=--version
-compiler.resolc030.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
-compiler.resolc030.semver=0.3.0
-compiler.resolc030.name=resolc 0.3.0
+compiler.resolc030_sol_pvm.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
+compiler.resolc030_sol_pvm.semver=0.3.0
+compiler.resolc030_sol_pvm.name=resolc 0.3.0 (PVM)
+compiler.resolc030_sol_pvm.instructionSet=pvm
+compiler.resolc030_sol_riscv.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
+compiler.resolc030_sol_riscv.semver=0.3.0
+compiler.resolc030_sol_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
+compiler.resolc030_sol_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -61,21 +61,21 @@ compiler.solx012.name=solx 0.1.2
 # The Resolc compiler supports compiling both Solidity and Yul (Solidity IR), thus
 # the same compiler is used for both languages. The compiler config IDs will clash
 # if they are not unique, therefore the IDs contain either '_yul' or '_sol'.
-group.resolc.compilers=resolc030_sol_pvm:resolc030_sol_riscv
+group.resolc.compilers=resolc040_sol_pvm:resolc040_sol_riscv
 group.resolc.compilerType=resolc
 group.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
 group.resolc.objdumperType=llvm
 group.resolc.supportsBinaryObject=true
 group.resolc.isSemver=true
 group.resolc.versionFlag=--version
-compiler.resolc030_sol_pvm.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
-compiler.resolc030_sol_pvm.semver=0.3.0
-compiler.resolc030_sol_pvm.name=resolc 0.3.0 (PVM)
-compiler.resolc030_sol_pvm.instructionSet=pvm
-compiler.resolc030_sol_riscv.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
-compiler.resolc030_sol_riscv.semver=0.3.0
-compiler.resolc030_sol_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
-compiler.resolc030_sol_riscv.instructionSet=riscv64
+compiler.resolc040_sol_pvm.exe=/opt/compiler-explorer/resolc-0.4.0/resolc
+compiler.resolc040_sol_pvm.semver=0.4.0
+compiler.resolc040_sol_pvm.name=resolc 0.4.0 (PVM)
+compiler.resolc040_sol_pvm.instructionSet=pvm
+compiler.resolc040_sol_riscv.exe=/opt/compiler-explorer/resolc-0.4.0/resolc
+compiler.resolc040_sol_riscv.semver=0.4.0
+compiler.resolc040_sol_riscv.name=resolc 0.4.0 (RISC-V 64-bits)
+compiler.resolc040_sol_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/solidity.amazon.properties
+++ b/etc/config/solidity.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&solc:&zksolc:&solx
+compilers=&solc:&zksolc:&solx:&resolc
 defaultCompiler=solc0830
 
 group.solc.compilers=solc0426:solc0517:solc0612:solc076:solc0821:solc0829:solc0830
@@ -57,6 +57,18 @@ compiler.solx011.name=solx 0.1.1
 compiler.solx012.exe=/opt/compiler-explorer/solx-0.1.2/solx
 compiler.solx012.semver=0.1.2
 compiler.solx012.name=solx 0.1.2
+
+group.resolc.compilers=resolc030
+group.resolc.compilerType=resolc
+group.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
+group.resolc.objdumperType=llvm
+group.resolc.supportsBinaryObject=true
+group.resolc.instructionSet=riscv64
+group.resolc.isSemver=true
+group.resolc.versionFlag=--version
+compiler.resolc030.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
+compiler.resolc030.semver=0.3.0
+compiler.resolc030.name=resolc 0.3.0
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -23,21 +23,21 @@ compiler.solx.compilerType=solx
 compiler.solx.instructionSet=evm
 compiler.solx.isSemVer=true
 
-group.resolc.compilers=resolc030_sol_pvm:resolc030_sol_riscv
+group.resolc.compilers=resolc040_sol_pvm:resolc040_sol_riscv
 group.resolc.compilerType=resolc
 group.resolc.objdumper=/usr/local/bin/llvm-objdump
 group.resolc.objdumperType=llvm
 group.resolc.supportsBinaryObject=true
 group.resolc.isSemver=true
 group.resolc.versionFlag=--version
-compiler.resolc030_sol_pvm.exe=/usr/local/bin/resolc
-compiler.resolc030_sol_pvm.semver=0.3.0
-compiler.resolc030_sol_pvm.name=resolc 0.3.0 (PVM)
-compiler.resolc030_sol_pvm.instructionSet=pvm
-compiler.resolc030_sol_riscv.exe=/usr/local/bin/resolc
-compiler.resolc030_sol_riscv.semver=0.3.0
-compiler.resolc030_sol_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
-compiler.resolc030_sol_riscv.instructionSet=riscv64
+compiler.resolc040_sol_pvm.exe=/usr/local/bin/resolc
+compiler.resolc040_sol_pvm.semver=0.4.0
+compiler.resolc040_sol_pvm.name=resolc 0.4.0 (PVM)
+compiler.resolc040_sol_pvm.instructionSet=pvm
+compiler.resolc040_sol_riscv.exe=/usr/local/bin/resolc
+compiler.resolc040_sol_riscv.semver=0.4.0
+compiler.resolc040_sol_riscv.name=resolc 0.4.0 (RISC-V 64-bits)
+compiler.resolc040_sol_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -1,4 +1,4 @@
-compilers=solc:zksolc:solx
+compilers=solc:zksolc:solx:resolc
 compilerType=solidity
 defaultCompiler=solc
 
@@ -22,6 +22,16 @@ compiler.solx.name=solx 0.1.2
 compiler.solx.compilerType=solx
 compiler.solx.instructionSet=evm
 compiler.solx.isSemVer=true
+
+compiler.resolc.exe=/usr/bin/resolc
+compiler.resolc.semver=0.3.0
+compiler.resolc.name=resolc 0.3.0
+compiler.resolc.compilerType=resolc
+compiler.resolc.supportsBinaryObject=true
+compiler.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
+compiler.resolc.objdumperType=llvm
+compiler.resolc.instructionSet=riscv64
+compiler.resolc.isSemVer=true
 
 #################################
 #################################

--- a/etc/config/solidity.defaults.properties
+++ b/etc/config/solidity.defaults.properties
@@ -1,4 +1,4 @@
-compilers=solc:zksolc:solx:resolc
+compilers=solc:zksolc:solx:&resolc
 compilerType=solidity
 defaultCompiler=solc
 
@@ -23,15 +23,21 @@ compiler.solx.compilerType=solx
 compiler.solx.instructionSet=evm
 compiler.solx.isSemVer=true
 
-compiler.resolc.exe=/usr/bin/resolc
-compiler.resolc.semver=0.3.0
-compiler.resolc.name=resolc 0.3.0
-compiler.resolc.compilerType=resolc
-compiler.resolc.supportsBinaryObject=true
-compiler.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
-compiler.resolc.objdumperType=llvm
-compiler.resolc.instructionSet=riscv64
-compiler.resolc.isSemVer=true
+group.resolc.compilers=resolc030_sol_pvm:resolc030_sol_riscv
+group.resolc.compilerType=resolc
+group.resolc.objdumper=/usr/local/bin/llvm-objdump
+group.resolc.objdumperType=llvm
+group.resolc.supportsBinaryObject=true
+group.resolc.isSemver=true
+group.resolc.versionFlag=--version
+compiler.resolc030_sol_pvm.exe=/usr/local/bin/resolc
+compiler.resolc030_sol_pvm.semver=0.3.0
+compiler.resolc030_sol_pvm.name=resolc 0.3.0 (PVM)
+compiler.resolc030_sol_pvm.instructionSet=pvm
+compiler.resolc030_sol_riscv.exe=/usr/local/bin/resolc
+compiler.resolc030_sol_riscv.semver=0.3.0
+compiler.resolc030_sol_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
+compiler.resolc030_sol_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/yul.amazon.properties
+++ b/etc/config/yul.amazon.properties
@@ -1,24 +1,24 @@
 compilers=&resolc
-defaultCompiler=resolc030_yul_pvm
+defaultCompiler=resolc040_yul_pvm
 
 # The Resolc compiler supports compiling both Solidity and Yul (Solidity IR), thus
 # the same compiler is used for both languages. The compiler config IDs will clash
 # if they are not unique, therefore the IDs contain either '_yul' or '_sol'.
-group.resolc.compilers=resolc030_yul_pvm:resolc030_yul_riscv
+group.resolc.compilers=resolc040_yul_pvm:resolc040_yul_riscv
 group.resolc.compilerType=resolc
 group.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
 group.resolc.objdumperType=llvm
 group.resolc.supportsBinaryObject=true
 group.resolc.isSemver=true
 group.resolc.versionFlag=--version
-compiler.resolc030_yul_pvm.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
-compiler.resolc030_yul_pvm.semver=0.3.0
-compiler.resolc030_yul_pvm.name=resolc 0.3.0 (PVM)
-compiler.resolc030_yul_pvm.instructionSet=pvm
-compiler.resolc030_yul_riscv.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
-compiler.resolc030_yul_riscv.semver=0.3.0
-compiler.resolc030_yul_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
-compiler.resolc030_yul_riscv.instructionSet=riscv64
+compiler.resolc040_yul_pvm.exe=/opt/compiler-explorer/resolc-0.4.0/resolc
+compiler.resolc040_yul_pvm.semver=0.4.0
+compiler.resolc040_yul_pvm.name=resolc 0.4.0 (PVM)
+compiler.resolc040_yul_pvm.instructionSet=pvm
+compiler.resolc040_yul_riscv.exe=/opt/compiler-explorer/resolc-0.4.0/resolc
+compiler.resolc040_yul_riscv.semver=0.4.0
+compiler.resolc040_yul_riscv.name=resolc 0.4.0 (RISC-V 64-bits)
+compiler.resolc040_yul_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/yul.amazon.properties
+++ b/etc/config/yul.amazon.properties
@@ -1,17 +1,24 @@
 compilers=&resolc
-defaultCompiler=resolc030_yul
+defaultCompiler=resolc030_yul_pvm
 
-group.resolc.compilers=resolc030_yul
+# The Resolc compiler supports compiling both Solidity and Yul (Solidity IR), thus
+# the same compiler is used for both languages. The compiler config IDs will clash
+# if they are not unique, therefore the IDs contain either '_yul' or '_sol'.
+group.resolc.compilers=resolc030_yul_pvm:resolc030_yul_riscv
 group.resolc.compilerType=resolc
 group.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
 group.resolc.objdumperType=llvm
 group.resolc.supportsBinaryObject=true
-group.resolc.instructionSet=riscv64
 group.resolc.isSemver=true
 group.resolc.versionFlag=--version
-compiler.resolc030_yul.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
-compiler.resolc030_yul.semver=0.3.0
-compiler.resolc030_yul.name=resolc 0.3.0
+compiler.resolc030_yul_pvm.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
+compiler.resolc030_yul_pvm.semver=0.3.0
+compiler.resolc030_yul_pvm.name=resolc 0.3.0 (PVM)
+compiler.resolc030_yul_pvm.instructionSet=pvm
+compiler.resolc030_yul_riscv.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
+compiler.resolc030_yul_riscv.semver=0.3.0
+compiler.resolc030_yul_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
+compiler.resolc030_yul_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/yul.amazon.properties
+++ b/etc/config/yul.amazon.properties
@@ -1,0 +1,25 @@
+compilers=&resolc
+defaultCompiler=resolc030_yul
+
+group.resolc.compilers=resolc030_yul
+group.resolc.compilerType=resolc
+group.resolc.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
+group.resolc.objdumperType=llvm
+group.resolc.supportsBinaryObject=true
+group.resolc.instructionSet=riscv64
+group.resolc.isSemver=true
+group.resolc.versionFlag=--version
+compiler.resolc030_yul.exe=/opt/compiler-explorer/resolc-0.3.0/resolc
+compiler.resolc030_yul.semver=0.3.0
+compiler.resolc030_yul.name=resolc 0.3.0
+
+#################################
+#################################
+# Installed libs (See c++.amazon.properties for a scheme of libs group)
+libs=
+
+#################################
+#################################
+# Installed tools
+
+tools=

--- a/etc/config/yul.defaults.properties
+++ b/etc/config/yul.defaults.properties
@@ -1,0 +1,21 @@
+compilers=resolc_yul
+compilerType=resolc
+defaultCompiler=resolc_yul
+
+# The Resolc compiler supports both Solidity and Yul (Solidity IR), thus the
+# same compiler is used for both languages. The compiler config IDs here will
+# clash if they are not unique, therefore the ID here is postfixed with '_yul'.
+compiler.resolc_yul.exe=/usr/bin/resolc
+compiler.resolc_yul.semver=0.3.0
+compiler.resolc_yul.name=resolc 0.3.0
+compiler.resolc_yul.compilerType=resolc
+compiler.resolc_yul.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
+compiler.resolc_yul.objdumperType=llvm
+compiler.resolc_yul.supportsBinaryObject=true
+compiler.resolc_yul.instructionSet=riscv64
+compiler.resolc_yul.isSemVer=true
+
+#################################
+#################################
+# Installed libs (See c++.amazon.properties for a scheme of libs group)
+libs=

--- a/etc/config/yul.defaults.properties
+++ b/etc/config/yul.defaults.properties
@@ -1,19 +1,22 @@
-compilers=resolc_yul
+compilers=&resolc
 compilerType=resolc
-defaultCompiler=resolc_yul
+defaultCompiler=resolc030_yul_pvm
 
-# The Resolc compiler supports both Solidity and Yul (Solidity IR), thus the
-# same compiler is used for both languages. The compiler config IDs here will
-# clash if they are not unique, therefore the ID here is postfixed with '_yul'.
-compiler.resolc_yul.exe=/usr/bin/resolc
-compiler.resolc_yul.semver=0.3.0
-compiler.resolc_yul.name=resolc 0.3.0
-compiler.resolc_yul.compilerType=resolc
-compiler.resolc_yul.objdumper=/opt/compiler-explorer/clang-21.1.0/bin/llvm-objdump
-compiler.resolc_yul.objdumperType=llvm
-compiler.resolc_yul.supportsBinaryObject=true
-compiler.resolc_yul.instructionSet=riscv64
-compiler.resolc_yul.isSemVer=true
+group.resolc.compilers=resolc030_yul_pvm:resolc030_yul_riscv
+group.resolc.compilerType=resolc
+group.resolc.objdumper=/usr/local/bin/llvm-objdump
+group.resolc.objdumperType=llvm
+group.resolc.supportsBinaryObject=true
+group.resolc.isSemver=true
+group.resolc.versionFlag=--version
+compiler.resolc030_yul_pvm.exe=/usr/local/bin/resolc
+compiler.resolc030_yul_pvm.semver=0.3.0
+compiler.resolc030_yul_pvm.name=resolc 0.3.0 (PVM)
+compiler.resolc030_yul_pvm.instructionSet=pvm
+compiler.resolc030_yul_riscv.exe=/usr/local/bin/resolc
+compiler.resolc030_yul_riscv.semver=0.3.0
+compiler.resolc030_yul_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
+compiler.resolc030_yul_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/etc/config/yul.defaults.properties
+++ b/etc/config/yul.defaults.properties
@@ -1,22 +1,22 @@
 compilers=&resolc
 compilerType=resolc
-defaultCompiler=resolc030_yul_pvm
+defaultCompiler=resolc040_yul_pvm
 
-group.resolc.compilers=resolc030_yul_pvm:resolc030_yul_riscv
+group.resolc.compilers=resolc040_yul_pvm:resolc040_yul_riscv
 group.resolc.compilerType=resolc
 group.resolc.objdumper=/usr/local/bin/llvm-objdump
 group.resolc.objdumperType=llvm
 group.resolc.supportsBinaryObject=true
 group.resolc.isSemver=true
 group.resolc.versionFlag=--version
-compiler.resolc030_yul_pvm.exe=/usr/local/bin/resolc
-compiler.resolc030_yul_pvm.semver=0.3.0
-compiler.resolc030_yul_pvm.name=resolc 0.3.0 (PVM)
-compiler.resolc030_yul_pvm.instructionSet=pvm
-compiler.resolc030_yul_riscv.exe=/usr/local/bin/resolc
-compiler.resolc030_yul_riscv.semver=0.3.0
-compiler.resolc030_yul_riscv.name=resolc 0.3.0 (RISC-V 64-bits)
-compiler.resolc030_yul_riscv.instructionSet=riscv64
+compiler.resolc040_yul_pvm.exe=/usr/local/bin/resolc
+compiler.resolc040_yul_pvm.semver=0.4.0
+compiler.resolc040_yul_pvm.name=resolc 0.4.0 (PVM)
+compiler.resolc040_yul_pvm.instructionSet=pvm
+compiler.resolc040_yul_riscv.exe=/usr/local/bin/resolc
+compiler.resolc040_yul_riscv.semver=0.4.0
+compiler.resolc040_yul_riscv.name=resolc 0.4.0 (RISC-V 64-bits)
+compiler.resolc040_yul_riscv.instructionSet=riscv64
 
 #################################
 #################################

--- a/examples/yul/default.yul
+++ b/examples/yul/default.yul
@@ -1,0 +1,43 @@
+object "Square" {
+    code {
+        {
+            let _1 := memoryguard(0x80)
+            mstore(64, _1)
+            if callvalue() { revert(0, 0) }
+            let _2 := datasize("Square_deployed")
+            codecopy(_1, dataoffset("Square_deployed"), _2)
+            return(_1, _2)
+        }
+    }
+    object "Square_deployed" {
+        code {
+            {
+                let _1 := memoryguard(0x80)
+                mstore(64, _1)
+                if iszero(lt(calldatasize(), 4))
+                {
+                    if eq(0xd27b3841, shr(224, calldataload(0)))
+                    {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+                        let value := calldataload(4)
+                        let _2 := and(value, 0xffffffff)
+                        if iszero(eq(value, _2)) { revert(0, 0) }
+                        let product_raw := mul(_2, _2)
+                        let product := and(product_raw, 0xffffffff)
+                        if iszero(eq(product, product_raw))
+                        {
+                            mstore(0, shl(224, 0x4e487b71))
+                            mstore(4, 0x11)
+                            revert(0, 0x24)
+                        }
+                        mstore(_1, product)
+                        return(_1, 32)
+                    }
+                }
+                revert(0, 0)
+            }
+        }
+        data ".metadata" hex"a26469706673582212209b2b1b86ce0e1a75faa800884ba155bd6bc6a6bc71f210370f818535dcfc5ee364736f6c634300081e0033"
+    }
+}

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -133,6 +133,7 @@ export {QNXCompiler} from './qnx.js';
 export {R8Compiler} from './r8.js';
 export {RacketCompiler} from './racket.js';
 export {RakuCompiler} from './raku.js';
+export {ResolcCompiler} from './resolc.js';
 export {RGACompiler} from './rga.js';
 export {RubyCompiler} from './ruby.js';
 export {RustCompiler} from './rust.js';

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -942,6 +942,13 @@ export class SolxParser extends RustParser {
     }
 }
 
+export class ResolcParser extends BaseParser {
+    override async parse() {
+        await this.getOptions('--help');
+        return this.compiler;
+    }
+}
+
 export class MrustcParser extends BaseParser {
     override async parse() {
         await this.getOptions('--help');

--- a/lib/compilers/resolc.ts
+++ b/lib/compilers/resolc.ts
@@ -29,6 +29,7 @@ import type {ActiveTool, CacheKey} from '../../types/compilation/compilation.int
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import type {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
+import {ResolcAsmParser} from '../parsers/asm-parser-resolc.js';
 import {changeExtension} from '../utils.js';
 import {type BaseParser, ResolcParser} from './argument-parsers.js';
 
@@ -56,6 +57,12 @@ export class ResolcCompiler extends BaseCompiler {
 
     static get key() {
         return 'resolc';
+    }
+
+    constructor(...args: ConstructorParameters<typeof BaseCompiler>) {
+        super(...args);
+
+        this.asm = new ResolcAsmParser(this.compilerProps);
     }
 
     override getSharedLibraryPathsAsArguments(): string[] {

--- a/lib/compilers/resolc.ts
+++ b/lib/compilers/resolc.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type {ActiveTool, CacheKey} from '../../types/compilation/compilation.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import type {SelectedLibraryVersion} from '../../types/libraries/libraries.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {changeExtension} from '../utils.js';
+import {type BaseParser, ResolcParser} from './argument-parsers.js';
+
+/**
+ * The kind of output requested by the user.
+ * Defaults to RISC-V, but can be changed via compiler options.
+ */
+enum OutputKind {
+    RiscV,
+    PolkaVM,
+}
+
+export class ResolcCompiler extends BaseCompiler {
+    private outputKind = OutputKind.RiscV;
+
+    static get key() {
+        return 'resolc';
+    }
+
+    override getSharedLibraryPathsAsArguments(): string[] {
+        return [];
+    }
+
+    override getArgumentParserClass(): typeof BaseParser {
+        return ResolcParser;
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, _outputFilename: string): string[] {
+        // For RISC-V output the binary object will be passed to llvm objdump.
+        filters.binaryObject = this.outputKind === OutputKind.RiscV;
+        // Keep the PolkaVM assembly header comments, such as the number of instructions and code size.
+        filters.commentOnly = false;
+
+        const options = ['-g', '--overwrite', '--debug-output-dir', 'artifacts'];
+
+        return options;
+    }
+
+    override isCfgCompiler(): boolean {
+        return false;
+    }
+
+    override getOutputFilename(dirPath: string): string {
+        const artifactExtension = '.pvmasm';
+        const basenamePrefix = dirPath.replaceAll('/', '_');
+        const contractName = this.getSolidityContractName(dirPath);
+        const outputFilename = path.join(
+            dirPath,
+            `artifacts/${basenamePrefix}_${this.compileFilename}.${contractName}${artifactExtension}`,
+        );
+
+        return outputFilename;
+    }
+
+    override getObjdumpOutputFilename(defaultOutputFilename: string): string {
+        return changeExtension(defaultOutputFilename, '.o');
+    }
+
+    override async doCompilation(
+        inputFilename: string,
+        dirPath: string,
+        key: CacheKey,
+        options: string[],
+        filters: ParseFiltersAndOutputOptions,
+        backendOptions: Record<string, any>,
+        libraries: SelectedLibraryVersion[],
+        tools: ActiveTool[],
+    ) {
+        this.outputKind = options.includes('--asm') ? OutputKind.PolkaVM : OutputKind.RiscV;
+
+        return super.doCompilation(inputFilename, dirPath, key, options, filters, backendOptions, libraries, tools);
+    }
+
+    /**
+     * Get the Solidity component/contract name used in the compile file.
+     *
+     * Example:
+     * ```solidity
+     * contract Square { ... } // Name = Square
+     * ```
+     */
+    private getSolidityContractName(dirPath: string): string {
+        return this.getContractName(dirPath, 'contract');
+    }
+
+    private getContractName(dirPath: string, preceedingKeyword: string): string {
+        const source = fs.readFileSync(`${dirPath}/${this.compileFilename}`, {encoding: 'utf8'});
+        const whitespace = /\s+/;
+        const sourceParts = source.split(whitespace);
+        const contractStart = sourceParts.indexOf(preceedingKeyword);
+
+        return contractStart >= 0 ? sourceParts[contractStart + 1] : 'contract_not_found';
+    }
+}

--- a/lib/compilers/resolc.ts
+++ b/lib/compilers/resolc.ts
@@ -30,7 +30,7 @@ import type {CompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import type {Language} from '../../types/languages.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
-import {ResolcAsmParser} from '../parsers/asm-parser-resolc.js';
+import {ResolcRiscVAsmParser} from '../parsers/asm-parser-resolc-riscv.js';
 import {changeExtension} from '../utils.js';
 import {type BaseParser, ResolcParser} from './argument-parsers.js';
 
@@ -67,7 +67,7 @@ export class ResolcCompiler extends BaseCompiler {
     constructor(...args: ConstructorParameters<typeof BaseCompiler>) {
         super(...args);
 
-        this.asm = new ResolcAsmParser(this.compilerProps);
+        this.asm = new ResolcRiscVAsmParser(this.compilerProps);
         this.compiler.supportsIrView = true;
         // The arg producing LLVM IR (among other output) is already
         // included in optionsForFilter(), but irArg needs to be set.

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -91,6 +91,10 @@ export class InstructionSets {
                 target: ['powerpc', 'ppc64', 'ppc'],
                 path: ['/powerpc-', '/powerpc64-', '/powerpc64le-'],
             },
+            pvm: {
+                target: [],
+                path: [],
+            },
             riscv64: {
                 target: ['rv64', 'riscv64'],
                 path: ['/riscv64-'],

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -972,6 +972,17 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
     },
+    yul: {
+        name: 'Yul (Solidity IR)',
+        monaco: 'yul',
+        extensions: ['.yul'],
+        alias: [],
+        logoFilename: 'solidity.svg',
+        logoFilenameDark: null,
+        formatter: null,
+        previewFilter: null,
+        monacoDisassembly: null,
+    },
     zig: {
         name: 'Zig',
         monaco: 'zig',

--- a/lib/parsers/asm-parser-resolc-riscv.ts
+++ b/lib/parsers/asm-parser-resolc-riscv.ts
@@ -25,7 +25,7 @@
 import {PropertyGetter} from '../properties.interfaces.js';
 import {AsmParser} from './asm-parser.js';
 
-export class ResolcAsmParser extends AsmParser {
+export class ResolcRiscVAsmParser extends AsmParser {
     constructor(compilerProps?: PropertyGetter) {
         super(compilerProps);
 

--- a/lib/parsers/asm-parser-resolc.ts
+++ b/lib/parsers/asm-parser-resolc.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {PropertyGetter} from '../properties.interfaces.js';
+import {AsmParser} from './asm-parser.js';
+
+export class ResolcAsmParser extends AsmParser {
+    constructor(compilerProps?: PropertyGetter) {
+        super(compilerProps);
+
+        // Example: "; artifacts/_var_folders_fj_1p_1d_T_compiler-explorer-compilerJzYPPi_example.yul.Square.yul:1"
+        this.lineRe = /^;\s+(?<file>\S+):(?<line>\d+)$/;
+    }
+}

--- a/static/modes/_all.ts
+++ b/static/modes/_all.ts
@@ -72,4 +72,5 @@ import './tablegen-mode';
 import './v-mode';
 import './vala-mode';
 import './wat-mode';
+import './yul-mode';
 import './zig-mode';

--- a/static/modes/yul-mode.ts
+++ b/static/modes/yul-mode.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as monaco from 'monaco-editor';
+
+export function definition(): monaco.languages.IMonarchLanguage {
+    return {
+        // Set defaultToken to 'invalid' to see what is not yet tokenized.
+        defaultToken: 'invalid',
+
+        keywords: [
+            'break',
+            'case',
+            'code',
+            'continue',
+            'data',
+            'default',
+            'false',
+            'for',
+            'function',
+            'hex',
+            'if',
+            'leave',
+            'let',
+            'object',
+            'switch',
+            'true',
+        ],
+
+        operators: [':='],
+
+        brackets: [
+            {open: '{', close: '}', token: 'delimiter.curly'},
+            {open: '(', close: ')', token: 'delimiter.parenthesis'},
+            {open: '[', close: ']', token: 'delimiter.square'},
+        ],
+
+        symbols: /[:=]+/,
+
+        delimiters: /[.,:]/,
+
+        escapes: /\\(?:['"\\nrt\n\r]|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4})/,
+
+        tokenizer: {
+            root: [
+                // Identifiers and keywords
+                [
+                    /[a-z][a-zA-Z0-9_]*/,
+                    {
+                        cases: {
+                            '@keywords': 'keyword',
+                            '@default': 'identifier',
+                        },
+                    },
+                ],
+
+                [/[a-zA-Z_$][a-zA-Z_$0-9.]*/, 'type.identifier'],
+
+                // Whitespace
+                {include: '@whitespace'},
+
+                // Delimiters and operators
+                [/[()[\]{}]/, '@brackets'],
+
+                [
+                    /@symbols/,
+                    {
+                        cases: {
+                            '@operators': 'operator',
+                            '@default': '',
+                        },
+                    },
+                ],
+
+                // Numbers
+                [/0x[0-9a-fA-F]+/, 'number.hex'],
+                [/\d+/, 'number'],
+
+                // Strings
+                [/"([^"\\]|\\.)*$/, 'string.invalid'], // non-terminated string
+                [/"/, 'string', '@string'],
+            ],
+
+            // Whitespace and comments
+            whitespace: [
+                [/[ \t\r\n]+/, 'white'],
+                [/\/\*/, 'comment', '@comment'],
+                [/\/\/.*$/, 'comment'],
+            ],
+
+            comment: [
+                [/[^/*]+/, 'comment'],
+                [/\/\*/, 'comment', '@push'], // Nested comment
+                ['\\*/', 'comment', '@pop'],
+                [/[/*]/, 'comment'],
+            ],
+
+            // Strings
+            string: [
+                [/[^\\"]+/, 'string'],
+                [/@escapes/, 'string.escape'],
+                [/\\./, 'string.escape.invalid'],
+                [/"/, 'string', '@pop'],
+            ],
+        },
+    };
+}
+
+function configuration(): monaco.languages.LanguageConfiguration {
+    return {
+        comments: {
+            lineComment: '//',
+            blockComment: ['/*', '*/'],
+        },
+
+        brackets: [
+            ['{', '}'],
+            ['[', ']'],
+            ['(', ')'],
+        ],
+
+        autoClosingPairs: [
+            {open: '{', close: '}'},
+            {open: '[', close: ']'},
+            {open: '(', close: ')'},
+            {open: '"', close: '"', notIn: ['string']},
+            {open: '/*', close: ' */', notIn: ['string']},
+        ],
+
+        surroundingPairs: [
+            {open: '{', close: '}'},
+            {open: '[', close: ']'},
+            {open: '(', close: ')'},
+            {open: '"', close: '"'},
+        ],
+    };
+}
+
+monaco.languages.register({id: 'yul'});
+monaco.languages.setMonarchTokensProvider('yul', definition());
+monaco.languages.setLanguageConfiguration('yul', configuration());

--- a/test/asm-parser-tests.ts
+++ b/test/asm-parser-tests.ts
@@ -26,7 +26,7 @@ import {describe, expect, it} from 'vitest';
 import {AsmParser} from '../lib/parsers/asm-parser.js';
 import {MlirAsmParser} from '../lib/parsers/asm-parser-mlir.js';
 import {PTXAsmParser} from '../lib/parsers/asm-parser-ptx.js';
-import {ResolcAsmParser} from '../lib/parsers/asm-parser-resolc.js';
+import {ResolcRiscVAsmParser} from '../lib/parsers/asm-parser-resolc-riscv.js';
 import type {ParsedAsmResult} from '../types/asmresult/asmresult.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
 
@@ -297,8 +297,8 @@ module {
     });
 });
 
-describe('ResolcAsmParser tests', () => {
-    const parser = new ResolcAsmParser();
+describe('ResolcRiscVAsmParser tests', () => {
+    const parser = new ResolcRiscVAsmParser();
 
     it('should identify instruction info and source line numbers', () => {
         const filters: Partial<ParseFiltersAndOutputOptions> = {binaryObject: true};

--- a/test/resolc-tests.ts
+++ b/test/resolc-tests.ts
@@ -150,10 +150,10 @@ describe('Resolc', () => {
                         text: '__entry:',
                     },
                     {
-                        text: ' addi	sp, sp, -0x10',
+                        text: '\t addi	sp, sp, -0x10',
                     },
                     {
-                        text: ' sd	ra, 0x8(sp)',
+                        text: '\t sd	ra, 0x8(sp)',
                     },
                 ],
             };
@@ -213,19 +213,19 @@ describe('Resolc', () => {
                         source: null,
                     },
                     {
-                        text: ' auipc	a1, 0x0',
+                        text: '\t auipc	a1, 0x0',
                         source: null,
                     },
                     {
-                        text: ' addi	sp, sp, -0x60',
+                        text: '\t addi	sp, sp, -0x60',
                         source: null,
                     },
                     {
-                        text: ' sd	ra, 0x58(sp)',
+                        text: '\t sd	ra, 0x58(sp)',
                         source: null,
                     },
                     {
-                        text: ' jalr	ra <.Lpcrel_hi4+0x3a>',
+                        text: '\t jalr	ra <.Lpcrel_hi4+0x3a>',
                         source: null,
                     },
                 ],

--- a/test/resolc-tests.ts
+++ b/test/resolc-tests.ts
@@ -41,11 +41,13 @@ const languages = {
 const solidityInfo = {
     exe: 'resolc',
     lang: languages.solidity.id as LanguageKey,
+    name: 'resolc 0.3.0 (RISC-V 64-bits)',
 };
 
 const yulInfo = {
     exe: 'resolc',
     lang: languages.yul.id as LanguageKey,
+    name: 'resolc 0.3.0 (RISC-V 64-bits)',
 };
 
 describe('Resolc', () => {
@@ -145,9 +147,6 @@ describe('Resolc', () => {
             const expected: ParsedAsmResult = {
                 asm: [
                     {
-                        text: '; RISC-V (to see PolkaVM Assembly, use compiler option "--asm")',
-                    },
-                    {
                         text: '__entry:',
                     },
                     {
@@ -209,9 +208,6 @@ describe('Resolc', () => {
 
             const expected: ParsedAsmResult = {
                 asm: [
-                    {
-                        text: '; RISC-V (to see PolkaVM Assembly, use compiler option "--asm")',
-                    },
                     {
                         text: '.Lpcrel_hi4:',
                         source: null,

--- a/test/resolc-tests.ts
+++ b/test/resolc-tests.ts
@@ -38,18 +38,6 @@ const languages = {
     yul: {id: 'yul'},
 };
 
-const solidityInfo = {
-    exe: 'resolc',
-    lang: languages.solidity.id as LanguageKey,
-    name: 'resolc 0.4.0 (RISC-V 64-bits)',
-};
-
-const yulInfo = {
-    exe: 'resolc',
-    lang: languages.yul.id as LanguageKey,
-    name: 'resolc 0.4.0 (RISC-V 64-bits)',
-};
-
 describe('Resolc', () => {
     let env: CompilationEnvironment;
 
@@ -57,8 +45,9 @@ describe('Resolc', () => {
         env = makeCompilationEnvironment({languages});
     });
 
-    const makeCompiler = (compilerInfo: Partial<CompilerInfo>) =>
-        new ResolcCompiler(makeFakeCompilerInfo(compilerInfo), env);
+    function makeCompiler(compilerInfo: Partial<CompilerInfo>): ResolcCompiler {
+        return new ResolcCompiler(makeFakeCompilerInfo(compilerInfo), env);
+    }
 
     describe('Common', () => {
         it('should return correct key', () => {
@@ -66,24 +55,30 @@ describe('Resolc', () => {
         });
     });
 
-    describe('Solidity', () => {
+    describe('From Solidity', () => {
+        const compilerInfo = {
+            exe: 'resolc',
+            lang: languages.solidity.id as LanguageKey,
+            name: 'resolc 0.4.0 (RISC-V 64-bits)',
+        };
+
         it('should instantiate successfully', () => {
-            const compiler = makeCompiler(solidityInfo);
-            expect(compiler.lang.id).toEqual(solidityInfo.lang);
+            const compiler = makeCompiler(compilerInfo);
+            expect(compiler.lang.id).toEqual(compilerInfo.lang);
         });
 
         it('should use Resolc argument parser', () => {
-            const compiler = makeCompiler(solidityInfo);
+            const compiler = makeCompiler(compilerInfo);
             expect(compiler.getArgumentParserClass()).toBe(ResolcParser);
         });
 
         it('should use debug options', () => {
-            const compiler = makeCompiler(solidityInfo);
+            const compiler = makeCompiler(compilerInfo);
             expect(compiler.optionsForFilter({})).toEqual(['-g', '--overwrite', '--debug-output-dir', 'artifacts']);
         });
 
         it('should generate output filenames', () => {
-            const compiler = makeCompiler(solidityInfo);
+            const compiler = makeCompiler(compilerInfo);
             const defaultOutputFilename = 'test/resolc/artifacts/test_resolc_example.sol.Square.pvmasm';
             expect(compiler.getOutputFilename('test/resolc')).toEqual(defaultOutputFilename);
             expect(compiler.getIrOutputFilename('test/resolc/example.sol')).toEqual(
@@ -94,157 +89,160 @@ describe('Resolc', () => {
             );
         });
 
-        it('should remove orphaned labels', async () => {
-            const compiler = makeCompiler(solidityInfo);
-
+        describe('To RISC-V', () => {
             const filters: Partial<ParseFiltersAndOutputOptions> = {
                 binaryObject: true,
                 libraryCode: true,
             };
 
-            const parsedAsm: ParsedAsmResult = {
-                asm: [
-                    {
-                        // Orphan
-                        text: 'memmove:',
-                    },
-                    {
-                        // Orphan
-                        text: '.LBB34_5:',
-                    },
-                    {
-                        // Orphan
-                        text: 'memset:',
-                    },
-                    {
-                        // Orphan
-                        text: '.LBB35_2:',
-                    },
-                    {
-                        text: '__entry:',
-                    },
-                    {
-                        text: ' addi	sp, sp, -0x10',
-                    },
-                    {
-                        text: ' sd	ra, 0x8(sp)',
-                    },
-                    {
-                        // Orphan
-                        text: '__last:',
-                    },
-                ],
-                labelDefinitions: {
-                    memmove: 1,
-                    ['.LBB34_5']: 2,
-                    memset: 3,
-                    ['.LBB35_2']: 4,
-                    __entry: 5,
-                    __last: 6,
-                },
-            };
+            it('should remove orphaned labels', async () => {
+                const compiler = makeCompiler(compilerInfo);
 
-            const expected: ParsedAsmResult = {
-                asm: [
-                    {
-                        text: '__entry:',
-                    },
-                    {
-                        text: '\t addi	sp, sp, -0x10',
-                    },
-                    {
-                        text: '\t sd	ra, 0x8(sp)',
-                    },
-                ],
-            };
-
-            const result = await compiler.postProcessAsm(parsedAsm, filters);
-            expect(result.asm.length).toEqual(expected.asm.length);
-            expect(result.asm).toMatchObject(expected.asm);
-        });
-
-        it('should remove Solidity <--> RISC-V source mappings', async () => {
-            const compiler = makeCompiler(solidityInfo);
-
-            const filters: Partial<ParseFiltersAndOutputOptions> = {
-                binaryObject: true,
-                libraryCode: true,
-            };
-
-            const parsedAsm: ParsedAsmResult = {
-                asm: [
-                    {
-                        text: '.Lpcrel_hi4:',
-                        source: null,
-                    },
-                    {
-                        text: ' auipc	a1, 0x0',
-                        source: null,
-                    },
-                    {
-                        text: ' addi	sp, sp, -0x60',
-                        source: {
-                            line: 1,
-                            file: null,
+                const parsedAsm: ParsedAsmResult = {
+                    asm: [
+                        {
+                            // Orphan
+                            text: 'memmove:',
                         },
-                    },
-                    {
-                        text: ' sd	ra, 0x58(sp)',
-                        source: {
-                            line: 1,
-                            file: null,
+                        {
+                            // Orphan
+                            text: '.LBB34_5:',
                         },
-                    },
-                    {
-                        text: ' jalr	ra <.Lpcrel_hi4+0x3a>',
-                        source: {
-                            line: 7,
-                            file: null,
+                        {
+                            // Orphan
+                            text: 'memset:',
                         },
+                        {
+                            // Orphan
+                            text: '.LBB35_2:',
+                        },
+                        {
+                            text: '__entry:',
+                        },
+                        {
+                            text: ' addi	sp, sp, -0x10',
+                        },
+                        {
+                            text: ' sd	ra, 0x8(sp)',
+                        },
+                        {
+                            // Orphan
+                            text: '__last:',
+                        },
+                    ],
+                    labelDefinitions: {
+                        memmove: 1,
+                        ['.LBB34_5']: 2,
+                        memset: 3,
+                        ['.LBB35_2']: 4,
+                        __entry: 5,
+                        __last: 6,
                     },
-                ],
-                labelDefinitions: {['.Lpcrel_hi4']: 1},
-            };
+                };
 
-            const expected: ParsedAsmResult = {
-                asm: [
-                    {
-                        text: '.Lpcrel_hi4:',
-                        source: null,
-                    },
-                    {
-                        text: '\t auipc	a1, 0x0',
-                        source: null,
-                    },
-                    {
-                        text: '\t addi	sp, sp, -0x60',
-                        source: null,
-                    },
-                    {
-                        text: '\t sd	ra, 0x58(sp)',
-                        source: null,
-                    },
-                    {
-                        text: '\t jalr	ra <.Lpcrel_hi4+0x3a>',
-                        source: null,
-                    },
-                ],
-            };
+                const expected: ParsedAsmResult = {
+                    asm: [
+                        {
+                            text: '__entry:',
+                        },
+                        {
+                            text: '\t addi	sp, sp, -0x10',
+                        },
+                        {
+                            text: '\t sd	ra, 0x8(sp)',
+                        },
+                    ],
+                };
 
-            const result = await compiler.postProcessAsm(parsedAsm, filters);
-            expect(result.asm.length).toEqual(expected.asm.length);
-            expect(result.asm).toMatchObject(expected.asm);
+                const result = await compiler.postProcessAsm(parsedAsm, filters);
+                expect(result.asm.length).toEqual(expected.asm.length);
+                expect(result.asm).toMatchObject(expected.asm);
+            });
+
+            it('should remove Solidity <--> RISC-V source mappings', async () => {
+                const compiler = makeCompiler(compilerInfo);
+
+                const parsedAsm: ParsedAsmResult = {
+                    asm: [
+                        {
+                            text: '.Lpcrel_hi4:',
+                            source: null,
+                        },
+                        {
+                            text: ' auipc	a1, 0x0',
+                            source: null,
+                        },
+                        {
+                            text: ' addi	sp, sp, -0x60',
+                            source: {
+                                line: 1,
+                                file: null,
+                            },
+                        },
+                        {
+                            text: ' sd	ra, 0x58(sp)',
+                            source: {
+                                line: 1,
+                                file: null,
+                            },
+                        },
+                        {
+                            text: ' jalr	ra <.Lpcrel_hi4+0x3a>',
+                            source: {
+                                line: 7,
+                                file: null,
+                            },
+                        },
+                    ],
+                    labelDefinitions: {['.Lpcrel_hi4']: 1},
+                };
+
+                const expected: ParsedAsmResult = {
+                    asm: [
+                        {
+                            text: '.Lpcrel_hi4:',
+                            source: null,
+                        },
+                        {
+                            text: '\t auipc	a1, 0x0',
+                            source: null,
+                        },
+                        {
+                            text: '\t addi	sp, sp, -0x60',
+                            source: null,
+                        },
+                        {
+                            text: '\t sd	ra, 0x58(sp)',
+                            source: null,
+                        },
+                        {
+                            text: '\t jalr	ra <.Lpcrel_hi4+0x3a>',
+                            source: null,
+                        },
+                    ],
+                };
+
+                const result = await compiler.postProcessAsm(parsedAsm, filters);
+                expect(result.asm.length).toEqual(expected.asm.length);
+                expect(result.asm).toMatchObject(expected.asm);
+            });
         });
     });
 
-    describe('Yul', () => {
+    describe('From Yul', () => {
+        const compilerInfo = {
+            exe: 'resolc',
+            lang: languages.yul.id as LanguageKey,
+            name: 'resolc 0.4.0 (RISC-V 64-bits)',
+        };
+
         it('should instantiate successfully', () => {
-            const compiler = makeCompiler(yulInfo);
-            expect(compiler.lang.id).toEqual(yulInfo.lang);
+            const compiler = makeCompiler(compilerInfo);
+            expect(compiler.lang.id).toEqual(compilerInfo.lang);
         });
 
         it('should use debug options', () => {
-            const compiler = makeCompiler(yulInfo);
+            const compiler = makeCompiler(compilerInfo);
             expect(compiler.optionsForFilter({})).toEqual([
                 '-g',
                 '--overwrite',
@@ -255,7 +253,7 @@ describe('Resolc', () => {
         });
 
         it('should generate output filenames', () => {
-            const compiler = makeCompiler(yulInfo);
+            const compiler = makeCompiler(compilerInfo);
             const defaultOutputFilename = 'test/resolc/artifacts/test_resolc_example.yul.Square.pvmasm';
             expect(compiler.getOutputFilename('test/resolc')).toEqual(defaultOutputFilename);
             expect(compiler.getIrOutputFilename('test/resolc/example.sol')).toEqual(

--- a/test/resolc-tests.ts
+++ b/test/resolc-tests.ts
@@ -41,13 +41,13 @@ const languages = {
 const solidityInfo = {
     exe: 'resolc',
     lang: languages.solidity.id as LanguageKey,
-    name: 'resolc 0.3.0 (RISC-V 64-bits)',
+    name: 'resolc 0.4.0 (RISC-V 64-bits)',
 };
 
 const yulInfo = {
     exe: 'resolc',
     lang: languages.yul.id as LanguageKey,
-    name: 'resolc 0.3.0 (RISC-V 64-bits)',
+    name: 'resolc 0.4.0 (RISC-V 64-bits)',
 };
 
 describe('Resolc', () => {

--- a/test/resolc-tests.ts
+++ b/test/resolc-tests.ts
@@ -1,0 +1,273 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {beforeAll, describe, expect, it} from 'vitest';
+
+import type {CompilationEnvironment} from '../lib/compilation-env.js';
+import {ResolcParser} from '../lib/compilers/argument-parsers.js';
+import {ResolcCompiler} from '../lib/compilers/index.js';
+import type {ParsedAsmResult} from '../types/asmresult/asmresult.interfaces.js';
+import type {CompilerInfo} from '../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
+import type {LanguageKey} from '../types/languages.interfaces.js';
+import {makeCompilationEnvironment, makeFakeCompilerInfo} from './utils.js';
+
+const languages = {
+    solidity: {id: 'solidity'},
+    yul: {id: 'yul'},
+};
+
+const solidityInfo = {
+    exe: 'resolc',
+    lang: languages.solidity.id as LanguageKey,
+};
+
+const yulInfo = {
+    exe: 'resolc',
+    lang: languages.yul.id as LanguageKey,
+};
+
+describe('Resolc', () => {
+    let env: CompilationEnvironment;
+
+    beforeAll(() => {
+        env = makeCompilationEnvironment({languages});
+    });
+
+    const makeCompiler = (compilerInfo: Partial<CompilerInfo>) =>
+        new ResolcCompiler(makeFakeCompilerInfo(compilerInfo), env);
+
+    describe('Common', () => {
+        it('should return correct key', () => {
+            expect(ResolcCompiler.key).toEqual('resolc');
+        });
+    });
+
+    describe('Solidity', () => {
+        it('should instantiate successfully', () => {
+            const compiler = makeCompiler(solidityInfo);
+            expect(compiler.lang.id).toEqual(solidityInfo.lang);
+        });
+
+        it('should use Resolc argument parser', () => {
+            const compiler = makeCompiler(solidityInfo);
+            expect(compiler.getArgumentParserClass()).toBe(ResolcParser);
+        });
+
+        it('should use debug options', () => {
+            const compiler = makeCompiler(solidityInfo);
+            expect(compiler.optionsForFilter({})).toEqual(['-g', '--overwrite', '--debug-output-dir', 'artifacts']);
+        });
+
+        it('should generate output filenames', () => {
+            const compiler = makeCompiler(solidityInfo);
+            const defaultOutputFilename = 'test/resolc/artifacts/test_resolc_example.sol.Square.pvmasm';
+            expect(compiler.getOutputFilename('test/resolc')).toEqual(defaultOutputFilename);
+            expect(compiler.getIrOutputFilename('test/resolc/example.sol')).toEqual(
+                'test/resolc/artifacts/test_resolc_example.sol.Square.unoptimized.ll',
+            );
+            expect(compiler.getObjdumpOutputFilename(defaultOutputFilename)).toEqual(
+                'test/resolc/artifacts/test_resolc_example.sol.Square.o',
+            );
+        });
+
+        it('should remove orphaned labels', async () => {
+            const compiler = makeCompiler(solidityInfo);
+
+            const filters: Partial<ParseFiltersAndOutputOptions> = {
+                binaryObject: true,
+                libraryCode: true,
+            };
+
+            const parsedAsm: ParsedAsmResult = {
+                asm: [
+                    {
+                        // Orphan
+                        text: 'memmove:',
+                    },
+                    {
+                        // Orphan
+                        text: '.LBB34_5:',
+                    },
+                    {
+                        // Orphan
+                        text: 'memset:',
+                    },
+                    {
+                        // Orphan
+                        text: '.LBB35_2:',
+                    },
+                    {
+                        text: '__entry:',
+                    },
+                    {
+                        text: ' addi	sp, sp, -0x10',
+                    },
+                    {
+                        text: ' sd	ra, 0x8(sp)',
+                    },
+                    {
+                        // Orphan
+                        text: '__last:',
+                    },
+                ],
+                labelDefinitions: {
+                    memmove: 1,
+                    ['.LBB34_5']: 2,
+                    memset: 3,
+                    ['.LBB35_2']: 4,
+                    __entry: 5,
+                    __last: 6,
+                },
+            };
+
+            const expected: ParsedAsmResult = {
+                asm: [
+                    {
+                        text: '; RISC-V (to see PolkaVM Assembly, use compiler option "--asm")',
+                    },
+                    {
+                        text: '__entry:',
+                    },
+                    {
+                        text: ' addi	sp, sp, -0x10',
+                    },
+                    {
+                        text: ' sd	ra, 0x8(sp)',
+                    },
+                ],
+            };
+
+            const result = await compiler.postProcessAsm(parsedAsm, filters);
+            expect(result.asm.length).toEqual(expected.asm.length);
+            expect(result.asm).toMatchObject(expected.asm);
+        });
+
+        it('should remove Solidity <--> RISC-V source mappings', async () => {
+            const compiler = makeCompiler(solidityInfo);
+
+            const filters: Partial<ParseFiltersAndOutputOptions> = {
+                binaryObject: true,
+                libraryCode: true,
+            };
+
+            const parsedAsm: ParsedAsmResult = {
+                asm: [
+                    {
+                        text: '.Lpcrel_hi4:',
+                        source: null,
+                    },
+                    {
+                        text: ' auipc	a1, 0x0',
+                        source: null,
+                    },
+                    {
+                        text: ' addi	sp, sp, -0x60',
+                        source: {
+                            line: 1,
+                            file: null,
+                        },
+                    },
+                    {
+                        text: ' sd	ra, 0x58(sp)',
+                        source: {
+                            line: 1,
+                            file: null,
+                        },
+                    },
+                    {
+                        text: ' jalr	ra <.Lpcrel_hi4+0x3a>',
+                        source: {
+                            line: 7,
+                            file: null,
+                        },
+                    },
+                ],
+                labelDefinitions: {['.Lpcrel_hi4']: 1},
+            };
+
+            const expected: ParsedAsmResult = {
+                asm: [
+                    {
+                        text: '; RISC-V (to see PolkaVM Assembly, use compiler option "--asm")',
+                    },
+                    {
+                        text: '.Lpcrel_hi4:',
+                        source: null,
+                    },
+                    {
+                        text: ' auipc	a1, 0x0',
+                        source: null,
+                    },
+                    {
+                        text: ' addi	sp, sp, -0x60',
+                        source: null,
+                    },
+                    {
+                        text: ' sd	ra, 0x58(sp)',
+                        source: null,
+                    },
+                    {
+                        text: ' jalr	ra <.Lpcrel_hi4+0x3a>',
+                        source: null,
+                    },
+                ],
+            };
+
+            const result = await compiler.postProcessAsm(parsedAsm, filters);
+            expect(result.asm.length).toEqual(expected.asm.length);
+            expect(result.asm).toMatchObject(expected.asm);
+        });
+    });
+
+    describe('Yul', () => {
+        it('should instantiate successfully', () => {
+            const compiler = makeCompiler(yulInfo);
+            expect(compiler.lang.id).toEqual(yulInfo.lang);
+        });
+
+        it('should use debug options', () => {
+            const compiler = makeCompiler(yulInfo);
+            expect(compiler.optionsForFilter({})).toEqual([
+                '-g',
+                '--overwrite',
+                '--debug-output-dir',
+                'artifacts',
+                '--yul',
+            ]);
+        });
+
+        it('should generate output filenames', () => {
+            const compiler = makeCompiler(yulInfo);
+            const defaultOutputFilename = 'test/resolc/artifacts/test_resolc_example.yul.Square.pvmasm';
+            expect(compiler.getOutputFilename('test/resolc')).toEqual(defaultOutputFilename);
+            expect(compiler.getIrOutputFilename('test/resolc/example.sol')).toEqual(
+                'test/resolc/artifacts/test_resolc_example.yul.Square.unoptimized.ll',
+            );
+            expect(compiler.getObjdumpOutputFilename(defaultOutputFilename)).toEqual(
+                'test/resolc/artifacts/test_resolc_example.yul.Square.o',
+            );
+        });
+    });
+});

--- a/test/resolc/example.sol
+++ b/test/resolc/example.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.4.0;
+
+contract Square {
+    function square(uint32 num) public pure returns (uint32) {
+        return num * num;
+    }
+}

--- a/test/resolc/example.yul
+++ b/test/resolc/example.yul
@@ -1,0 +1,43 @@
+object "Square" {
+    code {
+        {
+            let _1 := memoryguard(0x80)
+            mstore(64, _1)
+            if callvalue() { revert(0, 0) }
+            let _2 := datasize("Square_deployed")
+            codecopy(_1, dataoffset("Square_deployed"), _2)
+            return(_1, _2)
+        }
+    }
+    object "Square_deployed" {
+        code {
+            {
+                let _1 := memoryguard(0x80)
+                mstore(64, _1)
+                if iszero(lt(calldatasize(), 4))
+                {
+                    if eq(0xd27b3841, shr(224, calldataload(0)))
+                    {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+                        let value := calldataload(4)
+                        let _2 := and(value, 0xffffffff)
+                        if iszero(eq(value, _2)) { revert(0, 0) }
+                        let product_raw := mul(_2, _2)
+                        let product := and(product_raw, 0xffffffff)
+                        if iszero(eq(product, product_raw))
+                        {
+                            mstore(0, shl(224, 0x4e487b71))
+                            mstore(4, 0x11)
+                            revert(0, 0x24)
+                        }
+                        mstore(_1, product)
+                        return(_1, 32)
+                    }
+                }
+                revert(0, 0)
+            }
+        }
+        data ".metadata" hex"a26469706673582212209b2b1b86ce0e1a75faa800884ba155bd6bc6a6bc71f210370f818535dcfc5ee364736f6c634300081e0033"
+    }
+}

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -49,6 +49,7 @@ export const InstructionSetsList = [
     'msp430',
     'powerpc',
     'ptx',
+    'pvm',
     'python',
     'riscv32',
     'riscv64',

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -108,8 +108,9 @@ export type LanguageKey =
     | 'vb'
     | 'vyper'
     | 'wasm'
-    | 'zig'
-    | 'ylc';
+    | 'ylc'
+    | 'yul'
+    | 'zig';
 
 export interface Language {
     /** Id of language. Added programmatically based on CELanguages key */


### PR DESCRIPTION
## What

Adds [Revive's Resolc](https://github.com/paritytech/revive) compiler for compiling Solidity and Yul (Solidity IR) to RISC-V and PVM assembly.

### Main Additions

- [x] Implement new `ResolcCompiler`
- [x] Implement Yul language definition and config for Monaco
- [x] Add Resolc as a compiler for the Solidity and Yul languages
- [x] Enable viewing LLVM IR in a supplementary view
- [x] Adds PVM to the list of instruction sets (no PVM assembly parser or docs included in this PR)

The `ResolcCompiler` handles both kinds of language input as well as providing the ability to see either PVM or RISC-V output (see screenshot).

### Notes

Source mappings currently only exist between:
- Yul and RISC-V
- Yul and LLVM-IR

## CE Infra

Accompanying CE Infra PR: https://github.com/compiler-explorer/infra/pull/1855

## Screenshots

<img width="1502" height="904" alt="ce-yul-riscv-llvmir" src="https://github.com/user-attachments/assets/8e4bc725-3407-4f2a-9f83-a8f143507461" />

<img width="1502" height="904" alt="ce-sol-pvm" src="https://github.com/user-attachments/assets/6e6e6ef8-493f-419e-8e9b-2cfd1ec14f57" />