### PR TITLE
Add support for Swift LLVM IR

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -165,4 +165,4 @@ From oldest to newest contributor, we would like to thank:
 - [Florian Freitag](https://github.com/flofriday)
 - [Trevor Gross](https://github.com/tgross35)
 - [Alex Trotta](https://github.com/Ahajha)
-
+- [natinusala](https://github.com/natinusala)

--- a/lib/compilers/swift.ts
+++ b/lib/compilers/swift.ts
@@ -22,6 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import path from 'node:path';
+
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
@@ -35,6 +37,9 @@ export class SwiftCompiler extends BaseCompiler {
 
     constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(info, env);
+        this.compiler.supportsIrView = true;
+        this.compiler.irArg = ['-emit-ir'];
+        this.compiler.minIrArgs = ['-emit-ir'];
         this.compiler.optPipeline = {
             arg: ['-Xllvm', '-print-after-all', '-Xllvm', '-print-before-all'],
             moduleScopeArg: ['-Xllvm', '-print-module-scope'],
@@ -52,5 +57,9 @@ export class SwiftCompiler extends BaseCompiler {
 
     override isCfgCompiler() {
         return true;
+    }
+
+    override getIrOutputFilename(inputFilename: string): string {
+        return this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase).replace('.o', '.ll');
     }
 }


### PR DESCRIPTION
This adds support for the LLVM IR view for Swift, based on what other LLVM based compilers do.

I tested it on my machine and it seems to work well, including with the demangler. I'm not sure what `minIrArgs` is though, I added it because it was there for other languages.