### PR TITLE
Improve `variable.predefined` token legibility in dark themes

### DIFF
--- a/static/themes.ts
+++ b/static/themes.ts
@@ -118,7 +118,7 @@ editor.defineTheme('ce-dark', {
             fontStyle: 'bold',
         },
         {token: 'keyword.identifier.definition.herb', fontStyle: 'bold'},
-        {token: 'variable.predefined', foreground: '6f80aa'},
+        {token: 'variable.predefined', foreground: '949eb0'},
     ],
     colors: {},
 });
@@ -133,7 +133,7 @@ editor.defineTheme('ce-dark-plus', {
             fontStyle: 'bold',
         },
         {token: 'keyword.identifier.definition.herb', fontStyle: 'bold'},
-        {token: 'variable.predefined', foreground: '6f80aa'},
+        {token: 'variable.predefined', foreground: '949eb0'},
         {token: 'keyword.if.cpp', foreground: 'b66bb0'},
         {token: 'keyword.else.cpp', foreground: 'b66bb0'},
         {token: 'keyword.while.cpp', foreground: 'b66bb0'},
@@ -427,7 +427,7 @@ editor.defineTheme('ce-one-dark', {
             foreground: '61afef',
             fontStyle: 'bold',
         },
-        {token: 'variable.predefined', foreground: '6f80aa'},
+        {token: 'variable.predefined', foreground: '949eb0'},
         // General Identifiers
         {token: 'identifier.cpp', foreground: 'abb2bf'},
         // Annotations (includes items in attribute list)


### PR DESCRIPTION
Resolves #2837

This is a small change to slightly alter the foreground color of `variable.predefined` tokens in dark themes to improve legibility. These tokens look fine in the light theme, but for some reason monaco defines them as exactly the same color in vs-dark, which causes serious contrast issues. This PR's change to increase contrast is particularly relevant in diff views where the diff highlights could previously make tokens nearly invisible, but the new color also makes these tokens easier to read all-around. My goal for selecting the color was to try to match the same sort of "feel" that the these tokens have in the light theme.

Images (the assembly is different because I have a different compiler on my local machine, and I took the before screenshots from the main website):

| Theme | Before | After |
|--------|--------|--------|
| Light (unchanged) | <img width="450" height="259" alt="image" src="https://github.com/user-attachments/assets/67a9d986-0e9a-4be5-bee2-1bb967e9aed6" /> | <img width="449" height="258" alt="image" src="https://github.com/user-attachments/assets/17ed3978-bfd3-4bbf-9266-ccafb63a6e95" /> |
| Dark/Dark+ | <img width="448" height="263" alt="image" src="https://github.com/user-attachments/assets/189d96b7-9e74-4dda-90ac-9ef6a403d46e" /> | <img width="443" height="260" alt="image" src="https://github.com/user-attachments/assets/f2fd46dc-ffa0-4092-b080-d448ee627110" /> |
| One Dark | <img width="450" height="259" alt="image" src="https://github.com/user-attachments/assets/470b95b3-fc97-47c8-9fd9-76466de6b3f7" /> | <img width="446" height="258" alt="image" src="https://github.com/user-attachments/assets/e4244da5-ee39-46ea-a8f2-a924a121ff7d" /> | 

I also experimented with lowering the insert diff highlight opacity slightly on top of the token color change. That does further help with contrast, but it also makes the vibrance of insertion highlights different than deletion highlights and so rather than change those too I just figured I would leave them alone and try to make the minimal possible change.