### PR TITLE
Fix race condition in Rust opt pipeline view

### DIFF
--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -69,7 +69,7 @@ export class RustCompiler extends BaseCompiler {
         this.compiler.irArg = ['--emit', 'llvm-ir'];
         this.compiler.minIrArgs = ['--emit=llvm-ir'];
         this.compiler.optPipeline = {
-            arg: ['-C', 'llvm-args=-print-after-all -print-before-all'],
+            arg: ['-C', 'llvm-args=-print-after-all -print-before-all', '-C', 'extra-filename=llvm-opt-pipeline'],
             moduleScopeArg: ['-C', 'llvm-args=-print-module-scope'],
             noDiscardValueNamesArg: isNightly ? ['-Z', 'fewer-names=no'] : [],
         };


### PR DESCRIPTION
The same race condition that was reported in #7012 also affects the opt pipeline view.

I couldn’t reproduce the race condition locally, but on the live site it happens relatively often, e. g. in https://godbolt.org/z/4Y1qfvTvz.