### PR TITLE
Fix CppReference lookup functionality

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1066,8 +1066,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             langTag = preferredLanguage;
         }
         const url =
-        'https://www.google.com/search?q=' +
-        encodeURIComponent(word.word + ' site:' + langTag + '.cppreference.com');
+            'https://www.google.com/search?q=' +
+            encodeURIComponent(word.word + ' site:' + langTag + '.cppreference.com');
         window.open(url, '_blank', 'noopener');
     }
 


### PR DESCRIPTION
- Update search URL from deprecated internal search to Google site-specific search
- Uses URL: https://www.google.com/search?q=term+site:en.cppreference.com
- Fixes #8179 where CppReference lookup stopped working

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

## Video:

https://github.com/user-attachments/assets/99fd6e99-1fde-4902-9dd2-b7673fffc6d3

