### PR TITLE
Remember asm docs in browser

### DIFF
--- a/static/api/api.ts
+++ b/static/api/api.ts
@@ -48,7 +48,9 @@ const request = async <R>(uri: string, options?: RequestInit): Promise<TypedResp
 
 /** GET /api/asm/:arch/:instruction */
 export const getAssemblyDocumentation = async (options: AssemblyDocumentationRequest) =>
-    await request<AssemblyDocumentationResponse>(`/asm/${options.instructionSet}/${options.opcode}`);
+    await request<AssemblyDocumentationResponse>(`/asm/${options.instructionSet}/${options.opcode}`, {
+        credentials: 'omit',
+    });
 
 /** POST /api/format/:formatter */
 export const getFormattedCode = async (options: FormattingRequest) =>


### PR DESCRIPTION
This is a Caching fix for ASM documentation when hovering over asm opcodes.

The behavior is a little out of the ordinary, it will only do 1 network request per sessions per opcode - even if you "Disable cache" (!). Also the max age seems to be ignored.

When you refresh it will perform a network request again.

On production currently caching is only working partially through cloudfront and its requested multiple times on mouse hover.
