### PR TITLE
Restrict nsjail sysfs access for hwloc to improve security

### DIFF
--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -209,6 +209,87 @@ mount {
     is_bind: true
 }
 
+###
+# hwloc support (required by HPX library)
+
+mount {
+    src: "/sys/devices/system/cpu/online"
+    dst: "/sys/devices/system/cpu/online"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/sys/devices/system/cpu/possible"
+    dst: "/sys/devices/system/cpu/possible"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/sys/devices/system/cpu/cpu0/topology"
+    dst: "/sys/devices/system/cpu/cpu0/topology"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/sys/devices/system/cpu/cpu0/cache"
+    dst: "/sys/devices/system/cpu/cpu0/cache"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/sys/devices/system/cpu/cpu1/topology"
+    dst: "/sys/devices/system/cpu/cpu1/topology"
+    is_bind: true
+    rw: false
+    mandatory: false
+}
+
+mount {
+    src: "/sys/devices/system/cpu/cpu1/cache"
+    dst: "/sys/devices/system/cpu/cpu1/cache"
+    is_bind: true
+    rw: false
+    mandatory: false
+}
+
+mount {
+    src: "/sys/devices/system/node/online"
+    dst: "/sys/devices/system/node/online"
+    is_bind: true
+    rw: false
+    mandatory: false
+}
+
+mount {
+    src: "/sys/devices/system/node/possible"
+    dst: "/sys/devices/system/node/possible"
+    is_bind: true
+    rw: false
+    mandatory: false
+}
+
+mount {
+    src: "/sys/devices/system/node/node0/cpumap"
+    dst: "/sys/devices/system/node/node0/cpumap"
+    is_bind: true
+    rw: false
+    mandatory: false
+}
+
+mount {
+    src: "/sys/devices/system/node/node0/distance"
+    dst: "/sys/devices/system/node/node0/distance"
+    is_bind: true
+    rw: false
+    mandatory: false
+}
+# End hwloc support
+###
+
 mount {
     src: "/cefs"
     dst: "/cefs"


### PR DESCRIPTION
## Summary

Adds targeted, minimal sysfs mounts for hwloc (required by HPX library) while preventing security vulnerabilities from exposing too much system information.

## Security Improvements

**Blocked:**
- ❌ `/sys/devices/system/cpu/cpu*/cpuidle/` - Real-time activity counters that leak system usage patterns
- ❌ `/sys/devices/system/node/node*/meminfo` - Real-time memory usage that exposes other users' activity
- ❌ `/sys/devices/system/cpu/cpu*/cpufreq/`, `thermal_throttle/`, etc. - Unnecessary runtime state
- ❌ Access to cpu2+ and node1+ - Limited to minimal topology

**Allowed (read-only):**
- ✅ `/sys/devices/system/cpu/cpu0/topology/` - Static CPU topology needed by hwloc
- ✅ `/sys/devices/system/cpu/cpu0/cache/` - Static cache hierarchy needed by hwloc  
- ✅ `/sys/devices/system/cpu/cpu1/{topology,cache}` - Second CPU (optional)
- ✅ `/sys/devices/system/node/node0/{cpumap,distance}` - Static NUMA topology (optional)

## Implementation Details

Based on analysis of hwloc source code, only specific subdirectories within cpu0/cpu1 are mounted instead of entire CPU directories. This prevents exposure of:
- Real-time system activity monitoring via cpuidle counters
- Live memory usage patterns via node meminfo
- Detailed hardware state that could enable side-channel attacks

All mounts are read-only. CPU1 and NUMA node mounts are optional (`mandatory: false`) to support single-CPU systems.

## Related

- #7899 - HPX library support (requires hwloc)
- compiler-explorer/infra@ba25aed - Infrastructure changes for HPX deployment

## Testing

Tested locally to ensure:
- hwloc can successfully detect CPU topology
- Security-sensitive paths are blocked
- Configuration works on systems with/without NUMA

🤖 Generated with [Claude Code](https://claude.com/claude-code)