### PR TITLE
Make instruction set parsing compatible with `file` >= v5.46

### DIFF
--- a/lib/binaries/binary-utils.ts
+++ b/lib/binaries/binary-utils.ts
@@ -48,6 +48,9 @@ export class BinaryInfoLinux {
             case 'intel 80386': {
                 return 'x86';
             }
+            case 'intel i386': {
+                return 'x86';
+            }
             case '80386': {
                 return 'x86';
             }

--- a/test/execution-triple-tests.ts
+++ b/test/execution-triple-tests.ts
@@ -75,4 +75,11 @@ describe('Execution triple utils', () => {
         expect(info?.instructionSet).toEqual('avr');
         expect(info?.os).toEqual('linux');
     });
+    it('recognizes 32-bit Intel for file >= v5.46', () => {
+        const info = BinaryInfoLinux.parseFileInfo(
+            'ELF 32-bit LSB executable, Intel i386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, BuildID[sha1]=936152b4351a49d381553a593f68286e1069435f, for GNU/Linux 4.4.0, not stripped',
+        );
+        expect(info?.instructionSet).toEqual('x86');
+        expect(info?.os).toEqual('linux');
+    });
 });


### PR DESCRIPTION
The identifier for 32-bit Intel ELF files was changed in `file` v5.46: https://github.com/file/file/commit/45702aaa99b982af7bf0b7ffd60f8b0a831ff8b5.