### PR TITLE
Use latest GCC sysroot for trunk Arm clangs

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -990,12 +990,12 @@ compiler.armv8-clang900.alias=armv8-clang-9
 compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-clang-trunk.semver=(trunk)
 compiler.armv8-clang-trunk.isNightly=true
-compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.armv8-full-clang-trunk.semver=(all architectural features, trunk)
 compiler.armv8-full-clang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
+compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 # An alias of the original name for this compiler needs to be maintained to allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -753,21 +753,21 @@ compiler.armv7-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv7-cclang-trunk.semver=(trunk)
 compiler.armv7-cclang-trunk.isNightly=true
 # Arm v7-a with Neon and VFPv3
-compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-12.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
+compiler.armv7-cclang-trunk.options=-target arm-linux-gnueabihf --gcc-toolchain=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf --sysroot=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot
 
 compiler.armv8-cclang-trunk.name=armv8-a clang (trunk)
 compiler.armv8-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-cclang-trunk.semver=(trunk)
 compiler.armv8-cclang-trunk.isNightly=true
 # Arm v8-a
-compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+compiler.armv8-cclang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
 
 compiler.armv8-full-cclang-trunk.name=armv8-a clang (all architectural features, trunk)
 compiler.armv8-full-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 compiler.armv8-full-cclang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
+compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 # An alias of the original name for this compiler needs to be maintained to
 # allow old URLs to continue to work
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk


### PR DESCRIPTION
Fixes #8227

15.2.0 is the latest I saw used anywhere in Compiler Explorer.