### PR TITLE
Add zig 0.15.2 and make it the default zig compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4351,7 +4351,7 @@ compiler.djggp494.semver=4.9.4
 
 #################################
 # Zig c++
-group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxx0130:zcxx0140:zcxx0141:zcxx0151:zcxxtrunk
+group.zigcxx.compilers=zcxx060:zcxx070:zcxx071:zcxx080:zcxx090:zcxx0100:zcxx0110:zcxx0120:zcxx0121:zcxx0130:zcxx0140:zcxx0141:zcxx0151:zcxx0152:zcxxtrunk
 group.zigcxx.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcxx.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcxx.options=
@@ -4391,6 +4391,8 @@ compiler.zcxx0141.exe=/opt/compiler-explorer/zig-0.14.1/zig
 compiler.zcxx0141.semver=0.14.1
 compiler.zcxx0151.exe=/opt/compiler-explorer/zig-0.15.1/zig
 compiler.zcxx0151.semver=0.15.1
+compiler.zcxx0152.exe=/opt/compiler-explorer/zig-0.15.2/zig
+compiler.zcxx0152.semver=0.15.2
 compiler.zcxxtrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcxxtrunk.semver=trunk
 compiler.zcxxtrunk.isNightly=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4048,7 +4048,7 @@ compiler.tinycc0927.semver=0.9.27
 
 #################################
 # Zig cc
-group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcc0130:zcc0140:zcc0141:zcc0151:zcctrunk
+group.zigcc.compilers=zcc060:zcc070:zcc071:zcc080:zcc090:zcc0100:zcc0110:zcc0120:zcc0121:zcc0130:zcc0140:zcc0141:zcc0151:zcc0152:zcctrunk
 group.zigcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.zigcc.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
 group.zigcc.options=
@@ -4087,6 +4087,8 @@ compiler.zcc0141.exe=/opt/compiler-explorer/zig-0.14.1/zig
 compiler.zcc0141.semver=0.14.1
 compiler.zcc0151.exe=/opt/compiler-explorer/zig-0.15.1/zig
 compiler.zcc0151.semver=0.15.1
+compiler.zcc0152.exe=/opt/compiler-explorer/zig-0.15.2/zig
+compiler.zcc0152.semver=0.15.2
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 compiler.zcctrunk.isNightly=true

--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -1,8 +1,8 @@
 compilers=&zig
-defaultCompiler=z0151
+defaultCompiler=z0152
 
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
-group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130:z0140:z0141:z0151
+group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130:z0140:z0141:z0151:z0152
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
@@ -50,6 +50,8 @@ compiler.z0141.exe=/opt/compiler-explorer/zig-0.14.1/zig
 compiler.z0141.semver=0.14.1
 compiler.z0151.exe=/opt/compiler-explorer/zig-0.15.1/zig
 compiler.z0151.semver=0.15.1
+compiler.z0152.exe=/opt/compiler-explorer/zig-0.15.2/zig
+compiler.z0152.semver=0.15.2
 
 #################################
 #################################


### PR DESCRIPTION
zig `0.15.2` released on 2025-10-11.

Infra PR: https://github.com/compiler-explorer/infra/pull/1881