### PR TITLE
Adapt `isOutputLikelyLlvmIr` for Rust

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -182,10 +182,6 @@ export interface SimpleOutputFilenameCompiler {
     getOutputFilename(dirPath: string): string;
 }
 
-function isOutputLikelyLllvmIr(compilerOptions: string[]): boolean {
-    return compilerOptions && (compilerOptions.includes('-emit-llvm') || compilerOptions.includes('-mlir-to-llvmir'));
-}
-
 export class BaseCompiler {
     public compiler: CompilerInfo;
     public lang: Language;
@@ -3254,7 +3250,7 @@ export class BaseCompiler {
             if (this.compiler.supportsCfg && backendOptions.produceCfg && backendOptions.produceCfg.asm) {
                 const isLlvmIr =
                     this.compiler.instructionSet === 'llvm' ||
-                    (options && isOutputLikelyLllvmIr(options)) ||
+                    (options && this.isOutputLikelyLlvmIr(options)) ||
                     this.llvmIr.isLlvmIr(result.asm);
                 result.cfg = await cfg.generateStructure(this.compiler, result.asm, isLlvmIr, result);
             }
@@ -3368,10 +3364,14 @@ export class BaseCompiler {
         return result;
     }
 
+    protected isOutputLikelyLlvmIr(compilerOptions: string[]): boolean {
+        return compilerOptions.includes('-emit-llvm') || compilerOptions.includes('-mlir-to-llvmir');
+    }
+
     async processAsm(result, filters: ParseFiltersAndOutputOptions, options: string[]) {
         if (
             result.languageId === 'llvm-ir' ||
-            (options && isOutputLikelyLllvmIr(options)) ||
+            (options && this.isOutputLikelyLlvmIr(options)) ||
             this.llvmIr.isLlvmIr(result.asm)
         ) {
             return await this.llvmIr.processFromFilters(result.asm, filters);

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -338,4 +338,9 @@ export class RustCompiler extends BaseCompiler {
         );
         return super.runCompiler(compiler, newOptions, inputFilename, execOptions);
     }
+
+    override isOutputLikelyLlvmIr(options: string[]): boolean {
+        const emitIndex = options.indexOf('--emit');
+        return options.includes('--emit=llvm-ir') || (emitIndex >= 0 && options[emitIndex + 1] == 'llvm-ir');
+    }
 }


### PR DESCRIPTION
The existing heuristics don’t reliably recognise LLVM IR produced by `rustc` (e. g. when the generated code does not use any LLVM intrinsics), so this adds LLVM IR detection based on the `--emit=llvm-ir` and `--emit llvm-ir` command line flags.