### PR TITLE
Add BDE libraries

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4729,13 +4729,12 @@ libs.async_simple.description=Simple, light-weight and easy-to-use asynchronous 
 libs.async_simple.url=https://github.com/alibaba/async_simple
 
 libs.bde.name=BDE
-libs.bde.versions=trunk
+libs.bde.versions=431
 libs.bde.url=https://github.com/bloomberg/bde
 libs.bde.description=Bloomberg BDE Libraries (bsl, bal, bdl, bbl).
 libs.bde.packagedheaders=true
 libs.bde.staticliblink=bal:bbl:bdl:bsl:inteldfp:pcre2:bbryu
-libs.bde.versions.trunk.version=trunk
-libs.bde.versions.trunk.lookupversion=main
+libs.bde.versions.431.version=4.31.0.0
 
 libs.belleviews.name=Belle Views
 libs.belleviews.url=https://github.com/josuttis/belleviews


### PR DESCRIPTION
Requested in https://github.com/compiler-explorer/compiler-explorer/issues/5933.

Add Bloomberg BDE libraries:
- Basic Standard Library (BSL)
- Basic Development Library (BDL)
- Basic Application Library (BAL)
- Basic Business Library (BBL)

See https://github.com/compiler-explorer/infra/pull/1892 for the library build PR.
