### PR TITLE
Don't double escape metadata

### DIFF
--- a/lib/handlers/route-api.ts
+++ b/lib/handlers/route-api.ts
@@ -225,16 +225,12 @@ export class RouteAPI {
             });
     }
 
-    escapeLine(req: express.Request, line: string) {
-        return line.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-    }
-
     filterCode(req: express.Request, code: string, lang: Language) {
         let lines = code.split('\n');
         if (lang.previewFilter !== null) {
             lines = lines.filter(line => !lang.previewFilter || !lang.previewFilter.test(line));
         }
-        return lines.map(line => this.escapeLine(req, line)).join('\n');
+        return lines.join('\n');
     }
 
     getMetaDataFromLink(req: express.Request, link: ExpandedShortLink | null, config: any) {

--- a/test/unfurl-tests.ts
+++ b/test/unfurl-tests.ts
@@ -106,7 +106,7 @@ describe('Basic unfurls', () => {
         const res = await prom;
         expect(res.metadata).toEqual({
             ogDescription:
-                '\ntemplate&lt;typename T&gt;\nconcept TheSameAndAddable = requires(T a, T b) {\n    {a+b} -&gt; T;\n};\n\ntemplate&lt;TheSameAndAddable T&gt;\nT sum(T x, T y) {\n    return x + y;\n}\n\n#include &lt;string&gt;\n\nint main() {\n    int z = 0;\n    int w;\n\n    return sum(z, w);\n}\n',
+                '\ntemplate<typename T>\nconcept TheSameAndAddable = requires(T a, T b) {\n    {a+b} -> T;\n};\n\ntemplate<TheSameAndAddable T>\nT sum(T x, T y) {\n    return x + y;\n}\n\n#include <string>\n\nint main() {\n    int z = 0;\n    int w;\n\n    return sum(z, w);\n}\n',
             ogTitle: 'Compiler Explorer - C++',
         });
     });


### PR DESCRIPTION
Before this PR, source code in the `<meta name="description">` and `<meta property="og:description">` tags would be doubly escaped, leading to html escaped code showing up in link previews. Examples:

Discord:
<img width="465" height="167" alt="discord" src="https://github.com/user-attachments/assets/d2f867e6-f724-4177-8f1d-17986d13343f" />

Akkoma:
![akkoma](https://github.com/user-attachments/assets/22b11c48-1bef-4424-a70a-3948213a8354)


This fixes it by removing one layer of escaping.