### PR TITLE
Added Norcroft C and C++ compiler support.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -170,3 +170,4 @@ From oldest to newest contributor, we would like to thank:
 - [LJ](https://github.com/elle-j)
 - [Frank Leon Rose](https://github.com/frankleonrose)
 - [Oguz Ulgen](https://github.com/oulgen)
+- [Piers Wombwell](https://github.com/pwombwell)

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -115,6 +115,7 @@ export {Msp430Compiler} from './msp430.js';
 export {NasmCompiler} from './nasm.js';
 export {NimCompiler} from './nim.js';
 export {NixCompiler} from './nix.js';
+export {NorcroftCompiler} from './norcroft.js';
 export {NumbaCompiler} from './numba.js';
 export {NvccCompiler} from './nvcc.js';
 export {NvcppCompiler} from './nvcpp.js';

--- a/lib/compilers/norcroft.ts
+++ b/lib/compilers/norcroft.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import _ from 'underscore';
+import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {unwrap} from '../assert.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {logger} from '../logger.js';
+import {NorcroftObjAsmParser} from '../parsers/asm-parser-norcroft.js';
+
+export class NorcroftCompiler extends BaseCompiler {
+    constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(compilerInfo, env);
+
+        this.asm = new NorcroftObjAsmParser(this.compilerProps);
+    }
+
+    static get key() {
+        return 'norcroft';
+    }
+
+    override async getVersion() {
+        logger.info(`Gathering ${this.compiler.id} version information on ${this.compiler.exe}...`);
+        if (this.compiler.explicitVersion) {
+            logger.debug(`${this.compiler.id} has forced version output: ${this.compiler.explicitVersion}`);
+            return {stdout: this.compiler.explicitVersion, stderr: '', code: 0};
+        }
+        const execOptions = this.getDefaultExecOptions();
+        const versionFlag: string[] = [];
+        execOptions.timeoutMs = 0;
+        execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
+
+        try {
+            const res = await this.execCompilerCached(this.compiler.exe, versionFlag, execOptions);
+            return {stdout: res.stdout, stderr: res.stderr, code: res.code};
+        } catch (err) {
+            logger.error(`Unable to get version for compiler '${this.compiler.exe}' - ${err}`);
+            return null;
+        }
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
+        filters.binary = false;
+
+        if (_.some(unwrap(userOptions), opt => opt === '-help' || opt === '-h')) {
+            // Let the compiler print its own help text
+            return [];
+        }
+        if (!_.some(unwrap(userOptions), opt => opt === '-E')) {
+            filters.binary = false;
+        }
+        return ['-c', '-S', '--asm-includes-location', '-o', this.filename(outputFilename)];
+    }
+
+    override filterUserOptions(userOptions: string[]) {
+        return userOptions.filter(opt => opt !== '-run' && !opt.startsWith('-W'));
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptions & {env: Record<string, string>},
+    ) {
+        const result = await this.exec(compiler, options, execOptions);
+
+        // Norcroft diagnostics look like:
+        //   "<source>", line 11: Warning: message...
+        //   "<source>", line 37: Error: message...
+        // The generic applyParse_SourceWithLine expects:
+        //   <source>:11:1: warning: message...
+        //   <source>:37:1: error: message...
+        //
+        // Rewrite stderr to that shape so the generic parser can
+        // extract file/line/severity and drive hover markers.
+        if (typeof result.stderr === 'string') {
+            result.stderr = result.stderr
+                // Warnings
+                .replace(/^"([^"]+)",\s*line\s+(\d+):\s*Warning:\s*/gm, '$1:$2:1: warning: ')
+                // Errors and serious errors
+                .replace(/^"([^"]+)",\s*line\s+(\d+):\s*(Error|Serious error):\s*/gm, '$1:$2:1: error: ');
+        }
+
+        return this.transformToCompilationResult(result, inputFilename);
+    }
+}

--- a/lib/parsers/asm-parser-norcroft.ts
+++ b/lib/parsers/asm-parser-norcroft.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {AsmResultSource, ParsedAsmResult, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {PropertyGetter} from '../properties.interfaces.js';
+import * as utils from '../utils.js';
+
+import {AsmParser} from './asm-parser.js';
+
+export class NorcroftObjAsmParser extends AsmParser {
+    private readonly asmBinaryParser: AsmParser;
+    private readonly headerOrTrailer = /^\s*(?:\S+\s+)?(AREA|END|EXPORT|IMPORT|NOINIT|BASED|COMDEF|COMMON|DATA)\b/;
+    private readonly sourceFile = /^\s*;\s*source-file:\s+"([^"]+)",\s*line\s+(\d+)/;
+    private readonly lineNumber = /^\s*;\s*line:\s+(\d+)(?:\s+\d+)?/;
+    private readonly label = /^([|A-Za-z_.$][\w.$|]*)\s*$/; // label has no whitespace at start of line.
+    private readonly DCD = /^\s*(?:\S+\s+)?(DC[A-Z]*)\b/; // DCD, DCB, DCFD, etc...
+
+    constructor(compilerProps: PropertyGetter) {
+        super(compilerProps);
+        this.asmBinaryParser = new AsmParser(compilerProps);
+    }
+
+    override processAsm(asm: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
+        if (filters.binary) return this.asmBinaryParser.processBinaryAsm(asm, filters);
+
+        let currentfile = '';
+        let currentline: string | undefined;
+
+        const asmLines: ParsedAsmResultLine[] = [];
+        asm = asm.replace(/\u001A$/, '');
+
+        utils.eachLine(asm, line => {
+            let isDirective = false;
+
+            const labelmatch = line.match(this.label);
+            if (labelmatch && !labelmatch[1].startsWith('|')) {
+                // global label (eg. "main", not "|L030|") - reset any line number.
+                currentline = undefined;
+            }
+
+            // Header and trailer keywords should be white and reset any line number.
+            if (line.match(this.headerOrTrailer)) {
+                // possibly also current file?
+                currentline = undefined;
+                isDirective = true;
+            }
+
+            const sourcefilematch = line.match(this.sourceFile);
+            if (sourcefilematch) {
+                currentfile = sourcefilematch[1];
+                currentline = sourcefilematch[2];
+                isDirective = true;
+            }
+
+            const linenumbermatch = line.match(this.lineNumber);
+            if (linenumbermatch) {
+                currentline = linenumbermatch[1];
+                isDirective = true;
+            }
+
+            // Parse the line number from any updated string.
+            // Anything before here can parse or reset the current line.
+            // Anything after can filter a line from display (return) or whiten
+            // the line (set source to null).
+            let source: AsmResultSource | null = null;
+            if (currentfile && currentline) {
+                source = {
+                    file: filters.dontMaskFilenames ? currentfile : null,
+                    line: Number.parseInt(currentline, 10),
+                };
+            }
+
+            // Comments and blank lines should be filtered as directives.
+            // Note that this includes sourcefilematch and linenumber match -
+            // if the behaviour for them needs to change, check those bools.
+            const trimmed = line.trim();
+            if (trimmed === '' || trimmed.startsWith(';')) {
+                isDirective = true;
+                source = null; // also render white
+            }
+
+            if (labelmatch) {
+                source = null; // render all labels white
+            }
+
+            if (line.match(this.DCD)) {
+                source = null; // render all DCDs(etc) white
+            }
+
+            // Don't append directives if they're filtered out.
+            if (filters.directives && isDirective) return;
+
+            // All lines must be appended to appear in CE's output.
+            asmLines.push({
+                text: line,
+                source,
+            });
+        });
+
+        return {
+            asm: asmLines,
+        };
+    }
+}


### PR DESCRIPTION
The compiler should build easily on any Linux or macOS host, just by typing 'make'.

Needs dbedd37 from https://github.com/Norcroft/ncc-ng for CE to have support for line colouring.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
