### PR TITLE
Further fixes to Clojure compiler execution in CE infra

### DIFF
--- a/etc/scripts/clojure_wrapper.clj
+++ b/etc/scripts/clojure_wrapper.clj
@@ -113,7 +113,8 @@
     (with-open [out (io/writer (io/output-stream compile-filename))]
       (when missing-namespace?
         (let [ns-form (str "(ns " namespace ")")]
-          (println "Injecting namespace form on first line:" ns-form)
+          ;; Don't log injection - any text output results in compilation error indicator in UI
+          ;; (println "Injecting namespace form on first line:" ns-form)
           (.write out ns-form)))
       (io/copy input-file out))
 

--- a/etc/scripts/clojure_wrapper.clj
+++ b/etc/scripts/clojure_wrapper.clj
@@ -114,7 +114,6 @@
       (when missing-namespace?
         (let [ns-form (str "(ns " namespace ")")]
           ;; Don't log injection - any text output results in compilation error indicator in UI
-          ;; (println "Injecting namespace form on first line:" ns-form)
           (.write out ns-form)))
       (io/copy input-file out))
 

--- a/lib/compilers/clojure.ts
+++ b/lib/compilers/clojure.ts
@@ -121,6 +121,8 @@ export class ClojureCompiler extends JavaCompiler {
         if (!execOptions.customCwd) {
             execOptions.customCwd = path.dirname(inputFilename);
         }
+        const tmpDir = path.dirname(inputFilename);
+        execOptions.env.CLJ_CACHE = tmpDir;
 
         // The items in 'options' before the source file are user inputs.
         const sourceFileOptionIndex = options.findIndex(option => {

--- a/lib/compilers/clojure.ts
+++ b/lib/compilers/clojure.ts
@@ -37,7 +37,6 @@ import {JavaCompiler} from './java.js';
 export class ClojureCompiler extends JavaCompiler {
     compilerWrapperPath: string;
     defaultDeps: string;
-    configDir: string;
     javaHome: string;
 
     static override get key() {
@@ -53,9 +52,6 @@ export class ClojureCompiler extends JavaCompiler {
             this.compilerProps('compilerWrapper', '') ||
             utils.resolvePathFromAppRoot('etc', 'scripts', 'clojure_wrapper.clj');
         this.compiler.supportsClojureMacroExpView = true;
-        this.configDir =
-            this.compilerProps<string>(`compiler.${this.compiler.id}.config_dir`) ||
-            path.resolve(path.dirname(this.compiler.exe), '../.config');
         const repoDir =
             this.compilerProps<string>(`compiler.${this.compiler.id}.repo_dir`) ||
             path.resolve(path.dirname(this.compiler.exe), '../.m2/repository');
@@ -67,7 +63,6 @@ export class ClojureCompiler extends JavaCompiler {
         if (this.javaHome) {
             execOptions.env.JAVA_HOME = this.javaHome;
         }
-        execOptions.env.CLJ_CONFIG = this.configDir;
 
         return execOptions;
     }


### PR DESCRIPTION
- [x] Ensure `CLJ_CACHE` environment variable is set to a writable directory
- [x] Remove unnecessary `CLJ_CONFIG` environment variable
- [x] ~~Configure location of `clojure_wrapper.clj` (not necessary)~~
- [x] Remove logging of namespace injection - text output causes UI to show compiler error flag