### PR TITLE
Add --properties-dirs CLI option for custom local configuration

### DIFF
--- a/lib/app.interfaces.ts
+++ b/lib/app.interfaces.ts
@@ -26,6 +26,7 @@ import type {LoggingOptions} from './logger.js';
 
 export type AppArguments = {
     rootDir: string;
+    propertiesDirs?: string[];
     env: string[];
     hostname?: string;
     port: number;

--- a/lib/app/cli.ts
+++ b/lib/app/cli.ts
@@ -53,6 +53,7 @@ export function parsePortNumberForOptions(value: string): number {
 export interface CompilerExplorerOptions {
     env: string[];
     rootDir: string;
+    propertiesDirs?: string[];
     host?: string;
     port: number;
     propDebug?: boolean;
@@ -91,6 +92,7 @@ export function parseCommandLine(argv: string[]): CompilerExplorerOptions {
         .description('Interactively investigate compiler output')
         .option('--env <environments...>', 'Environment(s) to use', ['dev'])
         .option('--root-dir <dir>', 'Root directory for config files', './etc')
+        .option('--properties-dirs <dirs...>', 'Additional directories to load .properties files from')
         .option('--host <hostname>', 'Hostname to listen on')
         .option('--port <port>', 'Port to listen on', parsePortNumberForOptions, 10240)
         .option('--prop-debug', 'Debug properties')
@@ -181,6 +183,7 @@ export function convertOptionsToAppArguments(
 ): AppArguments {
     return {
         rootDir: options.rootDir,
+        propertiesDirs: options.propertiesDirs,
         env: options.env,
         hostname: options.host,
         port: options.port,

--- a/lib/app/config.ts
+++ b/lib/app/config.ts
@@ -142,9 +142,10 @@ export function loadConfiguration(appArgs: AppArguments): AppConfiguration {
     // Create property hierarchy based on environment
     const propHierarchy = createPropertyHierarchy(appArgs.env, appArgs.useLocalProps);
 
-    // Initialize properties from config directory
+    // Initialize properties from config directory and any additional directories
     const configDir = path.join(appArgs.rootDir, 'config');
-    props.initialize(configDir, propHierarchy);
+    const directories = [configDir, ...(appArgs.propertiesDirs || [])];
+    props.initialize(directories, propHierarchy);
 
     // Get compiler explorer properties
     const ceProps = props.propsFor('compiler-explorer');

--- a/test/app/cli-tests.ts
+++ b/test/app/cli-tests.ts
@@ -237,6 +237,7 @@ describe('CLI Module', () => {
 
             expect(result).toEqual({
                 rootDir: './etc',
+                propertiesDirs: undefined,
                 env: ['dev'],
                 hostname: 'localhost',
                 port: 10240,
@@ -265,6 +266,26 @@ describe('CLI Module', () => {
                     paperTrailIdentifier: 'dev',
                 },
             });
+        });
+
+        it('should pass through propertiesDirs when provided', () => {
+            const options = {
+                rootDir: './etc',
+                propertiesDirs: ['/extra/one', '/extra/two'],
+                env: ['dev'],
+                port: 10240,
+                cache: true,
+                remoteFetch: true,
+                local: true,
+                propDebug: false,
+                suppressConsoleLog: false,
+                version: false,
+                devMode: false,
+            } as CompilerExplorerOptions;
+
+            const result = convertOptionsToAppArguments(options, 'abc', '123', false);
+
+            expect(result.propertiesDirs).toEqual(['/extra/one', '/extra/two']);
         });
     });
 
@@ -305,6 +326,14 @@ describe('CLI Module', () => {
 
             expect(result.rootDir).toEqual('/custom/path');
             expect(result.metricsPort).toEqual(9000);
+        });
+
+        it('should parse --properties-dirs option with multiple directories', () => {
+            const argv = ['node', 'app.js', '--properties-dirs', '/path/one', '/path/two'];
+
+            const result = parseCommandLine(argv);
+
+            expect(result.propertiesDirs).toEqual(['/path/one', '/path/two']);
         });
     });
 

--- a/test/app/config-tests.ts
+++ b/test/app/config-tests.ts
@@ -346,7 +346,7 @@ describe('Config Module', () => {
             const result = loadConfiguration(appArgs);
 
             // Verify initialization happened correctly
-            expect(props.initialize).toHaveBeenCalledWith(path.normalize('/test/root/config'), expect.any(Array));
+            expect(props.initialize).toHaveBeenCalledWith([path.normalize('/test/root/config')], expect.any(Array));
             expect(props.propsFor).toHaveBeenCalledWith('compiler-explorer');
             // CompilerProps is a class, not a spy, so we can't check if it was called
 

--- a/test/base-compiler-tests.ts
+++ b/test/base-compiler-tests.ts
@@ -768,7 +768,7 @@ describe('Rust options', () => {
         ce = makeCompilationEnvironment({
             languages,
         });
-        props.initialize(path.resolve('./test/test-properties/rust'), ['local']);
+        props.initialize([path.resolve('./test/test-properties/rust')], ['local']);
     });
 
     afterAll(() => {
@@ -806,7 +806,7 @@ describe('Rust overrides', () => {
         ce = makeCompilationEnvironment({
             languages,
         });
-        props.initialize(path.resolve('./test/test-properties/rust'), ['local']);
+        props.initialize([path.resolve('./test/test-properties/rust')], ['local']);
     });
 
     afterAll(() => {

--- a/test/checks.ts
+++ b/test/checks.ts
@@ -35,7 +35,7 @@ describe('Live site checks', () => {
     let compilerProps: properties.CompilerProps;
 
     beforeAll(() => {
-        properties.initialize('etc/config/', ['amazon']);
+        properties.initialize(['etc/config/'], ['amazon']);
         ceProps = properties.propsFor('compiler-explorer');
         compilerProps = new properties.CompilerProps(languages, ceProps);
     });

--- a/test/exec-tests.ts
+++ b/test/exec-tests.ts
@@ -162,7 +162,7 @@ describe('Execution tests', async () => {
 
     describe('nsjail unit tests', () => {
         beforeAll(() => {
-            props.initialize(path.resolve('./test/test-properties/execution'), ['test']);
+            props.initialize([path.resolve('./test/test-properties/execution')], ['test']);
         });
         afterAll(() => {
             props.reset();
@@ -251,7 +251,7 @@ describe('Execution tests', async () => {
 
     describe('cewrapper unit tests', () => {
         beforeAll(() => {
-            props.initialize(path.resolve('./test/test-properties/execution'), ['test']);
+            props.initialize([path.resolve('./test/test-properties/execution')], ['test']);
         });
         afterAll(() => {
             props.reset();
@@ -277,7 +277,7 @@ describe('Execution tests', async () => {
 
     describe('Subdirectory execution', () => {
         beforeAll(() => {
-            props.initialize(path.resolve('./test/test-properties/execution'), ['test']);
+            props.initialize([path.resolve('./test/test-properties/execution')], ['test']);
         });
         afterAll(() => {
             props.reset();

--- a/test/properties-test.ts
+++ b/test/properties-test.ts
@@ -37,7 +37,7 @@ describe('Properties', () => {
     let compilerProps;
 
     beforeAll(() => {
-        properties.initialize('test/example-config/', ['test', 'overridden-base', 'overridden-tip']);
+        properties.initialize(['test/example-config/'], ['test', 'overridden-base', 'overridden-tip']);
         casesProps = properties.propsFor('cases');
         overridingProps = properties.propsFor('overwrite');
         compilerProps = new properties.CompilerProps(


### PR DESCRIPTION
Adds optional --properties-dirs command-line parameter to specify additional directories for loading .properties files. Properties from later directories override those from earlier ones.

This enables per-user custom configuration when running Compiler Explorer locally as an app, keeping personal settings separate from the main configuration directory.