### PR TITLE
Allow riscv64 run on current host

### DIFF
--- a/lib/execution/execution-triple.ts
+++ b/lib/execution/execution-triple.ts
@@ -68,6 +68,9 @@ class CurrentHostExecHelper {
         if (hostArch === 'ia32' && value === 'x86') {
             return true;
         }
+        if (hostArch === 'riscv64' && value === 'riscv64') {
+            return true;
+        }
 
         return false;
     }


### PR DESCRIPTION
Support execution when CE run on riscv64.
Tested on SpacemiT K1 board.
