### PR TITLE
Fix `[object Object]` output for CMake errors

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2867,7 +2867,7 @@ export class BaseCompiler {
                         stderr: [],
                         okToCache: false,
                         code: cmakeStepResult.code,
-                        asm: [{text: '<Build failed>'}],
+                        asm: '<CMake configure step failed>',
                     };
                     result.result.compilationOptions = this.getUsedEnvironmentVariableFlags(makeExecParams);
                     compilationTimeHistogram.observe((performance.now() - start) / 1000);
@@ -2890,7 +2890,7 @@ export class BaseCompiler {
                         stderr: [],
                         okToCache: false,
                         code: makeStepResult.code,
-                        asm: [{text: '<Build failed>'}],
+                        asm: '<CMake build step failed>',
                     };
                     compilationTimeHistogram.observe((performance.now() - start) / 1000);
                     return result;


### PR DESCRIPTION
When encountering an error when building a CMake project, the compiler pane shows `[object Object]` instead of a descriptive message.

Example: https://godbolt.org/z/jr5caE5xM