### PR TITLE
Add Rust crate datafusion v51.0.0

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -330,7 +330,7 @@ compiler.mrustc-master.isNightly=true
 #################################
 # Installed libs, generated from ce_install generate-rust-crates
 # Don't modify directly
-libs=ahash:aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:bumpalo:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:digest:either:env_logger:eyre:fastrand:fnv:futures:futures-channel:futures-core:futures-io:futures-sink:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:http-body:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:linux-raw-sys:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pin-utils:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-automata:regex-syntax:rustc_version:rustix:rustls:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:sha2:slab:smallvec:socket2:strsim:subtle:syn:tempfile:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:tokio-util:toml:tracing:tracing-core:typenum:unicode-bidi:unicode-ident:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:uuid:vec_map:version_check:wide:winapi:windows-sys:windows_aarch64_msvc:windows_i686_gnu:windows_i686_msvc:windows_x86_64_gnu:windows_x86_64_msvc:zerocopy
+libs=ahash:aho-corasick:ansi_term:anyhow:arrayvec:atty:autocfg:backtrace:base64:bincode:bitflags:block-buffer:bumpalo:byteorder:bytes:cc:cfg-if:chrono:clap:color-eyre:contracts:crossbeam-channel:crossbeam-deque:crossbeam-epoch:crossbeam-utils:dashmap:datafusion:digest:either:env_logger:eyre:fastrand:fnv:futures:futures-channel:futures-core:futures-io:futures-sink:futures-task:futures-util:generic-array:getrandom:h2:hashbrown:heck:http:http-body:httparse:hyper:idna:indexmap:itertools:itoa:lazy_static:libc:linux-raw-sys:lock_api:log:matches:memchr:memoffset:miniz_oxide:mio:ndarray:nix:num:num-integer:num-traits:num_cpus:num_traits:once_cell:opaque-debug:parking_lot:parking_lot_core:percent-encoding:phf:pin-project-lite:pin-utils:pkg-config:ppv-lite86:proc-macro-hack:proc-macro2:quote:rand:rand_chacha:rand_core:rayon:regex:regex-automata:regex-syntax:rustc_version:rustix:rustls:ryu:scopeguard:semver:semver-parser:serde:serde_derive:serde_json:sha2:slab:smallvec:socket2:strsim:subtle:syn:tempfile:termcolor:textwrap:thiserror:thiserror-impl:thread_local:time:tokio:tokio-util:toml:tracing:tracing-core:typenum:unicode-bidi:unicode-ident:unicode-normalization:unicode-segmentation:unicode-width:unicode-xid:url:uuid:vec_map:version_check:wide:winapi:windows-sys:windows_aarch64_msvc:windows_i686_gnu:windows_i686_msvc:windows_x86_64_gnu:windows_x86_64_msvc:zerocopy
 
 libs.ahash.name=ahash
 libs.ahash.url=https://crates.io/crates/ahash
@@ -515,6 +515,12 @@ libs.dashmap.url=https://crates.io/crates/dashmap
 libs.dashmap.versions=540
 libs.dashmap.versions.540.version=5.4.0
 libs.dashmap.versions.540.path=libdashmap.rlib
+
+libs.datafusion.name=datafusion
+libs.datafusion.url=https://crates.io/crates/datafusion
+libs.datafusion.versions=5100
+libs.datafusion.versions.5100.version=51.0.0
+libs.datafusion.versions.5100.path=libdatafusion.rlib
 
 libs.digest.name=digest
 libs.digest.url=https://crates.io/crates/digest


### PR DESCRIPTION
This PR adds the Rust crate **datafusion** version 51.0.0 to Compiler Explorer.

Related PR: https://github.com/compiler-explorer/infra/pull/1920