### PR TITLE
Fix GnuCOBOL license information

### DIFF
--- a/etc/config/cobol.amazon.properties
+++ b/etc/config/cobol.amazon.properties
@@ -6,8 +6,10 @@ group.gnucobol.groupName=GnuCOBOL
 group.gnucobol.compilers=gnucobol32:gnucobol32rc2:gnucobol31:gnucobol22:gnucobol11
 group.gnucobol.isSemVer=true
 group.gnucobol.baseName=GnuCOBOL
-group.gnucobol.licenseName=GPLv3
+group.gnucobol.licenseName=GPL-3.0-or-later
 group.gnucobol.licenseLink=https://sourceforge.net/p/gnucobol/code/HEAD/tree/trunk/COPYING
+group.gnucobol.licensePreamble=Copyright (c) 2025 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
+
 compiler.gnucobol32.exe=/opt/compiler-explorer/cobol/gnucobol-3.2/bin/cobc
 compiler.gnucobol32.name=GnuCOBOL 3.2
 compiler.gnucobol32.version=3.2
@@ -23,6 +25,8 @@ compiler.gnucobol22.version=2.2
 compiler.gnucobol11.exe=/opt/compiler-explorer/cobol/gnucobol-1.1/bin/cobc
 compiler.gnucobol11.name=GnuCOBOL 1.1
 compiler.gnucobol11.version=1.1
+compiler.gnucobol11.licenseName=GPL-2.0-or-later
+compiler.gnucobol11.licensePreamble=Copyright (c) 2012 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
 
 group.gcccobol.compilerType=gcccobol
 group.gcccobol.groupName=GCC


### PR DESCRIPTION
GC 1.1 is not GPLv3+ but GPLv2+.

Also fix other GC: all GC are using the "or later version" of the GPL.

fix #7309