### PR TITLE
Remove `tme` target feature from `armv8` clangs

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1019,7 +1019,7 @@ compiler.armv8-full-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.armv8-full-clang-trunk.semver=(all architectural features, trunk)
 compiler.armv8-full-clang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
+compiler.armv8-full-clang-trunk.options=-target aarch64-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 # An alias of the original name for this compiler needs to be maintained to allow old URLs to continue to work
 compiler.armv8-full-clang-trunk.alias=armv8.5-clang-trunk
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -773,7 +773,7 @@ compiler.armv8-full-cclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clan
 compiler.armv8-full-cclang-trunk.semver=(trunk allfeats)
 compiler.armv8-full-cclang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
+compiler.armv8-full-cclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 # An alias of the original name for this compiler needs to be maintained to
 # allow old URLs to continue to work
 compiler.armv8-full-cclang-trunk.alias=armv8.5-cclang-trunk

--- a/etc/config/cpp_for_opencl.amazon.properties
+++ b/etc/config/cpp_for_opencl.amazon.properties
@@ -175,7 +175,7 @@ compiler.armv8-full-cpp4oclclang-trunk.objdumper=/opt/compiler-explorer/gcc-snap
 compiler.armv8-full-cpp4oclclang-trunk.semver=(trunk allfeats)
 compiler.armv8-full-cpp4oclclang-trunk.isNightly=true
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
+compiler.armv8-full-cpp4oclclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 
 # SPIR-V Assembly
 group.spirv32cpp4oclclang.groupName=SPIR-V 32-bit clang (with llvm-spirv)

--- a/etc/config/openclc.amazon.properties
+++ b/etc/config/openclc.amazon.properties
@@ -195,7 +195,7 @@ compiler.armv8-full-oclcclang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/c
 compiler.armv8-full-oclcclang-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.armv8-full-oclcclang-trunk.semver=(trunk allfeats)
 # Arm v8-a with all supported architectural features
-compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
+compiler.armv8-full-oclcclang-trunk.options=-target aarch64-none-linux-gnu --gcc-toolchain=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot -march=armv8.8-a+crypto+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+brbe+f32mm+f64mm+fp16fml+ls64+sme+sme-f64f64+sme-i16i64+sme2
 
 # SPIR-V Assembly
 group.spirv32oclcclang.groupName=SPIR-V 32-bit clang (with llvm-spirv)


### PR DESCRIPTION
The `tme` feature was removed in https://github.com/llvm/llvm-project/pull/167687.

Fixes #8334.