### PR TITLE
Fix Sentry CLI v3.0.0 breaking change

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -116,7 +116,7 @@ jobs:
           export SENTRY_PROJECT=compiler-explorer
           npm run sentry -- releases new -p compiler-explorer "${{ needs.build_dist.outputs.release_name }}"
           npm run sentry -- releases set-commits --auto "${{ needs.build_dist.outputs.release_name }}"
-          npm run sentry -- releases files "${{ needs.build_dist.outputs.release_name }}" upload-sourcemaps out/dist/static
+          npm run sentry -- sourcemaps upload --release "${{ needs.build_dist.outputs.release_name }}" out/dist/static
       - name: Deploy
         uses: jakejarvis/s3-sync-action@master
         with:


### PR DESCRIPTION
## Summary
- Sentry CLI 3.0.0 removed the `releases files` subcommand
- Migrate to the new `sourcemaps upload --release` command syntax
- Fixes deploy failures: https://github.com/compiler-explorer/compiler-explorer/actions/runs/20253797661/job/58151514156

See: https://github.com/getsentry/sentry-cli/releases/tag/3.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)