### PR TITLE
Fix wine initialization never completing

### DIFF
--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -559,7 +559,7 @@ export function startWineInit() {
             setupOnError(stdout, 'stdout');
             setupOnError(stderr, 'stderr');
             const magicString = '!!EVERYTHING IS WORKING!!';
-            stdin.write(`echo ${magicString}`);
+            stdin.write(`echo ${magicString}\n`);
 
             let output = '';
             stdout.on('data', data => {


### PR DESCRIPTION
Previously, wine initialization would never complete because it waits for a magic string which cmd.exe never outputs, because the corresponding echo never executes. This change adds a newline to the end of the echo command, so the command executes, and wine initialization completes.
