### PR TITLE
Fix terminal colours in light theme

### DIFF
--- a/static/styles/themes/ansi-dark.scss
+++ b/static/styles/themes/ansi-dark.scss
@@ -1,4 +1,4 @@
-body {
+@mixin terminal-colors {
     --terminal-black: #4f5666;
     --terminal-red: #f85757;
     --terminal-green: #50d750;

--- a/static/styles/themes/dark-theme.scss
+++ b/static/styles/themes/dark-theme.scss
@@ -3,6 +3,8 @@
 
 html[data-theme='dark'] {
 
+@include ansi-dark.terminal-colors;
+
 ::-webkit-scrollbar {
     background: color.scale(#1e1e1e, $lightness: 10%);
 }

--- a/static/styles/themes/one-dark-theme.scss
+++ b/static/styles/themes/one-dark-theme.scss
@@ -14,6 +14,9 @@ $dark: #21252b;
 $darker: #1e1f22;
 
 html[data-theme='one-dark'] {
+
+@include ansi-dark.terminal-colors;
+
 // Export as CSS custom properties for use in explorer.scss
 --light: #{$light};
 --lighter: #{$lighter};


### PR DESCRIPTION
The light theme uses the terminal colours intended for the dark themes. This makes some colours, especially yellow, hard to read.

Example:
Currently:
<img width="677" height="208" alt="before" src="https://github.com/user-attachments/assets/ddac0e15-fe45-4130-a524-0ace9448e000" />

With this PR:
<img width="677" height="208" alt="after" src="https://github.com/user-attachments/assets/5e4340d8-c14f-4128-914c-032af3df109e" />

I believe this was regressed in #7970/#7971 where an `@import` of `ansi-dark.scss` nested in a `[data-theme='dark']` selector was changed to an unconditional `@use`, overriding the colours specified for the default theme.