### PR TITLE
Fix #8349: Add `const` to Max Array C/C++ examples where applicable.

### DIFF
--- a/examples/c++/Max_array.cpp
+++ b/examples/c++/Max_array.cpp
@@ -1,4 +1,4 @@
-void maxArray(double* x, double* y) {
+void maxArray(double* x, const double* y) {
     for (int i = 0; i < 65536; i++) {
         if (y[i] > x[i]) x[i] = y[i];
     }

--- a/examples/c++/Max_array_(Optimized).cpp
+++ b/examples/c++/Max_array_(Optimized).cpp
@@ -1,7 +1,7 @@
 // Compile with -O3 -march=native to see autovectorization
 typedef double *__attribute__((aligned(64))) aligned_double;
 
-void maxArray(aligned_double __restrict x, aligned_double __restrict y) {
+void maxArray(aligned_double __restrict x, const aligned_double __restrict y) {
     for (int i = 0; i < 65536; i++) {
         x[i] = ((y[i] > x[i]) ? y[i] : x[i]);
     }

--- a/examples/c/Max_array.c
+++ b/examples/c/Max_array.c
@@ -1,4 +1,4 @@
-void maxArray(double* x, double* y) {
+void maxArray(double* x, const double* y) {
     int i;
 
     for (i = 0; i < 65536; i++) {


### PR DESCRIPTION
As noted by Matt during his [Advent of Compiler Optimizations - Episode 20: Vectorization [0:55]](https://www.youtube.com/watch?v=d68x8TF7XJs&t=55s), `const` can and should be introduced here.

We don't need the elements of `y` to be modifiable.

Closes #8349 

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
