### PR TITLE
Remove `editorSetDecoration`

### DIFF
--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -83,7 +83,6 @@ export type EventMap = {
     editorLinkLine: (editorId: number, lineNumber: number, colBegin: number, colEnd: number, reveal: boolean) => void;
     editorApplyQuickfix: (editorId: number, range: monaco.IRange, text: string | null) => void;
     editorOpen: (editorId: number) => void;
-    editorSetDecoration: (editorId: number, lineNumber: number, reveal: boolean, column?: number) => void;
     executeResult: (executorId: number, compiler: any, result: any, language: Language) => void;
     executor: (
         executorId: number,

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -354,7 +354,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.eventHub.on('compiling', this.onCompiling, this);
         this.eventHub.on('executeResult', this.onExecuteResponse, this);
         this.eventHub.on('selectLine', this.onSelectLine, this);
-        this.eventHub.on('editorSetDecoration', this.onEditorSetDecoration, this);
         this.eventHub.on('editorDisplayFlow', this.onEditorDisplayFlow, this);
         this.eventHub.on('editorLinkLine', this.onEditorLinkLine, this);
         this.eventHub.on('editorApplyQuickfix', this.onEditorApplyQuickfix, this);
@@ -1267,7 +1266,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         });
 
         if (before.hoverShowSource && !after.hoverShowSource) {
-            this.onEditorSetDecoration(this.id, -1, false);
+            this.onEditorLinkLine(this.id, -1, -1, -1, false);
         }
 
         if (after.useVim && !before.useVim) {
@@ -1724,6 +1723,8 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                 this.pushRevealJump();
                 this.hub.activateTabForContainer(this.container);
                 this.editor.revealLineInCenter(lineNum);
+                this.editor.focus();
+                this.editor.setPosition({column: columnBegin >= 0 ? columnBegin : 0, lineNumber: lineNum});
             }
             this.decorations.linkedCode = [];
             if (lineNum && lineNum !== -1) {
@@ -1763,29 +1764,6 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     onEditorApplyQuickfix(editorId: number, range: monaco.IRange, text: string | null): void {
         if (editorId === this.id) {
             this.applyEdit({forceMoveMarkers: true, range, text});
-        }
-    }
-
-    onEditorSetDecoration(id: number, lineNum: number, reveal: boolean, column?: number): void {
-        if (Number(id) === this.id) {
-            if (reveal && lineNum) {
-                this.pushRevealJump();
-                this.editor.revealLineInCenter(lineNum);
-                this.editor.focus();
-                this.editor.setPosition({column: column || 0, lineNumber: lineNum});
-            }
-            this.decorations.linkedCode = [];
-            if (lineNum && lineNum !== -1) {
-                this.decorations.linkedCode.push({
-                    range: new monaco.Range(lineNum, 1, lineNum, 1),
-                    options: {
-                        isWholeLine: true,
-                        linesDecorationsClassName: 'linked-code-decoration-margin',
-                        inlineClassName: 'linked-code-decoration-inline',
-                    },
-                });
-            }
-            this.updateDecorations();
         }
     }
 

--- a/static/panes/tool.ts
+++ b/static/panes/tool.ts
@@ -514,15 +514,16 @@ export class Tool extends MonacoPane<monaco.editor.IStandaloneCodeEditor, ToolSt
         }
     }
 
-    add(msg: string, lineNum?: number, column?: number, flow?: number) {
+    add(msg: string, lineNum?: number, maybeColumn?: number, flow?: number) {
         const elem = $('<div/>').appendTo(this.plainContentRoot);
         if (lineNum && this.compilerInfo.editorId) {
+            const column = maybeColumn ?? -1;
             elem.empty();
             const editorId = unwrap(this.compilerInfo.editorId);
             $('<span class="linked-compiler-output-line"></span>')
                 .html(msg)
                 .on('click', e => {
-                    this.eventHub.emit('editorSetDecoration', editorId, lineNum, true, column);
+                    this.eventHub.emit('editorLinkLine', editorId, lineNum, column, column + 1, true);
                     if (flow) {
                         // TODO(jeremy-rifkin): Flow's type does not match what the event expects.
                         this.eventHub.emit('editorDisplayFlow', editorId, flow as any);
@@ -530,7 +531,9 @@ export class Tool extends MonacoPane<monaco.editor.IStandaloneCodeEditor, ToolSt
                     e.preventDefault();
                     return false;
                 })
-                .on('mouseover', () => this.eventHub.emit('editorSetDecoration', editorId, lineNum, false, column))
+                .on('mouseover', () =>
+                    this.eventHub.emit('editorLinkLine', editorId, lineNum, column, column + 1, false),
+                )
                 .appendTo(elem);
         } else {
             elem.html(msg);


### PR DESCRIPTION
The `editorSetDecoration` and `editorLinkLine` events are very similar: They highlight the source line that a (compiler or tool) output line points to.

However, there are some differences:
* `editorLinkLine` highlights the word at the pointed-to position in red.
* `editorSetDecoration` moves the cursor on click.
* `editorSetDecoration` is affected by the “highlight linked lines indefinitely” setting introduced in #4227.
* `editorSetDecoration` does not show the editor’s tab on click if it’s in the background.

These differences seem unintentional and the result of the duplication between these events to me, so this PR merges both behaviours as `editorLinkLine`.