### PR TITLE
Adding experimental Clang for template string objects (p3951)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -612,6 +612,7 @@ compiler.clang_p3776.notification=Experimental trailing commas; see <a href="htt
 compiler.clang_p3951.exe=/opt/compiler-explorer/clang-p3951-trunk/bin/clang++
 compiler.clang_p3951.semver=(template strings - P3951)
 compiler.clang_p3951.notification=Experimental P3951 Support (t"..."); see <a href="https://brevzin.github.io/cpp_proposals/3951_string_interpolation/p3951r0.html" target="_blank" rel="noopener noreferrer">P3951<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_p3951.options=-std=c++26 -freflection -fexpansion-statements -stdlib=libc++
 compiler.clang_p1061.exe=/opt/compiler-explorer/clang-p1061-trunk/bin/clang++
 compiler.clang_p1061.semver=(experimental P1061)
 compiler.clang_p1061.notification=Experimental Structure Bindings can introduce a Pack; see <a href="https://wg21.link/P1061" target="_blank" rel="noopener noreferrer">P1061<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
Implements string interpolation via template strings. Following https://github.com/compiler-explorer/infra/pull/1927.