### PR TITLE
Fix externalparser properties not surviving prediscovery serialization

### DIFF
--- a/lib/compiler-finder.ts
+++ b/lib/compiler-finder.ts
@@ -325,9 +325,8 @@ export class CompilerFinder {
             },
             externalparser: {
                 id: props('externalparser', ''),
-                props: (name: string, def: any) => {
-                    return props(`externalparser.${name}`, def);
-                },
+                exe: props('externalparser.exe', ''),
+                args: props('externalparser.args', ''),
             },
             license: {
                 link: props<string>('licenseLink'),
@@ -595,12 +594,6 @@ export class CompilerFinder {
             if (compiler.buildenvsetup) {
                 compiler.buildenvsetup.props = (propName, def) => {
                     return this.compilerProps(langId, 'buildenvsetup.' + propName, def);
-                };
-            }
-
-            if (compiler.externalparser) {
-                compiler.externalparser.props = (propName: string, def: any) => {
-                    return this.compilerProps(langId, 'externalparser.' + propName, def);
                 };
             }
 

--- a/lib/external-parsers/base.ts
+++ b/lib/external-parsers/base.ts
@@ -24,10 +24,13 @@ export class ExternalParserBase implements IExternalParser {
         this.compilerInfo = compilerInfo;
         this.envInfo = envInfo;
         this.objdumperPath = compilerInfo.objdumper;
-        this.parserPath = compilerInfo.externalparser.props('exe', '');
+        this.parserPath = compilerInfo.externalparser.exe;
         if (!fs.existsSync(this.parserPath)) {
-            logger.error(`External parser ${this.parserPath} does not exist`);
-            process.exit(1);
+            const msg = `External parser for compiler ${compilerInfo.id} does not exist: "${this.parserPath}"`;
+            logger.error(msg);
+            // Delay exit to allow async log transports (e.g., Loki) to flush
+            setTimeout(() => process.exit(1), 5000);
+            throw new Error(msg);
         }
         this.execFunc = execFunc;
     }

--- a/test/app/compiler-discovery-tests.ts
+++ b/test/app/compiler-discovery-tests.ts
@@ -162,13 +162,13 @@ describe('compiler-discovery module', () => {
                 id: 'gcc1',
                 lang: 'c++' as unknown as LanguageKey,
                 buildenvsetup: {id: '', props: vi.fn()},
-                externalparser: {id: ''},
+                externalparser: {id: '', exe: '', args: ''},
             },
             {
                 id: 'gcc2',
                 lang: 'c++' as unknown as LanguageKey,
                 buildenvsetup: {id: 'setup1', props: vi.fn()},
-                externalparser: {id: 'parser1'},
+                externalparser: {id: 'parser1', exe: '/path/to/parser', args: ''},
             },
         ];
 
@@ -185,7 +185,7 @@ describe('compiler-discovery module', () => {
                 id: 'gcc2',
                 lang: 'c++',
                 buildenvsetup: {id: 'setup1'},
-                externalparser: {id: 'parser1'},
+                externalparser: {id: 'parser1', exe: '/path/to/parser', args: ''},
                 cachedPossibleArguments: ['arg1', 'arg2'],
             },
         ];

--- a/types/compiler.interfaces.ts
+++ b/types/compiler.interfaces.ts
@@ -139,7 +139,11 @@ export type CompilerInfo = {
     disabledFilters: string[];
     optArg?: string;
     stackUsageArg?: string;
-    externalparser: any;
+    externalparser: {
+        id: string;
+        exe: string;
+        args: string;
+    };
     removeEmptyGccDump?: boolean;
     irArg?: string[];
     minIrArgs?: string[];


### PR DESCRIPTION
## Summary
- Fix externalparser not working with prediscovered compilers (e.g., MicroPython)
- The `externalparser.props` function was lost during JSON serialization, causing `exe` path to be undefined
- Now stores `exe` and `args` directly on the externalparser object
- Removes the unused `props` function pattern from externalparser
- Adds proper TypeScript typing for externalparser
- Improves error messages to include compiler ID
- Adds delay before process.exit to allow Loki logs to flush

## Test plan
- [x] TypeScript type check passes
- [x] Linter passes  
- [x] Unit tests pass
- [ ] Deploy to staging and verify MicroPython compilers work

🤖 Generated with [Claude Code](https://claude.com/claude-code)