### PR TITLE
Avoid `TypeError` when editor model is `null`

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1129,13 +1129,16 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     }
 
     updateSource(newSource: string): void {
-        // Create something that looks like an edit operation for the whole text
-        const operation = {
-            range: this.editor.getModel()!.getFullModelRange(),
-            forceMoveMarkers: true,
-            text: newSource,
-        };
-        this.applyEdit(operation);
+        const model = this.editor.getModel();
+        if (model) {
+            // Create something that looks like an edit operation for the whole text
+            const operation = {
+                range: model.getFullModelRange(),
+                forceMoveMarkers: true,
+                text: newSource,
+            };
+            this.applyEdit(operation);
+        }
 
         if (!this.awaitingInitialResults) {
             if (this.selection) {


### PR DESCRIPTION
#8354 accidentally replaced a `null` check (`?`) with a non-`null` assertion (`!`).

I don’t know if `getModel` can ever return `null` (all other usages check for `null`), so this PR reintroduces the `null` check.