### PR TITLE
Add relative line numbers setting

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1263,6 +1263,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             fontLigatures: this.settings.editorsFLigatures,
             wordWrap: this.settings.wordWrap ? 'bounded' : 'off',
             wordWrapColumn: this.editor.getLayoutInfo().viewportColumn, // Ensure the column count is up to date
+            lineNumbers: this.settings.relativeLineNumbers ? 'relative' : 'on',
         });
 
         if (before.hoverShowSource && !after.hoverShowSource) {

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -76,6 +76,7 @@ export interface SiteSettings {
     useSpaces: boolean;
     useVim: boolean;
     wordWrap: boolean;
+    relativeLineNumbers: boolean;
 }
 
 class BaseSetting {
@@ -308,6 +309,7 @@ export class Settings {
             ['.useSpaces', 'useSpaces', true],
             ['.useVim', 'useVim', false],
             ['.wordWrap', 'wordWrap', false],
+            ['.relativeLineNumbers', 'relativeLineNumbers', false],
         ];
 
         for (const [selector, name, defaultValue] of checkboxes) {

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -51,6 +51,7 @@ mixin input(cls, type, text, style)
               +checkbox("enableCommunityAds", "Show community events")
             #keybindings.tab-pane(role="group")
               +checkbox("useVim", "Vim editor mode")
+              +checkbox("relativeLineNumbers", "Show relative line numbers (useful for vim motions)")
               .the-save-option-to-auto-share
                 mb-3
                   label.form-label(for="settings-checkbox-enableCtrlS")


### PR DESCRIPTION
Adds a setting to enable relative line numbers in the editor. I placed it under Keybindings since it's mainly useful when using vim motions.

Uses Monaco's built-in `lineNumbers: 'relative'` option.

Closes #8355