### PR TITLE
Remove extra line spacing in stdout/stderr output

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -609,6 +609,7 @@ input.vim-check {
 
 .execution-stdoutstderr {
     overflow: unset;
+    line-height: 1;
 }
 
 .lib-arrow {


### PR DESCRIPTION
Sets `line-height: 1` for execution output to match terminal emulator behavior. This improves display of box-drawing characters and other cases where lines should connect vertically.

Closes #8240