### PR TITLE
Display helpful hints when compilation produces no assembly

### DIFF
--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -38,7 +38,8 @@ type DefKeys =
     | 'logoFilenameDark'
     | 'monacoDisassembly'
     | 'tooltip'
-    | 'digitSeparator';
+    | 'digitSeparator'
+    | 'noAsmHint';
 type LanguageDefinition = Pick<Language, DefKeys>;
 
 const definitions: Record<LanguageKey, LanguageDefinition> = {
@@ -64,6 +65,9 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: /^\s*#include/,
         monacoDisassembly: null,
         digitSeparator: "'",
+        noAsmHint:
+            '# Tip: Inline or template functions may not generate code.\n' +
+            '# Use __attribute__((noinline)) or instantiate templates explicitly.',
     },
     ada: {
         name: 'Ada',
@@ -804,6 +808,10 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
         digitSeparator: '_',
+        noAsmHint:
+            '# Tip: Small functions may be inlined and not appear in output.\n' +
+            '# Use #[inline(never)] or #[unsafe(no_mangle)] to prevent this.\n' +
+            '# For main(), declare it as pub fn main() to see it in output.',
     },
     sail: {
         name: 'Sail',

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1612,6 +1612,14 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             }
         }
 
+        // Show language-specific hint when no assembly is generated and compilation succeeded
+        if (!asm.length && result.code === 0 && this.currentLangId && this.currentLangId in languages) {
+            const hint = languages[this.currentLangId].noAsmHint;
+            if (hint) {
+                msg += '\n\n' + hint;
+            }
+        }
+
         editorModel?.setValue(msg);
 
         // restore a previous scroll if there was one

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -143,4 +143,6 @@ export interface Language {
     /** Default compiler for the language. This is populated when handed to the frontend. */
     defaultCompiler?: string;
     digitSeparator?: string;
+    /** Hint to display when no assembly is generated (e.g., for inlined functions) */
+    noAsmHint?: string;
 }


### PR DESCRIPTION
## Summary

This PR addresses a common source of confusion for users, especially those new to Compiler Explorer. When compilation succeeds but produces no visible assembly output, users often don't understand why.

**Changes:**
- Added optional `noAsmHint` field to the Language interface
- Added language-specific hints for Rust and C++ explaining common causes (inlining, dead code elimination)
- Display the hint in the compiler pane when `asm.length === 0` and `result.code === 0`

## Example hints

**Rust:**
```
# Tip: Small functions may be inlined and not appear in output.
# Use #[inline(never)] or #[unsafe(no_mangle)] to prevent this.
# For main(), declare it as pub fn main() to see it in output.
```

**C++:**
```
# Tip: Inline or template functions may not generate code.
# Use __attribute__((noinline)) or instantiate templates explicitly.
```

## Test plan

- [x] TypeScript checks pass
- [x] Lint passes
- [x] Verified `noAsmHint` appears in client-options.js
- [x] Manual testing with empty function compilation

Closes #7999