### PR TITLE
Add configurable tab width for assembly output

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -397,6 +397,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                         indentation: false,
                     },
                     vimInUse: false,
+                    tabSize: this.settings.asmTabWidth,
                 },
                 this.settings,
             ),
@@ -3475,6 +3476,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             fontFamily: this.settings.editorsFFont,
             codeLensFontFamily: this.settings.editorsFFont,
             fontLigatures: this.settings.editorsFLigatures,
+            tabSize: this.settings.asmTabWidth,
         });
     }
 

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -43,6 +43,7 @@ export interface SiteSettings {
     autoIndent: boolean;
     allowStoreCodeDebug: boolean;
     alwaysEnableAllSchemes: boolean;
+    asmTabWidth: number;
     colouriseAsm: boolean;
     colourScheme: ColourScheme;
     compileOnChange: boolean;
@@ -430,6 +431,13 @@ export class Settings {
                 max: 80,
             }),
             4,
+        );
+        this.add(
+            new Numeric(this.root.find('.asmTabWidth'), 'asmTabWidth', {
+                min: 1,
+                max: 80,
+            }),
+            12,
         );
     }
 

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -98,6 +98,7 @@ mixin input(cls, type, text, style)
               +checkbox("colouriseBrackets", "Colourise matching bracket pairs")
             #compilation.tab-pane(role="group")
               div
+                +input("asmTabWidth", "number", "Assembly output tab width (default 12 for long instruction names)")
                 +checkbox("compileOnChange", "Compile automatically when source changes")
                 +checkbox("autoDelayBeforeCompile", "Use automatic delay before compiling")
                 div


### PR DESCRIPTION
## Summary

Assembly output from compilers typically uses a single tab between instruction names and operands. With Monaco's default tab size of 4, longer instruction names like `vfmadd213sd` break the visual alignment of operands.

This PR adds a configurable "Assembly output tab width" setting (default: 12) that allows users to adjust how tabs are rendered in the compiler output pane. The default of 12 characters accommodates most x86 instruction names while maintaining readable alignment.

**Changes:**
- Added `asmTabWidth` to SiteSettings interface
- Added numeric input field in Settings > Compilation tab
- Applied setting to compiler pane Monaco editor on creation and settings change

## Before/After

With tab width 4 (current default):
```
vmovsd  xmm0, qword ptr [rdx + rax + 32]
vfmadd213sd     xmm1, xmm0, qword ptr [rsi + rax + 32]
vmovsd  qword ptr [rdi + rax + 32], xmm1
```

With tab width 12 (new default):
```
vmovsd      xmm0, qword ptr [rdx + rax + 32]
vfmadd213sd xmm1, xmm0, qword ptr [rsi + rax + 32]
vmovsd      qword ptr [rdi + rax + 32], xmm1
```

## Test plan

- [x] TypeScript checks pass
- [x] Lint passes
- [x] Setting appears in UI under Compilation tab
- [x] Tab width updates dynamically when changed

Closes #863