### PR TITLE
Fix CFG layout crash when graph has no blocks

### DIFF
--- a/static/graph-layout-core.ts
+++ b/static/graph-layout-core.ts
@@ -440,8 +440,14 @@ export class GraphLayoutCore {
     }
 
     setupRowsAndColumns() {
-        this.rowCount = Math.max(...this.blocks.map(block => block.row)) + 1; // one more row for zero offset
-        this.columnCount = Math.max(...this.blocks.map(block => block.col)) + 2; // blocks are two-wide
+        // Handle empty blocks case - Math.max() with empty array returns -Infinity
+        if (this.blocks.length === 0) {
+            this.rowCount = 0;
+            this.columnCount = 0;
+        } else {
+            this.rowCount = Math.max(...this.blocks.map(block => block.row)) + 1; // one more row for zero offset
+            this.columnCount = Math.max(...this.blocks.map(block => block.col)) + 2; // blocks are two-wide
+        }
         this.blockRows = Array(this.rowCount)
             .fill(0)
             .map(() => ({


### PR DESCRIPTION
## Summary

Fixes a runtime crash in the CFG (Control Flow Graph) visualization when the graph has no blocks. This can occur with empty functions or certain edge cases in the compiler output.

**Root cause:**
In `setupRowsAndColumns()`, when `this.blocks` is empty:
```javascript
this.rowCount = Math.max(...this.blocks.map(block => block.row)) + 1;
this.columnCount = Math.max(...this.blocks.map(block => block.col)) + 2;
```

`Math.max()` with an empty array returns `-Infinity`, so `columnCount` becomes `-Infinity + 2 = -Infinity`. Then `Array(this.columnCount)` creates an empty array, and later when `computeGridDimensions()` tries to access `this.blockColumns[block.col].width`, it fails with "undefined is not an object".

**Fix:**
Added an early check for empty blocks that sets `rowCount` and `columnCount` to 0. The resulting empty arrays are safe because there are no blocks to iterate over in subsequent methods.

## Test plan

- [x] TypeScript checks pass
- [x] Lint passes
- [x] Empty blocks case no longer crashes

Fixes #8318