### PR TITLE
Revert "Add configurable tab width for assembly output (#8370)"

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -397,7 +397,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                         indentation: false,
                     },
                     vimInUse: false,
-                    tabSize: this.settings.asmTabWidth,
                 },
                 this.settings,
             ),
@@ -3484,7 +3483,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             fontFamily: this.settings.editorsFFont,
             codeLensFontFamily: this.settings.editorsFFont,
             fontLigatures: this.settings.editorsFLigatures,
-            tabSize: this.settings.asmTabWidth,
         });
     }
 

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -43,7 +43,6 @@ export interface SiteSettings {
     autoIndent: boolean;
     allowStoreCodeDebug: boolean;
     alwaysEnableAllSchemes: boolean;
-    asmTabWidth: number;
     colouriseAsm: boolean;
     colourScheme: ColourScheme;
     compileOnChange: boolean;
@@ -433,13 +432,6 @@ export class Settings {
                 max: 80,
             }),
             4,
-        );
-        this.add(
-            new Numeric(this.root.find('.asmTabWidth'), 'asmTabWidth', {
-                min: 1,
-                max: 80,
-            }),
-            12,
         );
     }
 

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -99,7 +99,6 @@ mixin input(cls, type, text, style)
               +checkbox("colouriseBrackets", "Colourise matching bracket pairs")
             #compilation.tab-pane(role="group")
               div
-                +input("asmTabWidth", "number", "Assembly output tab width (default 12 for long instruction names)")
                 +checkbox("compileOnChange", "Compile automatically when source changes")
                 +checkbox("autoDelayBeforeCompile", "Use automatic delay before compiling")
                 div


### PR DESCRIPTION
## Summary

Reverts #8370 as the feature does not work as intended.

The `tabSize` Monaco setting only affects how tab characters are rendered, but the assembly output has tabs converted to spaces server-side by `expandTabs()` in `lib/parsers/asm-parser.ts` before reaching the client. Since there are no tab characters in the output Monaco receives, the setting has no effect.

Apologies for the broken PR - the before/after examples were examples of what to expect rather than from actual testing, and should have been labeled as such.

## Test plan

- [x] Revert applies cleanly
- [x] TypeScript checks pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)