### PR TITLE
Update default Mojo example to have non-empty assembly

### DIFF
--- a/examples/mojo/default.mojo
+++ b/examples/mojo/default.mojo
@@ -1,2 +1,6 @@
-fn square(n: Int) -> Int:
-  return n * n
+@export
+fn multiply[m: Int](n: Int) -> Int:
+  return m * n
+
+fn main():
+  _ = multiply[3](5)


### PR DESCRIPTION
The current default Mojo example results in no assembly, which is quite confusing to a first-time user.  Adding an `@export` would have been enough to fix that, but this example is a little more complete with a `main` function and using parameters.