### PR TITLE
Suppress crash reporting in Mojo compiler

### DIFF
--- a/lib/compilers/mojo.ts
+++ b/lib/compilers/mojo.ts
@@ -100,4 +100,10 @@ export class MojoCompiler extends BaseCompiler {
     override getArgumentParserClass() {
         return MojoParser;
     }
+
+    override getDefaultExecOptions() {
+        const execOptions = super.getDefaultExecOptions();
+        execOptions.env.MODULAR_CRASH_REPORTING_ENABLED = 'false';
+        return execOptions;
+    }
 }


### PR DESCRIPTION
Currently every run of the Mojo compiler prints a warning about a crash handler failing to initialise.

> Failed to initialize Crashpad.  Crash reporting will not be available.
> Cause: while locating crashpad handler: unable to locate crashpad handler
> executable

This is technically harmless, but adds noise to the output, and risks confusing the user into thinking they have an error or that the compiler has crashed. So just disable crash reporting.