### PR TITLE
Use prebuilt runtimes when linking with the Carbon toolchain

### DIFF
--- a/etc/config/carbon.amazon.properties
+++ b/etc/config/carbon.amazon.properties
@@ -1,10 +1,12 @@
 # Amazon prod environment settings
-compilers=carbon-trunk:carbon-explorer-trunk
-defaultCompiler=carbon-trunk
+compilers=carbon-x86-trunk:carbon-explorer-trunk
+defaultCompiler=carbon-x86-trunk
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
 
-compiler.carbon-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon
-compiler.carbon-trunk.name=Carbon (trunk)
+compiler.carbon-x86-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon
+compiler.carbon-x86-trunk.options=--prebuilt-runtimes=/opt/compiler-explorer/carbon-trunk-runtimes
+compiler.carbon-x86-trunk.name=x86_64 Carbon (trunk)
+compiler.carbon-x86-trunk.instructionSet=amd64
 
 # Older deprecated explorer
 compiler.carbon-explorer-trunk.compilerType=carbon-explorer

--- a/etc/config/carbon.defaults.properties
+++ b/etc/config/carbon.defaults.properties
@@ -1,14 +1,16 @@
 # Default settings for carbon
-compilers=carbon-trunk:carbon-explorer-trunk
-defaultCompiler=carbon-trunk
+compilers=carbon-x86-trunk:carbon-explorer-trunk
+defaultCompiler=carbon-x86-trunk
 compilerType=carbon
 needsMulti=false
 supportsExecute=true
 supportsBinary=true
 supportsBinaryObject=true
 
-compiler.carbon-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon
-compiler.carbon-trunk.name=Carbon (trunk)
+compiler.carbon-x86-trunk.exe=/opt/compiler-explorer/carbon-trunk/bin/carbon
+compiler.carbon-x86-trunk.options=--prebuilt-runtimes=/opt/compiler-explorer/carbon-trunk-runtimes
+compiler.carbon-x86-trunk.name=x86_64 Carbon (trunk)
+compiler.carbon-x86-trunk.instructionSet=amd64
 
 # Older deprecated explorer
 compiler.carbon-explorer-trunk.compilerType=carbon-explorer


### PR DESCRIPTION
This depends on https://github.com/compiler-explorer/infra/pull/1936 which builds the runtimes when installing the Carbon toolchain. Then this PR passes `--prebuilt-runtimes` to the `carbon link` step in order to use them. The result is that compiler explorer no longer times out when trying to link a binary with the Carbon toolchain.

The carbon.ts file is refactored a little in an attempt to improve clarity about what is going on, and some comments are added throughout.

Fixes https://github.com/carbon-language/carbon-lang/issues/6603.