### PR TITLE
[CUDA, clang] Switch clang CUDA compilers that use cuda-13.* to trunk

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -308,7 +308,7 @@ compiler.nvcc131u1.nvdisasm=/opt/compiler-explorer/cuda/13.1.1/bin/nvdisasm
 compiler.nvcc131u1.demangler=/opt/compiler-explorer/gcc-14.1.0/bin/c++filt
 compiler.nvcc131u1.objdumper=/opt/compiler-explorer/gcc-14.1.0/bin/objdump
 
-group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cuclang1600:cuclang1701:cuclang1810:cuclang1910:cuclang2010-1251:cuclang2010-1261:cuclang2010-1262:cuclang2010-1281:cuclang2010-1290:cuclang2010-1291:cuclang2110-1300:cuclang2110-1301:cuclang2110-1302:cuclang2110-1310:cltrunk
+group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001:cuclang1100:cuclang1600:cuclang1701:cuclang1810:cuclang1910:cuclang2010-1251:cuclang2010-1261:cuclang2010-1262:cuclang2010-1281:cuclang2010-1290:cuclang2010-1291:cltrunk-1300:cltrunk-1301:cltrunk-1302:cltrunk
 group.cuclang.isSemVer=true
 group.cuclang.baseName=clang
 group.cuclang.compilerType=clang-cuda
@@ -388,23 +388,21 @@ compiler.cuclang2010-1291.exe=/opt/compiler-explorer/clang-20.1.0/bin/clang++
 compiler.cuclang2010-1291.semver=20.1.0
 compiler.cuclang2010-1291.name=20.1.0 sm_90 CUDA-12.9.1
 compiler.cuclang2010-1291.options=--cuda-path=/opt/compiler-explorer/cuda/12.9.1 --cuda-gpu-arch=sm_90 --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
-compiler.cuclang2110-1300.exe=/opt/compiler-explorer/clang-21.1.0/bin/clang++
-compiler.cuclang2110-1300.semver=21.1.0
-compiler.cuclang2110-1300.name=21.1.0 sm_120a CUDA-13.0.0
-compiler.cuclang2110-1300.options=--cuda-path=/opt/compiler-explorer/cuda/13.0.0 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
-compiler.cuclang2110-1301.exe=/opt/compiler-explorer/clang-21.1.0/bin/clang++
-compiler.cuclang2110-1301.semver=21.1.0
-compiler.cuclang2110-1301.name=21.1.0 sm_120a CUDA-13.0.1
-compiler.cuclang2110-1301.options=--cuda-path=/opt/compiler-explorer/cuda/13.0.1 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
-compiler.cuclang2110-1302.exe=/opt/compiler-explorer/clang-21.1.0/bin/clang++
-compiler.cuclang2110-1302.semver=21.1.0
-compiler.cuclang2110-1302.name=21.1.0 sm_120a CUDA-13.0.2
-compiler.cuclang2110-1302.options=--cuda-path=/opt/compiler-explorer/cuda/13.0.2 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
-compiler.cuclang2110-1310.exe=/opt/compiler-explorer/clang-21.1.0/bin/clang++
-compiler.cuclang2110-1310.semver=21.1.0
-compiler.cuclang2110-1310.name=21.1.0 sm_120a CUDA-13.1.0
-compiler.cuclang2110-1310.options=--cuda-path=/opt/compiler-explorer/cuda/13.1.0 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
-
+compiler.cltrunk-1300.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.cltrunk-1300.semver=trunk
+compiler.cltrunk-1300.name=trunk sm_120a CUDA-13.0.0
+compiler.cltrunk-1300.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cltrunk-1300.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/13.0.0 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
+compiler.cltrunk-1301.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.cltrunk-1301.semver=trunk
+compiler.cltrunk-1301.name=trunk sm_120a CUDA-13.0.1
+compiler.cltrunk-1301.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cltrunk-1301.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/13.0.1 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
+compiler.cltrunk-1302.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.cltrunk-1302.semver=trunk
+compiler.cltrunk-1302.name=trunk sm_120a CUDA-13.0.2
+compiler.cltrunk-1302.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cltrunk-1302.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/13.0.2 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
 compiler.cltrunk.semver=trunk
 compiler.cltrunk.name=trunk sm_120a CUDA-13.1.0
 compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++


### PR DESCRIPTION
clang-21 has trouble compiling CUDA code using CUDA-13.

Switch to using trunk clang for now, until clang-22 is released.

Fixes CUDA compilation problems w/ cuda-13 introduced by #8374 