### PR TITLE
Drop GCC reflection nightly builds

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:greflection-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -195,7 +195,7 @@ compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gsnapshot.semver=(trunk)
 compiler.gsnapshot.isNightly=true
-compiler.gsnapshot.alias=g7snapshot
+compiler.gsnapshot.alias=g7snapshot:greflection-trunk
 compiler.gcontracts-trunk.exe=/opt/compiler-explorer/gcc-lock3-contracts-trunk/bin/g++
 compiler.gcontracts-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gcontracts-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -249,12 +249,6 @@ compiler.gcc-static-analysis-trunk.semver=(static analysis)
 compiler.gcc-static-analysis-trunk.isNightly=true
 compiler.gcc-static-analysis-trunk.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.gcc-static-analysis-trunk.hidden=true
-compiler.greflection-trunk.exe=/opt/compiler-explorer/gcc-reflection-trunk/bin/g++
-compiler.greflection-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
-compiler.greflection-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
-compiler.greflection-trunk.semver=(C++26 reflection)
-compiler.greflection-trunk.isNightly=true
-compiler.greflection-trunk.notification=Experimental C++26 Reflection; see <a href="https://forge.sourceware.org/marek/gcc/src/branch/reflection" target="_blank" rel="noopener noreferrer">GCC Forge<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 compiler.gcontracts-base-trunk.exe=/opt/compiler-explorer/gcc-contracts-base-trunk/bin/g++
 compiler.gcontracts-base-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt


### PR DESCRIPTION
## Summary
- Remove `greflection-trunk` compiler from the gcc86 group
- Remove the dedicated compiler configuration for GCC reflection trunk
- Add `greflection-trunk` as an alias for `gsnapshot` to preserve existing shortlinks

Fixes #8389

🤖 Generated with [Claude Code](https://claude.com/claude-code)