### PR TITLE
Support absolute paths in temp directory creation

### DIFF
--- a/lib/temp.ts
+++ b/lib/temp.ts
@@ -60,22 +60,26 @@ export function resetStats() {
 }
 
 /**
- * Create a temporary directory, always in the operating systems' temporary directory.
- * @param prefix a prefix for the directory name
+ * Create a temporary directory. If the prefix is an absolute path, use it directly;
+ * otherwise create the directory in the operating system's temporary directory.
+ * @param prefix a prefix for the directory name, or an absolute path prefix
  */
 export async function mkdir(prefix: string) {
-    const result = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+    const baseDir = path.isAbsolute(prefix) ? prefix : path.join(os.tmpdir(), prefix);
+    const result = await fs.promises.mkdtemp(baseDir);
     ++stats.numCreated;
     pendingRemoval.push(result);
     return result;
 }
 
 /**
- * Synchronously create a temporary directory, always in the operating systems' temporary directory.
- * @param prefix a prefix for the directory name
+ * Synchronously create a temporary directory. If the prefix is an absolute path, use it directly;
+ * otherwise create the directory in the operating system's temporary directory.
+ * @param prefix a prefix for the directory name, or an absolute path prefix
  */
 export function mkdirSync(prefix: string) {
-    const result = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    const baseDir = path.isAbsolute(prefix) ? prefix : path.join(os.tmpdir(), prefix);
+    const result = fs.mkdtempSync(baseDir);
     ++stats.numCreated;
     pendingRemoval.push(result);
     return result;

--- a/test/temp-tests.ts
+++ b/test/temp-tests.ts
@@ -76,4 +76,31 @@ describe('Creates and tracks temporary directories', () => {
         await temp.cleanup();
         expect(temp.getStats()).toEqual({numCreated: 1, numActive: 0, numRemoved: 0, numAlreadyGone: 1});
     });
+
+    it('uses absolute paths directly when provided', async () => {
+        const customBase = await fs.mkdtemp(path.join(osTemp, 'custom-base-'));
+        try {
+            const absolutePrefix = path.join(customBase, 'myprefix');
+            const newTemp = await temp.mkdir(absolutePrefix);
+            expect(newTemp).toContain(customBase);
+            expect(newTemp).toContain('myprefix');
+            expect(newTemp).not.toContain(path.join(osTemp, customBase));
+            expect(await utils.dirExists(newTemp)).toBe(true);
+        } finally {
+            await fs.rm(customBase, {recursive: true, force: true});
+        }
+    });
+
+    it('uses absolute paths directly for mkdirSync', async () => {
+        const customBase = await fs.mkdtemp(path.join(osTemp, 'custom-base-'));
+        try {
+            const absolutePrefix = path.join(customBase, 'syncprefix');
+            const newTemp = temp.mkdirSync(absolutePrefix);
+            expect(newTemp).toContain(customBase);
+            expect(newTemp).toContain('syncprefix');
+            expect(await utils.dirExists(newTemp)).toBe(true);
+        } finally {
+            await fs.rm(customBase, {recursive: true, force: true});
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- When an absolute path prefix is provided to `temp.mkdir()` or `temp.mkdirSync()`, use it directly instead of joining with `os.tmpdir()`
- This supports use cases where compilers need temporary directories in specific locations (e.g., shared NFS drives for remote compilation)
- Existing callers all use relative prefixes, so this is fully backwards compatible

## Test plan
- [x] Added tests for both `mkdir` and `mkdirSync` with absolute paths
- [x] Verified existing tests still pass
- [x] Checked all callers use relative paths (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)