### PR TITLE
Fix /api/tools/:language endpoint missing name field

### DIFF
--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -257,10 +257,10 @@ export class ApiHandler {
             const tool = toolsForLanguageObj[key];
             return {
                 id: key,
-                name: tool.name,
+                name: tool.tool.name,
                 type: tool.type,
-                languageId: tool.languageId || languageId,
-                allowStdin: tool.stdinHint !== 'disabled',
+                languageId: tool.tool.languageId || languageId,
+                allowStdin: tool.tool.stdinHint !== 'disabled',
             };
         });
     }


### PR DESCRIPTION
## Summary
- Fixed the `/api/tools/:language` API endpoint to correctly return the `name` field
- The `BaseTool` class stores tool properties in a nested `tool` property, but the API handler was incorrectly accessing `name`, `languageId`, and `stdinHint` directly on the class instance instead of via `tool.tool.*`
- Added tests to verify the tools endpoint returns the expected fields

Fixes #8399

## Test plan
- [x] Added unit test that verifies `name` field is included in response
- [x] Added test for empty tools list
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)