### PR TITLE
Fix ClientOptionsType.tools to use proper Tool type

### DIFF
--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -34,7 +34,7 @@ import {getRemoteId} from '../shared/remote-utils.js';
 import {CompilerInfo, Remote} from '../types/compiler.interfaces.js';
 import type {LanguageKey} from '../types/languages.interfaces.js';
 import type {Source} from '../types/source.interfaces.js';
-import type {ToolTypeKey} from '../types/tool.interfaces.js';
+import type {Tool, ToolTypeKey} from '../types/tool.interfaces.js';
 import {AppArguments} from './app.interfaces.js';
 import {logger} from './logger.js';
 import {ClientOptionsSource} from './options-handler.interfaces.js';
@@ -83,7 +83,7 @@ export type ClientOptionsType = {
     compilers: CompilerInfo[];
     libs: Record<string, Record<string, OptionsHandlerLibrary>>;
     remoteLibs: Record<any, any>;
-    tools: Record<any, any>;
+    tools: Record<LanguageKey, Record<string, Tool>>;
     defaultLibs: Record<LanguageKey, string>;
     defaultCompiler: Record<LanguageKey, string>;
     compileOptions: Record<LanguageKey, string>;


### PR DESCRIPTION
## Summary
- Changes `ClientOptionsType.tools` from `Record<any, any>` to `Record<LanguageKey, Record<string, Tool>>`
- This prevents bugs like the one fixed in #8406 where `tool.name` was used instead of `tool.tool.name`
- The `any` type was escaping type checking entirely

## Test plan
- [x] `npm run ts-check` passes
- [x] `npm run test-min` passes

🤖 Generated with [Claude Code](https://claude.ai/code)