### PR TITLE
Use CompilationInfo type instead of Record<any, any> in tooling

### DIFF
--- a/lib/tooling/compiler-dropin-tool.ts
+++ b/lib/tooling/compiler-dropin-tool.ts
@@ -43,12 +43,12 @@ export class CompilerDropinTool extends BaseTool {
         this.addOptionsToToolArgs = false;
     }
 
-    getToolchainPath(compilationInfo: Record<any, any>): string | false {
+    getToolchainPath(compilationInfo: CompilationInfo): string | false {
         return getToolchainPath(compilationInfo.compiler.exe, compilationInfo.compiler.options);
     }
 
     getOrderedArguments(
-        compilationInfo: Record<any, any>,
+        compilationInfo: CompilationInfo,
         includeflags: string[],
         libOptions: string[],
         args?: string[],

--- a/lib/tooling/microsoft-analysis-tool.ts
+++ b/lib/tooling/microsoft-analysis-tool.ts
@@ -25,6 +25,7 @@
 import path from 'node:path';
 
 import {splitArguments} from '../../shared/common-utils.js';
+import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../../types/tool.interfaces.js';
 import {unwrap} from '../assert.js';
 import {logger} from '../logger.js';
@@ -44,7 +45,7 @@ export class MicrosoftAnalysisTool extends BaseTool {
         this.addOptionsToToolArgs = false;
     }
 
-    async runCompilerTool(compilationInfo: Record<any, any>, inputFilepath?: string, args?: string[], stdin?: string) {
+    async runCompilerTool(compilationInfo: CompilationInfo, inputFilepath?: string, args?: string[], stdin?: string) {
         const execOptions = this.getDefaultExecOptions();
         if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);
         execOptions.input = stdin;
@@ -77,7 +78,7 @@ export class MicrosoftAnalysisTool extends BaseTool {
     }
 
     override async runTool(
-        compilationInfo: Record<any, any>,
+        compilationInfo: CompilationInfo,
         inputFilepath?: string,
         args?: string[],
         stdin?: string,

--- a/lib/tooling/sonar-tool.ts
+++ b/lib/tooling/sonar-tool.ts
@@ -179,7 +179,7 @@ export class SonarTool extends BaseTool {
     }
 
     buildCompilationCMD(
-        compilationInfo: Record<any, any>,
+        compilationInfo: CompilationInfo,
         inputFilePath: string,
         supportedLibraries?: Record<string, OptionsHandlerLibrary>,
     ) {

--- a/test/tool-tests.ts
+++ b/test/tool-tests.ts
@@ -34,6 +34,7 @@ import {
 } from '../lib/toolchain-utils.js';
 import {ToolEnv} from '../lib/tooling/base-tool.interface.js';
 import {CompilerDropinTool} from '../lib/tooling/compiler-dropin-tool.js';
+import {CompilationInfo} from '../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../types/tool.interfaces.js';
 
 describe('CompilerDropInTool', () => {
@@ -46,7 +47,7 @@ describe('CompilerDropInTool', () => {
                 options: '--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0',
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args: string[] = [];
         const sourcefile = 'example.cpp';
@@ -67,7 +68,7 @@ describe('CompilerDropInTool', () => {
                 options: '',
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args: string[] = [];
         const sourcefile = 'example.cpp';
@@ -88,7 +89,7 @@ describe('CompilerDropInTool', () => {
                 options: '',
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args: string[] = [];
         const sourcefile = 'example.cpp';
@@ -110,7 +111,7 @@ describe('CompilerDropInTool', () => {
                 options: '--gxx-name=/opt/compiler-explorer/gcc-8.2.0/bin/g++',
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args: string[] = [];
         const sourcefile = 'example.cpp';
@@ -134,7 +135,7 @@ describe('CompilerDropInTool', () => {
                 internalIncludePaths: ['/opt/compiler-explorer/windows/19.14.26423/include'],
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args = ['/MD', '/STD:c++latest', '/Ox'];
         const sourcefile = 'example.cpp';
@@ -153,7 +154,7 @@ describe('CompilerDropInTool', () => {
                 internalIncludePaths: ['/opt/compiler-explorer/clang-concepts-trunk/something/etc/include'],
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args: string[] = [];
         const sourcefile = 'example.cpp';
@@ -172,7 +173,7 @@ describe('CompilerDropInTool', () => {
                 internalIncludePaths: ['/opt/compiler-explorer/clang-concepts-trunk/something/etc/include'],
             },
             options: [],
-        };
+        } as unknown as CompilationInfo;
         const includeflags: string[] = [];
         const args: string[] = [];
         const sourcefile = 'example.cpp';


### PR DESCRIPTION
## Summary
- Replaces `Record<any, any>` with `CompilationInfo` for the `compilationInfo` parameter in tooling files
- The `CompilationInfo` type was already imported in 2 of 3 files but not used
- Follows up on #8407 which fixed the same issue for `tools` type

## Files changed
- `compiler-dropin-tool.ts` - use existing import
- `sonar-tool.ts` - use existing import  
- `microsoft-analysis-tool.ts` - add import
- `test/tool-tests.ts` - cast mock objects at declaration

## Test plan
- [x] `npm run ts-check` passes
- [x] `npm run test-min` passes

🤖 Generated with [Claude Code](https://claude.ai/code)