### PR TITLE
Add LFortran versions from 0.53 to 0.59

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1073,7 +1073,7 @@ compiler.flangtrunk-fc.alias=flangtrunknew-fc
 
 #################################
 # LFortran
-group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520
+group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520:lfortran0530:lfortran0540:lfortran0550:lfortran0560:lfortran0570:lfortran0580:lfortran0590
 group.lfortran.groupName=LFortran
 group.lfortran.baseName=LFortran
 group.lfortran.supportsBinary=true
@@ -1115,6 +1115,27 @@ compiler.lfortran0510.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.lfortran0520.exe=/opt/compiler-explorer/lfortran/v0.52.0/bin/lfortran
 compiler.lfortran0520.semver=0.52.0
 compiler.lfortran0520.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0530.exe=/opt/compiler-explorer/lfortran/v0.53.0/bin/lfortran
+compiler.lfortran0530.semver=0.53.0
+compiler.lfortran0530.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0540.exe=/opt/compiler-explorer/lfortran/v0.54.0/bin/lfortran
+compiler.lfortran0540.semver=0.54.0
+compiler.lfortran0540.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0550.exe=/opt/compiler-explorer/lfortran/v0.55.0/bin/lfortran
+compiler.lfortran0550.semver=0.55.0
+compiler.lfortran0550.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0560.exe=/opt/compiler-explorer/lfortran/v0.56.0/bin/lfortran
+compiler.lfortran0560.semver=0.56.0
+compiler.lfortran0560.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0570.exe=/opt/compiler-explorer/lfortran/v0.57.0/bin/lfortran
+compiler.lfortran0570.semver=0.57.0
+compiler.lfortran0570.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0580.exe=/opt/compiler-explorer/lfortran/v0.58.0/bin/lfortran
+compiler.lfortran0580.semver=0.58.0
+compiler.lfortran0580.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0590.exe=/opt/compiler-explorer/lfortran/v0.59.0/bin/lfortran
+compiler.lfortran0590.semver=0.59.0
+compiler.lfortran0590.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 
 ###############################
 # GCC for ARM 64bit


### PR DESCRIPTION
Adds recent LFortran versions.

Depends on https://github.com/compiler-explorer/infra/pull/1948
