### PR TITLE
Add NVIDIA licence metadata to NVCC, NVRTC, nvc++, nvc, and nvfortran

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4491,6 +4491,8 @@ group.nvcxx_x86_cxx.groupName=nvc++ x86
 group.nvcxx_x86_cxx.baseName=x86 nvc++
 group.nvcxx_x86_cxx.isSemVer=true
 group.nvcxx_x86_cxx.compilerCategories=nvc++
+group.nvcxx_x86_cxx.licenseName=NVIDIA HPC SDK EULA
+group.nvcxx_x86_cxx.licenseLink=https://docs.nvidia.com/hpc-sdk/eula/index.html
 
 compiler.nvcxx_x86_cxx22_7.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvdecode
 compiler.nvcxx_x86_cxx22_7.cuobjdump=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/22.7/cuda/11.7/bin/cuobjdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -439,6 +439,8 @@ group.nvc_x86.groupName=nvc x86
 group.nvc_x86.baseName=x86 nvc
 group.nvc_x86.isSemVer=true
 group.nvc_x86.compilerCategories=nvc
+group.nvc_x86.licenseName=NVIDIA HPC SDK EULA
+group.nvc_x86.licenseLink=https://docs.nvidia.com/hpc-sdk/eula/index.html
 
 compiler.nvc_x86_24_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvdecode
 compiler.nvc_x86_24_9.cuobjdump=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/cuobjdump

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -18,6 +18,8 @@ group.nvcc.includeFlag=-I
 group.nvcc.nvdisasm=/opt/compiler-explorer/cuda/11.7.0/bin/nvdisasm
 group.nvcc.rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
 group.nvcc.options=--keep-device-functions
+group.nvcc.licenseName=NVIDIA CUDA Toolkit EULA
+group.nvcc.licenseLink=https://docs.nvidia.com/cuda/eula/index.html
 compiler.nvcc91.semver=9.1.85
 compiler.nvcc91.exe=/opt/compiler-explorer/cuda/9.1.85/bin/nvcc
 compiler.nvcc91.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin
@@ -569,6 +571,8 @@ group.nvrtc.objdumper=/opt/compiler-explorer/cuda/12.9.1/bin/nvdisasm
 group.nvrtc.rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
 group.nvrtc.options=
 group.nvrtc.demangler=/opt/compiler-explorer/cuda/12.0.1/bin/cu++filt
+group.nvrtc.licenseName=NVIDIA CUDA Toolkit EULA
+group.nvrtc.licenseLink=https://docs.nvidia.com/cuda/eula/index.html
 compiler.nvrtc11.semver=11.0.2
 compiler.nvrtc11.exe=/opt/compiler-explorer/cuda/11.0.2/bin/nvrtc_cli
 compiler.nvrtc11u1.semver=11.0.3

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -330,6 +330,8 @@ group.nvfortran_x86.groupName=nvfortran x86
 group.nvfortran_x86.baseName=x86 nvfortran
 group.nvfortran_x86.isSemVer=true
 group.nvfortran_x86.compilerCategories=nvfortran
+group.nvfortran_x86.licenseName=NVIDIA HPC SDK EULA
+group.nvfortran_x86.licenseLink=https://docs.nvidia.com/hpc-sdk/eula/index.html
 
 compiler.nvfortran_x86_24_9.demangler=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/compilers/bin/nvdecode
 compiler.nvfortran_x86_24_9.cuobjdump=/opt/compiler-explorer/hpc_sdk/Linux_x86_64/24.9/cuda/12.6/bin/cuobjdump


### PR DESCRIPTION
Add `licenseName` and `licenseLink` to all NVIDIA compiler groups:

- **NVCC** and **NVRTC**: NVIDIA CUDA Toolkit EULA
- **nvc++** (C++), **nvc** (C), **nvfortran** (Fortran): NVIDIA HPC SDK EULA

These were the only compiler groups on CE with no licence metadata despite being proprietary software. The CUDA EULA (Section 1.7) explicitly requires compliance with US export controls (EAR/OFAC), including a clause that users confirm they are not in an embargoed country.

Related: #975