### PR TITLE
Add AVR GCC 7.3.0 compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3364,7 +3364,7 @@ compiler.cl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1250:avrg1310:avrg1320:avrg1330:avrg1340:avrg1410:avrg1420:avrg1430:avrg1510:avrg1520
+group.avr.compilers=avrg454:avrg464:avrg540:avrg730:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1250:avrg1310:avrg1320:avrg1330:avrg1340:avrg1410:avrg1420:avrg1430:avrg1510:avrg1520
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -3381,6 +3381,11 @@ compiler.avrg464.objdumper=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-objdump
 compiler.avrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
 compiler.avrg540.semver=5.4.0
 compiler.avrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+
+compiler.avrg730.exe=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-g++
+compiler.avrg730.semver=7.3.0
+compiler.avrg730.objdumper=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-objdump
+compiler.avrg730.demangler=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-c++filt
 
 compiler.avrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-g++
 compiler.avrg920.semver=9.2.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2876,7 +2876,7 @@ compiler.ccl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1250:cavrg1310:cavrg1320:cavrg1330:cavrg1340:cavrg1410:cavrg1420:cavrg1430:cavrg1510:cavrg1520
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg730:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1250:cavrg1310:cavrg1320:cavrg1330:cavrg1340:cavrg1410:cavrg1420:cavrg1430:cavrg1510:cavrg1520
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -2891,6 +2891,11 @@ compiler.cavrg540.semver=5.4.0
 compiler.cavrg540.supportsBinaryObject=true
 
 compiler.cavrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+
+compiler.cavrg730.exe=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-gcc
+compiler.cavrg730.semver=7.3.0
+compiler.cavrg730.objdumper=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-objdump
+compiler.cavrg730.demangler=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-c++filt
 
 compiler.cavrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-gcc
 compiler.cavrg920.semver=9.2.0

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -142,10 +142,15 @@ compiler.gimpleg152assert.semver=15.2 (assertions)
 
 ################################
 # GCC for AVR
-group.gimpleavr.compilers=gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1240:gimpleavrg1250:gimpleavrg1310:gimpleavrg1320:gimpleavrg1330:gimpleavrg1340:gimpleavrg1410:gimpleavrg1420:gimpleavrg1430:gimpleavrg1510:gimpleavrg1520
+group.gimpleavr.compilers=gimpleavrg730:gimpleavrg920:gimpleavrg930:gimpleavrg1030:gimpleavrg1100:gimpleavrg1210:gimpleavrg1220:gimpleavrg1230:gimpleavrg1240:gimpleavrg1250:gimpleavrg1310:gimpleavrg1320:gimpleavrg1330:gimpleavrg1340:gimpleavrg1410:gimpleavrg1420:gimpleavrg1430:gimpleavrg1510:gimpleavrg1520
 group.gimpleavr.groupName=AVR GCC
 group.gimpleavr.baseName=AVR gcc
 group.gimpleavr.isSemVer=true
+
+compiler.gimpleavrg730.exe=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-gcc
+compiler.gimpleavrg730.semver=7.3.0
+compiler.gimpleavrg730.objdumper=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-objdump
+compiler.gimpleavrg730.demangler=/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/avr-c++filt
 
 compiler.gimpleavrg920.exe=/opt/compiler-explorer/avr/gcc-9.2.0/bin/avr-gcc
 compiler.gimpleavrg920.semver=9.2.0


### PR DESCRIPTION
Add AVR GCC 7.3.0 to the C++, C, and GIMPLE compiler configs.

Binary installed at `/opt/compiler-explorer/avr/gcc-7.3.0/avr/bin/`

Built via gcc-cross-builder PR #78 (merged).

Closes #2965