### PR TITLE
Add CCC (Claude's C Compiler) to C language config

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust
+compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust
 defaultCompiler=cg152
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -4137,6 +4137,22 @@ compiler.chibicc-trunk.semver=(trunk)
 compiler.chibicc-trunk.explicitVersion=90d1f7f199cc55b13c7fdb5839d1409806633fdb
 compiler.chibicc-trunk.isNightly=true
 
+################################
+# Claude's C Compiler (CCC)
+group.ccc.isSemVer=true
+group.ccc.groupName=Claude's C Compiler
+group.ccc.compilers=ccc-trunk
+group.ccc.supportsExecute=true
+group.ccc.supportsBinary=true
+group.ccc.includeFlag=-I
+group.ccc.licenseLink=https://github.com/anthropics/claudes-c-compiler/blob/main/LICENSE
+group.ccc.licenseName=CC0 1.0 Universal
+group.ccc.licensePreamble=Public domain dedication by Anthropic
+
+compiler.ccc-trunk.name=CCC (trunk)
+compiler.ccc-trunk.exe=/opt/compiler-explorer/ccc-main/ccc
+compiler.ccc-trunk.semver=(trunk)
+compiler.ccc-trunk.isNightly=true
 
 ################################
 ## CompCert


### PR DESCRIPTION
Add compiler group and nightly trunk entry for [CCC](https://github.com/anthropics/claudes-c-compiler), a C compiler written entirely in Rust by Claude Opus 4.6.

## What is CCC?
A full C compiler with its own frontend, SSA-based IR, optimiser, code generator, assembler, and linker — no external toolchain needed. Targets x86-64, i686, AArch64, and RISC-V 64. Can build PostgreSQL, SQLite, the Linux kernel, and dozens more.

## Config
Follows the chibicc pattern — no custom compilerType needed. GCC-compatible flags (`-S`, `-o`, `-O`, `-g`, `-D`, `-I`) all work.

## Tested locally
- Assembly output with source line/column mapping ✅
- Execution (build + run) ✅
- Filters (labels, directives, comments) ✅
- Properties validation (89/89 tests pass) ✅

## Notes
- AT&T syntax only (`-masm=intel` silently ignored)
- All `-O` levels currently produce identical output (single optimisation pipeline)
- `--version` reports as GCC 14.2.0 for build system compat

Related PRs:
- Builder: compiler-explorer/misc-builder#122
- Install: compiler-explorer/infra#1960

Closes #8443

🤖 Generated by LLM (Claude, via OpenClaw)