### PR TITLE
feat(gcc): add GCC 11.5 for x86 C and C++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -161,6 +161,8 @@ compiler.g113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/g++
 compiler.g113.semver=11.3
 compiler.g114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/g++
 compiler.g114.semver=11.4
+compiler.g115.exe=/opt/compiler-explorer/gcc-11.5.0/bin/g++
+compiler.g115.semver=11.5
 compiler.g121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/g++
 compiler.g121.semver=12.1
 compiler.g122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/g++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -15,7 +15,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-18.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -149,6 +149,8 @@ compiler.cg113.exe=/opt/compiler-explorer/gcc-11.3.0/bin/gcc
 compiler.cg113.semver=11.3
 compiler.cg114.exe=/opt/compiler-explorer/gcc-11.4.0/bin/gcc
 compiler.cg114.semver=11.4
+compiler.cg115.exe=/opt/compiler-explorer/gcc-11.5.0/bin/gcc
+compiler.cg115.semver=11.5
 compiler.cg121.exe=/opt/compiler-explorer/gcc-12.1.0/bin/gcc
 compiler.cg121.semver=12.1
 compiler.cg122.exe=/opt/compiler-explorer/gcc-12.2.0/bin/gcc


### PR DESCRIPTION
Add x86-64 GCC 11.5 to C and C++ compiler groups.

Depends on compiler-explorer/infra PR for installation config.

Closes #7114

🤖 Generated by LLM (Claude, via OpenClaw)