### PR TITLE
feat(asm): add ca65 assembler (cc65 toolchain) for 6502

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&nasm:&gnuas:&llvmas:&llvmasarm64:&ptxas:&gnuasarm:&gnuasarm64:&gnuasriscv:&beebasm
+compilers=&nasm:&gnuas:&llvmas:&llvmasarm64:&ptxas:&gnuasarm:&gnuasarm64:&gnuasriscv:&beebasm:&ca65
 compilerType=assembly
 objdumper=/opt/compiler-explorer/gcc-12.1.0/bin/objdump
 supportsBinary=true
@@ -565,6 +565,30 @@ group.beebasm.instructionSet=6502
 
 compiler.beebasm109.semver=1.09
 compiler.beebasm109.exe=/opt/compiler-explorer/beebasm-1.09/beebasm
+
+group.ca65.compilers=ca65_217:ca65_218:ca65_219:ca65_trunk
+group.ca65.versionFlag=--version
+group.ca65.isSemVer=true
+group.ca65.baseName=ca65
+group.ca65.compilerType=ca65
+group.ca65.supportsBinary=false
+group.ca65.supportsExecute=false
+group.ca65.instructionSet=6502
+group.ca65.options=--include-dir /opt/compiler-explorer/6502/cc65-trunk/share/cc65/asminc
+
+compiler.ca65_217.semver=2.17
+compiler.ca65_217.exe=/opt/compiler-explorer/6502/cc65-2.17/bin/ca65
+compiler.ca65_217.options=--include-dir /opt/compiler-explorer/6502/cc65-2.17/share/cc65/asminc
+compiler.ca65_218.semver=2.18
+compiler.ca65_218.exe=/opt/compiler-explorer/6502/cc65-2.18/bin/ca65
+compiler.ca65_218.options=--include-dir /opt/compiler-explorer/6502/cc65-2.18/share/cc65/asminc
+compiler.ca65_219.semver=2.19
+compiler.ca65_219.exe=/opt/compiler-explorer/6502/cc65-2.19/bin/ca65
+compiler.ca65_219.options=--include-dir /opt/compiler-explorer/6502/cc65-2.19/share/cc65/asminc
+compiler.ca65_trunk.semver=(trunk)
+compiler.ca65_trunk.exe=/opt/compiler-explorer/6502/cc65-trunk/bin/ca65
+compiler.ca65_trunk.options=--include-dir /opt/compiler-explorer/6502/cc65-trunk/share/cc65/asminc
+compiler.ca65_trunk.isNightly=true
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -30,6 +30,7 @@ export {AvrGcc6502Compiler} from './avrgcc6502.js';
 export {BeebAsmCompiler} from './beebasm.js';
 export {C2RustCompiler} from './c2rust.js';
 export {C3Compiler} from './c3c.js';
+export {Ca65Compiler} from './ca65.js';
 export {CarbonCompiler, CarbonExplorerCompiler} from './carbon.js';
 export {Cc65Compiler} from './cc65.js';
 export {CerberusCompiler} from './cerberus.js';

--- a/lib/compilers/ca65.ts
+++ b/lib/compilers/ca65.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'node:path';
+
+import type {ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {AsmParserCa65} from '../parsers/asm-parser-ca65.js';
+
+export class Ca65Compiler extends BaseCompiler {
+    static get key() {
+        return 'ca65';
+    }
+
+    constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(compilerInfo, env);
+
+        this.asm = new AsmParserCa65(this.compilerProps);
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions) {
+        // ca65 listing output is always parsed as binary (address + hex + source format)
+        filters.binary = true;
+        return [];
+    }
+
+    override supportsObjdump() {
+        // ca65 output is a listing file, not a binary — objdump doesn't apply
+        return false;
+    }
+
+    override getSharedLibraryPathsAsArguments() {
+        return [];
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+    ) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+
+        const dirPath = path.dirname(inputFilename);
+        if (!execOptions.customCwd) {
+            execOptions.customCwd = dirPath;
+        }
+
+        const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase);
+
+        // Always generate a listing with full macro expansion, writing directly to the output file
+        const hasListingOpt = options.some(opt => opt === '-l' || opt === '--listing');
+        if (!hasListingOpt) {
+            options = ['-l', outputFilename, '-x', '-x', '--list-bytes', '0', ...options];
+        }
+
+        const compilerExecResult = await this.exec(compiler, options, execOptions);
+        const result = this.transformToCompilationResult(compilerExecResult, inputFilename);
+
+        result.forceBinaryView = true;
+
+        return result;
+    }
+
+    override isCfgCompiler(): boolean {
+        return true;
+    }
+}

--- a/lib/parsers/asm-parser-ca65.ts
+++ b/lib/parsers/asm-parser-ca65.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import type {ParsedAsmResult, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import type {PropertyGetter} from '../properties.interfaces.js';
+import {AsmParser} from './asm-parser.js';
+
+export class AsmParserCa65 extends AsmParser {
+    // ca65 listing format:
+    // AAAAAA  D  [HH HH HH ...]  source text
+    // where AAAAAA is hex address (may end with 'r' for relocatable),
+    // D is include depth, and HH are hex bytes.
+    // Lines may also be blank or contain just a page header.
+    listingLineRe: RegExp;
+    pageHeaderRe: RegExp;
+
+    constructor(compilerProps: PropertyGetter) {
+        super(compilerProps);
+
+        // Match: address (6 hex + optional 'r'), depth, optional hex/reloc bytes, then source.
+        // Hex bytes can include 'rr' (relocatable) and 'xx' (uninitialised) markers.
+        this.listingLineRe = /^([0-9A-Fa-f]{6}r?)\s+(\d+)\s{2}((?:(?:[0-9A-Fa-f]{2}|rr|xx)\s)*)\s*(.*)/;
+        // Page headers and file info lines from ca65 listing preamble
+        this.pageHeaderRe = /^\f|^ca65\s|^Main file\s|^Current file:/;
+    }
+
+    override processBinaryAsm(asm: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
+        const result: ParsedAsmResultLine[] = [];
+        const asmLines = asm.split('\n');
+
+        if (asmLines.length === 1 && asmLines[0][0] === '<') {
+            return {asm: [{text: asmLines[0], source: null}]};
+        }
+
+        for (const line of asmLines) {
+            if (line.trim() === '' || this.pageHeaderRe.test(line)) {
+                continue;
+            }
+
+            const match = line.match(this.listingLineRe);
+            if (match) {
+                const address = match[1];
+                const hexBytes = match[3].trim();
+                const sourceText = match[4];
+
+                if (!sourceText && !hexBytes) {
+                    continue;
+                }
+
+                let text: string;
+                if (hexBytes) {
+                    const addr = address.replace(/r$/, '');
+                    text = `${addr}: ${hexBytes.padEnd(12)} ${sourceText}`;
+                } else {
+                    text = '                     ' + sourceText;
+                }
+
+                result.push({text});
+            } else {
+                result.push({text: line});
+            }
+        }
+
+        return {asm: result};
+    }
+}

--- a/test/filters-cases/ca65-example.asm
+++ b/test/filters-cases/ca65-example.asm
@@ -1,0 +1,28 @@
+ca65 V2.19 - Git f166ca8
+Main file   : /tmp/ca65-test.s
+Current file: /tmp/ca65-test.s
+
+000000r 1               .segment "CODE"
+000000r 1               
+000000r 1               ; Simple 6502 test with macros
+000000r 1               .macro inc16 addr
+000000r 1                   inc addr
+000000r 1                   bne :+
+000000r 1                   inc addr+1
+000000r 1               :
+000000r 1               .endmacro
+000000r 1               
+000000r 1               .proc main
+000000r 1  A9 00            lda #$00
+000002r 1  8D 00 D0         sta $D000
+000005r 1                   inc16 counter
+000005r 0  EE rr rr     >  inc addr
+000008r 0  D0 03        >  bne :++
+00000Ar 0  EE rr rr     >  inc addr+1
+00000Dr 0               > :
+00000Dr 1  60               rts
+00000Er 1               .endproc
+00000Er 1               
+00000Er 1               .segment "BSS"
+000000r 1  xx xx        counter: .res 2
+000000r 1               

--- a/test/filters-cases/ca65-example.asm.binary.directives.labels.comments.json
+++ b/test/filters-cases/ca65-example.asm.binary.directives.labels.comments.json
@@ -1,0 +1,64 @@
+{
+  "asm": [
+    {
+      "text": "                     .segment \"CODE\""
+    },
+    {
+      "text": "                     ; Simple 6502 test with macros"
+    },
+    {
+      "text": "                     .macro inc16 addr"
+    },
+    {
+      "text": "                     inc addr"
+    },
+    {
+      "text": "                     bne :+"
+    },
+    {
+      "text": "                     inc addr+1"
+    },
+    {
+      "text": "                     :"
+    },
+    {
+      "text": "                     .endmacro"
+    },
+    {
+      "text": "                     .proc main"
+    },
+    {
+      "text": "000000: A9 00        lda #$00"
+    },
+    {
+      "text": "000002: 8D 00 D0     sta $D000"
+    },
+    {
+      "text": "                     inc16 counter"
+    },
+    {
+      "text": "000005: EE rr rr     >  inc addr"
+    },
+    {
+      "text": "000008: D0 03        >  bne :++"
+    },
+    {
+      "text": "00000A: EE rr rr     >  inc addr+1"
+    },
+    {
+      "text": "                     > :"
+    },
+    {
+      "text": "00000D: 60           rts"
+    },
+    {
+      "text": "                     .endproc"
+    },
+    {
+      "text": "                     .segment \"BSS\""
+    },
+    {
+      "text": "000000: xx xx        counter: .res 2"
+    }
+  ]
+}

--- a/test/filters-cases/ca65-example.asm.directives.comments.json
+++ b/test/filters-cases/ca65-example.asm.directives.comments.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.directives.json
+++ b/test/filters-cases/ca65-example.asm.directives.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.directives.labels.comments.json
+++ b/test/filters-cases/ca65-example.asm.directives.labels.comments.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/ca65-example.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/ca65-example.asm.directives.labels.comments.library.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.directives.labels.json
+++ b/test/filters-cases/ca65-example.asm.directives.labels.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.directives.library.json
+++ b/test/filters-cases/ca65-example.asm.directives.library.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/ca65-example.asm.none.json
+++ b/test/filters-cases/ca65-example.asm.none.json
@@ -1,0 +1,145 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "ca65 V2.19 - Git f166ca8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Main file   : /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "Current file: /tmp/ca65-test.s"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .segment \"CODE\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               ; Simple 6502 test with macros"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .macro inc16 addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   bne :+"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1                   inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .endmacro"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               .proc main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  A9 00            lda #$00"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000002r 1  8D 00 D0         sta $D000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 1                   inc16 counter"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000005r 0  EE rr rr     >  inc addr"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000008r 0  D0 03        >  bne :++"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Ar 0  EE rr rr     >  inc addr+1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 0               > :"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Dr 1  60               rts"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               "
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "00000Er 1               .segment \"BSS\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1  xx xx        counter: .res 2"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "000000r 1               "
+    }
+  ],
+  "labelDefinitions": {}
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,6 +36,7 @@ export const skipExpensiveTests = process.env.SKIP_EXPENSIVE_TESTS === 'true';
 import {CompilationEnvironment} from '../lib/compilation-env.js';
 import {CompilationQueue} from '../lib/compilation-queue.js';
 import {AsmParser} from '../lib/parsers/asm-parser.js';
+import {AsmParserCa65} from '../lib/parsers/asm-parser-ca65.js';
 import {CC65AsmParser} from '../lib/parsers/asm-parser-cc65.js';
 import {AsmEWAVRParser} from '../lib/parsers/asm-parser-ewavr.js';
 import {PTXAsmParser} from '../lib/parsers/asm-parser-ptx.js';
@@ -127,6 +128,7 @@ export function processAsm(filename: string, filters: ParseFiltersAndOutputOptio
     if (file.includes('Microsoft')) parser = new VcAsmParser();
     else if (filename.includes('sass-')) parser = new SassAsmParser();
     else if (filename.includes('ptx-')) parser = new PTXAsmParser();
+    else if (filename.includes('ca65-')) parser = new AsmParserCa65(fakeProps({}));
     else if (filename.includes('cc65-')) parser = new CC65AsmParser(fakeProps({}));
     else if (filename.includes('ewarm-')) parser = new AsmEWAVRParser(fakeProps({}));
     else {


### PR DESCRIPTION
Add ca65 as a standalone assembler under the Assembly language, reusing the existing cc65 toolchain installations (2.17, 2.18, 2.19, trunk).

ca65 generates a listing file with full macro expansion (`-x -x`) so users can debug macro output — the primary use case from the feature request.

**What's included:**
- `Ca65Compiler` class — runs ca65, captures the listing output
- `AsmParserCa65` — parses the ca65 listing format (address, hex bytes, source)
- Config for all 4 existing cc65 versions as ca65 assemblers
- Include paths set to each version's `asminc` directory

**How it works:**
Since ca65 produces object files in cc65's custom format (not ELF), we can't objdump them. Instead, we use ca65's `-l` (listing) flag with `-x -x` (full macro expansion) and `--list-bytes 0` (unlimited hex bytes per line). The listing shows addresses, generated bytes, and expanded source — exactly what users need for macro debugging.

Closes #7118