### PR TITLE
[Feature] Add NVVM IR as  additional input to CE

### DIFF
--- a/examples/nvvm/default.ll
+++ b/examples/nvvm/default.ll
@@ -1,0 +1,26 @@
+target triple = "nvptx64-unknown-cuda"
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
+
+define i32 @ave(i32 %a, i32 %b) {{
+entry:
+  %add = add nsw i32 %a, %b
+  %div = sdiv i32 %add, 2
+  ret i32 %div
+}}
+
+define void @simple(i32* %data) {{
+entry:
+  %0 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
+  %1 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
+  %mul = mul i32 %0, %1
+  %2 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  %add = add i32 %mul, %2
+  %call = call i32 @ave(i32 %add, i32 %add)
+  %idxprom = sext i32 %add to i64
+  store i32 %call, i32* %data, align 4
+  ret void
+}}
+
+declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.ntid.x() nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() nounwind readnone

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -121,6 +121,7 @@ export {NumbaCompiler} from './numba.js';
 export {NvccCompiler} from './nvcc.js';
 export {NvcppCompiler} from './nvcpp.js';
 export {NvrtcCompiler} from './nvrtc.js';
+export {NVVMCompiler} from './nvvm.js';
 export {OCamlCompiler} from './ocaml.js';
 export {OdinCompiler} from './odin.js';
 export {OptCompiler} from './opt.js';

--- a/lib/compilers/nvvm.ts
+++ b/lib/compilers/nvvm.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'node:path';
+
+import Semver from 'semver';
+
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {unwrap} from '../assert.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {SassAsmParser} from '../parsers/asm-parser-sass.js';
+import {asSafeVer} from '../utils.js';
+import {ClangParser} from './argument-parsers.js';
+
+export class NVVMCompiler extends BaseCompiler {
+    static get key() {
+        return 'nvvm';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(info, env);
+        this.asm = new SassAsmParser(this.compilerProps);
+    }
+
+    override getOutputFilename(dirPath) {
+        return path.join(dirPath, 'example.n001.ptx');
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
+        return ['--nvptx64-nvidia-cuda', '-o', this.filename(outputFilename)];
+    }
+
+    override async objdump(outputFilename: string, result: any, maxSize: number) {
+        // ptx -> cubin
+        const ptxas_args = ['-o', 'example.n001.bin'];
+        const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
+        await this.exec('ptxas', ptxas_args, execOptions);
+
+        // nvdisasm cubin -> SASS
+        const {nvdisasm, semver} = this.compiler;
+
+        const args = Semver.lt(asSafeVer(semver), '11.0.0', true)
+            ? [outputFilename, '-c', '-g']
+            : [outputFilename, '-c', '-g', '-hex'];
+
+        const {code, execTime, stdout} = await this.exec(unwrap(nvdisasm), args, {
+            maxOutput: maxSize,
+            customCwd: result.dirPath,
+        });
+
+        if (code === 0) {
+            result.objdumpTime = execTime;
+            result.asm = stdout;
+        } else {
+            result.asm = `<No output: ${path.basename(unwrap(nvdisasm))} returned ${code}>`;
+        }
+        return result;
+    }
+
+    override getArgumentParserClass() {
+        return ClangParser;
+    }
+}

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -640,6 +640,17 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
     },
+    nvvm: {
+        name: 'NVVM IR',
+        monaco: 'llvm-ir',
+        extensions: ['.ll'],
+        alias: [],
+        logoFilename: 'cuda.svg',
+        logoFilenameDark: 'cuda-dark.svg',
+        formatter: null,
+        previewFilter: null,
+        monacoDisassembly: null,
+    },
     numba: {
         name: 'Numba',
         monaco: 'python',

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -80,6 +80,7 @@ export type LanguageKey =
     | 'nim'
     | 'nix'
     | 'numba'
+    | 'nvvm'
     | 'ocaml'
     | 'odin'
     | 'objc'


### PR DESCRIPTION
# Motivation:

Discussion : #8184 This PR is intended to add NVVM IR input support to Compiler Explorer. CE accepts LLVM IR as input but does not currently have the capability to compile NVVM IR. We do have PTX support (refactored as part of #7615 ) and this would be an additional feature to support NVVM IR compilation flow  through libnvvm source.  This would allow users to add NVVM (which is PTX specific instructions made compatible with LLVM through NVPTX backend ).  
Currently marking as WIP.

cc @mattgodbolt @partouf  
