### PR TITLE
[llvm-ir]: Filter empty metadata nodes

### DIFF
--- a/lib/llvm-ir.ts
+++ b/lib/llvm-ir.ts
@@ -69,7 +69,7 @@ export class LlvmIrParser {
         }
 
         this.debugReference = /!dbg (!\d+)/;
-        this.metaNodeRe = /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]+?)\)/;
+        this.metaNodeRe = /^(!\d+) = (?:distinct )?!DI([A-Za-z]+)\(([^)]*?)\)/;
         this.otherMetaDirective = /^(!\d+) = (?:distinct )?!{.*}/;
         this.namedMetaDirective = /^(![.A-Z_a-z-]+) = (?:distinct )?!{.*}/;
         this.metaNodeOptionsRe = /(\w+): (!?\d+|\w+|""|"(?:[^"]|\\")*[^\\]")/gi;

--- a/test/llvm-ir-parser-tests.ts
+++ b/test/llvm-ir-parser-tests.ts
@@ -99,6 +99,13 @@ describe('llvm-ir parseMetaNode', () => {
             directory: '/home/compiler-explorer',
         });
     });
+
+    it('should parse meta nodes without operands', () => {
+        expect(llvmIrParser.parseMetaNode('!123 = distinct !DIAssignID()')).toEqual({
+            metaType: 'AssignID',
+            metaId: '!123',
+        });
+    });
 });
 
 describe('llvm-ir getSourceLineNumber', () => {


### PR DESCRIPTION
LLVM IR specialised metadata nodes can have no arguments, e. g. [`DIAssignID`](https://llvm.org/docs/LangRef.html#diassignid), which is commonly emitted by `clang` (https://godbolt.org/z/rb19oGMoT).

These were not filtered because the regex required at least one character in the field list.