### PR TITLE
Fix cypress typeRoots to find bundled types

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "es2015",
     "moduleResolution": "bundler",
     /* Code generation */
-    "typeRoots": ["../node_modules/@types"],
+    "typeRoots": ["../node_modules/@types", "../node_modules"],
     /* https://github.com/cypress-io/cypress/issues/26203#issuecomment-1571861397 */
     "sourceMap": false,
     "types": ["cypress"]


### PR DESCRIPTION
Add `../node_modules` to `typeRoots` in `cypress/tsconfig.json` so that TypeScript can find type definitions bundled directly in packages (like cypress) rather than only looking in `@types`.

Previously, `typeRoots` only included `../node_modules/@types`, which meant `tsc -p cypress/tsconfig.json` couldn't find cypress's bundled types at `node_modules/cypress/types/index.d.ts`.

Fixes #4831

🤖 Generated by LLM (Claude, via OpenClaw)