### PR TITLE
fix: add node_modules to cypress typeRoots

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "es2015",
     "moduleResolution": "bundler",
     /* Code generation */
-    "typeRoots": ["../node_modules/@types"],
+    "typeRoots": ["../node_modules/@types", "../node_modules"],
     /* https://github.com/cypress-io/cypress/issues/26203#issuecomment-1571861397 */
     "sourceMap": false,
     "types": ["cypress"]


### PR DESCRIPTION
Cypress bundles its types at `node_modules/cypress/types/` rather than in `@types`, so the `typeRoots` array in `cypress/tsconfig.json` needs to include `../node_modules` in addition to `../node_modules/@types`.

Without this, `npx tsc -p cypress/tsconfig.json --noEmit` fails with:
```
TS2688: Cannot find type definition file for 'cypress'
```

Fixes #4831

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*