### PR TITLE
fix: allow plus signs in property key names and values

### DIFF
--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -96,7 +96,7 @@ export function parseProperties(
     for (const [index, lineOrig] of blob.split('\n').entries()) {
         const line = lineOrig.replace(/#.*/, '').trim();
         if (!line) continue;
-        const split = line.match(/([^=+]+)(\+?=)(.*)/);
+        const split = line.match(/(.+?)(\+?=)(.*)/);
         if (!split) {
             onError({line: index + 1, text: lineOrig.trim()}, name);
             continue;

--- a/test/properties-test.ts
+++ b/test/properties-test.ts
@@ -211,6 +211,16 @@ describe('Properties append syntax', () => {
         expect(props.flag).toBe(true);
     });
 
+    it('should not trigger += when key contains a plus sign like abc+def=etc', () => {
+        const props = properties.parseProperties('abc+def=etc\n', '<test props>');
+        expect(props['abc+def']).toEqual('etc');
+    });
+
+    it('should preserve plus signs in values', () => {
+        const props = properties.parseProperties('abc=def+ghi\n', '<test props>');
+        expect(props.abc).toEqual('def+ghi');
+    });
+
     it('should preserve leading whitespace for += but trim trailing', () => {
         const props = properties.parseProperties('opts=-Wall\n' + 'opts+= -Wextra   \n', '<test props>');
         // Leading space preserved, trailing trimmed


### PR DESCRIPTION
## Summary
- Fixes the property parser regex to allow `+` in key names (e.g. `abc+def=etc`)
- The regex from #8387 used `[^=+]+` for key matching, which excluded `+` from key names entirely
- Changed to a lazy `.+?` match so `+` is only treated as the `+=` operator when immediately before `=`

This is a small targeted fix and does not address all edge cases with the `+=` syntax.

## Test plan
- [x] Added test: `abc+def=etc` correctly sets key `abc+def` to `etc`
- [x] Added test: `abc=def+ghi` correctly sets key `abc` to `def+ghi`
- [x] All existing `+=` append tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)