### PR TITLE
Add support for additional compiler options in .NET compilers

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -162,7 +162,7 @@ class DotNetCompiler extends BaseCompiler {
             if (!currentOption) {
                 continue;
             }
-            if (currentOption === '--compopt' || currentOption === '--compiler-options') {
+            if (currentOption === '-compopt' || currentOption === '--compiler-options') {
                 const value = options.shift();
                 if (value) {
                     compilerOptions.push(value);
@@ -603,7 +603,7 @@ do()
                 break;
             }
 
-            if (currentOption === '--compopt' || currentOption === '--compiler-options') {
+            if (currentOption === '-compopt' || currentOption === '--compiler-options') {
                 options.shift(); // skip the value for this option, we don't need it
                 continue;
             }


### PR DESCRIPTION
Today we only support passing options to the codegen backend, but not the compiler that produces IL.

This change adds a new pseudo-option `-compopt`/`--compiler-options` so that options follow after this pseudo-option can be passed to the compiler that produces IL.