### PR TITLE
feat(cypress): intercept-based fake compiler for E2E tests (Option C)

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          start: npm run dev -- --language c++ --no-local
+          start: npm run dev -- --language c++ --env cypress --no-local
           wait-on: 'http://localhost:10240'
           wait-on-timeout: 120
           config: screenshotOnRunFailure=true,video=false

--- a/cypress/e2e/claude-explain.cy.ts
+++ b/cypress/e2e/claude-explain.cy.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {setupFakeCompiler, stubCompileResponse} from '../support/fake-compile';
 import {clearAllIntercepts, setMonacoEditorContent, stubConsoleOutput} from '../support/utils';
 
 // Claude Explain specific test utilities
@@ -70,7 +71,8 @@ function setupClaudeExplainEnvironment() {
         'blockedProduction',
     );
 
-    // Set up configuration
+    // Set up fake compiler and configuration
+    setupFakeCompiler();
     cy.visit('/', {
         onBeforeLoad: (win: any) => {
             stubConsoleOutput(win);
@@ -496,7 +498,8 @@ describe('Claude Explain feature', () => {
 
     describe('Compilation state handling', () => {
         it('should handle compilation failures', () => {
-            // Add invalid code
+            // Stub a compilation failure and add invalid code
+            stubCompileResponse({code: 1, stderr: [{text: 'error: invalid code'}]});
             setMonacoEditorContent('this is not valid C++ code');
 
             openClaudeExplainPaneWithOptions();
@@ -591,6 +594,7 @@ describe('Claude Explain feature', () => {
                 }).as('blockedProduction');
 
                 // Visit the URL with configuration
+                setupFakeCompiler();
                 cy.visit(url, {
                     onBeforeLoad: (win: any) => {
                         win.compilerExplorerOptions = win.compilerExplorerOptions || {};

--- a/cypress/e2e/execute.cy.ts
+++ b/cypress/e2e/execute.cy.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {stubExecutorResponse} from '../support/fake-compile';
 import {
     assertNoConsoleOutput,
     compilerOutput,
@@ -55,9 +56,8 @@ describe('Executor', () => {
 
     it('should show program stdout', () => {
         waitForEditors();
-        setMonacoEditorContent(`\
-#include <cstdio>
-int main() { printf("hello from cypress"); return 0; }`);
+        stubExecutorResponse({stdout: [{text: 'hello from cypress'}]});
+        setMonacoEditorContent('int main() { return 0; }');
         monacoEditorTextShouldContain(compilerOutput(), 'main');
         openExecutor();
         executorPane().find('.execution-stdout', {timeout: 15000}).should('contain.text', 'hello from cypress');
@@ -65,6 +65,7 @@ int main() { printf("hello from cypress"); return 0; }`);
 
     it('should show non-zero exit code', () => {
         waitForEditors();
+        stubExecutorResponse({code: 42});
         setMonacoEditorContent('int main() { return 42; }');
         monacoEditorTextShouldContain(compilerOutput(), 'main');
         openExecutor();
@@ -73,11 +74,10 @@ int main() { printf("hello from cypress"); return 0; }`);
 
     it('should show stderr output', () => {
         waitForEditors();
-        setMonacoEditorContent(`\
-#include <cstdio>
-int main() { fprintf(stderr, "error output"); return 0; }`);
+        stubExecutorResponse({stderr: [{text: 'error output from test'}]});
+        setMonacoEditorContent('int main() { return 0; }');
         monacoEditorTextShouldContain(compilerOutput(), 'main');
         openExecutor();
-        executorPane().find('.execution-output', {timeout: 15000}).should('contain.text', 'error output');
+        executorPane().find('.execution-output', {timeout: 15000}).should('contain.text', 'error output from test');
     });
 });

--- a/cypress/e2e/frontend.cy.ts
+++ b/cypress/e2e/frontend.cy.ts
@@ -1,4 +1,5 @@
 import {serialiseState} from '../../shared/url-serialization.js';
+import {setupFakeCompiler} from '../support/fake-compile';
 import {assertNoConsoleOutput, stubConsoleOutput} from '../support/utils';
 
 const PANE_DATA_MAP = {
@@ -31,6 +32,7 @@ const PANE_DATA_MAP = {
 
 describe('Individual pane testing', () => {
     beforeEach(() => {
+        setupFakeCompiler();
         cy.visit('/', {
             onBeforeLoad: win => {
                 stubConsoleOutput(win);
@@ -124,36 +126,36 @@ function buildKnownGoodState() {
     // Define minimal component states for each pane type
     const paneStates: Record<string, any> = {
         codeEditor: {id: editorId, lang, source},
-        compiler: {compiler: 'gdefault', id: compilerId, lang, source: editorId},
+        compiler: {compiler: 'fake1', id: compilerId, lang, source: editorId},
         conformance: {editorid: editorId, langId: lang, source},
         output: {compiler: compilerId},
         executor: {compiler: compilerId},
-        opt: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        stackusage: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        pp: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        ast: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        ir: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        llvmOptPipelineView: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        device: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        rustmir: {compilerName: 'g++ default', editorid: editorId, id: compilerId, treeid: 0},
-        rusthir: {compilerName: 'g++ default', editorid: editorId, id: compilerId, treeid: 0},
-        rustmacroexp: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        haskellCore: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        haskellStg: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        haskellCmm: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        yul: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
-        clojuremacroexp: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
+        opt: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        stackusage: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        pp: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        ast: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        ir: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        llvmOptPipelineView: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        device: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        rustmir: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId, treeid: 0},
+        rusthir: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId, treeid: 0},
+        rustmacroexp: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        haskellCore: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        haskellStg: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        haskellCmm: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        yul: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
+        clojuremacroexp: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
         gccdump: {
-            compilerName: 'g++ default',
+            compilerName: 'Fake Compiler #1',
             editorid: editorId,
             id: compilerId,
             treeid: 0,
             gccDumpOptions: {},
         },
-        gnatdebugtree: {compilerName: 'g++ default', editorid: editorId, id: compilerId, treeid: 0},
-        gnatdebug: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
+        gnatdebugtree: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId, treeid: 0},
+        gnatdebug: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
         cfg: {editorid: editorId, id: compilerId},
-        explain: {compilerName: 'g++ default', editorid: editorId, id: compilerId},
+        explain: {compilerName: 'Fake Compiler #1', editorid: editorId, id: compilerId},
     };
 
     // Build all panes from PANE_DATA_MAP
@@ -177,6 +179,7 @@ function buildKnownGoodState() {
 
 describe('Known good state test', () => {
     beforeEach(() => {
+        setupFakeCompiler();
         const state = buildKnownGoodState();
         const hash = serialiseState(state);
         cy.visit(`/#${hash}`, {

--- a/cypress/e2e/gccdump.cy.ts
+++ b/cypress/e2e/gccdump.cy.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {stubCompileResponse} from '../support/fake-compile';
 import {
     assertNoConsoleOutput,
     findPane,
@@ -51,6 +52,19 @@ describe('GCC Tree/RTL dump', () => {
     });
 
     it('should show a pass picker with available passes', () => {
+        stubCompileResponse({
+            gccDumpOutput: {
+                all: [
+                    {name: '001t.original', header: '001t.original'},
+                    {name: '002t.gimple', header: '002t.gimple'},
+                ],
+                currentPassOutput: ';; Function main\n(nop)',
+                selectedPass: '001t.original',
+                treeDumpEnabled: true,
+                rtlDumpEnabled: true,
+                ipaDumpEnabled: true,
+            },
+        });
         setupAndWaitForCompilation();
         openGccDump();
         cy.get('.gccdump-pass-picker + .ts-wrapper .ts-control', {timeout: 10000}).should('be.visible').click();
@@ -58,10 +72,20 @@ describe('GCC Tree/RTL dump', () => {
     });
 
     it('should display tree dump content when a pass is selected', () => {
+        stubCompileResponse({
+            gccDumpOutput: {
+                all: [{name: '001t.original', header: '001t.original'}],
+                currentPassOutput: ';; Function main\n(nop)',
+                selectedPass: '001t.original',
+                treeDumpEnabled: true,
+                rtlDumpEnabled: true,
+                ipaDumpEnabled: true,
+            },
+        });
         setupAndWaitForCompilation();
         openGccDump();
         cy.get('.gccdump-pass-picker + .ts-wrapper .ts-control', {timeout: 10000}).should('be.visible').click();
         cy.get('.ts-dropdown .option:visible', {timeout: 10000}).first().click();
-        monacoEditorTextShouldContain(gccDumpPane().find('.monaco-editor'), 'square');
+        monacoEditorTextShouldContain(gccDumpPane().find('.monaco-editor'), 'Function main');
     });
 });

--- a/cypress/e2e/monaco-test.cy.ts
+++ b/cypress/e2e/monaco-test.cy.ts
@@ -22,11 +22,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {setupFakeCompiler} from '../support/fake-compile';
 import {setMonacoEditorContent} from '../support/utils';
 
 // TODO: all these tests ought to be able to use `should(have.text, ...)`.
 describe('Monaco Editor Utilities', () => {
     beforeEach(() => {
+        setupFakeCompiler();
         cy.visit('/');
     });
 

--- a/cypress/support/fake-compile.ts
+++ b/cypress/support/fake-compile.ts
@@ -1,0 +1,214 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * Cypress intercept-based fake compiler for E2E tests.
+ *
+ * All compilation is handled client-side via cy.intercept — no custom
+ * compiler class on the server. The server just needs valid compiler entries
+ * in its config (using /bin/true as a no-op binary).
+ *
+ * API:
+ *   setupFakeCompiler()           — call in beforeEach before cy.visit()
+ *   stubCompileResponse(data)     — override compile responses (queued)
+ *   stubExecutorResponse(data)    — override executor responses (queued)
+ *
+ * stubCompileResponse/stubExecutorResponse use cy.intercept internally,
+ * so they queue properly in the Cypress command chain. Each call replaces
+ * the previous intercept handler.
+ */
+
+const FAKE_CAPABILITIES = {
+    supportsGccDump: true,
+    supportsOptOutput: true,
+    supportsPpView: true,
+    supportsCfg: true,
+    supportsExecute: true,
+};
+
+function echoSourceAsAsm(source: string, options: string[], filters: Record<string, boolean>) {
+    const lines: Array<Record<string, any>> = [];
+    const displayOptions = options.filter(o => !o.startsWith('--fake-'));
+    if (displayOptions.length > 0) {
+        lines.push({text: `; Options: ${displayOptions.join(' ')}`, source: null, labels: []});
+    }
+    const activeFilters = Object.entries(filters)
+        .filter(([, v]) => v)
+        .map(([k]) => k);
+    if (activeFilters.length > 0) {
+        lines.push({text: `; Filters: ${activeFilters.join(' ')}`, source: null, labels: []});
+    }
+    for (const [i, line] of source.split('\n').entries()) {
+        lines.push({
+            text: line,
+            source: line.trim() ? {file: null, line: i + 1, mainsource: true} : null,
+            labels: [],
+        });
+    }
+    return lines;
+}
+
+function buildEchoResponse(reqBody: Record<string, any>): Record<string, any> {
+    const source = reqBody.source || '';
+    const userArgs = reqBody.options?.userArguments || '';
+    const options = userArgs ? userArgs.split(/\s+/).filter(Boolean) : [];
+    const filters = reqBody.options?.filters || {};
+    const backendOptions = reqBody.options?.compilerOptions || {};
+
+    if (backendOptions.executorRequest) {
+        return {
+            code: 0,
+            didExecute: true,
+            timedOut: false,
+            stdout: [],
+            stderr: [],
+            inputFilename: 'example.cpp',
+            compilationOptions: options,
+            downloads: [],
+            tools: [],
+            asm: [],
+            languageId: 'c++',
+            execResult: {
+                didExecute: true,
+                code: 0,
+                stdout: [],
+                stderr: [],
+                timedOut: false,
+                buildResult: {
+                    code: 0,
+                    timedOut: false,
+                    stdout: [],
+                    stderr: [],
+                    inputFilename: 'example.cpp',
+                    compilationOptions: [],
+                    downloads: [],
+                    executableFilename: '',
+                    tools: [],
+                    asm: [],
+                    languageId: 'c++',
+                },
+            },
+        };
+    }
+
+    return {
+        code: 0,
+        timedOut: false,
+        okToCache: true,
+        stdout: [],
+        stderr: [],
+        inputFilename: 'example.cpp',
+        compilationOptions: options,
+        downloads: [],
+        tools: [],
+        asm: echoSourceAsAsm(source, options, filters),
+        languageId: 'c++',
+    };
+}
+
+function deepMerge(target: Record<string, any>, source: Record<string, any>) {
+    for (const key of Object.keys(source)) {
+        if (
+            source[key] &&
+            typeof source[key] === 'object' &&
+            !Array.isArray(source[key]) &&
+            target[key] &&
+            typeof target[key] === 'object' &&
+            !Array.isArray(target[key])
+        ) {
+            deepMerge(target[key], source[key]);
+        } else {
+            target[key] = source[key];
+        }
+    }
+}
+
+/**
+ * Set up the fake compiler intercepts. Call BEFORE cy.visit().
+ *
+ * Default: echoes source as asm, with options and filters shown as comments.
+ */
+export function setupFakeCompiler() {
+    // Patch compiler capabilities in the client options
+    cy.intercept('GET', '**/client-options.js*', req => {
+        req.continue(res => {
+            const body = String(res.body);
+            try {
+                const jsonStart = body.indexOf('{');
+                const jsonEnd = body.lastIndexOf('}');
+                if (jsonStart >= 0 && jsonEnd > jsonStart) {
+                    const opts = JSON.parse(body.substring(jsonStart, jsonEnd + 1));
+                    if (opts.compilers) {
+                        for (const compiler of opts.compilers) {
+                            Object.assign(compiler, FAKE_CAPABILITIES);
+                        }
+                    }
+                    res.body = `window.compilerExplorerOptions = ${JSON.stringify(opts)};`;
+                }
+            } catch {
+                // If parsing fails, let it through unmodified
+            }
+        });
+    }).as('clientOptions');
+
+    // Default compile handler — echo source as asm
+    cy.intercept('POST', '/api/compiler/*/compile', req => {
+        req.reply(buildEchoResponse(req.body));
+    }).as('compile');
+}
+
+/**
+ * Override compile responses. This is a Cypress command (uses cy.intercept)
+ * so it queues properly in the command chain. Overrides are merged with the
+ * default echo response. Executor requests still use the default echo.
+ */
+export function stubCompileResponse(overrides: Record<string, any>) {
+    cy.intercept('POST', '/api/compiler/*/compile', req => {
+        const backendOptions = req.body.options?.compilerOptions || {};
+        if (backendOptions.executorRequest) {
+            req.reply(buildEchoResponse(req.body));
+        } else {
+            const base = buildEchoResponse(req.body);
+            deepMerge(base, overrides);
+            req.reply(base);
+        }
+    }).as('compile');
+}
+
+/**
+ * Override executor responses. Overrides are merged into execResult.
+ * Normal compile requests still use the default echo.
+ */
+export function stubExecutorResponse(overrides: Record<string, any>) {
+    cy.intercept('POST', '/api/compiler/*/compile', req => {
+        const backendOptions = req.body.options?.compilerOptions || {};
+        if (backendOptions.executorRequest) {
+            const base = buildEchoResponse(req.body);
+            deepMerge(base.execResult, overrides);
+            req.reply(base);
+        } else {
+            req.reply(buildEchoResponse(req.body));
+        }
+    }).as('compile');
+}

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -24,6 +24,8 @@
 
 import '../../static/global';
 
+import {setupFakeCompiler} from './fake-compile';
+
 export function stubConsoleOutput(win: Cypress.AUTWindow) {
     cy.stub(win.console, 'log').as('consoleLog');
     cy.stub(win.console, 'warn').as('consoleWarn');
@@ -41,6 +43,7 @@ export function assertNoConsoleOutput() {
  * `beforeEach` for any test that needs a fresh page load.
  */
 export function visitPage() {
+    setupFakeCompiler();
     cy.visit('/', {
         onBeforeLoad: win => {
             stubConsoleOutput(win);

--- a/etc/config/c++.cypress.properties
+++ b/etc/config/c++.cypress.properties
@@ -1,0 +1,12 @@
+# Cypress E2E test configuration.
+# Uses /bin/true as a no-op binary so the server starts successfully.
+# Cypress intercepts override compiler capabilities and handle all
+# compile requests — the real binary is never used for compilation.
+
+compilers=fake1:fake2
+compiler.fake1.exe=/bin/true
+compiler.fake1.name=Fake Compiler #1
+compiler.fake2.exe=/bin/true
+compiler.fake2.name=Fake Compiler #2
+
+tools=


### PR DESCRIPTION
## Summary

Alternative to #8490 (Option B). Replaces real compiler dependencies in Cypress E2E tests with `cy.intercept`-based response stubbing. All fake logic lives in Cypress code — no custom compiler class on the server.

### What changed

- **`cypress/support/fake-compile.ts`** (~210 lines): Intercept handlers that echo source as asm by default, with `stubCompileResponse()`/`stubExecutorResponse()` for canned overrides
- **`etc/config/c++.cypress.properties`**: `fake1`/`fake2` compilers using `/bin/true` as a no-op binary
- **`.github/workflows/test-frontend.yml`**: Uses `--env cypress` so the server picks up the cypress properties
- **All 12 test specs** updated to use the stub API instead of real compilers
- **81/81 tests passing**

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*