### PR TITLE
Fix ex-WINE MSVC compiler sort order

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -135,7 +135,7 @@ compiler.cl19_2015_u3_32_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.00.242
 compiler.cl19_2015_u3_32_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.00.24210/lib
 compiler.cl19_2015_u3_32_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.00.24210/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl19_2015_u3_32_exwine.name=x86 msvc v19.0 (ex-WINE)
-compiler.cl19_2015_u3_32_exwine.semver=19.00.24210
+compiler.cl19_2015_u3_32_exwine.semver=14.00.24210
 compiler.cl19_2015_u3_32_exwine.alias=cl19_2015_u3_32
 
 compiler.cl19_2015_u3_64_exwine.supportsBinary=false
@@ -145,14 +145,14 @@ compiler.cl19_2015_u3_64_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.00.242
 compiler.cl19_2015_u3_64_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.00.24210/lib
 compiler.cl19_2015_u3_64_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.00.24210/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl19_2015_u3_64_exwine.name=x64 msvc v19.0 (ex-WINE)
-compiler.cl19_2015_u3_64_exwine.semver=19.00.24210
+compiler.cl19_2015_u3_64_exwine.semver=14.00.24210
 compiler.cl19_2015_u3_64_exwine.alias=cl19_2015_u3_64
 
 compiler.cl19_2015_u3_arm_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.00.24210/bin/amd64_arm/cl.exe
 compiler.cl19_2015_u3_arm_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.00.24210/lib
 compiler.cl19_2015_u3_arm_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.00.24210/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl19_2015_u3_arm_exwine.name=ARM msvc v19.0 (ex-WINE)
-compiler.cl19_2015_u3_arm_exwine.semver=19.00.24210
+compiler.cl19_2015_u3_arm_exwine.semver=14.00.24210
 compiler.cl19_2015_u3_arm_exwine.alias=cl19_2015_u3_arm
 
 compiler.cl19_32_exwine.supportsBinary=false
@@ -162,7 +162,7 @@ compiler.cl19_32_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/n
 compiler.cl19_32_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/lib
 compiler.cl19_32_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl19_32_exwine.name=x86 msvc v19.10 (ex-WINE)
-compiler.cl19_32_exwine.semver=19.10.25017
+compiler.cl19_32_exwine.semver=14.10.25017
 compiler.cl19_32_exwine.alias=cl19_32
 
 compiler.cl19_64_exwine.supportsBinary=false
@@ -172,14 +172,14 @@ compiler.cl19_64_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/n
 compiler.cl19_64_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/lib
 compiler.cl19_64_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl19_64_exwine.name=x64 msvc v19.10 (ex-WINE)
-compiler.cl19_64_exwine.semver=19.10.25017
+compiler.cl19_64_exwine.semver=14.10.25017
 compiler.cl19_64_exwine.alias=cl19_64
 
 compiler.cl19_arm_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/bin/amd64_arm/cl.exe
 compiler.cl19_arm_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/lib
 compiler.cl19_arm_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.10.25017/lib/native/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl19_arm_exwine.name=ARM msvc v19.10 (ex-WINE)
-compiler.cl19_arm_exwine.semver=19.10.25017
+compiler.cl19_arm_exwine.semver=14.10.25017
 compiler.cl19_arm_exwine.alias=cl19_arm
 
 compiler.cl_new_32_exwine.supportsBinary=false
@@ -189,7 +189,7 @@ compiler.cl_new_32_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.14.26423/bin
 compiler.cl_new_32_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/lib
 compiler.cl_new_32_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl_new_32_exwine.name=x86 msvc v19.14 (ex-WINE)
-compiler.cl_new_32_exwine.semver=19.14.26423
+compiler.cl_new_32_exwine.semver=14.14.26423
 compiler.cl_new_32_exwine.alias=cl_new_32
 
 compiler.cl_new_64_exwine.supportsBinary=false
@@ -199,21 +199,21 @@ compiler.cl_new_64_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.14.26423/bin
 compiler.cl_new_64_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/lib
 compiler.cl_new_64_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl_new_64_exwine.name=x64 msvc v19.14 (ex-WINE)
-compiler.cl_new_64_exwine.semver=19.14.26423
+compiler.cl_new_64_exwine.semver=14.14.26423
 compiler.cl_new_64_exwine.alias=cl_new_64
 
 compiler.cl_new_arm32_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.14.26423/bin/Hostx64/arm/cl.exe
 compiler.cl_new_arm32_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/lib
 compiler.cl_new_arm32_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl_new_arm32_exwine.name=ARM msvc v19.14 (ex-WINE)
-compiler.cl_new_arm32_exwine.semver=19.14.26423
+compiler.cl_new_arm32_exwine.semver=14.14.26423
 compiler.cl_new_arm32_exwine.alias=cl_new_arm32
 
 compiler.cl_new_arm64_exwine.exe=Z:/compilers/msvc-legacy-from-wine/19.14.26423/bin/Hostx64/arm64/cl.exe
 compiler.cl_new_arm64_exwine.libPath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/lib
 compiler.cl_new_arm64_exwine.includePath=Z:/compilers/msvc-legacy-from-wine/19.14.26423/include;Z:/compilers/msvc-legacy-from-wine/10.0.10240.0/ucrt
 compiler.cl_new_arm64_exwine.name=ARM64 msvc v19.14 (ex-WINE)
-compiler.cl_new_arm64_exwine.semver=19.14.26423
+compiler.cl_new_arm64_exwine.semver=14.14.26423
 compiler.cl_new_arm64_exwine.alias=cl_new_arm64
 
 # end of WINE conversion


### PR DESCRIPTION
Fixes #8006

The ex-WINE compilers were appearing at the **top** of the MSVC compiler dropdown instead of the bottom, because they used the MSVC compiler version (`19.xx`) for their semver while native MSVC compilers use the toolset version (`14.xx`). Since `19.xx > 14.xx`, they sorted as "newest".

This aligns the ex-WINE semvers to the `14.xx` toolset versioning:
- `19.00.24210` → `14.00.24210` (VS 2015 Update 3)
- `19.10.25017` → `14.10.25017` (VS 2017 RTM)
- `19.14.26423` → `14.14.26423` (VS 2017 15.7)

These now sort correctly before `14.20` (VS 2019 16.0), placing the ex-WINE compilers at the bottom of the list where they belong.

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*