### PR TITLE
Fix nasm default output format to elf64

### DIFF
--- a/lib/compilers/nasm.ts
+++ b/lib/compilers/nasm.ts
@@ -64,7 +64,7 @@ export class NasmCompiler extends AssemblyCompiler {
         }
 
         if (!fmode) {
-            options = ['-g', '-f', 'elf', '-F', 'stabs'].concat(options);
+            options = ['-g', '-f', 'elf64', '-F', 'stabs'].concat(options);
         }
 
         return options;


### PR DESCRIPTION
Fixes #8273

The default NASM output format was `elf` (32-bit ELF), causing a spurious `64-bit unsigned relocation zero-extended from 32 bits [-w+zext-reloc]` warning when using 64-bit addressing (which is the common case on CE's x86-64 infrastructure).

Changed the default to `elf64`. Users who explicitly need 32-bit ELF output can still pass `-felf` to override.

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*