### PR TITLE
Centralize CORS handling for /api routes

### DIFF
--- a/lib/app/routes-setup.ts
+++ b/lib/app/routes-setup.ts
@@ -27,6 +27,7 @@ import type {Router} from 'express';
 import type {AppArguments} from '../app.interfaces.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 import {CompileHandler} from '../handlers/compile.js';
+import {cors} from '../handlers/middleware.js';
 import {NoScriptHandler} from '../handlers/noscript.js';
 import {RouteAPI} from '../handlers/route-api.js';
 import {ClientOptionsHandler} from '../options-handler.js';
@@ -87,6 +88,14 @@ export function setupRoutesAndApi(
         defArgs: appArgs,
         renderConfig,
         renderGoldenLayout,
+    });
+
+    router.use('/api', cors, (req, res, next) => {
+        if (req.method === 'OPTIONS') {
+            res.sendStatus(200);
+        } else {
+            next();
+        }
     });
 
     // Set up controllers

--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -68,17 +68,9 @@ export class ApiHandler {
         this.handle = express.Router();
         this.compilationEnvironment = compilationEnvironment;
         const cacheHeader = `public, max-age=${ceProps('apiMaxAgeSecs', 24 * 60 * 60)}`;
-        this.handle.use((req, res, next) => {
-            res.header({
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept',
-                'Cache-Control': cacheHeader,
-            });
-            if (req.method === 'OPTIONS') {
-                res.sendStatus(200);
-            } else {
-                next();
-            }
+        this.handle.use((_, res, next) => {
+            res.header('Cache-Control', cacheHeader);
+            next();
         });
         this.handle.route('/compilers').get(this.handleCompilers.bind(this)).all(methodNotAllowed);
 

--- a/lib/handlers/api/assembly-documentation-controller.ts
+++ b/lib/handlers/api/assembly-documentation-controller.ts
@@ -26,13 +26,13 @@ import express from 'express';
 
 import {getDocumentationProviderTypeByKey} from '../../asm-docs/index.js';
 import {unwrapString} from '../../assert.js';
-import {cached, cors} from '../middleware.js';
+import {cached} from '../middleware.js';
 import {HttpController} from './controller.interfaces.js';
 
 export class AssemblyDocumentationController implements HttpController {
     createRouter(): express.Router {
         const router = express.Router();
-        router.get('/api/asm/:arch/:opcode', cors, cached, this.getOpcodeDocumentation.bind(this));
+        router.get('/api/asm/:arch/:opcode', cached, this.getOpcodeDocumentation.bind(this));
         return router;
     }
 

--- a/lib/handlers/api/formatting-controller.ts
+++ b/lib/handlers/api/formatting-controller.ts
@@ -26,7 +26,7 @@ import express from 'express';
 
 import {unwrapString} from '../../assert.js';
 import {FormattingService} from '../../formatting-service.js';
-import {cached, cors, jsonOnly} from '../middleware.js';
+import {cached, jsonOnly} from '../middleware.js';
 import {HttpController} from './controller.interfaces.js';
 
 export class FormattingController implements HttpController {
@@ -34,8 +34,8 @@ export class FormattingController implements HttpController {
 
     createRouter(): express.Router {
         const router = express.Router();
-        router.post('/api/format/:tool', cors, cached, jsonOnly, this.format.bind(this));
-        router.get('/api/formats', cors, cached, this.getFormatters.bind(this));
+        router.post('/api/format/:tool', cached, jsonOnly, this.format.bind(this));
+        router.get('/api/formats', cached, this.getFormatters.bind(this));
         return router;
     }
 

--- a/lib/handlers/api/site-template-controller.ts
+++ b/lib/handlers/api/site-template-controller.ts
@@ -26,13 +26,13 @@ import express from 'express';
 
 import {SiteTemplateConfiguration} from '../../../types/features/site-templates.interfaces.js';
 import {getSiteTemplates} from '../../site-templates.js';
-import {cached, cors} from '../middleware.js';
+import {cached} from '../middleware.js';
 import {HttpController} from './controller.interfaces.js';
 
 export class SiteTemplateController implements HttpController {
     createRouter(): express.Router {
         const router = express.Router();
-        router.get('/api/siteTemplates', cors, cached, this.getSiteTemplates.bind(this));
+        router.get('/api/siteTemplates', cached, this.getSiteTemplates.bind(this));
         return router;
     }
 


### PR DESCRIPTION
This fixes some APIs that were failing due to CORS checks since the default handler would not respond to OPTIONS preflight requests from the browser.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
