### PR TITLE
Filter NVCC fatbinData label from assembly output

### DIFF
--- a/test/compilers/nvcc-tests.ts
+++ b/test/compilers/nvcc-tests.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {describe, expect, it} from 'vitest';
+
+import {NvccCompiler} from '../../lib/compilers/index.js';
+import {makeCompilationEnvironment} from '../utils.js';
+
+describe('nvcc tests', () => {
+    const languages = {cuda: {id: 'cuda'}};
+    const info = {exe: 'foobar', remote: true, lang: 'cuda', ldPath: []};
+    const nvcc = new NvccCompiler(info as any, makeCompilationEnvironment({languages}));
+    // Access protected method via type cast for testing
+    const removeBlob = (asm: string) => (nvcc as any).removeNvccFatbinaryBlob(asm);
+
+    it('removes #APP/#NO_APP block containing .nv_fatbin', () => {
+        const asm = `        .text
+#APP
+        .section .nv_fatbin, "a"
+.align 8
+fatbinData:
+.quad 0x00100001ba55ed50,0x0000000000000fa8
+.quad 0x0000000000000000,0x0000003400010007
+.text
+
+#NO_APP
+        .type   main, @function
+main:
+        ret
+`;
+        const result = removeBlob(asm);
+        expect(result).not.toContain('fatbinData');
+        expect(result).not.toContain('.nv_fatbin');
+        expect(result).not.toContain('#APP');
+        expect(result).not.toContain('#NO_APP');
+        expect(result).not.toContain('.quad 0x00100001');
+        expect(result).toContain('main:');
+        expect(result).toContain('ret');
+    });
+
+    it('preserves #APP/#NO_APP blocks that do NOT contain .nv_fatbin (user inline asm)', () => {
+        const asm = `        .text
+#APP
+        nop
+#NO_APP
+        ret
+`;
+        const result = removeBlob(asm);
+        expect(result).toContain('#APP');
+        expect(result).toContain('nop');
+        expect(result).toContain('#NO_APP');
+        expect(result).toContain('ret');
+    });
+
+    it('handles multiple APP blocks — only removes the fat-binary one', () => {
+        const asm = `        .text
+#APP
+        nop
+#NO_APP
+        call foo
+#APP
+        .section .nv_fatbin, "a"
+fatbinData:
+.quad 0xdeadbeef
+#NO_APP
+        ret
+`;
+        const result = removeBlob(asm);
+        expect(result).toContain('#APP');
+        expect(result).toContain('nop');
+        expect(result).not.toContain('fatbinData');
+        expect(result).not.toContain('.nv_fatbin');
+        expect(result).toContain('call foo');
+        expect(result).toContain('ret');
+    });
+
+    it('does not strip an APP block where .nv_fatbin appears only in a string, not a section directive', () => {
+        // A .string containing ".nv_fatbin" must not be mistaken for the section directive
+        const asm = `        .text
+#APP
+        .string "filename_or_fatbins"
+        .string ".nv_fatbin"
+#NO_APP
+        ret
+`;
+        const result = removeBlob(asm);
+        expect(result).toContain('#APP');
+        expect(result).toContain('.nv_fatbin');
+        expect(result).toContain('ret');
+    });
+
+    it('leaves asm unchanged when there are no #APP blocks', () => {
+        const asm = `        .text
+main:
+        xorl %eax, %eax
+        ret
+`;
+        expect(removeBlob(asm)).toBe(asm);
+    });
+
+    it('preserves an unclosed #APP block (malformed input)', () => {
+        const asm = `        .text
+#APP
+        nop
+`;
+        const result = removeBlob(asm);
+        expect(result).toContain('#APP');
+        expect(result).toContain('nop');
+    });
+});

--- a/test/filters-cases/nvcc-x86-host-example.asm
+++ b/test/filters-cases/nvcc-x86-host-example.asm
@@ -1,0 +1,110 @@
+        .file   "example.cudafe1.cpp"
+        .text
+.Ltext0:
+#APP
+        .section .nv_fatbin, "a"
+.align 8
+fatbinData:
+.quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08
+.quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011
+.quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d
+.quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000
+.quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003
+.quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261
+.quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e
+.quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e
+.quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571
+.quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950
+.quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e
+.quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67
+.quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873
+.quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f
+.quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336
+.text
+
+#NO_APP
+        .type   _ZL26__cudaUnregisterBinaryUtilv, @function
+_ZL26__cudaUnregisterBinaryUtilv:
+.LFB1304:
+        .file 1 "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h"
+        .loc 1 257 1 view -0
+        .cfi_startproc
+        subq    $8, %rsp
+        .cfi_def_cfa_offset 16
+        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi
+        call    __cudaUnregisterFatBinary
+        addq    $8, %rsp
+        .cfi_def_cfa_offset 8
+        ret
+        .cfi_endproc
+.LFE1304:
+        .size   _ZL26__cudaUnregisterBinaryUtilv, .-_ZL26__cudaUnregisterBinaryUtilv
+        .globl  main
+        .type   main, @function
+main:
+.LFB1305:
+        .file 2 "/app/example.cu"
+        .loc 2 23 1 view -0
+        .cfi_startproc
+        subq    $8, %rsp
+        .cfi_def_cfa_offset 16
+        movl    $0, %edi
+        movl    $0, %esi
+        call    _Z6squarePii
+        xorl    %eax, %eax
+        addq    $8, %rsp
+        .cfi_def_cfa_offset 8
+        ret
+        .cfi_endproc
+.LFE1305:
+        .size   main, .-main
+        .section        .rodata.str1.1,"aMS",@progbits,1
+.LC0:
+        .string "_Z6squarePii"
+        .text
+        .type   _ZL24__sti____cudaRegisterAllv, @function
+_ZL24__sti____cudaRegisterAllv:
+.LFB1329:
+        .file 3 "/app/example.fatbin.c"
+        .loc 3 2 44 is_stmt 1 view -0
+        .cfi_startproc
+        subq    $8, %rsp
+        .cfi_def_cfa_offset 16
+        movl    $_ZL15__fatDeviceText, %edi
+        call    __cudaRegisterFatBinary
+        movq    %rax, %rdi
+        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)
+        pushq   $0
+        .cfi_def_cfa_offset 24
+        movl    $0, %r9d
+        movl    $-1, %r8d
+        movl    $.LC0, %ecx
+        movq    %rcx, %rdx
+        movl    $_Z6squarePii, %esi
+        call    __cudaRegisterFunction
+        addq    $8, %rsp
+        .cfi_def_cfa_offset 16
+        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi
+        call    __cudaRegisterFatBinaryEnd
+        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi
+        call    atexit
+        addq    $8, %rsp
+        .cfi_def_cfa_offset 8
+        ret
+        .cfi_endproc
+.LFE1329:
+        .size   _ZL24__sti____cudaRegisterAllv, .-_ZL24__sti____cudaRegisterAllv
+        .section        .init_array,"aw"
+        .align 8
+        .quad   _ZL24__sti____cudaRegisterAllv
+        .section        .nvFatBinSegment,"a"
+        .align 8
+        .type   _ZL15__fatDeviceText, @object
+        .size   _ZL15__fatDeviceText, 24
+_ZL15__fatDeviceText:
+        .long   1180844977
+        .long   1
+        .quad   fatbinData
+        .quad   0
+        .local  _ZL20__cudaFatCubinHandle
+        .comm   _ZL20__cudaFatCubinHandle,8,8

--- a/test/filters-cases/nvcc-x86-host-example.asm.binary.directives.labels.comments.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.binary.directives.labels.comments.json
@@ -1,0 +1,4 @@
+{
+  "asm": [],
+  "labelDefinitions": {}
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.comments.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.comments.json
@@ -1,0 +1,477 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL26__cudaUnregisterBinaryUtilv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1304:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        call    __cudaUnregisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1304:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1305:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1305:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1329:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1329:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 37,
+    "_ZL15__fatDeviceText": 61,
+    "_ZL24__sti____cudaRegisterAllv": 39,
+    "_ZL26__cudaUnregisterBinaryUtilv": 19,
+    "fatbinData": 2,
+    "main": 27
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.json
@@ -1,0 +1,487 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#NO_APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL26__cudaUnregisterBinaryUtilv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1304:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        call    __cudaUnregisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1304:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1305:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1305:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1329:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1329:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 39,
+    "_ZL15__fatDeviceText": 63,
+    "_ZL24__sti____cudaRegisterAllv": 41,
+    "_ZL26__cudaUnregisterBinaryUtilv": 21,
+    "fatbinData": 3,
+    "main": 29
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.json
@@ -1,0 +1,442 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL26__cudaUnregisterBinaryUtilv:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        call    __cudaUnregisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 32,
+    "_ZL15__fatDeviceText": 54,
+    "_ZL24__sti____cudaRegisterAllv": 34,
+    "_ZL26__cudaUnregisterBinaryUtilv": 18,
+    "fatbinData": 1,
+    "main": 24
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -1,0 +1,417 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "example.cu",
+        "line": 23,
+        "mainsource": true
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": "example.fatbin.c",
+        "line": 2,
+        "mainsource": true
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 26,
+    "_ZL15__fatDeviceText": 48,
+    "_ZL24__sti____cudaRegisterAllv": 28,
+    "fatbinData": 1,
+    "main": 18
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.json
@@ -1,0 +1,391 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 26,
+    "_ZL15__fatDeviceText": 48,
+    "_ZL24__sti____cudaRegisterAllv": 28,
+    "fatbinData": 1,
+    "main": 18
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.json
@@ -1,0 +1,452 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "#APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#NO_APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL26__cudaUnregisterBinaryUtilv:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        call    __cudaUnregisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 34,
+    "_ZL15__fatDeviceText": 56,
+    "_ZL24__sti____cudaRegisterAllv": 36,
+    "_ZL26__cudaUnregisterBinaryUtilv": 20,
+    "fatbinData": 2,
+    "main": 26
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.library.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.library.json
@@ -1,0 +1,437 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#NO_APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL26__cudaUnregisterBinaryUtilv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1304:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1305:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1305:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1329:"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1329:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 33,
+    "_ZL15__fatDeviceText": 57,
+    "_ZL24__sti____cudaRegisterAllv": 35,
+    "_ZL26__cudaUnregisterBinaryUtilv": 21,
+    "fatbinData": 3,
+    "main": 23
+  }
+}

--- a/test/filters-cases/nvcc-x86-host-example.asm.none.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.none.json
@@ -1,0 +1,803 @@
+{
+  "asm": [
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .file   \"example.cudafe1.cpp\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .text"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".Ltext0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#APP"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "fatbinData:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00100001ba55ed50,0x0000000000000fa8,0x0000005001010002,0x0000000000000d08"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000003400010007,0x0000000f00000040,0x0000000000000011"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000000,0x0000000000000000,0x6178652f7070612f,0x0075632e656c706d"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x33010102464c457f,0x0000000000000007,0x0000007800be0002,0x0000000000000000"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x0000000000000c60,0x0000000000000920,0x0038004000340534,0x0001000d00400003"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x7472747368732e00,0x747274732e006261,0x746d79732e006261,0x746d79732e006261"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x78646e68735f6261,0x7466752e766e2e00,0x2e007972746e652e,0x006f666e692e766e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5a5f2e747865742e,0x5065726175717336,0x692e766e2e006969,0x73365a5f2e6f666e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6969506572617571,0x6168732e766e2e00,0x73365a5f2e646572,0x6969506572617571"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6e6f632e766e2e00,0x5f2e30746e617473,0x657261757173365a,0x6265642e00696950"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x00656e696c5f6775,0x6265642e6c65722e,0x00656e696c5f6775,0x756265645f766e2e"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x735f656e696c5f67,0x6c65722e00737361,0x756265645f766e2e,0x735f656e696c5f67"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x5f766e2e00737361,0x74705f6775626564,0x2e00007478745f78,0x6261747274736873"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x6261747274732e00,0x6261746d79732e00,0x6261746d79732e00,0x2e0078646e68735f"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "#NO_APP"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL26__cudaUnregisterBinaryUtilv",
+          "range": {
+            "endCol": 49,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .type   _ZL26__cudaUnregisterBinaryUtilv, @function"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL26__cudaUnregisterBinaryUtilv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1304:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .file 1 \"/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 1 257 1 view -0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_startproc"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 16"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        call    __cudaUnregisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": "/opt/compiler-explorer/cuda/12.0.1/bin/../targets/x86_64-linux/include/crt/host_runtime.h",
+        "line": 257
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1304:"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL26__cudaUnregisterBinaryUtilv",
+          "range": {
+            "endCol": 49,
+            "startCol": 17
+          }
+        },
+        {
+          "name": "_ZL26__cudaUnregisterBinaryUtilv",
+          "range": {
+            "endCol": 85,
+            "startCol": 53
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .size   _ZL26__cudaUnregisterBinaryUtilv, .-_ZL26__cudaUnregisterBinaryUtilv"
+    },
+    {
+      "labels": [
+        {
+          "name": "main",
+          "range": {
+            "endCol": 21,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .globl  main"
+    },
+    {
+      "labels": [
+        {
+          "name": "main",
+          "range": {
+            "endCol": 21,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .type   main, @function"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "main:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1305:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .file 2 \"/app/example.cu\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 2 23 1 view -0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_startproc"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 16"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        movl    $0, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        call    _Z6squarePii"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        xorl    %eax, %eax"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 1,
+        "file": null,
+        "line": 23
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1305:"
+    },
+    {
+      "labels": [
+        {
+          "name": "main",
+          "range": {
+            "endCol": 21,
+            "startCol": 17
+          }
+        },
+        {
+          "name": "main",
+          "range": {
+            "endCol": 29,
+            "startCol": 25
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .size   main, .-main"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .section        .rodata.str1.1,\"aMS\",@progbits,1"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LC0:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .string \"_Z6squarePii\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .text"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL24__sti____cudaRegisterAllv",
+          "range": {
+            "endCol": 47,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .type   _ZL24__sti____cudaRegisterAllv, @function"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL24__sti____cudaRegisterAllv:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFB1329:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .file 3 \"/app/example.fatbin.c\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .loc 3 2 44 is_stmt 1 view -0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_startproc"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        subq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 16"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL15__fatDeviceText, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinary"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rax, _ZL20__cudaFatCubinHandle(%rip)"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        pushq   $0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 24"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $0, %r9d"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $-1, %r8d"
+    },
+    {
+      "labels": [
+        {
+          "name": ".LC0",
+          "range": {
+            "endCol": 22,
+            "startCol": 18
+          }
+        }
+      ],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $.LC0, %ecx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    %rcx, %rdx"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_Z6squarePii, %esi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFunction"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 16"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movq    _ZL20__cudaFatCubinHandle(%rip), %rdi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    __cudaRegisterFatBinaryEnd"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        movl    $_ZL26__cudaUnregisterBinaryUtilv, %edi"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        call    atexit"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        addq    $8, %rsp"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_def_cfa_offset 8"
+    },
+    {
+      "labels": [],
+      "source": {
+        "column": 44,
+        "file": null,
+        "line": 2
+      },
+      "text": "        ret"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .cfi_endproc"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".LFE1329:"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL24__sti____cudaRegisterAllv",
+          "range": {
+            "endCol": 47,
+            "startCol": 17
+          }
+        },
+        {
+          "name": "_ZL24__sti____cudaRegisterAllv",
+          "range": {
+            "endCol": 81,
+            "startCol": 51
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .size   _ZL24__sti____cudaRegisterAllv, .-_ZL24__sti____cudaRegisterAllv"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .section        .init_array,\"aw\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .align 8"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL24__sti____cudaRegisterAllv",
+          "range": {
+            "endCol": 47,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   _ZL24__sti____cudaRegisterAllv"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .section        .nvFatBinSegment,\"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .align 8"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL15__fatDeviceText",
+          "range": {
+            "endCol": 37,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .type   _ZL15__fatDeviceText, @object"
+    },
+    {
+      "labels": [
+        {
+          "name": "_ZL15__fatDeviceText",
+          "range": {
+            "endCol": 37,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .size   _ZL15__fatDeviceText, 24"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "_ZL15__fatDeviceText:"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1180844977"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .long   1"
+    },
+    {
+      "labels": [
+        {
+          "name": "fatbinData",
+          "range": {
+            "endCol": 27,
+            "startCol": 17
+          }
+        }
+      ],
+      "source": null,
+      "text": "        .quad   fatbinData"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .quad   0"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .local  _ZL20__cudaFatCubinHandle"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": "        .comm   _ZL20__cudaFatCubinHandle,8,8"
+    }
+  ],
+  "labelDefinitions": {
+    ".LC0": 62,
+    "_ZL15__fatDeviceText": 104,
+    "_ZL24__sti____cudaRegisterAllv": 66,
+    "_ZL26__cudaUnregisterBinaryUtilv": 27,
+    "fatbinData": 7,
+    "main": 44
+  }
+}


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Closes #5178

## Problem

NVCC embeds the CUDA fat binary blob in the host-side x86 assembly inside a `#APP`/`#NO_APP` inline-assembly block, under a label called `fatbinData`. In a realistic kernel this can be 100+ lines of `.quad` hex values — a wall of noise before any user-readable code.

Example: https://godbolt.org/z/W3YMcq8oY

## Fix

Per-compiler pre-processing step in `NvccCompiler.processAsm()`: before the host assembly reaches the ASM parser, any `#APP`/`#NO_APP` block containing a `.nv_fatbin` section is stripped out entirely.

- Only `.nv_fatbin` blocks are removed; genuine user inline-assembly blocks (which also use `#APP`/`#NO_APP` but without `.nv_fatbin`) are left intact.
- Intentionally NVCC-specific — no changes to the base `AsmParser`, no false-positive risk for other compilers.
- Stripping happens before `findUsedLabels` runs, so `fatbinData` naturally disappears as unreferenced without any special-casing in the parser's label-filtering logic.
- Gated on the existing Labels filter: with no filters active everything remains visible; with Labels on the blob disappears.

## Testing

**New compiler unit tests** (`test/compilers/nvcc-tests.ts`):
- Strips `#APP`/`#NO_APP` blocks containing `.nv_fatbin`
- Preserves `#APP`/`#NO_APP` blocks without `.nv_fatbin` (user inline asm)
- Handles multiple mixed blocks correctly
- No-op when no `#APP` blocks present
- Gracefully handles malformed unclosed blocks

**New parser filter-case** (`test/filters-cases/nvcc-x86-host-example.asm`): representative NVCC 12.0 host assembly (real 15-line fat binary, boilerplate functions, `.nvFatBinSegment` section) with nine filter-combination snapshots documenting parser behaviour in isolation. These correctly show that the **base parser itself does not filter `fatbinData`** — that's the compiler pre-processor's job.

All 767 tests pass.