### PR TITLE
Add C++ library re2 v2025-07-17

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6391,9 +6391,9 @@ libs.re2.name=RE2
 libs.re2.url=https://github.com/google/re2/
 libs.re2.packagedheaders=true
 libs.re2.staticliblink=re2
-libs.re2.versions=20240702:2025-07-17
+libs.re2.versions=20240702:20250717
 libs.re2.versions.20240702.version=2024-07-02
-libs.re2.versions.2025-07-17.version=2025-07-17
+libs.re2.versions.20250717.version=2025-07-17
 
 libs.reactive_plus_plus.name=ReactivePlusPlus
 libs.reactive_plus_plus.url=https://github.com/victimsnino/ReactivePlusPlus


### PR DESCRIPTION
This PR adds the C++ library **re2** version 2025-07-17 to Compiler Explorer.

- GitHub URL: https://github.com/google/re2


Related PR: https://github.com/compiler-explorer/infra/pull/1988

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_