### PR TITLE
Add C++ library miniz v3.1.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4785,7 +4785,7 @@ compiler.g127.semver=1.27
 #################################
 #################################
 # Installed libs
-libs=abseil:array:async_simple:bde:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:fusedkernellibrary:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:hpx:immer:icu:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:perl:pipes:ppdt:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:re2:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan:graaf:med:zlib
+libs=abseil:array:async_simple:bde:belleviews:beman_any_view:beman_exemplar:beman_execution:beman_iterator_interface:beman_inplace_vector:beman_net:beman_optional:beman_scope:beman_task:benchmark:benri:blaze:boost:bmpi3:bmulti:brigand:bronto:catch2:cccl:cctz:cereal:cmcstl2:cnl:cppcoro:cppitertools:cpptrace:crosscables:ctbignum:cthash:ctre:date:dataframe:dawjson:dlib:doctest:eastl:eigen:enoki:entt:etl:eve:expected_lite:fastor:flux:fmt:fusedkernellibrary:gcem:gemmlowp:glaze:glm:gnufs:gnulibbacktrace:gnuexp:googletest:gsl:hdf5:hedley:hfsm:highfive:highway:hotels-template-library:hpx:immer:icu:jsoncons:jsoncpp:kiwaku:kokkos:kumi:kvasir:kyosu:lager:lagom:lexy:libassert:libbpf:libguarded:libsimdpp:libuv:llvm:llvmfs:lua:magic_enum:mfem:mimicpp:mlir:mp-coro:mp-units:namedtype:nanorange:nlohmann_json:nsimd:ofw:openssl:outcome:pegtl:perl:pipes:ppdt:proxy:pugixml:pybind11:python:rangesv3:raberu:rapidjson:re2:reactive_plus_plus:scnlib:seastar:seqan3:simde:simdjson:sol2:spdlog:spy:stdexec:strong_type:taojson:taskflow:tbb:thinkcell:tlexpected:toml11:tomlplusplus:trompeloeil:tts:type_safe:unifex:ureact:vcl:xercesc:xsimd:xtensor:xtl:yomm2:zug:cli11:avr-libstdcpp:curl:copperspice:sqlite:ztdcuneicode:ztdencodingtables:ztdidk:ztdstaticcontainers:ztdtext:ztdplatform:qt:quill:pcre2:widberg-defs:jwt-cpp:xieite:option:mdspan:graaf:med:zlib:miniz
 
 libs.abseil.name=Abseil
 libs.abseil.versions=202501270
@@ -6930,6 +6930,13 @@ libs.zlib.versions=131
 libs.zlib.packagedheaders=true
 libs.zlib.staticliblink=z
 libs.zlib.versions.131.version=1.3.1
+
+libs.miniz.name=miniz
+libs.miniz.url=https://github.com/richgel999/miniz
+libs.miniz.versions=311
+libs.miniz.versions.311.path=/opt/compiler-explorer/libs/miniz/3.1.1/include
+libs.miniz.versions.311.version=3.1.1
+libs.miniz.staticliblink=miniz
 
 #################################
 #################################


### PR DESCRIPTION
This PR adds the C++ library **miniz** version 3.1.1 to Compiler Explorer.

- GitHub URL: https://github.com/richgel999/miniz
- Library Type: static

Related PR: https://github.com/compiler-explorer/infra/pull/1999

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_