### PR TITLE
Update Mojo default example to compile with nightly and 0.26.1.0

### DIFF
--- a/examples/mojo/default.mojo
+++ b/examples/mojo/default.mojo
@@ -1,4 +1,3 @@
-@export
 fn multiply[m: Int](n: Int) -> Int:
   return m * n
 


### PR DESCRIPTION
Recent compilers do not allow parametric functions to be exported, so remove the keyword.  Note that this means the function now gets inlined with default optimization levels.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
