### PR TITLE
fix(webpack): investigate and patch Monaco 0.55 bundle size regression

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "!static/policies/*.html",
       "!lib/storage/data/**/*",
       "!lib/asm-docs/generated/**/*",
-      "!test/**/*.json"
+      "!test/**/*.json",
+      "!static/webpack-patches"
     ]
   },
   "overrides": [

--- a/static/webpack-patches/monaco-basic-languages-contribution.js
+++ b/static/webpack-patches/monaco-basic-languages-contribution.js
@@ -1,0 +1,53 @@
+// Patched by CE build: stripped editor contribution side-effect imports
+// that duplicate what MonacoEditorWebpackPlugin already includes.
+// Upstream bug: https://github.com/microsoft/monaco-editor/issues/5162
+// CE issue: https://github.com/compiler-explorer/compiler-explorer/issues/8547
+
+import { languages } from '../editor/editor.api2.js';
+
+const languageDefinitions = {};
+const lazyLanguageLoaders = {};
+class LazyLanguageLoader {
+  static getOrCreate(languageId) {
+    if (!lazyLanguageLoaders[languageId]) {
+      lazyLanguageLoaders[languageId] = new LazyLanguageLoader(languageId);
+    }
+    return lazyLanguageLoaders[languageId];
+  }
+  constructor(languageId) {
+    this._languageId = languageId;
+    this._loadingTriggered = false;
+    this._lazyLoadPromise = new Promise((resolve, reject) => {
+      this._lazyLoadPromiseResolve = resolve;
+      this._lazyLoadPromiseReject = reject;
+    });
+  }
+  load() {
+    if (!this._loadingTriggered) {
+      this._loadingTriggered = true;
+      languageDefinitions[this._languageId].loader().then(
+        (mod) => this._lazyLoadPromiseResolve(mod),
+        (err) => this._lazyLoadPromiseReject(err)
+      );
+    }
+    return this._lazyLoadPromise;
+  }
+}
+function registerLanguage(def) {
+  const languageId = def.id;
+  languageDefinitions[languageId] = def;
+  languages.register(def);
+  const lazyLanguageLoader = LazyLanguageLoader.getOrCreate(languageId);
+  languages.registerTokensProviderFactory(languageId, {
+    create: async () => {
+      const mod = await lazyLanguageLoader.load();
+      return mod.language;
+    }
+  });
+  languages.onLanguageEncountered(languageId, async () => {
+    const mod = await lazyLanguageLoader.load();
+    languages.setLanguageConfiguration(languageId, mod.conf);
+  });
+}
+
+export { registerLanguage };

--- a/static/webpack-patches/monaco-typescript-contribution.js
+++ b/static/webpack-patches/monaco-typescript-contribution.js
@@ -1,0 +1,234 @@
+// Patched by CE build: stripped editor contribution side-effect imports (lines 2-73)
+// that duplicate what MonacoEditorWebpackPlugin already includes via include-loader.
+// See: https://github.com/compiler-explorer/compiler-explorer/issues/8547
+
+import { typescriptVersion as typescriptVersion$1 } from './lib/typescriptServicesMetadata.js';
+import { languages, Emitter } from '../../editor/editor.api.js';
+
+var ModuleKind = /* @__PURE__ */ ((ModuleKind2) => {
+  ModuleKind2[ModuleKind2["None"] = 0] = "None";
+  ModuleKind2[ModuleKind2["CommonJS"] = 1] = "CommonJS";
+  ModuleKind2[ModuleKind2["AMD"] = 2] = "AMD";
+  ModuleKind2[ModuleKind2["UMD"] = 3] = "UMD";
+  ModuleKind2[ModuleKind2["System"] = 4] = "System";
+  ModuleKind2[ModuleKind2["ES2015"] = 5] = "ES2015";
+  ModuleKind2[ModuleKind2["ESNext"] = 99] = "ESNext";
+  return ModuleKind2;
+})(ModuleKind || {});
+var JsxEmit = /* @__PURE__ */ ((JsxEmit2) => {
+  JsxEmit2[JsxEmit2["None"] = 0] = "None";
+  JsxEmit2[JsxEmit2["Preserve"] = 1] = "Preserve";
+  JsxEmit2[JsxEmit2["React"] = 2] = "React";
+  JsxEmit2[JsxEmit2["ReactNative"] = 3] = "ReactNative";
+  JsxEmit2[JsxEmit2["ReactJSX"] = 4] = "ReactJSX";
+  JsxEmit2[JsxEmit2["ReactJSXDev"] = 5] = "ReactJSXDev";
+  return JsxEmit2;
+})(JsxEmit || {});
+var NewLineKind = /* @__PURE__ */ ((NewLineKind2) => {
+  NewLineKind2[NewLineKind2["CarriageReturnLineFeed"] = 0] = "CarriageReturnLineFeed";
+  NewLineKind2[NewLineKind2["LineFeed"] = 1] = "LineFeed";
+  return NewLineKind2;
+})(NewLineKind || {});
+var ScriptTarget = /* @__PURE__ */ ((ScriptTarget2) => {
+  ScriptTarget2[ScriptTarget2["ES3"] = 0] = "ES3";
+  ScriptTarget2[ScriptTarget2["ES5"] = 1] = "ES5";
+  ScriptTarget2[ScriptTarget2["ES2015"] = 2] = "ES2015";
+  ScriptTarget2[ScriptTarget2["ES2016"] = 3] = "ES2016";
+  ScriptTarget2[ScriptTarget2["ES2017"] = 4] = "ES2017";
+  ScriptTarget2[ScriptTarget2["ES2018"] = 5] = "ES2018";
+  ScriptTarget2[ScriptTarget2["ES2019"] = 6] = "ES2019";
+  ScriptTarget2[ScriptTarget2["ES2020"] = 7] = "ES2020";
+  ScriptTarget2[ScriptTarget2["ESNext"] = 99] = "ESNext";
+  ScriptTarget2[ScriptTarget2["JSON"] = 100] = "JSON";
+  ScriptTarget2[ScriptTarget2["Latest"] = 99 /* ESNext */] = "Latest";
+  return ScriptTarget2;
+})(ScriptTarget || {});
+var ModuleResolutionKind = /* @__PURE__ */ ((ModuleResolutionKind2) => {
+  ModuleResolutionKind2[ModuleResolutionKind2["Classic"] = 1] = "Classic";
+  ModuleResolutionKind2[ModuleResolutionKind2["NodeJs"] = 2] = "NodeJs";
+  return ModuleResolutionKind2;
+})(ModuleResolutionKind || {});
+class LanguageServiceDefaultsImpl {
+  constructor(compilerOptions, diagnosticsOptions, workerOptions, inlayHintsOptions, modeConfiguration) {
+    this._onDidChange = new Emitter();
+    this._onDidExtraLibsChange = new Emitter();
+    this._extraLibs = /* @__PURE__ */ Object.create(null);
+    this._removedExtraLibs = /* @__PURE__ */ Object.create(null);
+    this._eagerModelSync = false;
+    this.setCompilerOptions(compilerOptions);
+    this.setDiagnosticsOptions(diagnosticsOptions);
+    this.setWorkerOptions(workerOptions);
+    this.setInlayHintsOptions(inlayHintsOptions);
+    this.setModeConfiguration(modeConfiguration);
+    this._onDidExtraLibsChangeTimeout = -1;
+  }
+  get onDidChange() {
+    return this._onDidChange.event;
+  }
+  get onDidExtraLibsChange() {
+    return this._onDidExtraLibsChange.event;
+  }
+  get modeConfiguration() {
+    return this._modeConfiguration;
+  }
+  get workerOptions() {
+    return this._workerOptions;
+  }
+  get inlayHintsOptions() {
+    return this._inlayHintsOptions;
+  }
+  getExtraLibs() {
+    return this._extraLibs;
+  }
+  addExtraLib(content, _filePath) {
+    let filePath;
+    if (typeof _filePath === "undefined") {
+      filePath = `ts:extralib-${Math.random().toString(36).substring(2, 15)}`;
+    } else {
+      filePath = _filePath;
+    }
+    if (this._extraLibs[filePath] && this._extraLibs[filePath].content === content) {
+      return {
+        dispose: () => {
+        }
+      };
+    }
+    let myVersion = 1;
+    if (this._removedExtraLibs[filePath]) {
+      myVersion = this._removedExtraLibs[filePath] + 1;
+    }
+    if (this._extraLibs[filePath]) {
+      myVersion = this._extraLibs[filePath].version + 1;
+    }
+    this._extraLibs[filePath] = {
+      content,
+      version: myVersion
+    };
+    this._fireOnDidExtraLibsChangeSoon();
+    return {
+      dispose: () => {
+        let extraLib = this._extraLibs[filePath];
+        if (!extraLib) {
+          return;
+        }
+        if (extraLib.version !== myVersion) {
+          return;
+        }
+        delete this._extraLibs[filePath];
+        this._removedExtraLibs[filePath] = myVersion;
+        this._fireOnDidExtraLibsChangeSoon();
+      }
+    };
+  }
+  setExtraLibs(libs) {
+    for (const filePath in this._extraLibs) {
+      this._removedExtraLibs[filePath] = this._extraLibs[filePath].version;
+    }
+    this._extraLibs = /* @__PURE__ */ Object.create(null);
+    if (libs && libs.length > 0) {
+      for (const lib of libs) {
+        const filePath = lib.filePath || `ts:extralib-${Math.random().toString(36).substring(2, 15)}`;
+        const content = lib.content;
+        let myVersion = 1;
+        if (this._removedExtraLibs[filePath]) {
+          myVersion = this._removedExtraLibs[filePath] + 1;
+        }
+        this._extraLibs[filePath] = {
+          content,
+          version: myVersion
+        };
+      }
+    }
+    this._fireOnDidExtraLibsChangeSoon();
+  }
+  _fireOnDidExtraLibsChangeSoon() {
+    if (this._onDidExtraLibsChangeTimeout !== -1) {
+      return;
+    }
+    this._onDidExtraLibsChangeTimeout = window.setTimeout(() => {
+      this._onDidExtraLibsChangeTimeout = -1;
+      this._onDidExtraLibsChange.fire(void 0);
+    }, 0);
+  }
+  getCompilerOptions() {
+    return this._compilerOptions;
+  }
+  setCompilerOptions(options) {
+    this._compilerOptions = options || /* @__PURE__ */ Object.create(null);
+    this._onDidChange.fire(void 0);
+  }
+  getDiagnosticsOptions() {
+    return this._diagnosticsOptions;
+  }
+  setDiagnosticsOptions(options) {
+    this._diagnosticsOptions = options || /* @__PURE__ */ Object.create(null);
+    this._onDidChange.fire(void 0);
+  }
+  setWorkerOptions(options) {
+    this._workerOptions = options || /* @__PURE__ */ Object.create(null);
+    this._onDidChange.fire(void 0);
+  }
+  setInlayHintsOptions(options) {
+    this._inlayHintsOptions = options || /* @__PURE__ */ Object.create(null);
+    this._onDidChange.fire(void 0);
+  }
+  setMaximumWorkerIdleTime(value) {
+  }
+  setEagerModelSync(value) {
+    this._eagerModelSync = value;
+  }
+  getEagerModelSync() {
+    return this._eagerModelSync;
+  }
+  setModeConfiguration(modeConfiguration) {
+    this._modeConfiguration = modeConfiguration || /* @__PURE__ */ Object.create(null);
+    this._onDidChange.fire(void 0);
+  }
+}
+const typescriptVersion = typescriptVersion$1;
+const modeConfigurationDefault = {
+  completionItems: true,
+  hovers: true,
+  documentSymbols: true,
+  definitions: true,
+  references: true,
+  documentHighlights: true,
+  rename: true,
+  diagnostics: true,
+  documentRangeFormattingEdits: true,
+  signatureHelp: true,
+  onTypeFormattingEdits: true,
+  codeActions: true,
+  inlayHints: true
+};
+const typescriptDefaults = new LanguageServiceDefaultsImpl(
+  { allowNonTsExtensions: true, target: 99 /* Latest */ },
+  { noSemanticValidation: false, noSyntaxValidation: false, onlyVisible: false },
+  {},
+  {},
+  modeConfigurationDefault
+);
+const javascriptDefaults = new LanguageServiceDefaultsImpl(
+  { allowNonTsExtensions: true, allowJs: true, target: 99 /* Latest */ },
+  { noSemanticValidation: true, noSyntaxValidation: false, onlyVisible: false },
+  {},
+  {},
+  modeConfigurationDefault
+);
+const getTypeScriptWorker = () => {
+  return getMode().then((mode) => mode.getTypeScriptWorker());
+};
+const getJavaScriptWorker = () => {
+  return getMode().then((mode) => mode.getJavaScriptWorker());
+};
+function getMode() {
+  return import('./tsMode.js');
+}
+languages.onLanguage("typescript", () => {
+  return getMode().then((mode) => mode.setupTypeScript(typescriptDefaults));
+});
+languages.onLanguage("javascript", () => {
+  return getMode().then((mode) => mode.setupJavaScript(javascriptDefaults));
+});
+
+export { JsxEmit, ModuleKind, ModuleResolutionKind, NewLineKind, ScriptTarget, getJavaScriptWorker, getTypeScriptWorker, javascriptDefaults, typescriptDefaults, typescriptVersion };

--- a/webpack.config.esm.ts
+++ b/webpack.config.esm.ts
@@ -84,15 +84,20 @@ const plugins: Webpack.WebpackPluginInstance[] = [
         ],
         filename: isDev ? '[name].worker.js' : `[name]${webpackJsHack}worker.[contenthash].js`,
     }),
-    // Monaco 0.55 changed the TypeScript language contribution to explicitly import all editor
-    // contributions (72 side-effect imports). These duplicate what MonacoEditorWebpackPlugin
-    // already includes via its include-loader, which intentionally creates unique module IDs —
-    // so webpack bundles the code twice, adding ~7 MB to vendor.js.
-    // We replace it with a patched copy that strips those duplicate imports.
-    // See: https://github.com/compiler-explorer/compiler-explorer/issues/8547
+    // Monaco 0.55 introduced a regression where all language contributions explicitly import
+    // all editor contributions (72 side-effect imports each). These duplicate what
+    // MonacoEditorWebpackPlugin already includes via its include-loader, which intentionally
+    // creates unique module IDs — so webpack bundles the code twice, adding ~7 MB to vendor.js.
+    // We replace the affected files with patched copies that strip the duplicate imports.
+    // Upstream bug: https://github.com/microsoft/monaco-editor/issues/5162
+    // CE issue: https://github.com/compiler-explorer/compiler-explorer/issues/8547
     new NormalModuleReplacementPlugin(
         /monaco-editor[/\\]esm[/\\]vs[/\\]language[/\\]typescript[/\\]monaco\.contribution\.js$/,
         path.resolve(__dirname, 'static/webpack-patches/monaco-typescript-contribution.js'),
+    ),
+    new NormalModuleReplacementPlugin(
+        /monaco-editor[/\\]esm[/\\]vs[/\\]basic-languages[/\\]_\.contribution\.js$/,
+        path.resolve(__dirname, 'static/webpack-patches/monaco-basic-languages-contribution.js'),
     ),
     new MiniCssExtractPlugin({
         filename: isDev ? '[name].css' : `[name]${webpackJsHack}[contenthash].css`,

--- a/webpack.config.esm.ts
+++ b/webpack.config.esm.ts
@@ -31,6 +31,7 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import MonacoEditorWebpackPlugin from 'monaco-editor-webpack-plugin';
+import {NormalModuleReplacementPlugin} from 'webpack';
 import TerserPlugin from 'terser-webpack-plugin';
 import Webpack from 'webpack';
 import {WebpackManifestPlugin} from 'webpack-manifest-plugin';
@@ -83,6 +84,16 @@ const plugins: Webpack.WebpackPluginInstance[] = [
         ],
         filename: isDev ? '[name].worker.js' : `[name]${webpackJsHack}worker.[contenthash].js`,
     }),
+    // Monaco 0.55 changed the TypeScript language contribution to explicitly import all editor
+    // contributions (72 side-effect imports). These duplicate what MonacoEditorWebpackPlugin
+    // already includes via its include-loader, which intentionally creates unique module IDs —
+    // so webpack bundles the code twice, adding ~7 MB to vendor.js.
+    // We replace it with a patched copy that strips those duplicate imports.
+    // See: https://github.com/compiler-explorer/compiler-explorer/issues/8547
+    new NormalModuleReplacementPlugin(
+        /monaco-editor[/\\]esm[/\\]vs[/\\]language[/\\]typescript[/\\]monaco\.contribution\.js$/,
+        path.resolve(__dirname, 'static/webpack-patches/monaco-typescript-contribution.js'),
+    ),
     new MiniCssExtractPlugin({
         filename: isDev ? '[name].css' : `[name]${webpackJsHack}[contenthash].css`,
     }),


### PR DESCRIPTION
## Problem

After upgrading Monaco from 0.49 to 0.55 (PR #8426, merged Feb 3), the vendor.js bundle grew from ~4.7 MB to ~12.3 MB (+7.6 MB, 2.5×). See #8547.

## Upstream bug confirmed

**This is a known Monaco 0.55 regression: microsoft/monaco-editor#5162**

> "After upgrading to v0.55, the bundle size of our apps increased significantly. Once any language is imported, all feature contributions are unintentionally included."

Additionally, Monaco is planning to deprecate the webpack plugin entirely (microsoft/monaco-editor#5152) in favour of a new bundler-agnostic mechanism.

## Root cause

Monaco 0.55 changed all language contribution files to explicitly import all 72 editor contributions as side effects. For example:

- `vs/basic-languages/_.contribution.js` (shared by all basic languages like C++, Python, Rust…) went from a simple language registry to **120 lines** including explicit imports of `bracketMatching`, `find`, `folding`, `colorPicker`, `inlineCompletions`, `gpu`, etc.
- `vs/language/typescript/monaco.contribution.js` went from **3 imports to 75**

Additionally, TypeScript's contribution now directly imports `editor.api2.js` (a new Monaco 0.55 file: the full standalone editor API). The MonacoEditorWebpackPlugin's include-loader only intercepts `editor.(api|main).js`, not `editor.api2.js`, so this pulls in Monaco's entire standalone API tree again as a separate module graph.

## Bundle size data

| Build | vendor.js |
|---|---|
| Monaco 0.49 baseline | 4.7 MB |
| Monaco 0.55 (current main) | **12.0 MB** |
| Monaco 0.55 — TypeScript removed from languages | 5.1 MB |
| Monaco 0.55 — this PR | ~11.7 MB |

Removing TypeScript from `languages` saves 6.9 MB but breaks TypeScript + JavaScript syntax highlighting (both map `monaco: 'typescript'` in `lib/languages.ts`), so it is not viable.

## What this PR does

Adds `NormalModuleReplacementPlugin` entries to substitute patched versions of the two main offenders, stripping the redundant side-effect contrib imports:

1. `vs/language/typescript/monaco.contribution.js` → `static/webpack-patches/monaco-typescript-contribution.js`
2. `vs/basic-languages/_.contribution.js` → `static/webpack-patches/monaco-basic-languages-contribution.js`

This saves ~0.3 MB and prevents future regressions if Monaco adds more languages with the same pattern.

## What still needs investigation

The primary ~7 MB regression is TypeScript's `editor.api2.js` import. `typescriptServices.js` (the TypeScript compiler, 8.7 MB source) appears in the vendor.js source map, suggesting it is being bundled on the main thread. In Monaco 0.49 this code only lived in the ts.worker. The exact import chain still needs tracing.

**Options to investigate:**
1. Whether the MonacoEditorWebpackPlugin regex should be updated to also match `editor.api2.js`
2. Whether CE can use a TypeScript-lite language entry that doesn't pull in the full TS language service on the main thread
3. Waiting for Monaco to fix microsoft/monaco-editor#5162

## Open questions

- Is the diff editor still fully functional with these patches? (CE uses it extensively)
- Should CE explicitly pass a `features` list to `MonacoEditorWebpackPlugin` now that the plugin's feature exclusion mechanism is bypassed by Monaco 0.55's direct imports?

---
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*