### PR TITLE
Switch GitHub sponsor links from Matt to compiler-explorer org

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Since then, it has become a public website serving over
 [3,000,000 compilations per week](https://stats.compiler-explorer.com).
 
 You can financially support [this project on Patreon](https://patreon.com/mattgodbolt),
-[GitHub](https://github.com/sponsors/mattgodbolt/),
+[GitHub](https://github.com/sponsors/compiler-explorer/),
 [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=KQWQZ7GPY2GZ6&item_name=Compiler+Explorer+development&currency_code=USD&source=url),
 or by buying cool gear on the [Compiler Explorer store](https://shop.compiler-explorer.com).
 

--- a/views/bits/sponsors-content.pug
+++ b/views/bits/sponsors-content.pug
@@ -7,7 +7,7 @@ block content
         span.fab.fa-patreon
         | Patreon
       | , sponsor on&nbsp;
-      a.icon-link(href="https://github.com/sponsors/mattgodbolt" title="Help Compiler Explorer - sponsor on GitHub" target="_blank" rel="noopener")
+      a.icon-link(href="https://github.com/sponsors/compiler-explorer" title="Help Compiler Explorer - sponsor on GitHub" target="_blank" rel="noopener")
         span.fab.fa-github-alt
         | GitHub
       | , make a one-time donation on&nbsp;

--- a/views/menu-other.pug
+++ b/views/menu-other.pug
@@ -2,7 +2,7 @@ a.dropdown-item(href="https://www.patreon.com/bePatron?u=3691963" title="Help Co
     span.dropdown-icon.fab.fa-patreon
     | Become a Patron
     | &nbsp;
-a.dropdown-item(href="https://github.com/sponsors/mattgodbolt" title="Help Compiler Explorer - sponsor on GitHub" target="_blank" rel="noopener")
+a.dropdown-item(href="https://github.com/sponsors/compiler-explorer" title="Help Compiler Explorer - sponsor on GitHub" target="_blank" rel="noopener")
     span.dropdown-icon.fab.fa-github-alt
     | Sponsor on GitHub
     | &nbsp;


### PR DESCRIPTION
Matt's [sponsor page](https://github.com/sponsors/mattgodbolt) has a clear disclaimer to sponsor the project at https://github.com/sponsors/compiler-explorer instead. This just makes that one less step for people looking to support this amazing project.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
