### PR TITLE
feat(c): add ArchieSDK GCC 8.5.0 (Acorn Archimedes / arm-archie)

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1373,6 +1373,7 @@ group.carchiesdk.isSemVer=true
 group.carchiesdk.supportsBinary=true
 group.carchiesdk.supportsExecute=false
 group.carchiesdk.instructionSet=arm32
+group.carchiesdk.options=-mno-thumb-interwork
 
 compiler.carchieg850.exe=/opt/compiler-explorer/archiesdk/Release-1/bin/arm-archie-gcc
 compiler.carchieg850.semver=8.5.0


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds [ArchieSDK](https://gitlab.com/_targz/archiesdk) GCC 8.5.0 to the C compiler list — a cross-compiler targeting the Acorn Archimedes (RISC OS/Arthur, ARMv2/ARM2 soft-float).

## Changes

- Added `carchiesdk` group to `ccross` cross-compilers
- Group config: `instructionSet=arm32`, `supportsExecute=false`, `isSemVer=true`
- Compiler `carchieg850`: exe, semver, name, objdumper all set

## Install path

`/opt/compiler-explorer/archiesdk/Release-1/bin/arm-archie-gcc`

(The sysroot with Acorn Archimedes libc headers + libs is bundled at `…/SDK/` and baked into the compiler at build time.)

## Notes

- C only (GCC 8.5.0 is the last version to support ARMv2)
- No execute support (RISC OS binaries can't run on Linux)
- Companion infra install PR: compiler-explorer/infra#TBD

Closes #7982
