### PR TITLE
Fix AT&T warning showing for native langs w/ undefined intelAsm

### DIFF
--- a/static/assembly-syntax.ts
+++ b/static/assembly-syntax.ts
@@ -38,11 +38,11 @@ export function addAttSyntaxWarningIfNeeded(
 ): AssemblyInstructionInfo {
     if (syntax !== 'att') return data;
 
-    const referencesCardinalityOfOperands = (text: string): boolean =>
+    const referencesCardinalityOfSrcDstOperands = (text: string): boolean =>
         CARDINALITY_REGEX.test(text) && OPERAND_REGEX.test(text) && SOURCE_DEST_REGEX.test(text);
 
     // TODO: split so warn only shows in tooltip or html containing ref to cardinality of operands
-    return referencesCardinalityOfOperands(data.tooltip) || referencesCardinalityOfOperands(data.html)
+    return referencesCardinalityOfSrcDstOperands(data.tooltip) || referencesCardinalityOfSrcDstOperands(data.html)
         ? {
               ...data,
               tooltip: '***' + ATT_SYNTAX_WARNING + '***\n\n' + data.tooltip,
@@ -51,6 +51,6 @@ export function addAttSyntaxWarningIfNeeded(
         : data;
 }
 
-export function determineAssemblySyntax(supportsIntel: boolean, intelFilterEnabled: boolean = true): AssemblySyntax {
+export function determineAssemblySyntax(supportsIntel: boolean = false, intelFilterEnabled: boolean = true): AssemblySyntax {
     return supportsIntel && !intelFilterEnabled ? 'att' : 'intel';
 }

--- a/static/assembly-syntax.ts
+++ b/static/assembly-syntax.ts
@@ -28,6 +28,8 @@ const AssemblySyntaxesList = ['att', 'intel'] as const;
 export type AssemblySyntax = (typeof AssemblySyntaxesList)[number];
 
 export const ATT_SYNTAX_WARNING = 'WARNING: The information shown pertains to Intel syntax.';
+const CARDINALITY_REGEX = /\b(?:first|second|third|fourth)\b/i;
+const OPERAND_REGEX = /\boperands?\b/i;
 const SOURCE_DEST_REGEX = /\b(?:source|destination)\b/i;
 
 export function addAttSyntaxWarningIfNeeded(
@@ -36,10 +38,11 @@ export function addAttSyntaxWarningIfNeeded(
 ): AssemblyInstructionInfo {
     if (syntax !== 'att') return data;
 
-    const referencesCardinality = (text: string): boolean =>
-        CARDINALITY_REGEX.test(text) && SOURCE_DEST_REGEX.test(text);
+    const referencesCardinalityOfOperands = (text: string): boolean =>
+        CARDINALITY_REGEX.test(text) && OPERAND_REGEX.test(text) && SOURCE_DEST_REGEX.test(text);
 
-    return referencesCardinality(data.tooltip) || referencesCardinality(data.html)
+    // TODO: split so warn only shows in tooltip or html containing ref to cardinality of operands
+    return referencesCardinalityOfOperands(data.tooltip) || referencesCardinalityOfOperands(data.html)
         ? {
               ...data,
               tooltip: '***' + ATT_SYNTAX_WARNING + '***\n\n' + data.tooltip,
@@ -48,6 +51,6 @@ export function addAttSyntaxWarningIfNeeded(
         : data;
 }
 
-export function determineAssemblySyntax(supportsIntel: boolean, intelFilterEnabled: boolean): AssemblySyntax {
+export function determineAssemblySyntax(supportsIntel: boolean, intelFilterEnabled: boolean = true): AssemblySyntax {
     return supportsIntel && !intelFilterEnabled ? 'att' : 'intel';
 }

--- a/static/assembly-syntax.ts
+++ b/static/assembly-syntax.ts
@@ -48,3 +48,7 @@ export function addAttSyntaxWarningIfNeeded(
           }
         : data;
 }
+
+export function determineAssemblySyntax(supportsIntel: boolean, intelFilterEnabled: boolean): AssemblySyntax {
+    return supportsIntel && !intelFilterEnabled ? 'att' : 'intel';
+}

--- a/static/assembly-syntax.ts
+++ b/static/assembly-syntax.ts
@@ -41,14 +41,14 @@ export function addAttSyntaxWarningIfNeeded(
     const referencesCardinalityOfSrcDstOperands = (text: string): boolean =>
         CARDINALITY_REGEX.test(text) && OPERAND_REGEX.test(text) && SOURCE_DEST_REGEX.test(text);
 
-    // TODO: split so warn only shows in tooltip or html containing ref to cardinality of operands
-    return referencesCardinalityOfSrcDstOperands(data.tooltip) || referencesCardinalityOfSrcDstOperands(data.html)
-        ? {
-              ...data,
-              tooltip: '***' + ATT_SYNTAX_WARNING + '***\n\n' + data.tooltip,
-              html: '<b><em>' + ATT_SYNTAX_WARNING + '</em></b><br><br>' + data.html,
-          }
-        : data;
+    const tooltipRefs = referencesCardinalityOfSrcDstOperands(data.tooltip);
+    const htmlRefs = referencesCardinalityOfSrcDstOperands(data.html);
+    if (!tooltipRefs && !htmlRefs) return data;
+    return {
+        ...data,
+        ...(tooltipRefs && {tooltip: '***' + ATT_SYNTAX_WARNING + '***\n\n' + data.tooltip}),
+        ...(htmlRefs && {html: '<b><em>' + ATT_SYNTAX_WARNING + '</em></b><br><br>' + data.html}),
+    };
 }
 
 export function determineAssemblySyntax(supportsIntel: boolean = false, intelFilterEnabled: boolean): AssemblySyntax {

--- a/static/assembly-syntax.ts
+++ b/static/assembly-syntax.ts
@@ -28,7 +28,6 @@ const AssemblySyntaxesList = ['att', 'intel'] as const;
 export type AssemblySyntax = (typeof AssemblySyntaxesList)[number];
 
 export const ATT_SYNTAX_WARNING = 'WARNING: The information shown pertains to Intel syntax.';
-const CARDINALITY_REGEX = /\b(?:first|second|third|fourth|last)\s+operands?\b/i;
 const SOURCE_DEST_REGEX = /\b(?:source|destination)\b/i;
 
 export function addAttSyntaxWarningIfNeeded(

--- a/static/assembly-syntax.ts
+++ b/static/assembly-syntax.ts
@@ -51,6 +51,6 @@ export function addAttSyntaxWarningIfNeeded(
         : data;
 }
 
-export function determineAssemblySyntax(supportsIntel: boolean = false, intelFilterEnabled: boolean = true): AssemblySyntax {
+export function determineAssemblySyntax(supportsIntel: boolean = false, intelFilterEnabled: boolean): AssemblySyntax {
     return supportsIntel && !intelFilterEnabled ? 'att' : 'intel';
 }

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2831,7 +2831,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     }
 
     asmSyntax(): AssemblySyntax {
-        return determineAssemblySyntax(this.compiler?.supportsIntel ?? false, this.filters.isSet('intel'));
+        return determineAssemblySyntax(this.compiler?.supportsIntel, this.filters.isSet('intel'));
     }
 
     handlePopularArgumentsResult(result: Record<string, {description: string}> | null): void {

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -84,7 +84,7 @@ import {InstructionSet} from '../../types/instructionsets.js';
 import {LanguageKey} from '../../types/languages.interfaces.js';
 import {Tool} from '../../types/tool.interfaces.js';
 import {ArtifactHandler} from '../artifact-handler.js';
-import {type AssemblySyntax, addAttSyntaxWarningIfNeeded} from '../assembly-syntax.js';
+import {type AssemblySyntax, addAttSyntaxWarningIfNeeded, determineAssemblySyntax} from '../assembly-syntax.js';
 import {ICompilerShared} from '../compiler-shared.interfaces.js';
 import {CompilerShared} from '../compiler-shared.js';
 import {SourceAndFiles} from '../download-service.js';
@@ -2830,9 +2830,8 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         );
     }
 
-    // Non-x86 compilers (supportsIntel=false) always return 'intel' to suppress the AT&T warning.
     asmSyntax(): AssemblySyntax {
-        return this.compiler?.supportsIntel && !this.filters.isSet('intel') ? 'att' : 'intel';
+        return determineAssemblySyntax(this.compiler?.supportsIntel ?? false, this.filters.isSet('intel'));
     }
 
     handlePopularArgumentsResult(result: Record<string, {description: string}> | null): void {

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -2830,12 +2830,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         );
     }
 
-    // Only x86/x64 compilers (supportsIntel) can emit AT&T syntax.
-    // Non-x86 architectures default to 'intel' so they never trigger the AT&T warning.
+    // Non-x86 compilers (supportsIntel=false) always return 'intel' to suppress the AT&T warning.
     asmSyntax(): AssemblySyntax {
-        const isAtt =
-            this.compiler?.supportsIntel && !(this.filters.isSet('intel') && this.compiler.intelAsm.includes('intel'));
-        return isAtt ? 'att' : 'intel';
+        return this.compiler?.supportsIntel && !this.filters.isSet('intel') ? 'att' : 'intel';
     }
 
     handlePopularArgumentsResult(result: Record<string, {description: string}> | null): void {

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -123,15 +123,6 @@ describe(addAttSyntaxWarningIfNeeded, () => {
         expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
     });
 
-    it("handles last operand references", () => {
-        const data = makeInfo(
-            "The last operand is the source register",
-            "<p>Description</p>",
-        );
-        const result = addAttSyntaxWarningIfNeeded(data, "att");
-        expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
-    });
-
     describe("purity", () => {
         it("does not mutate the original data object regardless of syntax", () => {
             const data = makeInfo(

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -22,112 +22,157 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {describe, expect, it} from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import {type AssemblyInstructionInfo} from '../../types/assembly-docs.interfaces.js';
-import {ATT_SYNTAX_WARNING, addAttSyntaxWarningIfNeeded, determineAssemblySyntax} from '../assembly-syntax.js';
+import { type AssemblyInstructionInfo } from "../../types/assembly-docs.interfaces.js";
+import {
+    ATT_SYNTAX_WARNING,
+    addAttSyntaxWarningIfNeeded,
+    determineAssemblySyntax,
+} from "../assembly-syntax.js";
 
-function makeInfo(tooltip: string, html: string): AssemblyInstructionInfo {
-    return {tooltip, html, url: 'https://example.com'};
+function makeInfo(tooltip: string, html?: string): AssemblyInstructionInfo {
+    html = html ?? `<p>${tooltip}</p>`;
+    return { tooltip, html, url: "https://example.com" };
 }
 
-describe('addAttSyntaxWarningIfNeeded', () => {
-    it('does not warn for intel syntax', () => {
-        const data = makeInfo('first operand is the destination', 'first operand is the destination');
-        const result = addAttSyntaxWarningIfNeeded(data, 'intel');
-        expect(result).toEqual(data);
+describe(addAttSyntaxWarningIfNeeded, () => {
+    describe("warns when syntax is att and", () => {
+        it("tooltip references cardinality operand and source/destination", () => {
+            const data = makeInfo(
+                "first operand (destination)",
+                "<p>Simple description</p>",
+            );
+            const result = addAttSyntaxWarningIfNeeded(data, "att");
+
+            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+        });
+
+        it("html references cardinality operand and source/destination", () => {
+            const data = makeInfo(
+                "Simple tooltip",
+                "<p>second operand (source)</p>",
+            );
+            const result = addAttSyntaxWarningIfNeeded(data, "att");
+
+            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+        });
+
+        it("both tooltip and html reference cardinality and source/destination", () => {
+            const text =
+                "copies the first operand (source) to the second operand (destination)";
+            const data = makeInfo(text);
+            const result = addAttSyntaxWarningIfNeeded(data, "att");
+            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+        });
+    });
+    describe("does not warn when", () => {
+        it("intel syntax and references cardinal destination", () => {
+            const data = makeInfo("first operand (destination)");
+            const result = addAttSyntaxWarningIfNeeded(data, "intel");
+            expect(result).toEqual(data);
+        });
+
+        it("att syntax and no cardinality references exist", () => {
+            const data = makeInfo(
+                "Decrements the stack pointer and then stores the source operand on the top of the stack",
+            );
+            const result = addAttSyntaxWarningIfNeeded(data, "att");
+
+            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
+        });
+
+        it("cardinality is present but source/destination is absent", () => {
+            const data = makeInfo(
+                "Performs a signed multiplication of two operands",
+            );
+            const result = addAttSyntaxWarningIfNeeded(data, "att");
+
+            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+        });
+
+        it("source/destination is present but cardinality is absent", () => {
+            const data = makeInfo(
+                "Loads the value from the top of the stack to the location specified with the destination operand (or explicit opcode) and then increments the stack pointer.",
+            );
+            const result = addAttSyntaxWarningIfNeeded(data, "att");
+            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+        });
     });
 
-    it('does not warn for att syntax when no cardinality references exist', () => {
-        const data = makeInfo('Adds two values', '<p>Adds two values</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
+    it("does not cross-contaminate: tooltip cardinality + html source/dest alone should not warn", () => {
+        const data = makeInfo(
+            "The first operand is foo",
+            "<p>Copies bar to the destination register</p>",
+        );
+        const result = addAttSyntaxWarningIfNeeded(data, "att");
         expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
         expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
     });
 
-    it('does not warn when cardinality is present but source/destination is absent', () => {
-        const data = makeInfo('The first operand is added to the result', '<p>The first operand is added</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-    });
-
-    it('does not warn when source/destination is present but cardinality is absent', () => {
-        const data = makeInfo('Copies from source to destination', '<p>Copies source to destination</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-    });
-
-    it('warns when tooltip references cardinality operand and source/destination', () => {
-        const data = makeInfo('The first operand is the destination register', '<p>Simple description</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
-        expect(result.html).toContain(ATT_SYNTAX_WARNING);
-    });
-
-    it('warns when html references cardinality operand and source/destination', () => {
-        const data = makeInfo('Simple tooltip', '<p>The second operand is the source register</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
-        expect(result.html).toContain(ATT_SYNTAX_WARNING);
-    });
-
-    it('warns when both tooltip and html match', () => {
-        const text = 'The first operand is the source, the second operand is the destination';
-        const data = makeInfo(text, text);
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
-        expect(result.html).toContain(ATT_SYNTAX_WARNING);
-    });
-
-    it('does not cross-contaminate: tooltip cardinality + html source/dest alone should not warn', () => {
-        const data = makeInfo('The first operand is shifted left', '<p>Copies data to the destination register</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-        expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
-    });
-
-    it('handles fourth operand references', () => {
-        const data = makeInfo('The fourth operand specifies the destination mask', '<p>VBLENDVPS description</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
+    it("handles fourth operand references", () => {
+        const data = makeInfo(
+            "The fourth operand specifies the destination mask",
+            "<p>VBLENDVPS description</p>",
+        );
+        const result = addAttSyntaxWarningIfNeeded(data, "att");
         expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
     });
 
-    it('handles last operand references', () => {
-        const data = makeInfo('The last operand is the source register', '<p>Description</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
+    it("handles last operand references", () => {
+        const data = makeInfo(
+            "The last operand is the source register",
+            "<p>Description</p>",
+        );
+        const result = addAttSyntaxWarningIfNeeded(data, "att");
         expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
     });
 
-    it('does not mutate the original data object', () => {
-        const data = makeInfo('The first operand is the destination', '<p>The first operand is the destination</p>');
-        const originalTooltip = data.tooltip;
-        const originalHtml = data.html;
-        addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(data.tooltip).toBe(originalTooltip);
-        expect(data.html).toBe(originalHtml);
-    });
+    describe("purity", () => {
+        it("does not mutate the original data object regardless of syntax", () => {
+            const data = makeInfo(
+                "The first operand is the destination",
+                "<p>The first operand is the destination</p>",
+            );
+            const originalTooltip = data.tooltip;
+            const originalHtml = data.html;
 
-    it('preserves the url field unchanged', () => {
-        const data = makeInfo('The first operand is the destination', '<p>The first operand is the destination</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.url).toBe('https://example.com');
+            addAttSyntaxWarningIfNeeded(data, "att");
+            expect(data.tooltip).toBe(originalTooltip);
+            expect(data.html).toBe(originalHtml);
+        });
+
+        it("preserves the url field regardless of syntax", () => {
+            let result: AssemblyInstructionInfo;
+            const data: AssemblyInstructionInfo = makeInfo(
+                "The first operand (destination)",
+                "<p>The first operand (destination)</p>",
+            );
+
+            result = addAttSyntaxWarningIfNeeded(data, "att");
+            expect(result.url).toBe("https://example.com");
+            result = addAttSyntaxWarningIfNeeded(data, "intel");
+            expect(result.url).toBe("https://example.com");
+        });
     });
 });
 
-describe('determineAssemblySyntax', () => {
-    it('returns intel for non-x86 compiler with Intel filter off', () => {
-        expect(determineAssemblySyntax(false, false)).toBe('intel');
-    });
-
-    it('returns intel for non-x86 compiler with Intel filter on (stale toggle)', () => {
-        expect(determineAssemblySyntax(false, true)).toBe('intel');
-    });
-
-    it('returns att for x86 compiler with Intel filter off', () => {
-        expect(determineAssemblySyntax(true, false)).toBe('att');
-    });
-
-    it('returns intel for x86 compiler with Intel filter on', () => {
-        expect(determineAssemblySyntax(true, true)).toBe('intel');
-    });
-});
+describe.each([
+    [false, false, "intel"],
+    [false, true, "intel"],
+    [true, false, "att"],
+    [true, true, "intel"],
+])(
+    "determineAssemblySyntax(supportsIntel: %s, intelFilterEnabled: %s) returns %s",
+    (supportsIntel, intelFilterEnabled, expected) => {
+        it(`returns ${expected} when supportsIntel is ${supportsIntel} and intel asm syntax filter is ${intelFilterEnabled ? "en" : "dis"}abled`, () => {
+            expect(
+                determineAssemblySyntax(supportsIntel, intelFilterEnabled),
+            ).toBe(expected);
+        });
+    },
+);

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -152,18 +152,13 @@ describe(addAttSyntaxWarningIfNeeded, () => {
     });
 });
 
-describe.each([
-    [false, false, "intel"],
-    [false, true, "intel"],
-    [true, false, "att"],
-    [true, true, "intel"],
-])(
-    "determineAssemblySyntax(supportsIntel: %s, intelFilterEnabled: %s) returns %s",
-    (supportsIntel, intelFilterEnabled, expected) => {
-        it(`returns ${expected} when supportsIntel is ${supportsIntel} and intel asm syntax filter is ${intelFilterEnabled ? "en" : "dis"}abled`, () => {
-            expect(
-                determineAssemblySyntax(supportsIntel, intelFilterEnabled),
-            ).toBe(expected);
-        });
-    },
-);
+describe('determineAssemblySyntax', () => {
+    it.each([
+        [false, false, 'intel'],
+        [false, true, 'intel'],
+        [true, false, 'att'],
+        [true, true, 'intel'],
+    ])('returns %s when supportsIntel is %s and intel asm syntax filter is %s', (supportsIntel, intelFilterEnabled, expected) => {
+        expect(determineAssemblySyntax(supportsIntel as boolean, intelFilterEnabled as boolean)).toBe(expected);
+    });
+});

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -25,7 +25,7 @@
 import {describe, expect, it} from 'vitest';
 
 import {type AssemblyInstructionInfo} from '../../types/assembly-docs.interfaces.js';
-import {ATT_SYNTAX_WARNING, addAttSyntaxWarningIfNeeded} from '../assembly-syntax.js';
+import {ATT_SYNTAX_WARNING, addAttSyntaxWarningIfNeeded, determineAssemblySyntax} from '../assembly-syntax.js';
 
 function makeInfo(tooltip: string, html: string): AssemblyInstructionInfo {
     return {tooltip, html, url: 'https://example.com'};
@@ -111,5 +111,23 @@ describe('addAttSyntaxWarningIfNeeded', () => {
         const data = makeInfo('The first operand is the destination', '<p>The first operand is the destination</p>');
         const result = addAttSyntaxWarningIfNeeded(data, 'att');
         expect(result.url).toBe('https://example.com');
+    });
+});
+
+describe('determineAssemblySyntax', () => {
+    it('returns intel for non-x86 compiler with Intel filter off', () => {
+        expect(determineAssemblySyntax(false, false)).toBe('intel');
+    });
+
+    it('returns intel for non-x86 compiler with Intel filter on (stale toggle)', () => {
+        expect(determineAssemblySyntax(false, true)).toBe('intel');
+    });
+
+    it('returns att for x86 compiler with Intel filter off', () => {
+        expect(determineAssemblySyntax(true, false)).toBe('att');
+    });
+
+    it('returns intel for x86 compiler with Intel filter on', () => {
+        expect(determineAssemblySyntax(true, true)).toBe('intel');
     });
 });

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -25,27 +25,36 @@
 import {describe, expect, it} from 'vitest';
 
 import {type AssemblyInstructionInfo} from '../../types/assembly-docs.interfaces.js';
-import {ATT_SYNTAX_WARNING, addAttSyntaxWarningIfNeeded, determineAssemblySyntax} from '../assembly-syntax.js';
+import {
+    AssemblySyntax,
+    ATT_SYNTAX_WARNING,
+    addAttSyntaxWarningIfNeeded,
+    determineAssemblySyntax,
+} from '../assembly-syntax.js';
 
+const mockUrl = 'https://example.com';
 function makeInfo(tooltip: string, html?: string): AssemblyInstructionInfo {
     html = html ?? `<p>${tooltip}</p>`;
-    return {tooltip, html, url: 'https://example.com'};
+    return {tooltip, html, url: mockUrl};
 }
 
 describe(addAttSyntaxWarningIfNeeded, () => {
     describe('warns when syntax is att and', () => {
-        it('tooltip references cardinality operand and source/destination', () => {
+        const attSyntax: AssemblySyntax = 'att';
+        it('only tooltip references cardinality operand and source/destination', () => {
             const data = makeInfo('first operand (destination)', '<p>Simple description</p>');
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
+            const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
 
+            // TODO: only show on tooltip
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
 
-        it('html references cardinality operand and source/destination', () => {
+        it('only html references cardinality operand and source/destination', () => {
             const data = makeInfo('Simple tooltip', '<p>second operand (source)</p>');
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
+            const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
 
+            // TODO: only show on html
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
@@ -53,64 +62,75 @@ describe(addAttSyntaxWarningIfNeeded, () => {
         it('both tooltip and html reference cardinality and source/destination', () => {
             const text = 'copies the first operand (source) to the second operand (destination)';
             const data = makeInfo(text);
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
+            const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
     });
     describe('does not warn when', () => {
-        it('intel syntax and references cardinality of operands', () => {
-            const data = makeInfo('first operand (destination)');
-            const result = addAttSyntaxWarningIfNeeded(data, 'intel');
-            expect(result).toEqual(data);
+        describe('syntax is intel', () => {
+            it('and references cardinality of operands', () => {
+                const data = makeInfo('first operand (destination)');
+                const result = addAttSyntaxWarningIfNeeded(data, 'intel');
+                expect(result).toEqual(data);
+            });
         });
 
-        it('att syntax and no cardinality references exist', () => {
-            const data = makeInfo(
-                'Decrements the stack pointer and then stores the source operand on the top of the stack',
-            );
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
+        describe('syntax is att and', () => {
+            const attSyntax = 'att';
+            it('no cardinality references to destination/source operands', () => {
+                const data = makeInfo(
+                    'Decrements the stack pointer and then stores the source operand on the top of the stack',
+                );
+                const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
 
+                expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+                expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
+            });
+
+            it('cardinality is present but source/destination is absent', () => {
+                const data = makeInfo('Performs a signed multiplication of two operands');
+                const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
+
+                expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+                expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
+            });
+
+            it('source/destination is present but cardinality is absent', () => {
+                const popDesc =
+                    'Loads the value from the top of the stack to the location specified with the destination operand (or explicit opcode) and then increments the stack pointer.';
+                const data = makeInfo(popDesc);
+                const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
+                expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+                expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
+            });
+        });
+
+        it('does not warn if tooltip contains "operand" and html contains "destination"', () => {
+            const data = makeInfo('The first operand is foo', '<p>Copies bar to the destination register</p>');
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
             expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
             expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
         });
-
-        it('cardinality is present but source/destination is absent', () => {
-            const data = makeInfo('Performs a signed multiplication of two operands');
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
-
-            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-        });
-
-        it('source/destination is present but cardinality is absent', () => {
-            const data = makeInfo(
-                'Loads the value from the top of the stack to the location specified with the destination operand (or explicit opcode) and then increments the stack pointer.',
-            );
+        it('does not warn if tooltip contains "source" and html contains "operand"', () => {
+            const data = makeInfo('The source operand is foo', '<p>Copies bar to the last destination register</p>');
             const result = addAttSyntaxWarningIfNeeded(data, 'att');
             expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
         });
-    });
-
-    it('does not warn if tooltip ^ html reference cardinality of operands', () => {
-        const data = makeInfo('The first operand is foo', '<p>Copies bar to the destination register</p>');
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-        expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
-    });
-    it('handles fourth operand references', () => {
-        const haddpsDescription =
-            'Adds single precision floating-point values in the third and fourth dword of the destination operand and stores the result in the second dword of the destination operand.';
-        const data = makeInfo(haddpsDescription);
-        const result = addAttSyntaxWarningIfNeeded(data, 'att');
-        expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+        it('handles third and fourth operand references', () => {
+            const haddpsDescription =
+                'Adds single precision floating-point values in the third and fourth dword of the destination operand and stores the result in the second dword of the destination operand.';
+            const data = makeInfo(haddpsDescription);
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
+            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+        });
     });
 
     describe('purity', () => {
         it('does not mutate the original data object regardless of syntax', () => {
-            const data = makeInfo(
-                'The first operand is the destination',
-                '<p>The first operand is the destination</p>',
-            );
+            const data = makeInfo('first operand (destination)');
             const originalTooltip = data.tooltip;
             const originalHtml = data.html;
 
@@ -124,20 +144,25 @@ describe(addAttSyntaxWarningIfNeeded, () => {
             const data = makeInfo('the first operand (destination)');
 
             result = addAttSyntaxWarningIfNeeded(data, 'att');
-            expect(result.url).toBe('https://example.com');
+            expect(result.url).toBe(mockUrl);
             result = addAttSyntaxWarningIfNeeded(data, 'intel');
-            expect(result.url).toBe('https://example.com');
+            expect(result.url).toBe(mockUrl);
         });
     });
 });
 
 describe('determineAssemblySyntax', () => {
+    it('returns intel if supportsIntel is undefined', () => {
+        expect(determineAssemblySyntax(undefined, false)).toBe('intel');
+        expect(determineAssemblySyntax(undefined, true)).toBe('intel');
+        expect(determineAssemblySyntax(undefined, undefined)).toBe('intel');
+    })
     it.each([
-        [false, false, 'intel'],
-        [false, true, 'intel'],
-        [true, false, 'att'],
-        [true, true, 'intel'],
-    ])('returns %s when supportsIntel is %s and intel asm syntax filter is %s', (supportsIntel, intelFilterEnabled, expected) => {
-        expect(determineAssemblySyntax(supportsIntel as boolean, intelFilterEnabled as boolean)).toBe(expected);
+        ['intel', false, false],
+        ['intel', false, true],
+        ['att', true, false],
+        ['intel', true, true],
+    ])('returns %s when supportsIntel is %s and intel asm syntax filter is %s', (expected, supportsIntel, intelFilterEnabled) => {
+        expect(determineAssemblySyntax(supportsIntel, intelFilterEnabled)).toBe(expected);
     });
 });

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -22,132 +22,111 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { describe, expect, it } from "vitest";
+import {describe, expect, it} from 'vitest';
 
-import { type AssemblyInstructionInfo } from "../../types/assembly-docs.interfaces.js";
-import {
-    ATT_SYNTAX_WARNING,
-    addAttSyntaxWarningIfNeeded,
-    determineAssemblySyntax,
-} from "../assembly-syntax.js";
+import {type AssemblyInstructionInfo} from '../../types/assembly-docs.interfaces.js';
+import {ATT_SYNTAX_WARNING, addAttSyntaxWarningIfNeeded, determineAssemblySyntax} from '../assembly-syntax.js';
 
 function makeInfo(tooltip: string, html?: string): AssemblyInstructionInfo {
     html = html ?? `<p>${tooltip}</p>`;
-    return { tooltip, html, url: "https://example.com" };
+    return {tooltip, html, url: 'https://example.com'};
 }
 
 describe(addAttSyntaxWarningIfNeeded, () => {
-    describe("warns when syntax is att and", () => {
-        it("tooltip references cardinality operand and source/destination", () => {
-            const data = makeInfo(
-                "first operand (destination)",
-                "<p>Simple description</p>",
-            );
-            const result = addAttSyntaxWarningIfNeeded(data, "att");
+    describe('warns when syntax is att and', () => {
+        it('tooltip references cardinality operand and source/destination', () => {
+            const data = makeInfo('first operand (destination)', '<p>Simple description</p>');
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
 
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
 
-        it("html references cardinality operand and source/destination", () => {
-            const data = makeInfo(
-                "Simple tooltip",
-                "<p>second operand (source)</p>",
-            );
-            const result = addAttSyntaxWarningIfNeeded(data, "att");
+        it('html references cardinality operand and source/destination', () => {
+            const data = makeInfo('Simple tooltip', '<p>second operand (source)</p>');
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
 
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
 
-        it("both tooltip and html reference cardinality and source/destination", () => {
-            const text =
-                "copies the first operand (source) to the second operand (destination)";
+        it('both tooltip and html reference cardinality and source/destination', () => {
+            const text = 'copies the first operand (source) to the second operand (destination)';
             const data = makeInfo(text);
-            const result = addAttSyntaxWarningIfNeeded(data, "att");
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
     });
-    describe("does not warn when", () => {
-        it("intel syntax and references cardinal destination", () => {
-            const data = makeInfo("first operand (destination)");
-            const result = addAttSyntaxWarningIfNeeded(data, "intel");
+    describe('does not warn when', () => {
+        it('intel syntax and references cardinality of operands', () => {
+            const data = makeInfo('first operand (destination)');
+            const result = addAttSyntaxWarningIfNeeded(data, 'intel');
             expect(result).toEqual(data);
         });
 
-        it("att syntax and no cardinality references exist", () => {
+        it('att syntax and no cardinality references exist', () => {
             const data = makeInfo(
-                "Decrements the stack pointer and then stores the source operand on the top of the stack",
+                'Decrements the stack pointer and then stores the source operand on the top of the stack',
             );
-            const result = addAttSyntaxWarningIfNeeded(data, "att");
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
 
             expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
             expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
         });
 
-        it("cardinality is present but source/destination is absent", () => {
-            const data = makeInfo(
-                "Performs a signed multiplication of two operands",
-            );
-            const result = addAttSyntaxWarningIfNeeded(data, "att");
+        it('cardinality is present but source/destination is absent', () => {
+            const data = makeInfo('Performs a signed multiplication of two operands');
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
 
             expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
         });
 
-        it("source/destination is present but cardinality is absent", () => {
+        it('source/destination is present but cardinality is absent', () => {
             const data = makeInfo(
-                "Loads the value from the top of the stack to the location specified with the destination operand (or explicit opcode) and then increments the stack pointer.",
+                'Loads the value from the top of the stack to the location specified with the destination operand (or explicit opcode) and then increments the stack pointer.',
             );
-            const result = addAttSyntaxWarningIfNeeded(data, "att");
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
             expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
         });
     });
 
-    it("does not cross-contaminate: tooltip cardinality + html source/dest alone should not warn", () => {
-        const data = makeInfo(
-            "The first operand is foo",
-            "<p>Copies bar to the destination register</p>",
-        );
-        const result = addAttSyntaxWarningIfNeeded(data, "att");
+    it('does not warn if tooltip ^ html reference cardinality of operands', () => {
+        const data = makeInfo('The first operand is foo', '<p>Copies bar to the destination register</p>');
+        const result = addAttSyntaxWarningIfNeeded(data, 'att');
         expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
         expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
     });
-
-    it("handles fourth operand references", () => {
-        const data = makeInfo(
-            "The fourth operand specifies the destination mask",
-            "<p>VBLENDVPS description</p>",
-        );
-        const result = addAttSyntaxWarningIfNeeded(data, "att");
+    it('handles fourth operand references', () => {
+        const haddpsDescription =
+            'Adds single precision floating-point values in the third and fourth dword of the destination operand and stores the result in the second dword of the destination operand.';
+        const data = makeInfo(haddpsDescription);
+        const result = addAttSyntaxWarningIfNeeded(data, 'att');
         expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
     });
 
-    describe("purity", () => {
-        it("does not mutate the original data object regardless of syntax", () => {
+    describe('purity', () => {
+        it('does not mutate the original data object regardless of syntax', () => {
             const data = makeInfo(
-                "The first operand is the destination",
-                "<p>The first operand is the destination</p>",
+                'The first operand is the destination',
+                '<p>The first operand is the destination</p>',
             );
             const originalTooltip = data.tooltip;
             const originalHtml = data.html;
 
-            addAttSyntaxWarningIfNeeded(data, "att");
+            addAttSyntaxWarningIfNeeded(data, 'att');
             expect(data.tooltip).toBe(originalTooltip);
             expect(data.html).toBe(originalHtml);
         });
 
-        it("preserves the url field regardless of syntax", () => {
+        it('preserves the url field regardless of syntax', () => {
             let result: AssemblyInstructionInfo;
-            const data: AssemblyInstructionInfo = makeInfo(
-                "The first operand (destination)",
-                "<p>The first operand (destination)</p>",
-            );
+            const data = makeInfo('the first operand (destination)');
 
-            result = addAttSyntaxWarningIfNeeded(data, "att");
-            expect(result.url).toBe("https://example.com");
-            result = addAttSyntaxWarningIfNeeded(data, "intel");
-            expect(result.url).toBe("https://example.com");
+            result = addAttSyntaxWarningIfNeeded(data, 'att');
+            expect(result.url).toBe('https://example.com');
+            result = addAttSyntaxWarningIfNeeded(data, 'intel');
+            expect(result.url).toBe('https://example.com');
         });
     });
 });

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -41,28 +41,32 @@ function makeInfo(tooltip: string, html?: string): AssemblyInstructionInfo {
 describe(addAttSyntaxWarningIfNeeded, () => {
     describe('warns when syntax is att and', () => {
         const attSyntax: AssemblySyntax = 'att';
-        it('only tooltip references cardinality operand and source/destination', () => {
+        it('appends warning to tooltip and not html when only tooltip references cardinality operand and source/destination', () => {
             const data = makeInfo('first operand (destination)', '<p>Simple description</p>');
             const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
 
-            // TODO: only show on tooltip
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
-            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
         });
-
-        it('only html references cardinality operand and source/destination', () => {
+        it('appends warning to html and not tooltip only html references cardinality operand and source/destination', () => {
             const data = makeInfo('Simple tooltip', '<p>second operand (source)</p>');
             const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
 
-            // TODO: only show on html
-            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
-
         it('both tooltip and html reference cardinality and source/destination', () => {
             const text = 'copies the first operand (source) to the second operand (destination)';
             const data = makeInfo(text);
             const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
+            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
+            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+        });
+        it('handles third and fourth operand references', () => {
+            const haddpsDescription =
+                'Adds single precision floating-point values in the third and fourth dword of the destination operand and stores the result in the second dword of the destination operand.';
+            const data = makeInfo(haddpsDescription);
+            const result = addAttSyntaxWarningIfNeeded(data, 'att');
             expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
             expect(result.html).toContain(ATT_SYNTAX_WARNING);
         });
@@ -87,7 +91,6 @@ describe(addAttSyntaxWarningIfNeeded, () => {
                 expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
                 expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
             });
-
             it('cardinality is present but source/destination is absent', () => {
                 const data = makeInfo('Performs a signed multiplication of two operands');
                 const result = addAttSyntaxWarningIfNeeded(data, attSyntax);
@@ -95,7 +98,6 @@ describe(addAttSyntaxWarningIfNeeded, () => {
                 expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
                 expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
             });
-
             it('source/destination is present but cardinality is absent', () => {
                 const popDesc =
                     'Loads the value from the top of the stack to the location specified with the destination operand (or explicit opcode) and then increments the stack pointer.';
@@ -104,27 +106,21 @@ describe(addAttSyntaxWarningIfNeeded, () => {
                 expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
                 expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
             });
-        });
-
-        it('does not warn if tooltip contains "operand" and html contains "destination"', () => {
-            const data = makeInfo('The first operand is foo', '<p>Copies bar to the destination register</p>');
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
-            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-            expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
-        });
-        it('does not warn if tooltip contains "source" and html contains "operand"', () => {
-            const data = makeInfo('The source operand is foo', '<p>Copies bar to the last destination register</p>');
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
-            expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
-            expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
-        });
-        it('handles third and fourth operand references', () => {
-            const haddpsDescription =
-                'Adds single precision floating-point values in the third and fourth dword of the destination operand and stores the result in the second dword of the destination operand.';
-            const data = makeInfo(haddpsDescription);
-            const result = addAttSyntaxWarningIfNeeded(data, 'att');
-            expect(result.tooltip).toContain(ATT_SYNTAX_WARNING);
-            expect(result.html).toContain(ATT_SYNTAX_WARNING);
+            it('tooltip contains "operand" and html contains "destination"', () => {
+                const data = makeInfo('The first operand is foo', '<p>Copies bar to the destination register</p>');
+                const result = addAttSyntaxWarningIfNeeded(data, 'att');
+                expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+                expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
+            });
+            it('tooltip contains "source" and html contains "operand"', () => {
+                const data = makeInfo(
+                    'The source operand is foo',
+                    '<p>Copies bar to the last destination register</p>',
+                );
+                const result = addAttSyntaxWarningIfNeeded(data, 'att');
+                expect(result.tooltip).not.toContain(ATT_SYNTAX_WARNING);
+                expect(result.html).not.toContain(ATT_SYNTAX_WARNING);
+            });
         });
     });
 
@@ -138,7 +134,6 @@ describe(addAttSyntaxWarningIfNeeded, () => {
             expect(data.tooltip).toBe(originalTooltip);
             expect(data.html).toBe(originalHtml);
         });
-
         it('preserves the url field regardless of syntax', () => {
             let result: AssemblyInstructionInfo;
             const data = makeInfo('the first operand (destination)');

--- a/static/tests/assembly-syntax-tests.ts
+++ b/static/tests/assembly-syntax-tests.ts
@@ -152,12 +152,9 @@ describe(addAttSyntaxWarningIfNeeded, () => {
 });
 
 describe('determineAssemblySyntax', () => {
-    it('returns intel if supportsIntel is undefined', () => {
-        expect(determineAssemblySyntax(undefined, false)).toBe('intel');
-        expect(determineAssemblySyntax(undefined, true)).toBe('intel');
-        expect(determineAssemblySyntax(undefined, undefined)).toBe('intel');
-    })
     it.each([
+        ['intel', undefined, false],
+        ['intel', undefined, true],
         ['intel', false, false],
         ['intel', false, true],
         ['att', true, false],


### PR DESCRIPTION
Fixes #8567 

Fix bug where `asmSyntax` returned 'att' for compilers that do not define
`intelAsm` (e.g. Rust, Spice), but that do support Intel:

- The base compiler defaults `supportsIntel` property to `!!this.compiler.intelAsm`
- Aforementioned compilers override this in [optionsForFilter override](https://github.com/compiler-explorer/compiler-explorer/blob/6b1ff666f238bce450d9e0825f30113f1b91b9bd/lib/compilers/rust.ts#L272)

Before:

```typescript
// bug
const isAtt = /*...*/ !(this.filters.isSet('intel') && this.compiler.intelAsm.includes('intel'));
/*                            1                                 0                           */
/*                                                   0                                      */
/*                               !0 => 1                                                    */
```

Removing the check for intelAsm resolves this.

- Extracted the logic that determines the assembly syntax and added unit tests
  that cover all possible inputs.
- Verified with local Rust.

## Miscellany

- **rm handling of 'last operand'**
- **fix: order-agnostic refCardinalityOfSrcDstOperands**
  - Marked TODO: only show warnings where relevant, i.e. if the cardinality of
    src/dst operands is not shown in tooltip text but is shown in context menu,
    then the warning should only display in the context menu. Beyond scope of
    this PR.
- **optional supportsIntel arg, test undefined supportsIntel**

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
