### PR TITLE
Add CE Library Wizard documentation

### DIFF
--- a/docs/AddingALibrary.md
+++ b/docs/AddingALibrary.md
@@ -13,8 +13,8 @@ The easiest way to add a library to Compiler Explorer is to use the
 process — including forking repos, updating configuration files, and creating pull requests. It supports C, C++, Rust,
 Fortran, and Go.
 
-*Note: the wizard currently only runs on Linux and requires Git and the
-[GitHub CLI](https://cli.github.com/).*
+*Note: the wizard currently only runs on Linux and requires Git, the
+[GitHub CLI](https://cli.github.com/), and CMake (for libraries that use CMake).*
 
 ```bash
 git clone https://github.com/compiler-explorer/ce-library-wizard.git

--- a/docs/AddingALibrary.md
+++ b/docs/AddingALibrary.md
@@ -11,7 +11,7 @@ built, there are some caveats, best practices and good to knows. Consult the bot
 The easiest way to add a library to Compiler Explorer is to use the
 [CE Library Wizard](https://github.com/compiler-explorer/ce-library-wizard), a CLI tool that automates the entire
 process — including forking repos, updating configuration files, and creating pull requests. It supports C, C++, Rust,
-Fortran, and Go.
+Fortran, and Go. Note: the wizard currently only runs on Linux.
 
 ```bash
 git clone https://github.com/compiler-explorer/ce-library-wizard.git

--- a/docs/AddingALibrary.md
+++ b/docs/AddingALibrary.md
@@ -11,7 +11,8 @@ built, there are some caveats, best practices and good to knows. Consult the bot
 The easiest way to add a library to Compiler Explorer is to use the
 [CE Library Wizard](https://github.com/compiler-explorer/ce-library-wizard), a CLI tool that automates the entire
 process — including forking repos, updating configuration files, and creating pull requests. It supports C, C++, Rust,
-Fortran, and Go. Note: the wizard currently only runs on Linux.
+Fortran, and Go. Note: the wizard currently only runs on Linux and requires Git and the
+[GitHub CLI](https://cli.github.com/).
 
 ```bash
 git clone https://github.com/compiler-explorer/ce-library-wizard.git

--- a/docs/AddingALibrary.md
+++ b/docs/AddingALibrary.md
@@ -6,6 +6,58 @@ and then how to submit PRs to get it into the main CE site.
 Note that most libraries are Header-only. This is the easiest form of library to support. If the library needs to be
 built, there are some caveats, best practices and good to knows. Consult the bottom of this page for details.
 
+## CE Library Wizard (recommended)
+
+The easiest way to add a library to Compiler Explorer is to use the
+[CE Library Wizard](https://github.com/compiler-explorer/ce-library-wizard), a CLI tool that automates the entire
+process — including forking repos, updating configuration files, and creating pull requests. It supports C, C++, Rust,
+Fortran, and Go.
+
+```bash
+git clone https://github.com/compiler-explorer/ce-library-wizard.git
+cd ce-library-wizard
+./run.sh
+```
+
+This launches an interactive mode that guides you through the process. You can also use command-line flags directly:
+
+```bash
+# C++ library (auto-detects type)
+./run.sh --lang=c++ --lib=https://github.com/fmtlib/fmt --ver=10.2.1
+
+# Header-only C++ library
+./run.sh --lang=c++ --lib=https://github.com/bobluppes/graaf --ver=v1.1.1 --type=header-only
+
+# Rust crate
+./run.sh --lang=rust --lib=serde --ver=1.0.195
+
+# C library
+./run.sh --lang=c --lib=https://github.com/libuv/libuv --ver=1.46.0
+
+# Fortran library (requires fpm.toml)
+./run.sh --lang=fortran --lib=https://github.com/jacobwilliams/json-fortran --ver=8.5.0
+
+# Go module
+./run.sh --lang=go --lib=github.com/google/uuid --ver=v1.6.0
+
+# Multiple versions at once
+./run.sh --lang=c++ --lib=https://github.com/nlohmann/json --ver=3.11.1,3.11.2,3.11.3
+
+# Bulk-add top 100 Rust crates
+./run.sh --top-rust-crates
+```
+
+Useful options include `--verify` to preview changes, `--dry-run` to skip committing, `--install-test` to validate
+installation (C/C++), `--build-test=yes` to test building, and `--type=TYPE` to skip auto-detection (C/C++).
+
+For full documentation, see the
+[CE Library Wizard repository](https://github.com/compiler-explorer/ce-library-wizard).
+
+## Manual configuration
+
+The rest of this document describes how to add libraries manually, which is useful for understanding how the
+configuration works or for cases the wizard doesn't cover.
+
 If you're specifically looking for adding a Rust crate to CE, go here
 https://github.com/compiler-explorer/infra/blob/main/docs/adding_rust_crates.md
 

--- a/docs/AddingALibrary.md
+++ b/docs/AddingALibrary.md
@@ -11,8 +11,10 @@ built, there are some caveats, best practices and good to knows. Consult the bot
 The easiest way to add a library to Compiler Explorer is to use the
 [CE Library Wizard](https://github.com/compiler-explorer/ce-library-wizard), a CLI tool that automates the entire
 process — including forking repos, updating configuration files, and creating pull requests. It supports C, C++, Rust,
-Fortran, and Go. Note: the wizard currently only runs on Linux and requires Git and the
-[GitHub CLI](https://cli.github.com/).
+Fortran, and Go.
+
+*Note: the wizard currently only runs on Linux and requires Git and the
+[GitHub CLI](https://cli.github.com/).*
 
 ```bash
 git clone https://github.com/compiler-explorer/ce-library-wizard.git


### PR DESCRIPTION
## Summary
- Add documentation for the [CE Library Wizard](https://github.com/compiler-explorer/ce-library-wizard) to `AddingALibrary.md`
- Placed as the recommended approach before the manual configuration section
- Covers all supported languages (C, C++, Rust, Fortran, Go) with usage examples and common options

## Test plan
- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)