### PR TITLE
Update major dependencies: TypeScript 6, webpack-cli 7, webpack-dev-middleware 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,12 +116,12 @@
         "supertest": "^7.2.2",
         "terser-webpack-plugin": "^5.4.0",
         "ts-loader": "^9.5.4",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vitest": "^4.0.1",
         "vitest-fetch-mock": "^0.4.5",
         "webpack": "^5.105.4",
-        "webpack-cli": "^6.0.1",
-        "webpack-dev-middleware": "^7.4.5",
+        "webpack-cli": "^7.0.2",
+        "webpack-dev-middleware": "^8.0.2",
         "webpack-manifest-plugin": "^6.0.1"
       },
       "engines": {
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
+      "integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6271,53 +6271,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -16238,9 +16191,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16684,19 +16637,15 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
+      "integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
+        "@discoveryjs/json-ext": "^1.0.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
         "envinfo": "^7.14.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
@@ -16708,14 +16657,16 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "webpack-bundle-analyzer": {
@@ -16726,39 +16677,28 @@
         }
       }
     },
-    "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/webpack-dev-middleware": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
-      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-8.0.2.tgz",
+      "integrity": "sha512-MCBgoI025uJEcIYDT+R3mXUnhZA/GAxqwngADOwmHxMhQUgDztGow6AmyeEfI8L9KG2pDVg2kU6vjFnbCBH5Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^4.43.1",
-        "mime-types": "^3.0.1",
+        "memfs": "^4.56.10",
+        "mime-types": "^3.0.2",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^4.3.3"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": "^5.101.0"
       },
       "peerDependenciesMeta": {
         "webpack": {

--- a/package.json
+++ b/package.json
@@ -125,12 +125,12 @@
     "supertest": "^7.2.2",
     "terser-webpack-plugin": "^5.4.0",
     "ts-loader": "^9.5.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vitest": "^4.0.1",
     "vitest-fetch-mock": "^0.4.5",
     "webpack": "^5.105.4",
-    "webpack-cli": "^6.0.1",
-    "webpack-dev-middleware": "^7.4.5",
+    "webpack-cli": "^7.0.2",
+    "webpack-dev-middleware": "^8.0.2",
     "webpack-manifest-plugin": "^6.0.1"
   },
   "optionalDependencies": {
@@ -165,7 +165,7 @@
     "ts-check:tests": "tsc -p ./tsconfig.tests.json --noEmit",
     "ts-check:frontend-tests": "tsc -p ./tsconfig.frontend.tests.json --noEmit",
     "ts-check:cypress": "tsc -p ./cypress/tsconfig.json --noEmit",
-    "webpack": "node --no-warnings=ExperimentalWarning --import=tsx ./node_modules/webpack-cli/bin/cli.js --node-env=production --config webpack.config.esm.ts"
+    "webpack": "node --no-warnings=ExperimentalWarning --import=tsx ./node_modules/webpack-cli/bin/cli.js --config-node-env=production --config webpack.config.esm.ts"
   },
   "license": "BSD-2-Clause",
   "packageManager": "npm@11.2.0"

--- a/static/client.d.ts
+++ b/static/client.d.ts
@@ -46,6 +46,34 @@ declare module '*.png' {
     export default src;
 }
 
+declare module '*.css' {
+    const content: string;
+    export default content;
+}
+
+declare module '*.scss' {
+    const content: string;
+    export default content;
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/cpp/cpp' {
+    import type {languages} from 'monaco-editor';
+    export const conf: languages.LanguageConfiguration;
+    export const language: languages.IMonarchLanguage;
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/swift/swift' {
+    import type {languages} from 'monaco-editor';
+    export const conf: languages.LanguageConfiguration;
+    export const language: languages.IMonarchLanguage;
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/rust/rust' {
+    import type {languages} from 'monaco-editor';
+    export const conf: languages.LanguageConfiguration;
+    export const language: languages.IMonarchLanguage;
+}
+
 declare module 'lodash.clonedeep' {
     const cloneDeep: <T>(value: T) => T;
     export = cloneDeep;

--- a/static/modes/rust-mode.ts
+++ b/static/modes/rust-mode.ts
@@ -42,7 +42,7 @@ function definition(): monaco.languages.IMonarchLanguage {
     for (let i = 0; i < rustPatched.tokenizer.numbers.length; i++) {
         const rule = rustPatched.tokenizer.numbers[i];
         if (Array.isArray(rule) && rule[0] instanceof RegExp && rule[0].toString() === expectedPattern.toString()) {
-            rustPatched.tokenizer.numbers[i] = fixedPattern;
+            rustPatched.tokenizer.numbers[i] = fixedPattern as any;
             patternFound = true;
             break;
         }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Code generation */
     "sourceMap": true,
-    "downlevelIteration": true,
+    "ignoreDeprecations": "6.0",
     "importHelpers": true,
     /* Module resolution */
     "esModuleInterop": true,

--- a/tsconfig.frontend.json
+++ b/tsconfig.frontend.json
@@ -4,6 +4,7 @@
     /* Module resolution */
     "target": "es5",
     /* Code generation */
+    "downlevelIteration": true,
     "inlineSources": true,
     "strictPropertyInitialization": false,
     "lib": ["dom", "es5", "dom.iterable"]

--- a/tsconfig.frontend.tests.json
+++ b/tsconfig.frontend.tests.json
@@ -1,5 +1,5 @@
 {
     "extends": "./tsconfig.frontend.json",
-    "files": ["static/global.ts"],
+    "files": ["static/global.ts", "static/client.d.ts"],
     "include": ["static/tests/**/*.ts"],
 }


### PR DESCRIPTION
## Summary
- **TypeScript** 5.9.3 → 6.0.2
  - Removed deprecated `downlevelIteration` from `tsconfig.base.json` (kept in frontend config where ES5 target needs it)
  - Added `ignoreDeprecations: "6.0"` to suppress ES5 target deprecation warning (still functional, removed in TS7)
  - Added CSS/SCSS/monaco module declarations to `static/client.d.ts` for new TS6 side-effect import checking
  - Added `static/client.d.ts` to `tsconfig.frontend.tests.json` files list
  - Fixed strict type error in `rust-mode.ts` monkey-patch with type assertion
- **webpack-cli** 6.0.1 → 7.0.2
  - Renamed `--node-env` to `--config-node-env` in the webpack build script (breaking change in 7.0)
- **webpack-dev-middleware** 7.4.5 → 8.0.2
  - No code changes needed (only used as Express middleware, breaking `getFilenameFromUrl` async change is internal)

Note: golden-layout and monaco-editor were intentionally excluded from this update.

## Test plan
- [x] `npm run ts-check` — all 5 tsconfig targets pass
- [x] `npm run lint-check` — passes (18 pre-existing warnings, no errors)
- [x] `npm run test` — all 2263 tests pass (including expensive tests)
- [x] `npm run test:props` — all 90 property validation tests pass
- [x] `npm run webpack` — production build completes successfully
- [x] `npm run dev` — dev server boots and listens on localhost:10240
- [x] `npm run check` — full pre-commit check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)