### PR TITLE
[swift]: add 6.3 and 6.2.4 compilers

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&swift:&arm-swift
-demangler=/opt/compiler-explorer/swift-6.2/usr/bin/swift-demangle
-defaultCompiler=swift62
+demangler=/opt/compiler-explorer/swift-6.3/usr/bin/swift-demangle
+defaultCompiler=swift63
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 
 #################################
@@ -8,13 +8,13 @@ objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 #################################
 
 # swift (x86_64)
-group.swift.compilers=swift62:swift61:swift603:swift510:swift59:swift58:swift57:swift56:swift55:swift54:swift53:swift52:swift51:swift50:swift42:swift412:swift411:swift41:swift403:swift402:swift311:swiftdevsnapshot:swiftnightly
+group.swift.compilers=swift63:swift624:swift62:swift61:swift603:swift510:swift59:swift58:swift57:swift56:swift55:swift54:swift53:swift52:swift51:swift50:swift42:swift412:swift411:swift41:swift403:swift402:swift311:swiftdevsnapshot:swiftnightly
 group.swift.isSemVer=true
 group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc
 
 # arm-swift (aarch64)
-group.arm-swift.compilers=arm-swift62:arm-swift61:arm-swift603
+group.arm-swift.compilers=arm-swift63:arm-swift624:arm-swift62:arm-swift61:arm-swift603
 group.arm-swift.isSemVer=true
 group.arm-swift.groupName=swift (aarch64)
 group.arm-swift.baseName=aarch64 swiftc
@@ -38,6 +38,12 @@ compiler.swiftdevsnapshot.semver=devsnapshot
 
 # 6.x (x86)
 
+compiler.swift63.exe=/opt/compiler-explorer/swift-6.3/usr/bin/swiftc
+compiler.swift63.semver=6.3
+
+compiler.swift624.exe=/opt/compiler-explorer/swift-6.2.4/usr/bin/swiftc
+compiler.swift624.semver=6.2.4
+
 compiler.swift62.exe=/opt/compiler-explorer/swift-6.2/usr/bin/swiftc
 compiler.swift62.semver=6.2
 
@@ -48,6 +54,14 @@ compiler.swift603.exe=/opt/compiler-explorer/swift-6.0.3/usr/bin/swiftc
 compiler.swift603.semver=6.0.3
 
 # 6.x (arm)
+
+compiler.arm-swift63.exe=/opt/compiler-explorer/swift-6.3/usr/bin/swiftc
+compiler.arm-swift63.semver=6.3
+compiler.arm-swift63.options=-target aarch64-swift-linux-musl -sdk /opt/compiler-explorer/swift-6.3-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64 -resource-dir /opt/compiler-explorer/swift-6.3-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static
+
+compiler.arm-swift624.exe=/opt/compiler-explorer/swift-6.2.4/usr/bin/swiftc
+compiler.arm-swift624.semver=6.2.4
+compiler.arm-swift624.options=-target aarch64-swift-linux-musl -sdk /opt/compiler-explorer/swift-6.2.4-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64 -resource-dir /opt/compiler-explorer/swift-6.2.4-static-sdk/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static
 
 compiler.arm-swift62.exe=/opt/compiler-explorer/swift-6.2/usr/bin/swiftc
 compiler.arm-swift62.semver=6.2


### PR DESCRIPTION
Adds support for the 6.3 and 6.2.4 swift compilers.

Depends on: https://github.com/compiler-explorer/infra/pull/2045, https://github.com/compiler-explorer/infra/pull/2054