### PR TITLE
[opt-pipeline]: Reorder error conditions

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1554,9 +1554,9 @@ export class BaseCompiler {
         const output = await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
         const compileEnd = performance.now();
 
-        if (output.code) {
+        if (output.truncated) {
             return {
-                error: `Invocation failed: ${utils.resultLinesToText(output.stderr)}${utils.resultLinesToText(output.stdout)}}`,
+                error: 'Exceeded max output limit',
                 results: {},
                 compileTime: output.execTime || compileEnd - compileStart,
             };
@@ -1570,9 +1570,9 @@ export class BaseCompiler {
             };
         }
 
-        if (output.truncated) {
+        if (output.code) {
             return {
-                error: 'Exceeded max output limit',
+                error: `Invocation failed: ${utils.resultLinesToText(output.stderr)}${utils.resultLinesToText(output.stdout)}}`,
                 results: {},
                 compileTime: output.execTime || compileEnd - compileStart,
             };


### PR DESCRIPTION
When the opt pipeline compiler times out or produces too much output, it will exit with a non-zero exit code (tested with `clang++` and `rustc`), which means that
* the `timedOut` and `truncated` checks are unreachable
* when the compiler times out, it probably also produces *a lot* of output, which is included in the error message shown by the `code` check. This obscures the actual cause of the error.