### PR TITLE
Add Cranelift backend option for Rust

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&rust:&rustgcc:&mrustc:&rustccggcc
+compilers=&rust:&rustgcc:&mrustc:&rustccggcc:&rustccgcranelift
 objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
 linker=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 aarch64linker=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
@@ -312,6 +312,19 @@ compiler.rustbpfgtrunk.objdumper=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknow
 compiler.rustbpfgtrunk.demangler=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 compiler.rustbpfgtrunk.semver=(trunk)
 compiler.rustbpfgtrunk.isNightly=true
+
+# Rustc CG Cranelift (Cranelift backend for rustc compiler)
+group.rustccgcranelift.compilers=rustccgcranelift-nightly
+group.rustccgcranelift.compilerType=rustc-cg-cranelift
+group.rustccgcranelift.supportsBinary=true
+group.rustccgcranelift.supportsBinaryObject=true
+group.rustccgcranelift.options=-Zcodegen-backend=cranelift
+group.rustccgcranelift.unwiseOptions=-Ctarget-cpu=native|target-cpu=native
+compiler.rustccgcranelift-nightly.exe=/opt/compiler-explorer/rust-nightly/bin/rustc
+compiler.rustccgcranelift-nightly.name=rustc-cg-cranelift (nightly)
+compiler.rustccgcranelift-nightly.semver=nightly
+compiler.rustccgcranelift-nightly.isNightly=true
+compiler.rustccgcranelift-nightly.libPath=${exePath}/../lib/rustlib/x86_64-unknown-linux-gnu/lib
 
 # Rustc CG GCC (GCC backend for rustc compiler)
 group.rustccggcc.compilers=rustccggcc-master

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -143,6 +143,7 @@ export {ResolcCompiler} from './resolc.js';
 export {RGACompiler} from './rga.js';
 export {RubyCompiler} from './ruby.js';
 export {RustCompiler} from './rust.js';
+export {RustcCgCraneliftCompiler} from './rustc-cg-cranelift.js';
 export {RustcCgGCCCompiler} from './rustc-cg-gcc.js';
 export {SailCompiler} from './sail.js';
 export {ScalaCompiler} from './scala.js';

--- a/lib/compilers/rustc-cg-cranelift.ts
+++ b/lib/compilers/rustc-cg-cranelift.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {RustCompiler} from './rust.js';
+
+export class RustcCgCraneliftCompiler extends RustCompiler {
+    static override get key() {
+        return 'rustc-cg-cranelift';
+    }
+
+    constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(info, env);
+        this.compiler.supportsIrView = false;
+        this.compiler.supportsOptOutput = false;
+        this.compiler.optPipeline = undefined;
+    }
+
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
+        filters.binaryObject = true;
+        return super.optionsForFilter(filters, outputFilename, userOptions);
+    }
+}


### PR DESCRIPTION
Resolves #5716.

Cranelift currently does not support `--emit=asm`, so this PR mimics the behaviour of the wasmtime WASM compiler (which also uses Cranelift as its backend): It unconditionally checks “Compile to binary object”.  (See also https://github.com/compiler-explorer/compiler-explorer/issues/5716#issuecomment-2671167020.)