### PR TITLE
Add asm docs for RISC-V SGT/SGTU pseudoinstructions

### DIFF
--- a/etc/scripts/docenizers/docenizer-riscv64.py
+++ b/etc/scripts/docenizers/docenizer-riscv64.py
@@ -153,7 +153,7 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
                 f'<br><div><b>Equivalent ASM:</b><pre>{equiv}</pre></div>'
                 f'<br><div><b>ISA</b>: (pseudo)</div></div>'
             )
-            tooltip = f"Pseudo Instruction.\n\nEquivalent ASM:\n\n{equiv}\n\n"
+            tooltip = f"Psuedo Instruction.\n\nEquivalent ASM:\n\n{equiv}\n\n"
             info = json.dumps({"html": html, "tooltip": tooltip, "url": htmlhost}, indent=16, separators=(',', ': '), sort_keys=True)
             output.write(f'        case "{op}":\n')
             output.write(f'            return {info[:-1]}            }};\n\n')

--- a/etc/scripts/docenizers/docenizer-riscv64.py
+++ b/etc/scripts/docenizers/docenizer-riscv64.py
@@ -153,7 +153,7 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
                 f'<br><div><b>Equivalent ASM:</b><pre>{equiv}</pre></div>'
                 f'<br><div><b>ISA</b>: (pseudo)</div></div>'
             )
-            tooltip = f"Psuedo Instruction.\n\nEquivalent ASM:\n\n{equiv}\n\n"
+            tooltip = f"Pseudo Instruction.\n\nEquivalent ASM:\n\n{equiv}\n\n"
             info = json.dumps({"html": html, "tooltip": tooltip, "url": htmlhost}, indent=16, separators=(',', ': '), sort_keys=True)
             output.write(f'        case "{op}":\n')
             output.write(f'            return {info[:-1]}            }};\n\n')

--- a/etc/scripts/docenizers/docenizer-riscv64.py
+++ b/etc/scripts/docenizers/docenizer-riscv64.py
@@ -130,7 +130,34 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
             if record.opcode_alias:
                 output.write(f'        case "{record.opcode_alias}":\n')
             output.write(f'            return {str(record)[:-1]}            }};\n\n')
-        
+
+        # Pseudoinstructions missing from the upstream YAML data
+        extra_pseudos = [
+            {
+                "opcode": "SGT",
+                "args": "rd, rs, rt",
+                "equivalent": "slt rd, rt, rs",
+            },
+            {
+                "opcode": "SGTU",
+                "args": "rd, rs, rt",
+                "equivalent": "sltu rd, rt, rs",
+            },
+        ]
+        for pseudo in extra_pseudos:
+            op = pseudo["opcode"]
+            args = pseudo["args"]
+            equiv = pseudo["equivalent"]
+            html = (
+                f'<div><span class="opcode"><b>{op}</b> {args}</span>'
+                f'<br><div><b>Equivalent ASM:</b><pre>{equiv}</pre></div>'
+                f'<br><div><b>ISA</b>: (pseudo)</div></div>'
+            )
+            tooltip = f"Psuedo Instruction.\n\nEquivalent ASM:\n\n{equiv}\n\n"
+            info = json.dumps({"html": html, "tooltip": tooltip, "url": htmlhost}, indent=16, separators=(',', ': '), sort_keys=True)
+            output.write(f'        case "{op}":\n')
+            output.write(f'            return {info[:-1]}            }};\n\n')
+
         output.write("""
     }
 }

--- a/lib/asm-docs/generated/asm-docs-riscv64.ts
+++ b/lib/asm-docs/generated/asm-docs-riscv64.ts
@@ -6467,6 +6467,20 @@ export function getAsmOpcode(opcode: string | undefined): AssemblyInstructionInf
                 "url": "https://five-embeddev.github.io/riscv-docs-html/"
             };
 
+        case "SGT":
+            return {
+                "html": "<div><span class=\"opcode\"><b>SGT</b> rd, rs, rt</span><br><div><b>Equivalent ASM:</b><pre>slt rd, rt, rs</pre></div><br><div><b>ISA</b>: (pseudo)</div></div>",
+                "tooltip": "Psuedo Instruction.\n\nEquivalent ASM:\n\nslt rd, rt, rs\n\n",
+                "url": "https://five-embeddev.github.io/riscv-docs-html/"
+            };
+
+        case "SGTU":
+            return {
+                "html": "<div><span class=\"opcode\"><b>SGTU</b> rd, rs, rt</span><br><div><b>Equivalent ASM:</b><pre>sltu rd, rt, rs</pre></div><br><div><b>ISA</b>: (pseudo)</div></div>",
+                "tooltip": "Psuedo Instruction.\n\nEquivalent ASM:\n\nsltu rd, rt, rs\n\n",
+                "url": "https://five-embeddev.github.io/riscv-docs-html/"
+            };
+
 
     }
 }

--- a/test/handlers/asm-docs-tests.ts
+++ b/test/handlers/asm-docs-tests.ts
@@ -112,6 +112,9 @@ const TEST_MATRIX: Record<PropertyKey, [string, string, string, string][]> = {
             'https://docs.nvidia.com/cuda/cuda-binary-utilities/index.html#instruction-set-reference',
         ],
     ],
+    riscv64: [
+        ['SGT', 'Psuedo Instruction.', '<b>SGT</b> rd, rs, rt', 'https://five-embeddev.github.io/riscv-docs-html/'],
+    ],
     wdc65c816: [
         [
             'jsl',


### PR DESCRIPTION
## Summary
- Fixes #8622: adds assembly documentation entries for the RISC-V `sgt` and `sgtu` pseudoinstructions so the hover/"View assembly documentation" feature works instead of showing an error.
- `sgt rd, rs, rt` expands to `slt rd, rt, rs`; `sgtu rd, rs, rt` expands to `sltu rd, rt, rs`. Entries follow the same shape as the existing `SGTZ` pseudo entry.

## Test plan
- [x] `npx vitest run test/handlers/asm-docs-tests.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (no new errors)

---

This PR is authored by an LLM (Claude) acting on behalf of @mattgodbolt.