### PR TITLE
[odin] better explain @(export) and add two examples

### DIFF
--- a/examples/odin/default.odin
+++ b/examples/odin/default.odin
@@ -1,7 +1,12 @@
+// Type your code here, or load an example.
+// At higher optimization levels, procedures may be
+// automatically inlined and will not show up in the
+// output. Use the `@(export)` attribute on procedures
+// you wish to see in the output.
+
 package main
 
-import "core:fmt"
-
-main :: proc() {
-    fmt.println("Hello")
+@(export)
+square :: proc(num: int) -> int {
+	return num * num
 }

--- a/examples/odin/max_in_slice.odin
+++ b/examples/odin/max_in_slice.odin
@@ -1,0 +1,10 @@
+package main
+
+@(export)
+max_slice :: proc(array: []int) -> int {
+	max_val := min(int)
+	for elem in array {
+		max_val = max(max_val, elem)
+	}
+	return max_val
+}

--- a/examples/odin/sum_over_slice.odin
+++ b/examples/odin/sum_over_slice.odin
@@ -1,0 +1,10 @@
+package main
+
+@(export)
+sum_slice :: proc(array: []int) -> int {
+	sum := 0
+	for elem in array {
+		sum += elem
+	}
+	return sum
+}


### PR DESCRIPTION
there has repeatedly been some confusion around how to get procedures to show in the output at higher optimization levels. this modifies the default example to demonstrate and explain that behavior and adds two new examples to show some basic language usage