### PR TITLE
Make default Carbon code match that used by other languages

### DIFF
--- a/examples/carbon/default.carbon
+++ b/examples/carbon/default.carbon
@@ -1,11 +1,4 @@
-// To run this in Carbon Explorer you'll need to uncomment the following line:
-// package sample api;
-
+// Type your code here, or load an example.
 fn Square(x: i32) -> i32 {
   return x * x;
-}
-
-// To run this in Carbon Explorer you'll need to rename this "Main()".
-fn Run() -> i32 {
-  return Square(12);
 }


### PR DESCRIPTION
Don't define a `Run` (`main`) function. Remove comments mentioning Carbon Explorer, since that has been unmaintained for several years, and is very outdated at this point. Add "Type your code here" comment matching the default for other languages.