### PR TITLE
Add support for compiling code with libraries to clang-query.

### DIFF
--- a/lib/tooling/clang-query-tool.ts
+++ b/lib/tooling/clang-query-tool.ts
@@ -27,6 +27,7 @@ import path from 'node:path';
 
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../../types/tool.interfaces.js';
+import {OptionsHandlerLibrary} from '../options-handler.js';
 import {ToolEnv} from './base-tool.interface.js';
 import {BaseTool} from './base-tool.js';
 
@@ -41,16 +42,27 @@ export class ClangQueryTool extends BaseTool {
         this.addOptionsToToolArgs = false;
     }
 
-    override async runTool(compilationInfo: CompilationInfo, inputFilepath: string, args: string[], stdin: string) {
+    override async runTool(
+        compilationInfo: CompilationInfo,
+        inputFilepath: string,
+        args: string[],
+        stdin: string,
+        supportedLibraries?: Record<string, OptionsHandlerLibrary>,
+    ) {
         const sourcefile = inputFilepath;
         const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
 
-        const compileFlags = options.filter((option: string) => option !== sourcefile);
+        const includeflags = super.getIncludeArguments(compilationInfo.libraries, supportedLibraries || {}, dir);
+        const libOptions = super.getLibraryOptions(compilationInfo.libraries, supportedLibraries || {});
+
+        let compileFlags = options.filter((option: string) => option !== sourcefile);
         if (!compilerExe.includes('clang++')) {
             compileFlags.concat(this.tool.options);
         }
+        compileFlags = compileFlags.concat(includeflags);
+        compileFlags = compileFlags.concat(libOptions);
 
         const query_commands_file = this.getUniqueFilePrefix() + 'query_commands.txt';
 


### PR DESCRIPTION
I tested this locally on a few examples with clang-query-19.