### PR TITLE
Add Norcroft C and C++ compiler support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -173,3 +173,4 @@ From oldest to newest contributor, we would like to thank:
 - [Josh Brice](https://github.com/jjb0123)
 - [Sean Garwood](https://github.com/sean-garwood)
 - [Victor Vianna](https://github.com/victorvianna)
+- [Piers Wombwell](https://github.com/pwombwell)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang:&gcc-classic
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang:&gcc-classic:&npparm
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -4833,6 +4833,24 @@ group.gcc-classic.compilerCategories=gcc
 group.gcc-classic.instructionSet=amd64
 compiler.g127.exe=/opt/compiler-explorer/gcc-1.27/bin/g++
 compiler.g127.semver=1.27
+
+#################################
+# Norcroft ARM C++
+group.npparm.compilers=npparm-trunk
+group.npparm.groupName=Norcroft ARM C++
+group.npparm.baseName=Norcroft ARM C++
+group.npparm.compilerType=norcroft
+group.npparm.instructionSet=arm32
+group.npparm.supportsBinary=false
+group.npparm.supportsExecute=false
+group.npparm.isSemVer=true
+group.npparm.licenseName=BSD 3-clause
+group.npparm.licenseLink=https://github.com/Norcroft/ncc-ng/blob/main/LICENSE
+
+compiler.npparm-trunk.exe=/opt/compiler-explorer/ncc-ng-trunk/bin/n++
+compiler.npparm-trunk.name=Norcroft ARM C++ (trunk)
+compiler.npparm-trunk.semver=(trunk)
+compiler.npparm-trunk.isNightly=true
 
 #################################
 #################################

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -4842,6 +4842,7 @@ group.npparm.baseName=Norcroft ARM C++
 group.npparm.compilerType=norcroft
 group.npparm.instructionSet=arm32
 group.npparm.supportsBinary=false
+group.npparm.supportsBinaryObject=false
 group.npparm.supportsExecute=false
 group.npparm.isSemVer=true
 group.npparm.licenseName=BSD 3-clause

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4354,6 +4354,7 @@ group.nccarm.baseName=Norcroft ARM C
 group.nccarm.compilerType=norcroft
 group.nccarm.instructionSet=arm32
 group.nccarm.supportsBinary=false
+group.nccarm.supportsBinaryObject=false
 group.nccarm.supportsExecute=false
 group.nccarm.isSemVer=true
 group.nccarm.licenseName=BSD 3-clause

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust
+compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm
 defaultCompiler=cg152
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -4345,6 +4345,24 @@ group.c2rust.supportsBinaryObject=false
 
 compiler.c2rust-master.exe=/opt/compiler-explorer/c2rust-master/c2rust
 compiler.c2rust-master.name=C2Rust (master)
+
+#################################
+# Norcroft ARM C
+group.nccarm.compilers=nccarm-trunk
+group.nccarm.groupName=Norcroft ARM C
+group.nccarm.baseName=Norcroft ARM C
+group.nccarm.compilerType=norcroft
+group.nccarm.instructionSet=arm32
+group.nccarm.supportsBinary=false
+group.nccarm.supportsExecute=false
+group.nccarm.isSemVer=true
+group.nccarm.licenseName=BSD 3-clause
+group.nccarm.licenseLink=https://github.com/Norcroft/ncc-ng/blob/main/LICENSE
+
+compiler.nccarm-trunk.exe=/opt/compiler-explorer/ncc-ng-trunk/bin/ncc
+compiler.nccarm-trunk.name=Norcroft ARM C (trunk)
+compiler.nccarm-trunk.semver=(trunk)
+compiler.nccarm-trunk.isNightly=true
 
 #################################
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -118,6 +118,7 @@ export {Msp430Compiler} from './msp430.js';
 export {NasmCompiler} from './nasm.js';
 export {NimCompiler} from './nim.js';
 export {NixCompiler} from './nix.js';
+export {NorcroftCompiler} from './norcroft.js';
 export {NumbaCompiler} from './numba.js';
 export {NvccCompiler} from './nvcc.js';
 export {NvcppCompiler} from './nvcpp.js';

--- a/lib/compilers/norcroft.ts
+++ b/lib/compilers/norcroft.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import _ from 'underscore';
+import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {unwrap} from '../assert.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {logger} from '../logger.js';
+import {NorcroftObjAsmParser} from '../parsers/asm-parser-norcroft.js';
+
+export class NorcroftCompiler extends BaseCompiler {
+    constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(compilerInfo, env);
+
+        this.asm = new NorcroftObjAsmParser(this.compilerProps);
+    }
+
+    static get key() {
+        return 'norcroft';
+    }
+
+    override async getVersion() {
+        logger.info(`Gathering ${this.compiler.id} version information on ${this.compiler.exe}...`);
+        if (this.compiler.explicitVersion) {
+            logger.debug(`${this.compiler.id} has forced version output: ${this.compiler.explicitVersion}`);
+            return {stdout: this.compiler.explicitVersion, stderr: '', code: 0};
+        }
+        const execOptions = this.getDefaultExecOptions();
+        const versionFlag: string[] = [];
+        execOptions.timeoutMs = 0;
+        execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths([]);
+
+        try {
+            const res = await this.execCompilerCached(this.compiler.exe, versionFlag, execOptions);
+            return {stdout: res.stdout, stderr: res.stderr, code: res.code};
+        } catch (err) {
+            logger.error(`Unable to get version for compiler '${this.compiler.exe}' - ${err}`);
+            return null;
+        }
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
+        filters.binary = false;
+
+        if (_.some(unwrap(userOptions), opt => opt === '-help' || opt === '-h')) {
+            // Let the compiler print its own help text
+            return [];
+        }
+        if (!_.some(unwrap(userOptions), opt => opt === '-E')) {
+            filters.binary = false;
+        }
+        return ['-c', '-S', '--asm-includes-location', '-o', this.filename(outputFilename)];
+    }
+
+    override filterUserOptions(userOptions: string[]) {
+        return userOptions.filter(opt => opt !== '-run' && !opt.startsWith('-W'));
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptions & {env: Record<string, string>},
+    ) {
+        const result = await this.exec(compiler, options, execOptions);
+
+        // Norcroft diagnostics look like:
+        //   "<source>", line 11: Warning: message...
+        //   "<source>", line 37: Error: message...
+        // The generic applyParse_SourceWithLine expects:
+        //   <source>:11:1: warning: message...
+        //   <source>:37:1: error: message...
+        //
+        // Rewrite stderr to that shape so the generic parser can
+        // extract file/line/severity and drive hover markers.
+        if (typeof result.stderr === 'string') {
+            result.stderr = result.stderr
+                // Warnings
+                .replace(/^"([^"]+)",\s*line\s+(\d+):\s*Warning:\s*/gm, '$1:$2:1: warning: ')
+                // Errors and serious errors
+                .replace(/^"([^"]+)",\s*line\s+(\d+):\s*(Error|Serious error):\s*/gm, '$1:$2:1: error: ');
+        }
+
+        return this.transformToCompilationResult(result, inputFilename);
+    }
+}

--- a/lib/compilers/norcroft.ts
+++ b/lib/compilers/norcroft.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import _ from 'underscore';
+
 import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';

--- a/lib/compilers/norcroft.ts
+++ b/lib/compilers/norcroft.ts
@@ -22,6 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import path from 'node:path';
+
 import _ from 'underscore';
 
 import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
@@ -87,6 +89,15 @@ export class NorcroftCompiler extends BaseCompiler {
         inputFilename: string,
         execOptions: ExecutionOptions & {env: Record<string, string>},
     ) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+        if (!execOptions.customCwd) {
+            // ncc resolves relative paths against its cwd; without this it
+            // runs in the server's cwd and can't find the source file.
+            execOptions.customCwd = path.dirname(inputFilename);
+        }
+
         const result = await this.exec(compiler, options, execOptions);
 
         // Norcroft diagnostics look like:

--- a/lib/parsers/asm-parser-norcroft.ts
+++ b/lib/parsers/asm-parser-norcroft.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {AsmResultSource, ParsedAsmResult, ParsedAsmResultLine} from '../../types/asmresult/asmresult.interfaces.js';
+import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {PropertyGetter} from '../properties.interfaces.js';
+import * as utils from '../utils.js';
+
+import {AsmParser} from './asm-parser.js';
+
+export class NorcroftObjAsmParser extends AsmParser {
+    private readonly asmBinaryParser: AsmParser;
+    private readonly headerOrTrailer = /^\s*(?:\S+\s+)?(AREA|END|EXPORT|IMPORT|NOINIT|BASED|COMDEF|COMMON|DATA)\b/;
+    private readonly sourceFile = /^\s*;\s*source-file:\s+"([^"]+)",\s*line\s+(\d+)/;
+    private readonly lineNumber = /^\s*;\s*line:\s+(\d+)(?:\s+\d+)?/;
+    private readonly label = /^([|A-Za-z_.$][\w.$|]*)\s*$/; // label has no whitespace at start of line.
+    private readonly DCD = /^\s*(?:\S+\s+)?(DC[A-Z]*)\b/; // DCD, DCB, DCFD, etc...
+
+    constructor(compilerProps: PropertyGetter) {
+        super(compilerProps);
+        this.asmBinaryParser = new AsmParser(compilerProps);
+    }
+
+    override processAsm(asm: string, filters: ParseFiltersAndOutputOptions): ParsedAsmResult {
+        if (filters.binary) return this.asmBinaryParser.processBinaryAsm(asm, filters);
+
+        let currentfile = '';
+        let currentline: string | undefined;
+
+        const asmLines: ParsedAsmResultLine[] = [];
+        asm = asm.replace(/\u001A$/, '');
+
+        utils.eachLine(asm, line => {
+            let isDirective = false;
+
+            const labelmatch = line.match(this.label);
+            if (labelmatch && !labelmatch[1].startsWith('|')) {
+                // global label (eg. "main", not "|L030|") - reset any line number.
+                currentline = undefined;
+            }
+
+            // Header and trailer keywords should be white and reset any line number.
+            if (line.match(this.headerOrTrailer)) {
+                // possibly also current file?
+                currentline = undefined;
+                isDirective = true;
+            }
+
+            const sourcefilematch = line.match(this.sourceFile);
+            if (sourcefilematch) {
+                currentfile = sourcefilematch[1];
+                currentline = sourcefilematch[2];
+                isDirective = true;
+            }
+
+            const linenumbermatch = line.match(this.lineNumber);
+            if (linenumbermatch) {
+                currentline = linenumbermatch[1];
+                isDirective = true;
+            }
+
+            // Parse the line number from any updated string.
+            // Anything before here can parse or reset the current line.
+            // Anything after can filter a line from display (return) or whiten
+            // the line (set source to null).
+            let source: AsmResultSource | null = null;
+            if (currentfile && currentline) {
+                source = {
+                    file: filters.dontMaskFilenames ? currentfile : null,
+                    line: Number.parseInt(currentline, 10),
+                };
+            }
+
+            // Comments and blank lines should be filtered as directives.
+            // Note that this includes sourcefilematch and linenumber match -
+            // if the behaviour for them needs to change, check those bools.
+            const trimmed = line.trim();
+            if (trimmed === '' || trimmed.startsWith(';')) {
+                isDirective = true;
+                source = null; // also render white
+            }
+
+            if (labelmatch) {
+                source = null; // render all labels white
+            }
+
+            if (line.match(this.DCD)) {
+                source = null; // render all DCDs(etc) white
+            }
+
+            // Don't append directives if they're filtered out.
+            if (filters.directives && isDirective) return;
+
+            // All lines must be appended to appear in CE's output.
+            asmLines.push({
+                text: line,
+                source,
+            });
+        });
+
+        return {
+            asm: asmLines,
+        };
+    }
+}

--- a/lib/parsers/asm-parser-norcroft.ts
+++ b/lib/parsers/asm-parser-norcroft.ts
@@ -26,7 +26,6 @@ import {AsmResultSource, ParsedAsmResult, ParsedAsmResultLine} from '../../types
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {PropertyGetter} from '../properties.interfaces.js';
 import * as utils from '../utils.js';
-
 import {AsmParser} from './asm-parser.js';
 
 export class NorcroftObjAsmParser extends AsmParser {


### PR DESCRIPTION
Picks up #8297 from @pwombwell and finishes it per @mattgodbolt's review.

## Summary
- Adds `NorcroftCompiler` (`lib/compilers/norcroft.ts`) and `NorcroftObjAsmParser` (`lib/parsers/asm-parser-norcroft.ts`) from #8297 (all credit to @pwombwell).
- Wires the `ncc-ng-trunk` install into the Amazon property files as suggested in [this comment](https://github.com/compiler-explorer/compiler-explorer/pull/8297#issuecomment-3015xxx) — `nccarm` (C) and `npparm` (C++) groups pointing at `/opt/compiler-explorer/ncc-ng-trunk/bin/{ncc,n++}`.
- Rebased onto current `main` (resolves a trivial `CONTRIBUTORS.md` conflict and a one-line conflict in `c.amazon.properties`).

Depends on the matching infra change compiler-explorer/infra#1921 to make `/opt/compiler-explorer/ncc-ng-trunk/` exist on the nodes.

## Test plan
- [x] `npm run ts-check`
- [x] `npm run lint`
- [x] `npm run test:props` (90/90)
- [x] `npm run test-min` (1531 passed)
- [x] Smoke-test on a node that has the ncc-ng install once infra#1921 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)