### PR TITLE
Add GCC 16.1

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,13 +1,13 @@
 # Default settings for Ada
 compilers=&gnat:&gnatcross
-defaultCompiler=gnat152
+defaultCompiler=gnat161
 versionFlag=--version
 compilerType=ada
 
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=&gnatassert:gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat124:gnat125:gnat131:gnat132:gnat133:gnat134:gnat141:gnat142:gnat143:gnat151:gnat152:gnatsnapshot
+group.gnat.compilers=&gnatassert:gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat124:gnat125:gnat131:gnat132:gnat133:gnat134:gnat141:gnat142:gnat143:gnat151:gnat152:gnat161:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=X86-64 GNAT
 group.gnat.baseName=x86-64 gnat
@@ -69,6 +69,8 @@ compiler.gnat151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gnatmake
 compiler.gnat151.semver=15.1
 compiler.gnat152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gnatmake
 compiler.gnat152.semver=15.2
+compiler.gnat161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gnatmake
+compiler.gnat161.semver=16.1
 
 compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnatmake
 compiler.gnatsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -76,7 +78,7 @@ compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnatsnapshot.semver=(trunk)
 
 ## GNAT x86 build with "assertions" (--enable-checking=XXX)
-group.gnatassert.compilers=gnat104assert:gnat105assert:gnat111assert:gnat112assert:gnat113assert:gnat114assert:gnat121assert:gnat122assert:gnat123assert:gnat124assert:gnat125assert:gnat131assert:gnat132assert:gnat133assert:gnat134assert:gnat141assert:gnat142assert:gnat143assert:gnat151assert:gnat152assert
+group.gnatassert.compilers=gnat104assert:gnat105assert:gnat111assert:gnat112assert:gnat113assert:gnat114assert:gnat121assert:gnat122assert:gnat123assert:gnat124assert:gnat125assert:gnat131assert:gnat132assert:gnat133assert:gnat134assert:gnat141assert:gnat142assert:gnat143assert:gnat151assert:gnat152assert:gnat161assert
 group.gnatassert.groupName=GCC x86-64 (assertions)
 
 compiler.gnat104assert.exe=/opt/compiler-explorer/gcc-assertions-10.4.0/bin/gnatmake
@@ -119,6 +121,8 @@ compiler.gnat151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gnat
 compiler.gnat151assert.semver=15.1 (assertions)
 compiler.gnat152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gnatmake
 compiler.gnat152assert.semver=15.2 (assertions)
+compiler.gnat161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gnatmake
+compiler.gnat161assert.semver=16.1 (assertions)
 
 ################################
 # Cross GNAT

--- a/etc/config/algol68.amazon.properties
+++ b/etc/config/algol68.amazon.properties
@@ -19,7 +19,6 @@ compiler.ga68-g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/ga68
 compiler.ga68-g161.demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
 compiler.ga68-g161.objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 compiler.ga68-g161.semver=16.1.0
-compiler.ga68-g161.name=x86-64 ga68 16.1.0
 
 compiler.ga68-snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/ga68
 compiler.ga68-snapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/algol68.amazon.properties
+++ b/etc/config/algol68.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&ga68
-defaultCompiler=ga68-snapshot
+defaultCompiler=ga68-g161
 
 group.ga68.compilers=&ga68-x86
 group.ga68.supportsBinary=false
@@ -10,10 +10,16 @@ group.ga68.isSemVer=true
 group.ga68.unwiseOptions=-march=native
 
 # native compiler
-group.ga68-x86.compilers=ga68-snapshot
+group.ga68-x86.compilers=ga68-g161:ga68-snapshot
 group.ga68-x86.groupName=x86-64 GA68
 group.ga68-x86.baseName=x86-64 GA68
 group.ga68-x86.unwiseOptions=-march=native
+
+compiler.ga68-g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/ga68
+compiler.ga68-g161.demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
+compiler.ga68-g161.objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+compiler.ga68-g161.semver=16.1.0
+compiler.ga68-g161.name=x86-64 ga68 16.1.0
 
 compiler.ga68-snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/ga68
 compiler.ga68-snapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1784,7 +1784,7 @@ compiler.m68kclangtrunk.isNightly=true
 
 # GCC for m68k
 group.gccm68k.compilerType=m68k
-group.gccm68k.compilers=m68kg1310:m68kg1320:m68kg1410:m68kg1330:m68kg1420:m68kg1510:m68kg1430:m68kg1340:m68kg1520
+group.gccm68k.compilers=m68kg1310:m68kg1320:m68kg1410:m68kg1330:m68kg1420:m68kg1510:m68kg1430:m68kg1340:m68kg1520:m68kg1610
 group.gccm68k.supportsBinary=true
 group.gccm68k.supportsExecute=false
 group.gccm68k.baseName=M68K gcc
@@ -1835,6 +1835,11 @@ compiler.m68kg1520.exe=/opt/compiler-explorer/m68k/gcc-15.2.0/m68k-unknown-elf/b
 compiler.m68kg1520.semver=15.2.0
 compiler.m68kg1520.objdumper=/opt/compiler-explorer/m68k/gcc-15.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
 compiler.m68kg1520.demangler=/opt/compiler-explorer/m68k/gcc-15.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+compiler.m68kg1610.exe=/opt/compiler-explorer/m68k/gcc-16.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-g++
+compiler.m68kg1610.semver=16.1.0
+compiler.m68kg1610.objdumper=/opt/compiler-explorer/m68k/gcc-16.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
+compiler.m68kg1610.demangler=/opt/compiler-explorer/m68k/gcc-16.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
 
 ###############################
 # Cross for Tricore
@@ -1858,7 +1863,7 @@ compiler.tricoreg1130.demangler=/opt/compiler-explorer/tricore/gcc-11.3.0/tricor
 group.hppa.compilers=&gcchppa
 
 # GCC for HPPA
-group.gcchppa.compilers=hppag1420:hppag1430:hppag1510:hppag1520
+group.gcchppa.compilers=hppag1420:hppag1430:hppag1510:hppag1520:hppag1610
 group.gcchppa.supportsBinary=true
 group.gcchppa.supportsExecute=false
 group.gcchppa.baseName=HPPA gcc
@@ -1884,6 +1889,11 @@ compiler.hppag1520.exe=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux
 compiler.hppag1520.semver=15.2.0
 compiler.hppag1520.objdumper=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
 compiler.hppag1520.demangler=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
+compiler.hppag1610.exe=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-g++
+compiler.hppag1610.semver=16.1.0
+compiler.hppag1610.objdumper=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
+compiler.hppag1610.demangler=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
+
 
 ###############################
 # Cross for BPF
@@ -1938,7 +1948,7 @@ compiler.bpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang++
 compiler.bpfclang1300.semver=13.0.0
 
 # GCC for BPF
-group.gccbpf.compilers=bpfg1310:bpfg1320:bpfg1330:bpfg1340:bpfg1410:bpfgtrunk
+group.gccbpf.compilers=bpfg1310:bpfg1320:bpfg1330:bpfg1340:bpfg1410:bpfg1610:bpfgtrunk
 group.gccbpf.supportsBinary=true
 group.gccbpf.supportsExecute=false
 group.gccbpf.baseName=BPF gcc
@@ -1976,6 +1986,11 @@ compiler.bpfg1410.hidden=true
 compiler.bpfg1410.semver=14.1.0
 compiler.bpfg1410.objdumper=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.bpfg1410.demangler=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.bpfg1610.exe=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-g++
+compiler.bpfg1610.semver=16.1.0
+compiler.bpfg1610.objdumper=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-objdump
+compiler.bpfg1610.demangler=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
 
 compiler.bpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-none-g++
 compiler.bpfgtrunk.semver=trunk
@@ -1986,7 +2001,7 @@ compiler.bpfgtrunk.isNightly=true
 group.sparc.compilers=&gccsparc
 
 # GCC for SPARC
-group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1240:sparcg1250:sparcg1310:sparcg1320:sparcg1330:sparcg1340:sparcg1410:sparcg1420:sparcg1430:sparcg1510:sparcg1520
+group.gccsparc.compilers=sparcg1220:sparcg1230:sparcg1240:sparcg1250:sparcg1310:sparcg1320:sparcg1330:sparcg1340:sparcg1410:sparcg1420:sparcg1430:sparcg1510:sparcg1520:sparcg1610
 group.gccsparc.baseName=SPARC gcc
 group.gccsparc.groupName=SPARC GCC
 group.gccsparc.isSemVer=true
@@ -2055,13 +2070,18 @@ compiler.sparcg1520.exe=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-li
 compiler.sparcg1520.semver=15.2.0
 compiler.sparcg1520.objdumper=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.sparcg1520.demangler=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+compiler.sparcg1610.exe=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-g++
+compiler.sparcg1610.semver=16.1.0
+compiler.sparcg1610.objdumper=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.sparcg1610.demangler=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 
 ###############################
 # Cross for SPARC64
 group.sparc64.compilers=&gccsparc64
 
 # GCC for SPARC64
-group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310:sparc64g1320:sparc64g1410:sparc64g1330:sparc64g1240:sparc64g1420:sparc64g1510:sparc64g1430:sparc64g1340:sparc64g1250:sparc64g1520
+group.gccsparc64.compilers=sparc64g1220:sparc64g1230:sparc64g1310:sparc64g1320:sparc64g1410:sparc64g1330:sparc64g1240:sparc64g1420:sparc64g1510:sparc64g1430:sparc64g1340:sparc64g1250:sparc64g1520:sparc64g1610
 group.gccsparc64.baseName=SPARC64 gcc
 group.gccsparc64.groupName=SPARC64 GCC
 group.gccsparc64.isSemVer=true
@@ -2130,13 +2150,18 @@ compiler.sparc64g1520.exe=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-mult
 compiler.sparc64g1520.semver=15.2.0
 compiler.sparc64g1520.objdumper=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.sparc64g1520.demangler=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+compiler.sparc64g1610.exe=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-g++
+compiler.sparc64g1610.semver=16.1.0
+compiler.sparc64g1610.objdumper=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.sparc64g1610.demangler=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 
 ###############################
 # Cross for SPARC-LEON
 group.sparcleon.compilers=&gccsparcleon
 
 # GCC for SPARC-LEON
-group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1240:sparcleong1250:sparcleong1310:sparcleong1320:sparcleong1330:sparcleong1340:sparcleong1410:sparcleong1420:sparcleong1430:sparcleong1510:sparcleong1520
+group.gccsparcleon.compilers=sparcleong1220:sparcleong1220-1:sparcleong1230:sparcleong1240:sparcleong1250:sparcleong1310:sparcleong1320:sparcleong1330:sparcleong1340:sparcleong1410:sparcleong1420:sparcleong1430:sparcleong1510:sparcleong1520:sparcleong1610
 group.gccsparcleon.baseName=SPARC LEON gcc
 group.gccsparcleon.groupName=SPARC LEON GCC
 group.gccsparcleon.isSemVer=true
@@ -2207,6 +2232,11 @@ compiler.sparcleong1520.exe=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-l
 compiler.sparcleong1520.semver=15.2.0
 compiler.sparcleong1520.objdumper=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.sparcleong1520.demangler=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+compiler.sparcleong1610.exe=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
+compiler.sparcleong1610.semver=16.1.0
+compiler.sparcleong1610.objdumper=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.sparcleong1610.demangler=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 
 compiler.sparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-g++
 compiler.sparcleong1220-1.semver=12.2.0
@@ -2218,7 +2248,7 @@ compiler.sparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.0
 group.c6x.compilers=&gccc6x
 
 # GCC for TI C6x
-group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310:c6xg1320:c6xg1410:c6xg1330:c6xg1240:c6xg1420:c6xg1510:c6xg1430:c6xg1340:c6xg1250:c6xg1520
+group.gccc6x.compilers=c6xg1220:c6xg1230:c6xg1310:c6xg1320:c6xg1410:c6xg1330:c6xg1240:c6xg1420:c6xg1510:c6xg1430:c6xg1340:c6xg1250:c6xg1520:c6xg1610
 group.gccc6x.baseName=TI C6x gcc
 group.gccc6x.groupName=TI C6x GCC
 group.gccc6x.isSemVer=true
@@ -2287,6 +2317,11 @@ compiler.c6xg1520.exe=/opt/compiler-explorer/c6x/gcc-15.2.0/tic6x-elf/bin/tic6x-
 compiler.c6xg1520.semver=15.2.0
 compiler.c6xg1520.objdumper=/opt/compiler-explorer/c6x/gcc-15.2.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.c6xg1520.demangler=/opt/compiler-explorer/c6x/gcc-15.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+compiler.c6xg1610.exe=/opt/compiler-explorer/c6x/gcc-16.1.0/tic6x-elf/bin/tic6x-elf-g++
+compiler.c6xg1610.semver=16.1.0
+compiler.c6xg1610.objdumper=/opt/compiler-explorer/c6x/gcc-16.1.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.c6xg1610.demangler=/opt/compiler-explorer/c6x/gcc-16.1.0/tic6x-elf/bin/tic6x-elf-c++filt
+
 
 ###############################
 # Cross for loongarch64
@@ -2295,7 +2330,7 @@ group.loongarch64.compilers=&gccloongarch64
 # GCC for loongarch64
 group.gccloongarch64.baseName=loongarch64 gcc
 group.gccloongarch64.groupName=loongarch64 gcc
-group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310:loongarch64g1320:loongarch64g1410:loongarch64g1330:loongarch64g1240:loongarch64g1420:loongarch64g1510:loongarch64g1430:loongarch64g1340:loongarch64g1250:loongarch64g1520
+group.gccloongarch64.compilers=loongarch64g1220:loongarch64g1230:loongarch64g1310:loongarch64g1320:loongarch64g1410:loongarch64g1330:loongarch64g1240:loongarch64g1420:loongarch64g1510:loongarch64g1430:loongarch64g1340:loongarch64g1250:loongarch64g1520:loongarch64g1610
 group.gccloongarch64.isSemVer=true
 
 compiler.loongarch64g1220.exe=/opt/compiler-explorer/loongarch64/gcc-12.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
@@ -2362,6 +2397,11 @@ compiler.loongarch64g1520.exe=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loon
 compiler.loongarch64g1520.semver=15.2.0
 compiler.loongarch64g1520.objdumper=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.loongarch64g1520.demangler=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+compiler.loongarch64g1610.exe=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-g++
+compiler.loongarch64g1610.semver=16.1.0
+compiler.loongarch64g1610.objdumper=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.loongarch64g1610.demangler=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 
 ###############################
 # Cross for sh
@@ -2370,7 +2410,7 @@ group.sh.compilers=&gccsh
 # GCC for sh
 group.gccsh.baseName=sh gcc
 group.gccsh.groupName=sh gcc
-group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1240:shg1250:shg1310:shg1320:shg1330:shg1340:shg1410:shg1420:shg1430:shg1510:shg1520
+group.gccsh.compilers=shg494:shg950:shg1220:shg1230:shg1240:shg1250:shg1310:shg1320:shg1330:shg1340:shg1410:shg1420:shg1430:shg1510:shg1520:shg1610
 group.gccsh.isSemVer=true
 
 compiler.shg494.exe=/opt/compiler-explorer/sh/gcc-4.9.4/sh-unknown-elf/bin/sh-unknown-elf-g++
@@ -2447,6 +2487,11 @@ compiler.shg1520.exe=/opt/compiler-explorer/sh/gcc-15.2.0/sh-unknown-elf/bin/sh-
 compiler.shg1520.semver=15.2.0
 compiler.shg1520.objdumper=/opt/compiler-explorer/sh/gcc-15.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.shg1520.demangler=/opt/compiler-explorer/sh/gcc-15.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+compiler.shg1610.exe=/opt/compiler-explorer/sh/gcc-16.1.0/sh-unknown-elf/bin/sh-unknown-elf-g++
+compiler.shg1610.semver=16.1.0
+compiler.shg1610.objdumper=/opt/compiler-explorer/sh/gcc-16.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.shg1610.demangler=/opt/compiler-explorer/sh/gcc-16.1.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
 
 ###############################
 # Cross for s390x
@@ -2455,7 +2500,7 @@ group.s390x.compilers=&gccs390x
 # GCC for s390x
 group.gccs390x.baseName=s390x gcc
 group.gccs390x.groupName=s390x gcc
-group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310:s390xg1320:s390xg1410:s390xg1330:s390xg1240:s390xg1420:s390xg1510:s390xg1430:s390xg1340:s390xg1250:s390xg1520
+group.gccs390x.compilers=gccs390x1120:s390xg1210:s390xg1220:s390xg1230:s390xg1310:s390xg1320:s390xg1410:s390xg1330:s390xg1240:s390xg1420:s390xg1510:s390xg1430:s390xg1340:s390xg1250:s390xg1520:s390xg1610
 group.gccs390x.isSemVer=true
 group.gccs390x.objdumper=/opt/compiler-explorer/s390x/gcc-11.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 
@@ -2531,6 +2576,11 @@ compiler.s390xg1520.exe=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-
 compiler.s390xg1520.semver=15.2.0
 compiler.s390xg1520.objdumper=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.s390xg1520.demangler=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+compiler.s390xg1610.exe=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-g++
+compiler.s390xg1610.semver=16.1.0
+compiler.s390xg1610.objdumper=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.s390xg1610.demangler=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 
 ###############################
 # Cross compilers for PPC
@@ -2539,7 +2589,7 @@ group.ppcs.isSemVer=true
 group.ppcs.instructionSet=powerpc
 
 ## POWER
-group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1240:ppcg1250:ppcg1310:ppcg1320:ppcg1330:ppcg1340:ppcg1410:ppcg1420:ppcg1430:ppcg1510:ppcg1520
+group.ppc.compilers=ppcg48:ppcg1120:ppcg1210:ppcg1220:ppcg1230:ppcg1240:ppcg1250:ppcg1310:ppcg1320:ppcg1330:ppcg1340:ppcg1410:ppcg1420:ppcg1430:ppcg1510:ppcg1520:ppcg1610
 group.ppc.groupName=POWER GCC
 group.ppc.baseName=power gcc
 
@@ -2619,11 +2669,16 @@ compiler.ppcg1520.exe=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-
 compiler.ppcg1520.semver=15.2.0
 compiler.ppcg1520.objdumper=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppcg1520.demangler=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+compiler.ppcg1610.exe=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-g++
+compiler.ppcg1610.semver=16.1.0
+compiler.ppcg1610.objdumper=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.ppcg1610.demangler=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+
 
 ## POWER64
 group.ppc64.groupName=POWER64 GCC
 group.ppc64.baseName=power64 gcc
-group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310:ppc64g1320:ppc64gtrunk:ppc64g1410:ppc64g1330:ppc64g1240:ppc64g1420:ppc64g1510:ppc64g1430:ppc64g1340:ppc64g1250:ppc64g1520
+group.ppc64.compilers=ppc64g8:ppc64g9:ppc64g1120:ppc64g1210:ppc64clang:ppc64g1220:ppc64g1230:ppc64g1310:ppc64g1320:ppc64gtrunk:ppc64g1410:ppc64g1330:ppc64g1240:ppc64g1420:ppc64g1510:ppc64g1430:ppc64g1340:ppc64g1250:ppc64g1520:ppc64g1610
 
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
@@ -2707,6 +2762,11 @@ compiler.ppc64g1520.exe=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-un
 compiler.ppc64g1520.semver=15.2.0
 compiler.ppc64g1520.objdumper=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64g1520.demangler=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.ppc64g1610.exe=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
+compiler.ppc64g1610.semver=16.1.0
+compiler.ppc64g1610.objdumper=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.ppc64g1610.demangler=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 
 compiler.ppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64gtrunk.semver=trunk
@@ -2727,7 +2787,7 @@ compiler.ppc64clang.compilerCategories=clang
 
 ## POWER64LE
 group.ppc64le.groupName=POWER64LE GCC
-group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310:ppc64leg1320:ppc64legtrunk:ppc64leg1410:ppc64leg1330:ppc64leg1240:ppc64leg1420:ppc64leg1510:ppc64leg1430:ppc64leg1340:ppc64leg1250:ppc64leg1520
+group.ppc64le.compilers=ppc64leg630:ppc64leg8:ppc64leg9:ppc64leg1120:ppc64leg1210:ppc64leclang:ppc64leg1220:ppc64leg1230:ppc64leg1310:ppc64leg1320:ppc64legtrunk:ppc64leg1410:ppc64leg1330:ppc64leg1240:ppc64leg1420:ppc64leg1510:ppc64leg1430:ppc64leg1340:ppc64leg1250:ppc64leg1520:ppc64leg1610
 group.ppc64le.baseName=power64le gcc
 
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
@@ -2816,6 +2876,11 @@ compiler.ppc64leg1520.exe=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc6
 compiler.ppc64leg1520.semver=15.2.0
 compiler.ppc64leg1520.objdumper=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg1520.demangler=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.ppc64leg1610.exe=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
+compiler.ppc64leg1610.semver=16.1.0
+compiler.ppc64leg1610.objdumper=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.ppc64leg1610.demangler=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 
 compiler.ppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64legtrunk.semver=trunk
@@ -2844,7 +2909,7 @@ group.gccarm.includeFlag=-I
 # 32 bit
 group.gcc32arm.groupName=Arm 32-bit GCC
 group.gcc32arm.baseName=ARM GCC
-group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1250:armg1310:armg1320:armug1320:armg1330:armug1330:armg1340:armug1340:armg1410:armug1410:armg1420:armug1420:armg1430:armug1430:armg1510:armug1510:armg1520:armug1520:armgtrunk
+group.gcc32arm.compilers=armhfg54:armg454:armg464:arm541:armg630:armg640:arm710:armg730:armg750:armg820:armce820:arm831:armg850:arm921:arm930:arm940:arm950:arm1020:arm1021:arm1030:arm1031_07:arm1031_10:arm1040:armg1050:arm1100:arm1120:arm1121:arm1130:armg1140:arm1210:armg1220:armg1230:armg1240:armg1250:armg1310:armg1320:armug1320:armg1330:armug1330:armg1340:armug1340:armg1410:armug1410:armg1420:armug1420:armg1430:armug1430:armg1510:armug1510:armg1520:armug1520:armg1610:armug1610:armgtrunk
 group.gcc32arm.isSemVer=true
 group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.gcc32arm.instructionSet=arm32
@@ -2963,6 +3028,11 @@ compiler.armg1520.exe=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gn
 compiler.armg1520.semver=15.2.0
 compiler.armg1520.objdumper=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.armg1520.demangler=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.armg1610.exe=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.armg1610.semver=16.1.0
+compiler.armg1610.objdumper=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.armg1610.demangler=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 
 compiler.armug1320.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
 compiler.armug1320.name=ARM GCC 13.2.0 (unknown-eabi)
@@ -3011,6 +3081,11 @@ compiler.armug1520.semver=15.2.0
 compiler.armug1520.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-15.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.armug1520.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-15.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
 compiler.armug1520.name=ARM GCC 15.2.0 (unknown-eabi)
+compiler.armug1610.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-g++
+compiler.armug1610.semver=16.1.0
+compiler.armug1610.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.armug1610.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+
 
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)
@@ -3078,7 +3153,7 @@ compiler.armgtrunk.isNightly=true
 
 # 64 bit
 group.gcc64arm.groupName=Arm 64-bit GCC
-group.gcc64arm.compilers=aarchg54:arm64g494:arm64g550:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050:arm64g1320:arm64g1410:arm64g1330:arm64g1240:arm64g1420:arm64g1510:arm64g1430:arm64g1340:arm64g1250:arm64g1520
+group.gcc64arm.compilers=aarchg54:arm64g494:arm64g550:arm64g630:arm64g640:arm64g730:arm64g750:arm64g820:arm64g850:arm64g930:arm64g940:arm64g950:arm64g1020:arm64g1030:arm64g1040:arm64g1100:arm64g1120:arm64g1130:arm64g1140:arm64g1210:arm64gtrunk:arm64g1220:arm64g1230:arm64g1310:arm64g1050:arm64g1320:arm64g1410:arm64g1330:arm64g1240:arm64g1420:arm64g1510:arm64g1430:arm64g1340:arm64g1250:arm64g1520:arm64g1610
 group.gcc64arm.isSemVer=true
 group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.gcc64arm.instructionSet=aarch64
@@ -3207,6 +3282,11 @@ compiler.arm64g1520.exe=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-
 compiler.arm64g1520.semver=15.2.0
 compiler.arm64g1520.objdumper=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g1520.demangler=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.arm64g1610.exe=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1610.semver=16.1.0
+compiler.arm64g1610.objdumper=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.arm64g1610.demangler=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 compiler.arm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64gtrunk.semver=trunk
 compiler.arm64gtrunk.isNightly=true
@@ -3417,7 +3497,7 @@ compiler.cl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avrg540:avrg730:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1250:avrg1310:avrg1320:avrg1330:avrg1340:avrg1410:avrg1420:avrg1430:avrg1510:avrg1520
+group.avr.compilers=avrg454:avrg464:avrg540:avrg730:avrg920:avrg930:avrg1030:avrg1100:avrg1210:avrg1220:avrg1230:avrg1240:avrg1250:avrg1310:avrg1320:avrg1330:avrg1340:avrg1410:avrg1420:avrg1430:avrg1510:avrg1520:avrg1610
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -3524,6 +3604,11 @@ compiler.avrg1520.exe=/opt/compiler-explorer/avr/gcc-15.2.0/avr/bin/avr-g++
 compiler.avrg1520.semver=15.2.0
 compiler.avrg1520.objdumper=/opt/compiler-explorer/avr/gcc-15.2.0/avr/bin/avr-objdump
 compiler.avrg1520.demangler=/opt/compiler-explorer/avr/gcc-15.2.0/avr/bin/avr-c++filt
+compiler.avrg1610.exe=/opt/compiler-explorer/avr/gcc-16.1.0/avr/bin/avr-g++
+compiler.avrg1610.semver=16.1.0
+compiler.avrg1610.objdumper=/opt/compiler-explorer/avr/gcc-16.1.0/avr/bin/avr-objdump
+compiler.avrg1610.demangler=/opt/compiler-explorer/avr/gcc-16.1.0/avr/bin/avr-c++filt
+
 
 ###############################
 # Cross compiler for MIPS
@@ -3711,7 +3796,7 @@ compiler.mips64el-clang1300.semver=13.0.0
 
 ## MIPS
 group.mips.groupName=MIPS GCC
-group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1240:mipsg1250:mipsg1310:mipsg1320:mipsg1330:mipsg1340:mipsg1410:mipsg1420:mipsg1430:mipsg1510:mipsg1520
+group.mips.compilers=mips5:mipsg494:mipsg550:mips930:mipsg950:mips1120:mipsg1210:mipsg1220:mipsg1230:mipsg1240:mipsg1250:mipsg1310:mipsg1320:mipsg1330:mipsg1340:mipsg1410:mipsg1420:mipsg1430:mipsg1510:mipsg1520:mipsg1610
 group.mips.baseName=mips gcc
 
 compiler.mipsg494.exe=/opt/compiler-explorer/mips/gcc-4.9.4/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
@@ -3810,10 +3895,15 @@ compiler.mipsg1520.exe=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux
 compiler.mipsg1520.semver=15.2.0
 compiler.mipsg1520.objdumper=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.mipsg1520.demangler=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+compiler.mipsg1610.exe=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
+compiler.mipsg1610.semver=16.1.0
+compiler.mipsg1610.objdumper=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.mipsg1610.demangler=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 
 ## MIPS 64
 group.mips64.groupName=MIPS64 GCC
-group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips64g1410:mips64g1330:mips64g1240:mips64g1420:mips64g1510:mips64g1430:mips64g1340:mips64g1250:mips64g1520:mips564:mips112064
+group.mips64.compilers=mips64g494:mips64g550:mips64g950:mips64g1210:mips64g1220:mips64g1230:mips64g1310:mips64g1320:mips64g1410:mips64g1330:mips64g1240:mips64g1420:mips64g1510:mips64g1430:mips64g1340:mips64g1250:mips64g1520:mips64g1610:mips564:mips112064
 group.mips64.baseName=mips64 gcc
 
 compiler.mips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
@@ -3907,10 +3997,15 @@ compiler.mips64g1520.exe=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown
 compiler.mips64g1520.semver=15.2.0
 compiler.mips64g1520.objdumper=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.mips64g1520.demangler=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+compiler.mips64g1610.exe=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
+compiler.mips64g1610.semver=16.1.0
+compiler.mips64g1610.objdumper=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.mips64g1610.demangler=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 
 ## MIPS EL
 group.mipsel.groupName=MIPSEL GCC
-group.mipsel.compilers=mips5el:mipselg494:mipselg550:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1240:mipselg1250:mipselg1310:mipselg1320:mipselg1330:mipselg1340:mipselg1410:mipselg1420:mipselg1430:mipselg1510:mipselg1520
+group.mipsel.compilers=mips5el:mipselg494:mipselg550:mipselg950:mipselg1210:mipselg1220:mipselg1230:mipselg1240:mipselg1250:mipselg1310:mipselg1320:mipselg1330:mipselg1340:mipselg1410:mipselg1420:mipselg1430:mipselg1510:mipselg1520:mipselg1610
 group.mipsel.baseName=mipsel gcc
 
 compiler.mipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
@@ -4000,10 +4095,15 @@ compiler.mipselg1520.exe=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multili
 compiler.mipselg1520.semver=15.2.0
 compiler.mipselg1520.objdumper=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.mipselg1520.demangler=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+compiler.mipselg1610.exe=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-g++
+compiler.mipselg1610.semver=16.1.0
+compiler.mipselg1610.objdumper=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.mipselg1610.demangler=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 
 ## MIPS 64 EL
 group.mips64el.groupName=MIPS64EL GCC
-group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips64elg1410:mips64elg1330:mips64elg1240:mips64elg1420:mips64elg1510:mips64elg1430:mips64elg1340:mips64elg1250:mips64elg1520:mips564el
+group.mips64el.compilers=mips64elg494:mips64elg550:mips64elg950:mips64elg1210:mips64elg1220:mips64elg1230:mips64elg1310:mips64elg1320:mips64elg1410:mips64elg1330:mips64elg1240:mips64elg1420:mips64elg1510:mips64elg1430:mips64elg1340:mips64elg1250:mips64elg1520:mips64elg1610:mips564el
 group.mips64el.baseName=mips64 (el) gcc
 group.mips64el.compilerCategories=gcc
 
@@ -4094,6 +4194,11 @@ compiler.mips64elg1520.exe=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-m
 compiler.mips64elg1520.semver=15.2.0
 compiler.mips64elg1520.objdumper=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.mips64elg1520.demangler=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+compiler.mips64elg1610.exe=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-g++
+compiler.mips64elg1610.semver=16.1.0
+compiler.mips64elg1610.objdumper=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.mips64elg1610.demangler=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 
 ###############################
 # GCC for nanoMIPS
@@ -4129,7 +4234,7 @@ group.rvgcc.supportsBinary=true
 group.rvgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 32-bits
-group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310:rv64-gcc1320:rv64-gcc1410:rv64-gcc1330:rv64-gcc1240:rv64-gcc1420:rv64-gcc1510:rv64-gcc1430:rv64-gcc1340:rv64-gcc1250:rv64-gcc1520
+group.rv64gcc.compilers=rv64-gcctrunk:rv64-gcc1230:rv64-gcc1220:rv64-gcc1210:rv64-gcc1140:rv64-gcc1130:rv64-gcc1120:rv64-gcc1030:rv64-gcc1020:rv64-gcc940:rv64-gcc850:rv64-gcc820:rv64-gcc1310:rv64-gcc1320:rv64-gcc1410:rv64-gcc1330:rv64-gcc1240:rv64-gcc1420:rv64-gcc1510:rv64-gcc1430:rv64-gcc1340:rv64-gcc1250:rv64-gcc1520:rv64-gcc1610
 group.rv64gcc.groupName=RISC-V (64-bits) gcc
 group.rv64gcc.baseName=RISC-V (64-bits) gcc
 
@@ -4235,6 +4340,11 @@ compiler.rv64-gcc1520.exe=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unkn
 compiler.rv64-gcc1520.semver=15.2.0
 compiler.rv64-gcc1520.objdumper=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-gcc1520.demangler=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.rv64-gcc1610.exe=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.rv64-gcc1610.semver=16.1.0
+compiler.rv64-gcc1610.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-gcc1610.demangler=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 
 compiler.rv64-gcctrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.rv64-gcctrunk.semver=(trunk)
@@ -4243,7 +4353,7 @@ compiler.rv64-gcctrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv6
 compiler.rv64-gcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ## GCC for RISC-V 32-bits
-group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310:rv32-gcc1320:rv32-gcc1410:rv32-gcc1330:rv32-gcc1240:rv32-gcc1420:rv32-gcc1510:rv32-gcc1430:rv32-gcc1340:rv32-gcc1250:rv32-gcc1520
+group.rv32gcc.compilers=rv32-gcctrunk:rv32-gcc1230:rv32-gcc1220:rv32-gcc1210:rv32-gcc1140:rv32-gcc1130:rv32-gcc1120:rv32-gcc1030:rv32-gcc1020:rv32-gcc940:rv32-gcc850:rv32-gcc820:rv32-gcc1310:rv32-gcc1320:rv32-gcc1410:rv32-gcc1330:rv32-gcc1240:rv32-gcc1420:rv32-gcc1510:rv32-gcc1430:rv32-gcc1340:rv32-gcc1250:rv32-gcc1520:rv32-gcc1610
 group.rv32gcc.groupName=RISC-V (32-bits) gcc
 group.rv32gcc.baseName=RISC-V (32-bits) gcc
 
@@ -4348,6 +4458,11 @@ compiler.rv32-gcc1520.exe=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unkn
 compiler.rv32-gcc1520.semver=15.2.0
 compiler.rv32-gcc1520.objdumper=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-gcc1520.demangler=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.rv32-gcc1610.exe=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
+compiler.rv32-gcc1610.semver=16.1.0
+compiler.rv32-gcc1610.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-gcc1610.demangler=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
 
 compiler.rv32-gcctrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-g++
 compiler.rv32-gcctrunk.semver=(trunk)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&mosclang-trunk:&rv
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
-defaultCompiler=g152
+defaultCompiler=g161
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -191,6 +191,8 @@ compiler.g151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/g++
 compiler.g151.semver=15.1
 compiler.g152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/g++
 compiler.g152.semver=15.2
+compiler.g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/g++
+compiler.g161.semver=16.1
 
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -286,7 +288,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g151assert:g152assert
+group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g151assert:g152assert:g161assert
 group.gcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.g103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/g++
@@ -331,6 +333,8 @@ compiler.g151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/g++
 compiler.g151assert.semver=15.1 (assertions)
 compiler.g152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/g++
 compiler.g152assert.semver=15.2 (assertions)
+compiler.g161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/g++
+compiler.g161assert.semver=16.1 (assertions)
 
 ################################
 # Clang for x86

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1988,7 +1988,7 @@ compiler.bpfg1410.objdumper=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-no
 compiler.bpfg1410.demangler=/opt/compiler-explorer/bpf/gcc-14.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 compiler.bpfg1610.exe=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-g++
 compiler.bpfg1610.semver=16.1.0
-compiler.bpfg1610.objdumper=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-objdump
+compiler.bpfg1610.objdumper=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.bpfg1610.demangler=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
 
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&cgcc86:&cclang:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm
-defaultCompiler=cg152
+defaultCompiler=cg161
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-15.1.0/bin/objdump
@@ -15,7 +15,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cg161:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -179,6 +179,8 @@ compiler.cg151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gcc
 compiler.cg151.semver=15.1
 compiler.cg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 compiler.cg152.semver=15.2
+compiler.cg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
+compiler.cg161.semver=16.1
 
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -200,7 +202,7 @@ compiler.cg71.needsMulti=true
 compiler.cg72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg151assert:cg152assert
+group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg151assert:cg152assert:cg161assert
 group.cgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.cg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -245,6 +247,8 @@ compiler.cg151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gcc
 compiler.cg151assert.semver=15.1 (assertions)
 compiler.cg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcc
 compiler.cg152assert.semver=15.2 (assertions)
+compiler.cg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
+compiler.cg161assert.semver=16.1 (assertions)
 
 
 # Classic x86 compilers (32-bit only)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1271,7 +1271,7 @@ compiler.cbpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.cbpfclang1300.semver=13.0.0
 
 # GCC for BPF
-group.cgccbpf.compilers=cbpfg1310:cbpfg1320:cbpfg1330:cbpfg1340:cbpfg1410:cbpfg1420:cbpfg1430:cbpfg1510:cbpfg1520:cbpfgtrunk
+group.cgccbpf.compilers=cbpfg1310:cbpfg1320:cbpfg1330:cbpfg1340:cbpfg1410:cbpfg1420:cbpfg1430:cbpfg1510:cbpfg1520:cbpfgtrunk:cbpfg1610
 group.cgccbpf.supportsBinary=true
 group.cgccbpf.supportsExecute=false
 group.cgccbpf.baseName=BPF gcc
@@ -1323,6 +1323,11 @@ compiler.cbpfg1520.exe=/opt/compiler-explorer/bpf/gcc-15.2.0/bpf-unknown-none/bi
 compiler.cbpfg1520.semver=15.2.0
 compiler.cbpfg1520.objdumper=/opt/compiler-explorer/bpf/gcc-15.2.0/bpf-unknown-none/bin/bpf-unknown-objdump
 compiler.cbpfg1520.demangler=/opt/compiler-explorer/bpf/gcc-15.2.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+compiler.cbpfg1610.exe=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-gcc
+compiler.cbpfg1610.semver=16.1.0
+compiler.cbpfg1610.objdumper=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-objdump
+compiler.cbpfg1610.demangler=/opt/compiler-explorer/bpf/gcc-16.1.0/bpf-unknown-none/bin/bpf-unknown-none-c++filt
+
 
 compiler.cbpfgtrunk.exe=/opt/compiler-explorer/bpf/gcc-trunk/bpf-unknown-none/bin/bpf-unknown-gcc
 compiler.cbpfgtrunk.semver=trunk
@@ -1352,7 +1357,7 @@ compiler.ctricoreg1130.demangler=/opt/compiler-explorer/tricore/gcc-11.3.0/trico
 group.chppa.compilers=&cgcchppa
 
 # GCC for HPPA
-group.cgcchppa.compilers=chppag1420:chppag1430:chppag1510:chppag1520
+group.cgcchppa.compilers=chppag1420:chppag1430:chppag1510:chppag1520:chppag1610
 group.cgcchppa.baseName=HPPA gcc
 group.cgcchppa.groupName=HPPA GCC
 group.cgcchppa.isSemVer=true
@@ -1378,6 +1383,11 @@ compiler.chppag1520.exe=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linu
 compiler.chppag1520.semver=15.2.0
 compiler.chppag1520.objdumper=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
 compiler.chppag1520.demangler=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
+compiler.chppag1610.exe=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gcc
+compiler.chppag1610.semver=16.1.0
+compiler.chppag1610.objdumper=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
+compiler.chppag1610.demangler=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
+
 
 ###############################
 # ArchieSDK (Acorn Archimedes ARM2)
@@ -1418,7 +1428,7 @@ compiler.cm68kclangtrunk.isNightly=true
 
 # GCC for m68k
 group.cgccm68k.compilerType=m68k
-group.cgccm68k.compilers=cm68kg1310:cm68kg1320:cm68kg1410:cm68kg1330:cm68kg1420:cm68kg1510:cm68kg1430:cm68kg1340:cm68kg1520
+group.cgccm68k.compilers=cm68kg1310:cm68kg1320:cm68kg1410:cm68kg1330:cm68kg1420:cm68kg1510:cm68kg1430:cm68kg1340:cm68kg1520:cm68kg1610
 group.cgccm68k.supportsBinary=true
 group.cgccm68k.supportsExecute=false
 group.cgccm68k.baseName=M68K gcc
@@ -1470,13 +1480,18 @@ compiler.cm68kg1520.exe=/opt/compiler-explorer/m68k/gcc-15.2.0/m68k-unknown-elf/
 compiler.cm68kg1520.semver=15.2.0
 compiler.cm68kg1520.objdumper=/opt/compiler-explorer/m68k/gcc-15.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
 compiler.cm68kg1520.demangler=/opt/compiler-explorer/m68k/gcc-15.2.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+compiler.cm68kg1610.exe=/opt/compiler-explorer/m68k/gcc-16.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-gcc
+compiler.cm68kg1610.semver=16.1.0
+compiler.cm68kg1610.objdumper=/opt/compiler-explorer/m68k/gcc-16.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-objdump
+compiler.cm68kg1610.demangler=/opt/compiler-explorer/m68k/gcc-16.1.0/m68k-unknown-elf/bin/m68k-unknown-elf-c++filt
+
 
 ###############################
 # Cross for SPARC
 group.csparc.compilers=&cgccsparc
 
 # GCC for SPARC
-group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1240:csparcg1250:csparcg1310:csparcg1320:csparcg1330:csparcg1340:csparcg1410:csparcg1420:csparcg1430:csparcg1510:csparcg1520
+group.cgccsparc.compilers=csparcg1220:csparcg1230:csparcg1240:csparcg1250:csparcg1310:csparcg1320:csparcg1330:csparcg1340:csparcg1410:csparcg1420:csparcg1430:csparcg1510:csparcg1520:csparcg1610
 group.cgccsparc.baseName=SPARC gcc
 group.cgccsparc.groupName=SPARC GCC
 group.cgccsparc.isSemVer=true
@@ -1545,13 +1560,18 @@ compiler.csparcg1520.exe=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-l
 compiler.csparcg1520.semver=15.2.0
 compiler.csparcg1520.objdumper=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.csparcg1520.demangler=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+compiler.csparcg1610.exe=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gcc
+compiler.csparcg1610.semver=16.1.0
+compiler.csparcg1610.objdumper=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.csparcg1610.demangler=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+
 
 ###############################
 # Cross for SPARC64
 group.csparc64.compilers=&cgccsparc64
 
 # GCC for SPARC64
-group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310:csparc64g1320:csparc64g1410:csparc64g1330:csparc64g1240:csparc64g1420:csparc64g1510:csparc64g1430:csparc64g1340:csparc64g1250:csparc64g1520
+group.cgccsparc64.compilers=csparc64g1220:csparc64g1230:csparc64g1310:csparc64g1320:csparc64g1410:csparc64g1330:csparc64g1240:csparc64g1420:csparc64g1510:csparc64g1430:csparc64g1340:csparc64g1250:csparc64g1520:csparc64g1610
 group.cgccsparc64.baseName=SPARC64 gcc
 group.cgccsparc64.groupName=SPARC64 GCC
 group.cgccsparc64.isSemVer=true
@@ -1620,13 +1640,18 @@ compiler.csparc64g1520.exe=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-mul
 compiler.csparc64g1520.semver=15.2.0
 compiler.csparc64g1520.objdumper=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.csparc64g1520.demangler=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+compiler.csparc64g1610.exe=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gcc
+compiler.csparc64g1610.semver=16.1.0
+compiler.csparc64g1610.objdumper=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.csparc64g1610.demangler=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+
 
 ###############################
 # Cross for SPARC-LEON
 group.csparcleon.compilers=&cgccsparcleon
 
 # GCC for SPARC-LEON
-group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1240:csparcleong1250:csparcleong1310:csparcleong1320:csparcleong1330:csparcleong1340:csparcleong1410:csparcleong1420:csparcleong1430:csparcleong1510:csparcleong1520
+group.cgccsparcleon.compilers=csparcleong1220:csparcleong1220-1:csparcleong1230:csparcleong1240:csparcleong1250:csparcleong1310:csparcleong1320:csparcleong1330:csparcleong1340:csparcleong1410:csparcleong1420:csparcleong1430:csparcleong1510:csparcleong1520:csparcleong1610
 group.cgccsparcleon.baseName=SPARC LEON gcc
 group.cgccsparcleon.groupName=SPARC LEON GCC
 group.cgccsparcleon.isSemVer=true
@@ -1697,6 +1722,11 @@ compiler.csparcleong1520.exe=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-
 compiler.csparcleong1520.semver=15.2.0
 compiler.csparcleong1520.objdumper=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.csparcleong1520.demangler=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+compiler.csparcleong1610.exe=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
+compiler.csparcleong1610.semver=16.1.0
+compiler.csparcleong1610.objdumper=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.csparcleong1610.demangler=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+
 
 compiler.csparcleong1220-1.exe=/opt/compiler-explorer/sparc-leon/gcc-12.2.0-1/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gcc
 compiler.csparcleong1220-1.semver=12.2.0
@@ -1708,7 +1738,7 @@ compiler.csparcleong1220-1.demangler=/opt/compiler-explorer/sparc-leon/gcc-12.2.
 group.cc6x.compilers=&cgccc6x
 
 # GCC for TI C6x
-group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310:cc6xg1320:cc6xg1410:cc6xg1330:cc6xg1240:cc6xg1420:cc6xg1510:cc6xg1430:cc6xg1340:cc6xg1250:cc6xg1520
+group.cgccc6x.compilers=cc6xg1220:cc6xg1230:cc6xg1310:cc6xg1320:cc6xg1410:cc6xg1330:cc6xg1240:cc6xg1420:cc6xg1510:cc6xg1430:cc6xg1340:cc6xg1250:cc6xg1520:cc6xg1610
 group.cgccc6x.baseName=TI C6x gcc
 group.cgccc6x.groupName=TI C6x GCC
 group.cgccc6x.isSemVer=true
@@ -1777,13 +1807,18 @@ compiler.cc6xg1520.exe=/opt/compiler-explorer/c6x/gcc-15.2.0/tic6x-elf/bin/tic6x
 compiler.cc6xg1520.semver=15.2.0
 compiler.cc6xg1520.objdumper=/opt/compiler-explorer/c6x/gcc-15.2.0/tic6x-elf/bin/tic6x-elf-objdump
 compiler.cc6xg1520.demangler=/opt/compiler-explorer/c6x/gcc-15.2.0/tic6x-elf/bin/tic6x-elf-c++filt
+compiler.cc6xg1610.exe=/opt/compiler-explorer/c6x/gcc-16.1.0/tic6x-elf/bin/tic6x-elf-gcc
+compiler.cc6xg1610.semver=16.1.0
+compiler.cc6xg1610.objdumper=/opt/compiler-explorer/c6x/gcc-16.1.0/tic6x-elf/bin/tic6x-elf-objdump
+compiler.cc6xg1610.demangler=/opt/compiler-explorer/c6x/gcc-16.1.0/tic6x-elf/bin/tic6x-elf-c++filt
+
 
 ###############################
 # Cross for loongarch64
 group.cloongarch64.compilers=&cgccloongarch64
 
 # GCC for loongarch64
-group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310:cloongarch64g1320:cloongarch64g1410:cloongarch64g1330:cloongarch64g1240:cloongarch64g1420:cloongarch64g1510:cloongarch64g1430:cloongarch64g1340:cloongarch64g1250:cloongarch64g1520
+group.cgccloongarch64.compilers=cloongarch64g1220:cloongarch64g1230:cloongarch64g1310:cloongarch64g1320:cloongarch64g1410:cloongarch64g1330:cloongarch64g1240:cloongarch64g1420:cloongarch64g1510:cloongarch64g1430:cloongarch64g1340:cloongarch64g1250:cloongarch64g1520:cloongarch64g1610
 group.cgccloongarch64.baseName=loongarch64 gcc
 group.cgccloongarch64.groupName=loongarch64 GCC
 group.cgccloongarch64.isSemVer=true
@@ -1852,13 +1887,18 @@ compiler.cloongarch64g1520.exe=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loo
 compiler.cloongarch64g1520.semver=15.2.0
 compiler.cloongarch64g1520.objdumper=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.cloongarch64g1520.demangler=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+compiler.cloongarch64g1610.exe=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gcc
+compiler.cloongarch64g1610.semver=16.1.0
+compiler.cloongarch64g1610.objdumper=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.cloongarch64g1610.demangler=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+
 
 ###############################
 # Cross for sh
 group.csh.compilers=&cgccsh
 
 # GCC for sh
-group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1240:cshg1250:cshg1310:cshg1320:cshg1330:cshg1340:cshg1410:cshg1420:cshg1430:cshg1510:cshg1520
+group.cgccsh.compilers=cshg494:cshg950:cshg1220:cshg1230:cshg1240:cshg1250:cshg1310:cshg1320:cshg1330:cshg1340:cshg1410:cshg1420:cshg1430:cshg1510:cshg1520:cshg1610
 group.cgccsh.baseName=sh gcc
 group.cgccsh.groupName=sh GCC
 group.cgccsh.isSemVer=true
@@ -1937,13 +1977,18 @@ compiler.cshg1520.exe=/opt/compiler-explorer/sh/gcc-15.2.0/sh-unknown-elf/bin/sh
 compiler.cshg1520.semver=15.2.0
 compiler.cshg1520.objdumper=/opt/compiler-explorer/sh/gcc-15.2.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
 compiler.cshg1520.demangler=/opt/compiler-explorer/sh/gcc-15.2.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+compiler.cshg1610.exe=/opt/compiler-explorer/sh/gcc-16.1.0/sh-unknown-elf/bin/sh-unknown-elf-gcc
+compiler.cshg1610.semver=16.1.0
+compiler.cshg1610.objdumper=/opt/compiler-explorer/sh/gcc-16.1.0/sh-unknown-elf/bin/sh-unknown-elf-objdump
+compiler.cshg1610.demangler=/opt/compiler-explorer/sh/gcc-16.1.0/sh-unknown-elf/bin/sh-unknown-elf-c++filt
+
 
 ###############################
 # Cross for s390x
 group.cs390x.compilers=&cgccs390x
 
 # GCC for s390x
-group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310:cs390xg1320:cs390xg1410:cs390xg1330:cs390xg1240:cs390xg1420:cs390xg1510:cs390xg1430:cs390xg1340:cs390xg1250:cs390xg1520
+group.cgccs390x.compilers=cgccs390x112:cs390xg1210:cs390xg1220:cs390xg1230:cs390xg1310:cs390xg1320:cs390xg1410:cs390xg1330:cs390xg1240:cs390xg1420:cs390xg1510:cs390xg1430:cs390xg1340:cs390xg1250:cs390xg1520:cs390xg1610
 group.cgccs390x.baseName=s390x gcc
 group.cgccs390x.groupName=s390x GCC
 group.cgccs390x.isSemVer=true
@@ -2020,6 +2065,11 @@ compiler.cs390xg1520.exe=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux
 compiler.cs390xg1520.semver=15.2.0
 compiler.cs390xg1520.objdumper=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.cs390xg1520.demangler=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+compiler.cs390xg1610.exe=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gcc
+compiler.cs390xg1610.semver=16.1.0
+compiler.cs390xg1610.objdumper=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.cs390xg1610.demangler=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+
 
 ###############################
 # Cross compilers for PPC
@@ -2027,7 +2077,7 @@ group.cppcs.compilers=&cppc:&cppc64:&cppc64le
 group.cppcs.isSemVer=true
 group.cppcs.instructionSet=powerpc
 
-group.cppc.compilers=cppcg48:cppcg1120:cppcg1210:cppcg1220:cppcg1230:cppcg1240:cppcg1250:cppcg1310:cppcg1320:cppcg1330:cppcg1340:cppcg1410:cppcg1420:cppcg1430:cppcg1510:cppcg1520
+group.cppc.compilers=cppcg48:cppcg1120:cppcg1210:cppcg1220:cppcg1230:cppcg1240:cppcg1250:cppcg1310:cppcg1320:cppcg1330:cppcg1340:cppcg1410:cppcg1420:cppcg1430:cppcg1510:cppcg1520:cppcg1610
 group.cppc.groupName=POWER
 group.cppc.baseName=power gcc
 
@@ -2107,8 +2157,13 @@ compiler.cppcg1520.exe=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown
 compiler.cppcg1520.semver=15.2.0
 compiler.cppcg1520.objdumper=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.cppcg1520.demangler=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+compiler.cppcg1610.exe=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gcc
+compiler.cppcg1610.semver=16.1.0
+compiler.cppcg1610.objdumper=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.cppcg1610.demangler=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
-group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310:cppc64g1320:cppc64gtrunk:cppc64g1410:cppc64g1330:cppc64g1240:cppc64g1420:cppc64g1510:cppc64g1430:cppc64g1340:cppc64g1250:cppc64g1520
+
+group.cppc64.compilers=cppc64g8:cppc64g9:cppc64g1120:cppc64g1210:cppc64clang:cppc64g1220:cppc64g1230:cppc64g1310:cppc64g1320:cppc64gtrunk:cppc64g1410:cppc64g1330:cppc64g1240:cppc64g1420:cppc64g1510:cppc64g1430:cppc64g1340:cppc64g1250:cppc64g1520:cppc64g1610
 group.cppc64.groupName=POWER64
 group.cppc64.baseName=POWER64 gcc
 
@@ -2194,6 +2249,11 @@ compiler.cppc64g1520.exe=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-u
 compiler.cppc64g1520.semver=15.2.0
 compiler.cppc64g1520.objdumper=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.cppc64g1520.demangler=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.cppc64g1610.exe=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.cppc64g1610.semver=16.1.0
+compiler.cppc64g1610.objdumper=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.cppc64g1610.demangler=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+
 
 compiler.cppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
 compiler.cppc64gtrunk.semver=trunk
@@ -2209,7 +2269,7 @@ compiler.cppc64clang.semver=(snapshot)
 compiler.cppc64clang.isNightly=true
 compiler.cppc64clang.compilerCategories=clang
 
-group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310:cppc64leg1320:cppc64legtrunk:cppc64leg1410:cppc64leg1330:cppc64leg1240:cppc64leg1420:cppc64leg1510:cppc64leg1430:cppc64leg1340:cppc64leg1250:cppc64leg1520
+group.cppc64le.compilers=cppc64leg630:cppc64leg8:cppc64leg9:cppc64leg1120:cppc64leg1210:cppc64leclang:cppc64leg1220:cppc64leg1230:cppc64leg1310:cppc64leg1320:cppc64legtrunk:cppc64leg1410:cppc64leg1330:cppc64leg1240:cppc64leg1420:cppc64leg1510:cppc64leg1430:cppc64leg1340:cppc64leg1250:cppc64leg1520:cppc64leg1610
 group.cppc64le.groupName=POWER64LE GCC
 group.cppc64le.baseName=power64le gcc
 
@@ -2299,6 +2359,11 @@ compiler.cppc64leg1520.exe=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc
 compiler.cppc64leg1520.semver=15.2.0
 compiler.cppc64leg1520.objdumper=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.cppc64leg1520.demangler=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.cppc64leg1610.exe=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.cppc64leg1610.semver=16.1.0
+compiler.cppc64leg1610.objdumper=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.cppc64leg1610.demangler=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+
 
 compiler.cppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
 compiler.cppc64legtrunk.semver=trunk
@@ -2326,7 +2391,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1250:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1340:carmug1340:carmg1410:carmug1410:carmg1420:carmug1420:carmg1430:carmug1430:carmg1510:carmug1510:carmg1520:carmug1520:carmgtrunk
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1250:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1340:carmug1340:carmg1410:carmug1410:carmg1420:carmug1420:carmg1430:carmug1430:carmg1510:carmug1510:carmg1520:carmug1520:carmgtrunk:carmg1610:carmug1610
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32
@@ -2432,6 +2497,11 @@ compiler.carmg1520.exe=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-g
 compiler.carmg1520.semver=15.2.0
 compiler.carmg1520.objdumper=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.carmg1520.demangler=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.carmg1610.exe=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carmg1610.semver=16.1.0
+compiler.carmg1610.objdumper=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.carmg1610.demangler=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+
 
 compiler.carmug1320.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-13.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
 compiler.carmug1320.name=ARM GCC 13.2.0 (unknown-eabi)
@@ -2480,6 +2550,11 @@ compiler.carmug1520.semver=15.2.0
 compiler.carmug1520.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-15.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.carmug1520.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-15.2.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
 compiler.carmug1520.name=ARM GCC 15.2.0 (unknown-eabi)
+compiler.carmug1610.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-gcc
+compiler.carmug1610.semver=16.1.0
+compiler.carmug1610.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
+compiler.carmug1610.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+
 
 compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc
 compiler.carmce820.semver=8.2.0 (WinCE)
@@ -2528,7 +2603,7 @@ compiler.carmgtrunk.isNightly=true
 # 64 bit
 group.cgcc64arm.groupName=ARM64 gcc
 group.cgcc64arm.baseName=ARM64 GCC
-group.cgcc64arm.compilers=caarchg54:carm64g494:carm64g550:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050:carm64g1320:carm64g1410:carm64g1330:carm64g1240:carm64g1420:carm64g1510:carm64g1430:carm64g1340:carm64g1250:carm64g1520
+group.cgcc64arm.compilers=caarchg54:carm64g494:carm64g550:carm64g630:carm64g640:carm64g730:carm64g750:carm64g820:carm64g850:carm64g930:carm64g940:carm64g950:carm64g1020:carm64g1030:carm64g1040:carm64g1100:carm64g1120:carm64g1130:carm64g1140:carm64g1210:carm64gtrunk:carm64g1220:carm64g1230:carm64g1310:carm64g1050:carm64g1320:carm64g1410:carm64g1330:carm64g1240:carm64g1420:carm64g1510:carm64g1430:carm64g1340:carm64g1250:carm64g1520:carm64g1610
 group.cgcc64arm.isSemVer=true
 group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
 group.cgcc64arm.instructionSet=aarch64
@@ -2655,6 +2730,11 @@ compiler.carm64g1520.exe=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown
 compiler.carm64g1520.semver=15.2.0
 compiler.carm64g1520.objdumper=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.carm64g1520.demangler=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.carm64g1610.exe=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1610.semver=16.1.0
+compiler.carm64g1610.objdumper=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.carm64g1610.demangler=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+
 
 compiler.carm64gtrunk.exe=/opt/compiler-explorer/arm64/gcc-trunk/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64gtrunk.semver=trunk
@@ -2932,7 +3012,7 @@ compiler.ccl4302161.versionFlag=-version
 
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg730:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1250:cavrg1310:cavrg1320:cavrg1330:cavrg1340:cavrg1410:cavrg1420:cavrg1430:cavrg1510:cavrg1520
+group.cavr.compilers=cavrg454:cavrg464:cavrg540:cavrg730:cavrg920:cavrg930:cavrg1030:cavrg1100:cavrg1210:cavrg1220:cavrg1230:cavrg1240:cavrg1250:cavrg1310:cavrg1320:cavrg1330:cavrg1340:cavrg1410:cavrg1420:cavrg1430:cavrg1510:cavrg1520:cavrg1610
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -3037,6 +3117,11 @@ compiler.cavrg1520.exe=/opt/compiler-explorer/avr/gcc-15.2.0/avr/bin/avr-gcc
 compiler.cavrg1520.semver=15.2.0
 compiler.cavrg1520.objdumper=/opt/compiler-explorer/avr/gcc-15.2.0/avr/bin/avr-objdump
 compiler.cavrg1520.demangler=/opt/compiler-explorer/avr/gcc-15.2.0/avr/bin/avr-c++filt
+compiler.cavrg1610.exe=/opt/compiler-explorer/avr/gcc-16.1.0/avr/bin/avr-gcc
+compiler.cavrg1610.semver=16.1.0
+compiler.cavrg1610.objdumper=/opt/compiler-explorer/avr/gcc-16.1.0/avr/bin/avr-objdump
+compiler.cavrg1610.demangler=/opt/compiler-explorer/avr/gcc-16.1.0/avr/bin/avr-c++filt
+
 
 ###############################
 # Cross compilers for MIPS
@@ -3218,7 +3303,7 @@ compiler.mips64el-cclang1300.semver=13.0.0
 
 # GCC for all MIPS
 ## MIPS
-group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1240:cmipsg1250:cmipsg1310:cmipsg1320:cmipsg1330:cmipsg1340:cmipsg1410:cmipsg1420:cmipsg1430:cmipsg1510:cmipsg1520
+group.cmips.compilers=cmips5:cmipsg494:cmipsg550:cmips930:cmipsg950:cmips1120:cmipsg1210:cmipsg1220:cmipsg1230:cmipsg1240:cmipsg1250:cmipsg1310:cmipsg1320:cmipsg1330:cmipsg1340:cmipsg1410:cmipsg1420:cmipsg1430:cmipsg1510:cmipsg1520:cmipsg1610
 group.cmips.groupName=MIPS GCC
 group.cmips.baseName=mips gcc
 
@@ -3318,10 +3403,15 @@ compiler.cmipsg1520.exe=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linu
 compiler.cmipsg1520.semver=15.2.0
 compiler.cmipsg1520.objdumper=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.cmipsg1520.demangler=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+compiler.cmipsg1610.exe=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gcc
+compiler.cmipsg1610.semver=16.1.0
+compiler.cmipsg1610.objdumper=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.cmipsg1610.demangler=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+
 
 ## MIPS64
 group.cmips64.groupName=MIPS64 GCC
-group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips64g1410:cmips64g1330:cmips64g1240:cmips64g1420:cmips64g1510:cmips64g1430:cmips64g1340:cmips64g1250:cmips64g1520:cmips564:cmips112064
+group.cmips64.compilers=cmips64g494:cmips64g550:cmips64g950:cmips64g1210:cmips64g1220:cmips64g1230:cmips64g1310:cmips64g1320:cmips64g1410:cmips64g1330:cmips64g1240:cmips64g1420:cmips64g1510:cmips64g1430:cmips64g1340:cmips64g1250:cmips64g1520:cmips564:cmips112064:cmips64g1610
 group.cmips64.baseName=mips64 gcc
 
 compiler.cmips64g494.exe=/opt/compiler-explorer/mips64/gcc-4.9.4/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
@@ -3415,10 +3505,15 @@ compiler.cmips64g1520.exe=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknow
 compiler.cmips64g1520.semver=15.2.0
 compiler.cmips64g1520.objdumper=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.cmips64g1520.demangler=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+compiler.cmips64g1610.exe=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gcc
+compiler.cmips64g1610.semver=16.1.0
+compiler.cmips64g1610.objdumper=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.cmips64g1610.demangler=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+
 
 ## MIPS EL
 group.cmipsel.groupName=MIPSEL GCC
-group.cmipsel.compilers=cmips5el:cmipselg494:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1240:cmipselg1250:cmipselg1310:cmipselg1320:cmipselg1330:cmipselg1340:cmipselg1410:cmipselg1420:cmipselg1430:cmipselg1510:cmipselg1520
+group.cmipsel.compilers=cmips5el:cmipselg494:cmipselg550:cmipselg950:cmipselg1210:cmipselg1220:cmipselg1230:cmipselg1240:cmipselg1250:cmipselg1310:cmipselg1320:cmipselg1330:cmipselg1340:cmipselg1410:cmipselg1420:cmipselg1430:cmipselg1510:cmipselg1520:cmipselg1610
 group.cmipsel.baseName=mips (el) gcc
 
 compiler.cmipselg494.exe=/opt/compiler-explorer/mipsel/gcc-4.9.4/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-gcc
@@ -3508,10 +3603,15 @@ compiler.cmipselg1520.exe=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multil
 compiler.cmipselg1520.semver=15.2.0
 compiler.cmipselg1520.objdumper=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.cmipselg1520.demangler=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+compiler.cmipselg1610.exe=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gcc
+compiler.cmipselg1610.semver=16.1.0
+compiler.cmipselg1610.objdumper=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.cmipselg1610.demangler=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+
 
 ## MIPS64 EL
 group.cmips64el.groupName=MIPS64EL GCC
-group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips64elg1410:cmips64elg1330:cmips64elg1240:cmips64elg1420:cmips64elg1510:cmips64elg1430:cmips64elg1340:cmips64elg1250:cmips64elg1520:cmips564el
+group.cmips64el.compilers=cmips64elg494:cmips64elg550:cmips64elg950:cmips64elg1210:cmips64elg1220:cmips64elg1230:cmips64elg1310:cmips64elg1320:cmips64elg1410:cmips64elg1330:cmips64elg1240:cmips64elg1420:cmips64elg1510:cmips64elg1430:cmips64elg1340:cmips64elg1250:cmips64elg1520:cmips564el:cmips64elg1610
 group.cmips64el.baseName=mips64 (el) gcc
 
 compiler.cmips64elg494.exe=/opt/compiler-explorer/mips64el/gcc-4.9.4/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
@@ -3601,6 +3701,11 @@ compiler.cmips64elg1520.exe=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-
 compiler.cmips64elg1520.semver=15.2.0
 compiler.cmips64elg1520.objdumper=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.cmips64elg1520.demangler=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+compiler.cmips64elg1610.exe=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gcc
+compiler.cmips64elg1610.semver=16.1.0
+compiler.cmips64elg1610.objdumper=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.cmips64elg1610.demangler=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+
 
 ###############################
 # GCC for nanoMIPS
@@ -3637,7 +3742,7 @@ group.rvcgcc.supportsBinary=true
 group.rvcgcc.supportsBinaryObject=true
 
 ## GCC for RISC-V 64-bits
-group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310:rv64-cgcc1320:rv64-cgcc1410:rv64-cgcc1330:rv64-cgcc1240:rv64-cgcc1420:rv64-cgcc1510:rv64-cgcc1430:rv64-cgcc1340:rv64-cgcc1250:rv64-cgcc1520
+group.rv64-cgccs.compilers=rv64-cgcctrunk:rv64-cgcc1230:rv64-cgcc1210:rv64-cgcc1140:rv64-cgcc1130:rv64-cgcc1220:rv64-cgcc1120:rv64-cgcc1030:rv64-cgcc1020:rv64-cgcc940:rv64-cgcc850:rv64-cgcc820:rv64-cgcc1310:rv64-cgcc1320:rv64-cgcc1410:rv64-cgcc1330:rv64-cgcc1240:rv64-cgcc1420:rv64-cgcc1510:rv64-cgcc1430:rv64-cgcc1340:rv64-cgcc1250:rv64-cgcc1520:rv64-cgcc1610
 group.rv64-cgccs.groupName=RISC-V (64-bits) gcc
 group.rv64-cgccs.baseName=RISC-V (64-bits) gcc
 
@@ -3743,6 +3848,11 @@ compiler.rv64-cgcc1520.exe=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unk
 compiler.rv64-cgcc1520.semver=15.2.0
 compiler.rv64-cgcc1520.objdumper=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cgcc1520.demangler=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.rv64-cgcc1610.exe=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
+compiler.rv64-cgcc1610.semver=16.1.0
+compiler.rv64-cgcc1610.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-cgcc1610.demangler=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+
 
 compiler.rv64-cgcctrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc
 compiler.rv64-cgcctrunk.semver=(trunk)
@@ -3751,7 +3861,7 @@ compiler.rv64-cgcctrunk.demangler=/opt/compiler-explorer/riscv64/gcc-trunk/riscv
 compiler.rv64-cgcctrunk.isNightly=true
 
 ## GCC for RISC-V 32-bits
-group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230:rv32-cgcc1320:rv32-cgcc1410:rv32-cgcc1330:rv32-cgcc1240:rv32-cgcc1420:rv32-cgcc1510:rv32-cgcc1430:rv32-cgcc1340:rv32-cgcc1250:rv32-cgcc1520
+group.rv32-cgccs.compilers=rv32-cgcctrunk:rv32-cgcc1220:rv32-cgcc1210:rv32-cgcc1140:rv32-cgcc1130:rv32-cgcc1120:rv32-cgcc1030:rv32-cgcc1020:rv32-cgcc940:rv32-cgcc850:rv32-cgcc820:rv32-cgcc1310:rv32-cgcc1230:rv32-cgcc1320:rv32-cgcc1410:rv32-cgcc1330:rv32-cgcc1240:rv32-cgcc1420:rv32-cgcc1510:rv32-cgcc1430:rv32-cgcc1340:rv32-cgcc1250:rv32-cgcc1520:rv32-cgcc1610
 group.rv32-cgccs.groupName=RISC-V (32-bits) gcc
 group.rv32-cgccs.baseName=RISC-V (32-bits) gcc
 
@@ -3857,6 +3967,11 @@ compiler.rv32-cgcc1520.exe=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unk
 compiler.rv32-cgcc1520.semver=15.2.0
 compiler.rv32-cgcc1520.objdumper=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-cgcc1520.demangler=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.rv32-cgcc1610.exe=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
+compiler.rv32-cgcc1610.semver=16.1.0
+compiler.rv32-cgcc1610.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.rv32-cgcc1610.demangler=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+
 
 compiler.rv32-cgcctrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gcc
 compiler.rv32-cgcctrunk.semver=(trunk)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1271,7 +1271,7 @@ compiler.cbpfclang1300.exe=/opt/compiler-explorer/clang-13.0.0/bin/clang
 compiler.cbpfclang1300.semver=13.0.0
 
 # GCC for BPF
-group.cgccbpf.compilers=cbpfg1310:cbpfg1320:cbpfg1330:cbpfg1340:cbpfg1410:cbpfg1420:cbpfg1430:cbpfg1510:cbpfg1520:cbpfgtrunk:cbpfg1610
+group.cgccbpf.compilers=cbpfg1310:cbpfg1320:cbpfg1330:cbpfg1340:cbpfg1410:cbpfg1420:cbpfg1430:cbpfg1510:cbpfg1520:cbpfg1610:cbpfgtrunk
 group.cgccbpf.supportsBinary=true
 group.cgccbpf.supportsExecute=false
 group.cgccbpf.baseName=BPF gcc
@@ -2391,7 +2391,7 @@ group.cgccarm.includeFlag=-I
 # 32 bit
 group.cgcc32arm.groupName=Arm 32-bit GCC
 group.cgcc32arm.baseName=ARM GCC
-group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1250:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1340:carmug1340:carmg1410:carmug1410:carmg1420:carmug1420:carmg1430:carmug1430:carmg1510:carmug1510:carmg1520:carmug1520:carmgtrunk:carmg1610:carmug1610
+group.cgcc32arm.compilers=carmhfg54:carmg454:carmg464:carm541:carmg630:carmg640:carm710:carmg730:carmg750:carmg820:carmce820:carm831:carmg850:carm921:carm930:carm1020:carm1021:carm1030:carm1031_07:carm1031_10:carmg1050:carm1100:carm1120:carm1121:carm1130:carmg1140:carm1210:carmg1220:carmg1230:carmg1240:carmg1250:carmg1310:carmg1320:carmug1320:carmg1330:carmug1330:carmg1340:carmug1340:carmg1410:carmug1410:carmg1420:carmug1420:carmg1430:carmug1430:carmg1510:carmug1510:carmg1520:carmug1520:carmg1610:carmug1610:carmgtrunk
 group.cgcc32arm.isSemVer=true
 group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 group.cgcc32arm.instructionSet=arm32

--- a/etc/config/cobol.amazon.properties
+++ b/etc/config/cobol.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&gnucobol:&gcccobol
 defaultCompiler=gnucobol32
-objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
+objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 
 group.gnucobol.groupName=GnuCOBOL
 group.gnucobol.compilers=gnucobol32:gnucobol32rc2:gnucobol31:gnucobol22:gnucobol11
@@ -30,7 +30,7 @@ compiler.gnucobol11.licensePreamble=Copyright (c) 2012 Free Software Foundation,
 
 group.gcccobol.compilerType=gcccobol
 group.gcccobol.groupName=GCC
-group.gcccobol.compilers=&gcccobolassert:gcccobolsnapshot:gcccobol151:gcccobol152:gcccoboltrunk
+group.gcccobol.compilers=&gcccobolassert:gcccobolsnapshot:gcccobol151:gcccobol152:gcccobol161:gcccoboltrunk
 group.gcccobol.unwiseOptions=-march=native
 group.gcccobol.isSemVer=true
 group.gcccobol.baseName=GCC
@@ -47,12 +47,14 @@ compiler.gcccobol151.semver=15.1.0
 
 compiler.gcccobol152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcobol
 compiler.gcccobol152.semver=15.2.0
+compiler.gcccobol161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcobol
+compiler.gcccobol161.semver=16.1.0
 
 compiler.gcccoboltrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcobol
 compiler.gcccoboltrunk.semver=(GCC master)
 
 ## GCC (from upstream GCC, not GCCRS github) x86 build with "assertions" (--enable-checking=XXX)
-group.gcccobolassert.compilers=gcccobol151assert:gcccobol152assert
+group.gcccobolassert.compilers=gcccobol151assert:gcccobol152assert:gcccobol161assert
 group.gcccobolassert.groupName=x86-64 GCC (assertions)
 
 compiler.gcccobol151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gcobol
@@ -60,3 +62,5 @@ compiler.gcccobol151assert.semver=15.1.0 (GCC assertions)
 
 compiler.gcccobol152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcobol
 compiler.gcccobol152assert.semver=15.2.0 (GCC assertions)
+compiler.gcccobol161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcobol
+compiler.gcccobol161assert.semver=16.1.0 (GCC assertions)

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gdc:&ldc:&dmd:&dmd1:&gdccross
 defaultCompiler=ldc1_42
 
-group.gdc.compilers=&gdcassert:gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc124:gdc125:gdc131:gdc132:gdc133:gdc134:gdc141:gdc142:gdc143:gdc151:gdc152:gdctrunk
+group.gdc.compilers=&gdcassert:gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc124:gdc125:gdc131:gdc132:gdc133:gdc134:gdc141:gdc142:gdc143:gdc151:gdc152:gdc161:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
@@ -66,6 +66,8 @@ compiler.gdc151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gdc
 compiler.gdc151.semver=15.1
 compiler.gdc152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gdc
 compiler.gdc152.semver=15.2
+compiler.gdc161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gdc
+compiler.gdc161.semver=16.1
 
 compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -73,7 +75,7 @@ compiler.gdctrunk.semver=(trunk)
 compiler.gdctrunk.isNightly=true
 
 ## GDC x86 build with "assertions" (--enable-checking=XXX)
-group.gdcassert.compilers=gdc105assert:gdc111assert:gdc113assert:gdc114assert:gdc121assert:gdc122assert:gdc123assert:gdc124assert:gdc125assert:gdc131assert:gdc132assert:gdc133assert:gdc134assert:gdc141assert:gdc142assert:gdc143assert:gdc151assert:gdc152assert
+group.gdcassert.compilers=gdc105assert:gdc111assert:gdc113assert:gdc114assert:gdc121assert:gdc122assert:gdc123assert:gdc124assert:gdc125assert:gdc131assert:gdc132assert:gdc133assert:gdc134assert:gdc141assert:gdc142assert:gdc143assert:gdc151assert:gdc152assert:gdc161assert
 group.gdcassert.groupName=GDC x86-64 (assertions)
 
 compiler.gdc105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gdc
@@ -112,6 +114,8 @@ compiler.gdc151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gdc
 compiler.gdc151assert.semver=15.1 (assertions)
 compiler.gdc152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gdc
 compiler.gdc152assert.semver=15.2 (assertions)
+compiler.gdc161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gdc
+compiler.gdc161assert.semver=16.1 (assertions)
 
 ## CROSS GDC
 group.gdccross.compilers=&gdcloongarch64:&gdcs390x:&gdcppc:&gdcppc64:&gdcppc64le:&gdcmips64:&gdcmips:&gdcmipsel:&gdcarm:&gdcarm64:&gdcriscv:&gdcriscv64:&gdchppa

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gfortran_86:&ifort:&ifx:&nvfortran_x86:&cross:&clang_llvmflang:&lfortran
-defaultCompiler=gfortran152
-demangler=/opt/compiler-explorer/gcc-15.2.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
+defaultCompiler=gfortran161
+demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 compilerType=fortran
 
 buildenvsetup=ceconan-fortran
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran124:gfortran125:gfortran131:gfortran132:gfortran133:gfortran134:gfortran141:gfortran142:gfortran143:gfortran151:gfortran152:gfortransnapshot
+group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran124:gfortran125:gfortran131:gfortran132:gfortran133:gfortran134:gfortran141:gfortran142:gfortran143:gfortran151:gfortran152:gfortran161:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -90,6 +90,8 @@ compiler.gfortran151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gfortran
 compiler.gfortran151.semver=15.1
 compiler.gfortran152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gfortran
 compiler.gfortran152.semver=15.2
+compiler.gfortran161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gfortran
+compiler.gfortran161.semver=16.1
 
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -98,7 +100,7 @@ compiler.gfortransnapshot.semver=(trunk)
 compiler.gfortransnapshot.isNightly=true
 
 ## GFORTRAN x86 build with "assertions" (--enable-checking=XXX)
-group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran125assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran134assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert:gfortran152assert
+group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran125assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran134assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert:gfortran152assert:gfortran161assert
 group.gfortranassert.groupName=GFORTRAN x86-64 (assertions)
 group.gfortranassert.compilerCategories=gfortran
 
@@ -144,6 +146,8 @@ compiler.gfortran151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/
 compiler.gfortran151assert.semver=15.1 (assertions)
 compiler.gfortran152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gfortran
 compiler.gfortran152assert.semver=15.2 (assertions)
+compiler.gfortran161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gfortran
+compiler.gfortran161assert.semver=16.1 (assertions)
 
 ###############################
 # Intel Parallel Studio XE for x86

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gimplegcc86:&gimplecross:&wyrm
-defaultCompiler=gimpleg152
-demangler=/opt/compiler-explorer/gcc-15.2.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
+defaultCompiler=gimpleg161
+demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 needsMulti=false
 compilerType=gimple
 buildenvsetup=ceconan
@@ -12,7 +12,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.gimplegcc86.compilers=&gimplegcc86assert:gimpleg91:gimpleg92:gimpleg93:gimpleg94:gimpleg95:gimpleg101:gimpleg102:gimpleg103:gimpleg104:gimpleg105:gimpleg111:gimpleg112:gimpleg113:gimpleg114:gimpleg121:gimpleg122:gimpleg123:gimpleg124:gimpleg125:gimpleg131:gimpleg132:gimpleg133:gimpleg134:gimpleg141:gimpleg142:gimpleg143:gimpleg151:gimpleg152:gimplegsnapshot:gimplegstatic-analysis
+group.gimplegcc86.compilers=&gimplegcc86assert:gimpleg91:gimpleg92:gimpleg93:gimpleg94:gimpleg95:gimpleg101:gimpleg102:gimpleg103:gimpleg104:gimpleg105:gimpleg111:gimpleg112:gimpleg113:gimpleg114:gimpleg121:gimpleg122:gimpleg123:gimpleg124:gimpleg125:gimpleg131:gimpleg132:gimpleg133:gimpleg134:gimpleg141:gimpleg142:gimpleg143:gimpleg151:gimpleg152:gimpleg161:gimplegsnapshot:gimplegstatic-analysis
 group.gimplegcc86.groupName=GCC x86-64
 group.gimplegcc86.instructionSet=amd64
 group.gimplegcc86.isSemVer=true
@@ -78,6 +78,8 @@ compiler.gimpleg151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gcc
 compiler.gimpleg151.semver=15.1
 compiler.gimpleg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 compiler.gimpleg152.semver=15.2
+compiler.gimpleg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
+compiler.gimpleg161.semver=16.1
 
 compiler.gimplegsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.gimplegsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -94,7 +96,7 @@ compiler.gimplegstatic-analysis.options=-fanalyzer -fdiagnostics-urls=never -fdi
 compiler.gimplegstatic-analysis.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 ## GCC build with "assertions" (--enable-checking=XXX)
-group.gimplegcc86assert.compilers=gimpleg103assert:gimpleg104assert:gimpleg105assert:gimpleg111assert:gimpleg112assert:gimpleg113assert:gimpleg114assert:gimpleg121assert:gimpleg122assert:gimpleg123assert:gimpleg124assert:gimpleg125assert:gimpleg131assert:gimpleg132assert:gimpleg133assert:gimpleg134assert:gimpleg141assert:gimpleg142assert:gimpleg143assert:gimpleg151assert:gimpleg152assert
+group.gimplegcc86assert.compilers=gimpleg103assert:gimpleg104assert:gimpleg105assert:gimpleg111assert:gimpleg112assert:gimpleg113assert:gimpleg114assert:gimpleg121assert:gimpleg122assert:gimpleg123assert:gimpleg124assert:gimpleg125assert:gimpleg131assert:gimpleg132assert:gimpleg133assert:gimpleg134assert:gimpleg141assert:gimpleg142assert:gimpleg143assert:gimpleg151assert:gimpleg152assert:gimpleg161assert
 group.gimplegcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.gimpleg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -139,6 +141,8 @@ compiler.gimpleg151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/g
 compiler.gimpleg151assert.semver=15.1 (assertions)
 compiler.gimpleg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcc
 compiler.gimpleg152assert.semver=15.2 (assertions)
+compiler.gimpleg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
+compiler.gimpleg161assert.semver=16.1 (assertions)
 
 ################################
 # GCC for AVR

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -3,7 +3,7 @@ defaultCompiler=gl1260
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 buildenvsetup.host=https://conan.compiler-explorer.com
 
-group.gccgo.compilers=&gccgoassert:gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo124:gccgo125:gccgo131:gccgo132:gccgo133:gccgo134:gccgo141:gccgo142:gccgo143:gccgo151:gccgo152
+group.gccgo.compilers=&gccgoassert:gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo124:gccgo125:gccgo131:gccgo132:gccgo133:gccgo134:gccgo141:gccgo142:gccgo143:gccgo151:gccgo152:gccgo161
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -60,9 +60,11 @@ compiler.gccgo151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gccgo
 compiler.gccgo151.semver=15.1
 compiler.gccgo152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gccgo
 compiler.gccgo152.semver=15.2
+compiler.gccgo161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gccgo
+compiler.gccgo161.semver=16.1
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gccgoassert.compilers=gccgo105assert:gccgo111assert:gccgo112assert:gccgo113assert:gccgo114assert:gccgo121assert:gccgo122assert:gccgo123assert:gccgo124assert:gccgo125assert:gccgo131assert:gccgo132assert:gccgo133assert:gccgo134assert:gccgo141assert:gccgo142assert:gccgo143assert:gccgo151assert:gccgo152assert
+group.gccgoassert.compilers=gccgo105assert:gccgo111assert:gccgo112assert:gccgo113assert:gccgo114assert:gccgo121assert:gccgo122assert:gccgo123assert:gccgo124assert:gccgo125assert:gccgo131assert:gccgo132assert:gccgo133assert:gccgo134assert:gccgo141assert:gccgo142assert:gccgo143assert:gccgo151assert:gccgo152assert:gccgo161assert
 group.gccgoassert.groupName=x86 gccgo (assertions)
 
 compiler.gccgo105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gccgo
@@ -103,6 +105,8 @@ compiler.gccgo151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gcc
 compiler.gccgo151assert.semver=15.1 (assertions)
 compiler.gccgo152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gccgo
 compiler.gccgo152assert.semver=15.2 (assertions)
+compiler.gccgo161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gccgo
+compiler.gccgo161assert.semver=16.1 (assertions)
 
 group.gl.compilers=&x86gl:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl
 group.gl.versionFlag=version

--- a/etc/config/modula2.amazon.properties
+++ b/etc/config/modula2.amazon.properties
@@ -1,6 +1,6 @@
 # Default settings for modula2
 compilers=&gm2
-defaultCompiler=gm2152
+defaultCompiler=gm2161
 
 demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -15,7 +15,7 @@ needsMulti=false
 externalparser=CEAsmParser
 externalparser.exe=/usr/local/bin/asm-parser
 
-group.gm2.compilers=&gm2assert:gm2131:gm2132:gm2133:gm2134:gm2141:gm2142:gm2143:gm2151:gm2152:gm2snapshot
+group.gm2.compilers=&gm2assert:gm2131:gm2132:gm2133:gm2134:gm2141:gm2142:gm2143:gm2151:gm2152:gm2161:gm2snapshot
 group.gm2.compilerType=gm2
 group.gm2.instructionSet=amd64
 group.gm2.isSemVer=true
@@ -40,12 +40,14 @@ compiler.gm2151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gm2
 compiler.gm2151.semver=15.1
 compiler.gm2152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gm2
 compiler.gm2152.semver=15.2
+compiler.gm2161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gm2
+compiler.gm2161.semver=16.1
 
 compiler.gm2snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gm2
 compiler.gm2snapshot.semver=(snapshot)
 
 ## GFORTRAN x86 build with "assertions" (--enable-checking=XXX)
-group.gm2assert.compilers=gm2131assert:gm2132assert:gm2133assert:gm2134assert:gm2141assert:gm2142assert:gm2143assert:gm2151assert:gm2152assert
+group.gm2assert.compilers=gm2131assert:gm2132assert:gm2133assert:gm2134assert:gm2141assert:gm2142assert:gm2143assert:gm2151assert:gm2152assert:gm2161assert
 group.gm2assert.groupName=GM2 x86-64 (assertions)
 
 compiler.gm2131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gm2
@@ -66,3 +68,5 @@ compiler.gm2151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gm2
 compiler.gm2151assert.semver=15.1 (assertions)
 compiler.gm2152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gm2
 compiler.gm2152assert.semver=15.2 (assertions)
+compiler.gm2161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gm2
+compiler.gm2161assert.semver=16.1 (assertions)

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&objcppgcc86:&objcppcross
-defaultCompiler=objcppg152
-demangler=/opt/compiler-explorer/gcc-15.2.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
+defaultCompiler=objcppg161
+demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.objcppgcc86.compilers=&objcppgcc86assert:objcppg105:objcppg114:objcppg122:objcppg123:objcppg124:objcppg125:objcppg131:objcppg132:objcppg133:objcppg134:objcppg141:objcppg142:objcppg143:objcppg151:objcppg152:objcppgsnapshot
+group.objcppgcc86.compilers=&objcppgcc86assert:objcppg105:objcppg114:objcppg122:objcppg123:objcppg124:objcppg125:objcppg131:objcppg132:objcppg133:objcppg134:objcppg141:objcppg142:objcppg143:objcppg151:objcppg152:objcppg161:objcppgsnapshot
 group.objcppgcc86.groupName=GCC x86-64
 group.objcppgcc86.instructionSet=amd64
 group.objcppgcc86.baseName=x86-64 gcc
@@ -70,6 +70,8 @@ compiler.objcppg151.semver=15.1
 
 compiler.objcppg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/g++
 compiler.objcppg152.semver=15.2
+compiler.objcppg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/g++
+compiler.objcppg161.semver=16.1
 
 compiler.objcppgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.objcppgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -79,7 +81,7 @@ compiler.objcppgsnapshot.isNightly=true
 
 ## OBJC++ GCC x86 build with "assertions" (--enable-checking=XXX)
 group.objcppgcc86assert.groupName=GCC x86-64 (assertions)
-group.objcppgcc86assert.compilers=objcppg105assert:objcppg114assert:objcppg122assert:objcppg123assert:objcppg124assert:objcppg125assert:objcppg131assert:objcppg132assert:objcppg133assert:objcppg134assert:objcppg141assert:objcppg142assert:objcppg143assert:objcppg151assert:objcppg152assert
+group.objcppgcc86assert.compilers=objcppg105assert:objcppg114assert:objcppg122assert:objcppg123assert:objcppg124assert:objcppg125assert:objcppg131assert:objcppg132assert:objcppg133assert:objcppg134assert:objcppg141assert:objcppg142assert:objcppg143assert:objcppg151assert:objcppg152assert:objcppg161assert
 
 compiler.objcppg105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/g++
 compiler.objcppg105assert.semver=10.5 (assertions)
@@ -125,6 +127,8 @@ compiler.objcppg151assert.semver=15.1 (assertions)
 
 compiler.objcppg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/g++
 compiler.objcppg152assert.semver=15.2 (assertions)
+compiler.objcppg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/g++
+compiler.objcppg161assert.semver=16.1 (assertions)
 
 group.objcppcross.compilers=&objcppgccs
 

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&objcgcc86:&objccross
-defaultCompiler=objcg152
-demangler=/opt/compiler-explorer/gcc-15.2.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
+defaultCompiler=objcg161
+demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 needsMulti=false
 
 externalparser=CEAsmParser
@@ -9,7 +9,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.objcgcc86.compilers=&objcgcc86assert:objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg124:objcg125:objcg131:objcg132:objcg133:objcg134:objcg141:objcg142:objcg143:objcg151:objcg152:objcgsnapshot
+group.objcgcc86.compilers=&objcgcc86assert:objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg124:objcg125:objcg131:objcg132:objcg133:objcg134:objcg141:objcg142:objcg143:objcg151:objcg152:objcg161:objcgsnapshot
 group.objcgcc86.groupName=GCC x86-64
 group.objcgcc86.instructionSet=amd64
 group.objcgcc86.isSemVer=true
@@ -72,6 +72,8 @@ compiler.objcg151.semver=15.1
 
 compiler.objcg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 compiler.objcg152.semver=15.2
+compiler.objcg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
+compiler.objcg161.semver=16.1
 
 compiler.objcgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.objcgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -80,7 +82,7 @@ compiler.objcgsnapshot.semver=(trunk)
 compiler.objcgsnapshot.isNightly=true
 
 ## OBJC GCC x86 build with "assertions" (--enable-checking=XXX)
-group.objcgcc86assert.compilers=objcg105assert:objcg114assert:objcg122assert:objcg123assert:objcg124assert:objcg125assert:objcg131assert:objcg132assert:objcg133assert:objcg134assert:objcg141assert:objcg142assert:objcg143assert:objcg151assert:objcg152assert
+group.objcgcc86assert.compilers=objcg105assert:objcg114assert:objcg122assert:objcg123assert:objcg124assert:objcg125assert:objcg131assert:objcg132assert:objcg133assert:objcg134assert:objcg141assert:objcg142assert:objcg143assert:objcg151assert:objcg152assert:objcg161assert
 group.objcgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.objcg105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gcc
@@ -127,6 +129,8 @@ compiler.objcg151assert.semver=15.1 (assertions)
 
 compiler.objcg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcc
 compiler.objcg152assert.semver=15.2 (assertions)
+compiler.objcg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
+compiler.objcg161assert.semver=16.1 (assertions)
 
 ###############################
 # Cross Compilers

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&rust:&rustgcc:&mrustc:&rustccggcc:&rustccgcranelift
-objdumper=/opt/compiler-explorer/gcc-15.2.0/bin/objdump
-linker=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
+objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+linker=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 aarch64linker=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 defaultCompiler=r1950
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
@@ -254,7 +254,7 @@ group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
 group.rustgcc.notification=Rust GCC Frontend - Very early snapshot
 
 # native compiler
-group.gcc86.compilers=&gccrsassert:gccrs-snapshot:gccrs-g141:gccrs-g142:gccrs-g143:gccrs-g151:gccrs-g152:gcc-snapshot
+group.gcc86.compilers=&gccrsassert:gccrs-snapshot:gccrs-g141:gccrs-g142:gccrs-g143:gccrs-g151:gccrs-g152:gccrs-g161:gcc-snapshot
 group.gcc86.groupName=x86-64 GCCRS
 group.gcc86.baseName=x86-64 GCCRS
 group.gcc86.unwiseOptions=-march=native
@@ -273,6 +273,8 @@ compiler.gccrs-g151.semver=15.1 (GCC)
 
 compiler.gccrs-g152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gccrs
 compiler.gccrs-g152.semver=15.2 (GCC)
+compiler.gccrs-g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gccrs
+compiler.gccrs-g161.semver=16.1 (GCC)
 
 compiler.gcc-snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gccrs
 compiler.gcc-snapshot.semver=(GCC master)
@@ -283,7 +285,7 @@ compiler.gccrs-snapshot.semver=(GCCRS master)
 compiler.gccrs-snapshot.isNightly=true
 
 ## GCC (from upstream GCC, not GCCRS github) x86 build with "assertions" (--enable-checking=XXX)
-group.gccrsassert.compilers=gccrs-g141assert:gccrs-g142assert:gccrs-g143assert:gccrs-g151assert:gccrs-g152assert
+group.gccrsassert.compilers=gccrs-g141assert:gccrs-g142assert:gccrs-g143assert:gccrs-g151assert:gccrs-g152assert:gccrs-g161assert
 group.gccrsassert.groupName=x86-64 GCC (assertions)
 
 compiler.gccrs-g141assert.exe=/opt/compiler-explorer/gcc-assertions-14.1.0/bin/gccrs
@@ -300,6 +302,8 @@ compiler.gccrs-g151assert.semver=15.1 (GCC assertions)
 
 compiler.gccrs-g152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gccrs
 compiler.gccrs-g152assert.semver=15.2 (GCC assertions)
+compiler.gccrs-g161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gccrs
+compiler.gccrs-g161assert.semver=16.1 (GCC assertions)
 
 # cross compilers
 group.gcccross.compilers=&rustgccbpf


### PR DESCRIPTION
Add GCC 16.1.0 compilers across all supported languages and architectures.

## Native (x86-64)
- **C++/C:** `g161` / `g161assert`, set as default
- **Ada:** `gnat161` / `gnat161assert`
- **D:** `gdc161` / `gdc161assert`
- **Fortran:** `gfortran161` / `gfortran161assert`
- **Go:** `gccgo161` / `gccgo161assert`
- **COBOL:** `gcccobol161` / `gcccobol161assert`
- **Modula-2:** `gm2161` / `gm2161assert`
- **GIMPLE:** `gimpleg161` / `gimpleg161assert`
- **ObjC / ObjC++:** `objcg161` / `objcppg161`
- **Rust (GCC):** `gccrs-g161`
- **Algol68:** `ga68-g161` — GCC 16 is the first release to ship the `ga68` frontend; set as default, snapshot remains for trunk

## Cross-compilers (23 architectures)
arm, arm-unknown (eabi), arm64, avr, bpf, c6x, hppa, loongarch64, m68k, mips, mips64, mips64el, mipsel, powerpc, powerpc64, powerpc64le, riscv32, riscv64, s390x, sh, sparc, sparc64, sparc-leon.

Note: msp430 uses TI-specific distributions so is not added here.

**Depends on:** infra PR compiler-explorer/infra#2078 + S3 packages being available.

refs https://github.com/compiler-explorer/compiler-explorer/issues/7948

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

🤖 Generated by LLM (Claude, via OpenClaw)