### PR TITLE
[swift]: add 2.2.x compilers

### DIFF
--- a/etc/config/swift.amazon.properties
+++ b/etc/config/swift.amazon.properties
@@ -8,7 +8,7 @@ objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 #################################
 
 # swift (x86_64)
-group.swift.compilers=swift63:swift624:swift62:swift61:swift603:swift510:swift59:swift58:swift57:swift56:swift55:swift54:swift53:swift52:swift51:swift50:swift42:swift412:swift411:swift41:swift403:swift402:swift311:swiftdevsnapshot:swiftnightly
+group.swift.compilers=swift63:swift624:swift62:swift61:swift603:swift510:swift59:swift58:swift57:swift56:swift55:swift54:swift53:swift52:swift51:swift50:swift42:swift412:swift411:swift41:swift403:swift402:swift311:swift221:swift22:swiftdevsnapshot:swiftnightly
 group.swift.isSemVer=true
 group.swift.groupName=swift (x86-64)
 group.swift.baseName=x86-64 swiftc
@@ -143,6 +143,16 @@ compiler.swift402.supportsBinary=false
 compiler.swift311.exe=/opt/compiler-explorer/swift-3.1.1/usr/bin/swiftc
 compiler.swift311.semver=3.1.1
 compiler.swift311.supportsBinary=false
+
+# 2.x
+
+compiler.swift221.exe=/opt/compiler-explorer/swift-2.2.1/usr/bin/swiftc
+compiler.swift221.semver=2.2.1
+compiler.swift221.supportsBinary=false
+
+compiler.swift22.exe=/opt/compiler-explorer/swift-2.2/usr/bin/swiftc
+compiler.swift22.semver=2.2
+compiler.swift22.supportsBinary=false
 
 #################################
 #################################


### PR DESCRIPTION
Adds support for the available 2.x Swift compilers.

Depends on: https://github.com/compiler-explorer/infra/pull/2081
