### PR TITLE
[HLSL] Add DXC 1.10.2605.2 release

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&dxc:&rga:&clang:godbolt.org@443/winprod
 
-group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502:dxc_1_8_2505:dxc_1_8_2505_1:dxc_1_9_2602
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502:dxc_1_8_2505:dxc_1_8_2505_1:dxc_1_9_2602:dxc_1_10_2605_2
 group.dxc.groupName=DXC
 group.dxc.isSemVer=true
 group.dxc.baseName=DXC
@@ -36,6 +36,8 @@ compiler.dxc_1_8_2505_1.exe=/opt/compiler-explorer/dxc-1.8.2505.1/bin/dxc
 compiler.dxc_1_8_2505_1.semver=1.8.2505.1
 compiler.dxc_1_9_2602.exe=/opt/compiler-explorer/dxc-1.9.2602/bin/dxc
 compiler.dxc_1_9_2602.semver=1.9.2602
+compiler.dxc_1_10_2605_2.exe=/opt/compiler-explorer/dxc-1.10.2605.2/bin/dxc
+compiler.dxc_1_10_2605_2.semver=1.10.2605.2
 
 group.rga.compilers=rga262_dxctrunk:rga262_dxc172207:rga262_dxc162112:rga261_dxc172207:rga261_dxc162112:rga290_dxctrunk
 group.rga.groupName=RGA


### PR DESCRIPTION
This change adds the new DXC 1.10.2605.2 release. This PR depends on the infra PR below being merged and compilers built:

https://github.com/compiler-explorer/infra/pull/2082