### PR TITLE
Fix duplicate ARM GCC 16.1.0 name (missing unknown-eabi suffix)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -3085,6 +3085,7 @@ compiler.armug1610.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unk
 compiler.armug1610.semver=16.1.0
 compiler.armug1610.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.armug1610.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.armug1610.name=ARM GCC 16.1.0 (unknown-eabi)
 
 
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -2554,6 +2554,7 @@ compiler.carmug1610.exe=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-un
 compiler.carmug1610.semver=16.1.0
 compiler.carmug1610.objdumper=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-objdump
 compiler.carmug1610.demangler=/opt/compiler-explorer/arm/gcc-arm-unknown-16.1.0/arm-unknown-eabi/bin/arm-unknown-eabi-c++filt
+compiler.carmug1610.name=ARM GCC 16.1.0 (unknown-eabi)
 
 
 compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc


### PR DESCRIPTION
Fixes a cosmetic bug introduced in #8642: \`armug1610\` and \`carmug1610\` were missing the \`name\` property, causing both the regular and unknown-eabi ARM GCC 16.1.0 compilers to appear identically as "ARM GCC 16.1.0" in the UI.

All other \`armug*\` / \`carmug*\` entries have an explicit \`name=ARM GCC X.Y.Z (unknown-eabi)\` property; this PR adds the same for 16.1.0.

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*