### PR TITLE
Add GCC 16.1.0 cross Ada (GNAT) and Fortran compilers

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -137,7 +137,7 @@ group.gnatcross.compilerCategories=gcc
 
 ################################
 # GNAT for loongarch64
-group.gnatloongarch64.compilers=gnatloongarch641410:gnatloongarch641420:gnatloongarch641430:gnatloongarch641510:gnatloongarch641520
+group.gnatloongarch64.compilers=gnatloongarch641410:gnatloongarch641420:gnatloongarch641430:gnatloongarch641510:gnatloongarch641520:gnatloongarch641610
 group.gnatloongarch64.groupName=LOONGARCH64 GNAT
 group.gnatloongarch64.baseName=loongarch64 gnat
 
@@ -165,6 +165,10 @@ compiler.gnatloongarch641520.exe=/opt/compiler-explorer/loongarch64/gcc-15.2.0/l
 compiler.gnatloongarch641520.semver=15.2.0
 compiler.gnatloongarch641520.objdumper=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.gnatloongarch641520.demangler=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+compiler.gnatloongarch641610.exe=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gnatmake
+compiler.gnatloongarch641610.semver=16.1.0
+compiler.gnatloongarch641610.objdumper=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.gnatloongarch641610.demangler=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 ################################
 # GNAT for sparc-leon
@@ -209,7 +213,7 @@ compiler.gnatsparcleon1430.demangler=/opt/compiler-explorer/sparc-leon/gcc-14.3.
 
 ################################
 # GNAT for sparc
-group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1240:gnatsparc1250:gnatsparc1310:gnatsparc1320:gnatsparc1330:gnatsparc1340:gnatsparc1410:gnatsparc1420:gnatsparc1430:gnatsparc1510:gnatsparc1520
+group.gnatsparcs.compilers=gnatsparc1220:gnatsparc1230:gnatsparc1240:gnatsparc1250:gnatsparc1310:gnatsparc1320:gnatsparc1330:gnatsparc1340:gnatsparc1410:gnatsparc1420:gnatsparc1430:gnatsparc1510:gnatsparc1520:gnatsparc1610
 group.gnatsparcs.groupName=SPARC GNAT
 group.gnatsparcs.baseName=sparc gnat
 
@@ -277,10 +281,14 @@ compiler.gnatsparc1520.exe=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown
 compiler.gnatsparc1520.semver=15.2.0
 compiler.gnatsparc1520.objdumper=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.gnatsparc1520.demangler=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+compiler.gnatsparc1610.exe=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gnatmake
+compiler.gnatsparc1610.semver=16.1.0
+compiler.gnatsparc1610.objdumper=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.gnatsparc1610.demangler=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 ################################
 # GNAT for sparc64
-group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641240:gnatsparc641250:gnatsparc641310:gnatsparc641320:gnatsparc641330:gnatsparc641340:gnatsparc641410:gnatsparc641420:gnatsparc641430:gnatsparc641510:gnatsparc641520
+group.gnatsparc64s.compilers=gnatsparc641220:gnatsparc641230:gnatsparc641240:gnatsparc641250:gnatsparc641310:gnatsparc641320:gnatsparc641330:gnatsparc641340:gnatsparc641410:gnatsparc641420:gnatsparc641430:gnatsparc641510:gnatsparc641520:gnatsparc641610
 group.gnatsparc64s.groupName=SPARC64 GNAT
 group.gnatsparc64s.baseName=sparc64 gnat
 
@@ -348,10 +356,14 @@ compiler.gnatsparc641520.exe=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-m
 compiler.gnatsparc641520.semver=15.2.0
 compiler.gnatsparc641520.objdumper=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.gnatsparc641520.demangler=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+compiler.gnatsparc641610.exe=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gnatmake
+compiler.gnatsparc641610.semver=16.1.0
+compiler.gnatsparc641610.objdumper=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.gnatsparc641610.demangler=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 ################################
 # GNAT for riscv64
-group.gnatriscv64.compilers=gnatriscv64103:gnatriscv64112:gnatriscv641230:gnatriscv641240:gnatriscv641250:gnatriscv641310:gnatriscv641320:gnatriscv641330:gnatriscv641340:gnatriscv641410:gnatriscv641420:gnatriscv641430:gnatriscv641510:gnatriscv641520
+group.gnatriscv64.compilers=gnatriscv64103:gnatriscv64112:gnatriscv641230:gnatriscv641240:gnatriscv641250:gnatriscv641310:gnatriscv641320:gnatriscv641330:gnatriscv641340:gnatriscv641410:gnatriscv641420:gnatriscv641430:gnatriscv641510:gnatriscv641520:gnatriscv641610
 group.gnatriscv64.groupName=RISCV64 GNAT
 group.gnatriscv64.baseName=riscv64 gnat
 group.gnatriscv64.instructionSet=riscv64
@@ -425,10 +437,14 @@ compiler.gnatriscv641520.exe=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-u
 compiler.gnatriscv641520.semver=15.2.0
 compiler.gnatriscv641520.objdumper=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.gnatriscv641520.demangler=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.gnatriscv641610.exe=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gnatmake
+compiler.gnatriscv641610.semver=16.1.0
+compiler.gnatriscv641610.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.gnatriscv641610.demangler=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ################################
 # GNAT for s390x
-group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1240:gnats390x1310:gnats390x1320:gnats390x1330:gnats390x1410:gnats390x1420:gnats390x1510:gnats390x1430:gnats390x1340:gnats390x1250:gnats390x1520
+group.gnats390x.compilers=gnats390x1120:gnats390x1210:gnats390x1220:gnats390x1230:gnats390x1240:gnats390x1310:gnats390x1320:gnats390x1330:gnats390x1410:gnats390x1420:gnats390x1510:gnats390x1430:gnats390x1340:gnats390x1250:gnats390x1520:gnats390x1610
 group.gnats390x.groupName=S390X GNAT
 group.gnats390x.baseName=S390X GNAT
 
@@ -503,6 +519,10 @@ compiler.gnats390x1520.exe=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-lin
 compiler.gnats390x1520.semver=15.2.0
 compiler.gnats390x1520.objdumper=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.gnats390x1520.demangler=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+compiler.gnats390x1610.exe=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gnatmake
+compiler.gnats390x1610.semver=16.1.0
+compiler.gnats390x1610.objdumper=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.gnats390x1610.demangler=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 ################################
 # GNAT for ppc
@@ -511,7 +531,7 @@ group.gnatppcs.instructionSet=powerpc
 
 ## POWER
 group.gnatppc.groupName=POWERPC GNAT
-group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1240:gnatppc1250:gnatppc1310:gnatppc1320:gnatppc1330:gnatppc1340:gnatppc1410:gnatppc1420:gnatppc1430:gnatppc1510:gnatppc1520
+group.gnatppc.compilers=gnatppc1120:gnatppc1210:gnatppc1220:gnatppc1230:gnatppc1240:gnatppc1250:gnatppc1310:gnatppc1320:gnatppc1330:gnatppc1340:gnatppc1410:gnatppc1420:gnatppc1430:gnatppc1510:gnatppc1520:gnatppc1610
 group.gnatppc.baseName=powerpc gnat
 
 compiler.gnatppc1120.exe=/opt/compiler-explorer/powerpc/gcc-11.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
@@ -586,11 +606,15 @@ compiler.gnatppc1520.exe=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unkno
 compiler.gnatppc1520.semver=15.2.0
 compiler.gnatppc1520.objdumper=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.gnatppc1520.demangler=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+compiler.gnatppc1610.exe=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gnatmake
+compiler.gnatppc1610.semver=16.1.0
+compiler.gnatppc1610.objdumper=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.gnatppc1610.demangler=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 ## POWER64
 group.gnatppc64.groupName=POWER64 GNAT
 group.gnatppc64.baseName=powerpc64 gnat
-group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641250:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641340:gnatppc641410:gnatppc641420:gnatppc641430:gnatppc641510:gnatppc641520
+group.gnatppc64.compilers=gnatppc64trunk:gnatppc641120:gnatppc641210:gnatppc641220:gnatppc641230:gnatppc641240:gnatppc641250:gnatppc641310:gnatppc641320:gnatppc641330:gnatppc641340:gnatppc641410:gnatppc641420:gnatppc641430:gnatppc641510:gnatppc641520:gnatppc641610
 
 compiler.gnatppc641120.exe=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc641120.demangler=/opt/compiler-explorer/powerpc64/gcc-11.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
@@ -664,6 +688,10 @@ compiler.gnatppc641520.exe=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64
 compiler.gnatppc641520.semver=15.2.0
 compiler.gnatppc641520.objdumper=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.gnatppc641520.demangler=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.gnatppc641610.exe=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
+compiler.gnatppc641610.semver=16.1.0
+compiler.gnatppc641610.objdumper=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.gnatppc641610.demangler=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.gnatppc64trunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gnatmake
 compiler.gnatppc64trunk.semver=trunk
@@ -673,7 +701,7 @@ compiler.gnatppc64trunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/pow
 ## POWER64LE
 group.gnatppc64le.groupName=POWER64LE GNAT
 group.gnatppc64le.baseName=powerpc64le gnat
-group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310:gnatppc64le1320:gnatppc64letrunk:gnatppc64le1410:gnatppc64le1330:gnatppc64le1240:gnatppc64le1420:gnatppc64le1510:gnatppc64le1430:gnatppc64le1340:gnatppc64le1250:gnatppc64le1520
+group.gnatppc64le.compilers=gnatppc64le1120:gnatppc64le1210:gnatppc64le1220:gnatppc64le1230:gnatppc64le1310:gnatppc64le1320:gnatppc64letrunk:gnatppc64le1410:gnatppc64le1330:gnatppc64le1240:gnatppc64le1420:gnatppc64le1510:gnatppc64le1430:gnatppc64le1340:gnatppc64le1250:gnatppc64le1520:gnatppc64le1610
 
 compiler.gnatppc64le1120.exe=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64le1120.demangler=/opt/compiler-explorer/powerpc64le/gcc-11.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
@@ -747,6 +775,10 @@ compiler.gnatppc64le1520.exe=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/power
 compiler.gnatppc64le1520.semver=15.2.0
 compiler.gnatppc64le1520.objdumper=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.gnatppc64le1520.demangler=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.gnatppc64le1610.exe=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
+compiler.gnatppc64le1610.semver=16.1.0
+compiler.gnatppc64le1610.objdumper=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.gnatppc64le1610.demangler=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.gnatppc64letrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gnatmake
 compiler.gnatppc64letrunk.semver=trunk
@@ -761,7 +793,7 @@ group.gnatmipss.compilers=&gnatmips:&gnatmips64
 ## MIPS
 group.gnatmips.groupName=MIPS GNAT
 group.gnatmips.baseName=mips gnat
-group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1240:gnatmips1250:gnatmips1310:gnatmips1320:gnatmips1330:gnatmips1340:gnatmips1410:gnatmips1420:gnatmips1430:gnatmips1510:gnatmips1520
+group.gnatmips.compilers=gnatmips1120:gnatmips1210:gnatmips1220:gnatmips1230:gnatmips1240:gnatmips1250:gnatmips1310:gnatmips1320:gnatmips1330:gnatmips1340:gnatmips1410:gnatmips1420:gnatmips1430:gnatmips1510:gnatmips1520:gnatmips1610
 
 compiler.gnatmips1120.exe=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
 compiler.gnatmips1120.demangler=/opt/compiler-explorer/mips/gcc-11.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
@@ -835,11 +867,15 @@ compiler.gnatmips1520.exe=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-li
 compiler.gnatmips1520.semver=15.2.0
 compiler.gnatmips1520.objdumper=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.gnatmips1520.demangler=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+compiler.gnatmips1610.exe=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gnatmake
+compiler.gnatmips1610.semver=16.1.0
+compiler.gnatmips1610.objdumper=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.gnatmips1610.demangler=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 ## MIPS64
 group.gnatmips64.groupName=MIPS64 GNAT
 group.gnatmips64.baseName=mips64 gnat
-group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641240:gnatmips641250:gnatmips641310:gnatmips641320:gnatmips641330:gnatmips641340:gnatmips641410:gnatmips641420:gnatmips641430:gnatmips641510:gnatmips641520
+group.gnatmips64.compilers=gnatmips641120:gnatmips641210:gnatmips641220:gnatmips641230:gnatmips641240:gnatmips641250:gnatmips641310:gnatmips641320:gnatmips641330:gnatmips641340:gnatmips641410:gnatmips641420:gnatmips641430:gnatmips641510:gnatmips641520:gnatmips641610
 
 compiler.gnatmips641120.exe=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
 compiler.gnatmips641120.demangler=/opt/compiler-explorer/mips64/gcc-11.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
@@ -913,10 +949,14 @@ compiler.gnatmips641520.exe=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unkn
 compiler.gnatmips641520.semver=15.2.0
 compiler.gnatmips641520.objdumper=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.gnatmips641520.demangler=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+compiler.gnatmips641610.exe=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gnatmake
+compiler.gnatmips641610.semver=16.1.0
+compiler.gnatmips641610.objdumper=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.gnatmips641610.demangler=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 ################################
 # GNAT for arm64
-group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641240:gnatarm641250:gnatarm641310:gnatarm641320:gnatarm641330:gnatarm641340:gnatarm641410:gnatarm641420:gnatarm641430:gnatarm641510:gnatarm641520
+group.gnatarm64.compilers=gnatarm641210:gnatarm641220:gnatarm641230:gnatarm641240:gnatarm641250:gnatarm641310:gnatarm641320:gnatarm641330:gnatarm641340:gnatarm641410:gnatarm641420:gnatarm641430:gnatarm641510:gnatarm641520:gnatarm641610
 group.gnatarm64.groupName=ARM64 GNAT
 group.gnatarm64.baseName=arm64 gnat
 group.gnatarm64.instructionSet=aarch64
@@ -989,10 +1029,14 @@ compiler.gnatarm641520.exe=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unkno
 compiler.gnatarm641520.semver=15.2.0
 compiler.gnatarm641520.objdumper=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.gnatarm641520.demangler=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.gnatarm641610.exe=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gnatmake
+compiler.gnatarm641610.semver=16.1.0
+compiler.gnatarm641610.objdumper=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.gnatarm641610.demangler=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 ################################
 # GNAT for arm
-group.gnatarm.compilers=gnatarm103:gnatarm112:gnatarm1310:gnatarm1320:gnatarm1330:gnatarm1340:gnatarm1410:gnatarm1420:gnatarm1430:gnatarm1510:gnatarm1520
+group.gnatarm.compilers=gnatarm103:gnatarm112:gnatarm1310:gnatarm1320:gnatarm1330:gnatarm1340:gnatarm1410:gnatarm1420:gnatarm1430:gnatarm1510:gnatarm1520:gnatarm1610
 group.gnatarm.groupName=ARM GNAT
 group.gnatarm.baseName=arm gnat
 group.gnatarm.instructionSet=arm32
@@ -1051,10 +1095,14 @@ compiler.gnatarm1520.exe=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux
 compiler.gnatarm1520.semver=15.2.0
 compiler.gnatarm1520.objdumper=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.gnatarm1520.demangler=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.gnatarm1610.exe=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gnatmake
+compiler.gnatarm1610.semver=16.1.0
+compiler.gnatarm1610.objdumper=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.gnatarm1610.demangler=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 ################################
 # GNAT for HPPA
-group.gnathppa.compilers=gnathppa1420:gnathppa1430:gnathppa1510:gnathppa1520
+group.gnathppa.compilers=gnathppa1420:gnathppa1430:gnathppa1510:gnathppa1520:gnathppa1610
 group.gnathppa.groupName=HPPA GNAT
 group.gnathppa.baseName=hppa gnat
 group.gnathppa.isSemVer=true
@@ -1080,6 +1128,10 @@ compiler.gnathppa1520.exe=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-li
 compiler.gnathppa1520.semver=15.2.0
 compiler.gnathppa1520.objdumper=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
 compiler.gnathppa1520.demangler=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
+compiler.gnathppa1610.exe=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gnatmake
+compiler.gnathppa1610.semver=16.1.0
+compiler.gnathppa1610.objdumper=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
+compiler.gnathppa1610.demangler=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
 
 #################################
 #################################

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -452,7 +452,7 @@ compiler.ftricoreg1130.demangler=/opt/compiler-explorer/tricore/gcc-11.3.0/trico
 
 ###############################
 # GCC for HPPA
-group.gcchppa.compilers=fhppag1420:fhppag1430:fhppag1510:fhppag1520
+group.gcchppa.compilers=fhppag1420:fhppag1430:fhppag1510:fhppag1520:fhppag1610
 group.gcchppa.groupName=HPPA gfortran
 group.gcchppa.baseName=HPPA gfortran
 group.gcchppa.supportsBinary=true
@@ -477,10 +477,14 @@ compiler.fhppag1520.exe=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linu
 compiler.fhppag1520.semver=15.2.0
 compiler.fhppag1520.objdumper=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
 compiler.fhppag1520.demangler=/opt/compiler-explorer/hppa/gcc-15.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
+compiler.fhppag1610.exe=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gfortran
+compiler.fhppag1610.semver=16.1.0
+compiler.fhppag1610.objdumper=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-objdump
+compiler.fhppag1610.demangler=/opt/compiler-explorer/hppa/gcc-16.1.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for SPARC
-group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1250:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1340:fsparcg1410:fsparcg1420:fsparcg1430:fsparcg1510:fsparcg1520
+group.gccsparc.compilers=fsparcg1220:fsparcg1230:fsparcg1240:fsparcg1250:fsparcg1310:fsparcg1320:fsparcg1330:fsparcg1340:fsparcg1410:fsparcg1420:fsparcg1430:fsparcg1510:fsparcg1520:fsparcg1610
 group.gccsparc.groupName=SPARC gfortran
 group.gccsparc.baseName=SPARC gfortran
 group.gccsparc.compilerCategories=gfortran
@@ -549,10 +553,14 @@ compiler.fsparcg1520.exe=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-l
 compiler.fsparcg1520.semver=15.2.0
 compiler.fsparcg1520.objdumper=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
 compiler.fsparcg1520.demangler=/opt/compiler-explorer/sparc/gcc-15.2.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
+compiler.fsparcg1610.exe=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-gfortran
+compiler.fsparcg1610.semver=16.1.0
+compiler.fsparcg1610.objdumper=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-objdump
+compiler.fsparcg1610.demangler=/opt/compiler-explorer/sparc/gcc-16.1.0/sparc-unknown-linux-gnu/bin/sparc-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for SPARC64
-group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240:fsparc64g1420:fsparc64g1510:fsparc64g1430:fsparc64g1340:fsparc64g1250:fsparc64g1520
+group.gccsparc64.compilers=fsparc64g1220:fsparc64g1230:fsparc64g1310:fsparc64g1320:fsparc64g1410:fsparc64g1330:fsparc64g1240:fsparc64g1420:fsparc64g1510:fsparc64g1430:fsparc64g1340:fsparc64g1250:fsparc64g1520:fsparc64g1610
 group.gccsparc64.groupName=SPARC64 gfortran
 group.gccsparc64.baseName=SPARC64 gfortran
 group.gccsparc64.compilerCategories=gfortran
@@ -621,10 +629,14 @@ compiler.fsparc64g1520.exe=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-mul
 compiler.fsparc64g1520.semver=15.2.0
 compiler.fsparc64g1520.objdumper=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
 compiler.fsparc64g1520.demangler=/opt/compiler-explorer/sparc64/gcc-15.2.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
+compiler.fsparc64g1610.exe=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-gfortran
+compiler.fsparc64g1610.semver=16.1.0
+compiler.fsparc64g1610.objdumper=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-objdump
+compiler.fsparc64g1610.demangler=/opt/compiler-explorer/sparc64/gcc-16.1.0/sparc64-multilib-linux-gnu/bin/sparc64-multilib-linux-gnu-c++filt
 
 ###############################
 # GCC for SPARC LEON
-group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1250:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1340:fsparcleong1410:fsparcleong1420:fsparcleong1430:fsparcleong1510:fsparcleong1520
+group.gccsparcleon.compilers=fsparcleong1220:fsparcleong1220-1:fsparcleong1230:fsparcleong1240:fsparcleong1250:fsparcleong1310:fsparcleong1320:fsparcleong1330:fsparcleong1340:fsparcleong1410:fsparcleong1420:fsparcleong1430:fsparcleong1510:fsparcleong1520:fsparcleong1610
 group.gccsparcleon.groupName=SPARC LEON gfortran
 group.gccsparcleon.baseName=SPARC LEON gfortran
 group.gccsparcleon.compilerCategories=gfortran
@@ -700,10 +712,14 @@ compiler.fsparcleong1520.exe=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-
 compiler.fsparcleong1520.semver=15.2.0
 compiler.fsparcleong1520.objdumper=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
 compiler.fsparcleong1520.demangler=/opt/compiler-explorer/sparc-leon/gcc-15.2.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
+compiler.fsparcleong1610.exe=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-gfortran
+compiler.fsparcleong1610.semver=16.1.0
+compiler.fsparcleong1610.objdumper=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-objdump
+compiler.fsparcleong1610.demangler=/opt/compiler-explorer/sparc-leon/gcc-16.1.0/sparc-leon-linux-uclibc/bin/sparc-leon-linux-uclibc-c++filt
 
 ###############################
 # GCC for LOONGARCH64
-group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240:floongarch64g1420:floongarch64g1510:floongarch64g1430:floongarch64g1340:floongarch64g1250:floongarch64g1520
+group.gccloongarch64.compilers=floongarch64g1220:floongarch64g1230:floongarch64g1310:floongarch64g1320:floongarch64g1410:floongarch64g1330:floongarch64g1240:floongarch64g1420:floongarch64g1510:floongarch64g1430:floongarch64g1340:floongarch64g1250:floongarch64g1520:floongarch64g1610
 group.gccloongarch64.groupName=LOONGARCH64 gfortran
 group.gccloongarch64.baseName=LOONGARCH64 gfortran
 group.gccloongarch64.compilerCategories=gfortran
@@ -772,10 +788,14 @@ compiler.floongarch64g1520.exe=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loo
 compiler.floongarch64g1520.semver=15.2.0
 compiler.floongarch64g1520.objdumper=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
 compiler.floongarch64g1520.demangler=/opt/compiler-explorer/loongarch64/gcc-15.2.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
+compiler.floongarch64g1610.exe=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-gfortran
+compiler.floongarch64g1610.semver=16.1.0
+compiler.floongarch64g1610.objdumper=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-objdump
+compiler.floongarch64g1610.demangler=/opt/compiler-explorer/loongarch64/gcc-16.1.0/loongarch64-unknown-linux-gnu/bin/loongarch64-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for RISCV64
-group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240:friscv64g1420:friscv64g1510:friscv64g1430:friscv64g1340:friscv64g1250:friscv64g1520
+group.gccriscv64.compilers=friscv64g1140:friscv64g1220:friscv64g1230:friscv64g1310:friscv64g1320:friscv64g1410:friscv64g1330:friscv64g1240:friscv64g1420:friscv64g1510:friscv64g1430:friscv64g1340:friscv64g1250:friscv64g1520:friscv64g1610
 group.gccriscv64.groupName=RISCV64 gfortran
 group.gccriscv64.baseName=RISCV64 gfortran
 group.gccriscv64.compilerCategories=gfortran
@@ -849,10 +869,14 @@ compiler.friscv64g1520.exe=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unk
 compiler.friscv64g1520.semver=15.2.0
 compiler.friscv64g1520.objdumper=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.friscv64g1520.demangler=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
+compiler.friscv64g1610.exe=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gfortran
+compiler.friscv64g1610.semver=16.1.0
+compiler.friscv64g1610.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.friscv64g1610.demangler=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for RISCV
-group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1250:friscvg1310:friscvg1320:friscvg1330:friscvg1340:friscvg1410:friscvg1420:friscvg1430:friscvg1510:friscvg1520
+group.gccriscv.compilers=friscvg1140:friscvg1220:friscvg1230:friscvg1240:friscvg1250:friscvg1310:friscvg1320:friscvg1330:friscvg1340:friscvg1410:friscvg1420:friscvg1430:friscvg1510:friscvg1520:friscvg1610
 group.gccriscv.groupName=RISCV (32bit) gfortran
 group.gccriscv.baseName=RISCV (32bit) gfortran
 group.gccriscv.compilerCategories=gfortran
@@ -926,10 +950,14 @@ compiler.friscvg1520.exe=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unkno
 compiler.friscvg1520.semver=15.2.0
 compiler.friscvg1520.objdumper=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.friscvg1520.demangler=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
+compiler.friscvg1610.exe=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-gfortran
+compiler.friscvg1610.semver=16.1.0
+compiler.friscvg1610.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+compiler.friscvg1610.demangler=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1250:farmg1310:farmg1320:farmg1330:farmg1340:farmg1410:farmg1420:farmg1430:farmg1510:farmg1520
+group.gccarm.compilers=farmg640:farmg730:farmg820:farmg1050:farmg1140:farmg1210:farmg1220:farmg1230:farmg1240:farmg1250:farmg1310:farmg1320:farmg1330:farmg1340:farmg1410:farmg1420:farmg1430:farmg1510:farmg1520:farmg1610
 group.gccarm.groupName=ARM (32bit) gfortran
 group.gccarm.baseName=ARM (32bit) gfortran
 group.gccarm.compilerCategories=gfortran
@@ -1020,10 +1048,14 @@ compiler.farmg1520.exe=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-g
 compiler.farmg1520.semver=15.2.0
 compiler.farmg1520.objdumper=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
 compiler.farmg1520.demangler=/opt/compiler-explorer/arm/gcc-15.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
+compiler.farmg1610.exe=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gfortran
+compiler.farmg1610.semver=16.1.0
+compiler.farmg1610.objdumper=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+compiler.farmg1610.demangler=/opt/compiler-explorer/arm/gcc-16.1.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-c++filt
 
 ###############################
 ## GCC for s390x
-group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240:fs390xg1420:fs390xg1510:fs390xg1430:fs390xg1340:fs390xg1250:fs390xg1520
+group.gccs390x.compilers=fs390xg1210:fs390xg1220:fs390xg1230:fs390xg1310:fs390xg1320:fs390xg1410:fs390xg1330:fs390xg1240:fs390xg1420:fs390xg1510:fs390xg1430:fs390xg1340:fs390xg1250:fs390xg1520:fs390xg1610
 group.gccs390x.groupName=s390x gfortran
 group.gccs390x.baseName=s390x gfortran
 group.gccs390x.compilerCategories=gfortran
@@ -1096,6 +1128,10 @@ compiler.fs390xg1520.exe=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux
 compiler.fs390xg1520.semver=15.2.0
 compiler.fs390xg1520.objdumper=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
 compiler.fs390xg1520.demangler=/opt/compiler-explorer/s390x/gcc-15.2.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
+compiler.fs390xg1610.exe=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-gfortran
+compiler.fs390xg1610.semver=16.1.0
+compiler.fs390xg1610.objdumper=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-objdump
+compiler.fs390xg1610.demangler=/opt/compiler-explorer/s390x/gcc-16.1.0/s390x-ibm-linux-gnu/bin/s390x-ibm-linux-gnu-c++filt
 
 ###############################
 # LLVM Flang for X86
@@ -1212,7 +1248,7 @@ compiler.lfortran0590.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 
 ###############################
 # GCC for ARM 64bit
-group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240:farm64g1420:farm64g1510:farm64g1430:farm64g1340:farm64g1250:farm64g1520
+group.gccaarch64.compilers=farm64g494:farm64g550:farm64g640:farm64g730:farm64g820:farm64g1050:farm64g1210:farm64g1220:farm64g1230:farm64g1310:farm64g1140:farm64g1320:farm64g1410:farm64g1330:farm64g1240:farm64g1420:farm64g1510:farm64g1430:farm64g1340:farm64g1250:farm64g1520:farm64g1610
 group.gccaarch64.groupName=ARM (AARCH64) GCC
 group.gccaarch64.baseName=AARCH64 gfortran
 group.gccaarch64.compilerCategories=gfortran
@@ -1313,6 +1349,10 @@ compiler.farm64g1520.exe=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown
 compiler.farm64g1520.semver=15.2.0
 compiler.farm64g1520.objdumper=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.farm64g1520.demangler=/opt/compiler-explorer/arm64/gcc-15.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
+compiler.farm64g1610.exe=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran
+compiler.farm64g1610.semver=16.1.0
+compiler.farm64g1610.objdumper=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+compiler.farm64g1610.demangler=/opt/compiler-explorer/arm64/gcc-16.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for PPCs
@@ -1323,7 +1363,7 @@ group.ppcs.compilerCategories=gfortran
 
 ###############################
 # GCC for PPC
-group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1250:fppcg1310:fppcg1320:fppcg1330:fppcg1340:fppcg1410:fppcg1420:fppcg1430:fppcg1510:fppcg1520
+group.ppc.compilers=fppcg1210:fppcg1220:fppcg1230:fppcg1240:fppcg1250:fppcg1310:fppcg1320:fppcg1330:fppcg1340:fppcg1410:fppcg1420:fppcg1430:fppcg1510:fppcg1520:fppcg1610
 group.ppc.groupName=POWER gfortran
 group.ppc.baseName=POWER gfortran
 group.ppc.compilerCategories=gfortran
@@ -1396,10 +1436,14 @@ compiler.fppcg1520.exe=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown
 compiler.fppcg1520.semver=15.2.0
 compiler.fppcg1520.objdumper=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
 compiler.fppcg1520.demangler=/opt/compiler-explorer/powerpc/gcc-15.2.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
+compiler.fppcg1610.exe=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-gfortran
+compiler.fppcg1610.semver=16.1.0
+compiler.fppcg1610.objdumper=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-objdump
+compiler.fppcg1610.demangler=/opt/compiler-explorer/powerpc/gcc-16.1.0/powerpc-unknown-linux-gnu/bin/powerpc-unknown-linux-gnu-c++filt
 
 ###############################
 # GCC for PPC64
-group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240:fppc64g1420:fppc64g1510:fppc64g1430:fppc64g1340:fppc64g1250:fppc64g1520
+group.ppc64.compilers=fppc64g8:fppc64g9:fppc64g1210:fppc64g1220:fppc64g1230:fppc64g1310:fppc64g1320:fppc64gtrunk:fppc64g1410:fppc64g1330:fppc64g1240:fppc64g1420:fppc64g1510:fppc64g1430:fppc64g1340:fppc64g1250:fppc64g1520:fppc64g1610
 group.ppc64.groupName=POWER64 gfortran
 group.ppc64.baseName=POWER64 gfortran
 group.ppc64.compilerCategories=gfortran
@@ -1480,6 +1524,10 @@ compiler.fppc64g1520.exe=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-u
 compiler.fppc64g1520.semver=15.2.0
 compiler.fppc64g1520.objdumper=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.fppc64g1520.demangler=/opt/compiler-explorer/powerpc64/gcc-15.2.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
+compiler.fppc64g1610.exe=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.fppc64g1610.semver=16.1.0
+compiler.fppc64g1610.objdumper=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
+compiler.fppc64g1610.demangler=/opt/compiler-explorer/powerpc64/gcc-16.1.0/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-c++filt
 
 compiler.fppc64gtrunk.exe=/opt/compiler-explorer/powerpc64/gcc-trunk/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64gtrunk.semver=trunk
@@ -1488,7 +1536,7 @@ compiler.fppc64gtrunk.demangler=/opt/compiler-explorer/powerpc64/gcc-trunk/power
 
 ###############################
 # GCC for PPC64LE
-group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240:fppc64leg1420:fppc64leg1510:fppc64leg1430:fppc64leg1340:fppc64leg1250:fppc64leg1520
+group.ppc64le.compilers=fppc64leg8:fppc64leg9:fppc64leg1210:fppc64leg1220:fppc64leg1230:fppc64leg1310:fppc64leg1320:fppc64legtrunk:fppc64leg1410:fppc64leg1330:fppc64leg1240:fppc64leg1420:fppc64leg1510:fppc64leg1430:fppc64leg1340:fppc64leg1250:fppc64leg1520:fppc64leg1610
 group.ppc64le.groupName=POWER64le gfortran
 group.ppc64le.baseName=POWER64le gfortran
 group.ppc64le.compilerCategories=gfortran
@@ -1569,6 +1617,10 @@ compiler.fppc64leg1520.exe=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc
 compiler.fppc64leg1520.semver=15.2.0
 compiler.fppc64leg1520.objdumper=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.fppc64leg1520.demangler=/opt/compiler-explorer/powerpc64le/gcc-15.2.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
+compiler.fppc64leg1610.exe=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.fppc64leg1610.semver=16.1.0
+compiler.fppc64leg1610.objdumper=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
+compiler.fppc64leg1610.demangler=/opt/compiler-explorer/powerpc64le/gcc-16.1.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-c++filt
 
 compiler.fppc64legtrunk.exe=/opt/compiler-explorer/powerpc64le/gcc-trunk/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
 compiler.fppc64legtrunk.semver=trunk
@@ -1614,7 +1666,7 @@ compiler.frv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-
 
 ################################
 # GCC for MIPS
-group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1250:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1340:fmipsg1410:fmipsg1420:fmipsg1430:fmipsg1510:fmipsg1520
+group.gccmips.compilers=fmipsg494:fmipsg550:fmipsg950:fmipsg1210:fmipsg1220:fmipsg1230:fmipsg1240:fmipsg1250:fmipsg1310:fmipsg1320:fmipsg1330:fmipsg1340:fmipsg1410:fmipsg1420:fmipsg1430:fmipsg1510:fmipsg1520:fmipsg1610
 group.gccmips.groupName=MIPS gfortran
 group.gccmips.baseName=MIPS gfortran
 group.gccmips.compilerCategories=gfortran
@@ -1702,10 +1754,14 @@ compiler.fmipsg1520.exe=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linu
 compiler.fmipsg1520.semver=15.2.0
 compiler.fmipsg1520.objdumper=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.fmipsg1520.demangler=/opt/compiler-explorer/mips/gcc-15.2.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
+compiler.fmipsg1610.exe=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-gfortran
+compiler.fmipsg1610.semver=16.1.0
+compiler.fmipsg1610.objdumper=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
+compiler.fmipsg1610.demangler=/opt/compiler-explorer/mips/gcc-16.1.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-c++filt
 
 ################################
 # GCC for MIPS64
-group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240:fmips64g1420:fmips64g1510:fmips64g1430:fmips64g1340:fmips64g1250:fmips64g1520
+group.gccmips64.compilers=fmips64g494:fmips64g550:fmips64g950:fmips64g1210:fmips64g1220:fmips64g1230:fmips64g1310:fmips64g1320:fmips64g1410:fmips64g1330:fmips64g1240:fmips64g1420:fmips64g1510:fmips64g1430:fmips64g1340:fmips64g1250:fmips64g1520:fmips64g1610
 group.gccmips64.groupName=MIPS64 gfortran
 group.gccmips64.baseName=MIPS64 gfortran
 group.gccmips64.compilerCategories=gfortran
@@ -1793,10 +1849,14 @@ compiler.fmips64g1520.exe=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknow
 compiler.fmips64g1520.semver=15.2.0
 compiler.fmips64g1520.objdumper=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.fmips64g1520.demangler=/opt/compiler-explorer/mips64/gcc-15.2.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
+compiler.fmips64g1610.exe=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-gfortran
+compiler.fmips64g1610.semver=16.1.0
+compiler.fmips64g1610.objdumper=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
+compiler.fmips64g1610.demangler=/opt/compiler-explorer/mips64/gcc-16.1.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-c++filt
 
 ################################
 # GCC for MIPSEL
-group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1250:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1340:fmipselg1410:fmipselg1420:fmipselg1430:fmipselg1510:fmipselg1520
+group.gccmipsel.compilers=fmipselg494:fmipselg550:fmipselg950:fmipselg1210:fmipselg1220:fmipselg1230:fmipselg1240:fmipselg1250:fmipselg1310:fmipselg1320:fmipselg1330:fmipselg1340:fmipselg1410:fmipselg1420:fmipselg1430:fmipselg1510:fmipselg1520:fmipselg1610
 group.gccmipsel.groupName=MIPSel gfortran
 group.gccmipsel.baseName=MIPSel gfortran
 group.gccmipsel.compilerCategories=gfortran
@@ -1884,10 +1944,14 @@ compiler.fmipselg1520.exe=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multil
 compiler.fmipselg1520.semver=15.2.0
 compiler.fmipselg1520.objdumper=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
 compiler.fmipselg1520.demangler=/opt/compiler-explorer/mipsel/gcc-15.2.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
+compiler.fmipselg1610.exe=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-gfortran
+compiler.fmipselg1610.semver=16.1.0
+compiler.fmipselg1610.objdumper=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-objdump
+compiler.fmipselg1610.demangler=/opt/compiler-explorer/mipsel/gcc-16.1.0/mipsel-multilib-linux-gnu/bin/mipsel-multilib-linux-gnu-c++filt
 
 ################################
 # GCC for MIPS64el
-group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240:fmips64elg1420:fmips64elg1510:fmips64elg1430:fmips64elg1340:fmips64elg1250:fmips64elg1520
+group.gccmips64el.compilers=fmips64elg494:fmips64elg550:fmips64elg950:fmips64elg1210:fmips64elg1220:fmips64elg1230:fmips64elg1310:fmips64elg1320:fmips64elg1410:fmips64elg1330:fmips64elg1240:fmips64elg1420:fmips64elg1510:fmips64elg1430:fmips64elg1340:fmips64elg1250:fmips64elg1520:fmips64elg1610
 group.gccmips64el.groupName=MIPS64el gfortran
 group.gccmips64el.baseName=MIPS64el gfortran
 group.gccmips64el.compilerCategories=gfortran
@@ -1975,6 +2039,10 @@ compiler.fmips64elg1520.exe=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-
 compiler.fmips64elg1520.semver=15.2.0
 compiler.fmips64elg1520.objdumper=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
 compiler.fmips64elg1520.demangler=/opt/compiler-explorer/mips64el/gcc-15.2.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
+compiler.fmips64elg1610.exe=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-gfortran
+compiler.fmips64elg1610.semver=16.1.0
+compiler.fmips64elg1610.objdumper=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-objdump
+compiler.fmips64elg1610.demangler=/opt/compiler-explorer/mips64el/gcc-16.1.0/mips64el-multilib-linux-uclibc/bin/mips64el-multilib-linux-uclibc-c++filt
 
 #################################
 #################################


### PR DESCRIPTION
Follow-up to #8642 which added native GCC 16.1.0 and cross C/C++ compilers but missed the Ada and Fortran cross-compiler entries.

## Ada (GNAT) cross compilers added (13 architectures)
arm, arm64, hppa, loongarch64, mips, mips64, powerpc, powerpc64, powerpc64le, riscv64, s390x, sparc, sparc64

Note: sparc-leon skipped — `CT_CC_LANG_ADA` is disabled in the 16.1.0 ct-ng config for that target. Arches with Ada disabled in ct-ng (avr, bpf, c6x, m68k, mips64el, mipsel, msp430, riscv32) are also skipped.

## Fortran cross compilers added (17 architectures)
arm, arm64, hppa, loongarch64, mips, mips64, mips64el, mipsel, powerpc, powerpc64, powerpc64le, riscv32, riscv64, s390x, sparc, sparc64, sparc-leon

refs #7948

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

🤖 Generated by LLM (Claude, via OpenClaw)