### PR TITLE
✨ Updated and maintained (thephd.dev) compiler for Clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -537,7 +537,7 @@ compiler.clang2210.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-lin
 compiler.clang2210.debugPatched=true
 
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3822:clang_p3951:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_p1974:clang_chrisbazley
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3822:clang_p3951:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_p1974:clang_chrisbazley
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -653,10 +653,16 @@ compiler.clang_embed.semver=(std::embed)
 compiler.clang_embed.options=-std=c++2a -stdlib=libc++
 compiler.clang_embed.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_embed.hidden=true
-compiler.clang_dang.exe=/opt/compiler-explorer/clang-dang-main/bin/clang++
+compiler.clang_dang.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang++
 compiler.clang_dang.semver=(thephd.dev)
-compiler.clang_dang.options=-std=c++2a -stdlib=libc++
-compiler.clang_dang.notification=Embed, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
+compiler.clang_dang.options=-std=c++2d -stdlib=libc++
+compiler.clang_dang.notification=Generic, std::embed, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
+compiler.clang_dang.hidden=true
+compiler.clang_thephd_dev.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang++
+compiler.clang_thephd_dev.semver=(thephd.dev)
+compiler.clang_thephd_dev.options=-std=c++2d -stdlib=libc++
+compiler.clang_thephd_dev.isNightly=true
+compiler.clang_thephd_dev.notification=std::embed and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 compiler.clang_widberg.exe=/opt/compiler-explorer/clang-widberg-main/bin/clang++
 compiler.clang_widberg.semver=(widberg)
 compiler.clang_widberg.options=-std=c++2a -stdlib=libc++

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -266,7 +266,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang1500:cclang1600:cclang1701:cclang1810:cclang1910:cclang2010:cclang2110:cclang2210:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_widberg:cclang_swiftlang
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang352:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang501:cclang502:cclang600:cclang601:cclang700:cclang701:cclang710:cclang800:cclang801:cclang900:cclang901:cclang1000:cclang1001:cclang1100:cclang1101:cclang1200:cclang1201:cclang1300:cclang1301:cclang1400:cclang1500:cclang1600:cclang1701:cclang1810:cclang1910:cclang2010:cclang2110:cclang2210:cclang_trunk:cclang_assertions_trunk:cclang_dang:cclang_thephd_dev:cclang_widberg:cclang_swiftlang
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -425,6 +425,13 @@ compiler.cclang_dang.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_dang.semver=(thephd.dev)
 compiler.cclang_dang.isNightly=true
 compiler.cclang_dang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0 -std=c2x
+compiler.cclang_dang.hidden=true
+compiler.cclang_thephd_dev.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang
+compiler.cclang_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.cclang_thephd_dev.semver=(thephd.dev)
+compiler.cclang_thephd_dev.isNightly=true
+compiler.cclang_thephd_dev.options=--gcc-toolchain=/opt/compiler-explorer/gcc-16.1.0 -std=c2y
+compiler.cclang_thephd_dev.notification=Generic, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 compiler.cclang_widberg.exe=/opt/compiler-explorer/clang-widberg-main/bin/clang
 compiler.cclang_widberg.semver=(widberg)
 compiler.cclang_widberg.isNightly=true


### PR DESCRIPTION
This PR is fixing the previously-calcified Clang (thephd.dev) that was based off a branch that previously wasn't building (and now no longer exists).

I plan to keep this one going and helping for as long as I can, which should hopefully be better than earlier!

- [x] clang-builder: https://github.com/compiler-explorer/clang-builder/pull/107
- [x] clang-builder (with usable libunwind): https://github.com/compiler-explorer/clang-builder/pull/108
- [x] compiler-workflows: https://github.com/compiler-explorer/compiler-workflows/pull/62
- [ ] infra: https://github.com/compiler-explorer/infra/pull/2086
