### PR TITLE
Fix typo in the docs

### DIFF
--- a/docs/internal/AddingLinkableLibrary.md
+++ b/docs/internal/AddingLinkableLibrary.md
@@ -1,6 +1,6 @@
 Adding a library that is linked against:
 
-- If the library is a C shared library, you should not use these instructions, use the `after_staging_script` instead to
+- If the library is a C shared library, you should not use these instructions, use the `after_stage_script` instead to
   build the library during the installation
 - Check what buildsystem is used.
   - If CMake, it's going to be relatively easy.


### PR DESCRIPTION
I was a bit confused when I couldn’t find any other reference to `after_staging` except (after looking in the infra repo) for https://github.com/compiler-explorer/infra/commit/1db317ee458782ca00cca338721ab1a5e0a5d4d3.