### PR TITLE
Implement source mapping for .NET compilers

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -39,7 +39,10 @@ import {CompilationEnvironment} from '../compilation-env.js';
 import {AssemblyName, DotnetExtraConfiguration} from '../execution/dotnet-execution-env.js';
 import {IExecutionEnvironment} from '../execution/execution-env.interfaces.js';
 import {DotNetAsmParser} from '../parsers/asm-parser-dotnet.js';
+import {DotNetPdbParser, type DotNetSourceMapping} from '../parsers/pdb-parser-dotnet.js';
 import * as utils from '../utils.js';
+
+type DotNetCompilationResult = CompilationResult & {dotnetSourceMapping?: DotNetSourceMapping};
 
 class DotNetCompiler extends BaseCompiler {
     private readonly sdkBaseDir: string;
@@ -346,7 +349,7 @@ class DotNetCompiler extends BaseCompiler {
             '-warn:9',
             '-highentropyva+',
             '-nullable:enable',
-            '-debug-',
+            '-debug:portable',
             '-optimize+',
             '-warnaserror-',
             '-utf8output',
@@ -410,7 +413,7 @@ System.Diagnostics,System.Linq,System.Xml.Linq,System.Threading.Tasks`,
             '-errorreport:prompt',
             '-rootnamespace:CompilerExplorer',
             '-highentropyva+',
-            '-debug-',
+            '-debug:portable',
             '-optimize+',
             '-warnaserror-',
             '-utf8output',
@@ -477,6 +480,7 @@ Imports System.Reflection
             '--warnaserror:3239',
             '--fullpaths',
             '--flaterrors',
+            '--debug:portable',
             '--highentropyva+',
             '--targetprofile:netcore',
             '--nocopyfsharpcore',
@@ -549,6 +553,7 @@ do()
             '-nologo',
             '-quiet',
             '-optimize',
+            '-debug:OPT',
             buildToBinary ? '-exe' : '-dll',
             assemblyInfoPath,
             `-include:${programDir}`,
@@ -619,7 +624,7 @@ do()
                     if (normalizedName === 'DOTNET_JITDISASM') {
                         overrideDisasm = true;
                     }
-                    if (normalizedName === 'DOTNET_JITDISASMASSEMBILES') {
+                    if (normalizedName === 'DOTNET_JITDISASMASSEMBLIES') {
                         overrideAssembly = true;
                     }
                     if (normalizedName === 'DOTNET_JITDIFFABLEDASM' || normalizedName === 'DOTNET_JITDISASMDIFFABLE') {
@@ -651,7 +656,7 @@ do()
                             if (normalizedValue.startsWith('JITDISASM=')) {
                                 overrideDisasm = true;
                             }
-                            if (normalizedValue.startsWith('JITDISASMASSEMBILES=')) {
+                            if (normalizedValue.startsWith('JITDISASMASSEMBLIES=')) {
                                 overrideAssembly = true;
                             }
                             if (
@@ -709,9 +714,18 @@ do()
             }
         }
 
+        const mapDebugInfo = (isCoreRun && !isMono) || isCrossgen2 || isAot;
+
+        if (mapDebugInfo) {
+            if (needCodegenOptions) {
+                toolOptions.push('--codegenopt', 'JitDisasmWithDebugInfo=1');
+            }
+            envVarFileContents.push('DOTNET_JitDisasmWithDebugInfo=1');
+        }
+
         this.setCompilerExecOptions(execOptions, programDir);
 
-        const compilerResult = await this.buildToDll(
+        const compilerResult: DotNetCompilationResult = await this.buildToDll(
             compiler,
             compilerInfo,
             inputFilename,
@@ -721,6 +735,16 @@ do()
         );
         if (compilerResult.code !== 0) {
             return compilerResult;
+        }
+
+        if (mapDebugInfo) {
+            const pdbPath = utils.changeExtension(programDllPath, '.pdb');
+            if (await utils.fileExists(pdbPath)) {
+                compilerResult.dotnetSourceMapping = new DotNetPdbParser(
+                    await fs.readFile(programDllPath),
+                    await fs.readFile(pdbPath),
+                ).parse();
+            }
         }
 
         if (isIlDasm) {
@@ -793,6 +817,10 @@ do()
         }
 
         return compilerResult;
+    }
+
+    override async processAsm(result: DotNetCompilationResult, filters: ParseFiltersAndOutputOptions) {
+        return new DotNetAsmParser(result.dotnetSourceMapping).process(result.asm as string, filters);
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions) {

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -22,15 +22,280 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
+import {AsmResultSource, ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
 import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import * as utils from '../utils.js';
 import {IAsmParser} from './asm-parser.interfaces.js';
+import type {DotNetMethodKey, DotNetMethodSourceMapping, DotNetSourceMapping} from './pdb-parser-dotnet.js';
 
 type InlineLabel = {name: string; range: {startCol: number; endCol: number}};
-type Source = {file: string; line: number};
+
+function formatDotNetMethodKey(method: DotNetMethodKey) {
+    const typeName =
+        method.typeArguments.length === 0 ? method.typeName : `${method.typeName}[${method.typeArguments.join(',')}]`;
+    const methodKeyName =
+        method.methodArguments.length === 0
+            ? method.methodName
+            : `${method.methodName}[${method.methodArguments.join(',')}]`;
+
+    return `${typeName}:${methodKeyName}(${method.parameters.join(',')})${
+        method.returnType && method.returnType !== 'void' ? `:${method.returnType}` : ''
+    }`;
+}
+
+function parseJitDisasmMethodKey(methodName: string): DotNetMethodKey | null {
+    const methodKeyText = methodName
+        .trim()
+        .replace(/:this$/, '')
+        .replace(/::/g, ':');
+    const methodMatch = methodKeyText.match(/^(?<typeAndMethod>.+)\((?<parameters>.*)\)(?::(?<returnType>.*))?$/);
+    if (!methodMatch?.groups) {
+        return null;
+    }
+
+    const methodSeparator = methodMatch.groups.typeAndMethod.lastIndexOf(':');
+    if (methodSeparator === -1) {
+        return null;
+    }
+
+    const type = parseJitGenericName(methodMatch.groups.typeAndMethod.substring(0, methodSeparator), '!');
+    const method = parseJitGenericName(methodMatch.groups.typeAndMethod.substring(methodSeparator + 1), '!!');
+
+    return {
+        typeName: type.name,
+        typeArguments: type.arguments.map(canonicalizeJitTypeName),
+        methodName: method.name,
+        methodArguments: method.arguments.map(canonicalizeJitTypeName),
+        parameters: splitParameters(methodMatch.groups.parameters).map(canonicalizeJitTypeName),
+        returnType: methodMatch.groups.returnType ? canonicalizeJitTypeName(methodMatch.groups.returnType) : '',
+    };
+}
+
+function genericArgumentEnd(text: string, start: number) {
+    let depth = 0;
+
+    for (let index = start; index < text.length; index++) {
+        if (text[index] === '[') {
+            depth++;
+        } else if (text[index] === ']') {
+            depth--;
+            if (depth === 0) {
+                return index;
+            }
+        }
+    }
+
+    return -1;
+}
+
+function parseJitGenericName(name: string, genericParameterPrefix: '!' | '!!') {
+    let canonical = '';
+    const genericArguments: string[] = [];
+
+    for (let index = 0; index < name.length; index++) {
+        const char = name[index];
+        if (char === '[' && name[index + 1] !== ']') {
+            const end = genericArgumentEnd(name, index);
+            if (end !== -1) {
+                genericArguments.push(...splitParameters(name.substring(index + 1, end)));
+                index = end;
+                continue;
+            }
+        }
+
+        canonical += char;
+    }
+
+    if (genericArguments.length === 0) {
+        let genericParameterIndex = 0;
+        for (const arity of canonical.matchAll(/`(\d+)/g)) {
+            for (let index = 0; index < Number.parseInt(arity[1], 10); index++, genericParameterIndex++) {
+                genericArguments.push(`${genericParameterPrefix}${genericParameterIndex}`);
+            }
+        }
+    }
+
+    return {name: canonical.replace(/`\d+/g, ''), arguments: genericArguments};
+}
+
+function canonicalizeJitTypeName(typeName: string) {
+    const suffix = typeName.match(/(?:\[[,\s]*\]|\*|&)+$/)?.[0] ?? '';
+    const typeWithoutSuffix = suffix ? typeName.substring(0, typeName.length - suffix.length) : typeName;
+
+    let canonical = '';
+    for (let index = 0; index < typeWithoutSuffix.length; index++) {
+        const char = typeWithoutSuffix[index];
+        if (char === '[' && typeWithoutSuffix[index + 1] !== ']') {
+            const end = genericArgumentEnd(typeWithoutSuffix, index);
+            if (end !== -1) {
+                canonical += `[${splitParameters(typeWithoutSuffix.substring(index + 1, end))
+                    .map(canonicalizeJitTypeName)
+                    .join(',')}]`;
+                index = end;
+                continue;
+            }
+        }
+
+        canonical += char;
+    }
+
+    return `${canonical.replace(/`\d+/g, '')}${suffix}`;
+}
+
+function substituteMetadataGenericParameters(typeName: string, requestedMethod: DotNetMethodKey) {
+    return typeName.replace(/!!(\d+)|!(\d+)/g, (genericParameter, methodIndex, typeIndex) => {
+        if (methodIndex !== undefined) {
+            return requestedMethod.methodArguments[Number.parseInt(methodIndex, 10)] ?? genericParameter;
+        }
+        return requestedMethod.typeArguments[Number.parseInt(typeIndex, 10)] ?? genericParameter;
+    });
+}
+
+function splitParameters(parameters: string) {
+    const result: string[] = [];
+    let depth = 0;
+    let current = '';
+
+    for (const char of parameters) {
+        if (char === '[' || char === '(') {
+            depth++;
+        } else if ((char === ']' || char === ')') && depth > 0) {
+            depth--;
+        }
+
+        if (char === ',' && depth === 0) {
+            result.push(current.trim());
+            current = '';
+        } else {
+            current += char;
+        }
+    }
+
+    if (current.trim()) {
+        result.push(current.trim());
+    }
+
+    return result;
+}
 
 export class DotNetAsmParser implements IAsmParser {
+    private readonly sourceMapping: DotNetSourceMapping;
+    private readonly sourceMappingByName: Map<string, DotNetMethodSourceMapping>;
+
+    constructor(sourceMapping: DotNetSourceMapping = []) {
+        this.sourceMapping = sourceMapping;
+        this.sourceMappingByName = new Map(
+            sourceMapping.map(methodSourceMapping => [
+                formatDotNetMethodKey(methodSourceMapping.method),
+                methodSourceMapping,
+            ]),
+        );
+    }
+
+    private getMethodSourceMapping(methodName: string) {
+        const requestedMethod = parseJitDisasmMethodKey(methodName);
+        if (!requestedMethod) {
+            return undefined;
+        }
+
+        const exactMapping = this.sourceMappingByName.get(formatDotNetMethodKey(requestedMethod));
+        if (exactMapping) {
+            return exactMapping;
+        }
+
+        if (requestedMethod.typeArguments.length === 0 && requestedMethod.methodArguments.length === 0) {
+            return undefined;
+        }
+
+        for (const methodSourceMapping of this.sourceMapping) {
+            const candidate = methodSourceMapping.method;
+            if (
+                candidate.typeName !== requestedMethod.typeName ||
+                candidate.methodName !== requestedMethod.methodName ||
+                candidate.typeArguments.length !== requestedMethod.typeArguments.length ||
+                candidate.methodArguments.length !== requestedMethod.methodArguments.length ||
+                candidate.parameters.length !== requestedMethod.parameters.length
+            ) {
+                continue;
+            }
+
+            const candidateParameters = candidate.parameters.map(parameter =>
+                substituteMetadataGenericParameters(parameter, requestedMethod),
+            );
+            const candidateReturnType = substituteMetadataGenericParameters(candidate.returnType, requestedMethod);
+
+            if (
+                candidateParameters.every((parameter, index) => parameter === requestedMethod.parameters[index]) &&
+                candidateReturnType === requestedMethod.returnType
+            ) {
+                return methodSourceMapping;
+            }
+        }
+
+        return undefined;
+    }
+
+    private getSourceForOffset(methodSourceMapping: DotNetMethodSourceMapping | undefined, offset: number) {
+        if (!methodSourceMapping) {
+            return null;
+        }
+
+        if (methodSourceMapping.offsets[offset] !== undefined) {
+            return methodSourceMapping.offsets[offset];
+        }
+
+        let bestOffset: number | undefined;
+        for (const candidate of Object.keys(methodSourceMapping.offsets)
+            .map(Number)
+            .sort((a, b) => a - b)) {
+            if (candidate > offset) {
+                break;
+            }
+            bestOffset = candidate;
+        }
+
+        return bestOffset === undefined ? null : methodSourceMapping.offsets[bestOffset];
+    }
+
+    private computeSourceMappingForAsmLines(asmLines: string[]) {
+        const sources: Array<AsmResultSource | null> = [];
+        let currentMethodSourceMapping: DotNetMethodSourceMapping | undefined;
+        let currentSource: AsmResultSource | null = null;
+        const inlineRootOffsetRe = /INLRT\s+@\s*0x(?<offset>[0-9a-fA-F]+)/g;
+        const result = this.scanLabelsAndMethods(asmLines, false);
+
+        for (const line in asmLines) {
+            if (result.methodDef[line]) {
+                currentMethodSourceMapping = this.getMethodSourceMapping(result.methodDef[line]);
+                currentSource = null;
+            }
+
+            let lineSource: AsmResultSource | null = null;
+            if (result.labelDef[line]) {
+                currentSource = null;
+            }
+
+            const inlineRootOffsetMatches = Array.from(asmLines[line].matchAll(inlineRootOffsetRe));
+            const inlineRootOffsetMatch = inlineRootOffsetMatches.at(-1);
+            if (inlineRootOffsetMatch?.groups) {
+                lineSource = null;
+                currentSource = this.getSourceForOffset(
+                    currentMethodSourceMapping,
+                    Number.parseInt(inlineRootOffsetMatch.groups.offset, 16),
+                );
+            }
+
+            const trimmedAsmLine = asmLines[line].trimStart();
+            if (!inlineRootOffsetMatch && trimmedAsmLine !== '' && !trimmedAsmLine.startsWith(';')) {
+                lineSource = currentSource;
+            }
+
+            sources.push(lineSource);
+        }
+
+        return sources;
+    }
+
     scanLabelsAndMethods(asmLines: string[], removeUnused: boolean) {
         const labelDef: Record<number, {name: string; remove: boolean}> = {};
         const methodDef: Record<number, string> = {};
@@ -138,17 +403,29 @@ export class DotNetAsmParser implements IAsmParser {
 
         const asm: {
             text: string;
-            source: Source | null;
+            source: AsmResultSource | null;
             labels: InlineLabel[];
         }[] = [];
         let labelDefinitions: [string, number][] = [];
 
         let asmLines: string[] = this.cleanAsm(utils.splitLines(asmResult));
+        let sourceByLine = this.computeSourceMappingForAsmLines(asmLines);
         const startingLineCount = asmLines.length;
 
         if (filters.commentOnly) {
             const commentRe = /^\s*(;.*)$/;
-            asmLines = asmLines.flatMap(l => (commentRe.test(l) ? [] : [l]));
+            const filteredLines: string[] = [];
+            const filteredSources: Array<AsmResultSource | null> = [];
+
+            for (const index in asmLines) {
+                if (!commentRe.test(asmLines[index])) {
+                    filteredLines.push(asmLines[index]);
+                    filteredSources.push(sourceByLine[index]);
+                }
+            }
+
+            asmLines = filteredLines;
+            sourceByLine = filteredSources;
         }
 
         const result = this.scanLabelsAndMethods(asmLines, filters.labels!);
@@ -176,7 +453,7 @@ export class DotNetAsmParser implements IAsmParser {
 
             asm.push({
                 text: asmLines[line],
-                source: null,
+                source: sourceByLine[line],
                 labels,
             });
         }

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -31,7 +31,7 @@ import {getCanonicalTypeSignature} from './pdb-parser-dotnet.js';
 
 type InlineLabel = {name: string; range: {startCol: number; endCol: number}};
 
-function formatDotNetMethodKey(method: DotNetMethodKey) {
+function formatMethodKey(method: DotNetMethodKey) {
     const typeName =
         method.typeArguments.length === 0 ? method.typeName : `${method.typeName}[${method.typeArguments.join(',')}]`;
     const methodKeyName =
@@ -187,7 +187,7 @@ export class DotNetAsmParser implements IAsmParser {
         this.sourceMapping = sourceMapping;
         this.sourceMappingByName = new Map(
             sourceMapping.map(methodSourceMapping => [
-                formatDotNetMethodKey(methodSourceMapping.method),
+                formatMethodKey(methodSourceMapping.method),
                 methodSourceMapping,
             ]),
         );
@@ -199,7 +199,7 @@ export class DotNetAsmParser implements IAsmParser {
             return undefined;
         }
 
-        const exactMapping = this.sourceMappingByName.get(formatDotNetMethodKey(requestedMethod));
+        const exactMapping = this.sourceMappingByName.get(formatMethodKey(requestedMethod));
         if (exactMapping) {
             return exactMapping;
         }

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -27,6 +27,7 @@ import {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfa
 import * as utils from '../utils.js';
 import {IAsmParser} from './asm-parser.interfaces.js';
 import type {DotNetMethodKey, DotNetMethodSourceMapping, DotNetSourceMapping} from './pdb-parser-dotnet.js';
+import {getCanonicalTypeSignature} from './pdb-parser-dotnet.js';
 
 type InlineLabel = {name: string; range: {startCol: number; endCol: number}};
 
@@ -219,14 +220,28 @@ export class DotNetAsmParser implements IAsmParser {
                 continue;
             }
 
-            const candidateParameters = candidate.parameters.map(parameter =>
-                substituteMetadataGenericParameters(parameter, requestedMethod),
-            );
-            const candidateReturnType = substituteMetadataGenericParameters(candidate.returnType, requestedMethod);
+            const candidateParameters =
+                candidate.parameterTypes?.map(parameter => [
+                    getCanonicalTypeSignature(parameter, requestedMethod).text,
+                    getCanonicalTypeSignature(parameter, requestedMethod, false, false).text,
+                ]) ??
+                candidate.parameters.map(parameter => [
+                    substituteMetadataGenericParameters(parameter, requestedMethod),
+                ]);
+            const candidateReturnTypes = candidate.returnTypeSignature
+                ? [
+                      getCanonicalTypeSignature(candidate.returnTypeSignature, requestedMethod).text,
+                      getCanonicalTypeSignature(candidate.returnTypeSignature, requestedMethod, false, false).text,
+                  ]
+                : [substituteMetadataGenericParameters(candidate.returnType, requestedMethod)];
 
             if (
-                candidateParameters.every((parameter, index) => parameter === requestedMethod.parameters[index]) &&
-                candidateReturnType === requestedMethod.returnType
+                candidateParameters.every((parameters, index) =>
+                    parameters.includes(requestedMethod.parameters[index]),
+                ) &&
+                candidateReturnTypes
+                    .map(returnType => (returnType === 'void' ? '' : returnType))
+                    .includes(requestedMethod.returnType)
             ) {
                 return methodSourceMapping;
             }

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -30,6 +30,13 @@ import type {DotNetMethodKey, DotNetMethodSourceMapping, DotNetSourceMapping} fr
 import {getCanonicalTypeSignature} from './pdb-parser-dotnet.js';
 
 type InlineLabel = {name: string; range: {startCol: number; endCol: number}};
+type ScanLabelsAndMethodsResult = {
+    labelDef: Record<number, {name: string; remove: boolean}>;
+    labelUsage: Record<number, InlineLabel>;
+    methodDef: Record<number, string>;
+    methodUsage: Record<number, InlineLabel>;
+    allAvailable: string[];
+};
 
 function formatMethodKey(method: DotNetMethodKey) {
     const typeName =
@@ -272,12 +279,12 @@ export class DotNetAsmParser implements IAsmParser {
         return bestOffset === undefined ? null : methodSourceMapping.offsets[bestOffset];
     }
 
-    private computeSourceMappingForAsmLines(asmLines: string[]) {
+    private computeSourceMappingForAsmLines(asmLines: string[], result: ScanLabelsAndMethodsResult) {
         const sources: Array<AsmResultSource | null> = [];
         let currentMethodSourceMapping: DotNetMethodSourceMapping | undefined;
         let currentSource: AsmResultSource | null = null;
+        const inlineDebugInfoRe = /\bINL(?:RT|\d+)\s+@\s*(?:0x[0-9a-fA-F]+|\?\?\?)/;
         const inlineRootOffsetRe = /INLRT\s+@\s*0x(?<offset>[0-9a-fA-F]+)/g;
-        const result = this.scanLabelsAndMethods(asmLines, false);
 
         for (const line in asmLines) {
             if (result.methodDef[line]) {
@@ -287,6 +294,8 @@ export class DotNetAsmParser implements IAsmParser {
 
             let lineSource: AsmResultSource | null = null;
             if (result.labelDef[line]) {
+                // A JIT label starts a new native block. Require a fresh debug-info anchor
+                // before mapping instructions in that block to avoid source leaking across blocks.
                 currentSource = null;
             }
 
@@ -298,6 +307,9 @@ export class DotNetAsmParser implements IAsmParser {
                     currentMethodSourceMapping,
                     Number.parseInt(inlineRootOffsetMatch.groups.offset, 16),
                 );
+            } else if (inlineDebugInfoRe.test(asmLines[line])) {
+                // The IL location is unknown, so we can't get a precise source mapping for this instruction.
+                currentSource = null;
             }
 
             const trimmedAsmLine = asmLines[line].trimStart();
@@ -319,8 +331,8 @@ export class DotNetAsmParser implements IAsmParser {
         const allAvailable: string[] = [];
         const usedLabels: string[] = [];
 
-        const methodRefRe = /^(call|jmp|tail\.jmp)\s+(.*)/g;
-        const labelRefRe = /^\w+\s+.*?(G_M\w+)/g;
+        const methodRefRe = /^(call|jmp|tail\.jmp)\s+(.*)/;
+        const labelRefRe = /^\w+\s+.*?(G_M\w+)/;
         const removeCommentAndWsRe = /^\s*(?<line>.*?)(\s*;.*)?\s*$/;
 
         for (const line in asmLines) {
@@ -344,20 +356,20 @@ export class DotNetAsmParser implements IAsmParser {
                 continue;
             }
 
-            const labelResult = trimmedLine.matchAll(labelRefRe).next();
-            if (!labelResult.done) {
-                const name = labelResult.value[1];
+            const labelResult = trimmedLine.match(labelRefRe);
+            if (labelResult) {
+                const name = labelResult[1];
                 const index = asmLines[line].indexOf(name) + 1;
                 labelUsage[line] = {
-                    name: labelResult.value[1],
+                    name,
                     range: {startCol: index, endCol: index + name.length},
                 };
-                usedLabels.push(labelResult.value[1]);
+                usedLabels.push(name);
             }
 
-            const methodResult = trimmedLine.matchAll(methodRefRe).next();
-            if (!methodResult.done) {
-                let name = methodResult.value[2];
+            const methodResult = trimmedLine.match(methodRefRe);
+            if (methodResult) {
+                let name = methodResult[2];
                 if (name.startsWith('[')) {
                     if (name.endsWith(']')) {
                         // cases like `call [Foo]`, `jmp [Foo]`, `tail.jmp [Foo]`
@@ -424,16 +436,19 @@ export class DotNetAsmParser implements IAsmParser {
         let labelDefinitions: [string, number][] = [];
 
         let asmLines: string[] = this.cleanAsm(utils.splitLines(asmResult));
-        let sourceByLine = this.computeSourceMappingForAsmLines(asmLines);
+        let result = this.scanLabelsAndMethods(asmLines, filters.labels!);
+        let sourceByLine = this.computeSourceMappingForAsmLines(asmLines, result);
         const startingLineCount = asmLines.length;
 
         if (filters.commentOnly) {
             const commentRe = /^\s*(;.*)$/;
             const filteredLines: string[] = [];
             const filteredSources: Array<AsmResultSource | null> = [];
+            const lineMap: Record<number, number> = {};
 
             for (const index in asmLines) {
                 if (!commentRe.test(asmLines[index])) {
+                    lineMap[index] = filteredLines.length;
                     filteredLines.push(asmLines[index]);
                     filteredSources.push(sourceByLine[index]);
                 }
@@ -441,9 +456,32 @@ export class DotNetAsmParser implements IAsmParser {
 
             asmLines = filteredLines;
             sourceByLine = filteredSources;
-        }
 
-        const result = this.scanLabelsAndMethods(asmLines, filters.labels!);
+            const remappedResult: ScanLabelsAndMethodsResult = {
+                labelDef: {},
+                labelUsage: {},
+                methodDef: {},
+                methodUsage: {},
+                allAvailable: result.allAvailable,
+            };
+            for (const line in lineMap) {
+                const originalLine = Number.parseInt(line, 10);
+                const remappedLine = lineMap[originalLine];
+                if (result.labelDef[originalLine] !== undefined) {
+                    remappedResult.labelDef[remappedLine] = result.labelDef[originalLine];
+                }
+                if (result.labelUsage[originalLine] !== undefined) {
+                    remappedResult.labelUsage[remappedLine] = result.labelUsage[originalLine];
+                }
+                if (result.methodDef[originalLine] !== undefined) {
+                    remappedResult.methodDef[remappedLine] = result.methodDef[originalLine];
+                }
+                if (result.methodUsage[originalLine] !== undefined) {
+                    remappedResult.methodUsage[remappedLine] = result.methodUsage[originalLine];
+                }
+            }
+            result = remappedResult;
+        }
 
         for (const i in result.labelDef) {
             const label = result.labelDef[i];
@@ -460,10 +498,8 @@ export class DotNetAsmParser implements IAsmParser {
 
             const labels: InlineLabel[] = [];
             const label = result.labelUsage[line] || result.methodUsage[line];
-            if (label) {
-                if (result.allAvailable.includes(label.name)) {
-                    labels.push(label);
-                }
+            if (label && result.allAvailable.includes(label.name)) {
+                labels.push(label);
             }
 
             asm.push({
@@ -474,7 +510,7 @@ export class DotNetAsmParser implements IAsmParser {
         }
 
         let lineOffset = 1;
-        labelDefinitions = labelDefinitions.sort((a, b) => (a[1] < b[1] ? -1 : 1));
+        labelDefinitions = labelDefinitions.sort((a, b) => a[1] - b[1]);
 
         for (const index in labelDefinitions) {
             if (result.labelDef[labelDefinitions[index][1]] && result.labelDef[labelDefinitions[index][1]].remove) {
@@ -488,7 +524,7 @@ export class DotNetAsmParser implements IAsmParser {
 
         const endTime = process.hrtime.bigint();
         return {
-            asm: asm,
+            asm,
             labelDefinitions: Object.fromEntries(labelDefinitions.filter(i => i[1] !== -1)),
             parsingTime: utils.deltaTimeNanoToMili(startTime, endTime),
             filteredCount: startingLineCount - asm.length,

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -211,10 +211,6 @@ export class DotNetAsmParser implements IAsmParser {
             return exactMapping;
         }
 
-        if (requestedMethod.typeArguments.length === 0 && requestedMethod.methodArguments.length === 0) {
-            return undefined;
-        }
-
         for (const methodSourceMapping of this.sourceMapping) {
             const candidate = methodSourceMapping.method;
             if (
@@ -235,20 +231,9 @@ export class DotNetAsmParser implements IAsmParser {
                 candidate.parameters.map(parameter => [
                     substituteMetadataGenericParameters(parameter, requestedMethod),
                 ]);
-            const candidateReturnTypes = candidate.returnTypeSignature
-                ? [
-                      getCanonicalTypeSignature(candidate.returnTypeSignature, requestedMethod).text,
-                      getCanonicalTypeSignature(candidate.returnTypeSignature, requestedMethod, false, false).text,
-                  ]
-                : [substituteMetadataGenericParameters(candidate.returnType, requestedMethod)];
 
             if (
-                candidateParameters.every((parameters, index) =>
-                    parameters.includes(requestedMethod.parameters[index]),
-                ) &&
-                candidateReturnTypes
-                    .map(returnType => (returnType === 'void' ? '' : returnType))
-                    .includes(requestedMethod.returnType)
+                candidateParameters.every((parameters, index) => parameters.includes(requestedMethod.parameters[index]))
             ) {
                 return methodSourceMapping;
             }

--- a/lib/parsers/asm-parser-dotnet.ts
+++ b/lib/parsers/asm-parser-dotnet.ts
@@ -283,8 +283,8 @@ export class DotNetAsmParser implements IAsmParser {
         const sources: Array<AsmResultSource | null> = [];
         let currentMethodSourceMapping: DotNetMethodSourceMapping | undefined;
         let currentSource: AsmResultSource | null = null;
-        const inlineDebugInfoRe = /\bINL(?:RT|\d+)\s+@\s*(?:0x[0-9a-fA-F]+|\?\?\?)/;
-        const inlineRootOffsetRe = /INLRT\s+@\s*0x(?<offset>[0-9a-fA-F]+)/g;
+        const inlineDebugInfoRe = /\bINL(?:RT|\d+)\s+@\s*(?:0[xX][0-9a-fA-F]+|\?\?\?)/;
+        const inlineRootOffsetRe = /\bINLRT\s+@\s*0[xX](?<offset>[0-9a-fA-F]+)/g;
 
         for (const line in asmLines) {
             if (result.methodDef[line]) {
@@ -300,12 +300,14 @@ export class DotNetAsmParser implements IAsmParser {
             }
 
             const inlineRootOffsetMatches = Array.from(asmLines[line].matchAll(inlineRootOffsetRe));
-            const inlineRootOffsetMatch = inlineRootOffsetMatches.at(-1);
-            if (inlineRootOffsetMatch?.groups) {
+            const inlineRootOffset = inlineRootOffsetMatches.at(-1)?.groups?.offset;
+            if (inlineRootOffset !== undefined) {
                 lineSource = null;
+                // Inline chains may contain unknown child offsets, but a numeric INLRT still anchors the
+                // instruction to the root method's IL offset.
                 currentSource = this.getSourceForOffset(
                     currentMethodSourceMapping,
-                    Number.parseInt(inlineRootOffsetMatch.groups.offset, 16),
+                    Number.parseInt(inlineRootOffset, 16),
                 );
             } else if (inlineDebugInfoRe.test(asmLines[line])) {
                 // The IL location is unknown, so we can't get a precise source mapping for this instruction.
@@ -313,7 +315,7 @@ export class DotNetAsmParser implements IAsmParser {
             }
 
             const trimmedAsmLine = asmLines[line].trimStart();
-            if (!inlineRootOffsetMatch && trimmedAsmLine !== '' && !trimmedAsmLine.startsWith(';')) {
+            if (inlineRootOffset === undefined && trimmedAsmLine !== '' && !trimmedAsmLine.startsWith(';')) {
                 lineSource = currentSource;
             }
 

--- a/lib/parsers/pdb-parser-dotnet.ts
+++ b/lib/parsers/pdb-parser-dotnet.ts
@@ -572,9 +572,11 @@ export class DotNetPdbParser {
             case 0x0e: // String
                 return 'System.String';
             case 0x0f: // Pointer
-                return `${this.parseElementType(blob, offsetRef, resolveType)}*`;
+                this.parseElementType(blob, offsetRef, resolveType); // Pointer signatures are omitted in JIT disasm, ignoring the parsed pointed-to type here
+                return 'ptr';
             case 0x10: // ByReference
-                return `${this.parseElementType(blob, offsetRef, resolveType)}&`;
+                this.parseElementType(blob, offsetRef, resolveType); // ByRef signatures are omitted in JIT disasm, ignoring the parsed referenced type here
+                return 'byref';
             case 0x11: // ValueType
             case 0x12: // Class
                 return resolveType(this.readCompressedUInt(blob, offsetRef).value);

--- a/lib/parsers/pdb-parser-dotnet.ts
+++ b/lib/parsers/pdb-parser-dotnet.ts
@@ -1,0 +1,938 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import type {AsmResultSource} from '../../types/asmresult/asmresult.interfaces.js';
+
+export type OffsetSourceMap = Record<string, AsmResultSource | null>;
+export type DotNetMethodKey = {
+    typeName: string;
+    typeArguments: string[];
+    methodName: string;
+    methodArguments: string[];
+    parameters: string[];
+    returnType: string;
+};
+type DotNetTypeKey = {
+    name: string;
+    genericParameterCount: number;
+};
+type DotNetTypeRef = {
+    name: string;
+    namespaceName: string;
+    resolutionScope: number;
+};
+type DotNetTypeDef = {
+    name: string;
+    namespaceName: string;
+    extends: number;
+    fieldList: number;
+    methodList: number;
+};
+export type DotNetMethodSourceMapping = {
+    method: DotNetMethodKey;
+    offsets: OffsetSourceMap;
+};
+
+export type DotNetSourceMapping = DotNetMethodSourceMapping[];
+
+const hiddenSequencePoint = 0xfeefee;
+
+type MetadataStreams = Record<string, {offset: number; size: number}>;
+type RowCounts = Record<number, number>;
+type MetadataTables = {
+    buffer: Buffer;
+    streams: MetadataStreams;
+    rowCounts: RowCounts;
+    tableOffsets: Record<number, number>;
+    heapSizes: number;
+    typeSystemTableRows?: RowCounts;
+};
+
+class BufferCursor {
+    constructor(
+        private readonly buffer: Buffer,
+        public offset: number,
+    ) {}
+
+    readUInt8() {
+        const value = this.buffer.readUInt8(this.offset);
+        this.offset += 1;
+        return value;
+    }
+
+    readUInt16() {
+        const value = this.buffer.readUInt16LE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    readUInt32() {
+        const value = this.buffer.readUInt32LE(this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    readBigUInt64() {
+        const value = this.buffer.readBigUInt64LE(this.offset);
+        this.offset += 8;
+        return value;
+    }
+}
+
+const codedIndexes: Record<string, {tagBits: number; tables: number[]}> = {
+    CustomAttributeType: {tagBits: 3, tables: [0x06, 0x0a]},
+    HasConstant: {tagBits: 2, tables: [0x04, 0x08, 0x17]},
+    HasCustomAttribute: {
+        tagBits: 5,
+        tables: [
+            0x06, 0x04, 0x01, 0x02, 0x08, 0x09, 0x0a, 0x00, 0x0e, 0x17, 0x14, 0x11, 0x1a, 0x1b, 0x20, 0x23, 0x26, 0x27,
+            0x28, 0x2a, 0x2c, 0x2b,
+        ],
+    },
+    HasDeclSecurity: {tagBits: 2, tables: [0x02, 0x06, 0x20]},
+    HasFieldMarshal: {tagBits: 1, tables: [0x04, 0x08]},
+    HasSemantics: {tagBits: 1, tables: [0x14, 0x17]},
+    Implementation: {tagBits: 2, tables: [0x26, 0x23, 0x27]},
+    MemberForwarded: {tagBits: 1, tables: [0x04, 0x06]},
+    MemberRefParent: {tagBits: 3, tables: [0x02, 0x01, 0x1a, 0x06, 0x1b]},
+    MethodDefOrRef: {tagBits: 1, tables: [0x06, 0x0a]},
+    ResolutionScope: {tagBits: 2, tables: [0x00, 0x1a, 0x23, 0x01]},
+    TypeDefOrRef: {tagBits: 2, tables: [0x02, 0x01, 0x1b]},
+    TypeOrMethodDef: {tagBits: 1, tables: [0x02, 0x06]},
+};
+
+// .NET metadata and PDB parsing based on ECMA-335 and the Portable PDB specification.
+// The parser only implements the features necessary to extract source mappings for JIT-compiled code.
+export class DotNetPdbParser {
+    constructor(
+        private readonly assembly: Buffer,
+        private readonly pdb: Buffer,
+    ) {}
+
+    private readCompressedUInt(buffer: Buffer, offsetRef: {offset: number}) {
+        const firstByte = buffer.readUInt8(offsetRef.offset);
+        offsetRef.offset += 1;
+
+        if ((firstByte & 0x80) === 0) {
+            return {value: firstByte, bytes: 1};
+        }
+
+        if ((firstByte & 0xc0) === 0x80) {
+            const secondByte = buffer.readUInt8(offsetRef.offset);
+            offsetRef.offset += 1;
+            return {value: ((firstByte & 0x3f) << 8) | secondByte, bytes: 2};
+        }
+
+        const secondByte = buffer.readUInt8(offsetRef.offset);
+        const thirdByte = buffer.readUInt8(offsetRef.offset + 1);
+        const fourthByte = buffer.readUInt8(offsetRef.offset + 2);
+        offsetRef.offset += 3;
+        return {value: ((firstByte & 0x1f) << 24) | (secondByte << 16) | (thirdByte << 8) | fourthByte, bytes: 4};
+    }
+
+    private readCompressedSignedInt(buffer: Buffer, offsetRef: {offset: number}) {
+        const compressed = this.readCompressedUInt(buffer, offsetRef);
+        const value = compressed.value >> 1;
+        if ((compressed.value & 1) === 0) {
+            return value;
+        }
+
+        const signedBitCount = compressed.bytes === 1 ? 6 : compressed.bytes === 2 ? 13 : 28;
+        return value - (1 << signedBitCount);
+    }
+
+    private getMetadataRootOffset(buffer: Buffer) {
+        const metadataSignature = 0x424a5342;
+        if (buffer.length >= 4 && buffer.readUInt32LE(0) === metadataSignature) {
+            return 0; // Portable PDBs start directly at the metadata root.
+        }
+
+        if (buffer.length < 0x40 || buffer.readUInt16LE(0) !== 0x5a4d) {
+            throw new Error('Metadata root not found');
+        }
+
+        const peHeaderOffset = buffer.readUInt32LE(0x3c);
+        if (peHeaderOffset + 24 > buffer.length || buffer.readUInt32LE(peHeaderOffset) !== 0x00004550) {
+            throw new Error('Invalid PE header');
+        }
+
+        const sectionCount = buffer.readUInt16LE(peHeaderOffset + 6);
+        const optionalHeaderSize = buffer.readUInt16LE(peHeaderOffset + 20);
+        const optionalHeaderOffset = peHeaderOffset + 24;
+        const sectionTableOffset = optionalHeaderOffset + optionalHeaderSize;
+        if (sectionTableOffset + sectionCount * 40 > buffer.length) {
+            throw new Error('Invalid PE optional header');
+        }
+
+        const optionalHeaderMagic = buffer.readUInt16LE(optionalHeaderOffset);
+        const dataDirectoryOffset = optionalHeaderMagic === 0x20b ? 112 : optionalHeaderMagic === 0x10b ? 96 : -1;
+        const cliHeaderDirectoryOffset = optionalHeaderOffset + dataDirectoryOffset + 14 * 8;
+        if (dataDirectoryOffset === -1 || cliHeaderDirectoryOffset + 8 > sectionTableOffset) {
+            throw new Error('Invalid PE optional header');
+        }
+
+        const rvaToFileOffset = (rva: number) => {
+            for (let section = 0; section < sectionCount; section++) {
+                const sectionOffset = sectionTableOffset + section * 40;
+                const virtualSize = buffer.readUInt32LE(sectionOffset + 8);
+                const virtualAddress = buffer.readUInt32LE(sectionOffset + 12);
+                const rawDataSize = buffer.readUInt32LE(sectionOffset + 16);
+                const rawDataPointer = buffer.readUInt32LE(sectionOffset + 20);
+                const sectionSize = Math.max(virtualSize, rawDataSize);
+                if (rva >= virtualAddress && rva < virtualAddress + sectionSize) {
+                    return rawDataPointer + (rva - virtualAddress);
+                }
+            }
+
+            throw new Error('RVA not found in PE sections');
+        };
+
+        const cliHeaderRva = buffer.readUInt32LE(cliHeaderDirectoryOffset);
+        if (cliHeaderRva === 0) {
+            throw new Error('CLI header not found');
+        }
+
+        const cliHeaderOffset = rvaToFileOffset(cliHeaderRva);
+        if (cliHeaderOffset + 12 > buffer.length) {
+            throw new Error('Invalid CLI header');
+        }
+
+        const metadataRva = buffer.readUInt32LE(cliHeaderOffset + 8);
+        const metadataRoot = rvaToFileOffset(metadataRva);
+
+        if (metadataRoot + 4 > buffer.length || buffer.readUInt32LE(metadataRoot) !== metadataSignature) {
+            throw new Error('Invalid metadata signature');
+        }
+
+        return metadataRoot;
+    }
+
+    private parseMetadataStreams(buffer: Buffer): MetadataStreams {
+        const metadataRoot = this.getMetadataRootOffset(buffer);
+        const cursor = new BufferCursor(buffer, metadataRoot);
+
+        if (cursor.readUInt32() !== 0x424a5342) {
+            throw new Error('Invalid metadata signature');
+        }
+
+        cursor.readUInt16();
+        cursor.readUInt16();
+        cursor.readUInt32();
+
+        const versionLength = cursor.readUInt32();
+        cursor.offset = (cursor.offset + versionLength + 3) & ~3;
+
+        cursor.readUInt16();
+        const streamCount = cursor.readUInt16();
+        const streams: MetadataStreams = {};
+
+        for (let i = 0; i < streamCount; i++) {
+            const offset = cursor.readUInt32();
+            const size = cursor.readUInt32();
+            const nameStart = cursor.offset;
+
+            while (buffer.readUInt8(cursor.offset) !== 0) {
+                cursor.offset++;
+            }
+
+            const name = buffer.toString('utf8', nameStart, cursor.offset);
+            cursor.offset = (cursor.offset + 4) & ~3;
+            streams[name] = {offset: metadataRoot + offset, size};
+        }
+
+        return streams;
+    }
+
+    private heapIndexSize(heapSizes: number, bit: number) {
+        return (heapSizes & bit) === 0 ? 2 : 4;
+    }
+
+    private tableIndexSize(rowCounts: RowCounts, typeSystemTableRows: RowCounts | undefined, tableId: number) {
+        return (rowCounts[tableId] ?? typeSystemTableRows?.[tableId] ?? 0) < 0x10000 ? 2 : 4;
+    }
+
+    parse(): DotNetSourceMapping {
+        const assemblyMethods = this.parseAssemblyMethods();
+        const sequencePoints = this.parsePdbSequencePoints();
+        const sourceMapping: DotNetSourceMapping = [];
+
+        for (const methodRowId of Object.keys(sequencePoints).map(Number)) {
+            sourceMapping.push({method: assemblyMethods[methodRowId], offsets: sequencePoints[methodRowId]});
+        }
+
+        return sourceMapping;
+    }
+
+    private genericParameterArguments(count: number, prefix: '!' | '!!') {
+        return Array.from({length: count}, (_, index) => `${prefix}${index}`);
+    }
+
+    private fallbackMetadataNameGenericArity(name: string) {
+        const arity = name.match(/`(?<arity>\d+)$/);
+        return arity?.groups ? Number.parseInt(arity.groups.arity, 10) : 0;
+    }
+
+    private stripMetadataGenericArity(name: string, genericParameterCount: number) {
+        if (genericParameterCount === 0) {
+            return name;
+        }
+
+        const arity = `\`${genericParameterCount}`;
+        return name.endsWith(arity) ? name.substring(0, name.length - arity.length) : name;
+    }
+
+    private codedIndexSize(
+        codedIndex: keyof typeof codedIndexes,
+        rowCounts: RowCounts,
+        typeSystemTableRows?: RowCounts,
+    ) {
+        const definition = codedIndexes[codedIndex];
+        const largestRowCount = Math.max(
+            ...definition.tables.map(table => rowCounts[table] ?? typeSystemTableRows?.[table] ?? 0),
+        );
+        return largestRowCount < 1 << (16 - definition.tagBits) ? 2 : 4;
+    }
+
+    private tableRowSize(tableId: number, tables: MetadataTables) {
+        const strings = this.heapIndexSize(tables.heapSizes, 0x01);
+        const guid = this.heapIndexSize(tables.heapSizes, 0x02);
+        const blob = this.heapIndexSize(tables.heapSizes, 0x04);
+        const table = (id: number) => this.tableIndexSize(tables.rowCounts, tables.typeSystemTableRows, id);
+        const coded = (name: keyof typeof codedIndexes) =>
+            this.codedIndexSize(name, tables.rowCounts, tables.typeSystemTableRows);
+
+        switch (tableId) {
+            case 0x00: // Module
+                return 2 + strings + guid + guid + guid;
+            case 0x01: // TypeRef
+                return coded('ResolutionScope') + strings + strings;
+            case 0x02: // TypeDef
+                return 4 + strings + strings + coded('TypeDefOrRef') + table(0x04) + table(0x06);
+            case 0x03: // FieldPtr
+                return table(0x04);
+            case 0x04: // Field
+                return 2 + strings + blob;
+            case 0x05: // MethodPtr
+                return table(0x06);
+            case 0x06: // MethodDef
+                return 4 + 2 + 2 + strings + blob + table(0x08);
+            case 0x07: // ParamPtr
+                return table(0x08);
+            case 0x08: // Param
+                return 2 + 2 + strings;
+            case 0x09: // InterfaceImpl
+                return table(0x02) + coded('TypeDefOrRef');
+            case 0x0a: // MemberRef
+                return coded('MemberRefParent') + strings + blob;
+            case 0x0b: // Constant
+                return 2 + coded('HasConstant') + blob;
+            case 0x0c: // CustomAttribute
+                return coded('HasCustomAttribute') + coded('CustomAttributeType') + blob;
+            case 0x0d: // FieldMarshal
+                return coded('HasFieldMarshal') + blob;
+            case 0x0e: // DeclSecurity
+                return 2 + coded('HasDeclSecurity') + blob;
+            case 0x0f: // ClassLayout
+                return 2 + 4 + table(0x02);
+            case 0x10: // FieldLayout
+                return 4 + table(0x04);
+            case 0x11: // StandAloneSig
+                return blob;
+            case 0x12: // EventMap
+                return table(0x02) + table(0x14);
+            case 0x13: // EventPtr
+                return table(0x14);
+            case 0x14: // Event
+                return 2 + strings + coded('TypeDefOrRef');
+            case 0x15: // PropertyMap
+                return table(0x02) + table(0x17);
+            case 0x16: // PropertyPtr
+                return table(0x17);
+            case 0x17: // Property
+                return 2 + strings + blob;
+            case 0x18: // MethodSemantics
+                return 2 + table(0x06) + coded('HasSemantics');
+            case 0x19: // MethodImpl
+                return table(0x02) + coded('MethodDefOrRef') + coded('MethodDefOrRef');
+            case 0x1a: // ModuleRef
+                return strings;
+            case 0x1b: // TypeSpec
+                return blob;
+            case 0x1c: // ImplMap
+                return 2 + coded('MemberForwarded') + strings + table(0x1a);
+            case 0x1d: // FieldRVA
+                return 4 + table(0x04);
+            case 0x1e: // EncLog
+                return 4 + 4;
+            case 0x1f: // EncMap
+                return 4;
+            case 0x20: // Assembly
+                return 4 + 2 + 2 + 2 + 2 + 4 + blob + strings + strings;
+            case 0x21: // AssemblyProcessor
+                return 4;
+            case 0x22: // AssemblyOS
+                return 4 + 4 + 4;
+            case 0x23: // AssemblyRef
+                return 2 + 2 + 2 + 2 + 4 + blob + strings + strings + blob;
+            case 0x24: // AssemblyRefProcessor
+                return 4 + table(0x23);
+            case 0x25: // AssemblyRefOS
+                return 4 + 4 + 4 + table(0x23);
+            case 0x26: // File
+                return 4 + strings + blob;
+            case 0x27: // ExportedType
+                return 4 + 4 + strings + strings + coded('Implementation');
+            case 0x28: // ManifestResource
+                return 4 + 4 + strings + coded('Implementation');
+            case 0x29: // NestedClass
+                return table(0x02) + table(0x02);
+            case 0x2a: // GenericParam
+                return 2 + 2 + coded('TypeOrMethodDef') + strings;
+            case 0x2b: // MethodSpec
+                return coded('MethodDefOrRef') + blob;
+            case 0x2c: // GenericParamConstraint
+                return table(0x2a) + coded('TypeDefOrRef');
+            case 0x30: // Document
+                return blob + guid + blob + guid;
+            case 0x31: // MethodDebugInformation
+                return table(0x30) + blob;
+            case 0x32: // LocalScope
+                return table(0x06) + table(0x35) + table(0x33) + table(0x34) + 4 + 4;
+            case 0x33: // LocalVariable
+                return 2 + 2 + strings;
+            case 0x34: // LocalConstant
+                return strings + blob;
+            case 0x35: // ImportScope
+                return table(0x35) + blob;
+            case 0x36: // StateMachineMethod
+                return table(0x06) + table(0x06);
+            case 0x37: // CustomDebugInformation
+                return coded('HasCustomAttribute') + guid + blob;
+            default:
+                throw new Error(`Unsupported metadata table 0x${tableId.toString(16)}`);
+        }
+    }
+
+    private parsePdbTypeSystemTableRows(buffer: Buffer, streams: MetadataStreams): RowCounts {
+        const pdbStream = streams['#Pdb']!;
+
+        const cursor = new BufferCursor(buffer, pdbStream.offset + 24); // 20-byte PDB id, then entry point token.
+        const referencedTables = cursor.readBigUInt64();
+        const rowCounts: RowCounts = {};
+
+        for (let tableId = 0; tableId < 64; tableId++) {
+            if (((referencedTables >> BigInt(tableId)) & 1n) !== 0n) {
+                rowCounts[tableId] = cursor.readUInt32();
+            }
+        }
+
+        return rowCounts;
+    }
+
+    private parseMetadataTables(buffer: Buffer, streams: MetadataStreams, typeSystemTableRows?: RowCounts) {
+        const tableStream = (streams['#~'] ?? streams['#-'])!;
+
+        const cursor = new BufferCursor(buffer, tableStream.offset);
+        cursor.readUInt32();
+        cursor.readUInt8();
+        cursor.readUInt8();
+        const heapSizes = cursor.readUInt8();
+        cursor.readUInt8();
+        const validTables = cursor.readBigUInt64();
+        cursor.readBigUInt64(); // Sorted table mask; row counts are keyed only by the valid table mask above.
+
+        const rowCounts: RowCounts = {};
+        for (let tableId = 0; tableId < 64; tableId++) {
+            if (((validTables >> BigInt(tableId)) & 1n) !== 0n) {
+                rowCounts[tableId] = cursor.readUInt32();
+            }
+        }
+
+        const tables: MetadataTables = {
+            buffer,
+            heapSizes,
+            rowCounts,
+            streams,
+            tableOffsets: {},
+            typeSystemTableRows,
+        };
+
+        let tableOffset = cursor.offset;
+        for (let tableId = 0; tableId < 64; tableId++) {
+            const rowCount = rowCounts[tableId] ?? 0;
+            if (rowCount === 0) {
+                continue;
+            }
+
+            tables.tableOffsets[tableId] = tableOffset;
+            tableOffset += rowCount * this.tableRowSize(tableId, tables);
+        }
+
+        return tables;
+    }
+
+    private readIndex(buffer: Buffer, offset: number, size: number) {
+        return size === 2 ? buffer.readUInt16LE(offset) : buffer.readUInt32LE(offset);
+    }
+
+    private getString(tables: MetadataTables, index: number) {
+        if (index === 0) {
+            return '';
+        }
+
+        const strings = tables.streams['#Strings']!;
+
+        const start = strings.offset + index;
+        let end = start;
+        while (end < strings.offset + strings.size && tables.buffer.readUInt8(end) !== 0) {
+            end++;
+        }
+
+        return tables.buffer.toString('utf8', start, end);
+    }
+
+    private getBlob(tables: MetadataTables, index: number) {
+        if (index === 0) {
+            return Buffer.alloc(0);
+        }
+
+        const blobs = tables.streams['#Blob']!;
+
+        const offsetRef = {offset: blobs.offset + index};
+        const length = this.readCompressedUInt(tables.buffer, offsetRef).value;
+        return tables.buffer.subarray(offsetRef.offset, offsetRef.offset + length);
+    }
+
+    private rowOffset(tables: MetadataTables, tableId: number, rowId: number) {
+        const offset = tables.tableOffsets[tableId];
+        return offset + (rowId - 1) * this.tableRowSize(tableId, tables);
+    }
+
+    private parseElementType(
+        blob: Buffer,
+        offsetRef: {offset: number},
+        resolveType: (encoded: number) => string,
+    ): string {
+        while (blob[offsetRef.offset] === 0x1f || blob[offsetRef.offset] === 0x20) {
+            offsetRef.offset++;
+            this.readCompressedUInt(blob, offsetRef);
+        }
+
+        const type = blob.readUInt8(offsetRef.offset);
+        offsetRef.offset++;
+
+        switch (type) {
+            case 0x01: // Void
+                return 'void';
+            case 0x02: // Boolean
+                return 'bool';
+            case 0x03: // Char
+                return 'char';
+            case 0x04: // SByte
+                return 'sbyte';
+            case 0x05: // Byte
+                return 'byte';
+            case 0x06: // Int16
+                return 'short';
+            case 0x07: // UInt16
+                return 'ushort';
+            case 0x08: // Int32
+                return 'int';
+            case 0x09: // UInt32
+                return 'uint';
+            case 0x0a: // Int64
+                return 'long';
+            case 0x0b: // UInt64
+                return 'ulong';
+            case 0x0c: // Single
+                return 'float';
+            case 0x0d: // Double
+                return 'double';
+            case 0x0e: // String
+                return 'System.String';
+            case 0x0f: // Pointer
+                return `${this.parseElementType(blob, offsetRef, resolveType)}*`;
+            case 0x10: // ByReference
+                return `${this.parseElementType(blob, offsetRef, resolveType)}&`;
+            case 0x11: // ValueType
+            case 0x12: // Class
+                return resolveType(this.readCompressedUInt(blob, offsetRef).value);
+            case 0x13: // GenericTypeParameter
+                return `!${this.readCompressedUInt(blob, offsetRef).value}`;
+            case 0x14: // Array
+                {
+                    const elementType = this.parseElementType(blob, offsetRef, resolveType);
+                    const rank = this.readCompressedUInt(blob, offsetRef).value;
+                    const sizeCount = this.readCompressedUInt(blob, offsetRef).value;
+                    for (let i = 0; i < sizeCount; i++) {
+                        this.readCompressedUInt(blob, offsetRef);
+                    }
+                    const lowerBoundCount = this.readCompressedUInt(blob, offsetRef).value;
+                    for (let i = 0; i < lowerBoundCount; i++) {
+                        this.readCompressedSignedInt(blob, offsetRef);
+                    }
+                    return `${elementType}[${','.repeat(Math.max(rank - 1, 0))}]`;
+                }
+            case 0x15: // GenericTypeInstance
+                {
+                    const genericType = this.parseElementType(blob, offsetRef, resolveType);
+                    const argumentCount = this.readCompressedUInt(blob, offsetRef).value;
+                    const argumentsText: string[] = [];
+                    for (let i = 0; i < argumentCount; i++) {
+                        argumentsText.push(this.parseElementType(blob, offsetRef, resolveType));
+                    }
+                    return `${this.stripMetadataGenericArity(genericType, argumentCount)}[${argumentsText.join(',')}]`;
+                }
+            case 0x16: // TypedByReference
+                return 'System.TypedReference';
+            case 0x18: // IntPtr
+                return 'nint';
+            case 0x19: // UIntPtr
+                return 'nuint';
+            case 0x1c: // Object
+                return 'System.Object';
+            case 0x1b: // FunctionPointer
+                this.parseMethodSignature(blob, resolveType, offsetRef); // Function pointer signatures are omitted in JIT disasm, ignoring the parsed signature here
+                return 'ptr';
+            case 0x1d: // SZArray
+                return `${this.parseElementType(blob, offsetRef, resolveType)}[]`;
+            case 0x1e: // GenericMethodParameter
+                return `!!${this.readCompressedUInt(blob, offsetRef).value}`;
+            case 0x41: // Sentinel
+                return this.parseElementType(blob, offsetRef, resolveType);
+            case 0x45: // Pinned
+                return this.parseElementType(blob, offsetRef, resolveType);
+            default:
+                throw new Error(`Unsupported element type 0x${type.toString(16)}`);
+        }
+    }
+
+    private parseMethodSignature(
+        blob: Buffer,
+        resolveType: (encoded: number) => string,
+        offsetRef: {offset: number} = {offset: 0},
+    ) {
+        const callingConvention = blob.readUInt8(offsetRef.offset);
+        offsetRef.offset++;
+
+        const genericParameterCount =
+            (callingConvention & 0x10) !== 0 ? this.readCompressedUInt(blob, offsetRef).value : 0;
+
+        const parameterCount = this.readCompressedUInt(blob, offsetRef).value;
+        const returnType = this.parseElementType(blob, offsetRef, resolveType);
+
+        const parameters: string[] = [];
+        for (let i = 0; i < parameterCount; i++) {
+            parameters.push(this.parseElementType(blob, offsetRef, resolveType));
+        }
+
+        return {genericParameterCount, parameters, returnType};
+    }
+
+    private parseAssemblyMethods(): Record<number, DotNetMethodKey> {
+        const assembly = this.assembly;
+        const streams = this.parseMetadataStreams(assembly);
+        const tables = this.parseMetadataTables(assembly, streams);
+        const strings = this.heapIndexSize(tables.heapSizes, 0x01);
+        const blob = this.heapIndexSize(tables.heapSizes, 0x04);
+        const typeDefIndex = this.tableIndexSize(tables.rowCounts, tables.typeSystemTableRows, 0x02);
+        const methodDefIndex = this.tableIndexSize(tables.rowCounts, tables.typeSystemTableRows, 0x06);
+        const fieldIndex = this.tableIndexSize(tables.rowCounts, tables.typeSystemTableRows, 0x04);
+        const typeDefOrRef = this.codedIndexSize('TypeDefOrRef', tables.rowCounts, tables.typeSystemTableRows);
+        const resolutionScope = this.codedIndexSize('ResolutionScope', tables.rowCounts, tables.typeSystemTableRows);
+        const typeOrMethodDef = this.codedIndexSize('TypeOrMethodDef', tables.rowCounts, tables.typeSystemTableRows);
+        const typeRefs: Record<number, DotNetTypeRef> = {};
+        const typeDefs: Record<number, DotNetTypeDef> = {};
+        const fields: Record<number, {name: string; signature: number}> = {};
+        const nestedTypes: Record<number, number> = {};
+        const typeGenericParameterCounts: Record<number, number> = {};
+        const methodGenericParameterCounts: Record<number, number> = {};
+
+        for (let rowId = 1; rowId <= (tables.rowCounts[0x01] ?? 0); rowId++) {
+            const offset = this.rowOffset(tables, 0x01, rowId);
+            const resolutionScopeValue = this.readIndex(assembly, offset, resolutionScope);
+            const nameOffset = offset + resolutionScope;
+            const namespaceOffset = nameOffset + strings;
+            typeRefs[rowId] = {
+                name: this.getString(tables, this.readIndex(assembly, nameOffset, strings)),
+                namespaceName: this.getString(tables, this.readIndex(assembly, namespaceOffset, strings)),
+                resolutionScope: resolutionScopeValue,
+            };
+        }
+
+        for (let rowId = 1; rowId <= (tables.rowCounts[0x02] ?? 0); rowId++) {
+            const offset = this.rowOffset(tables, 0x02, rowId);
+            const nameOffset = offset + 4;
+            const namespaceOffset = nameOffset + strings;
+            const extendsOffset = namespaceOffset + strings;
+            const fieldListOffset = extendsOffset + typeDefOrRef;
+            const methodListOffset = fieldListOffset + fieldIndex;
+            typeDefs[rowId] = {
+                extends: this.readIndex(assembly, extendsOffset, typeDefOrRef),
+                fieldList: this.readIndex(assembly, fieldListOffset, fieldIndex),
+                methodList: this.readIndex(assembly, methodListOffset, methodDefIndex),
+                name: this.getString(tables, this.readIndex(assembly, nameOffset, strings)),
+                namespaceName: this.getString(tables, this.readIndex(assembly, namespaceOffset, strings)),
+            };
+        }
+
+        for (let rowId = 1; rowId <= (tables.rowCounts[0x04] ?? 0); rowId++) {
+            const offset = this.rowOffset(tables, 0x04, rowId);
+            const nameOffset = offset + 2;
+            const signatureOffset = nameOffset + strings;
+            fields[rowId] = {
+                name: this.getString(tables, this.readIndex(assembly, nameOffset, strings)),
+                signature: this.readIndex(assembly, signatureOffset, blob),
+            };
+        }
+
+        for (let rowId = 1; rowId <= (tables.rowCounts[0x29] ?? 0); rowId++) {
+            const offset = this.rowOffset(tables, 0x29, rowId);
+            const nested = this.readIndex(assembly, offset, typeDefIndex);
+            const enclosing = this.readIndex(assembly, offset + typeDefIndex, typeDefIndex);
+            nestedTypes[nested] = enclosing;
+        }
+
+        for (let rowId = 1; rowId <= (tables.rowCounts[0x2a] ?? 0); rowId++) {
+            const offset = this.rowOffset(tables, 0x2a, rowId);
+            const parameterNumber = assembly.readUInt16LE(offset);
+            const owner = this.readIndex(assembly, offset + 4, typeOrMethodDef);
+            const ownerRowId = owner >> 1;
+            const ownerTag = owner & 0x01;
+            const ownerCounts = ownerTag === 0 ? typeGenericParameterCounts : methodGenericParameterCounts;
+            ownerCounts[ownerRowId] = Math.max(ownerCounts[ownerRowId] ?? 0, parameterNumber + 1);
+        }
+
+        const resolvedTypeDefs: Record<number, DotNetTypeKey> = {};
+        const resolveTypeDef = (rowId: number): DotNetTypeKey => {
+            if (resolvedTypeDefs[rowId]) {
+                return resolvedTypeDefs[rowId];
+            }
+
+            const typeDef = typeDefs[rowId];
+            const enclosingType = nestedTypes[rowId]
+                ? resolveTypeDef(nestedTypes[rowId])
+                : {genericParameterCount: 0, name: ''};
+            const ownGenericParameterCount =
+                typeGenericParameterCounts[rowId] ?? this.fallbackMetadataNameGenericArity(typeDef.name);
+            const typeNameWithoutArity = this.stripMetadataGenericArity(typeDef.name, ownGenericParameterCount);
+            const typeName = enclosingType.name
+                ? `${enclosingType.name}+${typeNameWithoutArity}`
+                : typeDef.namespaceName
+                  ? `${typeDef.namespaceName}.${typeNameWithoutArity}`
+                  : typeNameWithoutArity;
+            resolvedTypeDefs[rowId] = {
+                genericParameterCount: enclosingType.genericParameterCount + ownGenericParameterCount,
+                name: typeName,
+            };
+            return resolvedTypeDefs[rowId];
+        };
+
+        const resolvedTypeDefsByRow: Record<number, DotNetTypeKey> = {};
+        for (const rowId of Object.keys(typeDefs).map(Number)) {
+            resolvedTypeDefsByRow[rowId] = resolveTypeDef(rowId);
+        }
+
+        const methodDeclaringTypes: Record<number, DotNetTypeKey> = {};
+        const sortedTypeDefs = Object.keys(typeDefs)
+            .map(Number)
+            .sort((a, b) => a - b);
+        const methodCount = tables.rowCounts[0x06] ?? 0;
+        for (let i = 0; i < sortedTypeDefs.length; i++) {
+            const typeDefRowId = sortedTypeDefs[i];
+            const start = typeDefs[typeDefRowId].methodList;
+            const end = i + 1 < sortedTypeDefs.length ? typeDefs[sortedTypeDefs[i + 1]].methodList : methodCount + 1;
+            for (let methodRowId = start; methodRowId < end; methodRowId++) {
+                methodDeclaringTypes[methodRowId] = resolvedTypeDefsByRow[typeDefRowId];
+            }
+        }
+
+        const methodInfos: Record<number, DotNetMethodKey> = {};
+        const resolvedTypeRefs: Record<number, string> = {};
+        const resolveTypeRef = (rowId: number): string => {
+            if (resolvedTypeRefs[rowId]) {
+                return resolvedTypeRefs[rowId];
+            }
+
+            const typeRef = typeRefs[rowId];
+            resolvedTypeRefs[rowId] =
+                (typeRef.resolutionScope & 0x03) === 3
+                    ? `${resolveTypeRef(typeRef.resolutionScope >> 2)}+${typeRef.name}`
+                    : typeRef.namespaceName
+                      ? `${typeRef.namespaceName}.${typeRef.name}`
+                      : typeRef.name;
+            return resolvedTypeRefs[rowId];
+        };
+        const enumUnderlyingTypes: Record<number, string> = {};
+        const resolvedTypeSpecs: Record<number, string> = {};
+        const resolveType = (encoded: number) => {
+            const tag = encoded & 0x03;
+            const rowId = encoded >> 2;
+            if (tag === 0) {
+                return enumUnderlyingTypes[rowId] ?? resolvedTypeDefsByRow[rowId].name;
+            }
+            if (tag === 1) {
+                return resolveTypeRef(rowId);
+            }
+            if (tag === 2) {
+                resolvedTypeSpecs[rowId] ??= this.parseElementType(
+                    this.getBlob(tables, this.readIndex(assembly, this.rowOffset(tables, 0x1b, rowId), blob)),
+                    {offset: 0},
+                    resolveType,
+                );
+                return resolvedTypeSpecs[rowId];
+            }
+            throw new Error(`Unsupported TypeDefOrRef tag ${tag}`);
+        };
+        for (let i = 0; i < sortedTypeDefs.length; i++) {
+            const typeDefRowId = sortedTypeDefs[i];
+            if (typeDefs[typeDefRowId].extends === 0 || resolveType(typeDefs[typeDefRowId].extends) !== 'System.Enum') {
+                continue;
+            }
+
+            const start = typeDefs[typeDefRowId].fieldList;
+            const end =
+                i + 1 < sortedTypeDefs.length
+                    ? typeDefs[sortedTypeDefs[i + 1]].fieldList
+                    : (tables.rowCounts[0x04] ?? 0) + 1;
+            for (let fieldRowId = start; fieldRowId < end; fieldRowId++) {
+                if (fields[fieldRowId].name === 'value__') {
+                    enumUnderlyingTypes[typeDefRowId] = this.parseElementType(
+                        this.getBlob(tables, fields[fieldRowId].signature),
+                        {offset: 1},
+                        resolveType,
+                    );
+                    break;
+                }
+            }
+        }
+        for (let rowId = 1; rowId <= methodCount; rowId++) {
+            const offset = this.rowOffset(tables, 0x06, rowId);
+            const type = methodDeclaringTypes[rowId];
+            const nameOffset = offset + 4 + 2 + 2;
+            const signatureOffset = nameOffset + strings;
+            const methodName = this.getString(tables, this.readIndex(assembly, nameOffset, strings));
+            const {
+                genericParameterCount: signatureGenericParameterCount,
+                parameters,
+                returnType,
+            } = this.parseMethodSignature(
+                this.getBlob(tables, this.readIndex(assembly, signatureOffset, blob)),
+                resolveType,
+            );
+
+            methodInfos[rowId] = {
+                methodArguments: this.genericParameterArguments(
+                    methodGenericParameterCounts[rowId] ?? signatureGenericParameterCount,
+                    '!!',
+                ),
+                methodName,
+                parameters,
+                returnType: returnType === 'void' ? '' : returnType,
+                typeArguments: this.genericParameterArguments(type.genericParameterCount, '!'),
+                typeName: type.name,
+            };
+        }
+
+        return methodInfos;
+    }
+
+    private decodeSequencePoints(blob: Buffer, initialDocument: number) {
+        const offsets: OffsetSourceMap = {};
+        if (blob.length === 0) {
+            return offsets;
+        }
+
+        const offsetRef = {offset: 0};
+        this.readCompressedUInt(blob, offsetRef);
+
+        if (initialDocument === 0) {
+            this.readCompressedUInt(blob, offsetRef); // The first sequence point carries the document row when needed.
+        }
+
+        let previousIlOffset = 0;
+        let hasPreviousIlOffset = false;
+        let previousNonHiddenLine = 0;
+        let previousNonHiddenColumn = 0;
+        let hasPreviousNonHiddenSource = false;
+
+        while (offsetRef.offset < blob.length) {
+            const deltaIlOffset = this.readCompressedUInt(blob, offsetRef).value;
+            if (deltaIlOffset === 0 && hasPreviousIlOffset) {
+                this.readCompressedUInt(blob, offsetRef); // Document switch record.
+                continue;
+            }
+
+            const ilOffset = hasPreviousIlOffset ? previousIlOffset + deltaIlOffset : deltaIlOffset;
+            const deltaLines = this.readCompressedUInt(blob, offsetRef).value;
+            const deltaColumns =
+                deltaLines === 0
+                    ? this.readCompressedUInt(blob, offsetRef).value
+                    : this.readCompressedSignedInt(blob, offsetRef);
+
+            if (deltaLines === 0 && deltaColumns === 0) {
+                offsets[ilOffset] = null;
+            } else {
+                const startLine = hasPreviousNonHiddenSource
+                    ? previousNonHiddenLine + this.readCompressedSignedInt(blob, offsetRef)
+                    : this.readCompressedUInt(blob, offsetRef).value;
+                const startColumn = hasPreviousNonHiddenSource
+                    ? previousNonHiddenColumn + this.readCompressedSignedInt(blob, offsetRef)
+                    : this.readCompressedUInt(blob, offsetRef).value;
+
+                if (startLine === hiddenSequencePoint) {
+                    offsets[ilOffset] = null;
+                } else {
+                    offsets[ilOffset] = {file: null, line: startLine, column: startColumn};
+                    previousNonHiddenLine = startLine;
+                    previousNonHiddenColumn = startColumn;
+                    hasPreviousNonHiddenSource = true;
+                }
+            }
+
+            previousIlOffset = ilOffset;
+            hasPreviousIlOffset = true;
+        }
+
+        return offsets;
+    }
+
+    private parsePdbSequencePoints(): Record<number, OffsetSourceMap> {
+        const pdb = this.pdb;
+        const streams = this.parseMetadataStreams(pdb);
+        const tables = this.parseMetadataTables(pdb, streams, this.parsePdbTypeSystemTableRows(pdb, streams));
+        const documentIndex = this.tableIndexSize(tables.rowCounts, tables.typeSystemTableRows, 0x30);
+        const blob = this.heapIndexSize(tables.heapSizes, 0x04);
+        const methodSequencePoints: Record<number, OffsetSourceMap> = {};
+
+        for (let methodRowId = 1; methodRowId <= (tables.rowCounts[0x31] ?? 0); methodRowId++) {
+            const offset = this.rowOffset(tables, 0x31, methodRowId);
+            const initialDocument = this.readIndex(pdb, offset, documentIndex);
+            const sequencePointsBlob = this.getBlob(tables, this.readIndex(pdb, offset + documentIndex, blob));
+            methodSequencePoints[methodRowId] = this.decodeSequencePoints(sequencePointsBlob, initialDocument);
+        }
+
+        return methodSequencePoints;
+    }
+}

--- a/lib/parsers/pdb-parser-dotnet.ts
+++ b/lib/parsers/pdb-parser-dotnet.ts
@@ -31,7 +31,16 @@ export type DotNetMethodKey = {
     methodName: string;
     methodArguments: string[];
     parameters: string[];
+    parameterTypes?: DotNetTypeSignature[];
     returnType: string;
+    returnTypeSignature?: DotNetTypeSignature;
+};
+export type DotNetTypeSignature = {
+    name: string;
+    arguments: DotNetTypeSignature[];
+    suffix: string;
+    typeKind: 'generic' | 'reference' | 'value';
+    genericParameter?: string;
 };
 type DotNetTypeKey = {
     name: string;
@@ -57,6 +66,73 @@ export type DotNetMethodSourceMapping = {
 export type DotNetSourceMapping = DotNetMethodSourceMapping[];
 
 const hiddenSequencePoint = 0xfeefee;
+const sharedGenericReferenceType = 'System.__Canon';
+
+function formatTypeSignature(type: DotNetTypeSignature): string {
+    if (type.name === '') {
+        return `${formatTypeSignature(type.arguments[0])}${type.suffix}`;
+    }
+
+    if (type.arguments.length === 0) {
+        return type.name;
+    }
+
+    return `${type.name}[${type.arguments.map(formatTypeSignature).join(',')}]${type.suffix}`;
+}
+
+export function getCanonicalTypeSignature(
+    type: DotNetTypeSignature,
+    requestedMethod: DotNetMethodKey,
+    isGenericArgument = false,
+    collapseSharedGenericReferences = true,
+): {text: string; containsSharedGenericReference: boolean} {
+    if (type.genericParameter) {
+        const isMethodParameter = type.genericParameter.startsWith('!!');
+        const index = Number.parseInt(type.genericParameter.substring(isMethodParameter ? 2 : 1), 10);
+        const text =
+            (isMethodParameter ? requestedMethod.methodArguments[index] : requestedMethod.typeArguments[index]) ??
+            type.genericParameter;
+        return {text, containsSharedGenericReference: text === sharedGenericReferenceType};
+    }
+
+    if (type.name === '') {
+        const elementType = getCanonicalTypeSignature(
+            type.arguments[0],
+            requestedMethod,
+            true,
+            collapseSharedGenericReferences,
+        );
+        if (collapseSharedGenericReferences && isGenericArgument && elementType.containsSharedGenericReference) {
+            return {text: sharedGenericReferenceType, containsSharedGenericReference: true};
+        }
+        return {
+            text: `${elementType.text}${type.suffix}`,
+            containsSharedGenericReference: elementType.containsSharedGenericReference,
+        };
+    }
+
+    if (type.arguments.length === 0) {
+        return {text: formatTypeSignature(type), containsSharedGenericReference: false};
+    }
+
+    const argumentsText = type.arguments.map(argument =>
+        getCanonicalTypeSignature(argument, requestedMethod, true, collapseSharedGenericReferences),
+    );
+    const containsSharedGenericReference = argumentsText.some(argument => argument.containsSharedGenericReference);
+    if (
+        collapseSharedGenericReferences &&
+        isGenericArgument &&
+        type.typeKind === 'reference' &&
+        containsSharedGenericReference
+    ) {
+        return {text: sharedGenericReferenceType, containsSharedGenericReference};
+    }
+
+    return {
+        text: `${type.name}[${argumentsText.map(argument => argument.text).join(',')}]${type.suffix}`,
+        containsSharedGenericReference,
+    };
+}
 
 type MetadataStreams = Record<string, {offset: number; size: number}>;
 type RowCounts = Record<number, number>;
@@ -122,8 +198,6 @@ const codedIndexes: Record<string, {tagBits: number; tables: number[]}> = {
     TypeOrMethodDef: {tagBits: 1, tables: [0x02, 0x06]},
 };
 
-// .NET metadata and PDB parsing based on ECMA-335 and the Portable PDB specification.
-// The parser only implements the features necessary to extract source mappings for JIT-compiled code.
 export class DotNetPdbParser {
     constructor(
         private readonly assembly: Buffer,
@@ -532,8 +606,8 @@ export class DotNetPdbParser {
     private parseElementType(
         blob: Buffer,
         offsetRef: {offset: number},
-        resolveType: (encoded: number) => string,
-    ): string {
+        resolveType: (encoded: number) => DotNetTypeSignature,
+    ): DotNetTypeSignature {
         while (blob[offsetRef.offset] === 0x1f || blob[offsetRef.offset] === 0x20) {
             offsetRef.offset++;
             this.readCompressedUInt(blob, offsetRef);
@@ -544,44 +618,50 @@ export class DotNetPdbParser {
 
         switch (type) {
             case 0x01: // Void
-                return 'void';
+                return {name: 'void', arguments: [], suffix: '', typeKind: 'value'};
             case 0x02: // Boolean
-                return 'bool';
+                return {name: 'bool', arguments: [], suffix: '', typeKind: 'value'};
             case 0x03: // Char
-                return 'char';
+                return {name: 'char', arguments: [], suffix: '', typeKind: 'value'};
             case 0x04: // SByte
-                return 'sbyte';
+                return {name: 'sbyte', arguments: [], suffix: '', typeKind: 'value'};
             case 0x05: // Byte
-                return 'byte';
+                return {name: 'byte', arguments: [], suffix: '', typeKind: 'value'};
             case 0x06: // Int16
-                return 'short';
+                return {name: 'short', arguments: [], suffix: '', typeKind: 'value'};
             case 0x07: // UInt16
-                return 'ushort';
+                return {name: 'ushort', arguments: [], suffix: '', typeKind: 'value'};
             case 0x08: // Int32
-                return 'int';
+                return {name: 'int', arguments: [], suffix: '', typeKind: 'value'};
             case 0x09: // UInt32
-                return 'uint';
+                return {name: 'uint', arguments: [], suffix: '', typeKind: 'value'};
             case 0x0a: // Int64
-                return 'long';
+                return {name: 'long', arguments: [], suffix: '', typeKind: 'value'};
             case 0x0b: // UInt64
-                return 'ulong';
+                return {name: 'ulong', arguments: [], suffix: '', typeKind: 'value'};
             case 0x0c: // Single
-                return 'float';
+                return {name: 'float', arguments: [], suffix: '', typeKind: 'value'};
             case 0x0d: // Double
-                return 'double';
+                return {name: 'double', arguments: [], suffix: '', typeKind: 'value'};
             case 0x0e: // String
-                return 'System.String';
+                return {name: 'System.String', arguments: [], suffix: '', typeKind: 'reference'};
             case 0x0f: // Pointer
                 this.parseElementType(blob, offsetRef, resolveType); // Pointer signatures are omitted in JIT disasm, ignoring the parsed pointed-to type here
-                return 'ptr';
+                return {name: 'ptr', arguments: [], suffix: '', typeKind: 'value'};
             case 0x10: // ByReference
                 this.parseElementType(blob, offsetRef, resolveType); // ByRef signatures are omitted in JIT disasm, ignoring the parsed referenced type here
-                return 'byref';
+                return {name: 'byref', arguments: [], suffix: '', typeKind: 'value'};
             case 0x11: // ValueType
             case 0x12: // Class
-                return resolveType(this.readCompressedUInt(blob, offsetRef).value);
+                {
+                    const resolved = resolveType(this.readCompressedUInt(blob, offsetRef).value);
+                    return {...resolved, typeKind: type === 0x11 ? 'value' : 'reference'};
+                }
             case 0x13: // GenericTypeParameter
-                return `!${this.readCompressedUInt(blob, offsetRef).value}`;
+                {
+                    const name = `!${this.readCompressedUInt(blob, offsetRef).value}`;
+                    return {name, arguments: [], suffix: '', typeKind: 'generic', genericParameter: name};
+                }
             case 0x14: // Array
                 {
                     const elementType = this.parseElementType(blob, offsetRef, resolveType);
@@ -594,33 +674,51 @@ export class DotNetPdbParser {
                     for (let i = 0; i < lowerBoundCount; i++) {
                         this.readCompressedSignedInt(blob, offsetRef);
                     }
-                    return `${elementType}[${','.repeat(Math.max(rank - 1, 0))}]`;
+                    return {
+                        name: '',
+                        arguments: [elementType],
+                        suffix: `[${','.repeat(Math.max(rank - 1, 0))}]`,
+                        typeKind: 'reference',
+                    };
                 }
             case 0x15: // GenericTypeInstance
                 {
                     const genericType = this.parseElementType(blob, offsetRef, resolveType);
                     const argumentCount = this.readCompressedUInt(blob, offsetRef).value;
-                    const argumentsText: string[] = [];
+                    const argumentsText: DotNetTypeSignature[] = [];
                     for (let i = 0; i < argumentCount; i++) {
                         argumentsText.push(this.parseElementType(blob, offsetRef, resolveType));
                     }
-                    return `${this.stripMetadataGenericArity(genericType, argumentCount)}[${argumentsText.join(',')}]`;
+                    return {
+                        name: this.stripMetadataGenericArity(genericType.name, argumentCount),
+                        arguments: argumentsText,
+                        suffix: '',
+                        typeKind: genericType.typeKind,
+                    };
                 }
             case 0x16: // TypedByReference
-                return 'System.TypedReference';
+                return {name: 'System.TypedReference', arguments: [], suffix: '', typeKind: 'value'};
             case 0x18: // IntPtr
-                return 'nint';
+                return {name: 'nint', arguments: [], suffix: '', typeKind: 'value'};
             case 0x19: // UIntPtr
-                return 'nuint';
+                return {name: 'nuint', arguments: [], suffix: '', typeKind: 'value'};
             case 0x1c: // Object
-                return 'System.Object';
+                return {name: 'System.Object', arguments: [], suffix: '', typeKind: 'reference'};
             case 0x1b: // FunctionPointer
                 this.parseMethodSignature(blob, resolveType, offsetRef); // Function pointer signatures are omitted in JIT disasm, ignoring the parsed signature here
-                return 'ptr';
+                return {name: 'ptr', arguments: [], suffix: '', typeKind: 'value'};
             case 0x1d: // SZArray
-                return `${this.parseElementType(blob, offsetRef, resolveType)}[]`;
+                return {
+                    name: '',
+                    arguments: [this.parseElementType(blob, offsetRef, resolveType)],
+                    suffix: '[]',
+                    typeKind: 'reference',
+                };
             case 0x1e: // GenericMethodParameter
-                return `!!${this.readCompressedUInt(blob, offsetRef).value}`;
+                {
+                    const name = `!!${this.readCompressedUInt(blob, offsetRef).value}`;
+                    return {name, arguments: [], suffix: '', typeKind: 'generic', genericParameter: name};
+                }
             case 0x41: // Sentinel
                 return this.parseElementType(blob, offsetRef, resolveType);
             case 0x45: // Pinned
@@ -632,7 +730,7 @@ export class DotNetPdbParser {
 
     private parseMethodSignature(
         blob: Buffer,
-        resolveType: (encoded: number) => string,
+        resolveType: (encoded: number) => DotNetTypeSignature,
         offsetRef: {offset: number} = {offset: 0},
     ) {
         const callingConvention = blob.readUInt8(offsetRef.offset);
@@ -644,7 +742,7 @@ export class DotNetPdbParser {
         const parameterCount = this.readCompressedUInt(blob, offsetRef).value;
         const returnType = this.parseElementType(blob, offsetRef, resolveType);
 
-        const parameters: string[] = [];
+        const parameters: DotNetTypeSignature[] = [];
         for (let i = 0; i < parameterCount; i++) {
             parameters.push(this.parseElementType(blob, offsetRef, resolveType));
         }
@@ -736,16 +834,17 @@ export class DotNetPdbParser {
             const enclosingType = nestedTypes[rowId]
                 ? resolveTypeDef(nestedTypes[rowId])
                 : {genericParameterCount: 0, name: ''};
-            const ownGenericParameterCount =
-                typeGenericParameterCounts[rowId] ?? this.fallbackMetadataNameGenericArity(typeDef.name);
-            const typeNameWithoutArity = this.stripMetadataGenericArity(typeDef.name, ownGenericParameterCount);
+            const metadataNameGenericArity = this.fallbackMetadataNameGenericArity(typeDef.name);
+            const genericParameterCount =
+                typeGenericParameterCounts[rowId] ?? enclosingType.genericParameterCount + metadataNameGenericArity;
+            const typeNameWithoutArity = this.stripMetadataGenericArity(typeDef.name, metadataNameGenericArity);
             const typeName = enclosingType.name
                 ? `${enclosingType.name}+${typeNameWithoutArity}`
                 : typeDef.namespaceName
                   ? `${typeDef.namespaceName}.${typeNameWithoutArity}`
                   : typeNameWithoutArity;
             resolvedTypeDefs[rowId] = {
-                genericParameterCount: enclosingType.genericParameterCount + ownGenericParameterCount,
+                genericParameterCount,
                 name: typeName,
             };
             return resolvedTypeDefs[rowId];
@@ -786,16 +885,23 @@ export class DotNetPdbParser {
                       : typeRef.name;
             return resolvedTypeRefs[rowId];
         };
-        const enumUnderlyingTypes: Record<number, string> = {};
-        const resolvedTypeSpecs: Record<number, string> = {};
-        const resolveType = (encoded: number) => {
+        const enumUnderlyingTypes: Record<number, DotNetTypeSignature> = {};
+        const resolvedTypeSpecs: Record<number, DotNetTypeSignature> = {};
+        const resolveType = (encoded: number): DotNetTypeSignature => {
             const tag = encoded & 0x03;
             const rowId = encoded >> 2;
             if (tag === 0) {
-                return enumUnderlyingTypes[rowId] ?? resolvedTypeDefsByRow[rowId].name;
+                return (
+                    enumUnderlyingTypes[rowId] ?? {
+                        name: resolvedTypeDefsByRow[rowId].name,
+                        arguments: [],
+                        suffix: '',
+                        typeKind: 'reference',
+                    }
+                );
             }
             if (tag === 1) {
-                return resolveTypeRef(rowId);
+                return {name: resolveTypeRef(rowId), arguments: [], suffix: '', typeKind: 'reference'};
             }
             if (tag === 2) {
                 resolvedTypeSpecs[rowId] ??= this.parseElementType(
@@ -809,7 +915,10 @@ export class DotNetPdbParser {
         };
         for (let i = 0; i < sortedTypeDefs.length; i++) {
             const typeDefRowId = sortedTypeDefs[i];
-            if (typeDefs[typeDefRowId].extends === 0 || resolveType(typeDefs[typeDefRowId].extends) !== 'System.Enum') {
+            if (
+                typeDefs[typeDefRowId].extends === 0 ||
+                formatTypeSignature(resolveType(typeDefs[typeDefRowId].extends)) !== 'System.Enum'
+            ) {
                 continue;
             }
 
@@ -843,6 +952,7 @@ export class DotNetPdbParser {
                 this.getBlob(tables, this.readIndex(assembly, signatureOffset, blob)),
                 resolveType,
             );
+            const returnTypeText = formatTypeSignature(returnType);
 
             methodInfos[rowId] = {
                 methodArguments: this.genericParameterArguments(
@@ -850,8 +960,10 @@ export class DotNetPdbParser {
                     '!!',
                 ),
                 methodName,
-                parameters,
-                returnType: returnType === 'void' ? '' : returnType,
+                parameters: parameters.map(formatTypeSignature),
+                parameterTypes: parameters,
+                returnType: returnTypeText === 'void' ? '' : returnTypeText,
+                returnTypeSignature: returnType,
                 typeArguments: this.genericParameterArguments(type.genericParameterCount, '!'),
                 typeName: type.name,
             };

--- a/lib/parsers/pdb-parser-dotnet.ts
+++ b/lib/parsers/pdb-parser-dotnet.ts
@@ -87,6 +87,7 @@ export function getCanonicalTypeSignature(
     collapseSharedGenericReferences = true,
 ): {text: string; containsSharedGenericReference: boolean} {
     if (type.genericParameter) {
+        // !n refers to the declaring type; !!n refers to the method.
         const isMethodParameter = type.genericParameter.startsWith('!!');
         const index = Number.parseInt(type.genericParameter.substring(isMethodParameter ? 2 : 1), 10);
         const text =
@@ -125,6 +126,7 @@ export function getCanonicalTypeSignature(
         type.typeKind === 'reference' &&
         containsSharedGenericReference
     ) {
+        // Shared generic JIT names collapse nested reference-type arguments to System.__Canon.
         return {text: sharedGenericReferenceType, containsSharedGenericReference};
     }
 
@@ -176,6 +178,7 @@ class BufferCursor {
     }
 }
 
+// ECMA-335 coded indexes pack a target-table tag into the low bits and a row id into the high bits.
 const codedIndexes: Record<string, {tagBits: number; tables: number[]}> = {
     CustomAttributeType: {tagBits: 3, tables: [0x06, 0x0a]},
     HasConstant: {tagBits: 2, tables: [0x04, 0x08, 0x17]},
@@ -208,6 +211,8 @@ export class DotNetPdbParser {
         const firstByte = buffer.readUInt8(offsetRef.offset);
         offsetRef.offset += 1;
 
+        // ECMA-335 compressed integers use 0xxxxxxx, 10xxxxxx, and 110xxxxx prefixes for
+        // 1-, 2-, and 4-byte encodings.
         if ((firstByte & 0x80) === 0) {
             return {value: firstByte, bytes: 1};
         }
@@ -233,6 +238,7 @@ export class DotNetPdbParser {
         }
 
         const signedBitCount = compressed.bytes === 1 ? 6 : compressed.bytes === 2 ? 13 : 28;
+        // Negative values are sign-extended from the payload width implied by the compressed size.
         return value - (1 << signedBitCount);
     }
 
@@ -242,6 +248,7 @@ export class DotNetPdbParser {
             return 0; // Portable PDBs start directly at the metadata root.
         }
 
+        // Assembly input is a PE file; the DOS header points to the PE header at offset 0x3c.
         if (buffer.length < 0x40 || buffer.readUInt16LE(0) !== 0x5a4d) {
             throw new Error('Metadata root not found');
         }
@@ -261,6 +268,7 @@ export class DotNetPdbParser {
 
         const optionalHeaderMagic = buffer.readUInt16LE(optionalHeaderOffset);
         const dataDirectoryOffset = optionalHeaderMagic === 0x20b ? 112 : optionalHeaderMagic === 0x10b ? 96 : -1;
+        // Data-directory entry 14 is the CLI header; it leads us to the managed metadata RVA.
         const cliHeaderDirectoryOffset = optionalHeaderOffset + dataDirectoryOffset + 14 * 8;
         if (dataDirectoryOffset === -1 || cliHeaderDirectoryOffset + 8 > sectionTableOffset) {
             throw new Error('Invalid PE optional header');
@@ -292,6 +300,7 @@ export class DotNetPdbParser {
             throw new Error('Invalid CLI header');
         }
 
+        // The CLI header stores the metadata directory at offset 8.
         const metadataRva = buffer.readUInt32LE(cliHeaderOffset + 8);
         const metadataRoot = rvaToFileOffset(metadataRva);
 
@@ -310,18 +319,20 @@ export class DotNetPdbParser {
             throw new Error('Invalid metadata signature');
         }
 
-        cursor.readUInt16();
-        cursor.readUInt16();
-        cursor.readUInt32();
+        cursor.readUInt16(); // MajorVersion
+        cursor.readUInt16(); // MinorVersion
+        cursor.readUInt32(); // Reserved
 
         const versionLength = cursor.readUInt32();
+        // Version string is null-padded and 4-byte aligned before the stream count.
         cursor.offset = (cursor.offset + versionLength + 3) & ~3;
 
-        cursor.readUInt16();
+        cursor.readUInt16(); // Flags
         const streamCount = cursor.readUInt16();
         const streams: MetadataStreams = {};
 
         for (let i = 0; i < streamCount; i++) {
+            // Each stream header is root-relative offset, byte size, and a 4-byte-aligned name.
             const offset = cursor.readUInt32();
             const size = cursor.readUInt32();
             const nameStart = cursor.offset;
@@ -349,15 +360,11 @@ export class DotNetPdbParser {
     parse(): DotNetSourceMapping {
         const assemblyMethods = this.parseAssemblyMethods();
         const sequencePoints = this.parsePdbSequencePoints();
+        // Assembly MethodDef rows and PDB MethodDebugInformation rows share the same row numbering.
         return Object.entries(sequencePoints).map(([methodRowId, offsets]) => ({
             method: assemblyMethods[Number(methodRowId)],
             offsets,
         }));
-    }
-
-    private fallbackMetadataNameGenericArity(name: string) {
-        const arity = name.match(/`(?<arity>\d+)$/);
-        return arity?.groups ? Number.parseInt(arity.groups.arity, 10) : 0;
     }
 
     private stripMetadataGenericArity(name: string, genericParameterCount: number) {
@@ -365,6 +372,8 @@ export class DotNetPdbParser {
             return name;
         }
 
+        // Strip the `N suffix from metadata generic type names.
+        // For example, List`1 becomes List, and Dictionary`2 becomes Dictionary.
         const arity = `\`${genericParameterCount}`;
         return name.endsWith(arity) ? name.substring(0, name.length - arity.length) : name;
     }
@@ -378,10 +387,12 @@ export class DotNetPdbParser {
         const largestRowCount = Math.max(
             ...definition.tables.map(table => rowCounts[table] ?? typeSystemTableRows?.[table] ?? 0),
         );
+        // A coded index must fit both the row id and the tag bits in either 16 or 32 bits.
         return largestRowCount < 1 << (16 - definition.tagBits) ? 2 : 4;
     }
 
     private tableRowSize(tableId: number, tables: MetadataTables) {
+        // The #~ heap-size flags decide whether heap indexes in table rows are 2 or 4 bytes.
         const strings = this.heapIndexSize(tables.heapSizes, 0x01);
         const guid = this.heapIndexSize(tables.heapSizes, 0x02);
         const blob = this.heapIndexSize(tables.heapSizes, 0x04);
@@ -505,6 +516,7 @@ export class DotNetPdbParser {
         const pdbStream = streams['#Pdb']!;
 
         const cursor = new BufferCursor(buffer, pdbStream.offset + 24); // 20-byte PDB id, then entry point token.
+        // Portable PDBs record which assembly type-system tables they reference, followed by row counts.
         const referencedTables = cursor.readBigUInt64();
         const rowCounts: RowCounts = {};
 
@@ -521,14 +533,15 @@ export class DotNetPdbParser {
         const tableStream = (streams['#~'] ?? streams['#-'])!;
 
         const cursor = new BufferCursor(buffer, tableStream.offset);
-        cursor.readUInt32();
-        cursor.readUInt8();
-        cursor.readUInt8();
+        cursor.readUInt32(); // Reserved
+        cursor.readUInt8(); // MajorVersion
+        cursor.readUInt8(); // MinorVersion
         const heapSizes = cursor.readUInt8();
-        cursor.readUInt8();
+        cursor.readUInt8(); // Reserved
         const validTables = cursor.readBigUInt64();
         cursor.readBigUInt64(); // Sorted table mask; row counts are keyed only by the valid table mask above.
 
+        // Row counts are present only for tables whose bit is set in the valid-table mask.
         const rowCounts: RowCounts = {};
         for (let tableId = 0; tableId < 64; tableId++) {
             if (((validTables >> BigInt(tableId)) & 1n) !== 0n) {
@@ -552,6 +565,7 @@ export class DotNetPdbParser {
                 continue;
             }
 
+            // Table rows are laid out consecutively after all row counts, in table-id order.
             tables.tableOffsets[tableId] = tableOffset;
             tableOffset += rowCount * this.tableRowSize(tableId, tables);
         }
@@ -560,11 +574,13 @@ export class DotNetPdbParser {
     }
 
     private readIndex(buffer: Buffer, offset: number, size: number) {
+        // Metadata indexes are either 2 or 4 bytes
         return size === 2 ? buffer.readUInt16LE(offset) : buffer.readUInt32LE(offset);
     }
 
     private getString(tables: MetadataTables, index: number) {
         if (index === 0) {
+            // Heap index zero is reserved as the empty string.
             return '';
         }
 
@@ -581,18 +597,21 @@ export class DotNetPdbParser {
 
     private getBlob(tables: MetadataTables, index: number) {
         if (index === 0) {
+            // Blob index zero is reserved as an empty blob.
             return Buffer.alloc(0);
         }
 
         const blobs = tables.streams['#Blob']!;
 
         const offsetRef = {offset: blobs.offset + index};
+        // Blob heap entries start with a compressed byte length.
         const length = this.readCompressedUInt(tables.buffer, offsetRef).value;
         return tables.buffer.subarray(offsetRef.offset, offsetRef.offset + length);
     }
 
     private rowOffset(tables: MetadataTables, tableId: number, rowId: number) {
         const offset = tables.tableOffsets[tableId];
+        // Convert a 1-based metadata row id to an absolute byte offset in the table stream.
         return offset + (rowId - 1) * this.tableRowSize(tableId, tables);
     }
 
@@ -601,6 +620,7 @@ export class DotNetPdbParser {
         offsetRef: {offset: number},
         resolveType: (encoded: number) => DotNetTypeSignature,
     ): DotNetTypeSignature {
+        // Skip required/optional custom modifiers and parse the modified type itself.
         while (blob[offsetRef.offset] === 0x1f || blob[offsetRef.offset] === 0x20) {
             offsetRef.offset++;
             this.readCompressedUInt(blob, offsetRef);
@@ -639,19 +659,23 @@ export class DotNetPdbParser {
             case 0x0e: // String
                 return {name: 'System.String', arguments: [], suffix: '', typeKind: 'reference'};
             case 0x0f: // Pointer
-                this.parseElementType(blob, offsetRef, resolveType); // Pointer signatures are omitted in JIT disasm, ignoring the parsed pointed-to type here
+                // Consume the pointed-to type to keep the cursor aligned; JIT method names print only ptr.
+                this.parseElementType(blob, offsetRef, resolveType);
                 return {name: 'ptr', arguments: [], suffix: '', typeKind: 'value'};
             case 0x10: // ByReference
-                this.parseElementType(blob, offsetRef, resolveType); // ByRef signatures are omitted in JIT disasm, ignoring the parsed referenced type here
+                // Consume the referenced type to keep the cursor aligned; JIT method names print only byref.
+                this.parseElementType(blob, offsetRef, resolveType);
                 return {name: 'byref', arguments: [], suffix: '', typeKind: 'value'};
             case 0x11: // ValueType
             case 0x12: // Class
                 {
+                    // Class/value signatures carry a TypeDefOrRef coded index.
                     const resolved = resolveType(this.readCompressedUInt(blob, offsetRef).value);
                     return {...resolved, typeKind: type === 0x11 ? 'value' : 'reference'};
                 }
             case 0x13: // GenericTypeParameter
                 {
+                    // Type generic parameters are placeholders until matched against a concrete JIT name.
                     const name = `!${this.readCompressedUInt(blob, offsetRef).value}`;
                     return {name, arguments: [], suffix: '', typeKind: 'generic', genericParameter: name};
                 }
@@ -659,6 +683,7 @@ export class DotNetPdbParser {
                 {
                     const elementType = this.parseElementType(blob, offsetRef, resolveType);
                     const rank = this.readCompressedUInt(blob, offsetRef).value;
+                    // Bounds are present in metadata but the JIT disassembly only prints rank, eg. [,].
                     const sizeCount = this.readCompressedUInt(blob, offsetRef).value;
                     for (let i = 0; i < sizeCount; i++) {
                         this.readCompressedUInt(blob, offsetRef);
@@ -676,6 +701,7 @@ export class DotNetPdbParser {
                 }
             case 0x15: // GenericTypeInstance
                 {
+                    // GENERICINST wraps the generic type followed by its concrete type arguments.
                     const genericType = this.parseElementType(blob, offsetRef, resolveType);
                     const argumentCount = this.readCompressedUInt(blob, offsetRef).value;
                     const argumentsText = Array.from({length: argumentCount}, () =>
@@ -697,7 +723,8 @@ export class DotNetPdbParser {
             case 0x1c: // Object
                 return {name: 'System.Object', arguments: [], suffix: '', typeKind: 'reference'};
             case 0x1b: // FunctionPointer
-                this.parseMethodSignature(blob, resolveType, offsetRef); // Function pointer signatures are omitted in JIT disasm, ignoring the parsed signature here
+                // Consume the full target signature; JIT method names print function pointers as ptr.
+                this.parseMethodSignature(blob, resolveType, offsetRef);
                 return {name: 'ptr', arguments: [], suffix: '', typeKind: 'value'};
             case 0x1d: // SZArray
                 return {
@@ -708,12 +735,15 @@ export class DotNetPdbParser {
                 };
             case 0x1e: // GenericMethodParameter
                 {
+                    // Method generic parameters are placeholders until matched against a concrete JIT name.
                     const name = `!!${this.readCompressedUInt(blob, offsetRef).value}`;
                     return {name, arguments: [], suffix: '', typeKind: 'generic', genericParameter: name};
                 }
             case 0x41: // Sentinel
+                // Varargs sentinel is not part of the type text we need for JIT matching.
                 return this.parseElementType(blob, offsetRef, resolveType);
             case 0x45: // Pinned
+                // Pinned is a local-signature modifier; preserve the underlying type only.
                 return this.parseElementType(blob, offsetRef, resolveType);
             default:
                 throw new Error(`Unsupported element type 0x${type.toString(16)}`);
@@ -725,6 +755,7 @@ export class DotNetPdbParser {
         resolveType: (encoded: number) => DotNetTypeSignature,
         offsetRef: {offset: number} = {offset: 0},
     ) {
+        // Method signatures start with the calling convention; bit 0x10 says a generic arity follows.
         const callingConvention = blob.readUInt8(offsetRef.offset);
         offsetRef.offset++;
 
@@ -760,9 +791,12 @@ export class DotNetPdbParser {
         const typeGenericParameterCounts: Record<number, number> = {};
         const methodGenericParameterCounts: Record<number, number> = {};
 
+        // TypeRef rows name external types referenced by signatures, for example System.String
+        // or System.Collections.Generic.Dictionary`2.
         for (let rowId = 1; rowId <= (tables.rowCounts[0x01] ?? 0); rowId++) {
             const offset = this.rowOffset(tables, 0x01, rowId);
             const resolutionScopeValue = this.readIndex(assembly, offset, resolutionScope);
+            // TypeRef layout: ResolutionScope, TypeName, TypeNamespace.
             const nameOffset = offset + resolutionScope;
             const namespaceOffset = nameOffset + strings;
             typeRefs[rowId] = {
@@ -772,8 +806,11 @@ export class DotNetPdbParser {
             };
         }
 
+        // TypeDef rows name types defined by the compiled assembly and define contiguous Field
+        // and MethodDef row ranges through their FieldList and MethodList columns.
         for (let rowId = 1; rowId <= (tables.rowCounts[0x02] ?? 0); rowId++) {
             const offset = this.rowOffset(tables, 0x02, rowId);
+            // TypeDef layout: Flags, TypeName, TypeNamespace, Extends, FieldList, MethodList.
             const nameOffset = offset + 4;
             const namespaceOffset = nameOffset + strings;
             const extendsOffset = namespaceOffset + strings;
@@ -788,8 +825,11 @@ export class DotNetPdbParser {
             };
         }
 
+        // Field rows are only consulted for enum value__ signatures so enum parameters can map
+        // to the primitive type printed by the JIT.
         for (let rowId = 1; rowId <= (tables.rowCounts[0x04] ?? 0); rowId++) {
             const offset = this.rowOffset(tables, 0x04, rowId);
+            // Field layout: Flags, Name, Signature.
             const nameOffset = offset + 2;
             const signatureOffset = nameOffset + strings;
             fields[rowId] = {
@@ -798,6 +838,7 @@ export class DotNetPdbParser {
             };
         }
 
+        // NestedClass rows let TypeDef names be reconstructed as Outer+Inner.
         for (let rowId = 1; rowId <= (tables.rowCounts[0x29] ?? 0); rowId++) {
             const offset = this.rowOffset(tables, 0x29, rowId);
             const nested = this.readIndex(assembly, offset, typeDefIndex);
@@ -805,17 +846,20 @@ export class DotNetPdbParser {
             nestedTypes[nested] = enclosing;
         }
 
+        // GenericParam rows tell us how many !n or !!n placeholders a type or method exposes.
         for (let rowId = 1; rowId <= (tables.rowCounts[0x2a] ?? 0); rowId++) {
             const offset = this.rowOffset(tables, 0x2a, rowId);
             const parameterNumber = assembly.readUInt16LE(offset);
             const owner = this.readIndex(assembly, offset + 4, typeOrMethodDef);
             const ownerRowId = owner >> 1;
+            // TypeOrMethodDef tag 0 owns type generic parameters; tag 1 owns method generic parameters.
             const ownerTag = owner & 0x01;
             const ownerCounts = ownerTag === 0 ? typeGenericParameterCounts : methodGenericParameterCounts;
             ownerCounts[ownerRowId] = Math.max(ownerCounts[ownerRowId] ?? 0, parameterNumber + 1);
         }
 
         const resolvedTypeDefs: Record<number, DotNetTypeKey> = {};
+        // Resolve nested type names and use GenericParam rows for generic arity.
         const resolveTypeDef = (rowId: number): DotNetTypeKey => {
             if (resolvedTypeDefs[rowId]) {
                 return resolvedTypeDefs[rowId];
@@ -825,10 +869,9 @@ export class DotNetPdbParser {
             const enclosingType = nestedTypes[rowId]
                 ? resolveTypeDef(nestedTypes[rowId])
                 : {genericParameterCount: 0, name: ''};
-            const metadataNameGenericArity = this.fallbackMetadataNameGenericArity(typeDef.name);
-            const genericParameterCount =
-                typeGenericParameterCounts[rowId] ?? enclosingType.genericParameterCount + metadataNameGenericArity;
-            const typeNameWithoutArity = this.stripMetadataGenericArity(typeDef.name, metadataNameGenericArity);
+            const genericParameterCount = typeGenericParameterCounts[rowId] ?? 0;
+            const ownGenericParameterCount = genericParameterCount - enclosingType.genericParameterCount;
+            const typeNameWithoutArity = this.stripMetadataGenericArity(typeDef.name, ownGenericParameterCount);
             const typeName = enclosingType.name
                 ? `${enclosingType.name}+${typeNameWithoutArity}`
                 : typeDef.namespaceName
@@ -854,6 +897,7 @@ export class DotNetPdbParser {
         for (let i = 0; i < sortedTypeDefs.length; i++) {
             const typeDefRowId = sortedTypeDefs[i];
             const start = typeDefs[typeDefRowId].methodList;
+            // MethodList is a start row; the next TypeDef's MethodList gives the exclusive end.
             const end = i + 1 < sortedTypeDefs.length ? typeDefs[sortedTypeDefs[i + 1]].methodList : methodCount + 1;
             for (let methodRowId = start; methodRowId < end; methodRowId++) {
                 methodDeclaringTypes[methodRowId] = resolvedTypeDefsByRow[typeDefRowId];
@@ -868,6 +912,7 @@ export class DotNetPdbParser {
             }
 
             const typeRef = typeRefs[rowId];
+            // A ResolutionScope tagged as TypeRef means this TypeRef is nested under another TypeRef.
             resolvedTypeRefs[rowId] =
                 (typeRef.resolutionScope & 0x03) === 3
                     ? `${resolveTypeRef(typeRef.resolutionScope >> 2)}+${typeRef.name}`
@@ -879,6 +924,7 @@ export class DotNetPdbParser {
         const enumUnderlyingTypes: Record<number, DotNetTypeSignature> = {};
         const resolvedTypeSpecs: Record<number, DotNetTypeSignature> = {};
         const resolveType = (encoded: number): DotNetTypeSignature => {
+            // TypeDefOrRef coded index tags: 0 = TypeDef, 1 = TypeRef, 2 = TypeSpec.
             const tag = encoded & 0x03;
             const rowId = encoded >> 2;
             if (tag === 0) {
@@ -895,6 +941,7 @@ export class DotNetPdbParser {
                 return {name: resolveTypeRef(rowId), arguments: [], suffix: '', typeKind: 'reference'};
             }
             if (tag === 2) {
+                // TypeSpec rows point back to signature blobs for constructed generic types.
                 resolvedTypeSpecs[rowId] ??= this.parseElementType(
                     this.getBlob(tables, this.readIndex(assembly, this.rowOffset(tables, 0x1b, rowId), blob)),
                     {offset: 0},
@@ -904,6 +951,8 @@ export class DotNetPdbParser {
             }
             throw new Error(`Unsupported TypeDefOrRef tag ${tag}`);
         };
+        // JIT signatures print enum parameters as their underlying primitive type, so precompute
+        // that substitution from System.Enum-derived TypeDefs.
         for (let i = 0; i < sortedTypeDefs.length; i++) {
             const typeDefRowId = sortedTypeDefs[i];
             if (
@@ -920,6 +969,7 @@ export class DotNetPdbParser {
                     : (tables.rowCounts[0x04] ?? 0) + 1;
             for (let fieldRowId = start; fieldRowId < end; fieldRowId++) {
                 if (fields[fieldRowId].name === 'value__') {
+                    // Field signatures start with their own calling-convention byte before the field type.
                     enumUnderlyingTypes[typeDefRowId] = this.parseElementType(
                         this.getBlob(tables, fields[fieldRowId].signature),
                         {offset: 1},
@@ -932,9 +982,11 @@ export class DotNetPdbParser {
         for (let rowId = 1; rowId <= methodCount; rowId++) {
             const offset = this.rowOffset(tables, 0x06, rowId);
             const type = methodDeclaringTypes[rowId];
+            // MethodDef layout: RVA, ImplFlags, Flags, Name, Signature, ParamList.
             const nameOffset = offset + 4 + 2 + 2;
             const signatureOffset = nameOffset + strings;
             const methodName = this.getString(tables, this.readIndex(assembly, nameOffset, strings));
+            // MethodDef.Signature is a blob index containing return type and parameter types.
             const {
                 genericParameterCount: signatureGenericParameterCount,
                 parameters,
@@ -970,10 +1022,12 @@ export class DotNetPdbParser {
         }
 
         const offsetRef = {offset: 0};
+        // Local signature token. Source mapping does not need local variables, but the blob starts with it.
         this.readCompressedUInt(blob, offsetRef);
 
         if (initialDocument === 0) {
-            this.readCompressedUInt(blob, offsetRef); // The first sequence point carries the document row when needed.
+            // The first sequence point carries the document row when MethodDebugInformation has none.
+            this.readCompressedUInt(blob, offsetRef);
         }
 
         let previousIlOffset = 0;
@@ -985,18 +1039,22 @@ export class DotNetPdbParser {
         while (offsetRef.offset < blob.length) {
             const deltaIlOffset = this.readCompressedUInt(blob, offsetRef).value;
             if (deltaIlOffset === 0 && hasPreviousIlOffset) {
-                this.readCompressedUInt(blob, offsetRef); // Document switch record.
+                // A zero IL delta after the first point is a document switch record, not a code span.
+                this.readCompressedUInt(blob, offsetRef);
                 continue;
             }
 
+            // IL offsets are delta-encoded after the first sequence point.
             const ilOffset = hasPreviousIlOffset ? previousIlOffset + deltaIlOffset : deltaIlOffset;
             const deltaLines = this.readCompressedUInt(blob, offsetRef).value;
+            // Same-line spans use unsigned column deltas; multi-line spans use signed deltas.
             const deltaColumns =
                 deltaLines === 0
                     ? this.readCompressedUInt(blob, offsetRef).value
                     : this.readCompressedSignedInt(blob, offsetRef);
 
             if (deltaLines === 0 && deltaColumns === 0) {
+                // Hidden sequence points suppress source mapping for this IL offset.
                 offsets[ilOffset] = null;
             } else {
                 const startLine = hasPreviousNonHiddenSource
@@ -1006,6 +1064,7 @@ export class DotNetPdbParser {
                     ? previousNonHiddenColumn + this.readCompressedSignedInt(blob, offsetRef)
                     : this.readCompressedUInt(blob, offsetRef).value;
 
+                // The Portable PDB hidden-line sentinel is another way to encode a hidden point.
                 if (startLine === hiddenSequencePoint) {
                     offsets[ilOffset] = null;
                 } else {
@@ -1034,6 +1093,7 @@ export class DotNetPdbParser {
         for (let methodRowId = 1; methodRowId <= (tables.rowCounts[0x31] ?? 0); methodRowId++) {
             const offset = this.rowOffset(tables, 0x31, methodRowId);
             const initialDocument = this.readIndex(pdb, offset, documentIndex);
+            // MethodDebugInformation rows are ordered by MethodDef row id and point to sequence-point blobs.
             const sequencePointsBlob = this.getBlob(tables, this.readIndex(pdb, offset + documentIndex, blob));
             methodSequencePoints[methodRowId] = this.decodeSequencePoints(sequencePointsBlob, initialDocument);
         }

--- a/lib/parsers/pdb-parser-dotnet.ts
+++ b/lib/parsers/pdb-parser-dotnet.ts
@@ -349,17 +349,10 @@ export class DotNetPdbParser {
     parse(): DotNetSourceMapping {
         const assemblyMethods = this.parseAssemblyMethods();
         const sequencePoints = this.parsePdbSequencePoints();
-        const sourceMapping: DotNetSourceMapping = [];
-
-        for (const methodRowId of Object.keys(sequencePoints).map(Number)) {
-            sourceMapping.push({method: assemblyMethods[methodRowId], offsets: sequencePoints[methodRowId]});
-        }
-
-        return sourceMapping;
-    }
-
-    private genericParameterArguments(count: number, prefix: '!' | '!!') {
-        return Array.from({length: count}, (_, index) => `${prefix}${index}`);
+        return Object.entries(sequencePoints).map(([methodRowId, offsets]) => ({
+            method: assemblyMethods[Number(methodRowId)],
+            offsets,
+        }));
     }
 
     private fallbackMetadataNameGenericArity(name: string) {
@@ -685,10 +678,9 @@ export class DotNetPdbParser {
                 {
                     const genericType = this.parseElementType(blob, offsetRef, resolveType);
                     const argumentCount = this.readCompressedUInt(blob, offsetRef).value;
-                    const argumentsText: DotNetTypeSignature[] = [];
-                    for (let i = 0; i < argumentCount; i++) {
-                        argumentsText.push(this.parseElementType(blob, offsetRef, resolveType));
-                    }
+                    const argumentsText = Array.from({length: argumentCount}, () =>
+                        this.parseElementType(blob, offsetRef, resolveType),
+                    );
                     return {
                         name: this.stripMetadataGenericArity(genericType.name, argumentCount),
                         arguments: argumentsText,
@@ -742,10 +734,9 @@ export class DotNetPdbParser {
         const parameterCount = this.readCompressedUInt(blob, offsetRef).value;
         const returnType = this.parseElementType(blob, offsetRef, resolveType);
 
-        const parameters: DotNetTypeSignature[] = [];
-        for (let i = 0; i < parameterCount; i++) {
-            parameters.push(this.parseElementType(blob, offsetRef, resolveType));
-        }
+        const parameters = Array.from({length: parameterCount}, () =>
+            this.parseElementType(blob, offsetRef, resolveType),
+        );
 
         return {genericParameterCount, parameters, returnType};
     }
@@ -955,16 +946,16 @@ export class DotNetPdbParser {
             const returnTypeText = formatTypeSignature(returnType);
 
             methodInfos[rowId] = {
-                methodArguments: this.genericParameterArguments(
-                    methodGenericParameterCounts[rowId] ?? signatureGenericParameterCount,
-                    '!!',
+                methodArguments: Array.from(
+                    {length: methodGenericParameterCounts[rowId] ?? signatureGenericParameterCount},
+                    (_, index) => `!!${index}`,
                 ),
                 methodName,
                 parameters: parameters.map(formatTypeSignature),
                 parameterTypes: parameters,
                 returnType: returnTypeText === 'void' ? '' : returnTypeText,
                 returnTypeSignature: returnType,
-                typeArguments: this.genericParameterArguments(type.genericParameterCount, '!'),
+                typeArguments: Array.from({length: type.genericParameterCount}, (_, index) => `!${index}`),
                 typeName: type.name,
             };
         }

--- a/static/modes/asm-mode.ts
+++ b/static/modes/asm-mode.ts
@@ -44,7 +44,7 @@ function definition(): monaco.languages.IMonarchLanguage {
                 // Label definition (anything looking like a label, followed by anything that's not valid in a demangled
                 // identifier, until we get to a colon followed by any whitespace. This is to avoid finding the colon in
                 // a scoped (blah::foo) identifier.
-                [/^[.a-zA-Z0-9_$?@][^#;/]*:(?=\s)/, {token: 'type.identifier'}],
+                [/^[.a-zA-Z0-9_$?@][^#;/]*:(?=\s|$)/, {token: 'type.identifier'}],
                 // Label definition (quoted)
                 [/^"([^"\\]|\\.)*":/, {token: 'type.identifier'}],
                 // Label definition (ARM style)

--- a/test/dotnet-parser-tests.ts
+++ b/test/dotnet-parser-tests.ts
@@ -1,0 +1,1009 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {Buffer} from 'buffer';
+
+import {describe, expect, it} from 'vitest';
+
+import {DotNetAsmParser} from '../lib/parsers/asm-parser-dotnet.js';
+import type {DotNetMethodKey, DotNetSourceMapping, DotNetTypeSignature} from '../lib/parsers/pdb-parser-dotnet.js';
+import {DotNetPdbParser, getCanonicalTypeSignature} from '../lib/parsers/pdb-parser-dotnet.js';
+import type {AsmResultSource, ParsedAsmResult} from '../types/asmresult/asmresult.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
+
+const filters = (overrides: ParseFiltersAndOutputOptions = {}): ParseFiltersAndOutputOptions => ({
+    commentOnly: false,
+    labels: false,
+    ...overrides,
+});
+
+const valueType = (name: string): DotNetTypeSignature => ({
+    name,
+    arguments: [],
+    suffix: '',
+    typeKind: 'value',
+});
+
+const referenceType = (name: string, args: DotNetTypeSignature[] = []): DotNetTypeSignature => ({
+    name,
+    arguments: args,
+    suffix: '',
+    typeKind: 'reference',
+});
+
+const genericParameter = (genericParameter: string): DotNetTypeSignature => ({
+    name: genericParameter,
+    arguments: [],
+    suffix: '',
+    typeKind: 'generic',
+    genericParameter,
+});
+
+const arrayType = (element: DotNetTypeSignature, suffix = '[]'): DotNetTypeSignature => ({
+    name: '',
+    arguments: [element],
+    suffix,
+    typeKind: 'reference',
+});
+
+function bytes(...values: number[]) {
+    return Buffer.from(values);
+}
+
+function u16(value: number) {
+    const buffer = Buffer.alloc(2);
+    buffer.writeUInt16LE(value, 0);
+    return buffer;
+}
+
+function u32(value: number) {
+    const buffer = Buffer.alloc(4);
+    buffer.writeUInt32LE(value, 0);
+    return buffer;
+}
+
+function u64(value: bigint) {
+    const buffer = Buffer.alloc(8);
+    buffer.writeUInt32LE(Number(value & 0xffff_ffffn), 0);
+    buffer.writeUInt32LE(Number((value >> 32n) & 0xffff_ffffn), 4);
+    return buffer;
+}
+
+function compressedUInt(value: number): Buffer {
+    if (value < 0x80) {
+        return bytes(value);
+    }
+
+    if (value < 0x4000) {
+        return bytes(0x80 | (value >> 8), value & 0xff);
+    }
+
+    return bytes(0xc0 | (value >> 24), (value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff);
+}
+
+function compressedSignedInt(value: number): Buffer {
+    const encoded = value >= 0 ? value << 1 : (((1 << 6) + value) << 1) | 1;
+    return compressedUInt(encoded);
+}
+
+function align4(value: number) {
+    return (value + 3) & ~3;
+}
+
+class StringHeapBuilder {
+    private readonly indexes = new Map<string, number>();
+    private readonly chunks = [Buffer.from([0])];
+    private length = 1;
+
+    index(value: string) {
+        const existing = this.indexes.get(value);
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        const index = this.length;
+        const chunk = Buffer.from(`${value}\0`, 'utf8');
+        this.chunks.push(chunk);
+        this.length += chunk.length;
+        this.indexes.set(value, index);
+        return index;
+    }
+
+    toBuffer() {
+        return Buffer.concat(this.chunks);
+    }
+}
+
+class BlobHeapBuilder {
+    private readonly chunks = [Buffer.from([0])];
+    private length = 1;
+
+    index(value: Buffer) {
+        const index = this.length;
+        const chunk = Buffer.concat([compressedUInt(value.length), value]);
+        this.chunks.push(chunk);
+        this.length += chunk.length;
+        return index;
+    }
+
+    toBuffer() {
+        return Buffer.concat(this.chunks);
+    }
+}
+
+function metadataRoot(streams: Array<{name: string; data: Buffer}>) {
+    // Emit a standalone ECMA-335 metadata root, starting at the BSJB signature.
+    const version = Buffer.from('v4.0.30319\0\0', 'utf8');
+    const streamHeadersSize = streams.reduce((size, stream) => size + 8 + align4(stream.name.length + 1), 0);
+    let streamDataOffset = align4(4 + 2 + 2 + 4 + 4 + version.length + 2 + 2 + streamHeadersSize);
+    const streamHeaders: Buffer[] = [];
+
+    // Stream headers contain offsets relative to the metadata root, followed by the byte size and
+    // a null-terminated, 4-byte-aligned stream name.
+    for (const stream of streams) {
+        streamDataOffset = align4(streamDataOffset);
+        streamHeaders.push(
+            Buffer.concat([
+                u32(streamDataOffset),
+                u32(stream.data.length),
+                Buffer.concat([
+                    Buffer.from(`${stream.name}\0`, 'utf8'),
+                    Buffer.alloc(align4(stream.name.length + 1) - (stream.name.length + 1)),
+                ]),
+            ]),
+        );
+        streamDataOffset += stream.data.length;
+    }
+
+    const header = Buffer.concat([
+        u32(0x424a5342), // BSJB metadata signature
+        u16(1), // MajorVersion
+        u16(1), // MinorVersion
+        u32(0), // Reserved
+        u32(version.length),
+        version,
+        u16(0), // Flags
+        u16(streams.length),
+        ...streamHeaders,
+    ]);
+    const dataStartPadding = Buffer.alloc(align4(header.length) - header.length);
+    let offset = align4(header.length);
+    const dataChunks: Buffer[] = [];
+    for (const stream of streams) {
+        const alignedOffset = align4(offset);
+        dataChunks.push(Buffer.alloc(alignedOffset - offset));
+        dataChunks.push(stream.data);
+        offset = alignedOffset + stream.data.length;
+    }
+
+    return Buffer.concat([header, dataStartPadding, ...dataChunks]);
+}
+
+function tableStream(rows: Record<number, Buffer[]>) {
+    // Emit a minimal #~ metadata table stream.
+    const tableIds = Object.keys(rows)
+        .map(Number)
+        .sort((left, right) => left - right);
+    const validTables = tableIds.reduce((mask, tableId) => mask | (1n << BigInt(tableId)), 0n);
+
+    return Buffer.concat([
+        u32(0), // Reserved
+        bytes(2, 0, 0, 1), // MajorVersion, MinorVersion, HeapSizes, Reserved
+        u64(validTables),
+        u64(0n), // Sorted table mask; the parser only needs the valid table mask and row order.
+        ...tableIds.map(tableId => u32(rows[tableId].length)),
+        ...tableIds.flatMap(tableId => rows[tableId]),
+    ]);
+}
+
+function methodSignature(returnType: Buffer, parameters: Buffer[], genericParameterCount = 0) {
+    return Buffer.concat([
+        bytes(genericParameterCount === 0 ? 0 : 0x10),
+        ...(genericParameterCount === 0 ? [] : [compressedUInt(genericParameterCount)]),
+        compressedUInt(parameters.length),
+        returnType,
+        ...parameters,
+    ]);
+}
+
+function typeDefOrRef(table: 'TypeDef' | 'TypeRef' | 'TypeSpec', row: number) {
+    return compressedUInt((row << 2) | (table === 'TypeDef' ? 0 : table === 'TypeRef' ? 1 : 2));
+}
+
+function typeOrMethodDef(table: 'TypeDef' | 'MethodDef', row: number) {
+    return (row << 1) | (table === 'TypeDef' ? 0 : 1);
+}
+
+function genericInstance(kind: 'class' | 'valuetype', type: Buffer, args: Buffer[]) {
+    return Buffer.concat([bytes(0x15, kind === 'class' ? 0x12 : 0x11), type, compressedUInt(args.length), ...args]);
+}
+
+function szArray(element: Buffer) {
+    return Buffer.concat([bytes(0x1d), element]);
+}
+
+function mdArray(element: Buffer, rank: number, sizes: number[] = [], lowerBounds: number[] = []) {
+    return Buffer.concat([
+        bytes(0x14),
+        element,
+        compressedUInt(rank),
+        compressedUInt(sizes.length),
+        ...sizes.map(compressedUInt),
+        compressedUInt(lowerBounds.length),
+        ...lowerBounds.map(compressedSignedInt),
+    ]);
+}
+
+function byRef(element: Buffer) {
+    return Buffer.concat([bytes(0x10), element]);
+}
+
+function pointer(element: Buffer) {
+    return Buffer.concat([bytes(0x0f), element]);
+}
+
+function functionPointer(returnType: Buffer, parameters: Buffer[]) {
+    return Buffer.concat([bytes(0x1b), methodSignature(returnType, parameters)]);
+}
+
+function fieldSignature(type: Buffer) {
+    return Buffer.concat([bytes(0x06), type]);
+}
+
+function sequencePoints(points: Array<{offset: number; line: number | null; column?: number}>) {
+    // Emit a Portable PDB sequence-points blob.
+    const chunks = [compressedUInt(0)]; // The local-signature token
+    let previousOffset = 0;
+    let previousLine = 0;
+    let previousColumn = 0;
+    let hasPrevious = false;
+
+    for (const point of points) {
+        chunks.push(compressedUInt(hasPrevious ? point.offset - previousOffset : point.offset));
+        if (point.line === null) {
+            // Hidden sequence point: delta lines and delta columns are both zero, and no source span follows.
+            chunks.push(compressedUInt(0), compressedUInt(0));
+        } else {
+            // Visible points in this fixture are one-column spans on a single source line.
+            chunks.push(compressedUInt(0), compressedUInt(1));
+            if (hasPrevious) {
+                chunks.push(compressedSignedInt(point.line - previousLine));
+                chunks.push(compressedSignedInt((point.column ?? 1) - previousColumn));
+            } else {
+                chunks.push(compressedUInt(point.line), compressedUInt(point.column ?? 1));
+            }
+            previousLine = point.line;
+            previousColumn = point.column ?? 1;
+        }
+
+        previousOffset = point.offset;
+        hasPrevious = true;
+    }
+
+    return Buffer.concat(chunks);
+}
+
+function ecma335Fixture() {
+    // Build a tiny ECMA-335 metadata root plus matching portable-PDB metadata.
+    //
+    // The modeled user types are:
+    //   Examples.Program
+    //   Examples.Outer<TOuter>
+    //   Examples.Outer<TOuter>.Inner<TInner>
+    //   Examples.Point
+    //   Examples.TinyEnum : byte
+    //
+    // The method rows cover primitive element types, enum/value-type resolution, TypeSpec resolution,
+    // required/optional custom modifiers, sentinels, pinned types, nested generics, arrays, byrefs,
+    // pointers, function pointers, and method/type generic parameters.
+    const strings = new StringHeapBuilder();
+    const blobs = new BlobHeapBuilder();
+
+    // TypeSpec row 1: System.Collections.Generic.Dictionary<System.String, int>.
+    const dictionaryOfStringAndIntType = genericInstance('class', typeDefOrRef('TypeRef', 1), [
+        bytes(0x0e),
+        bytes(0x08),
+    ]);
+
+    // Shared Mix<TMethod> signature fragment:
+    // Dictionary<!0, Examples.Outer+Inner<!0, List<!!0[]>>>.
+    const dictionaryType = genericInstance('class', typeDefOrRef('TypeRef', 1), [
+        bytes(0x13, 0),
+        genericInstance('class', typeDefOrRef('TypeDef', 3), [
+            bytes(0x13, 0),
+            genericInstance('class', typeDefOrRef('TypeRef', 2), [szArray(bytes(0x1e, 0))]),
+        ]),
+    ]);
+
+    // Examples.Outer+Inner<!0, !1>[].
+    const innerArrayType = szArray(
+        genericInstance('class', typeDefOrRef('TypeDef', 3), [bytes(0x13, 0), bytes(0x13, 1)]),
+    );
+
+    // !!0[,] with explicit size/lower-bound payloads, so the parser must consume and ignore the
+    // array-shape metadata while preserving the rank.
+    const methodArrayType = mdArray(bytes(0x1e, 0), 2, [3, 4], [0, -1]);
+
+    // Value-type encodings used to verify TypeDef and enum-underlying-type resolution.
+    const pointType = Buffer.concat([bytes(0x11), typeDefOrRef('TypeDef', 4)]);
+    const tinyEnumType = Buffer.concat([bytes(0x11), typeDefOrRef('TypeDef', 5)]);
+
+    // TypeRef row 3 is System.Enum; this exercises class TypeDefOrRef decoding separately from the
+    // TinyEnum value-type path above.
+    const enumClassType = Buffer.concat([bytes(0x12), typeDefOrRef('TypeRef', 3)]);
+    const valueTupleType = genericInstance('valuetype', typeDefOrRef('TypeRef', 4), [bytes(0x0e), bytes(0x08)]);
+    const typeSpecDictionary = Buffer.concat([bytes(0x12), typeDefOrRef('TypeSpec', 1)]);
+
+    // void PrimitiveKitchenSink(bool, char, sbyte, byte, short, ushort, int, uint, long, ulong,
+    //                           float, double, string, nint, nuint, object, typedref)
+    const primitiveSignature = blobs.index(
+        methodSignature(bytes(0x01), [
+            bytes(0x02),
+            bytes(0x03),
+            bytes(0x04),
+            bytes(0x05),
+            bytes(0x06),
+            bytes(0x07),
+            bytes(0x08),
+            bytes(0x09),
+            bytes(0x0a),
+            bytes(0x0b),
+            bytes(0x0c),
+            bytes(0x0d),
+            bytes(0x0e),
+            bytes(0x18),
+            bytes(0x19),
+            bytes(0x1c),
+            bytes(0x16),
+        ]),
+    );
+
+    // Examples.Point EnumAndValueTypes(Examples.Point, Examples.TinyEnum), where TinyEnum resolves to byte.
+    const enumAndValueTypesSignature = blobs.index(methodSignature(pointType, [pointType, tinyEnumType]));
+
+    // Dictionary<string, int> TypeSpecAndModifiers(
+    //     modreq(System.Enum) long,
+    //     modopt(System.Enum) int,
+    //     sentinel string,
+    //     pinned object,
+    //     System.Enum,
+    //     System.ValueTuple<string, int>,
+    //     Dictionary<string, int>)
+    const typeSpecAndModifiersSignature = blobs.index(
+        methodSignature(typeSpecDictionary, [
+            Buffer.concat([bytes(0x1f), typeDefOrRef('TypeRef', 3), bytes(0x0a)]),
+            Buffer.concat([bytes(0x20), typeDefOrRef('TypeRef', 3), bytes(0x08)]),
+            Buffer.concat([bytes(0x41), bytes(0x0e)]),
+            Buffer.concat([bytes(0x45), bytes(0x1c)]),
+            enumClassType,
+            valueTupleType,
+            typeSpecDictionary,
+        ]),
+    );
+
+    // Dictionary<!0, Inner<!0, List<!!0[]>>> Mix<TMethod>(
+    //     Dictionary<!0, Inner<!0, List<!!0[]>>>,
+    //     Inner<!0, !1>[],
+    //     !!0[,],
+    //     byref !!0,
+    //     byref !0,
+    //     pointer int,
+    //     function pointer Dictionary<!0, Inner<!0, List<!!0[]>>>(byref !1, pointer !!0[], function pointer void()))
+    const mixSignature = blobs.index(
+        methodSignature(
+            dictionaryType,
+            [
+                dictionaryType,
+                innerArrayType,
+                methodArrayType,
+                byRef(bytes(0x1e, 0)),
+                byRef(bytes(0x13, 0)),
+                pointer(bytes(0x08)),
+                functionPointer(dictionaryType, [
+                    byRef(bytes(0x13, 1)),
+                    pointer(szArray(bytes(0x1e, 0))),
+                    functionPointer(bytes(0x01), []),
+                ]),
+            ],
+            1,
+        ),
+    );
+    const addSignature = blobs.index(methodSignature(bytes(0x08), [bytes(0x08), bytes(0x08)]));
+    const enumFieldSignature = blobs.index(fieldSignature(bytes(0x05)));
+    const typeSpecSignature = blobs.index(dictionaryOfStringAndIntType);
+    const assemblyTables = tableStream({
+        // TypeRef rows:
+        //   1. System.Collections.Generic.Dictionary`2
+        //   2. System.Collections.Generic.List`1
+        //   3. System.Enum
+        //   4. System.ValueTuple`2
+        1: [
+            Buffer.concat([
+                u16(0),
+                u16(strings.index('Dictionary`2')),
+                u16(strings.index('System.Collections.Generic')),
+            ]),
+            Buffer.concat([u16(0), u16(strings.index('List`1')), u16(strings.index('System.Collections.Generic'))]),
+            Buffer.concat([u16(0), u16(strings.index('Enum')), u16(strings.index('System'))]),
+            Buffer.concat([u16(0), u16(strings.index('ValueTuple`2')), u16(strings.index('System'))]),
+        ],
+        // TypeDef rows. MethodList ranges assign MethodDef rows 1-4 to Program and row 5 to Inner.
+        // FieldList ranges assign the value__ field to TinyEnum.
+        2: [
+            Buffer.concat([
+                u32(0),
+                u16(strings.index('Program')),
+                u16(strings.index('Examples')),
+                u16(0),
+                u16(1),
+                u16(1),
+            ]),
+            Buffer.concat([
+                u32(0),
+                u16(strings.index('Outer`1')),
+                u16(strings.index('Examples')),
+                u16(0),
+                u16(1),
+                u16(5),
+            ]),
+            Buffer.concat([u32(0), u16(strings.index('Inner`1')), u16(0), u16(0), u16(1), u16(5)]),
+            Buffer.concat([
+                u32(0),
+                u16(strings.index('Point')),
+                u16(strings.index('Examples')),
+                u16(0),
+                u16(1),
+                u16(6),
+            ]),
+            Buffer.concat([
+                u32(0),
+                u16(strings.index('TinyEnum')),
+                u16(strings.index('Examples')),
+                u16((3 << 2) | 1),
+                u16(1),
+                u16(6),
+            ]),
+        ],
+        // Field row 1: TinyEnum.value__ : byte. This lets enum value types collapse to their
+        // underlying primitive signature in parser output.
+        4: [Buffer.concat([u16(0), u16(strings.index('value__')), u16(enumFieldSignature)])],
+        // MethodDef rows:
+        //   1. Program.Add
+        //   2. Program.PrimitiveKitchenSink
+        //   3. Program.EnumAndValueTypes
+        //   4. Program.TypeSpecAndModifiers
+        //   5. Outer.Inner.Mix
+        6: [
+            Buffer.concat([u32(0), u16(0), u16(0), u16(strings.index('Add')), u16(addSignature), u16(1)]),
+            Buffer.concat([
+                u32(0),
+                u16(0),
+                u16(0),
+                u16(strings.index('PrimitiveKitchenSink')),
+                u16(primitiveSignature),
+                u16(1),
+            ]),
+            Buffer.concat([
+                u32(0),
+                u16(0),
+                u16(0),
+                u16(strings.index('EnumAndValueTypes')),
+                u16(enumAndValueTypesSignature),
+                u16(1),
+            ]),
+            Buffer.concat([
+                u32(0),
+                u16(0),
+                u16(0),
+                u16(strings.index('TypeSpecAndModifiers')),
+                u16(typeSpecAndModifiersSignature),
+                u16(1),
+            ]),
+            Buffer.concat([u32(0), u16(0), u16(0), u16(strings.index('Mix')), u16(mixSignature), u16(1)]),
+        ],
+        // TypeSpec row 1 stores Dictionary<string, int>.
+        27: [u16(typeSpecSignature)],
+        // NestedClass row: TypeDef row 3 (Inner) is nested inside TypeDef row 2 (Outer).
+        41: [Buffer.concat([u16(3), u16(2)])],
+        // GenericParam rows:
+        //   Outer<TOuter>
+        //   Inner has !0/TOuter and !1/TInner in scope for nested generic signatures
+        //   Mix<TMethod>
+        42: [
+            Buffer.concat([u16(0), u16(0), u16(typeOrMethodDef('TypeDef', 2)), u16(strings.index('TOuter'))]),
+            Buffer.concat([u16(0), u16(0), u16(typeOrMethodDef('TypeDef', 3)), u16(strings.index('TOuter'))]),
+            Buffer.concat([u16(1), u16(0), u16(typeOrMethodDef('TypeDef', 3)), u16(strings.index('TInner'))]),
+            Buffer.concat([u16(0), u16(0), u16(typeOrMethodDef('MethodDef', 5)), u16(strings.index('TMethod'))]),
+        ],
+    });
+    const assembly = metadataRoot([
+        {name: '#~', data: assemblyTables},
+        {name: '#Strings', data: strings.toBuffer()},
+        {name: '#Blob', data: blobs.toBuffer()},
+    ]);
+
+    const pdbBlobs = new BlobHeapBuilder();
+    // Portable PDB sequence points keyed by MethodDebugInformation row number, which matches the
+    // MethodDef row id. Add also includes a hidden sequence point at IL offset 3.
+    const addSequencePoints = pdbBlobs.index(
+        sequencePoints([
+            {offset: 0, line: 46, column: 13},
+            {offset: 3, line: null},
+        ]),
+    );
+    const mixSequencePoints = pdbBlobs.index(
+        sequencePoints([
+            {offset: 0, line: 116, column: 17},
+            {offset: 32, line: 117, column: 17},
+            {offset: 40, line: 118, column: 17},
+            {offset: 54, line: 119, column: 17},
+        ]),
+    );
+    const primitiveSequencePoints = pdbBlobs.index(sequencePoints([{offset: 0, line: 80, column: 9}]));
+    const enumAndValueTypesSequencePoints = pdbBlobs.index(sequencePoints([{offset: 0, line: 90, column: 9}]));
+    const typeSpecAndModifiersSequencePoints = pdbBlobs.index(sequencePoints([{offset: 0, line: 100, column: 9}]));
+    const pdbTables = tableStream({
+        // Document row 1 is intentionally empty because the parser currently only preserves line/column.
+        48: [Buffer.concat([u16(0), u16(0), u16(0), u16(0)])],
+        // MethodDebugInformation rows 1-5 correspond to MethodDef rows 1-5 above.
+        49: [
+            Buffer.concat([u16(1), u16(addSequencePoints)]),
+            Buffer.concat([u16(1), u16(primitiveSequencePoints)]),
+            Buffer.concat([u16(1), u16(enumAndValueTypesSequencePoints)]),
+            Buffer.concat([u16(1), u16(typeSpecAndModifiersSequencePoints)]),
+            Buffer.concat([u16(1), u16(mixSequencePoints)]),
+        ],
+    });
+    const pdb = metadataRoot([
+        // The type-system table mask is empty; this fixture keeps all type-system rows in the assembly metadata.
+        {name: '#Pdb', data: Buffer.concat([Buffer.alloc(24), u64(0n)])},
+        {name: '#~', data: pdbTables},
+        {name: '#Blob', data: pdbBlobs.toBuffer()},
+    ]);
+
+    return {assembly, pdb};
+}
+
+const methodArrayType = arrayType(genericParameter('!!0'));
+const nestedInnerWithListType = referenceType('Examples.Outer+Inner', [
+    genericParameter('!0'),
+    referenceType('System.Collections.Generic.List', [methodArrayType]),
+]);
+const complexDictionaryType = referenceType('System.Collections.Generic.Dictionary', [
+    genericParameter('!0'),
+    nestedInnerWithListType,
+]);
+
+const source = (line: number, column: number): AsmResultSource => ({file: null, line, column});
+
+function findLine(result: ParsedAsmResult, text: string) {
+    return result.asm.find(line => line.text.trim() === text);
+}
+
+function requestedMethod(typeArguments: string[] = [], methodArguments: string[] = []): DotNetMethodKey {
+    return {
+        typeName: 'Example.Box',
+        typeArguments,
+        methodName: 'Project',
+        methodArguments,
+        parameters: [],
+        returnType: '',
+    };
+}
+
+const sourceMapping: DotNetSourceMapping = [
+    {
+        method: {
+            typeName: 'Examples.Program',
+            typeArguments: [],
+            methodName: 'Add',
+            methodArguments: [],
+            parameters: ['int', 'int'],
+            parameterTypes: [valueType('int'), valueType('int')],
+            returnType: 'int',
+            returnTypeSignature: valueType('int'),
+        },
+        offsets: {
+            0: source(46, 13),
+        },
+    },
+    {
+        method: {
+            typeName: 'Examples.Box',
+            typeArguments: ['!0'],
+            methodName: 'Identity',
+            methodArguments: ['!!0'],
+            parameters: ['!!0'],
+            parameterTypes: [genericParameter('!!0')],
+            returnType: '!!0',
+            returnTypeSignature: genericParameter('!!0'),
+        },
+        offsets: {
+            0: source(62, 13),
+            16: source(63, 13),
+        },
+    },
+    {
+        method: {
+            typeName: 'Examples.Counter',
+            typeArguments: [],
+            methodName: 'Increment',
+            methodArguments: [],
+            parameters: [],
+            parameterTypes: [],
+            returnType: '',
+            returnTypeSignature: valueType('void'),
+        },
+        offsets: {
+            0: source(74, 13),
+            14: source(75, 9),
+        },
+    },
+    {
+        method: {
+            typeName: 'Examples.Outer+Inner',
+            typeArguments: ['!0', '!1'],
+            methodName: 'Mix',
+            methodArguments: ['!!0'],
+            parameters: [
+                'System.Collections.Generic.Dictionary[!0,Examples.Outer+Inner[!0,System.Collections.Generic.List[!!0[]]]]',
+                'Examples.Outer+Inner[!0,!1][]',
+                '!!0[,]',
+                'byref',
+                'byref',
+                'ptr',
+                'ptr',
+            ],
+            parameterTypes: [
+                complexDictionaryType,
+                arrayType(referenceType('Examples.Outer+Inner', [genericParameter('!0'), genericParameter('!1')])),
+                arrayType(genericParameter('!!0'), '[,]'),
+                valueType('byref'),
+                valueType('byref'),
+                valueType('ptr'),
+                valueType('ptr'),
+            ],
+            returnType:
+                'System.Collections.Generic.Dictionary[!0,Examples.Outer+Inner[!0,System.Collections.Generic.List[!!0[]]]]',
+            returnTypeSignature: complexDictionaryType,
+        },
+        offsets: {
+            0: source(116, 17),
+            32: source(117, 17),
+            40: source(118, 17),
+            54: source(119, 17),
+        },
+    },
+];
+
+const addDisasm = [
+    '; Assembly listing for method Examples.Program:Add(int,int):int (FullOpts)',
+    'G_M34084_IG01:  ;; offset=0x0000',
+    'G_M34084_IG02:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x000[E--]',
+    '       lea      eax, [rcx+rdx]',
+    'G_M34084_IG03:  ;; offset=0x0003',
+    '       ret',
+].join('\n');
+
+const identityDisasm = [
+    '; Assembly listing for method Examples.Box`1[System.__Canon]:Identity[int](int):int:this (FullOpts)',
+    'G_M20789_IG01:  ;; offset=0x0000',
+    'G_M20789_IG02:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x000[E--]',
+    '       mov      rax, gword ptr [rcx+0x08]',
+    '                            ; INLRT @ 0x010[E--]',
+    '       mov      eax, r8d',
+    'G_M20789_IG03:  ;; offset=0x0007',
+    '       ret',
+].join('\n');
+
+const inlineChainDisasm = [
+    '; Assembly listing for method Examples.Box`1[System.__Canon]:Identity[int](int):int:this (FullOpts)',
+    'G_M29733_IG01:  ;; offset=0x0000',
+    '                            ; INL01 @ 0x000[E--] <- INLRT @ 0x010[E--]',
+    '       mov      eax, r8d',
+    'G_M29733_IG02:  ;; offset=0x0003',
+    '       ret',
+].join('\n');
+
+const inlineChainUnknownRootDisasm = [
+    '; Assembly listing for method Examples.Box`1[System.__Canon]:Identity[int](int):int:this (FullOpts)',
+    'G_M53476_IG01:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x000[E--]',
+    '       mov      rax, gword ptr [rcx+0x08]',
+    '                            ; INL01 @ 0x000[E--] <- INLRT @ ???',
+    '       mov      eax, r8d',
+    'G_M53476_IG02:  ;; offset=0x0007',
+    '       ret',
+].join('\n');
+
+const incrementDisasm = [
+    '; Assembly listing for method Examples.Counter:Increment():this (FullOpts)',
+    'G_M8093_IG01:  ;; offset=0x0000',
+    'G_M8093_IG02:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x000[E--]',
+    '       inc      dword ptr [rcx+0x08]',
+    'G_M8093_IG03:  ;; offset=0x0003',
+    '                            ; INLRT @ 0x00E[E--]',
+    '       ret',
+].join('\n');
+
+const complexSignatureDisasm = [
+    '; Assembly listing for method Examples.Outer`1+Inner`1[System.__Canon,int]:Mix[System.__Canon](System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon],System.__Canon[],System.__Canon[,],byref,byref,ptr,ptr):System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon] (FullOpts)',
+    'G_M48429_IG01:  ;; offset=0x0000',
+    '       push     r14',
+    'G_M48429_IG02:  ;; offset=0x0018',
+    '                            ; INLRT @ 0x000[E--]',
+    '       mov      ebp, dword ptr [rdi]',
+    '       mov      r14d, dword ptr [rsi+0x38]',
+    '       mov      rax, qword ptr [rsp+0x88]',
+    '       call     rax',
+    '                            ; INLRT @ 0x020[E--]',
+    '       xor      rcx, rcx',
+    '       mov      rdi, bword ptr [rsp+0x78]',
+    '       mov      gword ptr [rdi], rcx',
+    'G_M48429_IG03:  ;; offset=0x004A',
+    '                            ; INLRT @ 0x028[E--]',
+    '       sub      ecx, dword ptr [rbx+0x18]',
+    '       mov      rdx, gword ptr [rbx+8*rcx+0x20]',
+    '       mov      rcx, bword ptr [rsp+0x70]',
+    '       call     CORINFO_HELP_CHECKED_ASSIGN_REF',
+    '                            ; INLRT @ 0x036[E--]',
+    '       mov      rax, rsi',
+    'G_M48429_IG04:  ;; offset=0x0075',
+    '       ret',
+].join('\n');
+
+describe('DotNetAsmParser', () => {
+    it('maps source lines from debug-JIT INLRT offsets', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(addDisasm, filters());
+
+        expect(result.labelDefinitions).toMatchObject({
+            'Examples.Program:Add(int,int):int': 1,
+            G_M34084_IG01: 2,
+            G_M34084_IG02: 3,
+            G_M34084_IG03: 6,
+        });
+        expect(findLine(result, 'lea      eax, [rcx+rdx]')?.source).toEqual(source(46, 13));
+        expect(findLine(result, 'ret')?.source).toBeNull();
+    });
+
+    it('keeps source mapping attached when comment-only filtering removes INLRT lines', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(identityDisasm, filters({commentOnly: true}));
+
+        expect(result.asm.some(line => line.text.includes('INLRT'))).toBe(false);
+        expect(findLine(result, 'mov      rax, gword ptr [rcx+0x08]')?.source).toEqual(source(62, 13));
+        expect(findLine(result, 'mov      eax, r8d')?.source).toEqual(source(63, 13));
+    });
+
+    it('matches shared-generic JIT method names against metadata generic parameters', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(identityDisasm, filters());
+
+        expect(findLine(result, 'mov      rax, gword ptr [rcx+0x08]')?.source).toEqual(source(62, 13));
+        expect(findLine(result, 'mov      eax, r8d')?.source).toEqual(source(63, 13));
+    });
+
+    it('uses the root offset from recursive inline debug-info chains', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(inlineChainDisasm, filters());
+
+        expect(findLine(result, 'mov      eax, r8d')?.source).toEqual(source(63, 13));
+    });
+
+    it('does not leak source mapping through inline debug-info chains with unknown root offsets', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(inlineChainUnknownRootDisasm, filters());
+        const filteredResult = new DotNetAsmParser(sourceMapping).process(
+            inlineChainUnknownRootDisasm,
+            filters({commentOnly: true}),
+        );
+
+        expect(findLine(result, 'mov      rax, gword ptr [rcx+0x08]')?.source).toEqual(source(62, 13));
+        expect(findLine(result, 'mov      eax, r8d')?.source).toBeNull();
+        expect(findLine(filteredResult, 'mov      eax, r8d')?.source).toBeNull();
+    });
+
+    it('matches instance void methods that end with this in JIT disassembly', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(incrementDisasm, filters());
+
+        expect(findLine(result, 'inc      dword ptr [rcx+0x08]')?.source).toEqual(source(74, 13));
+        expect(findLine(result, 'ret')?.source).toEqual(source(75, 9));
+    });
+
+    it('matches nested generic, byref, pointer, and function-pointer signatures', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(complexSignatureDisasm, filters());
+
+        expect(findLine(result, 'call     rax')?.source).toEqual(source(116, 17));
+        expect(findLine(result, 'mov      gword ptr [rdi], rcx')?.source).toEqual(source(117, 17));
+        expect(findLine(result, 'sub      ecx, dword ptr [rbx+0x18]')?.source).toEqual(source(118, 17));
+        expect(findLine(result, 'mov      rax, rsi')?.source).toEqual(source(119, 17));
+    });
+});
+
+describe('DotNetPdbParser', () => {
+    it('parses ECMA-335 method signatures and portable-PDB sequence points', () => {
+        const fixture = ecma335Fixture();
+        const parsed = new DotNetPdbParser(fixture.assembly, fixture.pdb).parse();
+        const method = (name: string) => parsed.find(entry => entry.method.methodName === name)!;
+
+        expect(method('Add')).toMatchObject({
+            method: {
+                typeName: 'Examples.Program',
+                methodName: 'Add',
+                parameters: ['int', 'int'],
+                returnType: 'int',
+            },
+            offsets: {
+                0: source(46, 13),
+                3: null,
+            },
+        });
+
+        expect(method('PrimitiveKitchenSink').method).toMatchObject({
+            parameters: [
+                'bool',
+                'char',
+                'sbyte',
+                'byte',
+                'short',
+                'ushort',
+                'int',
+                'uint',
+                'long',
+                'ulong',
+                'float',
+                'double',
+                'System.String',
+                'nint',
+                'nuint',
+                'System.Object',
+                'System.TypedReference',
+            ],
+            returnType: '',
+        });
+        expect(method('PrimitiveKitchenSink').offsets).toEqual({0: source(80, 9)});
+
+        expect(method('EnumAndValueTypes').method).toMatchObject({
+            parameters: ['Examples.Point', 'byte'],
+            returnType: 'Examples.Point',
+        });
+        expect(method('EnumAndValueTypes').method.parameterTypes).toMatchObject([
+            {name: 'Examples.Point', typeKind: 'value'},
+            {name: 'byte', typeKind: 'value'},
+        ]);
+
+        expect(method('TypeSpecAndModifiers').method).toMatchObject({
+            parameters: [
+                'long',
+                'int',
+                'System.String',
+                'System.Object',
+                'System.Enum',
+                'System.ValueTuple[System.String,int]',
+                'System.Collections.Generic.Dictionary[System.String,int]',
+            ],
+            returnType: 'System.Collections.Generic.Dictionary[System.String,int]',
+        });
+
+        expect(method('Mix')).toMatchObject({
+            method: {
+                typeName: 'Examples.Outer+Inner',
+                typeArguments: ['!0', '!1'],
+                methodName: 'Mix',
+                methodArguments: ['!!0'],
+                parameters: [
+                    'System.Collections.Generic.Dictionary[!0,Examples.Outer+Inner[!0,System.Collections.Generic.List[!!0[]]]]',
+                    'Examples.Outer+Inner[!0,!1][]',
+                    '!!0[,]',
+                    'byref',
+                    'byref',
+                    'ptr',
+                    'ptr',
+                ],
+                returnType:
+                    'System.Collections.Generic.Dictionary[!0,Examples.Outer+Inner[!0,System.Collections.Generic.List[!!0[]]]]',
+            },
+            offsets: {
+                0: source(116, 17),
+                32: source(117, 17),
+                40: source(118, 17),
+                54: source(119, 17),
+            },
+        });
+    });
+});
+
+describe('DotNetPdbParser helpers', () => {
+    it('canonicalizes generic signatures using the requested JIT method arguments', () => {
+        const signature = referenceType('System.Collections.Generic.Dictionary', [
+            genericParameter('!0'),
+            valueType('int'),
+        ]);
+
+        expect(getCanonicalTypeSignature(signature, requestedMethod(['System.String'], ['int'])).text).toBe(
+            'System.Collections.Generic.Dictionary[System.String,int]',
+        );
+    });
+
+    it('canonicalizes deeply nested type and method generic parameters', () => {
+        const signature = referenceType('System.Collections.Generic.Dictionary', [
+            referenceType('Examples.Outer+Inner', [
+                genericParameter('!0'),
+                referenceType('System.Collections.Generic.List', [arrayType(genericParameter('!!0'))]),
+            ]),
+            arrayType(referenceType('System.ValueTuple', [genericParameter('!1'), genericParameter('!!1')]), '[,]'),
+        ]);
+
+        const result = getCanonicalTypeSignature(
+            signature,
+            requestedMethod(['System.String', 'nint'], ['int', 'System.Object']),
+        );
+
+        expect(result).toEqual({
+            text: 'System.Collections.Generic.Dictionary[Examples.Outer+Inner[System.String,System.Collections.Generic.List[int[]]],System.ValueTuple[nint,System.Object][,]]',
+            containsSharedGenericReference: false,
+        });
+    });
+
+    it('preserves array suffixes around canonical generic elements', () => {
+        const signature = arrayType(
+            referenceType('Examples.Outer+Inner', [genericParameter('!0'), genericParameter('!!0')]),
+            '[,,]',
+        );
+
+        expect(getCanonicalTypeSignature(signature, requestedMethod(['System.String'], ['int'])).text).toBe(
+            'Examples.Outer+Inner[System.String,int][,,]',
+        );
+    });
+
+    it('leaves unmatched generic parameters in canonical text', () => {
+        const signature = referenceType('Examples.Missing', [genericParameter('!2'), genericParameter('!!3')]);
+
+        expect(getCanonicalTypeSignature(signature, requestedMethod(['System.String'], ['int'])).text).toBe(
+            'Examples.Missing[!2,!!3]',
+        );
+    });
+
+    it('collapses shared generic references inside generic reference-type arguments', () => {
+        const signature = referenceType('System.Collections.Generic.Dictionary', [
+            valueType('int'),
+            referenceType('Examples.Box', [arrayType(genericParameter('!0'))]),
+        ]);
+
+        expect(getCanonicalTypeSignature(signature, requestedMethod(['System.__Canon'])).text).toBe(
+            'System.Collections.Generic.Dictionary[int,System.__Canon]',
+        );
+    });
+
+    it('can preserve shared generic reference structure when collapse is disabled', () => {
+        const signature = referenceType('System.Collections.Generic.Dictionary', [
+            valueType('int'),
+            referenceType('Examples.Box', [arrayType(genericParameter('!0'))]),
+        ]);
+
+        expect(getCanonicalTypeSignature(signature, requestedMethod(['System.__Canon']), false, false)).toEqual({
+            text: 'System.Collections.Generic.Dictionary[int,Examples.Box[System.__Canon[]]]',
+            containsSharedGenericReference: true,
+        });
+    });
+});

--- a/test/dotnet-parser-tests.ts
+++ b/test/dotnet-parser-tests.ts
@@ -695,6 +695,54 @@ const sourceMapping: DotNetSourceMapping = [
             54: source(119, 17),
         },
     },
+    {
+        method: {
+            typeName: 'MappingSample+<RunAsync>d__8',
+            typeArguments: ['!0', '!1', '!2'],
+            methodName: 'MoveNext',
+            methodArguments: [],
+            parameters: [],
+            parameterTypes: [],
+            returnType: '',
+            returnTypeSignature: valueType('void'),
+        },
+        offsets: {
+            24: source(104, 9),
+            54: source(106, 9),
+        },
+    },
+    {
+        method: {
+            typeName: 'MappingSample+<NormalizeAsync>d__10',
+            typeArguments: ['!0'],
+            methodName: 'MoveNext',
+            methodArguments: [],
+            parameters: [],
+            parameterTypes: [],
+            returnType: '',
+            returnTypeSignature: valueType('void'),
+        },
+        offsets: {
+            58: source(187, 29),
+            109: source(190, 13),
+        },
+    },
+    {
+        method: {
+            typeName: 'MappingSample+<Enumerate>d__9',
+            typeArguments: ['!0', '!1'],
+            methodName: 'MoveNext',
+            methodArguments: [],
+            parameters: [],
+            parameterTypes: [],
+            returnType: 'bool',
+            returnTypeSignature: valueType('bool'),
+        },
+        offsets: {
+            26: source(165, 14),
+            56: source(167, 13),
+        },
+    },
 ];
 
 const addDisasm = [
@@ -739,6 +787,15 @@ const inlineChainUnknownRootDisasm = [
     '       ret',
 ].join('\n');
 
+const inlineChainUnknownChildDisasm = [
+    '; Assembly listing for method MappingSample`1+<Enumerate>d__9`1[System.__Canon,int]:MoveNext():bool:this (FullOpts)',
+    'G_M49354_IG01:  ;; offset=0x0000',
+    '                            ; INL58 @ 0x009[E--] <- INL57 @ 0x020[E--] <- INL46 @ ??? <- INLRT @ 0x038[E--]',
+    '       mov      rcx, gword ptr [rbx+0x08]',
+    'G_M49354_IG02:  ;; offset=0x0007',
+    '       ret',
+].join('\n');
+
 const incrementDisasm = [
     '; Assembly listing for method Examples.Counter:Increment():this (FullOpts)',
     'G_M8093_IG01:  ;; offset=0x0000',
@@ -773,6 +830,39 @@ const complexSignatureDisasm = [
     '                            ; INLRT @ 0x036[E--]',
     '       mov      rax, rsi',
     'G_M48429_IG04:  ;; offset=0x0075',
+    '       ret',
+].join('\n');
+
+const iteratorStateMachineDisasm = [
+    '; Assembly listing for method MappingSample`1+<Enumerate>d__9`1[System.__Canon,int]:MoveNext():bool:this (FullOpts)',
+    'G_M49354_IG01:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x01A[E--]',
+    '       xor      ecx, ecx',
+    '                            ; INLRT @ 0x038[E--]',
+    '       mov      rcx, gword ptr [rbx+0x08]',
+    'G_M49354_IG02:  ;; offset=0x0008',
+    '       ret',
+].join('\n');
+
+const asyncIteratorStateMachineDisasm = [
+    '; Assembly listing for method MappingSample`1+<NormalizeAsync>d__10[System.__Canon]:MoveNext():this (FullOpts)',
+    'G_M1647_IG01:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x03A[E--]',
+    '       mov      rcx, gword ptr [rcx+0x10]',
+    '                            ; INLRT @ 0x06D[E--]',
+    '       mov      byte  ptr [rbp-0x28], 0',
+    'G_M1647_IG02:  ;; offset=0x0008',
+    '       ret',
+].join('\n');
+
+const asyncMethodStateMachineDisasm = [
+    '; Assembly listing for method MappingSample`1+<RunAsync>d__8`2[System.__Canon,IntParser,int]:MoveNext():this (FullOpts)',
+    'G_M33439_IG01:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x018[E--]',
+    '       cmp      gword ptr [rsi], 0',
+    '                            ; INLRT @ 0x036[E--]',
+    '       xor      ecx, ecx',
+    'G_M33439_IG02:  ;; offset=0x0008',
     '       ret',
 ].join('\n');
 
@@ -823,6 +913,12 @@ describe('DotNetAsmParser', () => {
         expect(findLine(filteredResult, 'mov      eax, r8d')?.source).toBeNull();
     });
 
+    it('uses the root offset when only an intermediate inline frame has an unknown offset', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(inlineChainUnknownChildDisasm, filters());
+
+        expect(findLine(result, 'mov      rcx, gword ptr [rbx+0x08]')?.source).toEqual(source(167, 13));
+    });
+
     it('matches instance void methods that end with this in JIT disassembly', () => {
         const result = new DotNetAsmParser(sourceMapping).process(incrementDisasm, filters());
 
@@ -837,6 +933,22 @@ describe('DotNetAsmParser', () => {
         expect(findLine(result, 'mov      gword ptr [rdi], rcx')?.source).toEqual(source(117, 17));
         expect(findLine(result, 'sub      ecx, dword ptr [rbx+0x18]')?.source).toEqual(source(118, 17));
         expect(findLine(result, 'mov      rax, rsi')?.source).toEqual(source(119, 17));
+    });
+
+    it('matches compiler-generated iterator and async state-machine MoveNext methods', () => {
+        const iteratorResult = new DotNetAsmParser(sourceMapping).process(iteratorStateMachineDisasm, filters());
+        const asyncIteratorResult = new DotNetAsmParser(sourceMapping).process(
+            asyncIteratorStateMachineDisasm,
+            filters(),
+        );
+        const asyncMethodResult = new DotNetAsmParser(sourceMapping).process(asyncMethodStateMachineDisasm, filters());
+
+        expect(findLine(iteratorResult, 'xor      ecx, ecx')?.source).toEqual(source(165, 14));
+        expect(findLine(iteratorResult, 'mov      rcx, gword ptr [rbx+0x08]')?.source).toEqual(source(167, 13));
+        expect(findLine(asyncIteratorResult, 'mov      rcx, gword ptr [rcx+0x10]')?.source).toEqual(source(187, 29));
+        expect(findLine(asyncIteratorResult, 'mov      byte  ptr [rbp-0x28], 0')?.source).toEqual(source(190, 13));
+        expect(findLine(asyncMethodResult, 'cmp      gword ptr [rsi], 0')?.source).toEqual(source(104, 9));
+        expect(findLine(asyncMethodResult, 'xor      ecx, ecx')?.source).toEqual(source(106, 9));
     });
 });
 

--- a/test/dotnet-parser-tests.ts
+++ b/test/dotnet-parser-tests.ts
@@ -594,6 +594,9 @@ const complexDictionaryType = referenceType('System.Collections.Generic.Dictiona
     genericParameter('!0'),
     nestedInnerWithListType,
 ]);
+const asyncRunResultType = referenceType('Result', [
+    referenceType('System.ValueTuple', [valueType('int'), referenceType('System.String')]),
+]);
 
 const source = (line: number, column: number): AsmResultSource => ({file: null, line, column});
 
@@ -693,6 +696,25 @@ const sourceMapping: DotNetSourceMapping = [
             32: source(117, 17),
             40: source(118, 17),
             54: source(119, 17),
+        },
+    },
+    {
+        method: {
+            typeName: 'MappingSample',
+            typeArguments: ['!0'],
+            methodName: 'RunAsync',
+            methodArguments: ['!!0', '!!1'],
+            parameters: ['System.Collections.Generic.IEnumerable[System.String]', 'System.Threading.CancellationToken'],
+            parameterTypes: [
+                referenceType('System.Collections.Generic.IEnumerable', [referenceType('System.String')]),
+                valueType('System.Threading.CancellationToken'),
+            ],
+            returnType: 'System.Threading.Tasks.ValueTask[Result[System.ValueTuple[int,System.String]]]',
+            returnTypeSignature: referenceType('System.Threading.Tasks.ValueTask', [asyncRunResultType]),
+        },
+        offsets: {
+            0: source(214, 9),
+            16: source(216, 9),
         },
     },
     {
@@ -866,6 +888,17 @@ const asyncMethodStateMachineDisasm = [
     '       ret',
 ].join('\n');
 
+const runtimeAsyncMethodDisasm = [
+    '; Assembly listing for method MappingSample`1[System.__Canon]:RunAsync[IntParser,int](System.Collections.Generic.IEnumerable`1[System.String],System.Threading.CancellationToken):Result`1[System.ValueTuple`2[int,System.String]]:this (FullOpts)',
+    'G_M40702_IG01:  ;; offset=0x0000',
+    '                            ; INLRT @ 0x000[E--]',
+    '       call     CORINFO_HELP_GETSHARED_GCSTATIC_BASE',
+    '                            ; INLRT @ 0x010[E--]',
+    '       mov      rcx, gword ptr [rax+0x08]',
+    'G_M40702_IG02:  ;; offset=0x0008',
+    '       ret',
+].join('\n');
+
 describe('DotNetAsmParser', () => {
     it('maps source lines from debug-JIT INLRT offsets', () => {
         const result = new DotNetAsmParser(sourceMapping).process(addDisasm, filters());
@@ -949,6 +982,13 @@ describe('DotNetAsmParser', () => {
         expect(findLine(asyncIteratorResult, 'mov      byte  ptr [rbp-0x28], 0')?.source).toEqual(source(190, 13));
         expect(findLine(asyncMethodResult, 'cmp      gword ptr [rsi], 0')?.source).toEqual(source(104, 9));
         expect(findLine(asyncMethodResult, 'xor      ecx, ecx')?.source).toEqual(source(106, 9));
+    });
+
+    it('should not take the return type into account when matching methods', () => {
+        const result = new DotNetAsmParser(sourceMapping).process(runtimeAsyncMethodDisasm, filters());
+
+        expect(findLine(result, 'call     CORINFO_HELP_GETSHARED_GCSTATIC_BASE')?.source).toEqual(source(214, 9));
+        expect(findLine(result, 'mov      rcx, gword ptr [rax+0x08]')?.source).toEqual(source(216, 9));
     });
 });
 


### PR DESCRIPTION
This PR implements the source mapping for .NET compilers (C#, F#, VB.NET and IL), supports CoreCLR, Crossgen2 and NativeAOT compilers.

- Add a parser that walks ECMA-335 metadata and Portable PDB sequence points to build IL-offset-to-source mappings for .NET methods
- Load PDBs emitted by the .NET compiler after building the dll, and then save the source mapping in the result
- Extend the .NET asm parser to match disassembly method signatures, including generic types, generic methods, and inline root offsets, so emitted asm lines inherit the correct source locations
- Use debug info emitted by the JIT `INLRT @ 0x##` as anchors to match the offset

Showcase:

![image1](https://github.com/user-attachments/assets/5309fe70-be87-4f94-b70c-21bb91f745be)

![image2](https://github.com/user-attachments/assets/9d15741e-08ff-4f20-8a32-efa0d8307dea)