### PR TITLE
✨ phd.embed library alternative to <embed> header

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6496,6 +6496,13 @@ libs.perl.versions.5422.options=-D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-a
 libs.perl.versions.5422.libpath=/opt/compiler-explorer/perl-5.42.2/lib/5.42.2/x86_64-linux-thread-multi/CORE
 libs.perl.versions.5422.liblink=perl-5.42.2
 
+libs.phd-embed.name=phd.embed
+libs.phd-embed.description=p1040 Library support header for the std::embed functionality
+libs.phd-embed.versions=main
+libs.phd-embed.url=https://github.com/ThePhD/embed
+libs.phd-embed.versions.main.version=main
+libs.phd-embed.versions.main.path=/opt/compiler-explorer/libs/phd/embed/main/include
+
 libs.pipes.name=Pipes
 libs.pipes.versions=trunk
 libs.pipes.url=https://github.com/joboccara/Pipes

--- a/etc/config/circle.amazon.properties
+++ b/etc/config/circle.amazon.properties
@@ -894,6 +894,13 @@ libs.pegtl.versions.trunk.path=/opt/compiler-explorer/libs/PEGTL/trunk/include
 libs.pegtl.versions.280.version=2.8.0
 libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
 
+libs.phd-embed.name=phd.embed
+libs.phd-embed.description=p1040 Library support header for the std::embed functionality
+libs.phd-embed.versions=main
+libs.phd-embed.url=https://github.com/ThePhD/embed
+libs.phd-embed.versions.main.version=main
+libs.phd-embed.versions.main.path=/opt/compiler-explorer/libs/phd/embed/main/include
+
 libs.pipes.name=Pipes
 libs.pipes.versions=trunk
 libs.pipes.url=https://github.com/joboccara/Pipes

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -2045,6 +2045,13 @@ libs.pegtl.versions.trunk.path=/opt/compiler-explorer/libs/PEGTL/trunk/include
 libs.pegtl.versions.280.version=2.8.0
 libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
 
+libs.phd-embed.name=phd.embed
+libs.phd-embed.description=p1040 Library support header for the std::embed functionality
+libs.phd-embed.versions=main
+libs.phd-embed.url=https://github.com/ThePhD/embed
+libs.phd-embed.versions.main.version=main
+libs.phd-embed.versions.main.path=/opt/compiler-explorer/libs/phd/embed/main/include
+
 libs.pipes.name=Pipes
 libs.pipes.versions=trunk
 libs.pipes.url=https://github.com/joboccara/Pipes


### PR DESCRIPTION
Adds the phd.embed library, which is an alternative for <embed> while the whole C++2d/C++29 flag situation irons out in implementations!

Should be painless to add.

- [x] ~~https://github.com/compiler-explorer/infra/pull/2088~~
- [x] https://github.com/compiler-explorer/infra/pull/2102