### PR TITLE
✨ C and C++ versions of GCC (with modifications to Clang) to allow both to be used

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -245,6 +245,12 @@ compiler.gcc-embed-trunk.semver=(std::embed)
 compiler.gcc-embed-trunk.isNightly=true
 compiler.gcc-embed-trunk.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.gcc-embed-trunk.hidden=true
+compiler.gcc_thephd_dev.exe=/opt/compiler-explorer/gcc-gcc.thephd.dev/bin/g++
+compiler.gcc_thephd_dev.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.gcc_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.gcc_thephd_dev.semver=(thephd.dev)
+compiler.gcc_thephd_dev.isNightly=true
+compiler.gcc_thephd_dev.notification=Generic, std::embed, Transparent Function Aliases, and more in this custom gcc-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 compiler.gcc-static-analysis-trunk.exe=/opt/compiler-explorer/gcc-static-analysis-trunk/bin/g++
 compiler.gcc-static-analysis-trunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gcc-static-analysis-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -658,7 +664,7 @@ compiler.clang_dang.semver=(thephd.dev)
 compiler.clang_dang.options=-std=c++2d -stdlib=libc++
 compiler.clang_dang.notification=Generic, std::embed, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 compiler.clang_dang.hidden=true
-compiler.clang_thephd_dev.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang++
+compiler.clang_thephd_dev.exe=/opt/compiler-explorer/clang-clang.thephd.dev/bin/clang++
 compiler.clang_thephd_dev.semver=(thephd.dev)
 compiler.clang_thephd_dev.options=-std=c++2d -stdlib=libc++
 compiler.clang_thephd_dev.isNightly=true

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -664,7 +664,7 @@ compiler.clang_dang.semver=(thephd.dev)
 compiler.clang_dang.options=-std=c++2d -stdlib=libc++
 compiler.clang_dang.notification=Generic, std::embed, Transparent Function Aliases, and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 compiler.clang_dang.hidden=true
-compiler.clang_thephd_dev.exe=/opt/compiler-explorer/clang-clang.thephd.dev/bin/clang++
+compiler.clang_thephd_dev.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang++
 compiler.clang_thephd_dev.semver=(thephd.dev)
 compiler.clang_thephd_dev.options=-std=c++2d -stdlib=libc++
 compiler.clang_thephd_dev.isNightly=true

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -245,7 +245,7 @@ compiler.gcc-embed-trunk.semver=(std::embed)
 compiler.gcc-embed-trunk.isNightly=true
 compiler.gcc-embed-trunk.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.gcc-embed-trunk.hidden=true
-compiler.gcc_thephd_dev.exe=/opt/compiler-explorer/gcc-gcc.thephd.dev/bin/g++
+compiler.gcc_thephd_dev.exe=/opt/compiler-explorer/gcc-thephd.dev/bin/g++
 compiler.gcc_thephd_dev.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.gcc_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gcc_thephd_dev.semver=(thephd.dev)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -15,7 +15,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=&cgcc86assert:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cg161:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=&cgcc86assert:cg_thephd_dev:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cg161:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -187,6 +187,13 @@ compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cgsnapshot.semver=(trunk)
 compiler.cgsnapshot.isNightly=true
+
+compiler.cg_thephd_dev.exe=/opt/compiler-explorer/gcc-gcc.thephd.dev/bin/gcc
+compiler.cg_thephd_dev.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.cg_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.cg_thephd_dev.semver=(thephd.dev)
+compiler.cg_thephd_dev.isNightly=true
+compiler.cg_thephd_dev.notification=std::embed and more in this custom clang-derived playground; see <a href="https://thephd.dev/portfolio/standard" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for other potential proposal implementations!
 
 compiler.cgstatic-analysis.hidden=true
 compiler.cgstatic-analysis.exe=/opt/compiler-explorer/gcc-static-analysis-trunk/bin/gcc
@@ -426,7 +433,7 @@ compiler.cclang_dang.semver=(thephd.dev)
 compiler.cclang_dang.isNightly=true
 compiler.cclang_dang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0 -std=c2x
 compiler.cclang_dang.hidden=true
-compiler.cclang_thephd_dev.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang
+compiler.cclang_thephd_dev.exe=/opt/compiler-explorer/clang-clang.thephd.dev/bin/clang
 compiler.cclang_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_thephd_dev.semver=(thephd.dev)
 compiler.cclang_thephd_dev.isNightly=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -188,7 +188,7 @@ compiler.cgsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cgsnapshot.semver=(trunk)
 compiler.cgsnapshot.isNightly=true
 
-compiler.cg_thephd_dev.exe=/opt/compiler-explorer/gcc-gcc.thephd.dev/bin/gcc
+compiler.cg_thephd_dev.exe=/opt/compiler-explorer/gcc-thephd.dev/bin/gcc
 compiler.cg_thephd_dev.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cg_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cg_thephd_dev.semver=(thephd.dev)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -433,7 +433,7 @@ compiler.cclang_dang.semver=(thephd.dev)
 compiler.cclang_dang.isNightly=true
 compiler.cclang_dang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-11.2.0 -std=c2x
 compiler.cclang_dang.hidden=true
-compiler.cclang_thephd_dev.exe=/opt/compiler-explorer/clang-clang.thephd.dev/bin/clang
+compiler.cclang_thephd_dev.exe=/opt/compiler-explorer/clang-thephd.dev/bin/clang
 compiler.cclang_thephd_dev.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.cclang_thephd_dev.semver=(thephd.dev)
 compiler.cclang_thephd_dev.isNightly=true


### PR DESCRIPTION
Hi again!

Sorry to be annoying, but this is a PR for GCC. I originally wasn't going to do this but someone asked, so here's the GCC version of thephd.dev that I'll keep afloat for as long as I can. Related PRs:

- [x] https://github.com/compiler-explorer/gcc-builder/pull/52
- [x] https://github.com/compiler-explorer/compiler-workflows/pull/63
- [x] https://github.com/compiler-explorer/infra/pull/2091

Even though the names changed and output folders changed for the builds, the top-level ID for the compilers remain the same here in the `.amazon.properties`, so I think this shouldn't break anything. (Please let me know if it does break something...!)