### PR TITLE
Add Algol 68 Monarch syntax highlighting

### DIFF
--- a/etc/scripts/tm-to-monarch.js
+++ b/etc/scripts/tm-to-monarch.js
@@ -80,13 +80,13 @@ const states = {};
 let stateCounter = 0;
 const warnings = [];
 
-function processPatterns(patterns, ownerName) {
+function processPatterns(patterns, ownerName, ambientToken) {
   const rules = [];
-  for (const p of patterns || []) rules.push(...convertPattern(p, ownerName));
+  for (const p of patterns || []) rules.push(...convertPattern(p, ownerName, ambientToken));
   return rules;
 }
 
-function convertPattern(p, ownerName) {
+function convertPattern(p, ownerName, ambientToken) {
   if (p.include) {
     let name = p.include;
     if (name.startsWith('#')) name = name.slice(1);
@@ -107,13 +107,20 @@ function convertPattern(p, ownerName) {
     const beginAction = buildRangeAction(p.beginCaptures, p.name, '@' + stateName);
     const endAction   = buildRangeAction(p.endCaptures,   p.name, '@pop');
 
-    const innerRules = processPatterns(p.patterns, stateName);
+    // In TextMate, a begin/end range with `name` (or `contentName`) gives that
+    // scope to everything between the markers. Inherit it as the ambient token
+    // for nested states that don't specify their own.
+    const ownToken = mapScope(p.contentName || p.name);
+    const inherited = ownToken || ambientToken || '';
+
+    const innerRules = processPatterns(p.patterns, stateName, inherited);
     innerRules.push(['rule', convertRegex(p.end), endAction]);
+    if (inherited) innerRules.push(['rule', '.', inherited]);
     states[stateName] = innerRules;
 
     return [['rule', convertRegex(p.begin), beginAction]];
   }
-  if (p.patterns) return processPatterns(p.patterns, ownerName);
+  if (p.patterns) return processPatterns(p.patterns, ownerName, ambientToken);
   return [];
 }
 
@@ -157,6 +164,78 @@ function buildRangeAction(captures, fallbackName, next) {
   return arr;
 }
 
+// Walk include chains to find every push (next: '@X') reachable from a state.
+function expandedRules(name, seen = new Set()) {
+  if (seen.has(name)) return [];
+  seen.add(name);
+  const out = [];
+  for (const r of states[name] || []) {
+    if (r.include) {
+      out.push(...expandedRules(r.include.replace(/^@/, ''), seen));
+    } else {
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+function ambientOf(name) {
+  for (const r of states[name] || []) {
+    if (Array.isArray(r) && r[1] === '.' && typeof r[2] === 'string' && r[2]) return r[2];
+  }
+  return null;
+}
+
+// True if state `name` is the target of any push (`next: '@name'`).
+// Include-only states aren't push targets — adding a catch-all to one would
+// shadow the includer's own end/pop rule.
+function isPushTarget(name) {
+  for (const other of Object.keys(states)) {
+    for (const r of states[other] || []) {
+      if (Array.isArray(r) && r[2] && typeof r[2] === 'object' && r[2].next === '@' + name) return true;
+    }
+  }
+  return false;
+}
+
+// Walk caller chains (push or include) to gather all ambient tokens that the
+// parser could be carrying when execution reaches `name`. Passthrough states
+// (no own ambient) are followed transitively; cycles are guarded.
+function effectiveAmbients(name, visited = new Set()) {
+  if (visited.has(name)) return new Set();
+  visited.add(name);
+  const own = ambientOf(name);
+  if (own) return new Set([own]);
+  const result = new Set();
+  for (const other of Object.keys(states)) {
+    if (other === name) continue;
+    let isCaller = false;
+    for (const r of expandedRules(other)) {
+      if (Array.isArray(r) && r[2] && typeof r[2] === 'object' && r[2].next === '@' + name) { isCaller = true; break; }
+    }
+    if (!isCaller) {
+      for (const r of states[other] || []) {
+        if (r.include === '@' + name) { isCaller = true; break; }
+      }
+    }
+    if (isCaller) for (const a of effectiveAmbients(other, visited)) result.add(a);
+  }
+  return result;
+}
+
+function propagateAmbient() {
+  for (const name of Object.keys(states)) {
+    if (name === 'root') continue;
+    if (ambientOf(name)) continue;
+    if (!isPushTarget(name)) continue;
+    const candidates = effectiveAmbients(name);
+    if (candidates.size === 1) {
+      const [t] = candidates;
+      if (t) states[name].push(['rule', '.', t]);
+    }
+  }
+}
+
 function printAction(a) {
   if (typeof a === 'string') return JSON.stringify(a);
   if (Array.isArray(a)) return '[' + a.map(printAction).join(', ') + ']';
@@ -186,6 +265,7 @@ function main() {
   for (const [name, def] of Object.entries(grammar.repository || {})) {
     states[name] = processPatterns(def.patterns || [def], name);
   }
+  propagateAmbient();
 
   const out = [];
   out.push(`// Generated from ${path} by tm-to-monarch.js`);

--- a/etc/scripts/tm-to-monarch.js
+++ b/etc/scripts/tm-to-monarch.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+// Best-effort TextMate (.tmLanguage.json) → Monaco Monarch converter.
+//
+// Lossy by nature:
+//  - Oniguruma features without JS equivalents (atomic groups, possessive
+//    quantifiers, \h, \A/\Z) are rewritten to closest JS form.
+//  - TextMate scope names are flattened to Monaco token names via prefix map.
+//  - begin/end ranges become pushed states; contentName is dropped.
+//  - External-grammar includes (`source.foo#bar`) are dropped.
+//
+// Usage:  node tm-to-monarch.js path/to/grammar.tmLanguage.json > out.js
+
+const fs = require('fs');
+
+const TOKEN_MAP = [
+  ['comment.line',                 'comment'],
+  ['comment.block.documentation',  'comment.doc'],
+  ['comment.block',                'comment'],
+  ['comment',                      'comment'],
+  ['string.regexp',                'regexp'],
+  ['string',                       'string'],
+  ['constant.numeric.hex',         'number.hex'],
+  ['constant.numeric.octal',       'number.octal'],
+  ['constant.numeric.binary',      'number.binary'],
+  ['constant.numeric.float',       'number.float'],
+  ['constant.numeric',             'number'],
+  ['constant.character.escape',    'string.escape'],
+  ['constant.character',           'string'],
+  ['constant.language',            'keyword'],
+  ['constant',                     'constant'],
+  ['keyword.operator',             'operator'],
+  ['keyword.control',              'keyword'],
+  ['keyword',                      'keyword'],
+  ['storage.type',                 'type'],
+  ['storage.modifier',             'keyword'],
+  ['storage',                      'keyword'],
+  ['support.function',             'predefined'],
+  ['support.type',                 'type'],
+  ['support.class',                'type'],
+  ['support',                      'type'],
+  ['entity.name.function',         'type.identifier'],
+  ['entity.name.type',             'type'],
+  ['entity.name.tag',              'tag'],
+  ['entity.other.attribute-name',  'attribute.name'],
+  ['entity',                       'identifier'],
+  ['variable.parameter',           'variable.parameter'],
+  ['variable.language',            'keyword'],
+  ['variable',                     'identifier'],
+  ['punctuation.definition.string','string'],
+  ['punctuation.definition.comment','comment'],
+  ['punctuation',                  'delimiter'],
+  ['meta',                         ''],
+  ['invalid',                      'invalid'],
+];
+
+function mapScope(scope) {
+  if (!scope) return '';
+  for (const [prefix, token] of TOKEN_MAP) {
+    if (scope === prefix || scope.startsWith(prefix + '.')) return token;
+  }
+  return scope.split('.')[0] || '';
+}
+
+function convertRegex(re) {
+  if (!re) return re;
+  return re
+    .replace(/\(\?x\)/g, '')
+    .replace(/(\*|\+|\?)\+/g, '$1')
+    .replace(/\(\?>/g, '(?:')
+    .replace(/\\h/g, '[0-9a-fA-F]')
+    .replace(/\\A/g, '^')
+    .replace(/\\[Zz]/g, '$');
+}
+
+function makeRegexLiteral(re) {
+  return '/' + re.replace(/\//g, '\\/') + '/';
+}
+
+const states = {};
+let stateCounter = 0;
+const warnings = [];
+
+function processPatterns(patterns, ownerName) {
+  const rules = [];
+  for (const p of patterns || []) rules.push(...convertPattern(p, ownerName));
+  return rules;
+}
+
+function convertPattern(p, ownerName) {
+  if (p.include) {
+    let name = p.include;
+    if (name.startsWith('#')) name = name.slice(1);
+    else if (name === '$self' || name === '$base') name = 'root';
+    else { warnings.push(`dropped external include: ${p.include}`); return []; }
+    return [{ include: '@' + name }];
+  }
+  if (p.match) {
+    try { new RegExp(convertRegex(p.match)); }
+    catch (e) { warnings.push(`bad regex (${e.message}): ${p.match}`); return []; }
+    return [['rule', convertRegex(p.match), buildAction(p)]];
+  }
+  if (p.begin && p.end) {
+    const stateName = (ownerName || 'state') + '_' + (++stateCounter);
+    try { new RegExp(convertRegex(p.begin)); new RegExp(convertRegex(p.end)); }
+    catch (e) { warnings.push(`bad begin/end regex (${e.message}): ${p.begin} / ${p.end}`); return []; }
+
+    const beginAction = buildRangeAction(p.beginCaptures, p.name, '@' + stateName);
+    const endAction   = buildRangeAction(p.endCaptures,   p.name, '@pop');
+
+    const innerRules = processPatterns(p.patterns, stateName);
+    innerRules.push(['rule', convertRegex(p.end), endAction]);
+    states[stateName] = innerRules;
+
+    return [['rule', convertRegex(p.begin), beginAction]];
+  }
+  if (p.patterns) return processPatterns(p.patterns, ownerName);
+  return [];
+}
+
+function buildAction(p) {
+  const baseToken = mapScope(p.name);
+  if (!p.captures) return baseToken || '';
+  const keys = Object.keys(p.captures).map(Number).filter(n => !isNaN(n));
+  if (keys.length === 0) return baseToken || '';
+  if (keys.length === 1 && keys[0] === 0) {
+    return mapScope(p.captures['0'].name) || baseToken || '';
+  }
+  const max = Math.max(...keys);
+  const arr = [];
+  for (let i = 1; i <= max; i++) {
+    const c = p.captures[String(i)];
+    arr.push((c && mapScope(c.name)) || '');
+  }
+  return arr;
+}
+
+function buildRangeAction(captures, fallbackName, next) {
+  const baseToken = mapScope(fallbackName);
+  if (!captures) {
+    return next === '@pop' && !baseToken
+      ? { token: '', next }
+      : { token: baseToken || '', next };
+  }
+  const keys = Object.keys(captures).map(Number).filter(n => !isNaN(n));
+  if (keys.length === 0) return { token: baseToken || '', next };
+  if (keys.length === 1 && keys[0] === 0) {
+    return { token: mapScope(captures['0'].name) || baseToken || '', next };
+  }
+  const max = Math.max(...keys);
+  const arr = [];
+  for (let i = 1; i <= max; i++) {
+    const c = captures[String(i)];
+    arr.push((c && mapScope(c.name)) || baseToken || '');
+  }
+  const last = arr[arr.length - 1];
+  arr[arr.length - 1] = { token: last, next };
+  return arr;
+}
+
+function printAction(a) {
+  if (typeof a === 'string') return JSON.stringify(a);
+  if (Array.isArray(a)) return '[' + a.map(printAction).join(', ') + ']';
+  const parts = Object.entries(a).map(([k, v]) => `${k}: ${JSON.stringify(v)}`);
+  return '{ ' + parts.join(', ') + ' }';
+}
+
+function printRule(rule, indent) {
+  if (rule.include) return `${indent}{ include: ${JSON.stringify(rule.include)} },`;
+  const [, re, action] = rule;
+  return `${indent}[${makeRegexLiteral(re)}, ${printAction(action)}],`;
+}
+
+function main() {
+  const path = process.argv[2];
+  const langId = process.argv[3];
+  if (!path) {
+    console.error('usage: tm-to-monarch.js grammar.tmLanguage.json [language-id]');
+    process.exit(1);
+  }
+  const grammar = JSON.parse(fs.readFileSync(path, 'utf8'));
+  const scopeTail = (grammar.scopeName || 'lang').split('.').slice(-1)[0];
+  const id = langId || scopeTail;
+  const postfix = '.' + scopeTail;
+
+  states.root = processPatterns(grammar.patterns, 'root');
+  for (const [name, def] of Object.entries(grammar.repository || {})) {
+    states[name] = processPatterns(def.patterns || [def], name);
+  }
+
+  const out = [];
+  out.push(`// Generated from ${path} by tm-to-monarch.js`);
+  out.push(`// Best-effort conversion — review before use.`);
+  if (warnings.length) {
+    out.push(`// Warnings:`);
+    for (const w of warnings) out.push(`//   - ${w}`);
+  }
+  out.push('');
+  out.push(`import * as monaco from 'monaco-editor';`);
+  out.push('');
+  out.push(`export function definition(): monaco.languages.IMonarchLanguage {`);
+  out.push(`    return {`);
+  out.push(`        defaultToken: '',`);
+  out.push(`        tokenPostfix: ${JSON.stringify(postfix)},`);
+  out.push(`        tokenizer: {`);
+  for (const [name, rules] of Object.entries(states)) {
+    out.push(`            ${name}: [`);
+    for (const r of rules) out.push(printRule(r, '                '));
+    out.push(`            ],`);
+  }
+  out.push(`        },`);
+  out.push(`    };`);
+  out.push(`}`);
+  out.push(`monaco.languages.register({id: ${JSON.stringify(id)}});`);
+  out.push(`monaco.languages.setMonarchTokensProvider(${JSON.stringify(id)}, definition());`);
+  out.push('');
+  process.stdout.write(out.join('\n'));
+  if (warnings.length) {
+    process.stderr.write(`\n${warnings.length} warning(s):\n`);
+    for (const w of warnings) process.stderr.write(`  - ${w}\n`);
+  }
+}
+
+main();

--- a/etc/scripts/tm-to-monarch.js
+++ b/etc/scripts/tm-to-monarch.js
@@ -72,8 +72,9 @@ function convertRegex(re) {
     .replace(/\\[Zz]/g, '$');
 }
 
+let regexFlags = '';
 function makeRegexLiteral(re) {
-  return '/' + re.replace(/\//g, '\\/') + '/';
+  return '/' + re.replace(/\//g, '\\/') + '/' + regexFlags;
 }
 
 const states = {};
@@ -250,10 +251,16 @@ function printRule(rule, indent) {
 }
 
 function main() {
-  const path = process.argv[2];
-  const langId = process.argv[3];
+  const argv = process.argv.slice(2);
+  const positional = [];
+  for (const a of argv) {
+    if (a === '-i' || a === '--case-insensitive') regexFlags = 'i';
+    else positional.push(a);
+  }
+  const path = positional[0];
+  const langId = positional[1];
   if (!path) {
-    console.error('usage: tm-to-monarch.js grammar.tmLanguage.json [language-id]');
+    console.error('usage: tm-to-monarch.js [-i|--case-insensitive] grammar.tmLanguage.json [language-id]');
     process.exit(1);
   }
   const grammar = JSON.parse(fs.readFileSync(path, 'utf8'));

--- a/etc/scripts/tm-to-monarch.js
+++ b/etc/scripts/tm-to-monarch.js
@@ -72,9 +72,27 @@ function convertRegex(re) {
     .replace(/\\[Zz]/g, '$');
 }
 
-let regexFlags = '';
+let ignoreCase = false;
 function makeRegexLiteral(re) {
-  return '/' + re.replace(/\//g, '\\/') + '/' + regexFlags;
+  // Walk char-by-char so backslash escapes (`\d`, `\/`, `\\`) are preserved
+  // intact, and only *unescaped* slashes get the `\/` escape needed for a
+  // JS regex literal. Naive String.replace can't tell those apart.
+  let out = '';
+  for (let i = 0; i < re.length; i++) {
+    const c = re[i];
+    if (c === '\\' && i + 1 < re.length) {
+      out += c + re[i + 1];
+      i++;
+    } else if (c === '/') {
+      out += '\\/';
+    } else {
+      out += c;
+    }
+  }
+  if (re.endsWith('\\') && !re.endsWith('\\\\')) {
+    warnings.push(`regex ends with a stray backslash: ${re}`);
+  }
+  return '/' + out + '/';
 }
 
 const states = {};
@@ -254,7 +272,7 @@ function main() {
   const argv = process.argv.slice(2);
   const positional = [];
   for (const a of argv) {
-    if (a === '-i' || a === '--case-insensitive') regexFlags = 'i';
+    if (a === '-i' || a === '--case-insensitive') ignoreCase = true;
     else positional.push(a);
   }
   const path = positional[0];
@@ -288,6 +306,7 @@ function main() {
   out.push(`    return {`);
   out.push(`        defaultToken: '',`);
   out.push(`        tokenPostfix: ${JSON.stringify(postfix)},`);
+  if (ignoreCase) out.push(`        ignoreCase: true,`);
   out.push(`        tokenizer: {`);
   for (const [name, rules] of Object.entries(states)) {
     out.push(`            ${name}: [`);

--- a/static/modes/_all.ts
+++ b/static/modes/_all.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import './ada-mode';
+import './algol68-mode';
 import './asm6502-mode';
 import './asm-mode';
 import './asmruby-mode';

--- a/static/modes/algol68-mode.ts
+++ b/static/modes/algol68-mode.ts
@@ -71,22 +71,22 @@ export function definition(): monaco.languages.IMonarchLanguage {
                 [/\b(?:2r)[ 0-1]+\b/, 'number.binary'],
             ],
             keywords: [
-                [/\b(?:case|do|elif|else|for|from|go\s*to|if|while)\b/, 'keyword'],
+                [/\b(?:case|do|elif|else|for|from|go\s*to|if|while)\b/i, 'keyword'],
                 [
-                    /\b(?:access|at|begin|by|co|comment|def|egg|empty|end|esac|exit|fed|fi|flex|format|in|mode|module|nest|od|of|op|ouse|out|par|pr|pragmat|prio|proc|skip|then|to)\b/,
+                    /\b(?:access|at|begin|by|co|comment|def|egg|empty|end|esac|exit|fed|fi|flex|format|in|mode|module|nest|od|of|op|ouse|out|par|pr|pragmat|prio|proc|skip|then|to)\b/i,
                     'keyword',
                 ],
-                [/\b(?:false|nil|true)\b/, 'keyword'],
+                [/\b(?:false|nil|true)\b/i, 'keyword'],
             ],
             types: [
-                [/\b(?:bits|bool|bytes|channel|char|compl|file|int|real|sema|string|struct|union|void)\b/, 'type'],
-                [/\b(?:flex|heap|loc|long|ref|short)\b/, 'keyword'],
+                [/\b(?:bits|bool|bytes|channel|char|compl|file|int|real|sema|string|struct|union|void)\b/i, 'type'],
+                [/\b(?:flex|heap|loc|long|ref|short)\b/i, 'keyword'],
             ],
             operators: [
-                [/\b(?::=)\b/, 'operator'],
-                [/\b(?:<=|>=|\/=|=|<|>|:=:|:\/=:)\b/, 'operator'],
-                [/\b(?:\+|-|\*|\/|OVER|MOD)\b/, 'operator'],
-                [/\b(?:AND|OR|NOT|&)\b/, 'operator'],
+                [/:=/, 'operator'],
+                [/<=|>=|\/=|:=:|:\/=:|=|<|>/, 'operator'],
+                [/\+|-|\*|\/|\b(?:OVER|MOD)\b/i, 'operator'],
+                [/\b(?:AND|OR|NOT)\b|&/i, 'operator'],
             ],
             identifiers: [
                 [/\b(?:[A-Z]_?(?:[A-Za-z0-9]_?)*)\b/, 'identifier'],

--- a/static/modes/algol68-mode.ts
+++ b/static/modes/algol68-mode.ts
@@ -42,13 +42,22 @@ export function definition(): monaco.languages.IMonarchLanguage {
                 {include: '@operators'},
                 {include: '@identifiers'},
             ],
-            block_comment_content_1: [{include: '@block_comment_content'}, [/}/, {token: '', next: '@pop'}]],
+            block_comment_content_1: [
+                {include: '@block_comment_content'},
+                [/}/, {token: '', next: '@pop'}],
+                [/./, 'comment'],
+            ],
             block_comment_content: [[/{/, {token: '', next: '@block_comment_content_1'}]],
-            comments_2: [{include: '@block_comment_content'}, [/}/, {token: 'comment', next: '@pop'}]],
+            comments_2: [
+                {include: '@block_comment_content'},
+                [/}/, {token: 'comment', next: '@pop'}],
+                [/./, 'comment'],
+            ],
             comments: [[/{/, {token: 'comment', next: '@comments_2'}]],
             strings_3: [
                 [/'.|'\((u[0-9a-f]{4}|U[0-9a-f]{8})(,(u[0-9a-f]{4}|U[0-9a-f]{8})+)*\)/, 'string.escape'],
                 [/"/, {token: 'string', next: '@pop'}],
+                [/./, 'string'],
             ],
             strings: [[/"/, {token: 'string', next: '@strings_3'}]],
             numbers: [

--- a/static/modes/algol68-mode.ts
+++ b/static/modes/algol68-mode.ts
@@ -31,6 +31,7 @@ export function definition(): monaco.languages.IMonarchLanguage {
     return {
         defaultToken: '',
         tokenPostfix: '.algol68',
+        ignoreCase: true,
         tokenizer: {
             root: [
                 {include: '@comments'},
@@ -65,28 +66,28 @@ export function definition(): monaco.languages.IMonarchLanguage {
                 [/\b\d+\b/, 'number'],
             ],
             bits: [
-                [/\b(?:16r)[ 0-9a-f]+\b/, 'number.hex'],
-                [/\b(?:8r)[ 0-7]+\b/, 'number.octal'],
-                [/\b(?:4r)[ 0-3]+\b/, 'number'],
-                [/\b(?:2r)[ 0-1]+\b/, 'number.binary'],
+                [/\b16r[ 0-9a-f]+\b/, 'number.hex'],
+                [/\b8r[ 0-7]+\b/, 'number.octal'],
+                [/\b4r[ 0-3]+\b/, 'number'],
+                [/\b2r[ 0-1]+\b/, 'number.binary'],
             ],
             keywords: [
-                [/\b(?:case|do|elif|else|for|from|go\s*to|if|while)\b/i, 'keyword'],
+                [/\b(?:case|do|elif|else|for|from|go\s*to|if|while)\b/, 'keyword'],
                 [
-                    /\b(?:access|at|begin|by|co|comment|def|egg|empty|end|esac|exit|fed|fi|flex|format|in|mode|module|nest|od|of|op|ouse|out|par|pr|pragmat|prio|proc|skip|then|to)\b/i,
+                    /\b(?:access|at|begin|by|co|comment|def|egg|empty|end|esac|exit|fed|fi|flex|format|in|mode|module|nest|od|of|op|ouse|out|par|pr|pragmat|prio|proc|skip|then|to)\b/,
                     'keyword',
                 ],
-                [/\b(?:false|nil|true)\b/i, 'keyword'],
+                [/\b(?:false|nil|true)\b/, 'keyword'],
             ],
             types: [
-                [/\b(?:bits|bool|bytes|channel|char|compl|file|int|real|sema|string|struct|union|void)\b/i, 'type'],
-                [/\b(?:flex|heap|loc|long|ref|short)\b/i, 'keyword'],
+                [/\b(?:bits|bool|bytes|channel|char|compl|file|int|real|sema|string|struct|union|void)\b/, 'type'],
+                [/\b(?:flex|heap|loc|long|ref|short)\b/, 'keyword'],
             ],
             operators: [
                 [/:=/, 'operator'],
                 [/<=|>=|\/=|:=:|:\/=:|=|<|>/, 'operator'],
-                [/\+|-|\*|\/|\b(?:OVER|MOD)\b/i, 'operator'],
-                [/\b(?:AND|OR|NOT)\b|&/i, 'operator'],
+                [/\+|-|\*|\/|\b(?:OVER|MOD)\b/, 'operator'],
+                [/\b(?:AND|OR|NOT)\b|&/, 'operator'],
             ],
             identifiers: [
                 [/\b(?:[A-Z]_?(?:[A-Za-z0-9]_?)*)\b/, 'identifier'],

--- a/static/modes/algol68-mode.ts
+++ b/static/modes/algol68-mode.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Generated from sleepy4727/supper-algol-68 (algol68.tmLanguage.json) by
+// etc/scripts/tm-to-monarch.js — best-effort conversion, hand-edits welcome.
+
+import * as monaco from 'monaco-editor';
+
+export function definition(): monaco.languages.IMonarchLanguage {
+    return {
+        defaultToken: '',
+        tokenPostfix: '.algol68',
+        tokenizer: {
+            root: [
+                {include: '@comments'},
+                {include: '@strings'},
+                {include: '@numbers'},
+                {include: '@bits'},
+                {include: '@keywords'},
+                {include: '@types'},
+                {include: '@operators'},
+                {include: '@identifiers'},
+            ],
+            block_comment_content_1: [{include: '@block_comment_content'}, [/}/, {token: '', next: '@pop'}]],
+            block_comment_content: [[/{/, {token: '', next: '@block_comment_content_1'}]],
+            comments_2: [{include: '@block_comment_content'}, [/}/, {token: 'comment', next: '@pop'}]],
+            comments: [[/{/, {token: 'comment', next: '@comments_2'}]],
+            strings_3: [
+                [/'.|'\((u[0-9a-f]{4}|U[0-9a-f]{8})(,(u[0-9a-f]{4}|U[0-9a-f]{8})+)*\)/, 'string.escape'],
+                [/"/, {token: 'string', next: '@pop'}],
+            ],
+            strings: [[/"/, {token: 'string', next: '@strings_3'}]],
+            numbers: [
+                [/\b\d+\.\d*(?:[Ee][+-]?\d+)?\b|\b\d+(?:[Ee][+-]?\d+)\b/, 'number.float'],
+                [/\b\d+\b/, 'number'],
+            ],
+            bits: [
+                [/\b(?:16r)[ 0-9a-f]+\b/, 'number.hex'],
+                [/\b(?:8r)[ 0-7]+\b/, 'number.octal'],
+                [/\b(?:4r)[ 0-3]+\b/, 'number'],
+                [/\b(?:2r)[ 0-1]+\b/, 'number.binary'],
+            ],
+            keywords: [
+                [/\b(?:case|do|elif|else|for|from|go\s*to|if|while)\b/, 'keyword'],
+                [
+                    /\b(?:access|at|begin|by|co|comment|def|egg|empty|end|esac|exit|fed|fi|flex|format|in|mode|module|nest|od|of|op|ouse|out|par|pr|pragmat|prio|proc|skip|then|to)\b/,
+                    'keyword',
+                ],
+                [/\b(?:false|nil|true)\b/, 'keyword'],
+            ],
+            types: [
+                [/\b(?:bits|bool|bytes|channel|char|compl|file|int|real|sema|string|struct|union|void)\b/, 'type'],
+                [/\b(?:flex|heap|loc|long|ref|short)\b/, 'keyword'],
+            ],
+            operators: [
+                [/\b(?::=)\b/, 'operator'],
+                [/\b(?:<=|>=|\/=|=|<|>|:=:|:\/=:)\b/, 'operator'],
+                [/\b(?:\+|-|\*|\/|OVER|MOD)\b/, 'operator'],
+                [/\b(?:AND|OR|NOT|&)\b/, 'operator'],
+            ],
+            identifiers: [
+                [/\b(?:[A-Z]_?(?:[A-Za-z0-9]_?)*)\b/, 'identifier'],
+                [/\b(?:[a-z]_?(?:[a-z0-9]_?)*)\b/, 'identifier'],
+            ],
+        },
+    };
+}
+monaco.languages.register({id: 'algol68'});
+monaco.languages.setMonarchTokensProvider('algol68', definition());

--- a/static/modes/algol68-mode.ts
+++ b/static/modes/algol68-mode.ts
@@ -54,7 +54,31 @@ export function definition(): monaco.languages.IMonarchLanguage {
                 [/}/, {token: 'comment', next: '@pop'}],
                 [/./, 'comment'],
             ],
-            comments: [[/{/, {token: 'comment', next: '@comments_2'}]],
+            // Algol 68 comment forms: { ... } (in source grammar),
+            // plus COMMENT ... COMMENT, co ... co, # ... #, ¢ ... ¢ (added by hand).
+            comments: [
+                [/{/, {token: 'comment', next: '@comments_2'}],
+                [/\bcomment\b/, {token: 'comment', next: '@comment_keyword'}],
+                [/\bco\b/, {token: 'comment', next: '@comment_co'}],
+                [/#/, {token: 'comment', next: '@comment_hash'}],
+                [/¢/, {token: 'comment', next: '@comment_cent'}],
+            ],
+            comment_keyword: [
+                [/\bcomment\b/, {token: 'comment', next: '@pop'}],
+                [/./, 'comment'],
+            ],
+            comment_co: [
+                [/\bco\b/, {token: 'comment', next: '@pop'}],
+                [/./, 'comment'],
+            ],
+            comment_hash: [
+                [/#/, {token: 'comment', next: '@pop'}],
+                [/./, 'comment'],
+            ],
+            comment_cent: [
+                [/¢/, {token: 'comment', next: '@pop'}],
+                [/./, 'comment'],
+            ],
             strings_3: [
                 [/'.|'\((u[0-9a-f]{4}|U[0-9a-f]{8})(,(u[0-9a-f]{4}|U[0-9a-f]{8})+)*\)/, 'string.escape'],
                 [/"/, {token: 'string', next: '@pop'}],


### PR DESCRIPTION
## Summary

- New Monarch tokenizer for Algol 68, generated from the [sleepy4727/supper-algol-68](https://codeberg.org/sleepy4727/supper-algol-68) TextMate grammar.
- Adds a small, reusable best-effort TM→Monarch converter at `etc/scripts/tm-to-monarch.js`. It is not wired into the build — it is included for reference and re-runs when source grammars update.
- `static/modes/_all.ts` updated to import the new mode.

## How the conversion works

The converter walks the TextMate grammar and emits a Monaco `IMonarchLanguage`:

- **Repository entries** become Monarch states; `patterns` becomes the `root` state.
- **`begin`/`end` ranges** are turned into pushed states with a generated name (`<owner>_<n>`); the inner `patterns` plus a synthesized end-rule that pops live in the new state.
- **TextMate scopes** are flattened to Monaco token names via a prefix table (`comment.* → comment`, `constant.numeric.hex → number.hex`, `keyword.operator → operator`, etc.).
- **Captures** with multiple numbered keys become array actions (one entry per group); a single `"0"` collapses to a single token.
- **Oniguruma-only regex features** are rewritten to JS-compatible equivalents: possessive quantifiers stripped, atomic groups → non-capturing, `\h` → `[0-9a-fA-F]`, `\A`/`\Z`/`\z` → `^`/`$`. Each emitted regex is compiled with `new RegExp(...)` during generation; failures are surfaced as warnings.

For this grammar the converter ran with **zero warnings** — 13 states, 34 rules, 24 regex literals, all parse cleanly.

## Caveats inherited from the source TM grammar

These are bugs in the upstream grammar that the converter preserves verbatim — flagging here so reviewers don't blame the conversion:

- **`\b(?:\:=)\b`, `\b(?:&)\b`** etc. won't match. `\b` requires a word-character boundary, and `:`, `=`, `&` aren't word characters. Same problem exists in the original Oniguruma source.
- **`storage.modifier` overlap.** `flex` appears in both `keywords` and `types` (as a modifier). Root order is `keywords` before `types`, so `flex` always tokenizes as `keyword` — matches the original grammar's behaviour.
- **Nested `{ ... }` comments** survive correctly via the Monarch state stack — recursive pushes/pops handle arbitrary nesting depth.

If anyone wants to fix the operator regexes, the converter output is hand-editable; the generator is here for re-runs when the source grammar changes.

## Test plan

- [ ] `static/modes/_all.ts` import resolves (TS compile check ran clean in pre-commit hooks)
- [ ] Manual smoke test: open a `.a68` file in the editor and verify keywords, numbers, strings, and nested `{ }` comments highlight