### PR TITLE
Stop bronto-refactor stdout being tagged as fake diagnostics

### DIFF
--- a/lib/tooling/bronto-refactor-tool.ts
+++ b/lib/tooling/bronto-refactor-tool.ts
@@ -26,8 +26,10 @@ import path from 'node:path';
 
 import {splitArguments} from '../../shared/common-utils.js';
 import {CompilationInfo} from '../../types/compilation/compilation.interfaces.js';
+import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {ToolInfo} from '../../types/tool.interfaces.js';
 import {OptionsHandlerLibrary} from '../options-handler.js';
+import {LineParseOption, parseOutput} from '../utils.js';
 import {ToolEnv} from './base-tool.interface.js';
 import {BaseTool} from './base-tool.js';
 
@@ -40,6 +42,19 @@ export class BrontoRefactorTool extends BaseTool {
         super(toolInfo, env);
 
         this.addOptionsToToolArgs = false;
+    }
+
+    // bronto-refactor's stdout is the refactored source code, not diagnostics. The default
+    // FileWithLine matcher would happily mistake e.g. `r.fetch_add(2, ...)` for a
+    // `filename:line:` reference and tag it as an error. We deliberately list the options we
+    // want rather than subtracting from DefaultLineParseOptions, so any future addition to
+    // the defaults is an explicit decision here.
+    protected override parseOutput(lines: string, inputFilename?: string, pathPrefix?: string): ResultLine[] {
+        return parseOutput(lines, inputFilename, pathPrefix, [
+            LineParseOption.SourceMasking,
+            LineParseOption.RootMasking,
+            LineParseOption.SourceWithLineMessage,
+        ]);
     }
 
     override async runTool(

--- a/test/tool-tests.ts
+++ b/test/tool-tests.ts
@@ -34,6 +34,7 @@ import {
     replaceToolchainArg,
 } from '../lib/toolchain-utils.js';
 import {ToolEnv} from '../lib/tooling/base-tool.interface.js';
+import {BrontoRefactorTool} from '../lib/tooling/bronto-refactor-tool.js';
 import {CompilerDropinTool} from '../lib/tooling/compiler-dropin-tool.js';
 import {CompilationInfo} from '../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../types/tool.interfaces.js';
@@ -242,5 +243,57 @@ describe('CompilerDropInTool', () => {
             '-fno-crash-diagnostics',
             '/app/example.cpp',
         ]);
+    });
+});
+
+describe('BrontoRefactorTool', () => {
+    function runTool(stdout: string, stderr: string) {
+        const tool = new BrontoRefactorTool({} as ToolInfo, {} as ToolEnv);
+        return tool.convertResult(
+            {
+                code: 0,
+                okToCache: true,
+                timedOut: false,
+                truncated: false,
+                stdout,
+                stderr,
+                filenameTransform: f => f,
+                execTime: 0,
+            },
+            'example.cpp',
+        );
+    }
+
+    // Output is refactored source code, not diagnostics. The default FileWithLine matcher
+    // would tag e.g. `r.fetch_add(2, ...)` as a `filename:line:` reference and surface it
+    // as an error in the editor.
+    it('Should not tag refactored source as diagnostics', () => {
+        const refactoredSource = [
+            '#include <atomic>',
+            'void foo(std::atomic<int>& r) {',
+            '  r.fetch_add(2, std::memory_order_relaxed);',
+            '  r.fetch_add(4, std::memory_order_relaxed);',
+            '}',
+        ].join('\n');
+
+        const result = runTool(refactoredSource, '');
+
+        const tagged = result.stdout.filter(line => line.tag);
+        expect(tagged).toEqual([]);
+    });
+
+    // Make sure dropping FileWithLineMessage didn't blunt the parser too much: real
+    // `<source>:N:M:` diagnostics on stderr should still be tagged via SourceWithLineMessage.
+    it('Should still tag real diagnostics from stderr', () => {
+        const result = runTool('', 'example.cpp:10:5: error: something went wrong\n');
+
+        expect(result.stderr).toHaveLength(1);
+        expect(result.stderr[0].tag).toEqual({
+            file: 'example.cpp',
+            line: 10,
+            column: 5,
+            text: 'error: something went wrong',
+            severity: 3,
+        });
     });
 });


### PR DESCRIPTION
## Summary

bronto-refactor emits the refactored source on stdout. The default `parseOutput` pipeline includes a `FileWithLineMessage` matcher whose regex (`SOURCE_WITH_FILENAME` in `lib/utils.ts`) is permissive enough to mistake any C++ member call with a numeric first argument — e.g. `r.fetch_add(2, std::memory_order_relaxed);` — for a `filename:line:` reference, treating `r.fetch_add` as a filename and `2` as a line number. The result was fake red error squigglies in the editor, with the trailing `, std::memory_order_relaxed);` shown as the diagnostic message.

`BrontoRefactorTool` now overrides `parseOutput` to drop `FileWithLineMessage`. `SourceWithLineMessage` is kept so genuine `<source>:N:M:` diagnostics on stderr still surface.

Reported via the web UI when running bronto-refactor on this:

```cpp
#include <atomic>
void foo(std::atomic<int>& r) {
    r.fetch_add(2, std::memory_order_relaxed);
    r.fetch_add(4, std::memory_order_relaxed);
}
```

## Out of scope

The `SOURCE_WITH_FILENAME` regex in `lib/utils.ts:154` is genuinely too loose — any tool whose stdout is source-like (formatters, refactorers) can hit this. Tightening it (require an extension, or `:`-only separator) is a separate change since it touches every compiler/tool that relies on `parseOutput`.

## Test plan

- [x] Added `test/tool-tests.ts` case asserting refactored source produces no tags.
- [x] Added a second case asserting a real `<source>:N:M:` diagnostic on stderr is still tagged (so we didn't over-blunt the parser).
- [x] Verified the first test fails on `main` and passes with the fix.
- [x] `npm run ts-check`, `npm run lint`, `npm run test -- --run tool-tests` all pass.
- [ ] Confirm in the web UI that the original repro no longer shows squigglies.

cc @fowles