### PR TITLE
Fix Algol 68 comments highlighting

### DIFF
--- a/static/modes/algol68-mode.ts
+++ b/static/modes/algol68-mode.ts
@@ -145,7 +145,13 @@ function definition(): monaco.languages.IMonarchLanguage {
 
             whitespace: [
                 [/[ \t\r\n]+/, 'white'],
-                [/{[^{]*}/, 'comment'],
+                [/{/, 'comment', '@nestingcomment'],
+            ],
+
+            nestingcomment: [
+                [/[^{}]+/, 'comment'],
+                [/{/, 'comment', '@push'],
+                [/}/, 'comment', '@pop'],
             ],
 
             string: [


### PR DESCRIPTION
Fix the mode introduced in #8677 to correctly highlight nested and multi-line comments on Algol 68.