### PR TITLE
Add VS Code / JetBrains keymap setting (default VS Code)

### DIFF
--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -61,7 +61,7 @@ import {MonacoPane} from './pane.js';
 
 import IModelDeltaDecoration = editor.IModelDeltaDecoration;
 
-import {getStaticImage} from '../utils';
+import {getStaticImage, isMacintosh} from '../utils';
 
 // Expose monaco on window for integration tests (e.g. Cypress)
 window.monaco = monaco;
@@ -1067,15 +1067,24 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         });
 
         // Bindings that match JetBrains defaults but conflict with widely-used VS Code defaults
-        // (e.g. Ctrl+D for multi-cursor) are only registered under the JetBrains keymap.
+        // (e.g. Ctrl+D for multi-cursor) are only registered under the JetBrains keymap. The
+        // Win/Linux and macOS JetBrains keymaps disagree on a couple of these (delete-line is
+        // Ctrl+Y vs Cmd+Backspace; block-comment is Ctrl+Shift+/ vs Option+Cmd+/), so we pick
+        // the right one per platform.
         if (this.settings.keymap === 'jetbrains') {
             this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, () => {
                 unwrap(this.editor.getAction('editor.action.duplicateSelection')).run();
             });
-            this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyY, () => {
+            const deleteLineKey = isMacintosh
+                ? monaco.KeyMod.CtrlCmd | monaco.KeyCode.Backspace
+                : monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyY;
+            this.editor.addCommand(deleteLineKey, () => {
                 unwrap(this.editor.getAction('editor.action.deleteLines')).run();
             });
-            this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Slash, () => {
+            const blockCommentKey = isMacintosh
+                ? monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.Slash
+                : monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Slash;
+            this.editor.addCommand(blockCommentKey, () => {
                 unwrap(this.editor.getAction('editor.action.blockComment')).run();
             });
         }

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1066,9 +1066,19 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             this.runFormatDocumentAction();
         });
 
-        this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, () => {
-            unwrap(this.editor.getAction('editor.action.duplicateSelection')).run();
-        });
+        // Bindings that match JetBrains defaults but conflict with widely-used VS Code defaults
+        // (e.g. Ctrl+D for multi-cursor) are only registered under the JetBrains keymap.
+        if (this.settings.keymap === 'jetbrains') {
+            this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, () => {
+                unwrap(this.editor.getAction('editor.action.duplicateSelection')).run();
+            });
+            this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyY, () => {
+                unwrap(this.editor.getAction('editor.action.deleteLines')).run();
+            });
+            this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Slash, () => {
+                unwrap(this.editor.getAction('editor.action.blockComment')).run();
+            });
+        }
     }
 
     runFormatDocumentAction(): void {

--- a/static/settings.ts
+++ b/static/settings.ts
@@ -37,6 +37,8 @@ import {Themes, themes} from './themes.js';
 
 export type FormatBase = 'Google' | 'LLVM' | 'Mozilla' | 'Chromium' | 'WebKit' | 'Microsoft' | 'GNU';
 
+export type Keymap = 'vscode' | 'jetbrains';
+
 export interface SiteSettings {
     autoCloseBrackets: boolean;
     autoCloseQuotes: boolean;
@@ -68,6 +70,7 @@ export interface SiteSettings {
     indefiniteLineHighlight: boolean;
     keepMultipleTabs: boolean;
     keepSourcesOnLangChange: boolean;
+    keymap: Keymap;
     newEditorLastLang: boolean;
     showMinimap: boolean;
     showQuickSuggestions: boolean;
@@ -397,6 +400,12 @@ export class Settings {
             {label: '4', desc: 'Compile'},
         ];
         addSelector('.enableCtrlS', 'enableCtrlS', enableCtrlSData, 'true');
+
+        const keymapData: {label: Keymap; desc: string}[] = [
+            {label: 'vscode', desc: 'VS Code'},
+            {label: 'jetbrains', desc: 'JetBrains'},
+        ];
+        addSelector('.keymap', 'keymap', keymapData, 'vscode');
     }
 
     private addSliders() {

--- a/static/utils.ts
+++ b/static/utils.ts
@@ -26,6 +26,9 @@ import bigInt from 'big-integer';
 
 import {addDigitSeparator} from '../shared/common-utils.js';
 
+// Mirrors monaco-editor's own platform detection (vs/base/common/platform.js).
+export const isMacintosh = typeof navigator !== 'undefined' && navigator.userAgent.indexOf('Macintosh') >= 0;
+
 /**
  * Get an image relative to `/public` in the source root.
  */

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -50,6 +50,9 @@ mixin input(cls, type, text, style)
               +checkbox("newEditorLastLang", "Use last selected language when opening new Editors")
               +checkbox("enableCommunityAds", "Show community events")
             #keybindings.tab-pane(role="group")
+              .mb-3
+                label.form-label(for="settings-select-keymap") Keymap (requires refresh to take effect)
+                select.form-select.keymap(id="settings-select-keymap")
               +checkbox("useVim", "Vim editor mode")
               +checkbox("relativeLineNumbers", "Show relative line numbers (useful for vim motions)")
               .the-save-option-to-auto-share

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -51,8 +51,9 @@ mixin input(cls, type, text, style)
               +checkbox("enableCommunityAds", "Show community events")
             #keybindings.tab-pane(role="group")
               .mb-3
-                label.form-label(for="settings-select-keymap") Keymap (requires refresh to take effect)
-                select.form-select.keymap(id="settings-select-keymap")
+                label.form-label(for="settings-select-keymap")
+                  | Keymap (requires refresh to take effect)&nbsp;
+                  select.form-select.keymap(id="settings-select-keymap")
               +checkbox("useVim", "Vim editor mode")
               +checkbox("relativeLineNumbers", "Show relative line numbers (useful for vim motions)")
               .the-save-option-to-auto-share

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -52,7 +52,8 @@ mixin input(cls, type, text, style)
             #keybindings.tab-pane(role="group")
               .mb-3
                 label.form-label(for="settings-select-keymap")
-                  | Keymap (requires refresh to take effect)&nbsp;
+                  | Keymap&nbsp;
+                  small.text-muted.fst-italic (requires refresh to take effect)&nbsp;
                   select.form-select.keymap(id="settings-select-keymap")
               +checkbox("useVim", "Vim editor mode")
               +checkbox("relativeLineNumbers", "Show relative line numbers (useful for vim motions)")

--- a/views/popups/settings.pug
+++ b/views/popups/settings.pug
@@ -53,18 +53,17 @@ mixin input(cls, type, text, style)
               .mb-3
                 label.form-label(for="settings-select-keymap")
                   | Keymap&nbsp;
-                  small.text-muted.fst-italic (requires refresh to take effect)&nbsp;
-                  select.form-select.keymap(id="settings-select-keymap")
+                  em (refresh required)
+                select.form-select.keymap(id="settings-select-keymap")
               +checkbox("useVim", "Vim editor mode")
               +checkbox("relativeLineNumbers", "Show relative line numbers (useful for vim motions)")
-              .the-save-option-to-auto-share
-                mb-3
-                  label.form-label(for="settings-checkbox-enableCtrlS")
-                    kbd Ctrl
-                    | +
-                    kbd S
-                    | &nbsp;behaviour
-                    select.form-select.enableCtrlS(id="settings-checkbox-enableCtrlS")
+              .the-save-option-to-auto-share.mb-3
+                label.form-label(for="settings-checkbox-enableCtrlS")
+                  kbd Ctrl
+                  | +
+                  kbd S
+                  | &nbsp;behaviour
+                select.form-select.enableCtrlS(id="settings-checkbox-enableCtrlS")
               .form-check.the-save-option-to-tree-save
                 input.form-check-input.enableCtrlStree(type="checkbox" id="settings-checkbox-enableCtrlStree")
                 label.form-check-label(for="settings-checkbox-enableCtrlStree")


### PR DESCRIPTION
## Summary
- Adds a **Settings → Keybindings → Keymap** dropdown with `VS Code` (default) and `JetBrains` options.
- Previously CE unconditionally bound `Ctrl+D` to duplicate-selection — a JetBrains habit that clobbered VS Code's `editor.action.addSelectionToNextFindMatch` (multi-cursor). VS Code users now keep their muscle memory; JetBrains users opt in.
- Under the JetBrains preset, also wires up `Ctrl+Y` → delete line and `Ctrl+Shift+/` → block comment.
- Drive-by tidy of the existing **Ctrl+S behaviour** dropdown in the same tab so it's full-width and consistent with every other settings dropdown (it had its `<select>` nested inside the `<label>` and used a `mb-3` typo that rendered as an unknown `<mb-3>` element).

## Audit notes
I went through every `addAction` / `addCommand` in `static/panes/{editor,compiler,ir-view,device-view}.ts` and only `Ctrl+D` was a clear VS Code/JetBrains conflict. The other custom bindings (`Ctrl+Enter`, `Ctrl+Shift+Enter`, `Ctrl+F8/F9/F10`, `Ctrl+Shift+F1`) are CE-feature-specific and don't conflict with either editor's defaults, so they're untouched.

Considered but skipped:
- `Alt+Up/Down` (move line) — already the Monaco/VS Code default; nothing to add.
- `Ctrl+W` / `Ctrl+Shift+W` (extend/shrink selection in JB) — browser-reserved, can't be intercepted.
- `Ctrl+B` (go-to-declaration in JB) — Firefox steals it for the bookmarks sidebar, and CE doesn't run language servers for compiled languages so it'd be a near no-op anyway.

## UX
The Keymap label reads "Keymap *(refresh required)*" with the parenthetical in `<em>` so it inherits the theme's foreground colour (no black-on-black on dark mode when selected). The binding decision is read at editor construction so a page reload is needed to pick up changes — consistent with how `autoIndent` / `enableCodeLens` already behave.

## Test plan
- [x] Open Settings → Keybindings, see the new Keymap dropdown defaulted to "VS Code", full-width and visually consistent with the Ctrl+S dropdown below it.
- [x] Switch theme to dark and confirm the "(refresh required)" hint is readable (and doesn't disappear when selected).
- [x] In default (VS Code) mode: `Ctrl+D` adds the next find match (multi-cursor); `Ctrl+Y` redoes; `Ctrl+Shift+/` does nothing custom.
- [x] Switch to JetBrains, refresh: `Ctrl+D` duplicates the selection; `Ctrl+Y` deletes the current line; `Ctrl+Shift+/` toggles a block comment.
- [x] Existing users with stored settings (no \`keymap\` key) get the VS Code default and lose the previous unconditional `Ctrl+D` binding (intended — switch to JetBrains to restore it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)