### PR TITLE
Add tagged beman library versions

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5027,28 +5027,38 @@ libs.belleviews.versions.trunk.version=trunk
 libs.belleviews.versions.trunk.path=/opt/compiler-explorer/libs/belleviews/trunk/sources
 
 libs.beman_any_view.name=beman.any_view
-libs.beman_any_view.versions=trunk
+libs.beman_any_view.versions=trunk:100:110
 libs.beman_any_view.url=https://github.com/bemanproject/any_view
 libs.beman_any_view.versions.trunk.version=trunk
 libs.beman_any_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_any_view/main/include
+libs.beman_any_view.versions.100.version=1.0.0
+libs.beman_any_view.versions.100.path=/opt/compiler-explorer/libs/beman_any_view/1.0.0/include
+libs.beman_any_view.versions.110.version=1.1.0
+libs.beman_any_view.versions.110.path=/opt/compiler-explorer/libs/beman_any_view/v1.1.0/include
 
 libs.beman_cache_latest.name=beman.cache_latest
-libs.beman_cache_latest.versions=trunk
+libs.beman_cache_latest.versions=trunk:010
 libs.beman_cache_latest.url=https://github.com/bemanproject/cache_latest
 libs.beman_cache_latest.versions.trunk.version=trunk
 libs.beman_cache_latest.versions.trunk.path=/opt/compiler-explorer/libs/beman_cache_latest/main/include
+libs.beman_cache_latest.versions.010.version=0.1.0
+libs.beman_cache_latest.versions.010.path=/opt/compiler-explorer/libs/beman_cache_latest/v0.1.0/include
 
 libs.beman_copyable_function.name=beman.copyable_function
-libs.beman_copyable_function.versions=trunk
+libs.beman_copyable_function.versions=trunk:010
 libs.beman_copyable_function.url=https://github.com/bemanproject/copyable_function
 libs.beman_copyable_function.versions.trunk.version=trunk
 libs.beman_copyable_function.versions.trunk.path=/opt/compiler-explorer/libs/beman_copyable_function/main/include
+libs.beman_copyable_function.versions.010.version=0.1.0
+libs.beman_copyable_function.versions.010.path=/opt/compiler-explorer/libs/beman_copyable_function/v0.1.0/include
 
 libs.beman_cstring_view.name=beman.cstring_view
-libs.beman_cstring_view.versions=trunk
+libs.beman_cstring_view.versions=trunk:010
 libs.beman_cstring_view.url=https://github.com/bemanproject/cstring_view
 libs.beman_cstring_view.versions.trunk.version=trunk
 libs.beman_cstring_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_cstring_view/main/include
+libs.beman_cstring_view.versions.010.version=0.1.0
+libs.beman_cstring_view.versions.010.path=/opt/compiler-explorer/libs/beman_cstring_view/v0.1.0/include
 
 libs.beman_execution.name=beman.execution
 libs.beman_execution.versions=trunk
@@ -5057,30 +5067,52 @@ libs.beman_execution.versions.trunk.version=trunk
 libs.beman_execution.versions.trunk.path=/opt/compiler-explorer/libs/beman_execution/main/include
 
 libs.beman_exemplar.name=beman.exemplar
-libs.beman_exemplar.versions=trunk
+libs.beman_exemplar.versions=trunk:100:200:210:211:220:221:230:240
 libs.beman_exemplar.url=https://github.com/bemanproject/exemplar
 libs.beman_exemplar.versions.trunk.version=trunk
 libs.beman_exemplar.versions.trunk.path=/opt/compiler-explorer/libs/beman_exemplar/main/include
+libs.beman_exemplar.versions.100.version=1.0.0
+libs.beman_exemplar.versions.100.path=/opt/compiler-explorer/libs/beman_exemplar/1.0.0/include
+libs.beman_exemplar.versions.200.version=2.0.0
+libs.beman_exemplar.versions.200.path=/opt/compiler-explorer/libs/beman_exemplar/2.0.0/include
+libs.beman_exemplar.versions.210.version=2.1.0
+libs.beman_exemplar.versions.210.path=/opt/compiler-explorer/libs/beman_exemplar/2.1.0/include
+libs.beman_exemplar.versions.211.version=2.1.1
+libs.beman_exemplar.versions.211.path=/opt/compiler-explorer/libs/beman_exemplar/2.1.1/include
+libs.beman_exemplar.versions.220.version=2.2.0
+libs.beman_exemplar.versions.220.path=/opt/compiler-explorer/libs/beman_exemplar/2.2.0/include
+libs.beman_exemplar.versions.221.version=2.2.1
+libs.beman_exemplar.versions.221.path=/opt/compiler-explorer/libs/beman_exemplar/2.2.1/include
+libs.beman_exemplar.versions.230.version=2.3.0
+libs.beman_exemplar.versions.230.path=/opt/compiler-explorer/libs/beman_exemplar/v2.3.0/include
+libs.beman_exemplar.versions.240.version=2.4.0
+libs.beman_exemplar.versions.240.path=/opt/compiler-explorer/libs/beman_exemplar/v2.4.0/include
 
 libs.beman_indices_view.name=beman.indices_view
-libs.beman_indices_view.versions=trunk
+libs.beman_indices_view.versions=trunk:010
 libs.beman_indices_view.url=https://github.com/bemanproject/indices_view
 libs.beman_indices_view.versions.trunk.version=trunk
 libs.beman_indices_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_indices_view/main/include
+libs.beman_indices_view.versions.010.version=0.1.0
+libs.beman_indices_view.versions.010.path=/opt/compiler-explorer/libs/beman_indices_view/v0.1.0/include
 
 libs.beman_inplace_vector.name=beman.inplace_vector
-libs.beman_inplace_vector.versions=trunk
+libs.beman_inplace_vector.versions=trunk:010
 libs.beman_inplace_vector.url=https://github.com/bemanproject/inplace_vector/
 libs.beman_inplace_vector.versions.trunk.version=trunk
 libs.beman_inplace_vector.versions.trunk.path=/opt/compiler-explorer/libs/beman_inplace_vector/main/include
+libs.beman_inplace_vector.versions.010.version=0.1.0
+libs.beman_inplace_vector.versions.010.path=/opt/compiler-explorer/libs/beman_inplace_vector/v0.1.0/include
 
 libs.beman_iterator_interface.name=beman.iterator_interface
-libs.beman_iterator_interface.versions=trunk
+libs.beman_iterator_interface.versions=trunk:010
 libs.beman_iterator_interface.url=https://github.com/bemanproject/iterator_interface
 libs.beman_iterator_interface.packagedheaders=true
 libs.beman_iterator_interface.staticliblink=beman.iterator_interface
 libs.beman_iterator_interface.versions.trunk.version=trunk
 libs.beman_iterator_interface.versions.trunk.lookupversion=main
+libs.beman_iterator_interface.versions.010.version=0.1.0
+libs.beman_iterator_interface.versions.010.lookupversion=v0.1.0
 
 libs.beman_map.name=beman.map
 libs.beman_map.versions=trunk
@@ -5089,10 +5121,14 @@ libs.beman_map.versions.trunk.version=trunk
 libs.beman_map.versions.trunk.path=/opt/compiler-explorer/libs/beman_map/main/include
 
 libs.beman_monadics.name=beman.monadics
-libs.beman_monadics.versions=trunk
+libs.beman_monadics.versions=trunk:010:100
 libs.beman_monadics.url=https://github.com/bemanproject/monadics
 libs.beman_monadics.versions.trunk.version=trunk
 libs.beman_monadics.versions.trunk.path=/opt/compiler-explorer/libs/beman_monadics/main/include
+libs.beman_monadics.versions.010.version=0.1.0
+libs.beman_monadics.versions.010.path=/opt/compiler-explorer/libs/beman_monadics/v0.1.0/include
+libs.beman_monadics.versions.100.version=1.0.0
+libs.beman_monadics.versions.100.path=/opt/compiler-explorer/libs/beman_monadics/v1.0.0/include
 
 libs.beman_net.name=beman.net
 libs.beman_net.versions=trunk
@@ -5101,22 +5137,28 @@ libs.beman_net.versions.trunk.version=trunk
 libs.beman_net.versions.trunk.path=/opt/compiler-explorer/libs/beman_net/main/include
 
 libs.beman_optional.name=beman.optional
-libs.beman_optional.versions=trunk
+libs.beman_optional.versions=trunk:100
 libs.beman_optional.url=https://github.com/bemanproject/optional
 libs.beman_optional.versions.trunk.version=trunk
 libs.beman_optional.versions.trunk.path=/opt/compiler-explorer/libs/beman_optional/main/include
+libs.beman_optional.versions.100.version=1.0.0
+libs.beman_optional.versions.100.path=/opt/compiler-explorer/libs/beman_optional/v1.0.0/include
 
 libs.beman_scan_view.name=beman.scan_view
-libs.beman_scan_view.versions=trunk
+libs.beman_scan_view.versions=trunk:010
 libs.beman_scan_view.url=https://github.com/bemanproject/scan_view
 libs.beman_scan_view.versions.trunk.version=trunk
 libs.beman_scan_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_scan_view/main/include
+libs.beman_scan_view.versions.010.version=0.1.0
+libs.beman_scan_view.versions.010.path=/opt/compiler-explorer/libs/beman_scan_view/v0.1.0/include
 
 libs.beman_scope.name=beman.scope
-libs.beman_scope.versions=trunk
+libs.beman_scope.versions=trunk:001
 libs.beman_scope.url=https://github.com/bemanproject/scope
 libs.beman_scope.versions.trunk.version=trunk
 libs.beman_scope.versions.trunk.path=/opt/compiler-explorer/libs/beman_scope/main/include
+libs.beman_scope.versions.001.version=0.0.1
+libs.beman_scope.versions.001.path=/opt/compiler-explorer/libs/beman_scope/0.0.1/include
 
 libs.beman_span.name=beman.span
 libs.beman_span.versions=trunk
@@ -5125,10 +5167,12 @@ libs.beman_span.versions.trunk.version=trunk
 libs.beman_span.versions.trunk.path=/opt/compiler-explorer/libs/beman_span/main/include
 
 libs.beman_take_before.name=beman.take_before
-libs.beman_take_before.versions=trunk
+libs.beman_take_before.versions=trunk:010
 libs.beman_take_before.url=https://github.com/bemanproject/take_before
 libs.beman_take_before.versions.trunk.version=trunk
 libs.beman_take_before.versions.trunk.path=/opt/compiler-explorer/libs/beman_take_before/main/include
+libs.beman_take_before.versions.010.version=0.1.0
+libs.beman_take_before.versions.010.path=/opt/compiler-explorer/libs/beman_take_before/v0.1.0/include
 
 libs.beman_task.name=beman.task
 libs.beman_task.versions=trunk
@@ -5137,22 +5181,34 @@ libs.beman_task.versions.trunk.version=trunk
 libs.beman_task.versions.trunk.path=/opt/compiler-explorer/libs/beman_task/main/include
 
 libs.beman_timed_lock_alg.name=beman.timed_lock_alg
-libs.beman_timed_lock_alg.versions=trunk
+libs.beman_timed_lock_alg.versions=trunk:100:110
 libs.beman_timed_lock_alg.url=https://github.com/bemanproject/timed_lock_alg
 libs.beman_timed_lock_alg.versions.trunk.version=trunk
 libs.beman_timed_lock_alg.versions.trunk.path=/opt/compiler-explorer/libs/beman_timed_lock_alg/main/include
+libs.beman_timed_lock_alg.versions.100.version=1.0.0
+libs.beman_timed_lock_alg.versions.100.path=/opt/compiler-explorer/libs/beman_timed_lock_alg/v1.0.0/include
+libs.beman_timed_lock_alg.versions.110.version=1.1.0
+libs.beman_timed_lock_alg.versions.110.path=/opt/compiler-explorer/libs/beman_timed_lock_alg/v1.1.0/include
 
 libs.beman_transform_view.name=beman.transform_view
-libs.beman_transform_view.versions=trunk
+libs.beman_transform_view.versions=trunk:010:020
 libs.beman_transform_view.url=https://github.com/bemanproject/transform_view
 libs.beman_transform_view.versions.trunk.version=trunk
 libs.beman_transform_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_transform_view/main/include
+libs.beman_transform_view.versions.010.version=0.1.0
+libs.beman_transform_view.versions.010.path=/opt/compiler-explorer/libs/beman_transform_view/v0.1.0/include
+libs.beman_transform_view.versions.020.version=0.2.0
+libs.beman_transform_view.versions.020.path=/opt/compiler-explorer/libs/beman_transform_view/v0.2.0/include
 
 libs.beman_utf_view.name=beman.utf_view
-libs.beman_utf_view.versions=trunk
+libs.beman_utf_view.versions=trunk:010:020
 libs.beman_utf_view.url=https://github.com/bemanproject/utf_view
 libs.beman_utf_view.versions.trunk.version=trunk
 libs.beman_utf_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_utf_view/main/include
+libs.beman_utf_view.versions.010.version=0.1.0
+libs.beman_utf_view.versions.010.path=/opt/compiler-explorer/libs/beman_utf_view/v0.1.0/include
+libs.beman_utf_view.versions.020.version=0.2.0
+libs.beman_utf_view.versions.020.path=/opt/compiler-explorer/libs/beman_utf_view/v0.2.0/include
 
 libs.benchmark.name=Google Benchmark
 libs.benchmark.versions=trunk:120:130:140:141:150:161:162


### PR DESCRIPTION
## Summary
- Each beman library currently exposes only the `trunk` version.
- Companion infra PR https://github.com/compiler-explorer/infra/pull/2111 installs every released git tag from `bemanproject/*` into `/opt/compiler-explorer/libs/beman_<lib>/<tag>`.
- This PR adds matching version entries to `c++.amazon.properties` so users can pick a specific tagged release.
- `beman_iterator_interface` uses the `lookupversion` form because it is built and conan-packaged.
- Repos with no tags (execution, map, net, span, task) are unchanged.

## Test plan
- [x] `npm run test:props` passes (90/90)
- [ ] Verify in staging once infra PR has run a discovery cycle