### PR TITLE
beman_iterator_interface: drop staticliblink and wrong lookupversion

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5108,7 +5108,6 @@ libs.beman_iterator_interface.name=beman.iterator_interface
 libs.beman_iterator_interface.versions=trunk:010
 libs.beman_iterator_interface.url=https://github.com/bemanproject/iterator_interface
 libs.beman_iterator_interface.packagedheaders=true
-libs.beman_iterator_interface.staticliblink=beman.iterator_interface
 libs.beman_iterator_interface.versions.trunk.version=trunk
 libs.beman_iterator_interface.versions.trunk.lookupversion=main
 libs.beman_iterator_interface.versions.010.version=0.1.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5111,7 +5111,6 @@ libs.beman_iterator_interface.packagedheaders=true
 libs.beman_iterator_interface.versions.trunk.version=trunk
 libs.beman_iterator_interface.versions.trunk.lookupversion=main
 libs.beman_iterator_interface.versions.010.version=0.1.0
-libs.beman_iterator_interface.versions.010.lookupversion=v0.1.0
 
 libs.beman_map.name=beman.map
 libs.beman_map.versions=trunk


### PR DESCRIPTION
## Summary

Two related fixes to make `beman_iterator_interface 0.1.0` actually work in CE:

### 1. Drop `staticliblink=beman.iterator_interface`

Upstream (`bemanproject/iterator_interface`) switched the cmake target to `add_library(... INTERFACE)` in April 2026, so there's no longer a `libbeman.iterator_interface.a` to link. Anyone selecting this library hits `cannot find -lbeman.iterator_interface` at the link step.

The companion infra change [compiler-explorer/infra#2113](https://github.com/compiler-explorer/infra/pull/2113) (merged) introduces a `lib_type: cmake_built_headeronly` that builds with cmake (so per-compiler `configure_file` substitutions like `BEMAN_ITERATOR_INTERFACE_USE_DEDUCING_THIS` apply) but produces only headers. With `packagedheaders=true` already in place, CE downloads the per-compiler headers from conan and `-I`s the `include/` subdir via `getIncludeArguments` (`lib/base-compiler.ts:1081-1093`); nothing needs to be linked.

### 2. Drop `lookupversion=v0.1.0`

The conan target_name is bare `0.1.0` — the infra-side `target_prefix: v` affects only which git tag we clone (`v0.1.0`), not the conan-stored version. With `lookupversion=v0.1.0` the CE worker queries `https://conan.compiler-explorer.com/.../v0.1.0/.../search` and gets back `Recipe not found`, so the per-compiler conan package is never downloaded and `#include <beman/iterator_interface/...>` fails with `No such file or directory`. Dropping the line lets it fall back to `version=0.1.0`, which matches the 281 packages from https://github.com/compiler-explorer/infra/actions/runs/25514037808.

I noticed this while trying to prove (via POST /api/compiler/g152/compile) that the prod binaries today only fail at link-time. The compile actually fails earlier with a missing-include error because CE never finds the conan recipe in the first place.

## Test plan

- [x] `npm run test:props` passes
- [x] Verified conan recipe exists at `0.1.0` and not at `v0.1.0` (`curl https://conan.compiler-explorer.com/v1/conans/beman_iterator_interface/0.1.0/.../search` returns 281 packages; the `v0.1.0` URL returns `Recipe not found`).
- [ ] Once deployed: `POST /api/compiler/g152/compile` with a small program that `#include <beman/iterator_interface/iterator_interface.hpp>` resolves and links without error.