### PR TITLE
MCP: list_libraries version-string match + HPPA/Go cross-compiler instructionSet retags

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1108,6 +1108,7 @@ group.gnathppa.baseName=hppa gnat
 group.gnathppa.isSemVer=true
 group.gnathppa.supportsBinary=true
 group.gnathppa.supportsExecute=false
+group.gnathppa.instructionSet=hppa
 
 compiler.gnathppa1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gnatmake
 compiler.gnathppa1420.semver=14.2.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1886,6 +1886,7 @@ group.gcchppa.supportsExecute=false
 group.gcchppa.baseName=HPPA gcc
 group.gcchppa.groupName=HPPA GCC
 group.gcchppa.isSemVer=true
+group.gcchppa.instructionSet=hppa
 
 compiler.hppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-g++
 compiler.hppag1420.semver=14.2.0

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1377,6 +1377,7 @@ group.cgcchppa.groupName=HPPA GCC
 group.cgcchppa.isSemVer=true
 group.cgcchppa.supportsBinary=true
 group.cgcchppa.supportsExecute=false
+group.cgcchppa.instructionSet=hppa
 
 compiler.chppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gcc
 compiler.chppag1420.semver=14.2.0

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1003,6 +1003,7 @@ group.gdchppa.groupName=GDC hppa
 group.gdchppa.includeFlag=-isystem
 group.gdchppa.isSemVer=true
 group.gdchppa.baseName=gdc hppa
+group.gdchppa.instructionSet=hppa
 
 compiler.gdchppa1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gdc
 compiler.gdchppa1420.semver=14.2.0

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -457,6 +457,7 @@ group.gcchppa.groupName=HPPA gfortran
 group.gcchppa.baseName=HPPA gfortran
 group.gcchppa.supportsBinary=true
 group.gcchppa.compilerCategories=gfortran
+group.gcchppa.instructionSet=hppa
 
 compiler.fhppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gfortran
 compiler.fhppag1420.semver=14.2.0

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -720,6 +720,7 @@ group.gimplehppa.groupName=HPPA GCC
 group.gimplehppa.isSemVer=true
 group.gimplehppa.supportsBinary=true
 group.gimplehppa.supportsExecute=false
+group.gimplehppa.instructionSet=hppa
 
 compiler.gimplehppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gcc
 compiler.gimplehppag1420.semver=14.2.0

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -210,6 +210,7 @@ group.386gl.compilers=386_gl114:386_gl115:386_gl116:386_gl117:386_gl118:386_gl11
 group.386gl.groupName=x86 GC
 group.386gl.baseName=x86 gc
 group.386gl.goarch=386
+group.386gl.instructionSet=x86
 
 compiler.386_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.386_gl114.semver=1.14
@@ -250,6 +251,7 @@ group.arm32gl.compilers=arm_gl114:arm_gl115:arm_gl116:arm_gl117:arm_gl118:arm_gl
 group.arm32gl.groupName=ARM GC
 group.arm32gl.baseName=ARM gc
 group.arm32gl.goarch=arm
+group.arm32gl.instructionSet=arm32
 
 compiler.arm_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.arm_gl114.semver=1.14
@@ -285,6 +287,7 @@ group.arm64gl.compilers=arm64_gl114:arm64_gl115:arm64_gl116:arm64_gl117:arm64_gl
 group.arm64gl.groupName=ARM64 GC
 group.arm64gl.baseName=ARM64 gc
 group.arm64gl.goarch=arm64
+group.arm64gl.instructionSet=aarch64
 
 compiler.arm64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.arm64_gl114.semver=1.14
@@ -327,6 +330,7 @@ group.mips32legl.compilers=mipsle_gl114:mipsle_gl115:mipsle_gl116:mipsle_gl117:m
 group.mips32legl.goarch=mipsle
 group.mips32legl.groupName=MIPSLE GC
 group.mips32legl.baseName=MIPSLE gc
+group.mips32legl.instructionSet=mips
 
 compiler.mipsle_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mipsle_gl114.semver=1.14
@@ -362,6 +366,7 @@ group.mips32begl.compilers=mips_gl114:mips_gl115:mips_gl116:mips_gl117:mips_gl11
 group.mips32begl.goarch=mips
 group.mips32begl.groupName=MIPS GC
 group.mips32begl.baseName=MIPS gc
+group.mips32begl.instructionSet=mips
 
 compiler.mips_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mips_gl114.semver=1.14
@@ -399,6 +404,7 @@ group.mips64begl.compilers=mips64_gl114:mips64_gl115:mips64_gl116:mips64_gl117:m
 group.mips64begl.goarch=mips64
 group.mips64begl.groupName=MIPS64 GC
 group.mips64begl.baseName=MIPS64 gc
+group.mips64begl.instructionSet=mips
 
 compiler.mips64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.mips64_gl114.semver=1.14
@@ -435,6 +441,7 @@ group.mips64legl.compilers=mips64le_gl114:mips64le_gl115:mips64le_gl116:mips64le
 group.mips64legl.goarch=mips64le
 group.mips64legl.groupName=MIPS64LE GC
 group.mips64legl.baseName=MIPS64LE gc
+group.mips64legl.instructionSet=mips
 
 
 compiler.mips64le_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
@@ -477,6 +484,7 @@ group.ppc64legl.compilers=ppc64le_gl114:ppc64le_gl115:ppc64le_gl116:ppc64le_gl11
 group.ppc64legl.goarch=ppc64le
 group.ppc64legl.groupName=POWER64LE GC
 group.ppc64legl.baseName=POWER64LE gc
+group.ppc64legl.instructionSet=powerpc
 
 compiler.ppc64le_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.ppc64le_gl114.semver=1.14
@@ -513,6 +521,7 @@ group.ppc64begl.compilers=ppc64_gl114:ppc64_gl115:ppc64_gl116:ppc64_gl117:ppc64_
 group.ppc64begl.goarch=ppc64
 group.ppc64begl.groupName=POWER64 GC
 group.ppc64begl.baseName=POWER64 gc
+group.ppc64begl.instructionSet=powerpc
 
 compiler.ppc64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.ppc64_gl114.semver=1.14
@@ -551,6 +560,7 @@ group.riscvgl.supportsBinary=false
 group.riscvgl.groupName=RISC-V 64 GC
 group.riscvgl.baseName=RISC-V 64 gc
 group.riscvgl.goarch=riscv64
+group.riscvgl.instructionSet=riscv64
 
 compiler.riscv64_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.riscv64_gl114.semver=1.14
@@ -589,6 +599,7 @@ group.s390xgl.supportsBinary=false
 group.s390xgl.goarch=s390x
 group.s390xgl.groupName=S390X GC
 group.s390xgl.baseName=S390X gc
+group.s390xgl.instructionSet=s390x
 
 
 compiler.s390x_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
@@ -630,6 +641,7 @@ group.wasmgl.groupName=WASM GC
 group.wasmgl.goarch=wasm
 group.wasmgl.goos=js
 group.wasmgl.baseName=WASM gc
+group.wasmgl.instructionSet=wasm32
 
 compiler.wasm_gl114.exe=/opt/compiler-explorer/golang-1.14/go/bin/go
 compiler.wasm_gl114.semver=1.14

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -121,6 +121,7 @@ group.x86gl.compilers=&amd64gl:&386gl
 group.amd64gl.compilers=6g141:gl172:gl185:gl187:gl192:gl194:gl1100:gl1101:gl1110:gl1120:gl1130:gl1140:gl1150:gl1160:gl1170:gl1180:gl1190:gl1200:gl12113:gl12212:gl1238:gl12413:gl1257:gl1260:gltip
 group.amd64gl.groupName=x86-64 GC
 group.amd64gl.baseName=x86-64 gc
+group.amd64gl.instructionSet=amd64
 
 compiler.6g141.exe=/opt/compiler-explorer/golang-1.4.1/go/bin/go
 compiler.6g141.semver=1.4.1

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -146,6 +146,7 @@ group.objcppgcchppa.baseName=HPPA gcc
 group.objcppgcchppa.isSemVer=true
 group.objcppgcchppa.supportsBinary=true
 group.objcppgcchppa.supportsExecute=false
+group.objcppgcchppa.instructionSet=hppa
 
 compiler.objcpphppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-g++
 compiler.objcpphppag1420.semver=14.2.0

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1324,6 +1324,7 @@ group.objchppa.isSemVer=true
 group.objchppa.supportsExecute=false
 group.objchppa.supportsBinary=true
 group.objchppa.supportsBinaryObject=true
+group.objchppa.instructionSet=hppa
 
 compiler.objchppag1420.exe=/opt/compiler-explorer/hppa/gcc-14.2.0/hppa-unknown-linux-gnu/bin/hppa-unknown-linux-gnu-gcc
 compiler.objchppag1420.semver=14.2.0

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -63,6 +63,10 @@ export class InstructionSets {
                 target: ['ez80'],
                 path: [],
             },
+            hppa: {
+                target: ['hppa'],
+                path: ['/hppa-', '/hppa-unknown-linux-gnu-'],
+            },
             kvx: {
                 target: ['kvx'],
                 path: ['/kvx-', '/k1-'],

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -65,7 +65,7 @@ export class InstructionSets {
             },
             hppa: {
                 target: ['hppa'],
-                path: ['/hppa-', '/hppa-unknown-linux-gnu-'],
+                path: ['/hppa-'],
             },
             kvx: {
                 target: ['kvx'],

--- a/lib/mcp/tools/compilers.ts
+++ b/lib/mcp/tools/compilers.ts
@@ -63,7 +63,7 @@ function pickLatest(
                 // mis-tagged cross-compiler that share major 16) don't fight for the
                 // same slot. Without `group`, an HPPA cross-compiler tagged amd64 would
                 // hijack the x86-64 GCC slot for its semver-major.
-                const groupKey = `${c.lang}\0${c.instructionSet ?? ''}\0${c.group ?? ''}`;
+                const groupKey = `${c.lang}\0${c.instructionSet ?? ''}\0${c.group}`;
                 let bucket = stableBuckets.get(groupKey);
                 if (!bucket) {
                     bucket = new Map();

--- a/lib/mcp/tools/compilers.ts
+++ b/lib/mcp/tools/compilers.ts
@@ -58,7 +58,12 @@ function pickLatest(
     for (const c of compilers) {
         switch (c.releaseTrack) {
             case 'stable': {
-                const groupKey = `${c.lang}\0${c.instructionSet ?? ''}`;
+                // Bucket by (lang, instructionSet, group) so different compiler families
+                // that happen to share an arch tag (e.g. an upstream gcc release and a
+                // mis-tagged cross-compiler that share major 16) don't fight for the
+                // same slot. Without `group`, an HPPA cross-compiler tagged amd64 would
+                // hijack the x86-64 GCC slot for its semver-major.
+                const groupKey = `${c.lang}\0${c.instructionSet ?? ''}\0${c.group ?? ''}`;
                 let bucket = stableBuckets.get(groupKey);
                 if (!bucket) {
                     bucket = new Map();

--- a/lib/mcp/tools/libraries.ts
+++ b/lib/mcp/tools/libraries.ts
@@ -42,8 +42,9 @@ export function registerLibrariesTool(server: McpServer, apiHandler: ApiHandler)
                 .string()
                 .optional()
                 .describe(
-                    'Case-insensitive AND-of-tokens filter on id and name. Numeric tokens match whole-word, ' +
-                        'alphanumeric substring. Prefer a library name like "boost"/"fmt" or an exact id.',
+                    'Case-insensitive AND-of-tokens filter on id, name, and version strings (so ' +
+                        '"boost 1.88" finds Boost when one of its versions matches 1.88.x). Numeric tokens ' +
+                        'match version-prefix; alphanumeric substring.',
                 ),
             maxResults: z
                 .number()
@@ -74,7 +75,16 @@ export function registerLibrariesTool(server: McpServer, apiHandler: ApiHandler)
                     isError: true,
                 };
             }
-            const filtered = applyMatch(all, match, lib => [lib.id, lib.name ?? '']);
+            // Include each version's `version` (human form, e.g. "1.88.0") and `id`
+            // (e.g. "188") in the haystack so a query like "boost 1.88" matches —
+            // the natural way an LLM phrases "find Boost 1.88" — without the agent
+            // having to first discover the library, then scan its versions array.
+            const filtered = applyMatch(all, match, lib => [
+                lib.id,
+                lib.name ?? '',
+                ...(lib.versions ?? []).map(v => v.version ?? ''),
+                ...(lib.versions ?? []).map(v => v.id),
+            ]);
             const {items, ...meta} = applyCap(
                 filtered,
                 maxResults ?? DEFAULT_MAX_RESULTS,

--- a/test/instructionsets-tests.ts
+++ b/test/instructionsets-tests.ts
@@ -51,4 +51,10 @@ describe('InstructionSets', () => {
 
         expect(isets.getCompilerInstructionSetHint(false, '/opt/compiler-explorer/gcc-12.2.0/bin/g++')).toBe('amd64');
     });
+
+    it('should recognize hppa from compiler target string', () => {
+        const isets = new InstructionSets();
+
+        expect(isets.getCompilerInstructionSetHint('hppa-unknown-linux-gnu')).toBe('hppa');
+    });
 });

--- a/test/mcp/mcp-tests.ts
+++ b/test/mcp/mcp-tests.ts
@@ -696,6 +696,49 @@ describe('MCP list_libraries tool', () => {
         expect(parsed.hint).toBeUndefined();
     });
 
+    it('match also searches version strings (so "boost 1.88" finds the right library)', async () => {
+        const {fakeServer, toolHandlers} = makeFakeServer();
+        const apiHandler = {
+            getLibrariesAsArray: () => [
+                {
+                    id: 'boost',
+                    name: 'Boost',
+                    versions: [
+                        {id: '187', version: '1.87.0'},
+                        {id: '188', version: '1.88.0'},
+                    ],
+                },
+                {id: 'fmt', name: '{fmt}', versions: [{id: '1100', version: '11.0.0'}]},
+                {id: 'eigen', name: 'Eigen', versions: [{id: '340', version: '3.4.0'}]},
+            ],
+        } as unknown as ApiHandler;
+        registerLibrariesTool(fakeServer, apiHandler);
+
+        // The "natural" LLM query: combine the library family name with the desired
+        // version. Pre-fix this returned [] because match only saw {id, name}.
+        const result = await toolHandlers.list_libraries({language: 'c++', match: 'boost 1.88'});
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.libraries.map((l: any) => l.id)).toEqual(['boost']);
+        // The full library is returned (with all its versions) so the caller can
+        // see the matching version's id to pass into compile.
+        expect(parsed.libraries[0].versions).toHaveLength(2);
+    });
+
+    it('match against a version id ("188") also works', async () => {
+        const {fakeServer, toolHandlers} = makeFakeServer();
+        const apiHandler = {
+            getLibrariesAsArray: () => [
+                {id: 'boost', name: 'Boost', versions: [{id: '188', version: '1.88.0'}]},
+                {id: 'fmt', name: '{fmt}', versions: [{id: '1100', version: '11.0.0'}]},
+            ],
+        } as unknown as ApiHandler;
+        registerLibrariesTool(fakeServer, apiHandler);
+
+        const result = await toolHandlers.list_libraries({language: 'c++', match: '188'});
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.libraries.map((l: any) => l.id)).toEqual(['boost']);
+    });
+
     it('returns a structured isError response when getLibrariesAsArray throws', async () => {
         const {fakeServer, toolHandlers} = makeFakeServer();
         const apiHandler = {

--- a/test/mcp/mcp-tests.ts
+++ b/test/mcp/mcp-tests.ts
@@ -461,6 +461,36 @@ describe('MCP list_compilers tool', () => {
         expect(parsed.compilers.map((c: any) => c.id).sort()).toEqual(['g142', 'g161']);
     });
 
+    it('latestPerMajor: distinct groups with the same arch+major do NOT compete (e.g. x86-64 gcc vs a mis-tagged HPPA gcc)', async () => {
+        const {fakeServer, toolHandlers} = makeFakeServer();
+        const apiHandler = {
+            compilers: [
+                makeCompiler('g161', 'c++', {
+                    isSemVer: true,
+                    semver: '16.1',
+                    instructionSet: 'amd64',
+                    releaseTrack: 'stable',
+                    group: 'gcc86',
+                }),
+                // Same lang+arch+major as g161 but different group ⇒ both should survive.
+                // (Guards against future re-introduction of mis-tagged cross-compilers
+                // hijacking the canonical-arch family's slot.)
+                makeCompiler('hppag1610', 'c++', {
+                    isSemVer: true,
+                    semver: '16.1.0',
+                    instructionSet: 'amd64',
+                    releaseTrack: 'stable',
+                    group: 'gcchppa',
+                }),
+            ],
+        } as unknown as ApiHandler;
+        registerCompilersTool(fakeServer, apiHandler);
+
+        const result = await toolHandlers.list_compilers({latestPerMajor: true});
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.compilers.map((c: any) => c.id).sort()).toEqual(['g161', 'hppag1610']);
+    });
+
     it('latestPerMajor: stable compilers grouped by (instructionSet, major), newest per major wins', async () => {
         const {fakeServer, toolHandlers} = makeFakeServer();
         const apiHandler = {

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -37,6 +37,7 @@ export const InstructionSetsList = [
     'eravm',
     'ez80',
     'hook',
+    'hppa',
     'core',
     'java',
     'kvx',


### PR DESCRIPTION
## Summary

Three related fixes prompted by driving the deployed MCP endpoint after #8644 / #8685 merged:

1. **`list_libraries` match also searches version strings.** The natural LLM query "find Boost 1.88" returned zero results — `list_libraries({language:"c++", match:"boost 1.88"})` only matched against `{id, name}`, so the version token never matched anything.

2. **HPPA + Go cross-compiler `instructionSet` retags.** Discovered via `list_compilers(match="gcc 16", instructionSet="amd64")` returning *only* `hppag1610` (HPPA cross-compiler) and missing plain `g161` (x86-64 GCC). Two layered causes — HPPA had no entry in `InstructionSetsList`, so the heuristic in `lib/instructionsets.ts` defaulted HPPA cross-compilers to `amd64`; and 12 Go cross-compiler groups (`386gl`, `arm32gl`, `arm64gl`, `mips*gl`, `ppc64*gl`, `riscvgl`, `s390xgl`, `wasmgl`) had never been tagged at all.

3. **Defensive bucketing in MCP `pickLatest`.** Belt-and-braces fix: bucket key is now `(lang, instructionSet, group)` so different compiler families that happen to share an arch tag can't fight for the same `latestPerMajor` slot.

## Changes

- `lib/mcp/tools/libraries.ts` — extend `applyMatch` haystack to include `versions[].version` (human form, e.g. `"1.88.0"`) and `versions[].id` (e.g. `"188"`).
- `lib/mcp/tools/compilers.ts` — `pickLatest` bucket key now includes `c.group`.
- `types/instructionsets.ts` + `lib/instructionsets.ts` — new `'hppa'` entry.
- `etc/config/{ada,c++,c,d,fortran,gimple,objc++,objc}.amazon.properties` — `group.<gnathppa|gcchppa|cgcchppa|gdchppa|gimplehppa|objcppgcchppa|objchppa>.instructionSet=hppa`.
- `etc/config/go.amazon.properties` — explicit `instructionSet=` for all 13 Go arch groups (12 cross + amd64gl for symmetry).
- `test/mcp/mcp-tests.ts` — covers the bucketing-by-group case.
- `test/instructionsets-tests.ts` — covers the hppa target-string branch.

## Follow-up

#8690 — drop the `lib/instructionsets.ts` path-based heuristic entirely in favour of required `instructionSet` properties (the path branch is Amazon-install-specific and silently mistags compilers on any non-Amazon layout).

## Test plan

- [x] `npm run test -- --run mcp` — passes (existing + 2 new)
- [x] `npm run test -- --run instructionsets` — passes (existing + 1 new)
- [x] `npm run test:props` — 90/90 pass
- [x] `make pre-commit` — exits 0
- [ ] Drive the staging endpoint with `list_libraries({language:"c++", match:"boost 1.88"})` and confirm Boost is returned with its versions.
- [ ] Drive the staging endpoint with `list_compilers({match:"gcc 16", instructionSet:"amd64", latestPerMajor:true})` and confirm `g161` (x86-64) appears and `hppag1610` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)