### PR TITLE
Add ICX 2026.0.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1582,7 +1582,7 @@ compiler.icc2021100.options=-gxx-name=/opt/compiler-explorer/gcc-12.2.0/bin/g++
 
 ################################
 # icx for x86
-group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icx202410:icx202420:icx202421:icx202500:icx202501:icx202503:icx202504:icx202510:icx202511:icx202520:icx202521:icx202530:icx202531:icxlatest
+group.icx.compilers=icx202112:icx202120:icx202130:icx202140:icx202200:icx202210:icx202220:icx202221:icx202300:icx202310:icx202321:icx202400:icx202410:icx202420:icx202421:icx202500:icx202501:icx202503:icx202504:icx202510:icx202511:icx202520:icx202521:icx202530:icx202531:icx202600:icxlatest
 group.icx.intelAsm=-masm=intel
 group.icx.options=
 group.icx.groupName=ICX x86-64
@@ -1745,10 +1745,16 @@ compiler.icx202531.libPath=/opt/compiler-explorer/intel-cpp-2025.3.1.16/compiler
 compiler.icx202531.semver=2025.3.1
 compiler.icx202531.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
-compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2025.3.1.16/compiler/latest/bin/icpx
-compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2025.3.1.16/compiler/latest/lib
-compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2025.3.1.16/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2025.3.1.16/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2025.3.1.16/umf/latest/lib
-compiler.icxlatest.semver=2025.3.1
+compiler.icx202600.exe=/opt/compiler-explorer/intel-cpp-2026.0.0.564/compiler/latest/bin/icpx
+compiler.icx202600.ldPath=/opt/compiler-explorer/intel-cpp-2026.0.0.564/compiler/latest/lib
+compiler.icx202600.libPath=/opt/compiler-explorer/intel-cpp-2026.0.0.564/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2026.0.0.564/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2026.0.0.564/umf/latest/lib
+compiler.icx202600.semver=2026.0.0
+compiler.icx202600.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
+
+compiler.icxlatest.exe=/opt/compiler-explorer/intel-cpp-2026.0.0.564/compiler/latest/bin/icpx
+compiler.icxlatest.ldPath=/opt/compiler-explorer/intel-cpp-2026.0.0.564/compiler/latest/lib
+compiler.icxlatest.libPath=/opt/compiler-explorer/intel-cpp-2026.0.0.564/compiler/latest/lib:/opt/compiler-explorer/intel-cpp-2026.0.0.564/tbb/latest/lib:/opt/compiler-explorer/intel-cpp-2026.0.0.564/umf/latest/lib
+compiler.icxlatest.semver=2026.0.0
 compiler.icxlatest.options=--gcc-toolchain=/opt/compiler-explorer/gcc-13.3.0
 
 ################################


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds Intel C/C++ Compiler (ICX) version 2026.0.0.564.

Requires the corresponding infra PR to land first to install the compiler.

Closes #8700

🤖 Generated by LLM (Claude, via OpenClaw)