### PR TITLE
[noscript] Fix generating shareable URL with storage to `s3`

### DIFF
--- a/lib/handlers/noscript.ts
+++ b/lib/handlers/noscript.ts
@@ -276,7 +276,7 @@ export class NoScriptHandler {
             // Fallback to direct encoding
             const stateString = JSON.stringify(state);
             const base64State = Buffer.from(stateString).toString('base64url');
-            return `/#${base64State}`;
+            return `clientstate/${base64State}`;
         }
     }
 }

--- a/lib/handlers/noscript.ts
+++ b/lib/handlers/noscript.ts
@@ -224,7 +224,7 @@ export class NoScriptHandler {
         }
 
         // Generating shareable URL
-        const shareableUrl = await this.generateShareableUrl(state);
+        const shareableUrl = await this.generateShareableUrl(state, req);
 
         const httpRoot = (this.renderConfig as any).httpRoot || '/';
         const relativeUrl = shareableUrl.substring(shareableUrl.lastIndexOf('/z/') + 1);
@@ -251,7 +251,7 @@ export class NoScriptHandler {
         res.render('noscript/share', renderConfig);
     }
 
-    async generateShareableUrl(state: ClientState): Promise<string> {
+    async generateShareableUrl(state: ClientState, req: express.Request): Promise<string> {
         try {
             // Creating the stored object like the main handler does
             const {config, configHash} = StorageBase.getSafeHash(state);
@@ -267,7 +267,7 @@ export class NoScriptHandler {
                     config: config,
                 };
 
-                await this.storageHandler.storeItem(storedObject, {} as express.Request);
+                await this.storageHandler.storeItem(storedObject, req);
             }
 
             return `/z/${result.uniqueSubHash}`;


### PR DESCRIPTION
Resolves #8701.

The `s3` storage backend requires an `express.Request` object to get the request’s IP address, but the code passed `{} as express.Request`, which led to an exception.

As a result, the fallback implementation was always used in prod, which generates a link of the form `godbolt.org/#base64_encoded_clientstate`, but `/#...` expects a `rison`-encoded string.