### PR TITLE
Support Triton 3.7.0

### DIFF
--- a/etc/config/triton.amazon.properties
+++ b/etc/config/triton.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&triton_nvidia:&triton_amd
-defaultCompiler=triton_nvidia_360
+defaultCompiler=triton_nvidia_370
 compilerType=triton
 interpreted=true
 supportsBinary=false
@@ -7,9 +7,12 @@ supportsExecute=false
 isSemVer=true
 notification=Experimental Triton support on Compiler Explorer. For tutorials, bugs reports, and feature requests, please visit <a href="https://github.com/ShawnZhong/compiler-explorer-triton">here</a>.
 
-group.triton_nvidia.compilers=triton_nvidia_360:triton_nvidia_351:triton_nvidia_350:triton_nvidia_340:triton_nvidia_331:triton_nvidia_330:triton_nvidia_320:triton_nvidia_310:triton_nvidia_300:triton_nvidia_231:triton_nvidia_230
+group.triton_nvidia.compilers=triton_nvidia_370:triton_nvidia_360:triton_nvidia_351:triton_nvidia_350:triton_nvidia_340:triton_nvidia_331:triton_nvidia_330:triton_nvidia_320:triton_nvidia_310:triton_nvidia_300:triton_nvidia_231:triton_nvidia_230
 group.triton_nvidia.groupName=Triton (Nvidia)
 group.triton_nvidia.options=--backend cuda --arch 90  --warp_size 32
+
+compiler.triton_nvidia_370.name=Triton 3.7.0 (Nvidia)
+compiler.triton_nvidia_370.exe=/opt/compiler-explorer/triton/v3.7.0/bin/python3
 
 compiler.triton_nvidia_360.name=Triton 3.6.0 (Nvidia)
 compiler.triton_nvidia_360.exe=/opt/compiler-explorer/triton/v3.6.0/bin/python3
@@ -44,9 +47,12 @@ compiler.triton_nvidia_231.exe=/opt/compiler-explorer/triton/v2.3.1/bin/python3
 compiler.triton_nvidia_230.name=Triton 2.3.0 (Nvidia)
 compiler.triton_nvidia_230.exe=/opt/compiler-explorer/triton/v2.3.0/bin/python3
 
-group.triton_amd.compilers=triton_amd_360:triton_amd_351:triton_amd_350:triton_amd_340:triton_amd_331:triton_amd_330:triton_amd_320:triton_amd_310:triton_amd_300
+group.triton_amd.compilers=triton_amd_370:triton_amd_360:triton_amd_351:triton_amd_350:triton_amd_340:triton_amd_331:triton_amd_330:triton_amd_320:triton_amd_310:triton_amd_300
 group.triton_amd.groupName=Triton (AMD)
 group.triton_amd.options=--backend hip --arch gfx942 --warp_size 32
+
+compiler.triton_amd_370.name=Triton 3.7.0 (AMD)
+compiler.triton_amd_370.exe=/opt/compiler-explorer/triton/v3.7.0/bin/python3
 
 compiler.triton_amd_360.name=Triton 3.6.0 (AMD)
 compiler.triton_amd_360.exe=/opt/compiler-explorer/triton/v3.6.0/bin/python3

--- a/etc/config/triton.defaults.properties
+++ b/etc/config/triton.defaults.properties
@@ -1,5 +1,5 @@
 compilers=&triton_nvidia:&triton_amd
-defaultCompiler=triton_nvidia_360
+defaultCompiler=triton_nvidia_370
 compilerType=triton
 interpreted=true
 supportsBinary=false
@@ -7,9 +7,12 @@ supportsExecute=false
 isSemVer=true
 notification=Experimental Triton support on Compiler Explorer. For tutorials, bugs reports, and feature requests, please visit <a href="https://github.com/ShawnZhong/compiler-explorer-triton">here</a>.
 
-group.triton_nvidia.compilers=triton_nvidia_360:triton_nvidia_351:triton_nvidia_350:triton_nvidia_340:triton_nvidia_331:triton_nvidia_330:triton_nvidia_320:triton_nvidia_310:triton_nvidia_300:triton_nvidia_231:triton_nvidia_230
+group.triton_nvidia.compilers=triton_nvidia_370:triton_nvidia_360:triton_nvidia_351:triton_nvidia_350:triton_nvidia_340:triton_nvidia_331:triton_nvidia_330:triton_nvidia_320:triton_nvidia_310:triton_nvidia_300:triton_nvidia_231:triton_nvidia_230
 group.triton_nvidia.groupName=Triton (Nvidia)
 group.triton_nvidia.options=--backend cuda --arch 90  --warp_size 32
+
+compiler.triton_nvidia_370.name=Triton 3.7.0 (Nvidia)
+compiler.triton_nvidia_370.exe=/opt/compiler-explorer/triton/v3.7.0/bin/python3
 
 compiler.triton_nvidia_360.name=Triton 3.6.0 (Nvidia)
 compiler.triton_nvidia_360.exe=/opt/compiler-explorer/triton/v3.6.0/bin/python3
@@ -44,9 +47,12 @@ compiler.triton_nvidia_231.exe=/opt/compiler-explorer/triton/v2.3.1/bin/python3
 compiler.triton_nvidia_230.name=Triton 2.3.0 (Nvidia)
 compiler.triton_nvidia_230.exe=/opt/compiler-explorer/triton/v2.3.0/bin/python3
 
-group.triton_amd.compilers=triton_amd_360:triton_amd_351:triton_amd_350:triton_amd_340:triton_amd_331:triton_amd_330:triton_amd_320:triton_amd_310:triton_amd_300
+group.triton_amd.compilers=triton_amd_370:triton_amd_360:triton_amd_351:triton_amd_350:triton_amd_340:triton_amd_331:triton_amd_330:triton_amd_320:triton_amd_310:triton_amd_300
 group.triton_amd.groupName=Triton (AMD)
 group.triton_amd.options=--backend hip --arch gfx942 --warp_size 32
+
+compiler.triton_amd_370.name=Triton 3.7.0 (AMD)
+compiler.triton_amd_370.exe=/opt/compiler-explorer/triton/v3.7.0/bin/python3
 
 compiler.triton_amd_360.name=Triton 3.6.0 (AMD)
 compiler.triton_amd_360.exe=/opt/compiler-explorer/triton/v3.6.0/bin/python3

--- a/etc/scripts/test_triton_wrapper.py
+++ b/etc/scripts/test_triton_wrapper.py
@@ -48,6 +48,7 @@ CONFIGS = [
     for backend in ["cuda", "hip"]
     for opt_pipeline in [True, False]
     for version_tuple in [
+        (3, 7, 0),
         (3, 6, 0),
         (3, 5, 1),
         (3, 5, 0),

--- a/etc/scripts/triton_wrapper.py
+++ b/etc/scripts/triton_wrapper.py
@@ -147,7 +147,7 @@ def setup_triton(
        requirs such patching to work.
 
     This function is a collection of hacks. It has been tested to work with Triton versions:
-    2.3.0, 2.3.1, 3.0.0, 3.1.0, 3.2.0, 3.3.0, 3.3.1, 3.4.0, 3.5.0, 3.5.1, 3.6.0.
+    2.3.0, 2.3.1, 3.0.0, 3.1.0, 3.2.0, 3.3.0, 3.3.1, 3.4.0, 3.5.0, 3.5.1, 3.6.0, 3.7.0.
     """
 
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"


### PR DESCRIPTION
Summary:
- add Triton 3.7.0 entries for Nvidia and AMD
- make Triton 3.7.0 the default compiler
- extend the Triton wrapper test matrix and tested-version note

Related changes[infra]: https://github.com/compiler-explorer/infra/pull/2124