### PR TITLE
Add `glibc` as a library

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4506,7 +4506,7 @@ libs.cs50.versions.910.libpath=/opt/compiler-explorer/libs/cs50/9.1.0/x86_64/lib
 libs.cs50.versions.910.liblink=cs50
 
 libs.glibc.name=glibc
-libs.glibc.versions=216:241
+libs.glibc.versions=216:241:242
 libs.glibc.versions.216.version=2.16
 libs.glibc.versions.216.libpath=/opt/compiler-explorer/libs/glibc/glibc-2.16/usr/lib64:/opt/compiler-explorer/libs/glibc/glibc-2.16/lib64
 libs.glibc.versions.216.sysroot=/opt/compiler-explorer/libs/glibc/glibc-2.16
@@ -4515,6 +4515,10 @@ libs.glibc.versions.241.version=2.41
 libs.glibc.versions.241.libpath=/opt/compiler-explorer/libs/glibc/glibc-2.41/usr/lib64:/opt/compiler-explorer/libs/glibc/glibc-2.41/lib64
 libs.glibc.versions.241.sysroot=/opt/compiler-explorer/libs/glibc/glibc-2.41
 libs.glibc.versions.241.dynamicLinker=/opt/compiler-explorer/libs/glibc/glibc-2.41/lib64/ld-linux-x86-64-so.2
+libs.glibc.versions.242.version=2.42
+libs.glibc.versions.242.libpath=/opt/compiler-explorer/libs/glibc/glibc-2.42/usr/lib64:/opt/compiler-explorer/libs/glibc/glibc-2.42/lib64
+libs.glibc.versions.242.sysroot=/opt/compiler-explorer/libs/glibc/glibc-2.42
+libs.glibc.versions.242.dynamicLinker=/opt/compiler-explorer/libs/glibc/glibc-2.42/lib64/ld-linux-x86-64-so.2
 
 libs.hedley.name=hedley
 libs.hedley.description=A C/C++ header to help move ifdefs out of your code

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4505,6 +4505,17 @@ libs.cs50.versions.910.path=/opt/compiler-explorer/libs/cs50/9.1.0/include
 libs.cs50.versions.910.libpath=/opt/compiler-explorer/libs/cs50/9.1.0/x86_64/lib:/opt/compiler-explorer/libs/cs50/9.1.0/x86/lib
 libs.cs50.versions.910.liblink=cs50
 
+libs.glibc.name=glibc
+libs.glibc.versions=216:241
+libs.glibc.versions.216.version=2.16
+libs.glibc.versions.216.libpath=/opt/compiler-explorer/libs/glibc/glibc-2.16/usr/lib64:/opt/compiler-explorer/libs/glibc/glibc-2.16/lib64
+libs.glibc.versions.216.sysroot=/opt/compiler-explorer/libs/glibc/glibc-2.16
+libs.glibc.versions.216.dynamicLinker=/opt/compiler-explorer/libs/glibc/glibc-2.16/lib64/ld-linux-x86-64-so.2
+libs.glibc.versions.241.version=2.41
+libs.glibc.versions.241.libpath=/opt/compiler-explorer/libs/glibc/glibc-2.41/usr/lib64:/opt/compiler-explorer/libs/glibc/glibc-2.41/lib64
+libs.glibc.versions.241.sysroot=/opt/compiler-explorer/libs/glibc/glibc-2.41
+libs.glibc.versions.241.dynamicLinker=/opt/compiler-explorer/libs/glibc/glibc-2.41/lib64/ld-linux-x86-64-so.2
+
 libs.hedley.name=hedley
 libs.hedley.description=A C/C++ header to help move ifdefs out of your code
 libs.hedley.versions=v12

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -995,6 +995,14 @@ export class BaseCompiler {
         });
     }
 
+    getSharedLibraryDynamicLinker(libraries: SelectedLibraryVersion[], dirPath?: string): string[] {
+        return libraries.flatMap(selectedLib => {
+            const foundVersion = this.findLibVersion(selectedLib);
+            if (!foundVersion || foundVersion.dynamicLinker === undefined) return [];
+            return [foundVersion.dynamicLinker];
+        });
+    }
+
     getSharedLibraryBinPaths(libraries: SelectedLibraryVersion[], dirPath?: string): string[] {
         return libraries.flatMap(selectedLib => {
             const foundVersion = this.findLibVersion(selectedLib);
@@ -1016,6 +1024,8 @@ export class BaseCompiler {
     ): string[] {
         const pathFlag = this.compiler.rpathFlag || this.defaultRpathFlag;
         const libPathFlag = this.compiler.libpathFlag || '-L';
+        // TODO: make configurable
+        const dynamicLinkerFlag = '-Wl,--dynamic-linker=';
 
         let toolchainLibraryPaths: string[] = [];
         if (toolchainPath) {
@@ -1033,6 +1043,7 @@ export class BaseCompiler {
             toolchainLibraryPaths.map(path => pathFlag + path),
             this.getSharedLibraryPaths(libraries, dirPath).map(path => pathFlag + path),
             this.getSharedLibraryPaths(libraries, dirPath).map(path => libPathFlag + path),
+            this.getSharedLibraryDynamicLinker(libraries, dirPath).map(path => dynamicLinkerFlag + path),
         );
     }
 
@@ -1080,6 +1091,9 @@ export class BaseCompiler {
 
     getIncludeArguments(libraries: SelectedLibraryVersion[], dirPath: string): string[] {
         const includeFlag = this.compiler.includeFlag || '-I';
+        // TODO: make configurable
+        const sysrootFlag = '--sysroot=';
+
         return libraries.flatMap(selectedLib => {
             const foundVersion = this.findLibVersion(selectedLib);
             if (!foundVersion) return [];
@@ -1088,6 +1102,9 @@ export class BaseCompiler {
             if (foundVersion.packagedheaders) {
                 const includePath = path.join(dirPath, selectedLib.id, 'include');
                 paths.push(includeFlag + includePath);
+            }
+            if (foundVersion.sysroot) {
+                paths.push(sysrootFlag + foundVersion.sysroot);
             }
             return paths;
         });

--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -59,6 +59,8 @@ export type VersionInfo = {
     options: string[];
     hidden: boolean;
     packagedheaders?: boolean;
+    sysroot?: string;
+    dynamicLinker?: string;
     $order?: number;
 };
 export type OptionsHandlerLibrary = {
@@ -357,10 +359,19 @@ export class ClientOptionsHandler implements ClientOptionsSource {
                                 versionObject.lookupname = libraries[lang][lib].lookupname;
                             }
 
+                            const sysroot = this.compilerProps<string>(lang, libVersionName + '.sysroot');
+                            if (sysroot !== undefined) {
+                                versionObject.sysroot = sysroot;
+                            }
+
                             const includes = this.compilerProps<string>(lang, libVersionName + '.path');
                             if (includes) {
                                 versionObject.path = includes.split(path.delimiter);
-                            } else if (version !== 'autodetect' && !versionObject.packagedheaders) {
+                            } else if (
+                                version !== 'autodetect' &&
+                                !versionObject.packagedheaders &&
+                                !versionObject.sysroot
+                            ) {
                                 logger.warn(`Library ${lib} ${version} (${lang}) has no include paths`);
                             }
 
@@ -379,6 +390,11 @@ export class ClientOptionsHandler implements ClientOptionsSource {
                                 libVersionName + '.packagedheaders',
                                 libraries[lang][lib].packagedheaders,
                             );
+
+                            const dynamicLinker = this.compilerProps<string>(lang, libVersionName + '.dynamicLinker');
+                            if (dynamicLinker !== undefined) {
+                                versionObject.dynamicLinker = dynamicLinker;
+                            }
 
                             libraries[lang][lib].versions[version] = versionObject;
                         }

--- a/types/libraries/libraries.interfaces.ts
+++ b/types/libraries/libraries.interfaces.ts
@@ -9,6 +9,8 @@ export type LibraryVersion = {
     path: string[];
     options: string[];
     packagedheaders?: boolean;
+    sysroot?: string;
+    dynamicLinker?: string;
 };
 
 export type Library = {


### PR DESCRIPTION
Resolves #3103.

Infra PR: https://github.com/compiler-explorer/infra/pull/2119

`glibc` requires (according to https://sourceware.org/glibc/wiki/Testing/Builds#Compile_against_glibc_in_an_installed_location) two previously unsupported compiler flags:
* `--sysroot` to set the include path (and inhibit the default include path, so that newer standard library headers (e. g. `<stdbit.h>`) cannot be included from `/usr/include` when using an old version of `glibc`). This flags acts like `-I`, so it’s added to the compiler flags in `getIncludeArguments`.
* `-Wl,--dynamic-linker` which selects the `glibc` build’s dynamic linker. This is a linker flag, so it’s added in `getSharedLibraryPathsAsArguments`.