### PR TITLE
Fixes the flash of white issue when theme is set to system and the user has dark mode enabled

### DIFF
--- a/views/_layout.pug
+++ b/views/_layout.pug
@@ -28,13 +28,22 @@ html(lang="en")
       | (function () {
       |   try {
       |     var settings = window.localStorage.getItem("!{localStoragePrefix}settings") || '{}';
-      |     var theme = JSON.parse(settings).theme || (
-      |         window.matchMedia ?
-      |             (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'default')
-      |             : 'dark'
-      |     );
-      |     if(theme === 'darkplus') theme = 'dark';
+      |     var theme = JSON.parse(settings).theme || 'system';
+      |     if (theme === 'system') {
+      |       if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      |         theme = 'dark';
+      |       } else {
+      |         theme = 'default';
+      |       }
+      |     }
+      |     if (theme === 'darkplus' || theme === 'real-dark') {
+      |       theme = 'dark';
+      |     }
+      |     if (theme === 'onedark') {
+      |       theme = 'one-dark';
+      |     }
       |     document.documentElement.setAttribute('data-theme', theme);
+      |
       |   } catch (e) {
       |     document.documentElement.setAttribute('data-theme', 'default');
       |   }


### PR DESCRIPTION
Currently, when the user's theme is set to "Same as system", the string "system" is written as the settings.theme key in Local Storage. When the page first loads, a JavaScript function in `<head>` injects the value of settings.theme ("system") into the `data-theme` attribute of the `<html>` tag with the aim of immediately selecting the correct CSS theme file. However, there is no matching CSS file for "data-theme=system" in static/styles/themes.

Eventually, the `setTheme()` function in static/themes.ts figures out the correct theme CSS file to use. In the interim, for users who have dark mode enabled on their system, they see a flash of white until `setTheme()` finishes because DOM rendering has already begun before `setTheme()` starts.

The fix is to set `data-theme` at the start to:

* "dark" when the system is in dark mode and (settings.theme  == "system" or unset); and
* "default"  when the system is **not** in dark mode and (settings.theme  == "system" or unset).

This PR also fixes a second issue: the "real-dark" and "onedark" settings.theme values are currently not handled properly by the `<head>` script. For "real-dark", `data-theme` needs to be "dark" and for "onedark", `data-theme` needs to be "one-dark". Again, this is handled correctly by static/themes.ts, so this bug merely results in a temporary flash were the wrong CSS is applied until static/themes.ts runs.

See demo: https://github.com/user-attachments/assets/e6d232dd-a805-46f2-9bd6-e730391862c5
