### PR TITLE
fix: Add pcre2 as a Qt dependency

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6669,6 +6669,7 @@ libs.qt.versions.6100.version=6.10.0
 libs.qt.versions.6100.path=/app/qt/include/QtCore
 libs.qt.versions.6110.version=6.11.0
 libs.qt.versions.6110.path=/app/qt/include/QtCore
+libs.qt.dependencies=pcre2-16
 
 libs.quill.name=Quill
 libs.quill.description=C++ Low Latency Logging Library


### PR DESCRIPTION
Qt versions later than 6.4.2 fail to link without pcre2: https://godbolt.org/z/5Theqa81v

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
