### PR TITLE
Add Mojo 0.26.2.0 and 1.0.0b1

### DIFF
--- a/etc/config/mojo.amazon.properties
+++ b/etc/config/mojo.amazon.properties
@@ -2,7 +2,7 @@ compilers=&mojo
 defaultCompiler=mojo_nightly
 compilerType=mojo
 
-group.mojo.compilers=mojo_0_25_6_0:mojo_0_25_7_0:mojo_0_26_1_0:mojo_nightly
+group.mojo.compilers=mojo_0_25_6_0:mojo_0_25_7_0:mojo_0_26_1_0:mojo_0_26_2_0:mojo_1_0_0b1:mojo_nightly
 group.mojo.isSemVer=true
 group.mojo.baseName=Mojo
 
@@ -14,6 +14,12 @@ compiler.mojo_0_25_7_0.semver=0.25.7.0
 
 compiler.mojo_0_26_1_0.exe=/opt/compiler-explorer/mojo-0.26.1.0/bin/mojo
 compiler.mojo_0_26_1_0.semver=0.26.1.0
+
+compiler.mojo_0_26_2_0.exe=/opt/compiler-explorer/mojo-0.26.2.0/bin/mojo
+compiler.mojo_0_26_2_0.semver=0.26.2.0
+
+compiler.mojo_1_0_0b1.exe=/opt/compiler-explorer/mojo-1.0.0b1/bin/mojo
+compiler.mojo_1_0_0b1.semver=1.0.0b1
 
 compiler.mojo_nightly.exe=/opt/compiler-explorer/mojo-nightly/bin/mojo
 compiler.mojo_nightly.semver=nightly


### PR DESCRIPTION
Add two Mojo versions that are available on PyPI but were missing from the compiler list:

- 0.26.2.0
- 1.0.0b1

The existing `mojo_0_25_6_0`, `mojo_0_25_7_0`, and `mojo_0_26_1_0` entries are deliberately kept per  [docs/AddingACompiler.md § "Don't remove or rename compilers on the public site"](https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingACompiler.md#dont-remove-or-rename-compilers-on-the-public-site). 

Please let me know if we should clean up older versions at some cadence.

Companion PR: compiler-explorer/infra#2126