### PR TITLE
Don’t discard overrides when cloning compiler

### DIFF
--- a/static/components.interfaces.ts
+++ b/static/components.interfaces.ts
@@ -94,6 +94,7 @@ export type PopulatedCompilerState = StateWithEditor & {
     compiler: string;
     libs?: unknown;
     lang?: string;
+    overrides?: ConfiguredOverrides;
 };
 export type CompilerForTreeState = StateWithLanguage & StateWithTree;
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -461,12 +461,12 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             const currentState = this.getCurrentState();
 
             // Extract only the fields we need, with proper defaults
-            const {source = DEFAULT_EDITOR_ID, filters, options = '', compiler, libs, lang} = currentState;
+            const {source = DEFAULT_EDITOR_ID, filters, options = '', compiler, libs, lang, overrides} = currentState;
 
             return {
                 type: 'component',
                 componentName: COMPILER_COMPONENT_NAME,
-                componentState: {source, filters, options, compiler, libs, lang},
+                componentState: {source, filters, options, compiler, libs, lang, overrides},
             };
         };
         const createOptView = () => {


### PR DESCRIPTION
Resolves #8732.
