### PR TITLE
Fix #8318: add missing cfg positioning constraints

### DIFF
--- a/static/graph-layout-core.ts
+++ b/static/graph-layout-core.ts
@@ -173,7 +173,12 @@ function calculateTreePacking(left: BoundingBox, right: BoundingBox, narrowLayou
         offset -= rightBound;
         offsets.push(offset);
     }
-    return offsets.length === 0 ? 0 : offsets.reduce((a, b) => Math.min(a, b));
+    // For rows that only exist in the right tree, the constraint is that the
+    // right subtree must not be shifted to negative columns.
+    for (const rightRow of right.rows.slice(left.rows.length)) {
+        offsets.push(-left.width - rightRow.start);
+    }
+    return offsets.length === 0 ? 0 : offsets.reduce((a, b) => Math.max(a, b));
 }
 
 function combineRowBounds(left: RowBound[], right: RowBound[]) {


### PR DESCRIPTION
Before:
<img width="1320" height="611" alt="image" src="https://github.com/user-attachments/assets/5af974cc-d24d-43da-972e-927b86a08f1e" />


After:
<img width="1647" height="830" alt="image" src="https://github.com/user-attachments/assets/6b8b35bf-48e9-4fb6-9aeb-e2a4090a4198" />

