### PR TITLE
Fix optional-chain lint errors

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -839,11 +839,11 @@ export class BaseCompiler {
         return options;
     }
 
-    findLibVersion(selectedLib: SelectedLibraryVersion): false | VersionInfo {
-        if (!this.supportedLibraries) return false;
+    findLibVersion(selectedLib: SelectedLibraryVersion): null | VersionInfo {
+        if (!this.supportedLibraries) return null;
 
         const foundLib = _.find(this.supportedLibraries, (o, libId) => libId === selectedLib.id);
-        if (!foundLib) return false;
+        if (!foundLib) return null;
 
         const result: VersionInfo | undefined = _.find(
             foundLib.versions,
@@ -853,7 +853,7 @@ export class BaseCompiler {
             },
         );
 
-        if (!result) return false;
+        if (!result) return null;
 
         const copiedResult = structuredClone(result);
         copiedResult.name = foundLib.name;
@@ -3281,7 +3281,7 @@ export class BaseCompiler {
             }
             // TODO rephrase this so we don't need to reassign
             result = filters.demangle ? await this.postProcessAsm(result, filters) : result;
-            if (this.compiler.supportsCfg && backendOptions.produceCfg && backendOptions.produceCfg.asm) {
+            if (this.compiler.supportsCfg && backendOptions.produceCfg?.asm) {
                 const isLlvmIr =
                     this.compiler.instructionSet === 'llvm' ||
                     (options && this.isOutputLikelyLlvmIr(options)) ||
@@ -3453,7 +3453,7 @@ export class BaseCompiler {
             }
 
             const opt = doc.toJS();
-            if (!opt.DebugLoc || !opt.DebugLoc.File || !opt.DebugLoc.File.includes(compileFileName)) continue;
+            if (!opt.DebugLoc?.File?.includes(compileFileName)) continue;
 
             const strOpt = JSON.stringify(opt);
             if (!remarksSet.has(strOpt)) {
@@ -3817,7 +3817,7 @@ but nothing was dumped. Possible causes are:
     }
 
     async getTargetsAsOverrideValues(): Promise<CompilerOverrideOption[]> {
-        if (!this.buildenvsetup || !this.buildenvsetup.getCompilerArch()) {
+        if (!this.buildenvsetup?.getCompilerArch()) {
             const targets = await this.argParser.getPossibleTargets();
 
             return targets.map(target => {

--- a/lib/cfg/cfg-parsers/python.ts
+++ b/lib/cfg/cfg-parsers/python.ts
@@ -80,7 +80,7 @@ export class PythonCFGParser extends BaseCFGParser {
             if (line.text.startsWith('Disassembly of')) {
                 const srcLineStr = line.text.match(/line (\d+)/)?.[1];
                 const srcLineNum = srcLineStr ? Number.parseInt(srcLineStr, 10) : null;
-                if (srcLineNum && fullRes && fullRes.inputFilename) {
+                if (srcLineNum && fullRes?.inputFilename) {
                     if (src === null) {
                         src = await fs.readFile(fullRes.inputFilename, 'utf8');
                         const srcLine = src.split('\n')[srcLineNum - 1];

--- a/lib/compilers/rust.ts
+++ b/lib/compilers/rust.ts
@@ -162,7 +162,7 @@ export class RustCompiler extends BaseCompiler {
         const includeFlag = '--extern';
         return libraries.flatMap(selectedLib => {
             const foundVersion = this.findLibVersion(selectedLib);
-            if (!foundVersion || !foundVersion.name) return [];
+            if (!foundVersion?.name) return [];
             const lowercaseLibName = foundVersion.name.replaceAll('-', '_');
             return foundVersion.path.flatMap(rlib => {
                 return [

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -130,7 +130,7 @@ export async function executeDirect(
     const kill =
         options.killChild ||
         (() => {
-            if (running && child && child.pid) {
+            if (running && child?.pid) {
                 // Close the stdin pipe on our end, otherwise we'll get an EPIPE
                 child.stdin.destroy();
                 treeKill(child.pid);

--- a/lib/handlers/api/formatting-controller.ts
+++ b/lib/handlers/api/formatting-controller.ts
@@ -49,7 +49,7 @@ export class FormattingController implements HttpController {
             return;
         }
         // Ensure there is source code to format
-        if (!req.body || !req.body.source) {
+        if (!req.body?.source) {
             res.status(400).json({exit: 0, answer: ''});
             return;
         }

--- a/lib/handlers/route-api.ts
+++ b/lib/handlers/route-api.ts
@@ -228,7 +228,7 @@ export class RouteAPI {
     filterCode(req: express.Request, code: string, lang: Language) {
         let lines = code.split('\n');
         if (lang.previewFilter !== null) {
-            lines = lines.filter(line => !lang.previewFilter || !lang.previewFilter.test(line));
+            lines = lines.filter(line => !lang.previewFilter?.test(line));
         }
         return lines.join('\n');
     }

--- a/lib/pe32-support.ts
+++ b/lib/pe32-support.ts
@@ -276,7 +276,7 @@ export class PELabelReconstructor {
                 }
 
                 const lineInfo = this.mapFileReader.getLineInfoByAddress(undefined, address);
-                if (lineInfo && currentSegment && currentSegment.unitName) {
+                if (lineInfo && currentSegment?.unitName) {
                     this.asmLines.splice(lineIdx, 0, '/app/' + currentSegment.unitName + ':' + lineInfo.lineNumber);
                     lineIdx++;
                 } else if (segmentChanged && currentSegment) {

--- a/lib/properties-validator.ts
+++ b/lib/properties-validator.ts
@@ -130,7 +130,7 @@ function isSuspiciousPath(path: string): boolean {
  * Handles group references (&groupname), remote references (id@host), and regular IDs.
  */
 export function parseCompilersList(value: string): string[] {
-    if (!value || !value.trim()) return [];
+    if (!value?.trim()) return [];
     return value.split(':').filter(id => id.trim() !== '');
 }
 

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -1668,7 +1668,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
         this.decorations.labelUsages = [];
         this.assembly.forEach((obj, line) => {
-            if (!obj.labels || !obj.labels.length) return;
+            if (!obj.labels?.length) return;
 
             obj.labels.forEach(label => {
                 this.decorations.labelUsages.push({
@@ -3630,8 +3630,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             const hoverShowAsmDoc = this.settings.hoverShowAsmDoc;
             if (
                 hoverShowAsmDoc &&
-                this.compiler &&
-                this.compiler.supportsAsmDocs &&
+                this.compiler?.supportsAsmDocs &&
                 this.isWordAsmKeyword(e.target.position.lineNumber, currentWord)
             ) {
                 try {
@@ -3681,7 +3680,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         const pos = ed.getPosition();
         if (!pos || !ed.getModel()) return;
         const word = ed.getModel()?.getWordAtPosition(pos);
-        if (!word || !word.word) return;
+        if (!word?.word) return;
         const opcode = word.word.toUpperCase();
 
         function newGitHubIssueUrl(): string {

--- a/static/panes/device-view.ts
+++ b/static/panes/device-view.ts
@@ -138,7 +138,7 @@ export class DeviceAsm extends MonacoPane<monaco.editor.IStandaloneCodeEditor, D
         const pos = ed.getPosition();
         if (!pos || !ed.getModel()) return;
         const word = ed.getModel()?.getWordAtPosition(pos);
-        if (!word || !word.word) return;
+        if (!word?.word) return;
         const opcode = word.word.toUpperCase();
 
         function newGitHubIssueUrl(): string {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -1098,7 +1098,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         const pos = ed.getPosition();
         if (!pos || !ed.getModel()) return;
         const word = ed.getModel()?.getWordAtPosition(pos);
-        if (!word || !word.word) return;
+        if (!word?.word) return;
         const preferredLanguage = this.getPreferredLanguageTag();
         // This list comes from the footer of the page
         const cpprefLangs = ['ar', 'cs', 'de', 'en', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'tr', 'zh'];
@@ -1117,7 +1117,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         const pos = ed.getPosition();
         if (!pos || !ed.getModel()) return;
         const word = ed.getModel()?.getWordAtPosition(pos);
-        if (!word || !word.word) return;
+        if (!word?.word) return;
         const url = 'https://cloogle.org/#' + encodeURIComponent(word.word);
         window.open(url, '_blank', 'noopener');
     }

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -152,7 +152,7 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
         const pos = ed.getPosition();
         if (!pos || !ed.getModel()) return;
         const word = ed.getModel()?.getWordAtPosition(pos);
-        if (!word || !word.word) return;
+        if (!word?.word) return;
         const opcode = word.word.toUpperCase();
 
         function newGitHubIssueUrl(): string {

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -217,7 +217,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
     }
 
     updateButtons() {
-        if (!this.compiler || !this.compiler.optPipeline) return;
+        if (!this.compiler?.optPipeline) return;
 
         const {supportedOptions, supportedFilters, initialOptionsState, initialFiltersState} =
             this.compiler.optPipeline;


### PR DESCRIPTION
Biome started emitting 18 warnings like:
```
  ℹ Unsafe fix: Change to an optional chain.
  
    218 218 │   
    219 219 │       updateButtons() {
    220     │ - ········if·(!this.compiler·||·!this.compiler.optPipeline)·return;
        220 │ + ········if·(!this.compiler?.optPipeline)·return;
    221 221 │   
    222 222 │           const {supportedOptions, supportedFilters, initialOptionsState, initialFiltersState} =
```
This fixes them. Although the suggested fixes are labeled 'unsafe', in these particular cases they in fact are.