### PR TITLE
Fix #8563: python bytecode basic-block parsing fixes

### DIFF
--- a/lib/cfg/cfg-parsers/python.ts
+++ b/lib/cfg/cfg-parsers/python.ts
@@ -37,7 +37,9 @@ export class PythonCFGParser extends BaseCFGParser {
     }
 
     override isFunctionEnd(x: string) {
-        return x.startsWith('Disassembly of');
+        // After processFuncNames, function headers are renamed but still don't start with spaces.
+        // All Python bytecode instructions start with spaces, so any non-space-starting line is a function boundary.
+        return !x.startsWith(' ');
     }
 
     private isJmpTarget(inst: string) {
@@ -64,7 +66,23 @@ export class PythonCFGParser extends BaseCFGParser {
         ) {
             i++;
         }
-        return bytecode.slice(i).filter(x => x.text && x.text.trim() !== '');
+        // Filter out empty lines and ExceptionTable sections
+        let inExceptionTable = false;
+        return bytecode.slice(i).filter(x => {
+            if (!x.text || x.text.trim() === '') return false;
+            if (x.text.startsWith('ExceptionTable:')) {
+                inExceptionTable = true;
+                return false;
+            }
+            if (inExceptionTable) {
+                if (x.text.startsWith('Disassembly of') || x.text.startsWith('Function #')) {
+                    inExceptionTable = false;
+                    return true;
+                }
+                return false;
+            }
+            return true;
+        });
     }
 
     override async processFuncNames(bytecode: AssemblyLine[], fullRes?: CompilationResult): Promise<AssemblyLine[]> {
@@ -83,9 +101,9 @@ export class PythonCFGParser extends BaseCFGParser {
                 if (srcLineNum && fullRes?.inputFilename) {
                     if (src === null) {
                         src = await fs.readFile(fullRes.inputFilename, 'utf8');
-                        const srcLine = src.split('\n')[srcLineNum - 1];
-                        funcName = srcLine.match(/def (\w+)\(/)?.[1];
                     }
+                    const srcLine = src.split('\n')[srcLineNum - 1];
+                    funcName = srcLine?.match(/def (\w+)\(/)?.[1];
                 }
                 if (funcName) line.text = funcName;
                 else line.text = `Function #${funcIdx++}`;

--- a/lib/cfg/cfg-parsers/python.ts
+++ b/lib/cfg/cfg-parsers/python.ts
@@ -88,7 +88,8 @@ export class PythonCFGParser extends BaseCFGParser {
     override async processFuncNames(bytecode: AssemblyLine[], fullRes?: CompilationResult): Promise<AssemblyLine[]> {
         // replace 'Disassembly of' with function name
         const res: ResultLine[] = [];
-        let src: string | null = null;
+        const src: string | null = fullRes?.inputFilename ? await fs.readFile(fullRes.inputFilename, 'utf8') : null;
+        const srcLines = src ? src.split('\n') : null;
 
         let funcIdx = 0;
 
@@ -98,11 +99,8 @@ export class PythonCFGParser extends BaseCFGParser {
             if (line.text.startsWith('Disassembly of')) {
                 const srcLineStr = line.text.match(/line (\d+)/)?.[1];
                 const srcLineNum = srcLineStr ? Number.parseInt(srcLineStr, 10) : null;
-                if (srcLineNum && fullRes?.inputFilename) {
-                    if (src === null) {
-                        src = await fs.readFile(fullRes.inputFilename, 'utf8');
-                    }
-                    const srcLine = src.split('\n')[srcLineNum - 1];
+                if (srcLineNum && srcLines) {
+                    const srcLine = srcLines[srcLineNum - 1];
                     funcName = srcLine?.match(/def (\w+)\(/)?.[1];
                 }
                 if (funcName) line.text = funcName;

--- a/lib/cfg/instruction-sets/python.ts
+++ b/lib/cfg/instruction-sets/python.ts
@@ -36,7 +36,7 @@ export class PythonInstructionSetInfo extends BaseInstructionSetInfo {
     //   print([opcode.opname[op] for op in dis.hasjump])
 
     static conditionalJumps = new RegExp(
-        ['POP_JUMP_IF_FALSE', 'POP_JUMP_IF_NONE', 'POP_JUMP_IF_NOT_NONE', 'POP_JUMP_IF_TRUE'].join('|'),
+        ['POP_JUMP_IF_FALSE', 'POP_JUMP_IF_NONE', 'POP_JUMP_IF_NOT_NONE', 'POP_JUMP_IF_TRUE', 'FOR_ITER'].join('|'),
     );
     static unconditionalJumps = new RegExp(
         ['JUMP_BACKWARD', 'JUMP_BACKWARD_NO_INTERRUPT', 'JUMP_FORWARD', 'JUMP', 'JUMP_NO_INTERRUPT'].join('|'),
@@ -45,7 +45,7 @@ export class PythonInstructionSetInfo extends BaseInstructionSetInfo {
         ['RETURN_VALUE', 'RETURN_CONST', 'RETURN_GENERATOR', 'YIELD_VALUE', 'SEND'].join('|'),
     );
     override isJmpInstruction(instruction: string) {
-        return instruction.includes('JUMP');
+        return instruction.includes('JUMP') || instruction.includes('FOR_ITER');
     }
 
     override getInstructionType(instruction: string) {

--- a/test/cfg-cases/cfg-python.basic.json
+++ b/test/cfg-cases/cfg-python.basic.json
@@ -50,7 +50,7 @@
             }
         },
         {
-            "text": "Disassembly of <code object square at 0x55a2b8e95ff0, file \"example.py\", line 1>:",
+            "text": "Function #0",
             "source": {
                 "line": null,
                 "file": null

--- a/test/cfg-cases/cfg-python.basic2.json
+++ b/test/cfg-cases/cfg-python.basic2.json
@@ -543,11 +543,19 @@
                 },
                 {
                     "id": "140",
-                    "label": "140:\n        >>  140 FOR_ITER                98 (to 340)\n            144 STORE_FAST               1 (page)\n  9         146 LOAD_FAST                1 (page)\n            148 LOAD_ATTR               13 (NULL|self + absolute)\n            168 CALL                     0\n            176 LOAD_ATTR               15 (NULL|self + open)\n            196 LOAD_CONST               4 ('r')\n            198 CALL                     1\n            206 BEFORE_WITH\n            208 STORE_FAST               2 (fp)\n 10         210 LOAD_GLOBAL             17 (NULL + BeautifulSoup)\n            220 LOAD_FAST                2 (fp)\n            222 LOAD_ATTR               19 (NULL|self + read)\n            242 CALL                     0\n            250 LOAD_CONST               5 ('html.parser')\n            252 CALL                     2\n            260 STORE_FAST               3 (soup)\n 11         262 LOAD_GLOBAL             21 (NULL + _cleanup)\n            272 LOAD_FAST                3 (soup)\n            274 CALL                     1\n            282 STORE_FAST               4 (clean_soup)\n 12         284 LOAD_FAST                4 (clean_soup)\n            286 GET_ITER"
+                    "label": "140:\n        >>  140 FOR_ITER                98 (to 340)"
+                },
+                {
+                    "id": "144",
+                    "label": "144:\n            144 STORE_FAST               1 (page)\n  9         146 LOAD_FAST                1 (page)\n            148 LOAD_ATTR               13 (NULL|self + absolute)\n            168 CALL                     0\n            176 LOAD_ATTR               15 (NULL|self + open)\n            196 LOAD_CONST               4 ('r')\n            198 CALL                     1\n            206 BEFORE_WITH\n            208 STORE_FAST               2 (fp)\n 10         210 LOAD_GLOBAL             17 (NULL + BeautifulSoup)\n            220 LOAD_FAST                2 (fp)\n            222 LOAD_ATTR               19 (NULL|self + read)\n            242 CALL                     0\n            250 LOAD_CONST               5 ('html.parser')\n            252 CALL                     2\n            260 STORE_FAST               3 (soup)\n 11         262 LOAD_GLOBAL             21 (NULL + _cleanup)\n            272 LOAD_FAST                3 (soup)\n            274 CALL                     1\n            282 STORE_FAST               4 (clean_soup)\n 12         284 LOAD_FAST                4 (clean_soup)\n            286 GET_ITER"
                 },
                 {
                     "id": "288",
-                    "label": "288:\n        >>  288 FOR_ITER                13 (to 318)\n            292 STORE_FAST               5 (tag)\n 13         294 LOAD_GLOBAL             23 (NULL + print)\n            304 LOAD_FAST                5 (tag)\n            306 CALL                     1\n            314 POP_TOP\n            316 JUMP_BACKWARD           15 (to 288)"
+                    "label": "288:\n        >>  288 FOR_ITER                13 (to 318)"
+                },
+                {
+                    "id": "292",
+                    "label": "292:\n            292 STORE_FAST               5 (tag)\n 13         294 LOAD_GLOBAL             23 (NULL + print)\n            304 LOAD_FAST                5 (tag)\n            306 CALL                     1\n            314 POP_TOP\n            316 JUMP_BACKWARD           15 (to 288)"
                 },
                 {
                     "id": "318",
@@ -571,7 +579,7 @@
                 },
                 {
                     "id": "362",
-                    "label": "362:\n        >>  362 COPY                     3\n            364 POP_EXCEPT\n            366 RERAISE                  1\nExceptionTable:\n  208 to 318 -> 344 [2] lasti\n  344 to 352 -> 362 [4] lasti"
+                    "label": "362:\n        >>  362 COPY                     3\n            364 POP_EXCEPT\n            366 RERAISE                  1"
                 }
             ],
             "edges": [
@@ -601,12 +609,36 @@
                 },
                 {
                     "from": "140",
+                    "to": "340",
+                    "arrows": "to",
+                    "color": "green"
+                },
+                {
+                    "from": "140",
+                    "to": "144",
+                    "arrows": "to",
+                    "color": "red"
+                },
+                {
+                    "from": "144",
                     "to": "288",
                     "arrows": "to",
                     "color": "grey"
                 },
                 {
                     "from": "288",
+                    "to": "318",
+                    "arrows": "to",
+                    "color": "green"
+                },
+                {
+                    "from": "288",
+                    "to": "292",
+                    "arrows": "to",
+                    "color": "red"
+                },
+                {
+                    "from": "292",
                     "to": "288",
                     "arrows": "to",
                     "color": "blue"


### PR DESCRIPTION
Before:
<img width="1642" height="547" alt="image" src="https://github.com/user-attachments/assets/ef37ebd5-cfe4-43a6-8ea0-c08dc32f0b8f" />


After:
<img width="1747" height="711" alt="image" src="https://github.com/user-attachments/assets/99a7bcdb-9500-4095-a028-76e80b4c8e0f" />
