### PR TITLE
Cache pass dumps to avoid recompiling on selection change

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1884,7 +1884,7 @@ export class BaseCompiler {
         if (!selectedPasses) selectedPasses = ['ipa', 'tree', 'rtl'];
 
         // #6744: the pass name (group 2) can contain a single space, for 'rtl pre'
-        const internalNameRe = new RegExp('^\\s*(' + selectedPasses.join('|') + ')-([\\w_-]+(?: [\\w_-]+)?).*ON$');
+        const internalNameRe = new RegExp('^\\s*(' + selectedPasses.join('|') + ')-([\\w_-]+(?: [\\w_-]+)?)');
         const match = internalDumpName.match(internalNameRe);
         if (match) {
             // for 'rtl pre', file_ext should be just 'pre'
@@ -3568,6 +3568,7 @@ export class BaseCompiler {
             selectedPass: opts.pass ?? null,
             currentPassOutput: '<No pass selected>',
             syntaxHighlight: false,
+            passDumps: {} as Record<string, string>,
         };
         const treeDumpsNotInPasses: any[] = [];
 
@@ -3629,7 +3630,9 @@ export class BaseCompiler {
                     // don't add it to the drop down menu
                     if (f.length === 0) continue;
 
-                    if (opts.pass && opts.pass.name === selectizeObject.name) dumpFileName = path.join(rootDir, f[0]);
+                    const filePath = path.join(rootDir, f[0]);
+                    if (opts.pass && opts.pass.name === selectizeObject.name) dumpFileName = filePath;
+                    output.passDumps[selectizeObject.filename_suffix] = (await utils.tryReadTextFile(filePath)) ?? '';
                 }
 
                 output.all.push(selectizeObject);

--- a/static/components.ts
+++ b/static/components.ts
@@ -24,6 +24,7 @@
 
 import GoldenLayout from 'golden-layout';
 
+import {GccDumpOutput} from '../types/compilation/compilation.interfaces.js';
 import {ConfiguredOverrides} from '../types/compilation/compiler-overrides.interfaces.js';
 import {ConfiguredRuntimeTools} from '../types/execution/execution.interfaces.js';
 import {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
@@ -69,7 +70,6 @@ import {
     TREE_COMPONENT_NAME,
     YUL_VIEW_COMPONENT_NAME,
 } from './components.interfaces.js';
-import {GccDumpViewState} from './panes/gccdump-view.interfaces.js';
 import {SentryCapture} from './sentry.js';
 
 /** Get an empty compiler component. */
@@ -493,7 +493,7 @@ export function getGccDumpViewWith(
     compilerName: string,
     editorid: number,
     treeid: number,
-    gccDumpOutput: GccDumpViewState,
+    gccDumpOutput: GccDumpOutput | undefined,
 ): ComponentConfig<typeof GCC_DUMP_VIEW_COMPONENT_NAME> {
     return {
         type: 'component',

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -77,6 +77,7 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
     inhibitPassSelect = false;
     cursorSelectionThrottledFunction: ((e: any) => void) & _.Cancelable;
     selectedPass: string | null = null;
+    passDumps: Record<string, string> = {};
 
     constructor(hub: Hub, container: Container, state: GccDumpViewState & MonacoPaneState) {
         super(hub, container, state);
@@ -313,7 +314,25 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
         }
 
         if (this.inhibitPassSelect !== true) {
-            this.eventHub.emit('gccDumpPassSelected', this.compilerInfo.compilerId, selectedPass, true);
+            const suffix = selectedPass.filename_suffix;
+            if (suffix !== null && suffix in this.passDumps) {
+                // All pass dumps are already cached — display directly without recompile.
+                const content = this.passDumps[suffix];
+                const hasMeaningfulContent = !/^\s*$/.test(content);
+                const model = this.editor.getModel();
+                if (model) {
+                    monaco.editor.setModelLanguage(model, hasMeaningfulContent ? 'gccdump-rtl-gimple' : 'plaintext');
+                }
+                this.showGccDumpResults(
+                    hasMeaningfulContent
+                        ? content
+                        : `Pass '${selectedPass.name}' was requested\nbut nothing was dumped. Possible causes are:\n - pass is not valid in this (maybe you changed the compiler options);\n - pass is valid but did not emit anything (eg. it was not executed).`,
+                );
+                this.eventHub.emit('gccDumpPassSelected', this.compilerInfo.compilerId, selectedPass, false);
+            } else {
+                // Pass dumps not cached (compiler doesn't support dumping all at once) — recompile.
+                this.eventHub.emit('gccDumpPassSelected', this.compilerInfo.compilerId, selectedPass, true);
+            }
         }
 
         // To keep shared URL compatible, we keep on storing only a string in the
@@ -355,16 +374,8 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
     override onCompileResult(id: number, compiler: CompilerInfo, result: CompilationResult) {
         if (this.compilerInfo.compilerId !== id) return;
 
-        const model = this.editor.getModel();
-        if (model) {
-            if (result.gccDumpOutput?.syntaxHighlight) {
-                monaco.editor.setModelLanguage(model, 'gccdump-rtl-gimple');
-            } else {
-                monaco.editor.setModelLanguage(model, 'plaintext');
-            }
-        }
         if (compiler.supportsGccDump && result.gccDumpOutput) {
-            const currOutput = result.gccDumpOutput.currentPassOutput;
+            this.passDumps = result.gccDumpOutput.passDumps ?? {};
 
             // if result contains empty selected pass, probably means
             // we requested an invalid/outdated pass.
@@ -373,7 +384,25 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
                 this.selectedPass = null;
             }
             this.updatePass(this.filters, this.selectize, result.gccDumpOutput);
-            this.showGccDumpResults(currOutput);
+
+            // When all pass dumps are cached, prefer showing the selected pass from the cache
+            // so that the display is consistent with client-side pass switching.
+            let displayContent = result.gccDumpOutput.currentPassOutput;
+            let useSyntaxHighlight = result.gccDumpOutput.syntaxHighlight;
+            if (this.selectedPass !== null && this.selectedPass in this.passDumps) {
+                const content = this.passDumps[this.selectedPass];
+                const hasMeaningfulContent = !/^\s*$/.test(content);
+                displayContent = hasMeaningfulContent
+                    ? content
+                    : `Pass '${this.selectedPass}' was requested\nbut nothing was dumped. Possible causes are:\n - pass is not valid in this (maybe you changed the compiler options);\n - pass is valid but did not emit anything (eg. it was not executed).`;
+                useSyntaxHighlight = hasMeaningfulContent;
+            }
+
+            const model = this.editor.getModel();
+            if (model) {
+                monaco.editor.setModelLanguage(model, useSyntaxHighlight ? 'gccdump-rtl-gimple' : 'plaintext');
+            }
+            this.showGccDumpResults(displayContent);
 
             // enable UI on first successful compilation or after an invalid compiler selection (eg. clang)
             if (!this.uiIsReady) {
@@ -381,11 +410,16 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
                 this.onUiReady();
             }
         } else {
+            this.passDumps = {};
             this.selectize.clear(true);
             this.selectedPass = null;
             this.updatePass(this.filters, this.selectize, null);
             this.uiIsReady = false;
             this.onUiNotReady();
+            const model = this.editor.getModel();
+            if (model) {
+                monaco.editor.setModelLanguage(model, 'plaintext');
+            }
             if (!compiler.supportsGccDump) {
                 this.showGccDumpResults('<Tree/RTL output is not supported for this compiler (GCC only)>');
             } else {

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -392,10 +392,12 @@ export class GccDump extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Gcc
             if (this.selectedPass !== null && this.selectedPass in this.passDumps) {
                 const content = this.passDumps[this.selectedPass];
                 const hasMeaningfulContent = !/^\s*$/.test(content);
+                const passName = result.gccDumpOutput.selectedPass?.name ?? this.selectedPass;
                 displayContent = hasMeaningfulContent
                     ? content
-                    : `Pass '${this.selectedPass}' was requested\nbut nothing was dumped. Possible causes are:\n - pass is not valid in this (maybe you changed the compiler options);\n - pass is valid but did not emit anything (eg. it was not executed).`;
+                    : `Pass '${passName}' was requested\nbut nothing was dumped. Possible causes are:\n - pass is not valid in this (maybe you changed the compiler options);\n - pass is valid but did not emit anything (eg. it was not executed).`;
                 useSyntaxHighlight = hasMeaningfulContent;
+            }
             }
 
             const model = this.editor.getModel();

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -160,6 +160,15 @@ export type PPOutput = {
     output: string;
 };
 
+export type GccDumpOutput = {
+    all: GccDumpViewSelectedPass[];
+    selectedPass: GccDumpViewSelectedPass | null;
+    currentPassOutput: string;
+    syntaxHighlight: boolean;
+    /** Maps filename_suffix to dump content. Populated when all passes are dumped at once. */
+    passDumps?: Record<string, string>;
+};
+
 export type CompilationResult = {
     code: number;
     timedOut: boolean;
@@ -184,7 +193,7 @@ export type CompilationResult = {
     dirPath?: string;
     compilationOptions?: string[];
     downloads?: BuildEnvDownloadInfo[];
-    gccDumpOutput?;
+    gccDumpOutput?: GccDumpOutput;
     languageId?: string;
     asmKeywordTypes?: string[];
     result?: CompilationResult; // cmake inner result


### PR DESCRIPTION
Also based on #7870 discussion: don't filter passes initially marked as OFF. Hopefully this fixes #7870 


