### PR TITLE
Add Ruby 4.0.2 and 4.0.5

### DIFF
--- a/etc/config/ruby.amazon.properties
+++ b/etc/config/ruby.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&ruby
-defaultCompiler=ruby347
+defaultCompiler=ruby405
 
 group.ruby.compilers=ruby405:ruby402:ruby347:ruby334:ruby324:ruby316:ruby307:ruby278:ruby268:ruby259
 group.ruby.isSemVer=true

--- a/etc/config/ruby.amazon.properties
+++ b/etc/config/ruby.amazon.properties
@@ -1,12 +1,16 @@
 compilers=&ruby
 defaultCompiler=ruby347
 
-group.ruby.compilers=ruby347:ruby334:ruby324:ruby316:ruby307:ruby278:ruby268:ruby259
+group.ruby.compilers=ruby405:ruby402:ruby347:ruby334:ruby324:ruby316:ruby307:ruby278:ruby268:ruby259
 group.ruby.isSemVer=true
 group.ruby.baseName=Ruby
 group.ruby.groupName=Ruby YARV
 group.ruby.compilerType=ruby
 
+compiler.ruby405.semver=4.0.5
+compiler.ruby405.exe=/opt/compiler-explorer/ruby-4.0.5/bin/ruby
+compiler.ruby402.semver=4.0.2
+compiler.ruby402.exe=/opt/compiler-explorer/ruby-4.0.2/bin/ruby
 compiler.ruby347.semver=3.4.7
 compiler.ruby347.exe=/opt/compiler-explorer/ruby-3.4.7/bin/ruby
 compiler.ruby334.semver=3.3.4


### PR DESCRIPTION
Adds the Ruby 4.0.x line to the frontend config. Both versions are built and installed by infra (s3tarballs, tarballs present in S3 at `opt/ruby-4.0.2.tar.xz` and `opt/ruby-4.0.5.tar.xz`), but were never exposed in `ruby.amazon.properties` — the group topped out at 3.4.7.

- infra: ruby 4.0.2 (compiler-explorer/infra#2076, merged), ruby 4.0.5 (compiler-explorer/infra#2137, merged)
- exe paths match the infra install dirs (`/opt/compiler-explorer/ruby-X.Y.Z/bin/ruby`)
- `defaultCompiler` bumped to `ruby405` (latest)
- `test:props` passes

Draft pending the in-place install check on the admin server.