### PR TITLE
Bump Node floor to v22

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -42,10 +42,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20.18.2
+          node-version: 22.12.0
           check-latest: false
           cache: npm
       - name: Install prerequisites

--- a/etc/scripts/find-node
+++ b/etc/scripts/find-node
@@ -24,7 +24,7 @@ find_node() {
 
 NODE="$(find_node)"
 
-NODE_MIN_VERSION=20
+NODE_MIN_VERSION=22
 NODE_VERSION_USED=22
 NODE_VERSION=$(${NODE} --version)
 NODE_MAJOR_VERSION=$(echo "${NODE_VERSION}" | cut -f1 -d. | sed 's/^v//g')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "version": "0.0.3",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "main": "./app.ts",
   "dependencies": {


### PR DESCRIPTION
Raises Compiler Explorer's minimum Node version from 20 to 22, aligning the declared floor with what production actually runs (Node 22.13.1 across the fleet).

## Why
- Production already runs Node 22.13.1 everywhere; the declared floor (`>=20`) lagged reality.
- It's a prerequisite for upcoming dependency majors — commander 15 requires Node >=22.12.

## Changes
- `package.json`: `engines.node` `>=20.0.0` → `>=22.0.0`.
- `etc/scripts/find-node`: `NODE_MIN_VERSION` `20` → `22`.
- `.github/workflows/test-and-deploy.yml`: the `build_minimum_support` job moves from Node 20.18.2 to 22.12.0 (the genuine floor), since `find-node` now rejects Node <22.

Split out from the major-dependency PR (#8761) so it can land independently. #8761 will rebase cleanly on top once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)