### PR TITLE
Fix flaky Windows exec timeout test

### DIFF
--- a/test/exec-tests.ts
+++ b/test/exec-tests.ts
@@ -83,9 +83,11 @@ describe('Execution tests', async () => {
                     timedOut: false,
                 });
             });
-            it('handles timouts', async () => {
+            it('handles timeouts', async () => {
+                // Start-Sleep actually blocks; the bare string "sleep 5" is just echoed by PowerShell and
+                // exits immediately, making the timeout a race against process startup (flaky on CI).
                 await expect(
-                    testExecOutput(exec.execute('powershell', ['-Command', '"sleep 5"'], {timeoutMs: 10})),
+                    testExecOutput(exec.execute('powershell', ['-Command', 'Start-Sleep -Seconds 5'], {timeoutMs: 10})),
                 ).resolves.toEqual({
                     code: 1,
                     okToCache: false,
@@ -134,7 +136,7 @@ describe('Execution tests', async () => {
                     timedOut: false,
                 });
             });
-            it('handles timouts', async () => {
+            it('handles timeouts', async () => {
                 await expect(testExecOutput(exec.execute('sleep', ['5'], {timeoutMs: 10}))).resolves.toEqual({
                     code: -1,
                     okToCache: false,


### PR DESCRIPTION
## Problem

The Windows variant of the `Execution tests > Executes external commands > handles timeouts` test (`test/exec-tests.ts`) is flaky on CI. It ran:

```ts
exec.execute('powershell', ['-Command', '"sleep 5"'], {timeoutMs: 10})
```

The embedded double-quotes make `"sleep 5"` a **string literal** that PowerShell just echoes and exits immediately — it never sleeps. The test only "passed" by racing the 10 ms timeout against PowerShell's startup. When PowerShell wins the race it returns `code: 0` / `stdout: "sleep 5"` instead of the expected killed result, intermittently failing the Windows `test` job.

(Spotted while verifying CI on #8737 — the only failure there was this test, unrelated to that PR.)

## Fix

Use `Start-Sleep -Seconds 5`, which actually blocks, so the 10 ms timeout deterministically kills it. The expected result block is unchanged (`code: 1` is what `taskkill` yields for an externally-killed process on Windows). Added a comment explaining the rationale, and fixed the `timouts` → `timeouts` typo in both the Windows and POSIX test names.

## Testing

- POSIX branch runs locally: `npx vitest run test/exec-tests.ts` → 22 passed.
- The Windows branch can only run on a Windows runner; the change is confined to the command string and leaves the assertion identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)