### PR TITLE
Add clang-cl 22.1.6

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -9,7 +9,7 @@ group.clang-cl.compilers=clang-cl2216:clang-cl1810
 group.clang-cl.baseName=clang-cl
 group.clang-cl.compilerType=clang-cl
 group.clang-cl.compilerCategories=clang-cl
-group.clang-cl.demangler=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/x64/undname.exe
+group.clang-cl.demangler=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/undname.exe
 group.clang-cl.demanglerType=win32
 group.clang-cl.groupName=clang-cl
 group.clang-cl.intelAsm=-mllvm --x86-asm-syntax=intel

--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -5,11 +5,11 @@ demangler=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/c++filt.exe
 buildenvsetup=ceconan
 buildenvsetup.host=https://conan.compiler-explorer.com
 
-group.clang-cl.compilers=clang-cl1810
+group.clang-cl.compilers=clang-cl2216:clang-cl1810
 group.clang-cl.baseName=clang-cl
 group.clang-cl.compilerType=clang-cl
 group.clang-cl.compilerCategories=clang-cl
-group.clang-cl.demangler=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/undname.exe
+group.clang-cl.demangler=Z:/compilers/msvc/14.41.34120-14.41.34123.0/bin/Hostx64/x64/undname.exe
 group.clang-cl.demanglerType=win32
 group.clang-cl.groupName=clang-cl
 group.clang-cl.intelAsm=-mllvm --x86-asm-syntax=intel
@@ -20,6 +20,9 @@ group.clang-cl.licenseName=LLVM Apache 2
 group.clang-cl.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
 group.clang-cl.supportsBinary=false
 group.clang-cl.supportsExecute=false
+
+compiler.clang-cl2216.exe=Z:/compilers/clang-cl-22.1.6/bin/clang-cl.exe
+compiler.clang-cl2216.semver=22.1.6
 
 compiler.clang-cl1810.exe=Z:/compilers/clang-cl-18.1.0/bin/clang-cl.exe
 compiler.clang-cl1810.semver=18.1.0


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Companion to compiler-explorer/infra#2140 and compiler-explorer/compiler-explorer#8763.

Adds clang-cl 22.1.6 to the Windows config (`c++.amazonwin.properties`), corresponding to the new install target in infra#2140.

Depends on compiler-explorer/infra#2140 (must be installed first).