### PR TITLE
Fix c2rust output location parsing

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -188,9 +188,12 @@ function applyParse_SourceWithLine(lineObj: ResultLine, filteredLine: string, in
 function applyParse_FileWithLine(lineObj: ResultLine, filteredLine: string) {
     const match = filteredLine.match(SOURCE_WITH_FILENAME);
     if (match) {
+        const filename = match[1];
+        if (!filename.includes('.')) return;
+
         const message = match[5].trim();
         lineObj.tag = {
-            file: match[1],
+            file: filename,
             line: Number.parseInt(match[2], 10),
             column: Number.parseInt(match[4] || '0', 10),
             text: message,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -151,7 +151,7 @@ function parseSeverity(message: string): number {
 }
 
 const SOURCE_RE = /^\s*<source>[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
-const SOURCE_WITH_FILENAME = /^\s*([\w.]+)[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
+const SOURCE_WITH_FILENAME = /^\s*([\w.]*\.[\w.]+)[(:](\d+)(:?,?(\d+):?)?[):]*\s*(.*)/;
 const ATFILELINE_RE = /\s*at ([\w-/.]+):(\d+)/;
 
 export enum LineParseOption {
@@ -189,8 +189,6 @@ function applyParse_FileWithLine(lineObj: ResultLine, filteredLine: string) {
     const match = filteredLine.match(SOURCE_WITH_FILENAME);
     if (match) {
         const filename = match[1];
-        if (!filename.includes('.')) return;
-
         const message = match[5].trim();
         lineObj.tag = {
             file: filename,

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -109,6 +109,9 @@ describe('Parses compiler output', () => {
             },
         ]);
     });
+    it('does not treat c2rust AST node lines as source locations', () => {
+        expect(utils.parseOutput('CTypeId(42): Located {', 'example.c')).toEqual([{text: 'CTypeId(42): Located {'}]);
+    });
     it('replaces all references to input source', () => {
         expect(utils.parseOutput('bob.cpp:1 error in bob.cpp', 'bob.cpp')).toEqual([
             {


### PR DESCRIPTION
## Summary

Fixes #8709.

This tightens the generic `file:line` parser so c2rust AST dump lines like `CTypeId(42): Located {` are left as plain output instead of being interpreted as source diagnostics.

## Test plan

- `npm test -- test/utils-tests.ts`
- `npm run lint-check -- lib/utils.ts test/utils-tests.ts`
- `npm run ts-check:tests`
- `npm run ts-check:backend`
- `git diff --check`
