### PR TITLE
Indent the Mojo example with 4 spaces

### DIFF
--- a/examples/mojo/default.mojo
+++ b/examples/mojo/default.mojo
@@ -1,5 +1,5 @@
 def multiply[m: Int](n: Int) -> Int:
-  return m * n
+    return m * n
 
 def main():
-  _ = multiply[3](5)
+    _ = multiply[3](5)


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

The editor seems to be configured to a 4 space indentation by default which is weird if the example uses 2 spaces. Also the Mojo documentation uses 4 spaces.