### PR TITLE
clang-cl: Set Windows and VS SDK paths

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -5,7 +5,7 @@ demangler=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/c++filt.exe
 buildenvsetup=ceconan
 buildenvsetup.host=https://conan.compiler-explorer.com
 
-group.clang-cl.compilers=clang-cl2216:clang-cl1810
+group.clang-cl.compilers=clang-cl2216:clang-cl2216-v19_50_VS18_2:clang-cl1810
 group.clang-cl.baseName=clang-cl
 group.clang-cl.compilerType=clang-cl
 group.clang-cl.compilerCategories=clang-cl
@@ -18,14 +18,23 @@ group.clang-cl.instructionSet=amd64
 group.clang-cl.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
 group.clang-cl.licenseName=LLVM Apache 2
 group.clang-cl.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
-group.clang-cl.supportsBinary=false
-group.clang-cl.supportsExecute=false
+group.clang-cl.supportsBinary=true
+group.clang-cl.supportsExecute=true
+group.clang-cl.baseOptions=/winsdkdir Z:/compilers/windows-kits-10 /EHsc /utf-8 /MD
+group.clang-cl.extraPath=Z:/compilers/debug_nonredist/x64/Microsoft.VC142.DebugCRT
 
 compiler.clang-cl2216.exe=Z:/compilers/clang-cl-22.1.6/bin/clang-cl.exe
 compiler.clang-cl2216.semver=22.1.6
+compiler.clang-cl2216.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
+
+compiler.clang-cl2216-v19_50_VS18_2.exe=Z:/compilers/clang-cl-22.1.6/bin/clang-cl.exe
+compiler.clang-cl2216-v19_50_VS18_2.name=22.1.6 (msvc v19.50 VS18.2)
+compiler.clang-cl2216-v19_50_VS18_2.semver=22.1.6+14.50.35723.0
+compiler.clang-cl2216-v19_50_VS18_2.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
 
 compiler.clang-cl1810.exe=Z:/compilers/clang-cl-18.1.0/bin/clang-cl.exe
 compiler.clang-cl1810.semver=18.1.0
+compiler.clang-cl1810.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
 
 group.mingw64.compilers=&mingw64_ucrt_gcc:&mingw64_ucrt_clang
 group.mingw64.isSemVer=true


### PR DESCRIPTION
Clang-cl can take additional options to construct a VS environment:

```
  /diasdkdir <dir>        Path to the DIA SDK
  /vctoolsdir <dir>       Path to the VCToolChain
  /vctoolsversion <value> For use with /winsysroot, defaults to newest found
  /winsdkdir <dir>        Path to the Windows SDK
  /winsdkversion <value>  Full version of the Windows SDK, defaults to newest found
  /winsysroot <dir>       Same as "/diasdkdir <dir>/DIA SDK" /vctoolsdir <dir>/VC/Tools/MSVC/<vctoolsversion> "/winsdkdir <dir>/Windows Kits/10"
```

The two important ones are `/vctoolsdir` and `/winsdkdir`. `/vstoolsdir` sets the path to the Visual Studio VC version to be used. It's needed to resolve STL includes and the path to `msvcrt(d).lib`. The `/winsdkdir` flag sets the Windows SDK path for includes and libraries.

This also means that clang-cl is always paired with some version of a VS installation. The "22.1.6" and "18.1.0" entries will always use the latest versions. "22.1.6 (msvc v19.50 VS18.2)" was added to have a fixed pair of versions.

I also added `/EHsc` (enables exceptions), `/utf-8` (source and runtime encoding; already default on clang-cl), and `/MD` (use DLL runtime) to match the VS compilers. Furthermore, I added the `extraPath` to the CRT which also matches the VS group.

All this should allow linking and execution. I tested this locally with my local installations.