### PR TITLE
Fix Mojo compiler type binding in defaults config

### DIFF
--- a/etc/config/mojo.defaults.properties
+++ b/etc/config/mojo.defaults.properties
@@ -1,6 +1,6 @@
 compilers=&mojo
-mojo.defaultCompiler=mojo_nightly
-mojo.compilerType=mojo
+defaultCompiler=mojo_nightly
+compilerType=mojo
 
 group.mojo.compilers=mojo_nightly
 


### PR DESCRIPTION
`etc/config/mojo.defaults.properties` declared `compilerType` and `defaultCompiler`
with a stray `mojo.` prefix:

```properties
mojo.defaultCompiler=mojo_nightly
mojo.compilerType=mojo

Mojo is the only language whose defaults file uses this prefixed form. Every other
language uses the unprefixed compilerType= / defaultCompiler=. The prefixed keys
are no-ops, so without another config layer setting the unprefixed values, Mojo
compilers fall back to BaseCompiler instead of using MojoCompiler.

On godbolt.org this was masked because mojo.amazon.properties separately sets the
unprefixed compilerType=mojo / defaultCompiler=mojo_nightly. But any local or
self-hosted deployment (defaults + *.local.properties, no amazon layer) gets a
broken Mojo compiler: it invokes the binary with C-style flags
(-g -o output.s -S) instead of mojo build --emit=asm, and every compile fails
with unrecognized argument '-o'.

Fix
Drop the mojo. prefix so the keys match the convention used by all other languages:

defaultCompiler=mojo_nightly
compilerType=mojo
Testing
Verified locally with a real mojo==1.0.0b1 install (via pip) and a
mojo.local.properties pointing at it. Before the fix, compiles fell back to
BaseCompiler and failed. After the fix, MojoCompiler binds correctly and all
modes work:

ASM — build --emit=asm -o output.s produces target assembly
LLVM IR — --emit=llvm produces valid IR
Execute — program builds and runs (exit 0)
Binary — compiles successfully
No change to godbolt.org behavior (the amazon config already set these correctly).
npm run test:props passes (90/90).