### PR TITLE
Fix diff picker labels after option changes

### DIFF
--- a/cypress/e2e/diff.cy.ts
+++ b/cypress/e2e/diff.cy.ts
@@ -25,6 +25,7 @@
 import {
     addCompilerFromEditor,
     assertNoConsoleOutput,
+    compilerPane,
     findPane,
     lastCompilerContent,
     monacoEditorTextShouldContain,
@@ -58,6 +59,24 @@ describe('Diff view', () => {
     it('should open a diff view pane from the Add menu', () => {
         waitForEditors();
         openDiffView();
+    });
+
+    it('should update selected compiler labels when compiler options change', () => {
+        waitForEditors();
+
+        compilerPane().find('input.options').clear().type('-O2');
+        compilerPane().find('input.options').should('have.value', '-O2');
+
+        openDiffView();
+
+        const lhsPicker = () => findPane('Diff').find('select.diff-picker.lhs + .ts-wrapper .ts-control');
+
+        lhsPicker().should('contain.text', '-O2');
+
+        compilerPane().find('input.options').clear().type('-O1');
+
+        lhsPicker().should('contain.text', '-O1');
+        lhsPicker().should('not.contain.text', '-O2');
     });
 
     it('should show diff content with two compiler panes', () => {

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -570,10 +570,14 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
     updateCompilersFor(selectize: TomSelect, id: number | string) {
         selectize.clearOptions();
         for (const [_, compiler] of Object.entries(this.compilers)) {
+            const optionId = compiler.id.toString();
             selectize.addOption(compiler);
+            selectize.updateOption(optionId, compiler);
         }
-        if (id in this.compilers) {
-            selectize.setValue(id.toString());
+        selectize.refreshOptions(false);
+        const selectedId = id.toString();
+        if (selectedId in this.compilers) {
+            selectize.setValue(selectedId);
         }
     }
 


### PR DESCRIPTION
Fixes #8756.

## Summary
- Refresh existing TomSelect option data for diff picker entries when compiler metadata changes
- Preserve the selected compiler while repainting the visible picker label
- Add a Cypress regression for updating compiler options after the diff view is open

## Testing
- npx biome check static/panes/diff.ts cypress/e2e/diff.cy.ts
- npm run ts-check:frontend
- npm run ts-check:cypress
- npm run check-frontend-imports
- CYPRESS_CACHE_FOLDER=/tmp/compiler-explorer-107-cypress-cache npx cypress run --spec cypress/e2e/diff.cy.ts