### PR TITLE
Fix shader_explorer: bump to 0.1.2 and version the ids

### DIFF
--- a/etc/config/glsl.amazon.properties
+++ b/etc/config/glsl.amazon.properties
@@ -12,7 +12,7 @@ compiler.glslang-validator-trunk.exe=/opt/compiler-explorer/glslang-trunk/glslan
 compiler.glslang-validator-trunk.name=glslang (trunk)
 compiler.glslang-validator-trunk.isNightly=true
 
-compiler.shaderexplorer_glsl.exe=/opt/compiler-explorer/shader-explorer-0.1.0/bin/shader_explorer
+compiler.shaderexplorer_glsl.exe=/opt/compiler-explorer/shader-explorer-0.1.2/bin/shader_explorer
 compiler.shaderexplorer_glsl.name=shader_explorer
 compiler.shaderexplorer_glsl.compilerType=shader-explorer
 compiler.shaderexplorer_glsl.versionFlag=--version

--- a/etc/config/glsl.amazon.properties
+++ b/etc/config/glsl.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&glslang:shaderexplorer_glsl
+compilers=&glslang:shaderexplorer_glsl012
 
 defaultCompiler=glslang-validator-trunk
 supportsBinary=false
@@ -12,10 +12,10 @@ compiler.glslang-validator-trunk.exe=/opt/compiler-explorer/glslang-trunk/glslan
 compiler.glslang-validator-trunk.name=glslang (trunk)
 compiler.glslang-validator-trunk.isNightly=true
 
-compiler.shaderexplorer_glsl.exe=/opt/compiler-explorer/shader-explorer-0.1.2/bin/shader_explorer
-compiler.shaderexplorer_glsl.name=shader_explorer
-compiler.shaderexplorer_glsl.compilerType=shader-explorer
-compiler.shaderexplorer_glsl.versionFlag=--version
-compiler.shaderexplorer_glsl.supportsBinary=false
-compiler.shaderexplorer_glsl.supportsExecute=false
-compiler.shaderexplorer_glsl.options=--lang glsl --target asm --no-color
+compiler.shaderexplorer_glsl012.exe=/opt/compiler-explorer/shader-explorer-0.1.2/bin/shader_explorer
+compiler.shaderexplorer_glsl012.name=shader_explorer 0.1.2
+compiler.shaderexplorer_glsl012.compilerType=shader-explorer
+compiler.shaderexplorer_glsl012.versionFlag=--version
+compiler.shaderexplorer_glsl012.supportsBinary=false
+compiler.shaderexplorer_glsl012.supportsExecute=false
+compiler.shaderexplorer_glsl012.options=--lang glsl --target asm --no-color

--- a/etc/config/slang.amazon.properties
+++ b/etc/config/slang.amazon.properties
@@ -25,7 +25,7 @@ compiler.slangc_2026_2.name=slangc 2026.2
 compiler.slangc_2026_8_1.exe=/opt/compiler-explorer/slang-2026.8.1/bin/slangc
 compiler.slangc_2026_8_1.name=slangc 2026.8.1
 
-compiler.shaderexplorer_slang.exe=/opt/compiler-explorer/shader-explorer-0.1.0/bin/shader_explorer
+compiler.shaderexplorer_slang.exe=/opt/compiler-explorer/shader-explorer-0.1.2/bin/shader_explorer
 compiler.shaderexplorer_slang.name=shader_explorer
 compiler.shaderexplorer_slang.compilerType=shader-explorer
 compiler.shaderexplorer_slang.versionFlag=--version

--- a/etc/config/slang.amazon.properties
+++ b/etc/config/slang.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&defaultslangc:shaderexplorer_slang
+compilers=&defaultslangc:shaderexplorer_slang012
 
 defaultCompiler=slangc_2026_8_1
 supportsBinary=false
@@ -25,10 +25,10 @@ compiler.slangc_2026_2.name=slangc 2026.2
 compiler.slangc_2026_8_1.exe=/opt/compiler-explorer/slang-2026.8.1/bin/slangc
 compiler.slangc_2026_8_1.name=slangc 2026.8.1
 
-compiler.shaderexplorer_slang.exe=/opt/compiler-explorer/shader-explorer-0.1.2/bin/shader_explorer
-compiler.shaderexplorer_slang.name=shader_explorer
-compiler.shaderexplorer_slang.compilerType=shader-explorer
-compiler.shaderexplorer_slang.versionFlag=--version
-compiler.shaderexplorer_slang.supportsBinary=false
-compiler.shaderexplorer_slang.supportsExecute=false
-compiler.shaderexplorer_slang.options=--lang slang --target asm --no-color
+compiler.shaderexplorer_slang012.exe=/opt/compiler-explorer/shader-explorer-0.1.2/bin/shader_explorer
+compiler.shaderexplorer_slang012.name=shader_explorer 0.1.2
+compiler.shaderexplorer_slang012.compilerType=shader-explorer
+compiler.shaderexplorer_slang012.versionFlag=--version
+compiler.shaderexplorer_slang012.supportsBinary=false
+compiler.shaderexplorer_slang012.supportsExecute=false
+compiler.shaderexplorer_slang012.options=--lang slang --target asm --no-color


### PR DESCRIPTION
## Problem

Staging compiler discovery for the latest build aborts with `Failed to create 2 out of 6023 compilers` (`exitOnCompilerFailure=true`). The two failures are `shaderexplorer_glsl` and `shaderexplorer_slang`: both point their `exe` at `/opt/compiler-explorer/shader-explorer-0.1.0/bin/shader_explorer`, which doesn't exist on the box. infra installs shader-explorer **0.1.2** (the `0.1.0` pin and `0.1.2` install shipped skewed in compiler-explorer#8573 / infra#2038).

## Fix

- Point both `shader_explorer` exes at `0.1.2` to match what infra installs.
- Version the compiler ids: `shaderexplorer_glsl` -> `shaderexplorer_glsl012`, `shaderexplorer_slang` -> `shaderexplorer_slang012`, and surface the version in the display name. Ids are immutable, so an unversioned id silently changes meaning on a binary bump; from now on a bump adds a new id instead.

The old unversioned ids only ever resolved to 0.1.0 (now uninstalled) and the feature is days old, so the short-link exposure of the rename is negligible.

## Test

- `npm run test:props` passes (90).
- No other references to the old ids anywhere in the tree.