### PR TITLE
Fix builtin sourcePath configuration

### DIFF
--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -29,29 +29,42 @@ import path from 'node:path';
 import type {Source, SourceApiEntry, SourceEntry} from '../../types/source.interfaces.js';
 import * as props from '../properties.js';
 
-const EXAMPLES_PATH = props.get('builtin', 'sourcePath', './examples/') as string;
 const NAME_SUBSTUTION_PATTERN = /_/g;
-const ALL_EXAMPLES: SourceEntry[] = fs.readdirSync(EXAMPLES_PATH).flatMap(folder => {
+let examplesPath: string | undefined;
+let allExamples: SourceEntry[] | undefined;
+
+function readExamples(configuredExamplesPath: string): SourceEntry[] {
     // Recurse through the language folders
-    const folderPath = path.join(EXAMPLES_PATH, folder);
-    return fs.readdirSync(folderPath).map(file => {
-        // Recurse through the source files
-        const filePath = path.join(folderPath, file);
-        const fileName = path.parse(filePath).name;
-        return {
-            lang: folder,
-            name: fileName.replaceAll(NAME_SUBSTUTION_PATTERN, ' '),
-            path: filePath,
-            file: fileName,
-        };
+    return fs.readdirSync(configuredExamplesPath).flatMap(folder => {
+        const folderPath = path.join(configuredExamplesPath, folder);
+        return fs.readdirSync(folderPath).map(file => {
+            // Recurse through the source files
+            const filePath = path.join(folderPath, file);
+            const fileName = path.parse(filePath).name;
+            return {
+                lang: folder,
+                name: fileName.replaceAll(NAME_SUBSTUTION_PATTERN, ' '),
+                path: filePath,
+                file: fileName,
+            };
+        });
     });
-});
+}
+
+function getExamples(): SourceEntry[] {
+    const configuredExamplesPath = props.get<string>('builtin', 'sourcePath', './examples/');
+    if (allExamples === undefined || examplesPath !== configuredExamplesPath) {
+        examplesPath = configuredExamplesPath;
+        allExamples = readExamples(configuredExamplesPath);
+    }
+    return allExamples;
+}
 
 export const builtin: Source = {
     name: 'Examples',
     urlpart: 'builtin',
     async load(language: string, filename: string): Promise<{file: string}> {
-        const example = ALL_EXAMPLES.find(e => e.lang === language && e.file === filename);
+        const example = getExamples().find(e => e.lang === language && e.file === filename);
         if (example === undefined) {
             return {file: 'No path found'};
         }
@@ -62,7 +75,7 @@ export const builtin: Source = {
         }
     },
     async list(): Promise<SourceApiEntry[]> {
-        return ALL_EXAMPLES.map(e => ({
+        return getExamples().map(e => ({
             lang: e.lang,
             name: e.name,
             file: e.file,

--- a/test/sources/builtin-tests.ts
+++ b/test/sources/builtin-tests.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir() {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ce-builtin-sources-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+}
+
+describe('builtin source provider', () => {
+    afterEach(async () => {
+        const props = await import('../../lib/properties.js');
+        props.reset();
+        vi.resetModules();
+
+        await Promise.all(tempDirs.splice(0).map(tempDir => fs.rm(tempDir, {recursive: true, force: true})));
+    });
+
+    it('uses sourcePath configured after the module has been imported', async () => {
+        const tempDir = await makeTempDir();
+        const examplesPath = path.join(tempDir, 'custom-examples');
+        const languagePath = path.join(examplesPath, 'customlang');
+        const configPath = path.join(tempDir, 'config');
+        const source = 'int configured_example() { return 42; }\n';
+
+        await fs.mkdir(languagePath, {recursive: true});
+        await fs.mkdir(configPath, {recursive: true});
+        await fs.writeFile(path.join(languagePath, 'configured_example.cpp'), source);
+        await fs.writeFile(path.join(configPath, 'builtin.test.properties'), `sourcePath=${examplesPath}\n`);
+
+        vi.resetModules();
+        const {builtin} = await import('../../lib/sources/builtin.js');
+        const props = await import('../../lib/properties.js');
+
+        props.initialize(configPath, ['test']);
+
+        await expect(builtin.list()).resolves.toEqual([
+            {
+                lang: 'customlang',
+                name: 'configured example',
+                file: 'configured_example',
+            },
+        ]);
+        await expect(builtin.load('customlang', 'configured_example')).resolves.toEqual({file: source});
+    });
+});


### PR DESCRIPTION
## Summary

- defer scanning builtin examples until `list()` or `load()` is called
- refresh the cached examples if `builtin.sourcePath` changes
- add a regression test that imports the builtin source provider before properties are initialized, then verifies a custom `sourcePath` is used

Closes #8601.

## Tests

- `npm run test -- --run test/sources/builtin-tests.ts --reporter=dot`
- `npm run test-min -- --run test/sources/builtin-tests.ts --reporter=dot`
- `npm run ts-check`
- `npx biome check lib/sources/builtin.ts test/sources/builtin-tests.ts --write`
- `npm run lint-check -- lib/sources/builtin.ts test/sources/builtin-tests.ts`
- `git diff --check`
