### PR TITLE
Add FXC (D3DCompiler) compilers to HLSL

### DIFF
--- a/etc/config/hlsl.amazonwin.properties
+++ b/etc/config/hlsl.amazonwin.properties
@@ -1,4 +1,18 @@
-compilers=&amd_rga
+compilers=&fxc:&amd_rga
+
+group.fxc.compilers=fxc_10_0_19041:fxc_10_0_26100
+group.fxc.groupName=FXC (D3DCompiler)
+group.fxc.isSemVer=true
+group.fxc.baseName=FXC
+group.fxc.compilerType=fxc
+
+compiler.fxc_10_0_19041.exe=Z:/compilers/fxc/10.0.19041/x64/fxc.exe
+compiler.fxc_10_0_19041.semver=10.0.19041.5609
+compiler.fxc_10_0_19041.name=FXC 10.0.19041.5609
+
+compiler.fxc_10_0_26100.exe=Z:/compilers/fxc/10.0.26100/x64/fxc.exe
+compiler.fxc_10_0_26100.semver=10.0.26100.8249
+compiler.fxc_10_0_26100.name=FXC 10.0.26100.8249
 
 group.amd_rga.compilers=rga_2_9_1:rga_2_10:rga_2_11:rga_2_12:rga_2_13
 group.amd_rga.groupName=AMD Radeon GPU Analyzer

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -84,6 +84,7 @@ export {FakeCompiler} from './fake-for-test.js';
 export {FlangCompiler} from './flang.js';
 export {FlangFC1Compiler} from './flang-fc1.js';
 export {FortranCompiler} from './fortran.js';
+export {FXCCompiler} from './fxc.js';
 export {GA68Compiler} from './ga68.js';
 export {GCCCompiler} from './gcc.js';
 export {GCCCobolCompiler} from './gcccobol.js';

--- a/lib/compilers/fxc.ts
+++ b/lib/compilers/fxc.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+
+// FXC is Microsoft's legacy Direct3D (D3DCompiler) HLSL shader compiler. It produces DX bytecode
+// rather than DXIL, and does not understand DXC-specific flags such as -Qembed_debug, so it cannot
+// share HLSLCompiler's optionsForFilter.
+export class FXCCompiler extends BaseCompiler {
+    static get key() {
+        return 'fxc';
+    }
+
+    constructor(info: any, env: any) {
+        super(info, env);
+
+        this.compiler.supportsIntel = false;
+    }
+
+    override optionsForFilter(
+        filters: ParseFiltersAndOutputOptions,
+        outputFilename: string,
+        userOptions?: string[],
+    ): string[] {
+        return [
+            '-Zi', // Embed debug information so the assembly listing carries source associations
+            `-Fc${outputFilename}`, // Output the human-readable assembly listing
+        ];
+    }
+}


### PR DESCRIPTION
Adds the two newly-installed FXC SDK versions to the HLSL language, per [infra#2150](https://github.com/compiler-explorer/infra/issues/2150):

- `fxc_10_0_19041` — FXC 10.0.19041.5609
- `fxc_10_0_26100` — FXC 10.0.26100.8249

## Details

- FXC is Microsoft's legacy Direct3D (D3DCompiler) HLSL shader compiler. It is Windows-only (`.exe`), so the entries live in `hlsl.amazonwin.properties` using `Z:/compilers/fxc/<sdk>/x64/fxc.exe` paths (x64 arch; the 10.0.19041 SDK lacks the arm64 `d3dcompiler_47.dll`).
- FXC gets its own `fxc` compiler type (`lib/compilers/fxc.ts`) rather than reusing `HLSLCompiler`, because `HLSLCompiler.optionsForFilter` emits `-Qembed_debug`, a DXC-only flag FXC does not understand. The new type overrides `optionsForFilter` to emit `-Zi` and `-Fc<outputFilename>` (assembly listing).
- Registered in `lib/compilers/_all.ts`.

## Note

This lands in the `.amazonwin` (live godbolt.org Windows) config, so the compiler-finder will try to run `fxc.exe` at the `Z:/compilers/fxc/...` paths on startup — the FXC EFS install from infra#2150 should be deployed to the Windows instances before/with merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)