### PR TITLE
Silence spurious MiniCssExtractPlugin "Conflicting order" warnings

### DIFF
--- a/webpack.config.esm.ts
+++ b/webpack.config.esm.ts
@@ -85,6 +85,10 @@ const plugins: Webpack.WebpackPluginInstance[] = [
     }),
     new MiniCssExtractPlugin({
         filename: isDev ? '[name].css' : `[name]${webpackJsHack}[contenthash].css`,
+        // monaco-editor imports hundreds of tiny CSS files in orders that differ between chunks,
+        // which MiniCssExtractPlugin can't reconcile into one global order. The ordering is
+        // irrelevant (monaco's CSS is self-scoped), so silence the spurious "Conflicting order" warnings.
+        ignoreOrder: true,
     }),
     new WebpackManifestPlugin({
         fileName: path.resolve(manifestPath, 'manifest.json'),


### PR DESCRIPTION
## What

Set `ignoreOrder: true` on `MiniCssExtractPlugin` to suppress the ~93 "Conflicting order" warnings emitted on every production build.

## Why

`monaco-editor` imports hundreds of tiny CSS files in orders that differ between chunks, which `MiniCssExtractPlugin` cannot reconcile into a single global order. This floods the build log — most visibly in the [Windows build logs](https://github.com/compiler-explorer/compiler-explorer/actions/runs/26931502531/job/79451960804) — with warnings like:

```
WARNING in chunk vendor [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ...monaco-editor/esm/vs/editor/browser/widget/codeEditor/editor.css
despite it was not able to fulfill desired ordering with these modules: ...
```

The ordering is irrelevant here (monaco's CSS is self-scoped), so the warnings are pure noise.

## Result

Production build now compiles with **2 warnings** (the pre-existing asset-size hints) instead of **95**.

## Tradeoff / note

`ignoreOrder` is plugin-wide — it also silences conflicting-order warnings for CE's own CSS, not just monaco's. In practice all current warnings come from monaco, and CE's own SCSS uses scoped selectors rather than relying on cross-file import order for the cascade, so this isn't masking a real CE problem today. If we'd rather keep the check active for our own CSS, the alternative is isolating monaco into its own `splitChunks` cacheGroup — heavier config, left out here in favour of the idiomatic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)