### PR TITLE
Fix Lean CFG parsing

### DIFF
--- a/lib/cfg/cfg.ts
+++ b/lib/cfg/cfg.ts
@@ -43,6 +43,7 @@ function isLLVMBased({compilerType, version}: CompilerInfo) {
         compilerType === 'swift' ||
         compilerType === 'zig' ||
         compilerType === 'ispc' ||
+        compilerType === 'lean' ||
         compilerType === 'snowball'
     );
 }

--- a/lib/compilers/lean.ts
+++ b/lib/compilers/lean.ts
@@ -43,6 +43,10 @@ export class LeanCompiler extends BaseCompiler {
         this.compiler.supportsLeanCView = true;
     }
 
+    override isCfgCompiler() {
+        return true;
+    }
+
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {
         return [`--c=${this.getLeanCOutputFilename(outputFilename)}`];
     }


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->


I've noticed that the CFG view for Lean is not working correctly. It should be marked as LLVM based. Confirmed this fixes the issue for me locally.