### PR TITLE
Harden lazy-loaded API fetches (languages/compilers/libraries/tools)

### DIFF
--- a/static/main.ts
+++ b/static/main.ts
@@ -796,4 +796,27 @@ async function start() {
     hub.layout.eventHub.emit('settingsChange', settings); // Ensure everyone knows the settings
 }
 
-$(start);
+$(() => {
+    start().catch((e: unknown) => {
+        // The bootstrap (notably languagesService.getLanguages()) failed even after retries, so the page
+        // never finished initializing. Surface it to the console and Sentry, and offer the user a reload
+        // rather than leaving them staring at a blank page.
+        console.error('Compiler Explorer failed to start', e);
+        SentryCapture(e, 'start');
+        try {
+            new Alert().ask(
+                'Failed to load Compiler Explorer',
+                'Compiler Explorer could not finish loading, likely due to a network problem. ' +
+                    'Please check your connection and reload the page.',
+                {
+                    yes: () => window.location.reload(),
+                    yesHtml: 'Reload',
+                    noHtml: 'Dismiss',
+                },
+            );
+        } catch (alertError) {
+            // If even the alert machinery isn't ready, there's nothing more we can do but log it.
+            console.error('Could not display the startup failure alert', alertError);
+        }
+    });
+});

--- a/static/services/compilers.service.ts
+++ b/static/services/compilers.service.ts
@@ -25,6 +25,7 @@
 import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import {optionsHash} from '../options.js';
 import {SentryCapture} from '../sentry.js';
+import {fetchApiJson} from './fetch-utils.js';
 
 export class CompilersService {
     private readonly loadPromises = new Map<string, Promise<Record<string, CompilerInfo>>>();
@@ -104,11 +105,9 @@ export class CompilersService {
     ];
 
     private async fetchCompilersForLang(langId: string): Promise<Record<string, CompilerInfo>> {
-        const response = await fetch(
+        const compilers = await fetchApiJson<CompilerInfo[]>(
             `${window.httpRoot}api/compilers/${encodeURIComponent(langId)}?fields=${CompilersService.compilerFields.join(',')}&hash=${optionsHash}`,
-            {headers: {Accept: 'application/json'}},
         );
-        const compilers: CompilerInfo[] = await response.json();
         const result: Record<string, CompilerInfo> = {};
         for (const compiler of compilers) {
             result[compiler.id] = compiler;

--- a/static/services/compilers.service.ts
+++ b/static/services/compilers.service.ts
@@ -30,6 +30,7 @@ export class CompilersService {
     private readonly loadPromises = new Map<string, Promise<Record<string, CompilerInfo>>>();
 
     async getCompilersForLang(langId: string): Promise<Record<string, CompilerInfo>> {
+        if (!langId) return {};
         let promise = this.loadPromises.get(langId);
         if (!promise) {
             promise = this.fetchCompilersForLang(langId);

--- a/static/services/fetch-utils.ts
+++ b/static/services/fetch-utils.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+export interface FetchJsonOptions {
+    /** Number of retry attempts after the first try (so total attempts = retries + 1). */
+    retries?: number;
+    /** Base backoff delay in milliseconds; doubles each retry. */
+    baseDelayMs?: number;
+}
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Fetch JSON from a CE API endpoint with retries on transient failures.
+ *
+ * The languages, compilers, libraries and tools lists are lazy-loaded at
+ * runtime (see #8549) rather than baked into the page, so they're newly exposed
+ * to transient network blips (`fetch` rejects with `TypeError: Failed to fetch`)
+ * and brief server hiccups (5xx) that would otherwise break pane initialization.
+ * Browsers never retry `fetch`, so we do it here with exponential backoff.
+ *
+ * Only network failures and 5xx responses are retried. Client errors (4xx) and
+ * malformed bodies won't change on retry, so they fail fast. A non-ok response
+ * that exhausts its retries throws an Error carrying the status, rather than
+ * letting an error body fall through to the caller as if it were valid data.
+ */
+export async function fetchApiJson<T>(url: string, options: FetchJsonOptions = {}): Promise<T> {
+    const {retries = 2, baseDelayMs = 250} = options;
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        if (attempt > 0) await delay(baseDelayMs * 2 ** (attempt - 1));
+
+        let response: Response;
+        try {
+            response = await fetch(url, {headers: {Accept: 'application/json'}});
+        } catch (e) {
+            // Network-level failure ("Failed to fetch"): retry.
+            lastError = e;
+            continue;
+        }
+
+        if (response.ok) return (await response.json()) as T;
+
+        const error = new Error(`Request failed: ${response.status} ${response.statusText} for ${url}`);
+        // Client errors won't succeed on retry; fail fast.
+        if (response.status < 500) throw error;
+        lastError = error;
+    }
+    throw lastError;
+}

--- a/static/services/languages.service.ts
+++ b/static/services/languages.service.ts
@@ -25,6 +25,7 @@
 import {Language, LanguageKey} from '../../types/languages.interfaces.js';
 import {optionsHash} from '../options.js';
 import {SentryCapture} from '../sentry.js';
+import {fetchApiJson} from './fetch-utils.js';
 
 export type LanguageMap = Partial<Record<LanguageKey, Language>>;
 
@@ -76,11 +77,9 @@ export class LanguagesService {
     ];
 
     private async fetchLanguages(): Promise<LanguageMap> {
-        const response = await fetch(
+        const languages = await fetchApiJson<Language[]>(
             `${window.httpRoot}api/languages?fields=${LanguagesService.languageFields.join(',')}&hash=${optionsHash}`,
-            {headers: {Accept: 'application/json'}},
         );
-        const languages: Language[] = await response.json();
         const result: LanguageMap = {};
         for (const lang of languages) {
             result[lang.id] = lang;

--- a/static/services/libs.service.ts
+++ b/static/services/libs.service.ts
@@ -47,6 +47,7 @@ export class LibsService {
     ];
 
     async getLibsForLang(langId: string): Promise<LanguageLibs> {
+        if (!langId) return {};
         let promise = this.loadPromises.get(langId);
         if (!promise) {
             promise = this.fetchLibsForLang(langId);
@@ -60,6 +61,7 @@ export class LibsService {
     }
 
     async getRemoteLibs(langId: string, remoteUrl: string): Promise<LanguageLibs> {
+        if (!langId) return {};
         const remoteId = getRemoteId(remoteUrl, langId);
         let promise = this.loadPromises.get(remoteId);
         if (!promise) {

--- a/static/services/libs.service.ts
+++ b/static/services/libs.service.ts
@@ -28,6 +28,7 @@ import {getRemoteId} from '../../shared/remote-utils.js';
 import {LanguageLibs} from '../options.interfaces.js';
 import {optionsHash} from '../options.js';
 import {SentryCapture} from '../sentry.js';
+import {fetchApiJson} from './fetch-utils.js';
 
 export class LibsService {
     private readonly loadPromises = new Map<string, Promise<LanguageLibs>>();
@@ -72,11 +73,9 @@ export class LibsService {
     }
 
     private async fetchLibsForLang(langId: string): Promise<LanguageLibs> {
-        const response = await fetch(
+        const libsArr = await fetchApiJson<any[]>(
             `${window.httpRoot}api/libraries/${encodeURIComponent(langId)}?fields=${LibsService.libFields.join(',')}&hash=${optionsHash}`,
-            {headers: {Accept: 'application/json'}},
         );
-        const libsArr = await response.json();
         return this.libArrayToRecord(libsArr);
     }
 
@@ -87,8 +86,7 @@ export class LibsService {
             `${encodeURIComponent(langId)}?fields=${LibsService.libFields.join(',')}`,
         );
         try {
-            const response = await fetch(url, {headers: {Accept: 'application/json'}});
-            const libsArr = await response.json();
+            const libsArr = await fetchApiJson<any[]>(url);
             return this.libArrayToRecord(libsArr);
         } catch (e) {
             SentryCapture(e, `fetchRemoteLibs(${langId}, ${remoteUrl})`);
@@ -97,6 +95,9 @@ export class LibsService {
     }
 
     private libArrayToRecord(libsArr: any[]): LanguageLibs {
+        if (!Array.isArray(libsArr)) {
+            throw new Error(`Expected an array of libraries but got ${typeof libsArr}`);
+        }
         const libs: LanguageLibs = {};
         for (const lib of libsArr) {
             const versions = Object.fromEntries(lib.versions.map((v: any) => [v.id, v]));

--- a/static/services/tools.service.ts
+++ b/static/services/tools.service.ts
@@ -47,6 +47,7 @@ export class ToolsService {
     }
 
     async getToolsForLang(langId: string): Promise<Record<string, ToolEntry>> {
+        if (!langId) return {};
         let promise = this.loadPromises.get(langId);
         if (!promise) {
             promise = this.fetchToolsForLang(langId);

--- a/static/services/tools.service.ts
+++ b/static/services/tools.service.ts
@@ -24,6 +24,7 @@
 
 import {optionsHash} from '../options.js';
 import {SentryCapture} from '../sentry.js';
+import {fetchApiJson} from './fetch-utils.js';
 
 export type ToolEntry = {
     id: string;
@@ -64,10 +65,9 @@ export class ToolsService {
     }
 
     private async fetchToolsForLang(langId: string): Promise<Record<string, ToolEntry>> {
-        const response = await fetch(`${window.httpRoot}api/tools/${encodeURIComponent(langId)}?hash=${optionsHash}`, {
-            headers: {Accept: 'application/json'},
-        });
-        const toolsArr: ToolEntry[] = await response.json();
+        const toolsArr = await fetchApiJson<ToolEntry[]>(
+            `${window.httpRoot}api/tools/${encodeURIComponent(langId)}?hash=${optionsHash}`,
+        );
         const result: Record<string, ToolEntry> = {};
         for (const tool of toolsArr) {
             result[tool.id] = tool;

--- a/static/tests/fetch-utils-tests.ts
+++ b/static/tests/fetch-utils-tests.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {fetchApiJson} from '../services/fetch-utils.js';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: `status ${status}`,
+        json: async () => body,
+    } as Response;
+}
+
+describe('fetchApiJson', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the parsed body on success', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse([{id: 'a'}]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchApiJson('/api/x', {baseDelayMs: 0})).resolves.toEqual([{id: 'a'}]);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on network failure and eventually succeeds', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(jsonResponse([{id: 'b'}]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchApiJson('/api/x', {baseDelayMs: 0})).resolves.toEqual([{id: 'b'}]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 5xx and eventually succeeds', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(null, 503))
+            .mockResolvedValueOnce(jsonResponse([{id: 'c'}]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchApiJson('/api/x', {baseDelayMs: 0})).resolves.toEqual([{id: 'c'}]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry on 4xx and throws', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse(null, 404));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchApiJson('/api/x', {baseDelayMs: 0})).rejects.toThrow(/404/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after exhausting retries on persistent network failure', async () => {
+        const err = new TypeError('Failed to fetch');
+        const fetchMock = vi.fn().mockRejectedValue(err);
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchApiJson('/api/x', {retries: 2, baseDelayMs: 0})).rejects.toBe(err);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+});


### PR DESCRIPTION
Since #8549, the languages, compilers, libraries and tools lists are lazy-loaded from the API at runtime instead of being baked into the page. This moved those fetches from "always present at page load" to "live network requests during pane init", which exposed a cluster of Sentry-reported failures. This PR fixes three of them.

## 1. Empty langId hits the wrong API route (`6ab9bb6a6`)
**Sentry:** `TypeError: Object is not iterable` in `fetchLibsForLang()` → `libArrayToRecord`.

A pane initialized before its language was resolved passes `currentLangId ?? ''` into the services. An empty language builds a request to `api/libraries/` (trailing slash, no param), which Express routes to the *all-libraries* handler instead of the per-language one — returning the libs object keyed by language with HTTP 200. `libArrayToRecord`'s `for...of` then throws on the object.

Fix: short-circuit empty `langId` in the libs/tools/compilers services so no malformed request is made. The same exposure existed for tools (404 → HTML) and compilers (wrong all-compilers data).

## 2. No retry on transient network failures (`489450c4a`)
**Sentry:** `TypeError: Failed to fetch` / `NetworkError when attempting to fetch resource` in `fetchCompilersForLang(...)`, `fetchLanguages`, etc.

A bare `fetch()` rejects on any momentary network blip, which broke pane init and spammed Sentry. Browsers never retry `fetch`, so a hiccup the old embedded data never noticed now surfaces as a hard error.

Fix: a shared `fetchApiJson` helper that retries network failures and 5xx with exponential backoff, fails fast on 4xx, and validates `response.ok` (so an error body never flows through as if it were valid data). All four services route through it. `libArrayToRecord` also gets an explicit array check for a clearer message than "Object is not iterable". Covered by new unit tests.

## 3. Bootstrap failure shows a blank page (`285880083`)
`start()` awaits `languagesService.getLanguages()` as its first step. A hard failure there (after the retries above) rejected the whole bootstrap, leaving the user on a blank page with only an unhandled rejection in Sentry — and `SentryCapture` doesn't log to the console either.

Fix: wrap `$(start)` to log the failure to the console, capture it to Sentry with a `start` context, and show the user an alert offering to reload.

## Testing
- New `static/tests/fetch-utils-tests.ts` covers success, network-retry, 5xx-retry, no-retry-on-4xx, and give-up-after-retries.
- `npm run lint`, all `ts-check` projects, and related tests pass via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)