### PR TITLE
Use compiler's demangler type for LLVM IR

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -196,6 +196,7 @@ export class BaseCompiler {
     protected stubText: string;
     protected compilerWrapper: string | undefined;
     protected asm: IAsmParser;
+    protected llvmIrDemanglerClass: typeof BaseDemangler;
     protected llvmIr: LlvmIrParser;
     protected llvmPassDumpParser: LlvmPassDumpParser;
     protected llvmAst: LlvmAstParser;
@@ -258,16 +259,6 @@ export class BaseCompiler {
             this.compiler.disabledFilters = (this.compiler.disabledFilters as any).split(',');
         }
 
-        this.asm = new AsmParser(this.compilerProps);
-        const irDemangler = new LLVMIRDemangler(this.compiler.demangler, this);
-        this.llvmIr = new LlvmIrParser(this.compilerProps, irDemangler);
-        this.llvmPassDumpParser = new LlvmPassDumpParser();
-        this.llvmAst = new LlvmAstParser(this.compilerProps);
-
-        this.toolchainPath = getToolchainPath(this.compiler.exe, this.compiler.options);
-
-        this.possibleArguments = new CompilerArguments(this.compiler.id);
-        this.possibleTools = _.values(compilerInfo.tools) as ITool[];
         const demanglerExe = this.compiler.demangler;
         if (demanglerExe && this.compiler.demanglerType) {
             this.demanglerClass = getDemanglerTypeByKey(this.compiler.demanglerType);
@@ -276,6 +267,18 @@ export class BaseCompiler {
         if (objdumperExe && this.compiler.objdumperType) {
             this.objdumperClass = getObjdumperTypeByKey(this.compiler.objdumperType);
         }
+
+        this.asm = new AsmParser(this.compilerProps);
+        this.llvmIrDemanglerClass = this.demanglerClass ?? BaseDemangler;
+        const irDemangler = new LLVMIRDemangler(new this.llvmIrDemanglerClass(this.compiler.demangler, this));
+        this.llvmIr = new LlvmIrParser(this.compilerProps, irDemangler);
+        this.llvmPassDumpParser = new LlvmPassDumpParser();
+        this.llvmAst = new LlvmAstParser(this.compilerProps);
+
+        this.toolchainPath = getToolchainPath(this.compiler.exe, this.compiler.options);
+
+        this.possibleArguments = new CompilerArguments(this.compiler.id);
+        this.possibleTools = _.values(compilerInfo.tools) as ITool[];
 
         this.outputFilebase = 'output';
 
@@ -1591,7 +1594,7 @@ export class BaseCompiler {
             if (optPipelineOptions.demangle) {
                 // apply demangles after parsing, would otherwise greatly complicate the parsing of the passes
                 // new this.demanglerClass(this.compiler.demangler, this);
-                const demangler = new LLVMIRDemangler(this.compiler.demangler, this);
+                const demangler = new LLVMIRDemangler(new this.llvmIrDemanglerClass(this.compiler.demangler, this));
                 // collect labels off the raw input
                 if (this.compiler.debugPatched) {
                     demangler.collect({asm: output.stdout});

--- a/lib/demangler/base.ts
+++ b/lib/demangler/base.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
-import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import type {DemanglerExecutionOptions, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {UnprocessedExecResult} from '../../types/execution/execution.interfaces.js';
 import {unwrap} from '../assert.js';
 import {BaseCompiler} from '../base-compiler.js';
@@ -173,7 +173,7 @@ export class BaseDemangler extends AsmRegex {
     protected processOutput(output: UnprocessedExecResult) {
         if (output.stdout.length === 0 && output.stderr.length > 0) {
             logger.error(`Error executing demangler ${this.demanglerExe}`, output);
-            return this.result;
+            return;
         }
 
         const lines = utils.splitLines(output.stdout);
@@ -182,11 +182,10 @@ export class BaseDemangler extends AsmRegex {
             throw new Error('Internal issue in demangler');
         }
         for (let i = 0; i < lines.length; ++i) this.addTranslation(this.input[i], lines[i]);
+    }
 
-        const translations = [
-            ...unwrap(this.symbolstore).listTranslations(),
-            ...this.othersymbols.listTranslations(),
-        ].filter(elem => elem[0] !== elem[1]);
+    protected applyTranslations() {
+        const translations = this.getTranslations();
         if (translations.length > 0) {
             const tree = new PrefixTree(translations);
             const translationsDict = Object.fromEntries(translations);
@@ -218,7 +217,7 @@ export class BaseDemangler extends AsmRegex {
         return this.compiler.exec(this.demanglerExe, this.demanglerArguments, options);
     }
 
-    public async process(result: ParsedAsmResult, execOptions?: ExecutionOptions): Promise<ParsedAsmResult> {
+    public async process(result: ParsedAsmResult, execOptions?: DemanglerExecutionOptions): Promise<ParsedAsmResult> {
         const options = execOptions || {};
         this.result = result;
 
@@ -226,7 +225,13 @@ export class BaseDemangler extends AsmRegex {
             this.symbolstore = new SymbolStore();
         }
 
-        this.collectLabels();
+        if (options.overrideSymbols) {
+            for (const symbol of options.overrideSymbols) {
+                this.symbolstore.add(symbol);
+            }
+        } else {
+            this.collectLabels();
+        }
 
         options.input = this.getInput();
 
@@ -234,6 +239,16 @@ export class BaseDemangler extends AsmRegex {
             return this.result;
         }
 
-        return this.processOutput(await this.execDemangler(options));
+        this.processOutput(await this.execDemangler(options));
+        if (options.skipTranslation) {
+            return this.result;
+        }
+        return this.applyTranslations();
+    }
+
+    public getTranslations() {
+        return [...unwrap(this.symbolstore).listTranslations(), ...this.othersymbols.listTranslations()].filter(
+            elem => elem[0] !== elem[1],
+        );
     }
 }

--- a/lib/demangler/llvm.ts
+++ b/lib/demangler/llvm.ts
@@ -22,60 +22,57 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
 import {OptPipelineResults} from '../../types/compilation/opt-pipeline-output.interfaces.js';
-import {UnprocessedExecResult} from '../../types/execution/execution.interfaces.js';
 import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
-import {logger} from '../logger.js';
-import {SymbolStore} from '../symbol-store.js';
-import * as utils from '../utils.js';
 import {BaseDemangler} from './base.js';
 import {PrefixTree} from './prefix-tree.js';
 
-export class LLVMIRDemangler extends BaseDemangler {
+export class LLVMIRDemangler {
     // Identifiers can be quoted: https://llvm.org/docs/LangRef.html#identifiers
     llvmSymbolRE = /@(?<symbol>[\w$.]+)/gi;
     llvmQuotedSymbolRE = /@"(?<symbol>[^"]+)"/gi;
+
+    symbolDemangler: BaseDemangler;
+    result: ParsedAsmResult;
+    labels: string[];
 
     static get key() {
         return 'llvm-ir';
     }
 
-    protected override collectLabels() {
+    constructor(symbolDemangler: BaseDemangler) {
+        this.symbolDemangler = symbolDemangler;
+        this.result = {
+            asm: [],
+        };
+        this.labels = [];
+    }
+
+    public canDemangle() {
+        return this.symbolDemangler.canDemangle();
+    }
+
+    private collectLabels() {
+        const labels = new Set<string>();
         for (const line of this.result.asm) {
             const text = line.text;
             if (!text) continue;
 
             const matches = [...text.matchAll(this.llvmSymbolRE), ...text.matchAll(this.llvmQuotedSymbolRE)];
             for (const match of matches) {
-                this.symbolstore!.add(match.groups!.symbol);
+                labels.add(match.groups!.symbol);
             }
         }
+        this.labels = [...labels];
     }
 
     public collect(result: {asm: ResultLine[]}) {
         this.result = result;
-        if (!this.symbolstore) {
-            this.symbolstore = new SymbolStore();
-            this.collectLabels();
-        }
+        this.collectLabels();
     }
 
-    protected processPassOutput(passOutput: OptPipelineResults, demanglerOutput: UnprocessedExecResult) {
-        if (demanglerOutput.stdout.length === 0 && demanglerOutput.stderr.length > 0) {
-            logger.error(`Error executing demangler ${this.demanglerExe}`, demanglerOutput);
-            return passOutput;
-        }
-
-        const lines = utils.splitLines(demanglerOutput.stdout);
-        if (lines.length > this.input.length) {
-            logger.error(`Demangler output issue ${lines.length} > ${this.input.length}`, this.input, demanglerOutput);
-            throw new Error('Internal issue in demangler');
-        }
-        for (let i = 0; i < lines.length; ++i) this.addTranslation(this.input[i], lines[i]);
-
-        const translations = [...this.symbolstore!.listTranslations(), ...this.othersymbols.listTranslations()].filter(
-            elem => elem[0] !== elem[1],
-        );
+    protected processPassOutput(passOutput: OptPipelineResults, translations: [string, string][]) {
         if (translations.length > 0) {
             const tree = new PrefixTree(translations);
             for (const [functionName, passes] of Object.entries(passOutput)) {
@@ -96,13 +93,19 @@ export class LLVMIRDemangler extends BaseDemangler {
     }
 
     public async demangleLLVMPasses(passOutput: OptPipelineResults) {
-        const options = {
-            input: this.getInput(),
-        };
-
-        if (options.input === '') {
+        if (this.labels.length === 0) {
             return passOutput;
         }
-        return this.processPassOutput(passOutput, await this.execDemangler(options));
+        await this.symbolDemangler.process({asm: []}, {overrideSymbols: this.labels, skipTranslation: true});
+        return this.processPassOutput(passOutput, this.symbolDemangler.getTranslations());
+    }
+
+    public async process(result: ParsedAsmResult) {
+        this.result = result;
+        this.collectLabels();
+        if (this.labels.length === 0) {
+            return result;
+        }
+        return await this.symbolDemangler.process(result, {overrideSymbols: this.labels});
     }
 }

--- a/lib/demangler/nvhpc.ts
+++ b/lib/demangler/nvhpc.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import {BaseCompiler} from '../base-compiler.js';
+import {SymbolStore} from '../symbol-store.js';
 import {BaseDemangler} from './base.js';
 import {LLVMIRDemangler} from './llvm.js';
 
@@ -35,11 +36,16 @@ export class NVHPCDemangler extends BaseDemangler {
 
     constructor(demanglerExe: string, compiler: BaseCompiler, demanglerArguments: string[] = []) {
         super(demanglerExe, compiler, demanglerArguments);
-        this.llvmDemangler = new LLVMIRDemangler(demanglerExe, compiler);
+        this.llvmDemangler = new LLVMIRDemangler(this);
     }
 
     protected override collectLabels() {
         this.llvmDemangler.collect(this.result as any);
-        this.symbolstore = this.llvmDemangler.symbolstore;
+        if (!this.symbolstore) {
+            this.symbolstore = new SymbolStore();
+        }
+        for (const symbol of this.llvmDemangler.labels) {
+            this.symbolstore.add(symbol);
+        }
     }
 }

--- a/lib/demangler/pascal.ts
+++ b/lib/demangler/pascal.ts
@@ -23,7 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
-import type {ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
+import type {DemanglerExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {SymbolStore} from '../symbol-store.js';
 import {BaseDemangler} from './base.js';
@@ -221,7 +221,7 @@ export class PascalDemangler extends BaseDemangler {
         return text;
     }
 
-    public override async process(result: ParsedAsmResult, execOptions?: ExecutionOptions) {
+    public override async process(result: ParsedAsmResult, execOptions?: DemanglerExecutionOptions) {
         const options = execOptions || {};
         this.result = result;
 

--- a/lib/demangler/win32-llvm.ts
+++ b/lib/demangler/win32-llvm.ts
@@ -71,6 +71,7 @@ export class LLVMWin32Demangler extends Win32Demangler {
         const stdin = symbolArray.join('\n') + '\n';
         await demangleFromStdin(stdin);
 
+        this.translations = translations;
         return translations;
     }
 }

--- a/lib/demangler/win32.ts
+++ b/lib/demangler/win32.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import type {ParsedAsmResult} from '../../types/asmresult/asmresult.interfaces.js';
+import {DemanglerExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
 import type {UnprocessedExecResult} from '../../types/execution/execution.interfaces.js';
 import {assert, unwrap} from '../assert.js';
 import {BaseCompiler} from '../base-compiler.js';
@@ -40,6 +41,7 @@ export class Win32Demangler extends CppDemangler {
     allDecoratedLabelsWithQuotes: RegExp;
     hasQuotesAroundDecoratedLabels: null | boolean;
     win32RawSymbols?: string[];
+    translations: Record<string, string>;
 
     constructor(demanglerExe: string, compiler: BaseCompiler, demanglerArguments: string[] = []) {
         super(demanglerExe, compiler, demanglerArguments);
@@ -57,6 +59,7 @@ export class Win32Demangler extends CppDemangler {
         // we set this to true if we see it, and false if we don't
         // null means we haven't set it yet.
         this.hasQuotesAroundDecoratedLabels = null;
+        this.translations = {};
     }
 
     protected override collectLabels() {
@@ -75,7 +78,7 @@ export class Win32Demangler extends CppDemangler {
         }
     }
 
-    protected override processOutput(translations: UnprocessedExecResult): ParsedAsmResult {
+    protected override processOutput(translations: UnprocessedExecResult) {
         assert(false, "Win32Demangler.processOutput shouldn't be called");
     }
 
@@ -161,10 +164,12 @@ export class Win32Demangler extends CppDemangler {
         }
 
         await Promise.all(commandLineArray.map(demangleSingleSet));
+        this.translations = translations;
         return translations;
     }
 
-    public override async process(result: ParsedAsmResult) {
+    public override async process(result: ParsedAsmResult, execOptions?: DemanglerExecutionOptions) {
+        const options = execOptions ?? {};
         if (!this.demanglerExe) {
             logger.error("Attempted to demangle, but there's no demangler set");
             return result;
@@ -172,7 +177,24 @@ export class Win32Demangler extends CppDemangler {
 
         this.result = result;
 
-        this.collectLabels();
-        return this.processTranslations(await this.createTranslations());
+        if (options.overrideSymbols) {
+            this.win32RawSymbols = [];
+            for (const sym of options.overrideSymbols) {
+                this.win32RawSymbols.push(sym);
+            }
+        } else {
+            this.collectLabels();
+        }
+
+        await this.createTranslations();
+
+        if (options.skipTranslation) {
+            return result;
+        }
+        return this.processTranslations(this.translations);
+    }
+
+    public override getTranslations(): [string, string][] {
+        return Object.entries(this.translations);
     }
 }

--- a/test/demangler-tests.ts
+++ b/test/demangler-tests.ts
@@ -65,10 +65,6 @@ class DummyCppDemangler extends CppDemangler {
     public override collectLabels = super.collectLabels;
 }
 
-class DummyLlvmDemangler extends LLVMIRDemangler {
-    public override collectLabels = super.collectLabels;
-}
-
 class DummyWin32Demangler extends Win32Demangler {
     public override collectLabels = super.collectLabels;
 }
@@ -473,7 +469,8 @@ describe.skipIf(process.platform === 'win32')('LLVM IR demangler', () => {
             ],
         };
 
-        const demangler = new DummyLlvmDemangler(cppfiltpath, new DummyCompiler(), ['-n']);
+        const baseDemangler = new DummyCppDemangler(cppfiltpath, new DummyCompiler(), ['-n']);
+        const demangler = new LLVMIRDemangler(baseDemangler);
 
         return Promise.all([
             demangler
@@ -497,7 +494,8 @@ describe.skipIf(process.platform === 'win32')('LLVM IR demangler', () => {
             ],
         };
 
-        const demangler = new DummyLlvmDemangler(cppfiltpath, new DummyCompiler(), ['-n']);
+        const baseDemangler = new DummyCppDemangler(cppfiltpath, new DummyCompiler(), ['-n']);
+        const demangler = new LLVMIRDemangler(baseDemangler);
 
         return Promise.all([
             demangler

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -268,6 +268,13 @@ export type ExecutionOptions = {
 
 export type ExecutionOptionsWithEnv = ExecutionOptions & {env: Record<string, string>};
 
+export type DemanglerExecutionOptions = ExecutionOptions & {
+    // List of symbols to demangle - don't scan the input.
+    overrideSymbols?: string[];
+    // Don't apply translations to the input - return it as-is.
+    skipTranslation?: boolean;
+};
+
 export type BuildResult = CompilationResult & {
     downloads: BuildEnvDownloadInfo[];
     executableFilename: string;


### PR DESCRIPTION
The `LLVMIRDemangler` derived from `BaseDemangler`. It called the demangler executable as-if it was `c++filt`. This would fail if the demangler was `(llvm-)undname` (demangler for Microsoft names), because it has a different output.

This PR refactors `LLVMIRDemangler` to take a demangler instance that it calls into. `BaseDemangler` was extended to allow demangling a fixed set of symbols and to skip applying the names. Both are needed for the IR demangler. This way, the demangler instance can handle the details of parsing the stdout and `LLVMIRDemangler` can provide the names and apply the transforms.