### PR TITLE
clang-cl: fix IR/AST arguments

### DIFF
--- a/lib/compilers/clangcl.ts
+++ b/lib/compilers/clangcl.ts
@@ -27,6 +27,7 @@ import path from 'node:path';
 import {LLVMIrBackendOptions} from '../../types/compilation/ir.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {unwrap} from '../assert.js';
 import {CompilationEnvironment} from '../compilation-env.js';
 import {Win32Compiler} from './win32.js';
@@ -40,7 +41,7 @@ export class ClangCLCompiler extends Win32Compiler {
         super(info, env);
 
         this.compiler.supportsIrView = true;
-        this.compiler.irArg = ['-Xclang', '-emit-llvm'];
+        this.compiler.irArg = ['-Xclang', '-emit-llvm', '-c'];
         this.compiler.minIrArgs = ['-emit-llvm'];
         this.compiler.supportsIntel = false;
         this.compiler.includeFlag = '/clang:-isystem';
@@ -54,9 +55,7 @@ export class ClangCLCompiler extends Win32Compiler {
         filters: ParseFiltersAndOutputOptions,
     ) {
         // These options make Clang produce an IR
-        const newOptions = options
-            .filter(option => option !== '/FA' && !option.startsWith('/Fa'))
-            .concat(unwrap(this.compiler.irArg));
+        const newOptions = this.optionsForIntermediate(options).concat(unwrap(this.compiler.irArg));
 
         const execOptions = this.getDefaultExecOptions();
         // A higher max output is needed for when the user includes headers
@@ -74,6 +73,10 @@ export class ClangCLCompiler extends Win32Compiler {
         };
     }
 
+    override generateAST(inputFilename: string, options: string[]): Promise<ResultLine[]> {
+        return super.generateAST(inputFilename, this.optionsForIntermediate(options));
+    }
+
     override getIrOutputFilename(inputFilename: string): string {
         return this.filename(path.dirname(inputFilename) + '/output.s.obj');
     }
@@ -83,5 +86,14 @@ export class ClangCLCompiler extends Win32Compiler {
 
         // Force the debugging info flag or we can't source locations.
         return ['/Z7'].concat(options);
+    }
+
+    protected optionsForIntermediate(options: string[]) {
+        options = options.filter(option => option !== '/FA' && !option.startsWith('/Fa'));
+        const linkIdx = options.indexOf('/link');
+        if (linkIdx !== -1) {
+            return options.slice(0, linkIdx);
+        }
+        return options;
     }
 }


### PR DESCRIPTION
When the user specified `/link` in the options or enabled "Link to binary", clang-cl wouldn't generate IR or an AST.
Two changes fix this:
- Strip `/link` and all options after it. These are unused for IR and AST generation anyway.
- Always specify `-c` for IR generation. For the AST, `-fsyntax-only` is already specified in the base class.