### PR TITLE
clang-cl: Use llvm-undname and fix compiler name

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -9,8 +9,8 @@ group.clang-cl.compilers=clang-cl2216:clang-cl2216-v19_50_VS18_2:clang-cl1810
 group.clang-cl.baseName=clang-cl
 group.clang-cl.compilerType=clang-cl
 group.clang-cl.compilerCategories=clang-cl
-group.clang-cl.demangler=Z:/compilers/msvc/14.41.33923-14.41.33923.0/bin/Hostx64/x64/undname.exe
-group.clang-cl.demanglerType=win32
+group.clang-cl.demangler=Z:/compilers/clang-cl-22.1.6/bin/llvm-undname.exe
+group.clang-cl.demanglerType=win32-llvm
 group.clang-cl.groupName=clang-cl
 group.clang-cl.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang-cl.isSemVer=true
@@ -28,7 +28,7 @@ compiler.clang-cl2216.semver=22.1.6
 compiler.clang-cl2216.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
 
 compiler.clang-cl2216-v19_50_VS18_2.exe=Z:/compilers/clang-cl-22.1.6/bin/clang-cl.exe
-compiler.clang-cl2216-v19_50_VS18_2.name=22.1.6 (msvc v19.50 VS18.2)
+compiler.clang-cl2216-v19_50_VS18_2.name=clang-cl 22.1.6 (msvc v19.50 VS18.2)
 compiler.clang-cl2216-v19_50_VS18_2.semver=22.1.6+14.50.35723.0
 compiler.clang-cl2216-v19_50_VS18_2.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
 


### PR DESCRIPTION
Two tiny changes:
- We're using Clang, so we should also use LLVM's demangler, `llvm-undname`.
- The name of clang-cl with a fixed VS SDK was missing the `clang-cl` prefix. If I understand correctly, then this is fine, because the compiler is identified by the ID (`clang-cl2216-v19_50_VS18_2`), not the name.