### PR TITLE
clang-cl: Remove unused /Fm argument

### DIFF
--- a/lib/compilers/clangcl.ts
+++ b/lib/compilers/clangcl.ts
@@ -39,6 +39,7 @@ export class ClangCLCompiler extends Win32Compiler {
     constructor(info: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(info, env);
 
+        this.supportsMapFile = false;
         this.compiler.supportsIrView = true;
         this.compiler.irArg = ['-Xclang', '-emit-llvm'];
         this.compiler.minIrArgs = ['-emit-llvm'];

--- a/lib/compilers/win32.ts
+++ b/lib/compilers/win32.ts
@@ -48,6 +48,7 @@ export class Win32Compiler extends BaseCompiler {
     }
 
     binaryAsmParser: VcAsmParser;
+    supportsMapFile = true;
 
     constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
         super(compilerInfo, env);
@@ -248,25 +249,29 @@ export class Win32Compiler extends BaseCompiler {
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
         if (filters.binary) {
-            const mapFilename = outputFilename + '.map';
-            const mapFileReader = new MapFileReaderVS(mapFilename);
-
-            filters.preProcessBinaryAsmLines = asmLines => {
-                const reconstructor = new PELabelReconstructor(asmLines, false, mapFileReader);
-                reconstructor.run('output.s.obj');
-
-                return reconstructor.asmLines;
-            };
-
-            return [
+            const options = [
                 '/nologo',
                 '/FA', // assembly listing with source and machine code
                 '/Fa' + this.filename(outputFilename.replace(/\.exe$/, '')), // assembly listing
                 '/Fo' + this.filename(outputFilename.replace(/\.exe$/, '') + '.obj'), // object file
-                '/Fm' + this.filename(mapFilename),
                 '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), 'output')),
                 '/Zi', // complete debugging information
             ];
+
+            if (this.supportsMapFile) {
+                const mapFilename = outputFilename + '.map';
+                const mapFileReader = new MapFileReaderVS(mapFilename);
+
+                filters.preProcessBinaryAsmLines = asmLines => {
+                    const reconstructor = new PELabelReconstructor(asmLines, false, mapFileReader);
+                    reconstructor.run('output.s.obj');
+
+                    return reconstructor.asmLines;
+                };
+                options.push('/Fm' + this.filename(mapFilename));
+            }
+
+            return options;
         }
         return [
             '/nologo',


### PR DESCRIPTION
clang-cl doesn't write mapfiles like MSVC, so it doesn't support `/Fm` and it used to report a warning: 
```
clang-cl: warning: argument unused during compilation: '/FmC:\Windows\TEMP\compiler-explorer-compiler6Pv4en\output.s.exe.map' [-Wunused-command-line-argument]
```

To still get the function labels, we should use `llvm-objdump`. However, that doesn't read the generated debug info file right now. I've opened https://github.com/llvm/llvm-project/pull/201150 to fix this.