### PR TITLE
clang-cl: Add as a C compiler as well

### DIFF
--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -1,4 +1,4 @@
-compilers=&cmingw64:&vc
+compilers=&cclang-cl:&cmingw64:&vc
 objdumper=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/objdump.exe
 demangler=Z:/compilers/mingw-w64-12.2.0-15.0.7-10.0.0-ucrt-r4/bin/c++filt.exe
 
@@ -54,6 +54,37 @@ compiler.cmingw64_ucrt_clang_1406.semver=14.0.6
 
 compiler.cmingw64_ucrt_clang_1403.exe=Z:/compilers/mingw-w64-11.3.0-14.0.3-10.0.0-ucrt-r3/bin/clang.exe
 compiler.cmingw64_ucrt_clang_1403.semver=14.0.3
+
+group.cclang-cl.compilers=cclang-cl2216:cclang-cl2216-v19_50_VS18_2:cclang-cl1810
+group.cclang-cl.baseName=clang-cl
+group.cclang-cl.compilerType=clang-cl
+group.cclang-cl.compilerCategories=clang-cl
+group.cclang-cl.demangler=Z:/compilers/clang-cl-22.1.6/bin/llvm-undname.exe
+group.cclang-cl.demanglerType=win32-llvm
+group.cclang-cl.groupName=clang-cl
+group.cclang-cl.intelAsm=-mllvm --x86-asm-syntax=intel
+group.cclang-cl.isSemVer=true
+group.cclang-cl.instructionSet=amd64
+group.cclang-cl.licenseLink=https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT
+group.cclang-cl.licenseName=LLVM Apache 2
+group.cclang-cl.licensePreamble=The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+group.cclang-cl.supportsBinary=true
+group.cclang-cl.supportsExecute=true
+group.cclang-cl.baseOptions=/winsdkdir Z:/compilers/windows-kits-10 /EHsc /utf-8 /MD
+group.cclang-cl.extraPath=Z:/compilers/debug_nonredist/x64/Microsoft.VC142.DebugCRT
+
+compiler.cclang-cl2216.exe=Z:/compilers/clang-cl-22.1.6/bin/clang-cl.exe
+compiler.cclang-cl2216.semver=22.1.6
+compiler.cclang-cl2216.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
+
+compiler.cclang-cl2216-v19_50_VS18_2.exe=Z:/compilers/clang-cl-22.1.6/bin/clang-cl.exe
+compiler.cclang-cl2216-v19_50_VS18_2.name=clang-cl 22.1.6 (msvc v19.50 VS18.2)
+compiler.cclang-cl2216-v19_50_VS18_2.semver=22.1.6+14.50.35723.0
+compiler.cclang-cl2216-v19_50_VS18_2.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
+
+compiler.cclang-cl1810.exe=Z:/compilers/clang-cl-18.1.0/bin/clang-cl.exe
+compiler.cclang-cl1810.semver=18.1.0
+compiler.cclang-cl1810.options=/vctoolsdir Z:/compilers/msvc/14.50.35717-14.50.35723.0
 
 group.vc.compilers=&vc_x86:&vc_x64:&vc_arm64:&vc_arm32
 group.vc.options=/EHsc /utf-8


### PR DESCRIPTION
From https://github.com/compiler-explorer/compiler-explorer/issues/1967#issuecomment-4637348742:
> Would it be possible to add it also to C language selection?

The VS compilers are added there as well. This adds `cclang-cl*` compilers. They're copy-pasted from the c++ ones, but the names were prefixed with `c`. https://github.com/compiler-explorer/compiler-explorer/pull/8791 is already applied here.