### PR TITLE
fix: Lean C view with lazy-loaded metadata

### DIFF
--- a/static/services/compilers.service.ts
+++ b/static/services/compilers.service.ts
@@ -90,6 +90,7 @@ export class CompilersService {
         'supportsHaskellCoreView',
         'supportsHaskellStgView',
         'supportsHaskellCmmView',
+        'supportsLeanCView',
         'supportsClojureMacroExpView',
         'supportsYulView',
         'supportsCfg',


### PR DESCRIPTION
https://github.com/compiler-explorer/compiler-explorer/pull/8549 made the Lean C View unavailable because `supportsLeanCView` was not included in the list of lazy-loaded compiler fields.