### PR TITLE
fix: remove indentation from program execution output

### DIFF
--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -604,7 +604,6 @@ input.vim-check {
 
 .program-exec-output {
     font-family: 'Courier New', Courier, monospace;
-    padding-left: 2%;
 }
 
 .execution-stdoutstderr {


### PR DESCRIPTION
## Summary

Remove extra `padding-left: 2%` from `.program-exec-output` CSS class that caused program output in the compiler output pane to appear indented.

## Related issue

Fixes #8785

## Details

The `.program-exec-output` class (used in `output.ts` for rendering program execution output) had `padding-left: 2%` applied, which visually indented the output. The executor pane does not apply this extra padding to its program output, creating an inconsistency.

Removing this padding makes the program output flush-left, matching the executor pane behavior as suggested by @partouf.

## Checks run

- `npm run ts-check` (with NODE_OPTIONS="--max-old-space-size=4096"): PASS
- `npm run lint` (biome): PASS, no fixes applied
- `npm run test-min`: 112 passed, 1 skipped (742 expensive tests skipped), 1684 tests passed
- `git diff --check`: PASS

## Visual smoke

Could not complete visual smoke test due to VPS memory limitations (dev server OOM during webpack compilation). The change is CSS-only (1 line removed) and visually verifiable by checking that program output in the compiler output pane appears flush-left rather than indented.

Opening as draft until visual smoke is confirmed.