### PR TITLE
feat(msvc): add MSVC v19.51 (VS 2026 18.6) compilers for C and C++

### DIFF
--- a/etc/config/c++.amazonwin.properties
+++ b/etc/config/c++.amazonwin.properties
@@ -106,7 +106,7 @@ group.vcpp.licenseLink=https://visualstudio.microsoft.com/license-terms/vs2022-g
 group.vcpp.licensePreamble=The use of this compiler is only permitted for internal evaluation purposes and is otherwise governed by the MSVC License Agreement.
 group.vcpp.licenseInvasive=true
 
-group.vcpp_x86.compilers=vcpp_v19_latest_x86:cl19_2015_u3_32_exwine:cl19_32_exwine:cl_new_32_exwine:vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86:vcpp_v19_32_VS17_2_x86:vcpp_v19_34_VS17_4_x86:vcpp_v19_36_VS17_6_x86:vcpp_v19_38_VS17_8_x86:vcpp_v19_39_VS17_9_x86:vcpp_v19_40_VS17_10_x86:vcpp_v19_41_VS17_11_x86:vcpp_v19_42_VS17_12_x86:vcpp_v19_43_VS17_13_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_44_VS17_14_x86:vcpp_v19_50_VS18_0_x86:vcpp_v19_50_VS18_2_x86
+group.vcpp_x86.compilers=vcpp_v19_latest_x86:cl19_2015_u3_32_exwine:cl19_32_exwine:cl_new_32_exwine:vcpp_v19_24_VS16_4_x86:vcpp_v19_25_VS16_5_x86:vcpp_v19_27_VS16_7_x86:vcpp_v19_28_VS16_8_x86:vcpp_v19_28_VS16_9_x86:vcpp_v19_29_VS16_10_x86:vcpp_v19_29_VS16_11_x86:vcpp_v19_20_VS16_0_x86:vcpp_v19_21_VS16_1_x86:vcpp_v19_22_VS16_2_x86:vcpp_v19_23_VS16_3_x86:vcpp_v19_30_VS17_0_x86:vcpp_v19_31_VS17_1_x86:vcpp_v19_33_VS17_3_x86:vcpp_v19_35_VS17_5_x86:vcpp_v19_37_VS17_7_x86:vcpp_v19_32_VS17_2_x86:vcpp_v19_34_VS17_4_x86:vcpp_v19_36_VS17_6_x86:vcpp_v19_38_VS17_8_x86:vcpp_v19_39_VS17_9_x86:vcpp_v19_40_VS17_10_x86:vcpp_v19_41_VS17_11_x86:vcpp_v19_42_VS17_12_x86:vcpp_v19_43_VS17_13_x86:vcpp_v19_26_VS16_6_x86:vcpp_v19_44_VS17_14_x86:vcpp_v19_50_VS18_0_x86:vcpp_v19_50_VS18_2_x86:vcpp_v19_51_VS18_6_x86
 group.vcpp_x86.groupName=MSVC x86
 group.vcpp_x86.isSemVer=true
 group.vcpp_x86.supportsBinary=true
@@ -114,7 +114,7 @@ group.vcpp_x86.supportsExecute=true
 group.vcpp_x86.instructionSet=amd64
 group.vcpp_x86.extraPath=Z:/compilers/debug_nonredist/x86/Microsoft.VC142.DebugCRT
 
-group.vcpp_x64.compilers=vcpp_v19_latest_x64:cl19_2015_u3_64_exwine:cl19_64_exwine:cl_new_64_exwine:vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64:vcpp_v19_32_VS17_2_x64:vcpp_v19_34_VS17_4_x64:vcpp_v19_36_VS17_6_x64:vcpp_v19_38_VS17_8_x64:vcpp_v19_39_VS17_9_x64:vcpp_v19_40_VS17_10_x64:vcpp_v19_41_VS17_11_x64:vcpp_v19_42_VS17_12_x64:vcpp_v19_43_VS17_13_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_44_VS17_14_x64:vcpp_v19_50_VS18_0_x64:vcpp_v19_50_VS18_2_x64
+group.vcpp_x64.compilers=vcpp_v19_latest_x64:cl19_2015_u3_64_exwine:cl19_64_exwine:cl_new_64_exwine:vcpp_v19_24_VS16_4_x64:vcpp_v19_25_VS16_5_x64:vcpp_v19_27_VS16_7_x64:vcpp_v19_28_VS16_8_x64:vcpp_v19_28_VS16_9_x64:vcpp_v19_29_VS16_10_x64:vcpp_v19_29_VS16_11_x64:vcpp_v19_20_VS16_0_x64:vcpp_v19_21_VS16_1_x64:vcpp_v19_22_VS16_2_x64:vcpp_v19_23_VS16_3_x64:vcpp_v19_30_VS17_0_x64:vcpp_v19_31_VS17_1_x64:vcpp_v19_33_VS17_3_x64:vcpp_v19_35_VS17_5_x64:vcpp_v19_37_VS17_7_x64:vcpp_v19_32_VS17_2_x64:vcpp_v19_34_VS17_4_x64:vcpp_v19_36_VS17_6_x64:vcpp_v19_38_VS17_8_x64:vcpp_v19_39_VS17_9_x64:vcpp_v19_40_VS17_10_x64:vcpp_v19_41_VS17_11_x64:vcpp_v19_42_VS17_12_x64:vcpp_v19_43_VS17_13_x64:vcpp_v19_26_VS16_6_x64:vcpp_v19_44_VS17_14_x64:vcpp_v19_50_VS18_0_x64:vcpp_v19_50_VS18_2_x64:vcpp_v19_51_VS18_6_x64
 group.vcpp_x64.groupName=MSVC x64
 group.vcpp_x64.isSemVer=true
 group.vcpp_x64.supportsBinary=true
@@ -122,7 +122,7 @@ group.vcpp_x64.supportsExecute=true
 group.vcpp_x64.instructionSet=amd64
 group.vcpp_x64.extraPath=Z:/compilers/debug_nonredist/x64/Microsoft.VC142.DebugCRT
 
-group.vcpp_arm64.compilers=vcpp_v19_latest_arm64:cl_new_arm64_exwine:vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64:vcpp_v19_32_VS17_2_arm64:vcpp_v19_34_VS17_4_arm64:vcpp_v19_36_VS17_6_arm64:vcpp_v19_38_VS17_8_arm64:vcpp_v19_39_VS17_9_arm64:vcpp_v19_40_VS17_10_arm64:vcpp_v19_41_VS17_11_arm64:vcpp_v19_42_VS17_12_arm64:vcpp_v19_43_VS17_13_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_44_VS17_14_arm64:vcpp_v19_50_VS18_0_arm64:vcpp_v19_50_VS18_2_arm64
+group.vcpp_arm64.compilers=vcpp_v19_latest_arm64:cl_new_arm64_exwine:vcpp_v19_28_VS16_9_arm64:vcpp_v19_29_VS16_10_arm64:vcpp_v19_29_VS16_11_arm64:vcpp_v19_25_VS16_5_arm64:vcpp_v19_27_VS16_7_arm64:vcpp_v19_24_VS16_4_arm64:vcpp_v19_28_VS16_8_arm64:vcpp_v19_20_VS16_0_arm64:vcpp_v19_21_VS16_1_arm64:vcpp_v19_22_VS16_2_arm64:vcpp_v19_23_VS16_3_arm64:vcpp_v19_30_VS17_0_arm64:vcpp_v19_31_VS17_1_arm64:vcpp_v19_33_VS17_3_arm64:vcpp_v19_35_VS17_5_arm64:vcpp_v19_37_VS17_7_arm64:vcpp_v19_32_VS17_2_arm64:vcpp_v19_34_VS17_4_arm64:vcpp_v19_36_VS17_6_arm64:vcpp_v19_38_VS17_8_arm64:vcpp_v19_39_VS17_9_arm64:vcpp_v19_40_VS17_10_arm64:vcpp_v19_41_VS17_11_arm64:vcpp_v19_42_VS17_12_arm64:vcpp_v19_43_VS17_13_arm64:vcpp_v19_26_VS16_6_arm64:vcpp_v19_44_VS17_14_arm64:vcpp_v19_50_VS18_0_arm64:vcpp_v19_50_VS18_2_arm64:vcpp_v19_51_VS18_6_arm64
 group.vcpp_arm64.groupName=MSVC arm64
 group.vcpp_arm64.isSemVer=true
 group.vcpp_arm64.supportsBinary=false
@@ -807,25 +807,43 @@ compiler.vcpp_v19_50_VS18_2_arm64.includePath=Z:/compilers/msvc/14.50.35717-14.5
 compiler.vcpp_v19_50_VS18_2_arm64.name=arm64 msvc v19.50 VS18.2
 compiler.vcpp_v19_50_VS18_2_arm64.semver=14.50.35723.0
 
+compiler.vcpp_v19_51_VS18_6_x86.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x86/cl.exe
+compiler.vcpp_v19_51_VS18_6_x86.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_51_VS18_6_x86.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_51_VS18_6_x86.name=x86 msvc v19.51 VS18.6
+compiler.vcpp_v19_51_VS18_6_x86.semver=14.51.36246.0
+
+compiler.vcpp_v19_51_VS18_6_x64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_51_VS18_6_x64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_51_VS18_6_x64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_51_VS18_6_x64.name=x64 msvc v19.51 VS18.6
+compiler.vcpp_v19_51_VS18_6_x64.semver=14.51.36246.0
+
+compiler.vcpp_v19_51_VS18_6_arm64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_51_VS18_6_arm64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_51_VS18_6_arm64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_51_VS18_6_arm64.name=arm64 msvc v19.51 VS18.6
+compiler.vcpp_v19_51_VS18_6_arm64.semver=14.51.36246.0
+
 ########################################
 # Latest version: may be a duplicate but this is to always have a "latest" in the drop down
-compiler.vcpp_v19_latest_x86.exe=Z:/compilers/msvc/14.50.35717-14.50.35723.0/bin/Hostx64/x86/cl.exe
-compiler.vcpp_v19_latest_x86.libPath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib;Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib/x86;Z:/compilers/msvc/14.50.35717-14.50.35723.0/atlmfc/lib/x86;Z:/compilers/msvc/14.50.35717-14.50.35723.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
-compiler.vcpp_v19_latest_x86.includePath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_latest_x86.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x86/cl.exe
+compiler.vcpp_v19_latest_x86.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vcpp_v19_latest_x86.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_latest_x86.name=x86 msvc v19.latest
-compiler.vcpp_v19_latest_x86.semver=14.50.35723.0
+compiler.vcpp_v19_latest_x86.semver=14.51.36246.0
 
-compiler.vcpp_v19_latest_x64.exe=Z:/compilers/msvc/14.50.35717-14.50.35723.0/bin/Hostx64/x64/cl.exe
-compiler.vcpp_v19_latest_x64.libPath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib;Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib/x64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/atlmfc/lib/x64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
-compiler.vcpp_v19_latest_x64.includePath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_latest_x64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x64/cl.exe
+compiler.vcpp_v19_latest_x64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vcpp_v19_latest_x64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_latest_x64.name=x64 msvc v19.latest
-compiler.vcpp_v19_latest_x64.semver=14.50.35723.0
+compiler.vcpp_v19_latest_x64.semver=14.51.36246.0
 
-compiler.vcpp_v19_latest_arm64.exe=Z:/compilers/msvc/14.50.35717-14.50.35723.0/bin/Hostx64/arm64/cl.exe
-compiler.vcpp_v19_latest_arm64.libPath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib;Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib/arm64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
-compiler.vcpp_v19_latest_arm64.includePath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vcpp_v19_latest_arm64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/arm64/cl.exe
+compiler.vcpp_v19_latest_arm64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vcpp_v19_latest_arm64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vcpp_v19_latest_arm64.name=arm64 msvc v19.latest
-compiler.vcpp_v19_latest_arm64.semver=14.50.35723.0
+compiler.vcpp_v19_latest_arm64.semver=14.51.36246.0
 ########################################
 
 libs.abseil.name=Abseil

--- a/etc/config/c.amazonwin.properties
+++ b/etc/config/c.amazonwin.properties
@@ -74,19 +74,19 @@ group.vc.licenseLink=https://visualstudio.microsoft.com/license-terms/vs2022-ga-
 group.vc.licensePreamble=The use of this compiler is only permitted for internal evaluation purposes and is otherwise governed by the MSVC License Agreement.
 group.vc.licenseInvasive=true
 
-group.vc_x86.compilers=vc_v19_latest_x86:ccl19_2015_u3_32_exwine:ccl19_32_exwine:ccl_new_32_exwine:vc_v19_24_VS16_4_x86:vc_v19_25_VS16_5_x86:vc_v19_27_VS16_7_x86:vc_v19_28_VS16_8_x86:vc_v19_28_VS16_9_x86:vc_v19_29_VS16_10_x86:vc_v19_29_VS16_11_x86:vc_v19_20_VS16_0_x86:vc_v19_21_VS16_1_x86:vc_v19_22_VS16_2_x86:vc_v19_23_VS16_3_x86:vc_v19_26_VS16_6_x86:vc_v19_30_VS17_0_x86:vc_v19_31_VS17_1_x86:vc_v19_33_VS17_3_x86:vc_v19_35_VS17_5_x86:vc_v19_37_VS17_7_x86:vc_v19_32_VS17_2_x86:vc_v19_34_VS17_4_x86:vc_v19_36_VS17_6_x86:vc_v19_38_VS17_8_x86:vc_v19_39_VS17_9_x86:vc_v19_40_VS17_10_x86:vc_v19_41_VS17_11_x86:vc_v19_42_VS17_12_x86:vc_v19_43_VS17_13_x86:vc_v19_44_VS17_14_x86:vc_v19_50_VS18_0_x86:vc_v19_50_VS18_2_x86
+group.vc_x86.compilers=vc_v19_latest_x86:ccl19_2015_u3_32_exwine:ccl19_32_exwine:ccl_new_32_exwine:vc_v19_24_VS16_4_x86:vc_v19_25_VS16_5_x86:vc_v19_27_VS16_7_x86:vc_v19_28_VS16_8_x86:vc_v19_28_VS16_9_x86:vc_v19_29_VS16_10_x86:vc_v19_29_VS16_11_x86:vc_v19_20_VS16_0_x86:vc_v19_21_VS16_1_x86:vc_v19_22_VS16_2_x86:vc_v19_23_VS16_3_x86:vc_v19_26_VS16_6_x86:vc_v19_30_VS17_0_x86:vc_v19_31_VS17_1_x86:vc_v19_33_VS17_3_x86:vc_v19_35_VS17_5_x86:vc_v19_37_VS17_7_x86:vc_v19_32_VS17_2_x86:vc_v19_34_VS17_4_x86:vc_v19_36_VS17_6_x86:vc_v19_38_VS17_8_x86:vc_v19_39_VS17_9_x86:vc_v19_40_VS17_10_x86:vc_v19_41_VS17_11_x86:vc_v19_42_VS17_12_x86:vc_v19_43_VS17_13_x86:vc_v19_44_VS17_14_x86:vc_v19_50_VS18_0_x86:vc_v19_50_VS18_2_x86:vc_v19_51_VS18_6_x86
 group.vc_x86.groupName=MSVC x86
 group.vc_x86.isSemVer=true
 group.vc_x86.supportsBinary=true
 group.vc_x86.supportsExecute=true
 
-group.vc_x64.compilers=vc_v19_latest_x64:ccl19_2015_u3_64_exwine:ccl19_64_exwine:ccl_new_64_exwine:vc_v19_24_VS16_4_x64:vc_v19_25_VS16_5_x64:vc_v19_27_VS16_7_x64:vc_v19_28_VS16_8_x64:vc_v19_28_VS16_9_x64:vc_v19_29_VS16_10_x64:vc_v19_29_VS16_11_x64:vc_v19_20_VS16_0_x64:vc_v19_21_VS16_1_x64:vc_v19_22_VS16_2_x64:vc_v19_23_VS16_3_x64:vc_v19_26_VS16_6_x64:vc_v19_30_VS17_0_x64:vc_v19_31_VS17_1_x64:vc_v19_33_VS17_3_x64:vc_v19_35_VS17_5_x64:vc_v19_37_VS17_7_x64:vc_v19_32_VS17_2_x64:vc_v19_34_VS17_4_x64:vc_v19_36_VS17_6_x64:vc_v19_38_VS17_8_x64:vc_v19_39_VS17_9_x64:vc_v19_40_VS17_10_x64:vc_v19_41_VS17_11_x64:vc_v19_42_VS17_12_x64:vc_v19_43_VS17_13_x64:vc_v19_44_VS17_14_x64:vc_v19_50_VS18_0_x64:vc_v19_50_VS18_2_x64
+group.vc_x64.compilers=vc_v19_latest_x64:ccl19_2015_u3_64_exwine:ccl19_64_exwine:ccl_new_64_exwine:vc_v19_24_VS16_4_x64:vc_v19_25_VS16_5_x64:vc_v19_27_VS16_7_x64:vc_v19_28_VS16_8_x64:vc_v19_28_VS16_9_x64:vc_v19_29_VS16_10_x64:vc_v19_29_VS16_11_x64:vc_v19_20_VS16_0_x64:vc_v19_21_VS16_1_x64:vc_v19_22_VS16_2_x64:vc_v19_23_VS16_3_x64:vc_v19_26_VS16_6_x64:vc_v19_30_VS17_0_x64:vc_v19_31_VS17_1_x64:vc_v19_33_VS17_3_x64:vc_v19_35_VS17_5_x64:vc_v19_37_VS17_7_x64:vc_v19_32_VS17_2_x64:vc_v19_34_VS17_4_x64:vc_v19_36_VS17_6_x64:vc_v19_38_VS17_8_x64:vc_v19_39_VS17_9_x64:vc_v19_40_VS17_10_x64:vc_v19_41_VS17_11_x64:vc_v19_42_VS17_12_x64:vc_v19_43_VS17_13_x64:vc_v19_44_VS17_14_x64:vc_v19_50_VS18_0_x64:vc_v19_50_VS18_2_x64:vc_v19_51_VS18_6_x64
 group.vc_x64.groupName=MSVC x64
 group.vc_x64.isSemVer=true
 group.vc_x64.supportsBinary=true
 group.vc_x64.supportsExecute=true
 
-group.vc_arm64.compilers=vc_v19_latest_arm64:ccl_new_arm64_exwine:vc_v19_28_VS16_9_arm64:vc_v19_29_VS16_10_arm64:vc_v19_29_VS16_11_arm64:vc_v19_25_VS16_5_arm64:vc_v19_27_VS16_7_arm64:vc_v19_24_VS16_4_arm64:vc_v19_28_VS16_8_arm64:vc_v19_20_VS16_0_arm64:vc_v19_21_VS16_1_arm64:vc_v19_22_VS16_2_arm64:vc_v19_23_VS16_3_arm64:vc_v19_26_VS16_6_arm64:vc_v19_30_VS17_0_arm64:vc_v19_31_VS17_1_arm64:vc_v19_33_VS17_3_arm64:vc_v19_35_VS17_5_arm64:vc_v19_37_VS17_7_arm64:vc_v19_32_VS17_2_arm64:vc_v19_34_VS17_4_arm64:vc_v19_36_VS17_6_arm64:vc_v19_38_VS17_8_arm64:vc_v19_39_VS17_9_arm64:vc_v19_40_VS17_10_arm64:vc_v19_41_VS17_11_arm64:vc_v19_42_VS17_12_arm64:vc_v19_43_VS17_13_arm64:vc_v19_44_VS17_14_arm64:vc_v19_50_VS18_0_arm64:vc_v19_50_VS18_2_arm64
+group.vc_arm64.compilers=vc_v19_latest_arm64:ccl_new_arm64_exwine:vc_v19_28_VS16_9_arm64:vc_v19_29_VS16_10_arm64:vc_v19_29_VS16_11_arm64:vc_v19_25_VS16_5_arm64:vc_v19_27_VS16_7_arm64:vc_v19_24_VS16_4_arm64:vc_v19_28_VS16_8_arm64:vc_v19_20_VS16_0_arm64:vc_v19_21_VS16_1_arm64:vc_v19_22_VS16_2_arm64:vc_v19_23_VS16_3_arm64:vc_v19_26_VS16_6_arm64:vc_v19_30_VS17_0_arm64:vc_v19_31_VS17_1_arm64:vc_v19_33_VS17_3_arm64:vc_v19_35_VS17_5_arm64:vc_v19_37_VS17_7_arm64:vc_v19_32_VS17_2_arm64:vc_v19_34_VS17_4_arm64:vc_v19_36_VS17_6_arm64:vc_v19_38_VS17_8_arm64:vc_v19_39_VS17_9_arm64:vc_v19_40_VS17_10_arm64:vc_v19_41_VS17_11_arm64:vc_v19_42_VS17_12_arm64:vc_v19_43_VS17_13_arm64:vc_v19_44_VS17_14_arm64:vc_v19_50_VS18_0_arm64:vc_v19_50_VS18_2_arm64:vc_v19_51_VS18_6_arm64
 group.vc_arm64.groupName=MSVC arm64
 group.vc_arm64.isSemVer=true
 group.vc_arm64.supportsBinary=false
@@ -757,25 +757,43 @@ compiler.vc_v19_50_VS18_2_arm64.includePath=Z:/compilers/msvc/14.50.35717-14.50.
 compiler.vc_v19_50_VS18_2_arm64.name=arm64 msvc v19.50 VS18.2
 compiler.vc_v19_50_VS18_2_arm64.semver=14.50.35723.0
 
+compiler.vc_v19_51_VS18_6_x86.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x86/cl.exe
+compiler.vc_v19_51_VS18_6_x86.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vc_v19_51_VS18_6_x86.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_51_VS18_6_x86.name=x86 msvc v19.51 VS18.6
+compiler.vc_v19_51_VS18_6_x86.semver=14.51.36246.0
+
+compiler.vc_v19_51_VS18_6_x64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x64/cl.exe
+compiler.vc_v19_51_VS18_6_x64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vc_v19_51_VS18_6_x64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_51_VS18_6_x64.name=x64 msvc v19.51 VS18.6
+compiler.vc_v19_51_VS18_6_x64.semver=14.51.36246.0
+
+compiler.vc_v19_51_VS18_6_arm64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/arm64/cl.exe
+compiler.vc_v19_51_VS18_6_arm64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vc_v19_51_VS18_6_arm64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_51_VS18_6_arm64.name=arm64 msvc v19.51 VS18.6
+compiler.vc_v19_51_VS18_6_arm64.semver=14.51.36246.0
+
 ########################################
 # Latest version: may be a duplicate but this is to always have a "latest" in the drop down
-compiler.vc_v19_latest_x86.exe=Z:/compilers/msvc/14.50.35717-14.50.35723.0/bin/Hostx64/x86/cl.exe
-compiler.vc_v19_latest_x86.libPath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib;Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib/x86;Z:/compilers/msvc/14.50.35717-14.50.35723.0/atlmfc/lib/x86;Z:/compilers/msvc/14.50.35717-14.50.35723.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
-compiler.vc_v19_latest_x86.includePath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_latest_x86.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x86/cl.exe
+compiler.vc_v19_latest_x86.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x86;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x86;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x86;
+compiler.vc_v19_latest_x86.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vc_v19_latest_x86.name=x86 msvc v19.latest
-compiler.vc_v19_latest_x86.semver=14.50.35723.0
+compiler.vc_v19_latest_x86.semver=14.51.36246.0
 
-compiler.vc_v19_latest_x64.exe=Z:/compilers/msvc/14.50.35717-14.50.35723.0/bin/Hostx64/x64/cl.exe
-compiler.vc_v19_latest_x64.libPath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib;Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib/x64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/atlmfc/lib/x64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
-compiler.vc_v19_latest_x64.includePath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_latest_x64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/x64/cl.exe
+compiler.vc_v19_latest_x64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/x64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/x64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/x64;
+compiler.vc_v19_latest_x64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vc_v19_latest_x64.name=x64 msvc v19.latest
-compiler.vc_v19_latest_x64.semver=14.50.35723.0
+compiler.vc_v19_latest_x64.semver=14.51.36246.0
 
-compiler.vc_v19_latest_arm64.exe=Z:/compilers/msvc/14.50.35717-14.50.35723.0/bin/Hostx64/arm64/cl.exe
-compiler.vc_v19_latest_arm64.libPath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib;Z:/compilers/msvc/14.50.35717-14.50.35723.0/lib/arm64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.50.35717-14.50.35723.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
-compiler.vc_v19_latest_arm64.includePath=Z:/compilers/msvc/14.50.35717-14.50.35723.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
+compiler.vc_v19_latest_arm64.exe=Z:/compilers/msvc/14.51.36231-14.51.36246.0/bin/Hostx64/arm64/cl.exe
+compiler.vc_v19_latest_arm64.libPath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib;Z:/compilers/msvc/14.51.36231-14.51.36246.0/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/atlmfc/lib/arm64;Z:/compilers/msvc/14.51.36231-14.51.36246.0/ifc/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/ucrt/arm64;Z:/compilers/windows-kits-10/lib/10.0.22621.0/um/arm64;
+compiler.vc_v19_latest_arm64.includePath=Z:/compilers/msvc/14.51.36231-14.51.36246.0/include;Z:/compilers/windows-kits-10/include/10.0.22621.0/cppwinrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/shared;Z:/compilers/windows-kits-10/include/10.0.22621.0/ucrt;Z:/compilers/windows-kits-10/include/10.0.22621.0/um;Z:/compilers/windows-kits-10/include/10.0.22621.0/winrt;
 compiler.vc_v19_latest_arm64.name=arm64 msvc v19.latest
-compiler.vc_v19_latest_arm64.semver=14.50.35723.0
+compiler.vc_v19_latest_arm64.semver=14.51.36246.0
 ########################################
 
 


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds the MSVC v14.51 (cl.exe v19.51) toolset from Visual Studio 2026 18.6 (released May 2026) for x86, x64, and arm64, and advances the `latest` MSVC aliases to point at it.

- New compilers: `vcpp_v19_51_VS18_6_x86`, `vcpp_v19_51_VS18_6_x64`, `vcpp_v19_51_VS18_6_arm64`
- Zip: `14.51.36231-14.51.36246.0` (packaged 2026-06-02, cl.exe reports 14.51.36246.0)
- All existing compiler entries and IDs left unchanged

Infra PR: compiler-explorer/infra#2167

Closes #8723

🤖 Generated by LLM (Claude, via OpenClaw)