### PR TITLE
Removing removed -fexpansion-statements

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -634,7 +634,7 @@ compiler.clang_p3951.options=-std=c++26 -freflection -fexpansion-statements -std
 compiler.clang_barry.exe=/opt/compiler-explorer/clang-barry-clang-trunk/bin/clang++
 compiler.clang_barry.semver=(barry prototypes)
 compiler.clang_barry.notification=Barry's various prototypes; see <a href="https://github.com/brevzin/llvm-project/tree/compiler-explorer/barry" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
-compiler.clang_barry.options=-std=c++26 -freflection -fexpansion-statements -stdlib=libc++
+compiler.clang_barry.options=-std=c++26 -freflection -stdlib=libc++
 compiler.clang_p1061.exe=/opt/compiler-explorer/clang-p1061-trunk/bin/clang++
 compiler.clang_p1061.semver=(experimental P1061)
 compiler.clang_p1061.notification=Experimental Structure Bindings can introduce a Pack; see <a href="https://wg21.link/P1061" target="_blank" rel="noopener noreferrer">P1061<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

I did some cleanup on my fork and removed a bunch of flags for things that don't need flags anymore. `-fexpansion-statements` was one of them. 