### PR TITLE
Make compilation queue timeout effective; exit on uncaught exceptions

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -53,10 +53,14 @@ function signalHandler(name: string) {
 }
 
 function uncaughtHandler(err: Error, origin: NodeJS.UncaughtExceptionOrigin) {
-    logger.info(`stopping process: Uncaught exception: ${err}\nException origin: ${origin}`);
-    // The app will exit naturally from here, but if we call `process.exit()` we may lose log lines.
-    // see https://github.com/winstonjs/winston/issues/1504#issuecomment-1033087411
+    logger.error(`stopping process: Uncaught exception: ${err}\nException origin: ${origin}`);
+    // A process with live server listeners never exits "naturally": after an uncaught exception we'd
+    // limp on in an undefined state (#8811). Exit after a short delay so winston can flush its
+    // transports (calling `process.exit()` immediately may lose log lines, see
+    // https://github.com/winstonjs/winston/issues/1504#issuecomment-1033087411), and let the load
+    // balancer replace the instance.
     process.exitCode = 1;
+    setTimeout(() => process.exit(1), 1000);
 }
 
 // Parse command line arguments

--- a/app.ts
+++ b/app.ts
@@ -53,7 +53,7 @@ function signalHandler(name: string) {
 }
 
 function uncaughtHandler(err: Error, origin: NodeJS.UncaughtExceptionOrigin) {
-    logger.error(`stopping process: Uncaught exception: ${err}\nException origin: ${origin}`);
+    logger.error(`stopping process: Uncaught exception (origin: ${origin}):`, err);
     // A process with live server listeners never exits "naturally": after an uncaught exception we'd
     // limp on in an undefined state (#8811). Exit after a short delay so winston can flush its
     // transports (calling `process.exit()` immediately may lose log lines, see

--- a/lib/compilation-queue.ts
+++ b/lib/compilation-queue.ts
@@ -108,10 +108,8 @@ export class CompilationQueue {
                     queueCompleted.inc();
                 }
             },
-            // No explicit timeout here: the queue-wide timeout from compilationEnvTimeoutMs applies.
-            // Passing `timeout: undefined` would override and disable it (p-queue spreads the options
-            // over its defaults), letting a never-settling job wedge a queue slot forever — which also
-            // permanently disables temp dir cleanup, which only runs when the queue is idle (#8811).
+            // NB: an explicit `timeout: undefined` here would silently disable the queue-wide timeout
+            // (p-queue spreads per-call options over its defaults).
             {priority: options?.highPriority ? 100 : 0},
         );
     }

--- a/lib/compilation-queue.ts
+++ b/lib/compilation-queue.ts
@@ -108,8 +108,6 @@ export class CompilationQueue {
                     queueCompleted.inc();
                 }
             },
-            // NB: an explicit `timeout: undefined` here would silently disable the queue-wide timeout
-            // (p-queue spreads per-call options over its defaults).
             {priority: options?.highPriority ? 100 : 0},
         );
     }

--- a/lib/compilation-queue.ts
+++ b/lib/compilation-queue.ts
@@ -108,7 +108,11 @@ export class CompilationQueue {
                     queueCompleted.inc();
                 }
             },
-            {priority: options?.highPriority ? 100 : 0, timeout: undefined},
+            // No explicit timeout here: the queue-wide timeout from compilationEnvTimeoutMs applies.
+            // Passing `timeout: undefined` would override and disable it (p-queue spreads the options
+            // over its defaults), letting a never-settling job wedge a queue slot forever — which also
+            // permanently disables temp dir cleanup, which only runs when the queue is idle (#8811).
+            {priority: options?.highPriority ? 100 : 0},
         );
     }
 

--- a/test/compilation-queue-tests.ts
+++ b/test/compilation-queue-tests.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {describe, expect, it} from 'vitest';
+
+import {CompilationQueue} from '../lib/compilation-queue.js';
+
+describe('CompilationQueue', () => {
+    it('runs an enqueued job and returns its result', async () => {
+        const queue = new CompilationQueue(1, 1000, 1000);
+        await expect(queue.enqueue(async () => 42)).resolves.toEqual(42);
+        expect(queue.status().busy).toBe(false);
+    });
+
+    it('does not deadlock when a job enqueues another job', async () => {
+        const queue = new CompilationQueue(1, 1000, 1000);
+        const result = await queue.enqueue(() => {
+            return queue.enqueue(async () => 42);
+        });
+        expect(result).toEqual(42);
+    });
+
+    it('times out a job that never settles, freeing the queue', async () => {
+        // A job whose promise never settles (e.g. a download severed mid-stream, see #8811)
+        // must not occupy a queue slot forever: the queue timeout has to reject it so the
+        // queue can go back to being non-busy (which gates temp dir cleanup).
+        const queue = new CompilationQueue(1, 100, 1000);
+        const wedged = queue.enqueue(() => new Promise(() => {}));
+        await expect(wedged).rejects.toThrow(/timed out/i);
+
+        await expect(queue.enqueue(async () => 'still works')).resolves.toEqual('still works');
+        expect(queue.status().busy).toBe(false);
+    }, 5_000);
+});

--- a/test/compilation-queue-tests.ts
+++ b/test/compilation-queue-tests.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {TimeoutError} from 'p-queue';
 import {describe, expect, it} from 'vitest';
 
 import {CompilationQueue} from '../lib/compilation-queue.js';
@@ -47,7 +48,7 @@ describe('CompilationQueue', () => {
         // queue can go back to being non-busy (which gates temp dir cleanup).
         const queue = new CompilationQueue(1, 100, 1000);
         const wedged = queue.enqueue(() => new Promise(() => {}));
-        await expect(wedged).rejects.toThrow(/timed out/i);
+        await expect(wedged).rejects.toThrow(TimeoutError);
 
         await expect(queue.enqueue(async () => 'still works')).resolves.toEqual('still works');
         expect(queue.status().busy).toBe(false);

--- a/test/compilation-queue-tests.ts
+++ b/test/compilation-queue-tests.ts
@@ -51,5 +51,7 @@ describe('CompilationQueue', () => {
 
         await expect(queue.enqueue(async () => 'still works')).resolves.toEqual('still works');
         expect(queue.status().busy).toBe(false);
-    }, 5_000);
+        // Generous test budget: the 100ms queue timeout can fire very late when vitest workers
+        // saturate the machine (e.g. during pre-commit runs).
+    }, 15_000);
 });


### PR DESCRIPTION
Part of #8811 (production disk-full incident). Companion to #8812 — this is the systemic backstop so no future never-settling job can wedge the system.

Two changes:

**Queue timeout was dead config.** `enqueue()` passed `timeout: undefined` to p-queue's `add()`; p-queue spreads per-call options over its defaults, so this overrode and *disabled* the queue-wide timeout configured from `compilationEnvTimeoutMs` (default 300s). A job whose promise never settled therefore occupied a queue slot forever — and since temp dir cleanup only runs when the queue is fully idle, one wedged slot permanently disabled cleanup and filled the disk. Removing the override makes the timeout effective: in p-queue v9 a timed-out task rejects with `TimeoutError`, freeing the slot. (The timeout doesn't kill underlying work — that remains the exec layer's job — but the system makes progress again.)

**Uncaught exceptions now actually stop the process.** The handler set `process.exitCode = 1` assuming the app would "exit naturally", but a process with live server listeners never does: during the incident the instance limped on half-dead for hours, passing healthchecks while every compilation failed. Now it exits after a 1s delay (letting winston flush its transports), and the load balancer replaces the instance.

The new queue test fails against the previous code: a never-settling job is never rejected and `status().busy` stays true forever. Also adds basic enqueue/nested-enqueue coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)