### PR TITLE
Fail healthcheck when temp filesystem free space is low

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -22,6 +22,7 @@ pageloadUrl=https://lambda.compiler-explorer.com/pageload
 explainApiEndpoint=https://api.compiler-explorer.com/explain
 storageSolution=s3
 healthCheckFilePath=/efs/.health
+healthCheckMinFreeSpaceMiB=2048
 showSponsors=true
 logCompilerCacheAccesses=false
 

--- a/lib/app/controllers.ts
+++ b/lib/app/controllers.ts
@@ -50,6 +50,7 @@ export interface ApiControllers {
  * @param formattingService - The formatting service instance
  * @param compilationQueue - The compilation queue instance
  * @param healthCheckFilePath - Optional path to health check file
+ * @param healthCheckMinFreeSpaceMiB - Minimum free space on the temp filesystem to be healthy (0 disables)
  * @param isExecutionWorker - Whether the server is running as an execution worker
  * @param isCompilationWorker - Whether the server is running as a compilation worker
  * @param formDataHandler - Handler for form data
@@ -60,6 +61,7 @@ export function setupControllersAndHandlers(
     formattingService: FormattingService,
     compilationQueue: CompilationQueue,
     healthCheckFilePath: string | null,
+    healthCheckMinFreeSpaceMiB: number,
     isExecutionWorker: boolean,
     isCompilationWorker: boolean,
     formDataHandler: express.Handler,
@@ -77,6 +79,7 @@ export function setupControllersAndHandlers(
         healthCheckFilePath,
         compileHandler,
         isExecutionWorker,
+        healthCheckMinFreeSpaceMiB,
     );
 
     return {

--- a/lib/app/main.ts
+++ b/lib/app/main.ts
@@ -82,6 +82,7 @@ export async function initialiseApplication(options: ApplicationOptions): Promis
     const isExecutionWorker = ceProps<boolean>('execqueue.is_worker', false);
     const isCompilationWorker = ceProps<boolean>('compilequeue.is_worker', false);
     const healthCheckFilePath = ceProps('healthCheckFilePath', null) as string | null;
+    const healthCheckMinFreeSpaceMiB = ceProps<number>('healthCheckMinFreeSpaceMiB', 100);
 
     const formDataHandler = createFormDataHandler();
 
@@ -90,6 +91,7 @@ export async function initialiseApplication(options: ApplicationOptions): Promis
         compilationEnvironment.formattingService,
         compilationEnvironment.compilationQueue,
         healthCheckFilePath,
+        healthCheckMinFreeSpaceMiB,
         isExecutionWorker,
         isCompilationWorker,
         formDataHandler,

--- a/lib/handlers/api/healthcheck-controller.ts
+++ b/lib/handlers/api/healthcheck-controller.ts
@@ -107,7 +107,7 @@ export class HealthcheckController implements HttpController {
                     return;
                 }
             } catch (e) {
-                logger.error(`*** HEALTH CHECK FAILURE: while checking free space on '${tempDir}' got ${e}`);
+                logger.error(`*** HEALTH CHECK FAILURE: while checking free space on '${tempDir}':`, e);
                 SentryCapture(e, 'Health check free space');
                 res.status(500).send();
                 return;

--- a/lib/handlers/api/healthcheck-controller.ts
+++ b/lib/handlers/api/healthcheck-controller.ts
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import fs from 'node:fs/promises';
+import os from 'node:os';
 
 import express from 'express';
 
@@ -41,6 +42,7 @@ export class HealthcheckController implements HttpController {
         private readonly healthCheckFilePath: string | null,
         private readonly compileHandler: ICompileHandler,
         private readonly isExecutionWorker: boolean,
+        private readonly minFreeSpaceMiB: number = 0,
     ) {}
 
     public setCompilationWorkerHealthCheck(healthCheck: () => boolean): void {
@@ -86,6 +88,30 @@ export class HealthcheckController implements HttpController {
             logger.error('*** HEALTH CHECK FAILURE: execution worker has failed permanently');
             res.status(500).send();
             return;
+        }
+
+        // Require some free space on the filesystem hosting our temporary directory: report unhealthy
+        // before compilations start failing with ENOSPC, so the load balancer replaces the instance
+        // while it can still limp along (see #8811).
+        if (this.minFreeSpaceMiB > 0) {
+            const tempDir = os.tmpdir();
+            try {
+                const stats = await fs.statfs(tempDir);
+                const freeMiB = (stats.bavail * stats.bsize) / (1024 * 1024);
+                if (freeMiB < this.minFreeSpaceMiB) {
+                    logger.error(
+                        `*** HEALTH CHECK FAILURE: only ${freeMiB.toFixed(0)}MiB free on '${tempDir}', ` +
+                            `need at least ${this.minFreeSpaceMiB}MiB`,
+                    );
+                    res.status(500).send();
+                    return;
+                }
+            } catch (e) {
+                logger.error(`*** HEALTH CHECK FAILURE: while checking free space on '${tempDir}' got ${e}`);
+                SentryCapture(e, 'Health check free space');
+                res.status(500).send();
+                return;
+            }
         }
 
         // If we have a healthcheck file, we require that it exists and it is non-empty. The /efs/.health file contents

--- a/lib/handlers/api/healthcheck-controller.ts
+++ b/lib/handlers/api/healthcheck-controller.ts
@@ -23,13 +23,13 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import fs from 'node:fs/promises';
-import os from 'node:os';
 
 import express from 'express';
 
 import {CompilationQueue} from '../../compilation-queue.js';
 import {logger} from '../../logger.js';
 import {SentryCapture} from '../../sentry.js';
+import * as temp from '../../temp.js';
 import {ICompileHandler} from '../compile.interfaces.js';
 import {HttpController} from './controller.interfaces.js';
 
@@ -42,7 +42,7 @@ export class HealthcheckController implements HttpController {
         private readonly healthCheckFilePath: string | null,
         private readonly compileHandler: ICompileHandler,
         private readonly isExecutionWorker: boolean,
-        private readonly minFreeSpaceMiB: number = 0,
+        private readonly minFreeSpaceMiB: number,
     ) {}
 
     public setCompilationWorkerHealthCheck(healthCheck: () => boolean): void {
@@ -94,7 +94,7 @@ export class HealthcheckController implements HttpController {
         // before compilations start failing with ENOSPC, so the load balancer replaces the instance
         // while it can still limp along (see #8811).
         if (this.minFreeSpaceMiB > 0) {
-            const tempDir = os.tmpdir();
+            const tempDir = temp.getTempRoot();
             try {
                 const stats = await fs.statfs(tempDir);
                 const freeMiB = (stats.bavail * stats.bsize) / (1024 * 1024);

--- a/lib/temp.ts
+++ b/lib/temp.ts
@@ -61,12 +61,20 @@ export function resetStats() {
 }
 
 /**
+ * The directory under which this module creates temporary directories (unless callers pass
+ * an absolute prefix). Configurable via the --tmp-dir command line option.
+ */
+export function getTempRoot(): string {
+    return os.tmpdir();
+}
+
+/**
  * Create a temporary directory. If the prefix is an absolute path, use it directly;
  * otherwise create the directory in the operating system's temporary directory.
  * @param prefix a prefix for the directory name, or an absolute path prefix
  */
 export async function mkdir(prefix: string) {
-    const baseDir = path.isAbsolute(prefix) ? prefix : path.join(os.tmpdir(), prefix);
+    const baseDir = path.isAbsolute(prefix) ? prefix : path.join(getTempRoot(), prefix);
     const result = await fs.promises.mkdtemp(baseDir);
     ++stats.numCreated;
     pendingRemoval.push(result);
@@ -79,7 +87,7 @@ export async function mkdir(prefix: string) {
  * @param prefix a prefix for the directory name, or an absolute path prefix
  */
 export function mkdirSync(prefix: string) {
-    const baseDir = path.isAbsolute(prefix) ? prefix : path.join(os.tmpdir(), prefix);
+    const baseDir = path.isAbsolute(prefix) ? prefix : path.join(getTempRoot(), prefix);
     const result = fs.mkdtempSync(baseDir);
     ++stats.numCreated;
     pendingRemoval.push(result);

--- a/lib/temp.ts
+++ b/lib/temp.ts
@@ -62,7 +62,9 @@ export function resetStats() {
 
 /**
  * The directory under which this module creates temporary directories (unless callers pass
- * an absolute prefix). Configurable via the --tmp-dir command line option.
+ * an absolute prefix). The --tmp-dir command line option is not read directly: at startup
+ * setupTempDir() exports it as $TMP (or $TEMP on Windows/WSL), which os.tmpdir() consults.
+ * See lib/app/temp-dir.ts.
  */
 export function getTempRoot(): string {
     return os.tmpdir();

--- a/test/handlers/health-check-tests.ts
+++ b/test/handlers/health-check-tests.ts
@@ -178,6 +178,12 @@ describe('Health checks for free temp space', () => {
         await request(app).get('/healthcheck').expect(500);
     });
 
+    it('should respond with OK when free space is exactly the minimum', async () => {
+        app = makeApp(100);
+        vi.spyOn(fs, 'statfs').mockResolvedValue({bavail: 100, bsize: oneMiB} as any);
+        await request(app).get('/healthcheck').expect(200, 'Everything is awesome');
+    });
+
     it('should respond with 500 when free space cannot be determined', async () => {
         app = makeApp(100);
         vi.spyOn(fs, 'statfs').mockRejectedValue(new Error('no statfs here'));

--- a/test/handlers/health-check-tests.ts
+++ b/test/handlers/health-check-tests.ts
@@ -42,7 +42,7 @@ describe('Health checks', () => {
         };
         compilationQueue = new CompilationQueue(1, 1000 * 1000, 1000 * 1000);
         app = express();
-        const controller = new HealthcheckController(compilationQueue, null, compileHandlerMock, false);
+        const controller = new HealthcheckController(compilationQueue, null, compileHandlerMock, false, 0);
         app.use(controller.createRouter());
     });
 
@@ -71,7 +71,7 @@ describe('Health checks without lang/comp', () => {
         };
         compilationQueue = new CompilationQueue(1, 1000 * 1000, 1000 * 1000);
         app = express();
-        const controller = new HealthcheckController(compilationQueue, null, compileHandlerMock, false);
+        const controller = new HealthcheckController(compilationQueue, null, compileHandlerMock, false, 0);
         app.use(controller.createRouter());
     });
 
@@ -90,7 +90,7 @@ describe('Health checks without lang/comp but in execution worker mode', () => {
         };
         compilationQueue = new CompilationQueue(1, 1000 * 1000, 1000 * 1000);
         app = express();
-        const controller = new HealthcheckController(compilationQueue, null, compileHandlerMock, true);
+        const controller = new HealthcheckController(compilationQueue, null, compileHandlerMock, true, 0);
         app.use(controller.createRouter());
     });
 
@@ -110,11 +110,11 @@ describe('Health checks on disk', () => {
         const compilationQueue = new CompilationQueue(1, 1000 * 1000, 1000 * 1000);
 
         healthyApp = express();
-        const hc1 = new HealthcheckController(compilationQueue, '/fake/.health', compileHandlerMock, false);
+        const hc1 = new HealthcheckController(compilationQueue, '/fake/.health', compileHandlerMock, false, 0);
         healthyApp.use(hc1.createRouter());
 
         unhealthyApp = express();
-        const hc2 = new HealthcheckController(compilationQueue, '/fake/.nonexist', compileHandlerMock, false);
+        const hc2 = new HealthcheckController(compilationQueue, '/fake/.nonexist', compileHandlerMock, false, 0);
         unhealthyApp.use(hc2.createRouter());
 
         mockfs({

--- a/test/handlers/health-check-tests.ts
+++ b/test/handlers/health-check-tests.ts
@@ -22,10 +22,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import fs from 'node:fs/promises';
+
 import express from 'express';
 import mockfs from 'mock-fs';
 import request from 'supertest';
-import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest';
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {CompilationQueue} from '../../lib/compilation-queue.js';
 import {HealthcheckController} from '../../lib/handlers/api/healthcheck-controller.js';
@@ -135,5 +137,57 @@ describe('Health checks on disk', () => {
             .get('/healthcheck')
             .expect(200, 'Everything is fine')
             .expect('content-type', /text\/html/);
+    });
+});
+
+describe('Health checks for free temp space', () => {
+    let app: express.Express;
+
+    const oneMiB = 1024 * 1024;
+
+    function makeApp(minFreeSpaceMiB: number): express.Express {
+        const compileHandlerMock = {
+            hasLanguages: () => true,
+        };
+        const compilationQueue = new CompilationQueue(1, 1000 * 1000, 1000 * 1000);
+        const result = express();
+        const controller = new HealthcheckController(
+            compilationQueue,
+            null,
+            compileHandlerMock,
+            false,
+            minFreeSpaceMiB,
+        );
+        result.use(controller.createRouter());
+        return result;
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should respond with OK when there is enough free space', async () => {
+        app = makeApp(100);
+        vi.spyOn(fs, 'statfs').mockResolvedValue({bavail: 200, bsize: oneMiB} as any);
+        await request(app).get('/healthcheck').expect(200, 'Everything is awesome');
+    });
+
+    it('should respond with 500 when free space is below the minimum', async () => {
+        app = makeApp(100);
+        vi.spyOn(fs, 'statfs').mockResolvedValue({bavail: 99, bsize: oneMiB} as any);
+        await request(app).get('/healthcheck').expect(500);
+    });
+
+    it('should respond with 500 when free space cannot be determined', async () => {
+        app = makeApp(100);
+        vi.spyOn(fs, 'statfs').mockRejectedValue(new Error('no statfs here'));
+        await request(app).get('/healthcheck').expect(500);
+    });
+
+    it('should not check free space when disabled', async () => {
+        app = makeApp(0);
+        const statfsSpy = vi.spyOn(fs, 'statfs');
+        await request(app).get('/healthcheck').expect(200, 'Everything is awesome');
+        expect(statfsSpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Part of #8811 (production disk-full incident).

During the incident `/healthcheck` stayed green for hours while every compilation failed with ENOSPC: the empty-job queue check passed (one of two queue slots still worked), and the EFS health-file read doesn't touch the root filesystem — so the load balancer never replaced the instance.

This adds a free-space check on the filesystem where compilation temp dirs are actually created: `lib/temp.ts` gains `getTempRoot()`, used both by `temp.mkdir()` and the healthcheck, so the two can't drift apart. (That resolves via `os.tmpdir()`; `--tmp-dir` flows into it as `$TMP` via `setupTempDir()` — `/nosym/tmp` in prod.) Below the threshold the healthcheck returns 500 and the load balancer replaces the instance *before* hard failure. A `statfs` failure is itself treated as unhealthy.

Configuration: `healthCheckMinFreeSpaceMiB` — required constructor argument (no code default, per review); `amazon.properties` sets 2048 (at the incident's ~300MB/min fill rate that gives the LB several minutes to act); the ceProps fallback is 100 for unconfigured/local instances; 0 disables the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)