### PR TITLE
Add review-calibration guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ This file provides guidance to AI Agents when working with code in this reposito
   In this case, the function name already clearly states what it does.
 - Comments should provide additional context or explain "why" something is done, not just restate "what" is being done.
 - Only add function header comments when they provide meaningful information beyond what the function name and signature convey.
+- Don't add comments narrating a change's history, the bug it fixes, or warning against code you deliberately *didn't* write (e.g. options intentionally not passed). That rationale belongs in the commit/PR/issue; regression protection belongs in a test.
 - Use British English spellings for things like "initialise" and "colour", but only in new code. It's a preference not a hard requirement
 - Use modern Typescript features like optional chaining when updating existing code or adding new code
 
@@ -60,6 +61,11 @@ This file provides guidance to AI Agents when working with code in this reposito
   - Shared types should be imported from `types/` directory instead
   - This separation is enforced by pre-commit hooks (`npm run check-frontend-imports`)
   - Violations will cause build failures and prevent commits
+
+## Security Review Calibration
+- Internal, CE-controlled endpoints (e.g. the conan library server) are not hostile: treat crafted-content hardening there as hygiene. Apply small fixes inline, file larger ones as follow-up issues, and don't block PRs on them.
+- The genuinely hostile input surface is user-submitted source code and compilation output, handled by nsjail sandboxing and the `/nosym/tmp` nosymfollow mount in production.
+- Prioritise robustness failures (promises that never settle, hangs, resource leaks) over crafted-input scenarios: the former have caused real outages (issue #8811).
 
 ## Worker Mode Configuration
 - **Compilation Workers**: New feature for offloading compilation tasks to dedicated worker instances


### PR DESCRIPTION
Moves working agreements that came out of the #8811 incident response from one developer machine's local agent memory into the shared repo guidance, per review feedback:

- **Comments**: no narrating change history or warning against deliberately-absent code; rationale goes in the commit/PR/issue, regression protection goes in a test.
- **Security review calibration**: internal CE-controlled endpoints (conan etc.) get hygiene fixes inline and heavier hardening as follow-up issues, never blockers; the hostile surface is user-submitted code (nsjail + nosymfollow); robustness failures (never-settling promises, hangs, leaks) outrank crafted-input hypotheticals — the former actually take instances down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)