### PR TITLE
Make --tmp-dir authoritative over inherited environment

### DIFF
--- a/lib/app/temp-dir.ts
+++ b/lib/app/temp-dir.ts
@@ -23,10 +23,21 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import child_process from 'node:child_process';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
 import {logger} from '../logger.js';
+
+function exportTempDir(tmpDir: string) {
+    // Set every variable os.tmpdir() may consult (TMPDIR first on POSIX; TEMP then TMP on
+    // Windows) so the configured directory wins regardless of platform or inherited
+    // environment, and so spawned tools reading any of them agree. Setting only TMP, as we
+    // once did, let an inherited TMPDIR silently override --tmp-dir.
+    process.env.TMPDIR = tmpDir;
+    process.env.TMP = tmpDir;
+    process.env.TEMP = tmpDir;
+}
 
 /**
  * Set up temporary directory, especially for WSL environments
@@ -34,12 +45,10 @@ import {logger} from '../logger.js';
  * @param isWsl - Whether running under Windows Subsystem for Linux
  */
 export function setupTempDir(tmpDir: string | undefined, isWsl: boolean): void {
-    // If a tempDir is supplied, use it
     if (tmpDir) {
-        if (isWsl) {
-            process.env.TEMP = tmpDir; // for Windows
-        } else {
-            process.env.TMP = tmpDir; // for Linux
+        exportTempDir(tmpDir);
+        if (path.resolve(os.tmpdir()) !== path.resolve(tmpDir)) {
+            throw new Error(`Unable to set the temporary dir to ${tmpDir} - stuck at ${os.tmpdir()}`);
         }
     }
     // If running under WSL without explicit tmpDir, try to use Windows %TEMP%
@@ -48,10 +57,10 @@ export function setupTempDir(tmpDir: string | undefined, isWsl: boolean): void {
             const windowsTemp = child_process.execSync('cmd.exe /c echo %TEMP%').toString().replaceAll('\\', '/');
             const driveLetter = windowsTemp.substring(0, 1).toLowerCase();
             const directoryPath = windowsTemp.substring(2).trim();
-            process.env.TEMP = path.join('/mnt', driveLetter, directoryPath);
+            exportTempDir(path.join('/mnt', driveLetter, directoryPath));
         } catch {
             logger.warn('Unable to invoke cmd.exe to get windows %TEMP% path.');
         }
     }
-    logger.info(`Using temporary dir: ${process.env.TEMP || process.env.TMP}`);
+    logger.info(`Using temporary dir: ${os.tmpdir()}`);
 }

--- a/lib/app/temp-dir.ts
+++ b/lib/app/temp-dir.ts
@@ -33,7 +33,9 @@ function exportTempDir(tmpDir: string) {
     // Set every variable os.tmpdir() may consult (TMPDIR first on POSIX; TEMP then TMP on
     // Windows) so the configured directory wins regardless of platform or inherited
     // environment, and so spawned tools reading any of them agree. Setting only TMP, as we
-    // once did, let an inherited TMPDIR silently override --tmp-dir.
+    // once did, let an inherited TMPDIR silently override --tmp-dir. Main thread only: a
+    // worker thread's process.env writes are invisible to os.tmpdir(), which reads the real
+    // environment via safeGetenv.
     process.env.TMPDIR = tmpDir;
     process.env.TMP = tmpDir;
     process.env.TEMP = tmpDir;

--- a/lib/temp.ts
+++ b/lib/temp.ts
@@ -63,7 +63,7 @@ export function resetStats() {
 /**
  * The directory under which this module creates temporary directories (unless callers pass
  * an absolute prefix). The --tmp-dir command line option is not read directly: at startup
- * setupTempDir() exports it as $TMP (or $TEMP on Windows/WSL), which os.tmpdir() consults.
+ * setupTempDir() exports it as $TMPDIR/$TMP/$TEMP, which os.tmpdir() consults.
  * See lib/app/temp-dir.ts.
  */
 export function getTempRoot(): string {
@@ -129,6 +129,10 @@ export function cleanupSync() {
     const toRemove = pendingRemoval.splice(0, pendingRemoval.length);
     for (const dir of toRemove) {
         try {
+            if (!fs.existsSync(dir)) {
+                ++stats.numAlreadyGone;
+                continue;
+            }
             fs.rmSync(dir, {recursive: true, force: true});
             ++stats.numRemoved;
         } catch {

--- a/lib/temp.ts
+++ b/lib/temp.ts
@@ -121,6 +121,22 @@ export async function cleanup() {
     logger.debug(`Removed ${numRemoved} (${numAlreadyGone} already gone) of ${toRemove.length} temporary directories`);
 }
 
-process.on('exit', async () => {
-    await cleanup();
+/**
+ * Synchronously remove all temporary directories created by this module; for use at process
+ * exit, where asynchronous work never runs.
+ */
+export function cleanupSync() {
+    const toRemove = pendingRemoval.splice(0, pendingRemoval.length);
+    for (const dir of toRemove) {
+        try {
+            fs.rmSync(dir, {recursive: true, force: true});
+            ++stats.numRemoved;
+        } catch {
+            // Best effort only: we may be partway through exiting.
+        }
+    }
+}
+
+process.on('exit', () => {
+    cleanupSync();
 });

--- a/test/app/temp-dir-tests.ts
+++ b/test/app/temp-dir-tests.ts
@@ -23,43 +23,54 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 import child_process from 'node:child_process';
+import os from 'node:os';
 import process from 'node:process';
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {setupTempDir} from '../../lib/app/temp-dir.js';
 
+const TEMP_VARS = ['TMPDIR', 'TMP', 'TEMP'] as const;
+
 describe('setupTempDir', () => {
-    let originalEnv: NodeJS.ProcessEnv;
+    let savedVars: Record<string, string | undefined>;
 
     beforeEach(() => {
-        originalEnv = {...process.env};
+        // Save and clear the individual variables rather than reassigning process.env
+        // wholesale: a replaced process.env is a plain object whose writes no longer reach
+        // the real environment, while os.tmpdir() reads the real environment.
+        savedVars = Object.fromEntries(TEMP_VARS.map(v => [v, process.env[v]]));
+        for (const v of TEMP_VARS) delete process.env[v];
         vi.spyOn(child_process, 'execSync');
     });
 
     afterEach(() => {
-        process.env = originalEnv;
+        for (const v of TEMP_VARS) {
+            if (savedVars[v] === undefined) delete process.env[v];
+            else process.env[v] = savedVars[v];
+        }
         vi.restoreAllMocks();
     });
 
-    it('should set TMP env var with tmpDir option on non-WSL', () => {
+    it('should set all temp env vars with tmpDir option', () => {
         // Skip on Windows as it has different environment variable defaults
         if (process.platform === 'win32') return;
 
         setupTempDir('/custom/tmp', false);
 
+        expect(process.env.TMPDIR).toEqual('/custom/tmp');
         expect(process.env.TMP).toEqual('/custom/tmp');
-        expect(process.env.TEMP).toBeUndefined();
+        expect(process.env.TEMP).toEqual('/custom/tmp');
     });
 
-    it('should set TEMP env var with tmpDir option on WSL', () => {
-        // Skip on Windows as it has different environment variable defaults
+    it('should make os.tmpdir() return the configured dir even when TMPDIR was inherited', () => {
+        // Skip on Windows, where os.tmpdir() does not consult TMPDIR
         if (process.platform === 'win32') return;
 
-        setupTempDir('/custom/tmp', true);
+        process.env.TMPDIR = '/inherited/elsewhere';
+        setupTempDir('/custom/tmp', false);
 
-        expect(process.env.TEMP).toEqual('/custom/tmp');
-        expect(process.env.TMP).toEqual(originalEnv.TMP);
+        expect(os.tmpdir()).toEqual('/custom/tmp');
     });
 
     it('should try to use Windows TEMP on WSL without tmpDir option', () => {
@@ -71,6 +82,7 @@ describe('setupTempDir', () => {
         setupTempDir(undefined, true);
 
         expect(process.env.TEMP).toEqual('/mnt/c/Users/user/AppData/Local/Temp');
+        expect(os.tmpdir()).toEqual('/mnt/c/Users/user/AppData/Local/Temp');
         expect(child_process.execSync).toHaveBeenCalledWith('cmd.exe /c echo %TEMP%');
     });
 });

--- a/test/temp-tests.ts
+++ b/test/temp-tests.ts
@@ -105,3 +105,13 @@ describe('Creates and tracks temporary directories', () => {
         }
     });
 });
+
+describe('cleanupSync', () => {
+    it('synchronously removes pending directories', async () => {
+        const dir = await temp.mkdir('ce-temp-test');
+        expect(await utils.dirExists(dir)).toBe(true);
+        temp.cleanupSync();
+        expect(await utils.dirExists(dir)).toBe(false);
+        expect(temp.getStats().numActive).toEqual(0);
+    });
+});


### PR DESCRIPTION
Fixes #8816.

- `setupTempDir()` exports the configured dir as `TMPDIR`, `TMP` *and* `TEMP`. POSIX `os.tmpdir()` consults `TMPDIR` first, so the old TMP-only export meant an inherited `TMPDIR` silently defeated `--tmp-dir` (verified empirically; prod was protected only by `sudo env_reset` in start.sh). Setting all three also covers native Windows (`TEMP` > `TMP` there) and WSL, and means spawned tools reading any of the variables agree.
- Restores the `os.tmpdir() !== tmpDir → throw` sanity check from 613d7f688 (#6052), lost in the #7681 split refactor.
- The startup log now prints `os.tmpdir()` — the value that actually matters — instead of `TEMP || TMP`, which printed `undefined` on a default Linux run.
- The `lib/temp.ts` exit hook was `process.on('exit', async ...)`: exit handlers can't await, so it never removed anything. Replaced with a synchronous `cleanupSync()` (tested).
- Test hygiene fix that the work surfaced: the temp-dir tests restored the environment by reassigning `process.env` wholesale; a replaced `process.env` is a plain object whose writes never reach the real environment, while `os.tmpdir()` reads the real environ via `safeGetenv` — so the suite silently leaked env state across tests (and into any test running later in the same worker). Now saves/restores the individual variables.

The WSL `%TEMP%`-discovery-failure path (`wsl-vc.ts` parsing garbage on fallback, #8816 item 4) is deliberately untouched — Windows-specific and unverifiable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)