### PR TITLE
Fix flaky pane tests: wait for initial compile before opening dropdown

### DIFF
--- a/cypress/e2e/claude-explain.cy.ts
+++ b/cypress/e2e/claude-explain.cy.ts
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {clearAllIntercepts, setMonacoEditorContent, stubConsoleOutput} from '../support/utils';
+import {clearAllIntercepts, setMonacoEditorContent, stubConsoleOutput, waitForInitialCompile} from '../support/utils';
 
 // Claude Explain specific test utilities
 function mockClaudeExplainAPI() {
@@ -57,6 +57,7 @@ function mockClaudeExplainAPI() {
 }
 
 function openClaudeExplainPane() {
+    waitForInitialCompile();
     cy.get('[data-cy="new-compiler-dropdown-btn"]:visible').click();
     cy.get('[data-cy="new-view-explain-btn"]:visible').click();
 }

--- a/cypress/e2e/claude-explain.cy.ts
+++ b/cypress/e2e/claude-explain.cy.ts
@@ -22,7 +22,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {clearAllIntercepts, setMonacoEditorContent, stubConsoleOutput, waitForInitialCompile} from '../support/utils';
+import {
+    clearAllIntercepts,
+    setMonacoEditorContent,
+    stubConsoleOutput,
+    waitForCompilationToSettle,
+} from '../support/utils';
 
 // Claude Explain specific test utilities
 function mockClaudeExplainAPI() {
@@ -57,7 +62,9 @@ function mockClaudeExplainAPI() {
 }
 
 function openClaudeExplainPane() {
-    waitForInitialCompile();
+    // Cannot use setupAndWaitForCompilation: some tests have replaced the default source
+    // (and so its expected output) before opening the pane.
+    waitForCompilationToSettle();
     cy.get('[data-cy="new-compiler-dropdown-btn"]:visible').click();
     cy.get('[data-cy="new-view-explain-btn"]:visible').click();
 }

--- a/cypress/e2e/frontend.cy.ts
+++ b/cypress/e2e/frontend.cy.ts
@@ -1,5 +1,5 @@
 import {serialiseState} from '../../shared/url-serialization.js';
-import {assertNoConsoleOutput, stubConsoleOutput, waitForInitialCompile} from '../support/utils';
+import {assertNoConsoleOutput, setupAndWaitForCompilation, stubConsoleOutput} from '../support/utils';
 
 const PANE_DATA_MAP = {
     codeEditor: {name: 'Editor', selector: 'new-editor'},
@@ -37,7 +37,7 @@ describe('Individual pane testing', () => {
             },
         });
 
-        waitForInitialCompile();
+        setupAndWaitForCompilation();
 
         cy.get('[data-cy="new-compiler-dropdown-btn"]:visible').click();
         // Shows every pane button even if the compiler does not support it

--- a/cypress/e2e/frontend.cy.ts
+++ b/cypress/e2e/frontend.cy.ts
@@ -1,5 +1,5 @@
 import {serialiseState} from '../../shared/url-serialization.js';
-import {assertNoConsoleOutput, stubConsoleOutput} from '../support/utils';
+import {assertNoConsoleOutput, stubConsoleOutput, waitForInitialCompile} from '../support/utils';
 
 const PANE_DATA_MAP = {
     codeEditor: {name: 'Editor', selector: 'new-editor'},
@@ -37,12 +37,7 @@ describe('Individual pane testing', () => {
             },
         });
 
-        // Wait for the initial compilation to finish: its result handler re-renders the
-        // add-pane dropdown contents (updateButtons() runs just before the status icon leaves
-        // its spinner state), which can otherwise detach a dropdown button mid-click.
-        cy.get('.status-icon', {timeout: 30_000}).should($icon => {
-            expect($icon.hasClass('fa-check-circle') || $icon.hasClass('fa-times-circle')).to.be.true;
-        });
+        waitForInitialCompile();
 
         cy.get('[data-cy="new-compiler-dropdown-btn"]:visible').click();
         // Shows every pane button even if the compiler does not support it

--- a/cypress/e2e/frontend.cy.ts
+++ b/cypress/e2e/frontend.cy.ts
@@ -37,6 +37,13 @@ describe('Individual pane testing', () => {
             },
         });
 
+        // Wait for the initial compilation to finish: its result handler re-renders the
+        // add-pane dropdown contents (updateButtons() runs just before the status icon leaves
+        // its spinner state), which can otherwise detach a dropdown button mid-click.
+        cy.get('.status-icon', {timeout: 30_000}).should($icon => {
+            expect($icon.hasClass('fa-check-circle') || $icon.hasClass('fa-times-circle')).to.be.true;
+        });
+
         cy.get('[data-cy="new-compiler-dropdown-btn"]:visible').click();
         // Shows every pane button even if the compiler does not support it
         cy.get('[data-cy="new-compiler-pane-dropdown"]:visible button').each($btn => {

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -49,10 +49,6 @@ export function visitPage() {
 }
 
 /**
- * Find a GoldenLayout pane by matching text in its visible tab title.
- * Returns the `.lm_content` element within the matching stack.
- */
-/**
  * Wait for the in-flight compilation (any source, successful or not) to settle. A compile
  * result re-renders the add-pane dropdown contents (updateButtons() runs just before the
  * status icon reaches a terminal state), which can detach a dropdown button mid-click: call
@@ -64,6 +60,10 @@ export function waitForCompilationToSettle() {
     );
 }
 
+/**
+ * Find a GoldenLayout pane by matching text in its visible tab title.
+ * Returns the `.lm_content` element within the matching stack.
+ */
 export function findPane(titleMatch: string) {
     return cy.contains('span.lm_title:visible', titleMatch).closest('.lm_item.lm_stack').find('.lm_content');
 }

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -52,6 +52,15 @@ export function visitPage() {
  * Find a GoldenLayout pane by matching text in its visible tab title.
  * Returns the `.lm_content` element within the matching stack.
  */
+export function waitForInitialCompile() {
+    // The initial compilation's result handler re-renders the add-pane dropdown contents
+    // (updateButtons() runs just before the status icon reaches a terminal state), which can
+    // detach a dropdown button mid-click; wait for it before touching the dropdown.
+    cy.get('.status-icon.fa-check-circle:visible, .status-icon.fa-times-circle:visible', {timeout: 30_000}).should(
+        'exist',
+    );
+}
+
 export function findPane(titleMatch: string) {
     return cy.contains('span.lm_title:visible', titleMatch).closest('.lm_item.lm_stack').find('.lm_content');
 }

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -52,10 +52,13 @@ export function visitPage() {
  * Find a GoldenLayout pane by matching text in its visible tab title.
  * Returns the `.lm_content` element within the matching stack.
  */
-export function waitForInitialCompile() {
-    // The initial compilation's result handler re-renders the add-pane dropdown contents
-    // (updateButtons() runs just before the status icon reaches a terminal state), which can
-    // detach a dropdown button mid-click; wait for it before touching the dropdown.
+/**
+ * Wait for the in-flight compilation (any source, successful or not) to settle. A compile
+ * result re-renders the add-pane dropdown contents (updateButtons() runs just before the
+ * status icon reaches a terminal state), which can detach a dropdown button mid-click: call
+ * this before touching the dropdown.
+ */
+export function waitForCompilationToSettle() {
     cy.get('.status-icon.fa-check-circle:visible, .status-icon.fa-times-circle:visible', {timeout: 30_000}).should(
         'exist',
     );
@@ -140,6 +143,7 @@ export function compilerPane() {
 /** Wait for editors and verify the default code has compiled (looks for "square" in output). */
 export function setupAndWaitForCompilation() {
     waitForEditors();
+    waitForCompilationToSettle();
     monacoEditorTextShouldContain(compilerOutput(), 'square');
 }
 


### PR DESCRIPTION
Fixes #8815.

The "Individual pane testing" `beforeEach` opened the add-pane dropdown (and force-enabled its buttons) immediately after `cy.visit('/')`. The initial compilation's result handler calls `updateButtons()`, re-rendering the dropdown contents — if that landed between Cypress locating a pane button and clicking it, the click failed with `page updated while this command was executing`. It always hit the *Clojure Macro* pane because panes few compilers support are exactly the buttons whose state changes when compiler capabilities arrive. `claude-explain.cy.ts`'s pane opener had the identical unguarded click.

The wait helpers are layered, not parallel:
- `waitForCompilationToSettle()` (new primitive): the compile status icon reaches a terminal state (`fa-check-circle`/`fa-times-circle`). The result handler calls `updateButtons()` immediately *before* setting that icon (`compiler.ts:1930-1932`), so the signal is ordered after the hazard. Works for any source, successful or failed, and for recompiles after content changes.
- `setupAndWaitForCompilation()` (existing helper, now built on the primitive): adds the default-source `'square'` output assertion, as before.

The pane tests use `setupAndWaitForCompilation()`; `openClaudeExplainPane()` uses the primitive because several of its tests replace the default source (whose output assertion would then fail) before opening the pane.

Verified locally against the CI server configuration (`npm run dev -- --language c++ --no-local`): `frontend.cy.ts` (24), `claude-explain.cy.ts` (16), and `compile.cy.ts` (14, exercising the rebuilt helper) all pass. Being a flake fix, repeated CI runs are the real proof; the failure hit at least 4 times today across unrelated PRs, so a regression should surface quickly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)