### PR TITLE
Assembly: Add RISC-V Binutils trunk

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -171,7 +171,7 @@ group.gnuasriscv.supportsExecute=false
 group.gnuasriscv.versionFlag=--version
 
 ## GNU as for RISC-V 64-bits
-group.gnuasriscv64.compilers=gnuasriscv64g820:gnuasriscv64g1020:gnuasriscv64g1140:gnuasriscv64g1320:gnuasriscv64g1420:gnuasriscv64g1510
+group.gnuasriscv64.compilers=gnuasriscv64g820:gnuasriscv64g1020:gnuasriscv64g1140:gnuasriscv64g1320:gnuasriscv64g1420:gnuasriscv64g1510:gnuasriscv64gtrunk
 group.gnuasriscv64.groupName=RISC-V (64-bits) binutils
 group.gnuasriscv64.baseName=RISC-V (64-bits) binutils
 
@@ -205,8 +205,14 @@ compiler.gnuasriscv64g1510.name=RISC-V binutils 2.45.0
 compiler.gnuasriscv64g1510.semver=2.45.0
 compiler.gnuasriscv64g1510.objdumper=/opt/compiler-explorer/riscv64/gcc-15.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
+compiler.gnuasriscv64gtrunk.exe=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-as
+compiler.gnuasriscv64gtrunk.name=RISC-V binutils (trunk)
+compiler.gnuasriscv64gtrunk.semver=(trunk)
+compiler.gnuasriscv64gtrunk.isNightly=true
+compiler.gnuasriscv64gtrunk.objdumper=/opt/compiler-explorer/riscv64/gcc-trunk/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+
 ## GNU as for RISC-V 32-bits
-group.gnuasriscv32.compilers=gnuasriscv32g820:gnuasriscv32g1020:gnuasriscv32g1140:gnuasriscv32g1320:gnuasriscv32g1420:gnuasriscv32g1510
+group.gnuasriscv32.compilers=gnuasriscv32g820:gnuasriscv32g1020:gnuasriscv32g1140:gnuasriscv32g1320:gnuasriscv32g1420:gnuasriscv32g1510:gnuasriscv32gtrunk
 group.gnuasriscv32.groupName=RISC-V (32-bits) binutils
 group.gnuasriscv32.baseName=RISC-V (32-bits) binutils
 
@@ -239,6 +245,12 @@ compiler.gnuasriscv32g1510.exe=/opt/compiler-explorer/riscv32/gcc-15.1.0/riscv32
 compiler.gnuasriscv32g1510.name=RISC-V binutils 2.45.0
 compiler.gnuasriscv32g1510.semver=2.45.0
 compiler.gnuasriscv32g1510.objdumper=/opt/compiler-explorer/riscv32/gcc-15.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
+
+compiler.gnuasriscv32gtrunk.exe=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-as
+compiler.gnuasriscv32gtrunk.name=RISC-V binutils (trunk)
+compiler.gnuasriscv32gtrunk.semver=(trunk)
+compiler.gnuasriscv32gtrunk.isNightly=true
+compiler.gnuasriscv32gtrunk.objdumper=/opt/compiler-explorer/riscv32/gcc-trunk/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 
 group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas352:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas1001:llvmas1100:llvmas1101:llvmas1200:llvmas1201:llvmas1300:llvmas1400:llvmas1500:llvmas1600:llvmas1701:llvmas1810:llvmas1910:llvmas2010:llvmas2110:llvmas2210:llvmas_trunk:llvmas_assertions_trunk
 group.llvmas.versionFlag=--version


### PR DESCRIPTION
Add RISC-V GNUAS trunk entries for both RV64 and RV32.

The GNUAS assembly view already provides binutils trunk entries for x86-64
and AArch64, but RISC-V currently only lists released binutils versions up to
2.45.0.

This patch follows the existing GNUAS trunk style by appending the trunk
entries after the released versions and marking them as nightly. The paths
reuse the existing RISC-V gcc-trunk toolchain layout and expose the
corresponding assembler and objdump binaries.