### PR TITLE
Construct builtin examples source explicitly at startup

### DIFF
--- a/lib/app/controllers.ts
+++ b/lib/app/controllers.ts
@@ -24,6 +24,7 @@
 
 import express from 'express';
 
+import type {Source} from '../../types/source.interfaces.js';
 import {CompilationQueue} from '../compilation-queue.js';
 import {FormattingService} from '../formatting-service.js';
 import {AssemblyDocumentationController} from '../handlers/api/assembly-documentation-controller.js';
@@ -33,7 +34,6 @@ import {NoScriptController} from '../handlers/api/noscript-controller.js';
 import {SiteTemplateController} from '../handlers/api/site-template-controller.js';
 import {SourceController} from '../handlers/api/source-controller.js';
 import {CompileHandler} from '../handlers/compile.js';
-import {sources} from '../sources/index.js';
 
 export interface ApiControllers {
     siteTemplateController: SiteTemplateController;
@@ -46,6 +46,7 @@ export interface ApiControllers {
 
 /**
  * Initialize all API controllers used by the application
+ * @param sources - The configured source providers (e.g. builtin examples)
  * @param compileHandler - The compile handler instance
  * @param formattingService - The formatting service instance
  * @param compilationQueue - The compilation queue instance
@@ -57,6 +58,7 @@ export interface ApiControllers {
  * @returns Object containing all initialized controllers
  */
 export function setupControllersAndHandlers(
+    sources: Source[],
     compileHandler: CompileHandler,
     formattingService: FormattingService,
     compilationQueue: CompilationQueue,

--- a/lib/app/main.ts
+++ b/lib/app/main.ts
@@ -38,7 +38,7 @@ import {logger} from '../logger.js';
 import {setupMetricsServer} from '../metrics-server.js';
 import {ClientOptionsHandler} from '../options-handler.js';
 import {SetupSentry} from '../sentry.js';
-import {sources} from '../sources/index.js';
+import {createSources} from '../sources/index.js';
 import {loadSponsorsFromString} from '../sponsors.js';
 import {getStorageTypeByKey} from '../storage/index.js';
 import {initializeCompilationEnvironment} from './compilation-env.js';
@@ -73,6 +73,7 @@ export async function initialiseApplication(options: ApplicationOptions): Promis
         awsProps,
     );
 
+    const sources = createSources();
     const clientOptionsHandler = new ClientOptionsHandler(sources, compilerProps, appArgs);
     const storageType = getStorageTypeByKey(storageSolution);
     const storageHandler = new storageType(config.httpRoot, compilerProps, awsProps);
@@ -87,6 +88,7 @@ export async function initialiseApplication(options: ApplicationOptions): Promis
     const formDataHandler = createFormDataHandler();
 
     const controllers = setupControllersAndHandlers(
+        sources,
         compileHandler,
         compilationEnvironment.formattingService,
         compilationEnvironment.compilationQueue,

--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -33,7 +33,7 @@ import {CompilerOverrideOptions} from '../../types/compilation/compiler-override
 import {Argument} from '../../types/compiler-arguments.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {logger} from '../logger.js';
-import * as props from '../properties.js';
+import {getExamplesRoot} from '../sources/builtin.js';
 import * as utils from '../utils.js';
 import {JuliaCompiler} from './julia.js';
 
@@ -1220,7 +1220,7 @@ export class GolangParser extends GCCParser {
         // NB this file _must_ be visible to the jail, if you're using one. This may bite on a local install when your
         // example path may not match paths available in the jail (e.g. `/infra/.deploy/examples`)
         // TODO: find a way to invoke GoLang without needing a real example Go file.
-        const examplesRoot = props.get<string>('builtin', 'sourcePath', './examples/');
+        const examplesRoot = getExamplesRoot();
         const exampleFilepath = path.resolve(path.join(examplesRoot, 'go/default.go'));
         const results = await Promise.all([
             this.getOptions('build -o /tmp/output.s "-gcflags=-S --help" ' + exampleFilepath),

--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -32,11 +32,9 @@ import * as props from '../properties.js';
 const NAME_SUBSTUTION_PATTERN = /_/g;
 
 function readExamples(examplesPath: string): SourceEntry[] {
-    // Recurse through the language folders
     return fs.readdirSync(examplesPath).flatMap(folder => {
         const folderPath = path.join(examplesPath, folder);
         return fs.readdirSync(folderPath).map(file => {
-            // Recurse through the source files
             const filePath = path.join(folderPath, file);
             const fileName = path.parse(filePath).name;
             return {

--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -30,13 +30,11 @@ import type {Source, SourceApiEntry, SourceEntry} from '../../types/source.inter
 import * as props from '../properties.js';
 
 const NAME_SUBSTUTION_PATTERN = /_/g;
-let examplesPath: string | undefined;
-let allExamples: SourceEntry[] | undefined;
 
-function readExamples(configuredExamplesPath: string): SourceEntry[] {
+function readExamples(examplesPath: string): SourceEntry[] {
     // Recurse through the language folders
-    return fs.readdirSync(configuredExamplesPath).flatMap(folder => {
-        const folderPath = path.join(configuredExamplesPath, folder);
+    return fs.readdirSync(examplesPath).flatMap(folder => {
+        const folderPath = path.join(examplesPath, folder);
         return fs.readdirSync(folderPath).map(file => {
             // Recurse through the source files
             const filePath = path.join(folderPath, file);
@@ -51,20 +49,17 @@ function readExamples(configuredExamplesPath: string): SourceEntry[] {
     });
 }
 
-function getExamples(): SourceEntry[] {
-    const configuredExamplesPath = props.get<string>('builtin', 'sourcePath', './examples/');
-    if (allExamples === undefined || examplesPath !== configuredExamplesPath) {
-        examplesPath = configuredExamplesPath;
-        allExamples = readExamples(configuredExamplesPath);
-    }
-    return allExamples;
-}
+export class BuiltinSource implements Source {
+    readonly name = 'Examples';
+    readonly urlpart = 'builtin';
+    private readonly examples: SourceEntry[];
 
-export const builtin: Source = {
-    name: 'Examples',
-    urlpart: 'builtin',
+    constructor(examplesPath: string) {
+        this.examples = readExamples(examplesPath);
+    }
+
     async load(language: string, filename: string): Promise<{file: string}> {
-        const example = getExamples().find(e => e.lang === language && e.file === filename);
+        const example = this.examples.find(e => e.lang === language && e.file === filename);
         if (example === undefined) {
             return {file: 'No path found'};
         }
@@ -73,12 +68,17 @@ export const builtin: Source = {
         } catch {
             return {file: 'Could not read file'};
         }
-    },
+    }
+
     async list(): Promise<SourceApiEntry[]> {
-        return getExamples().map(e => ({
+        return this.examples.map(e => ({
             lang: e.lang,
             name: e.name,
             file: e.file,
         }));
-    },
-};
+    }
+}
+
+export function createBuiltinSource(): BuiltinSource {
+    return new BuiltinSource(props.get<string>('builtin', 'sourcePath', './examples/'));
+}

--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -82,5 +82,12 @@ export function getExamplesRoot(): string {
 }
 
 export function createBuiltinSource(): BuiltinSource {
-    return new BuiltinSource(getExamplesRoot());
+    const examplesRoot = getExamplesRoot();
+    try {
+        return new BuiltinSource(examplesRoot);
+    } catch (e) {
+        throw new Error(`Unable to read builtin examples from "${examplesRoot}" (set via builtin.sourcePath)`, {
+            cause: e,
+        });
+    }
 }

--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -79,6 +79,10 @@ export class BuiltinSource implements Source {
     }
 }
 
+export function getExamplesRoot(): string {
+    return props.get<string>('builtin', 'sourcePath', './examples/');
+}
+
 export function createBuiltinSource(): BuiltinSource {
-    return new BuiltinSource(props.get<string>('builtin', 'sourcePath', './examples/'));
+    return new BuiltinSource(getExamplesRoot());
 }

--- a/lib/sources/index.ts
+++ b/lib/sources/index.ts
@@ -22,6 +22,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {builtin} from './builtin.js';
+import type {Source} from '../../types/source.interfaces.js';
+import {createBuiltinSource} from './builtin.js';
 
-export const sources = [builtin];
+export function createSources(): Source[] {
+    return [createBuiltinSource()];
+}

--- a/test/sources/builtin-tests.ts
+++ b/test/sources/builtin-tests.ts
@@ -96,4 +96,15 @@ describe('createBuiltinSource', () => {
             {lang: 'customlang', name: 'configured example', file: 'configured_example'},
         ]);
     });
+
+    it('throws with builtin.sourcePath context when the configured dir is missing', async () => {
+        const missingPath = path.join(await makeTempDir(), 'does-not-exist');
+        const configPath = path.join(await makeTempDir(), 'config');
+        await fs.mkdir(configPath, {recursive: true});
+        await fs.writeFile(path.join(configPath, 'builtin.test.properties'), `sourcePath=${missingPath}\n`);
+
+        props.initialize(configPath, ['test']);
+
+        expect(() => createBuiltinSource()).toThrow(/builtin\.sourcePath/);
+    });
 });

--- a/test/sources/builtin-tests.ts
+++ b/test/sources/builtin-tests.ts
@@ -68,6 +68,13 @@ describe('BuiltinSource', () => {
         await expect(builtin.load('customlang', 'nope')).resolves.toEqual({file: 'No path found'});
     });
 
+    it('returns "Could not read file" when a listed example becomes unreadable', async () => {
+        const examplesPath = await makeExamplesDir('int x;\n');
+        const builtin = new BuiltinSource(examplesPath);
+        await fs.rm(examplesPath, {recursive: true, force: true});
+        await expect(builtin.load('customlang', 'configured_example')).resolves.toEqual({file: 'Could not read file'});
+    });
+
     it('fails fast when constructed with a non-existent sourcePath', async () => {
         const missingPath = path.join(await makeTempDir(), 'does-not-exist');
         expect(() => new BuiltinSource(missingPath)).toThrow();

--- a/test/sources/builtin-tests.ts
+++ b/test/sources/builtin-tests.ts
@@ -26,7 +26,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, it} from 'vitest';
 
 import * as props from '../../lib/properties.js';
 import {BuiltinSource, createBuiltinSource} from '../../lib/sources/builtin.js';
@@ -47,11 +47,12 @@ async function makeExamplesDir(source: string) {
     return examplesPath;
 }
 
-describe('BuiltinSource', () => {
-    afterEach(async () => {
-        await Promise.all(tempDirs.splice(0).map(tempDir => fs.rm(tempDir, {recursive: true, force: true})));
-    });
+afterEach(async () => {
+    props.reset();
+    await Promise.all(tempDirs.splice(0).map(tempDir => fs.rm(tempDir, {recursive: true, force: true})));
+});
 
+describe('BuiltinSource', () => {
     it('lists and loads examples from the given directory', async () => {
         const source = 'int configured_example() { return 42; }\n';
         const builtin = new BuiltinSource(await makeExamplesDir(source));
@@ -67,20 +68,13 @@ describe('BuiltinSource', () => {
         await expect(builtin.load('customlang', 'nope')).resolves.toEqual({file: 'No path found'});
     });
 
-    it('fails fast when constructed with a non-existent sourcePath', () => {
-        expect(() => new BuiltinSource(path.join(os.tmpdir(), 'ce-does-not-exist-12345'))).toThrow();
+    it('fails fast when constructed with a non-existent sourcePath', async () => {
+        const missingPath = path.join(await makeTempDir(), 'does-not-exist');
+        expect(() => new BuiltinSource(missingPath)).toThrow();
     });
 });
 
 describe('createBuiltinSource', () => {
-    afterEach(() => {
-        props.reset();
-    });
-
-    beforeEach(() => {
-        props.reset();
-    });
-
     it('reads sourcePath from properties at construction time', async () => {
         const source = 'int configured_example() { return 42; }\n';
         const examplesPath = await makeExamplesDir(source);

--- a/test/sources/builtin-tests.ts
+++ b/test/sources/builtin-tests.ts
@@ -26,7 +26,10 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import {afterEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import * as props from '../../lib/properties.js';
+import {BuiltinSource, createBuiltinSource} from '../../lib/sources/builtin.js';
 
 const tempDirs: string[] = [];
 
@@ -36,40 +39,60 @@ async function makeTempDir() {
     return tempDir;
 }
 
-describe('builtin source provider', () => {
-    afterEach(async () => {
-        const props = await import('../../lib/properties.js');
-        props.reset();
-        vi.resetModules();
+async function makeExamplesDir(source: string) {
+    const examplesPath = path.join(await makeTempDir(), 'custom-examples');
+    const languagePath = path.join(examplesPath, 'customlang');
+    await fs.mkdir(languagePath, {recursive: true});
+    await fs.writeFile(path.join(languagePath, 'configured_example.cpp'), source);
+    return examplesPath;
+}
 
+describe('BuiltinSource', () => {
+    afterEach(async () => {
         await Promise.all(tempDirs.splice(0).map(tempDir => fs.rm(tempDir, {recursive: true, force: true})));
     });
 
-    it('uses sourcePath configured after the module has been imported', async () => {
-        const tempDir = await makeTempDir();
-        const examplesPath = path.join(tempDir, 'custom-examples');
-        const languagePath = path.join(examplesPath, 'customlang');
-        const configPath = path.join(tempDir, 'config');
+    it('lists and loads examples from the given directory', async () => {
         const source = 'int configured_example() { return 42; }\n';
+        const builtin = new BuiltinSource(await makeExamplesDir(source));
 
-        await fs.mkdir(languagePath, {recursive: true});
+        await expect(builtin.list()).resolves.toEqual([
+            {lang: 'customlang', name: 'configured example', file: 'configured_example'},
+        ]);
+        await expect(builtin.load('customlang', 'configured_example')).resolves.toEqual({file: source});
+    });
+
+    it('returns "No path found" for an unknown example', async () => {
+        const builtin = new BuiltinSource(await makeExamplesDir('int x;\n'));
+        await expect(builtin.load('customlang', 'nope')).resolves.toEqual({file: 'No path found'});
+    });
+
+    it('fails fast when constructed with a non-existent sourcePath', () => {
+        expect(() => new BuiltinSource(path.join(os.tmpdir(), 'ce-does-not-exist-12345'))).toThrow();
+    });
+});
+
+describe('createBuiltinSource', () => {
+    afterEach(() => {
+        props.reset();
+    });
+
+    beforeEach(() => {
+        props.reset();
+    });
+
+    it('reads sourcePath from properties at construction time', async () => {
+        const source = 'int configured_example() { return 42; }\n';
+        const examplesPath = await makeExamplesDir(source);
+        const configPath = path.join(await makeTempDir(), 'config');
         await fs.mkdir(configPath, {recursive: true});
-        await fs.writeFile(path.join(languagePath, 'configured_example.cpp'), source);
         await fs.writeFile(path.join(configPath, 'builtin.test.properties'), `sourcePath=${examplesPath}\n`);
-
-        vi.resetModules();
-        const {builtin} = await import('../../lib/sources/builtin.js');
-        const props = await import('../../lib/properties.js');
 
         props.initialize(configPath, ['test']);
 
+        const builtin = createBuiltinSource();
         await expect(builtin.list()).resolves.toEqual([
-            {
-                lang: 'customlang',
-                name: 'configured example',
-                file: 'configured_example',
-            },
+            {lang: 'customlang', name: 'configured example', file: 'configured_example'},
         ]);
-        await expect(builtin.load('customlang', 'configured_example')).resolves.toEqual({file: source});
     });
 });


### PR DESCRIPTION
Follow-up to #8779 (which fixed #8601, `builtin.sourcePath` being ignored). Two related changes:

### 1. Construct the builtin source explicitly at startup (restore fail-fast)

#8779 made the builtin "Examples" source read its config lazily, on the first `list()`/`load()`. That fixed correctness but moved the failure mode: a misconfigured `sourcePath` (missing/unreadable dir) no longer fails at startup. The server boots, passes healthchecks, takes traffic, and then throws on the first request that opens Examples.

This restores fail-fast by constructing the source explicitly once configuration is loaded:

- Replace the `builtin` module-level singleton with a `BuiltinSource` class whose constructor scans the examples directory, plus a `createBuiltinSource()` factory that reads `builtin.sourcePath`.
- `lib/sources/index.ts` exposes `createSources()` instead of a top-level `sources` array (a top-level array would re-run config reads at import time, reintroducing #8601).
- `initialiseApplication` constructs the sources after config load and passes the `Source[]` to `ClientOptionsHandler` and `setupControllersAndHandlers` (both already accept injected sources).

A bad `sourcePath` now throws during startup, before the instance reports healthy. The lazy fix's correctness (config read after `initialize()`) is preserved.

### 2. Single source of truth for the examples path

`GolangParser` independently re-read `('builtin', 'sourcePath', './examples/')` to locate `go/default.go`, duplicating where the examples directory is defined. Export `getExamplesRoot()` from `lib/sources/builtin.ts` and use it in both `createBuiltinSource()` and `GolangParser`, so the config key and default live in one place. Behaviour is unchanged (same value resolved); it removes the drift risk if the key or default ever changes.

### Tests
Tests construct `BuiltinSource` directly with a fixture directory (no import-order/`resetModules` dance), cover the unknown-example path, assert fail-fast on a non-existent dir, and verify `createBuiltinSource()` reads the configured path.

- `npx vitest --run test/sources/builtin-tests.ts test/compilers/argument-parsers-tests.ts`
- `npm run ts-check`
- `npm run lint-check`