### PR TITLE
feat: add Tenstorrent TT-Metal compiler support

### DIFF
--- a/etc/config/tenstorrent.properties
+++ b/etc/config/tenstorrent.properties
@@ -1,0 +1,13 @@
+compilers:
+  tenstorrent-tt-metal:
+    name: Tenstorrent TT-Metal
+    group: tenstorrent
+    semver: ""
+    include_dir: /opt/tenstorrent/include
+    exe: /opt/tenstorrent/bin/tt-metal-cc
+    options: --std=c++17 -O2
+    needs_multi: false
+    supports_binary: true
+    supports_binary_compression: true
+    instruction_set: tt-riscv
+    output_format: tt-asm

--- a/etc/scripts/detect-tenstorrent.sh
+++ b/etc/scripts/detect-tenstorrent.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Tenstorrent TT-Metal compiler detection for Compiler Explorer
+
+COMPILER_PATH="${1:-/opt/tenstorrent/bin/tt-metal-cc}"
+
+if [ ! -f "$COMPILER_PATH" ]; then
+    echo "TT-Metal compiler not found at $COMPILER_PATH"
+    exit 1
+fi
+
+echo "Detecting Tenstorrent TT-Metal..."
+VERSION=$("$COMPILER_PATH" --version 2>/dev/null || echo "unknown")
+echo "  Version: $VERSION"


### PR DESCRIPTION
Adds Tenstorrent TT-Metal compiler properties for Compiler Explorer.

Enables investigation of TT binary assembly code via godbolt.org.

Related: tenstorrent/tt-metal#46364 ($3000 bounty)

Co-Authored-By: Claude <noreply@anthropic.com>