### PR TITLE
Fix Clang AST linkage highlighting

### DIFF
--- a/static/modes/_all.ts
+++ b/static/modes/_all.ts
@@ -30,6 +30,7 @@ import './asmruby-mode';
 import './c3-mode';
 import './carbon-mode';
 import './clean-mode';
+import './clang-ast-mode';
 import './cmake-mode';
 import './cobol-mode';
 import './cppcircle-mode';

--- a/static/modes/clang-ast-mode.ts
+++ b/static/modes/clang-ast-mode.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import $ from 'jquery';
+import * as monaco from 'monaco-editor';
+import * as cpp from 'monaco-editor/esm/vs/basic-languages/cpp/cpp';
+
+export function definition(): monaco.languages.IMonarchLanguage {
+    const clangAst = $.extend(true, {}, cpp.language);
+    clangAst.tokenPostfix = '.clang-ast';
+    clangAst.tokenizer.root.unshift([/(?:internal|external|module)-linkage\b/, 'keyword.ast-linkage']);
+    return clangAst;
+}
+
+monaco.languages.register({id: 'clang-ast'});
+monaco.languages.setLanguageConfiguration('clang-ast', cpp.conf);
+monaco.languages.setMonarchTokensProvider('clang-ast', definition());

--- a/static/panes/ast-view.ts
+++ b/static/panes/ast-view.ts
@@ -181,7 +181,7 @@ export class Ast extends MonacoPane<monaco.editor.IStandaloneCodeEditor, AstStat
 
         // TODO: This is inelegant. Previously took advantage of fourth argument for the compileResult event.
         // I'm guessing it's not part of the TS rewrite because it's not always passed by the emitter.
-        const lang = compiler.lang === 'c++' ? 'cpp' : compiler.lang;
+        const lang = compiler.lang === 'c++' ? 'clang-ast' : compiler.lang;
         const model = this.editor.getModel();
         if (model != null && this.getCurrentEditorLanguage() !== lang) {
             monaco.editor.setModelLanguage(model, lang);

--- a/static/tests/modes/clang-ast-mode-tests.ts
+++ b/static/tests/modes/clang-ast-mode-tests.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as monaco from 'monaco-editor';
+import {describe, expect, it} from 'vitest';
+
+import '../../modes/clang-ast-mode.js';
+
+describe('clang-ast mode', () => {
+    it('tokenises Clang linkage specifiers as complete keywords', () => {
+        const tokens = monaco.editor.tokenize(
+            'internal-linkage external-linkage module-linkage linkage',
+            'clang-ast',
+        )[0];
+
+        expect(tokens.map(({offset, type}) => ({offset, type}))).toEqual([
+            {offset: 0, type: 'keyword.ast-linkage.clang-ast'},
+            {offset: 16, type: ''},
+            {offset: 17, type: 'keyword.ast-linkage.clang-ast'},
+            {offset: 33, type: ''},
+            {offset: 34, type: 'keyword.ast-linkage.clang-ast'},
+            {offset: 48, type: ''},
+            {offset: 49, type: 'identifier.clang-ast'},
+        ]);
+    });
+});


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Fixes #8672

This adds a Clang AST Monaco mode for C++ AST output so Clang linkage specifiers are highlighted as whole tokens without changing normal C++ source highlighting.

Validation:

- `npm run test -- --run static/tests/modes/clang-ast-mode-tests.ts`
  - Test Files 1 passed (1)
  - Tests 1 passed (1)
- `npm run ts-check`
  - passed
- `npm run lint-check`
  - Checked 798 files. No fixes applied.
- `npm run test-min -- --reporter dot`
  - Test Files 116 passed, 1 skipped
  - Tests 1708 passed, 743 skipped
