### PR TITLE
Add OpenSearch shortcut for shortlinks (`ce <id>` in the address bar)

### DIFF
--- a/lib/app/server-config.ts
+++ b/lib/app/server-config.ts
@@ -204,6 +204,11 @@ export function setupBasicRoutes(
         .get('/sitemap.xml', cached, (req, res) => {
             res.set('Content-Type', 'application/xml');
             res.render('sitemap');
+        })
+        .get('/search.xml', cached, (req, res) => {
+            const base = `${req.protocol}://${req.get('host')}${options.httpRoot}`;
+            res.set('Content-Type', 'application/opensearchdescription+xml');
+            res.render('opensearch', renderConfig({searchUrlTemplate: `${base}z/{searchTerms}`}));
         });
 
     router

--- a/views/meta.pug
+++ b/views/meta.pug
@@ -1,4 +1,6 @@
 link(rel="icon" href=`${staticRoot}${faviconFilename}`)
+if !embedded
+  link(rel="search" type="application/opensearchdescription+xml" href=`${httpRoot}search.xml` title="Compiler Explorer shortcut")
 meta(charset="utf-8")
 - var userScalable = mobileViewer ? "yes" : "no"
 meta(name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=" + userScalable + ", shrink-to-fit=no")

--- a/views/opensearch.pug
+++ b/views/opensearch.pug
@@ -1,0 +1,7 @@
+doctype xml
+OpenSearchDescription(xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/")
+  ShortName ce
+  Description Compiler Explorer shortcut
+  InputEncoding UTF-8
+  Image(width="16" height="16" type="image/x-icon")= `${staticRoot}${faviconFilename}`
+  Url(type="text/html" template=searchUrlTemplate)


### PR DESCRIPTION
## What

Adds [OpenSearch](https://developer.mozilla.org/en-US/docs/Web/XML/Guides/OpenSearch) support so browsers can register a `ce` keyword. Once registered, typing `ce <shortlink>` in the address bar redirects to `/z/<shortlink>`.

## How

- **`views/opensearch.pug`** — an OpenSearch 1.1 description document.
- **`/search.xml` route** (`lib/app/server-config.ts`) — mirrors the existing `/sitemap.xml` route; serves the doc with `Content-Type: application/opensearchdescription+xml`.
- **`views/meta.pug`** — advertises it via `<link rel="search">` on the main page (omitted on embed pages, where OpenSearch discovery doesn't apply).

The search URL template (`…/z/{searchTerms}`) is built from the request (`{protocol}://{host}{httpRoot}`, the same pattern as `lib/storage/base.ts`), and the favicon uses the env-resolved `staticRoot`/`faviconFilename`, so it's correct across prod/beta/staging/local.

## Activation note

This is opt-in *discovery*, not automatic activation — browsers register the engine after visiting the site, and the user typically activates the `ce` keyword once (Chrome: Settings → Search engines → Site search; Firefox surfaces it in the address bar). Chrome's auto-discovery is also gated on a secure context, so this is best validated on an HTTPS environment (e.g. staging/beta) rather than a plain-HTTP dev box.

## Testing

Verified against a local instance:
- `GET /search.xml` → `200`, correct content-type, well-formed XML, `{searchTerms}` placeholder preserved, `<Url template>` absolute and host-derived.
- `<link rel="search">` present on `/`, absent on `/e`.
- favicon URL resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)