### PR TITLE
Add Mojo 1.0.0b2

### DIFF
--- a/etc/config/mojo.amazon.properties
+++ b/etc/config/mojo.amazon.properties
@@ -2,7 +2,7 @@ compilers=&mojo
 defaultCompiler=mojo_nightly
 compilerType=mojo
 
-group.mojo.compilers=mojo_0_25_6_0:mojo_0_25_7_0:mojo_0_26_1_0:mojo_0_26_2_0:mojo_1_0_0b1:mojo_nightly
+group.mojo.compilers=mojo_0_25_6_0:mojo_0_25_7_0:mojo_0_26_1_0:mojo_0_26_2_0:mojo_1_0_0b1:mojo_1_0_0b2:mojo_nightly
 group.mojo.isSemVer=true
 group.mojo.baseName=Mojo
 
@@ -20,6 +20,9 @@ compiler.mojo_0_26_2_0.semver=0.26.2.0
 
 compiler.mojo_1_0_0b1.exe=/opt/compiler-explorer/mojo-1.0.0b1/bin/mojo
 compiler.mojo_1_0_0b1.semver=1.0.0b1
+
+compiler.mojo_1_0_0b2.exe=/opt/compiler-explorer/mojo-1.0.0b2/bin/mojo
+compiler.mojo_1_0_0b2.semver=1.0.0b2
 
 compiler.mojo_nightly.exe=/opt/compiler-explorer/mojo-nightly/bin/mojo
 compiler.mojo_nightly.semver=nightly


### PR DESCRIPTION
Add Mojo **1.0.0b2**, published to PyPI on 2026-06-18.

- Appends `mojo_1_0_0b2` to the `group.mojo.compilers` list (before `mojo_nightly`).
- Adds the `exe` and `semver` properties for `/opt/compiler-explorer/mojo-1.0.0b2/bin/mojo`.

Existing `mojo_0_25_6_0`, `mojo_0_25_7_0`, `mojo_0_26_1_0`, `mojo_0_26_2_0`, and `mojo_1_0_0b1`
entries are deliberately kept per [docs/AddingACompiler.md § "Don't remove or rename compilers on
the public site"](https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingACompiler.md#dont-remove-or-rename-compilers-on-the-public-site).

**Companion infra PR required:** a matching change in `compiler-explorer/infra`
(`bin/yaml/mojo.yaml`, `type: pip`, `mojo==1.0.0b2`) is needed to install the binary on the public
site. That is in a separate repository and not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
