### PR TITLE
fix: consolidate /z/<id> URL parsing into a single robust helper

### DIFF
--- a/lib/handlers/noscript.ts
+++ b/lib/handlers/noscript.ts
@@ -32,6 +32,7 @@ import {ClientStateNormalizer} from '../clientstate-normalizer.js';
 import {logger} from '../logger.js';
 import {ClientOptionsHandler} from '../options-handler.js';
 import {getSafeHash, StorageBase} from '../storage/index.js';
+import {extractShortId} from '../url-utils.js';
 import {RenderConfig} from './handler.interfaces.js';
 import {cached, csp} from './middleware.js';
 
@@ -227,8 +228,8 @@ export class NoScriptHandler {
         const shareableUrl = await this.generateShareableUrl(state, req);
 
         const httpRoot = (this.renderConfig as any).httpRoot || '/';
-        const relativeUrl = shareableUrl.substring(shareableUrl.lastIndexOf('/z/') + 1);
-        const shortlink = `${req.protocol}://${req.get('host')}${httpRoot}${relativeUrl}`;
+        const shortId = extractShortId(shareableUrl);
+        const shortlink = `${req.protocol}://${req.get('host')}${httpRoot}z/${shortId}`;
 
         logger.debug('Shareable URL:', shortlink);
 

--- a/lib/mcp/tools/shortlinks.ts
+++ b/lib/mcp/tools/shortlinks.ts
@@ -32,6 +32,7 @@ import type {ApiHandler} from '../../handlers/api.js';
 import {logger} from '../../logger.js';
 import type {StorageBase} from '../../storage/base.js';
 import {getSafeHash} from '../../storage/base.js';
+import {extractShortId} from '../../url-utils.js';
 import {normaliseRequestLibraries} from '../library-utils.js';
 
 // CE shortlinks save the canonical "config" shape used by the web app, where each
@@ -167,9 +168,8 @@ export function registerShortlinkTools(
             openWorldHint: false,
         },
         async ({id}) => {
-            // Extract ID from URL if a full URL was provided
-            const match = id.match(/\/z\/([^/]+)$/);
-            const shortId = match ? match[1] : id;
+            // Extract the short id whether a full URL or a bare id was provided.
+            const shortId = extractShortId(id);
 
             try {
                 const result = await storageHandler.expandId(shortId);

--- a/lib/storage/remote.ts
+++ b/lib/storage/remote.ts
@@ -26,6 +26,7 @@ import * as express from 'express';
 
 import {logger} from '../logger.js';
 import {CompilerProps} from '../properties.js';
+import {extractShortId} from '../url-utils.js';
 import {ExpandedShortLink, StorageBase} from './base.js';
 
 export class StorageRemote extends StorageBase {
@@ -78,8 +79,8 @@ export class StorageRemote extends StorageBase {
             return;
         }
 
-        const relativeUrl = url.substring(url.lastIndexOf('/z/') + 1);
-        const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}${relativeUrl}`;
+        const shortId = extractShortId(url);
+        const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}z/${shortId}`;
 
         res.send({url: shortlink});
     }

--- a/lib/url-utils.ts
+++ b/lib/url-utils.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * Extract the short link id from a `/z/<id>` URL or path.
+ *
+ * Accepts a full URL (`https://godbolt.org/z/abc`), a path (`/z/abc`), or a
+ * bare id (`abc`), and correctly ignores query strings, fragments and trailing
+ * slashes — the pitfalls of the various ad-hoc `lastIndexOf('/z/')` / regex
+ * implementations this replaces.
+ */
+export function extractShortId(input: string): string {
+    let pathname = input;
+    try {
+        // Works for absolute URLs; throws for paths/bare ids.
+        pathname = new URL(input).pathname;
+    } catch {
+        // Not an absolute URL — treat the input as a path and drop any
+        // query string or fragment ourselves.
+        pathname = input.split(/[?#]/)[0];
+    }
+
+    const segments = pathname.split('/').filter(Boolean);
+    const zIdx = segments.lastIndexOf('z');
+    if (zIdx >= 0 && zIdx < segments.length - 1) {
+        return segments[zIdx + 1];
+    }
+    // No `/z/<id>` structure: fall back to the last path segment, or the
+    // original input if there were no segments at all.
+    return segments.at(-1) ?? input;
+}

--- a/test/url-utils-tests.ts
+++ b/test/url-utils-tests.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {describe, expect, it} from 'vitest';
+
+import {extractShortId} from '../lib/url-utils.js';
+
+describe('extractShortId', () => {
+    it('extracts the id from a full URL', () => {
+        expect(extractShortId('https://godbolt.org/z/abc')).toEqual('abc');
+    });
+
+    it('extracts the id from a path (generateShareableUrl shape)', () => {
+        expect(extractShortId('/z/abc')).toEqual('abc');
+    });
+
+    it('ignores query strings', () => {
+        expect(extractShortId('https://godbolt.org/z/abc?utm=foo')).toEqual('abc');
+        expect(extractShortId('/z/abc?utm=foo')).toEqual('abc');
+    });
+
+    it('ignores fragments', () => {
+        expect(extractShortId('https://godbolt.org/z/abc#section')).toEqual('abc');
+    });
+
+    it('ignores trailing slashes', () => {
+        expect(extractShortId('https://godbolt.org/z/abc/')).toEqual('abc');
+        expect(extractShortId('/z/abc/')).toEqual('abc');
+    });
+
+    it('handles a non-root httpRoot', () => {
+        expect(extractShortId('https://example.com/foo/z/abc')).toEqual('abc');
+    });
+
+    it('passes a bare id through unchanged', () => {
+        expect(extractShortId('abc')).toEqual('abc');
+    });
+});


### PR DESCRIPTION
Fixes #8645

## What
Three call sites extracted the short id from a `/z/<id>` URL with their own ad-hoc logic:
- `lib/handlers/noscript.ts` and `lib/storage/remote.ts` — `substring(lastIndexOf('/z/') + 1)`
- `lib/mcp/tools/shortlinks.ts` — `id.match(/\/z\/([^/]+)$/)`

Each mishandled query strings (`/z/abc?utm=foo`), fragments (`/z/abc#x`), and trailing slashes.

## Fix
Add `lib/url-utils.ts#extractShortId`, a single helper that handles a full URL, a path, or a bare id and strips query/fragment/trailing-slash. It is used at all three sites. Note `generateShareableUrl` returns a path (`/z/<hash>`), so the helper deliberately handles non-absolute inputs (a bare `new URL()` would throw there); the noscript/remote sites rebuild the link as `${httpRoot}z/${id}`.

## Tests
Added `test/url-utils-tests.ts` covering full URL, path, query string, fragment, trailing slash, non-root httpRoot, and bare id. `ts-check`, `biome`, and the related vitest suites pass locally.
