### PR TITLE
Bump RazorForge to 0.1.0, 0.1.1, and 0.2.0

### DIFF
--- a/etc/config/razorforge.amazon.properties
+++ b/etc/config/razorforge.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&razorforge
 compilerType=razorforge
-defaultCompiler=razorforge004
+defaultCompiler=razorforge010
 supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
-group.razorforge.compilers=razorforge004
+group.razorforge.compilers=razorforge010
 group.razorforge.isSemVer=true
 group.razorforge.baseName=razorforge
 
-compiler.razorforge004.semver=0.0.4-alpha
-compiler.razorforge004.exe=/opt/compiler-explorer/razorforge-0.0.4-alpha/RazorForge
+compiler.razorforge010.semver=0.1.0
+compiler.razorforge010.exe=/opt/compiler-explorer/razorforge-0.1.0/RazorForge

--- a/etc/config/razorforge.amazon.properties
+++ b/etc/config/razorforge.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&razorforge
 compilerType=razorforge
-defaultCompiler=razorforge011
+defaultCompiler=razorforge020
 supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
-group.razorforge.compilers=razorforge010:razorforge011
+group.razorforge.compilers=razorforge010:razorforge011:razorforge020
 group.razorforge.isSemVer=true
 group.razorforge.baseName=razorforge
 
@@ -12,3 +12,5 @@ compiler.razorforge010.semver=0.1.0
 compiler.razorforge010.exe=/opt/compiler-explorer/razorforge-0.1.0/RazorForge
 compiler.razorforge011.semver=0.1.1
 compiler.razorforge011.exe=/opt/compiler-explorer/razorforge-0.1.1/RazorForge
+compiler.razorforge020.semver=0.2.0
+compiler.razorforge020.exe=/opt/compiler-explorer/razorforge-0.2.0/RazorForge

--- a/etc/config/razorforge.amazon.properties
+++ b/etc/config/razorforge.amazon.properties
@@ -1,12 +1,14 @@
 compilers=&razorforge
 compilerType=razorforge
-defaultCompiler=razorforge010
+defaultCompiler=razorforge011
 supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
-group.razorforge.compilers=razorforge010
+group.razorforge.compilers=razorforge010:razorforge011
 group.razorforge.isSemVer=true
 group.razorforge.baseName=razorforge
 
 compiler.razorforge010.semver=0.1.0
 compiler.razorforge010.exe=/opt/compiler-explorer/razorforge-0.1.0/RazorForge
+compiler.razorforge011.semver=0.1.1
+compiler.razorforge011.exe=/opt/compiler-explorer/razorforge-0.1.1/RazorForge

--- a/etc/config/razorforge.defaults.properties
+++ b/etc/config/razorforge.defaults.properties
@@ -5,4 +5,4 @@ supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
 compiler.razorforgedefault.name=RazorForge
-compiler.razorforgedefault.exe=/opt/compiler-explorer/razorforge-0.1.1/RazorForge
+compiler.razorforgedefault.exe=/opt/compiler-explorer/razorforge-0.2.0/RazorForge

--- a/etc/config/razorforge.defaults.properties
+++ b/etc/config/razorforge.defaults.properties
@@ -5,4 +5,4 @@ supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
 compiler.razorforgedefault.name=RazorForge
-compiler.razorforgedefault.exe=/opt/compiler-explorer/razorforge-0.1.0/RazorForge
+compiler.razorforgedefault.exe=/opt/compiler-explorer/razorforge-0.1.1/RazorForge

--- a/etc/config/razorforge.defaults.properties
+++ b/etc/config/razorforge.defaults.properties
@@ -5,4 +5,4 @@ supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
 compiler.razorforgedefault.name=RazorForge
-compiler.razorforgedefault.exe=/opt/compiler-explorer/razorforge-0.0.4-alpha/RazorForge
+compiler.razorforgedefault.exe=/opt/compiler-explorer/razorforge-0.1.0/RazorForge


### PR DESCRIPTION
Bumps the RazorForge compiler from `0.0.4-alpha` to the `0.1.0` release (initial support added in #8825).

v0.1.0 is the first stable (non-`-alpha`) tag, so the install path drops the `-alpha` suffix:
`/opt/compiler-explorer/razorforge-0.0.4-alpha/RazorForge` → `/opt/compiler-explorer/razorforge-0.1.0/RazorForge`.

The matching install recipe is in compiler-explorer/infra#2192 (tarball URL verified `200`).