### PR TITLE
Fix #8585: update riscv objdumper paths

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1282,7 +1282,7 @@ group.rvclang.debugPatched=true
 
 group.rv32clang.compilers=rv32-clang:rv32-clang2210:rv32-clang2110:rv32-clang2010:rv32-clang1910:rv32-clang1810:rv32-clang1701:rv32-clang1600:rv32-clang1500:rv32-clang1400:rv32-clang1301:rv32-clang1300:rv32-clang1201:rv32-clang1200:rv32-clang1101:rv32-clang1100:rv32-clang1001:rv32-clang1000:rv32-clang901:rv32-clang900
 group.rv32clang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
-group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+group.rv32clang.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 group.rv32clang.baseName=RISC-V rv32gc clang
 group.rv32clang.groupName=RISC-V 32 Clang
 group.rv32clang.compilerCategories=clang
@@ -1290,19 +1290,15 @@ group.rv32clang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.rv32-clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.rv32-clang900.semver=9.0.0
-compiler.rv32-clang900.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang900.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang++
 compiler.rv32-clang901.semver=9.0.1
-compiler.rv32-clang901.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang901.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
 compiler.rv32-clang1000.semver=10.0.0
-compiler.rv32-clang1000.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1000.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang++
 compiler.rv32-clang1001.semver=10.0.1
-compiler.rv32-clang1001.objdumper=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
 compiler.rv32-clang1001.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-8.2.0/riscv32-unknown-elf
 compiler.rv32-clang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang++
 compiler.rv32-clang1100.semver=11.0.0
@@ -1340,14 +1336,14 @@ compiler.rv32-clang2210.semver=22.1.0
 compiler.rv32-clang2210.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
 compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv32-clang.semver=(trunk)
-compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-clang.isNightly=true
 compiler.rv32-clang.alias=rv32clang
 compiler.rv32-clang.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
 
 group.rv64clang.compilers=rv64-clang:rv64-clang2210:rv64-clang2110:rv64-clang2010:rv64-clang1910:rv64-clang1810:rv64-clang1701:rv64-clang1600:rv64-clang1500:rv64-clang1400:rv64-clang1301:rv64-clang1300:rv64-clang1201:rv64-clang1200:rv64-clang1101:rv64-clang1100:rv64-clang1001:rv64-clang1000:rv64-clang901:rv64-clang900
 group.rv64clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-10.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+group.rv64clang.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64clang.baseName=RISC-V rv64gc clang
 group.rv64clang.groupName=RISC-V 64 Clang
 group.rv64clang.compilerCategories=clang
@@ -1405,7 +1401,7 @@ compiler.rv64-clang2210.semver=22.1.0
 compiler.rv64-clang2210.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv64-clang.semver=(trunk)
-compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.isNightly=true
 compiler.rv64-clang.alias=rv64clang
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1400,7 +1400,6 @@ compiler.rv64-clang2210.semver=22.1.0
 compiler.rv64-clang2210.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-15.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv64-clang.semver=(trunk)
-compiler.rv64-clang.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-clang.isNightly=true
 compiler.rv64-clang.alias=rv64clang
 compiler.rv64-clang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-14.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1336,7 +1336,6 @@ compiler.rv32-clang2210.semver=22.1.0
 compiler.rv32-clang2210.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-15.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot
 compiler.rv32-clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.rv32-clang.semver=(trunk)
-compiler.rv32-clang.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 compiler.rv32-clang.isNightly=true
 compiler.rv32-clang.alias=rv32clang
 compiler.rv32-clang.options=-target riscv32-unknown-linux-gnu -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv32/gcc-14.2.0/riscv32-unknown-linux-gnu/riscv32-unknown-linux-gnu/sysroot

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -942,7 +942,7 @@ group.rvcclang.compilerCategories=clang
 
 group.rv32cclang.compilers=rv32-cclang:rv32-cclang2210:rv32-cclang2110:rv32-cclang2010:rv32-cclang1910:rv32-cclang1810:rv32-cclang1701:rv32-cclang1600:rv32-cclang1500:rv32-cclang1400:rv32-cclang1301:rv32-cclang1300:rv32-cclang1200:rv32-cclang1201:rv32-cclang1101:rv32-cclang1100:rv32-cclang1001:rv32-cclang1000:rv32-cclang901:rv32-cclang900
 group.rv32cclang.options=-target riscv32-unknown-elf -march=rv32gc -mabi=ilp32d --gcc-toolchain=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf
-group.rv32cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-10.2.0/riscv32-unknown-elf/bin/riscv32-unknown-elf-objdump
+group.rv32cclang.objdumper=/opt/compiler-explorer/riscv32/gcc-16.1.0/riscv32-unknown-linux-gnu/bin/riscv32-unknown-linux-gnu-objdump
 group.rv32cclang.baseName=RISC-V rv32gc clang
 group.rv32cclang.groupName=RISC-V 32 Clang
 group.rv32cclang.licenseName=LLVM Apache 2
@@ -1004,7 +1004,7 @@ compiler.rv32-cclang.isNightly=true
 
 group.rv64cclang.compilers=rv64-cclang:rv64-cclang2210:rv64-cclang2110:rv64-cclang2010:rv64-cclang1910:rv64-cclang1810:rv64-cclang1701:rv64-cclang1600:rv64-cclang1500:rv64-cclang1400:rv64-cclang1301:rv64-cclang1300:rv64-cclang1200:rv64-cclang1201:rv64-cclang1101:rv64-cclang1100:rv64-cclang1001:rv64-cclang1000:rv64-cclang901:rv64-cclang900
 group.rv64cclang.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
-group.rv64cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
+group.rv64cclang.objdumper=/opt/compiler-explorer/riscv64/gcc-16.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 group.rv64cclang.baseName=RISC-V rv64gc clang
 group.rv64cclang.groupName=RISC-V 64 Clang
 group.rv64cclang.compilerCategories=clang
@@ -1012,19 +1012,15 @@ group.rv64cclang.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 
 compiler.rv64-cclang900.semver=9.0.0
 compiler.rv64-cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
-compiler.rv64-cclang900.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang900.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-cclang901.semver=9.0.1
 compiler.rv64-cclang901.exe=/opt/compiler-explorer/clang-9.0.1/bin/clang
-compiler.rv64-cclang901.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang901.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
 compiler.rv64-cclang1000.semver=10.0.0
-compiler.rv64-cclang1000.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang1000.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-cclang1001.exe=/opt/compiler-explorer/clang-10.0.1/bin/clang
 compiler.rv64-cclang1001.semver=10.0.1
-compiler.rv64-cclang1001.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 compiler.rv64-cclang1001.options=-target riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d --gcc-toolchain=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu --sysroot=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/riscv64-unknown-linux-gnu/sysroot
 compiler.rv64-cclang1100.exe=/opt/compiler-explorer/clang-11.0.0/bin/clang
 compiler.rv64-cclang1100.semver=11.0.0


### PR DESCRIPTION
Updated to gcc 16.1.0 (not trunk), for all riscv versions not explicitly stating an earlier one
