### PR TITLE
Accept GoldenLayout format in /clientstate/ URLs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -383,9 +383,54 @@ If JSON is present in the request's `Accept` header, the compilation results are
 
 ### `POST /api/shortener` - saves given state _forever_ to a shortlink and returns the unique id for the link
 
-The body of this post should be in the format of a [ClientState](../lib/clientstate.ts) Be sure that the Content-Type of
-your post is application/json. The body must be a JSON object (e.g. `{"sessions": [...]}`); a JSON string at the top
+Be sure that the Content-Type of your post is application/json. The body must be a JSON object; a JSON string at the top
 level is not accepted.
+
+The state you save is either of two objects:
+
+- a [ClientState](../lib/clientstate.ts) (`{"sessions": [...]}`), which describes the editors, compilers, and executors
+  without pinning a particular window arrangement, or
+- a **GoldenLayout** (`{"content": [...]}`), which additionally captures a full custom panel layout.
+
+Post that state object directly as the body. It is the exact object that gets stored and later delivered when the
+shortlink is opened (via `/z/<id>`), and it is the same state object accepted by `/clientstate/<base64>` (there it is
+base64-encoded in the URL rather than sent in a POST body).
+
+You may optionally wrap the state object under a top-level `config` key (`{"config": <state>}`); only the value of
+`config` is stored. This wrapper is what the site itself sends when you create a short link from the UI (its state is a
+GoldenLayout captured from the current layout), and it is accepted for both forms.
+
+To save a client state _with a layout_, post a GoldenLayout. This one stacks an editor above its compiler in a single
+column (the compiler's `source` refers to the editor's `id`):
+
+```JSON
+{
+  "content": [
+    {
+      "type": "column",
+      "content": [
+        {
+          "type": "component",
+          "componentName": "codeEditor",
+          "componentState": {"id": 1, "lang": "c++", "source": "int square(int n) { return n * n; }"}
+        },
+        {
+          "type": "component",
+          "componentName": "compiler",
+          "componentState": {
+            "id": 1,
+            "source": 1,
+            "lang": "c++",
+            "compiler": "g82",
+            "options": "-O2",
+            "filters": {"intel": true, "demangle": true}
+          }
+        }
+      ]
+    }
+  ]
+}
+```
 
 **⚠️ Important: Shell Escaping**
 
@@ -465,11 +510,11 @@ etcetera, otherwise `<sourceid>` can be set to 1.
 
 ### `GET /clientstate/<base64>` - Opens the website in a given state
 
-This call is to open the website with a given state (without having to store the state first with /api/shortener)
-Instead of sending the ClientState JSON in the post body, it will have to be encoded with base64 and attached directly
-onto the URL. It is possible to compress the JSON string with the zlib deflate method (compression used by gzip;
-available for many programming languages like [javascript](https://nodejs.org/api/zlib.html)). It is automatically
-detected.
+This call is to open the website with a given state (without having to store the state first with /api/shortener). The
+state is the same object described under `POST /api/shortener` above; here it is encoded with base64 and attached
+directly onto the URL instead of being sent in a POST body. It is possible to compress the JSON string with the zlib
+deflate method (compression used by gzip; available for many programming languages like
+[javascript](https://nodejs.org/api/zlib.html)). It is automatically detected.
 
 To avoid problems in reading base64 by the API, some characters must be kept in unicode. Therefore, before calling the
 API, it is necessary to replace these characters with their respective unicodes. A suggestion is to use the Regex
@@ -477,9 +522,10 @@ expression `/[\u007F-\uFFFF]/g` that allows mapping these characters.
 
 ### `GET /noscript/clientstate/<base64>` - Opens the noscript version of the website in a given state
 
-This is the noscript equivalent of `/clientstate/<base64>`. It opens the noscript version of the website with a given
-state. The base64-encoded ClientState JSON works the same way as the regular `/clientstate/`
-endpoint.
+This is the noscript equivalent of `/clientstate/<base64>`, and accepts the same base64-encoded state in the same way.
+
+Because the noscript version renders a simplified static page, a custom GoldenLayout panel arrangement is not preserved;
+the layout is flattened to its editors, compilers, and executors.
 
 # Implementations
 

--- a/lib/clientstate-normalizer.ts
+++ b/lib/clientstate-normalizer.ts
@@ -22,6 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import zlib from 'node:zlib';
+
 import {assert} from './assert.js';
 import {
     ClientState,
@@ -31,6 +33,7 @@ import {
     ClientStateSession,
     ClientStateTree,
 } from './clientstate.js';
+import {logger} from './logger.js';
 
 type BasicGoldenLayoutStruct = {
     type: string;
@@ -1391,4 +1394,62 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
             }
         }
     }
+}
+
+// Decode a base64/inline client-state buffer into a raw config object, transparently
+// inflating it first if it was compressed with zlib deflate (as used by gzip).
+export function extractJsonFromBufferAndInflateIfRequired(buffer: Buffer): any {
+    const firstByte = buffer.at(0); // for uncompressed data this is probably '{'
+    const isGzipUsed = firstByte !== undefined && (firstByte & 0x0f) === 0x8; // https://datatracker.ietf.org/doc/html/rfc1950, https://datatracker.ietf.org/doc/html/rfc1950, for '{' this yields 11
+
+    let jsonString: string;
+    if (isGzipUsed) {
+        try {
+            jsonString = zlib.inflateSync(buffer).toString();
+        } catch (inflateError) {
+            logger.debug('Failed to inflate gzipped buffer, falling back to raw buffer', inflateError);
+            jsonString = buffer.toString();
+        }
+    } else {
+        jsonString = buffer.toString();
+    }
+
+    try {
+        return JSON.parse(jsonString);
+    } catch (parseError) {
+        logger.debug('Failed to parse JSON from client state', {
+            error: parseError,
+            jsonString: jsonString.substring(0, 100) + (jsonString.length > 100 ? '...' : ''),
+            bufferLength: buffer.length,
+        });
+        const errorMessage = parseError instanceof Error ? parseError.message : 'Unknown parsing error';
+        throw new Error(`Invalid JSON in client state: ${errorMessage}`);
+    }
+}
+
+// Goldenify a fully-constructed ClientState into its default GoldenLayout representation.
+export function goldenLayoutFromClientState(state: ClientState): GoldenLayoutRootStruct {
+    const goldenifier = new ClientStateGoldenifier();
+    goldenifier.fromClientState(state);
+    return goldenifier.golden;
+}
+
+// Interpret a raw config (either GoldenLayout `{content}` or ClientState `{sessions}`)
+// as a GoldenLayout, passing GoldenLayout through unchanged.
+export function configToGoldenLayout(config: any): GoldenLayoutRootStruct {
+    if (config.content) {
+        return config;
+    }
+    return goldenLayoutFromClientState(new ClientState(config));
+}
+
+// Interpret a raw config (either GoldenLayout `{content}` or ClientState `{sessions}`)
+// as a ClientState, normalizing GoldenLayout back into sessions.
+export function configToClientState(config: any): ClientState {
+    if (config.content) {
+        const normalizer = new ClientStateNormalizer();
+        normalizer.fromGoldenLayout(config);
+        return normalizer.normalized;
+    }
+    return new ClientState(config);
 }

--- a/lib/handlers/noscript.ts
+++ b/lib/handlers/noscript.ts
@@ -28,7 +28,7 @@ import {LanguageKey} from '../../types/languages.interfaces.js';
 import {isMobileViewer} from '../app/url-handlers.js';
 import {unwrapString} from '../assert.js';
 import {ClientState} from '../clientstate.js';
-import {ClientStateNormalizer} from '../clientstate-normalizer.js';
+import {configToClientState, extractJsonFromBufferAndInflateIfRequired} from '../clientstate-normalizer.js';
 import {logger} from '../logger.js';
 import {ClientOptionsHandler} from '../options-handler.js';
 import {getSafeHash, StorageBase} from '../storage/index.js';
@@ -55,7 +55,7 @@ export class NoScriptHandler {
                 /^\/noscript\/clientstate\/(?<clientstatebase64>.*)/,
                 cached,
                 csp,
-                this.clientStateHandlerNoScript.bind(this),
+                this.unstoredStateHandlerNoScript.bind(this),
             )
             .get('/noscript/sponsors', cached, csp, (req, res) => {
                 res.render(
@@ -81,17 +81,7 @@ export class NoScriptHandler {
         this.storageHandler
             .expandId(id)
             .then(result => {
-                const config = JSON.parse(result.config);
-
-                let clientstate: ClientState;
-                if (config.content) {
-                    const normalizer = new ClientStateNormalizer();
-                    normalizer.fromGoldenLayout(config);
-
-                    clientstate = normalizer.normalized;
-                } else {
-                    clientstate = new ClientState(config);
-                }
+                const clientstate = configToClientState(JSON.parse(result.config));
 
                 this.renderNoScriptLayout(clientstate, req, res);
 
@@ -108,11 +98,11 @@ export class NoScriptHandler {
             });
     }
 
-    clientStateHandlerNoScript(req: express.Request, res: express.Response, next: express.NextFunction) {
+    unstoredStateHandlerNoScript(req: express.Request, res: express.Response, next: express.NextFunction) {
         try {
             const buffer = Buffer.from(unwrapString(req.params.clientstatebase64), 'base64');
-            const config = JSON.parse(buffer.toString());
-            const clientstate = new ClientState(config);
+            const config = extractJsonFromBufferAndInflateIfRequired(buffer);
+            const clientstate = configToClientState(config);
 
             this.renderNoScriptLayout(clientstate, req, res);
         } catch (err) {

--- a/lib/handlers/route-api.ts
+++ b/lib/handlers/route-api.ts
@@ -22,14 +22,18 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import zlib from 'node:zlib';
-
 import express from 'express';
 
 import {Language} from '../../types/languages.interfaces.js';
 import {unwrap, unwrapString} from '../assert.js';
 import {ClientState} from '../clientstate.js';
-import {ClientStateGoldenifier, ClientStateNormalizer} from '../clientstate-normalizer.js';
+import {
+    ClientStateNormalizer,
+    configToClientState,
+    configToGoldenLayout,
+    extractJsonFromBufferAndInflateIfRequired,
+    goldenLayoutFromClientState,
+} from '../clientstate-normalizer.js';
 import {logger} from '../logger.js';
 import {setupMcpEndpoint} from '../mcp/index.js';
 import {SentryCapture} from '../sentry.js';
@@ -88,17 +92,7 @@ export class RouteAPI {
         this.storageHandler
             .expandId(id)
             .then(result => {
-                const config = JSON.parse(result.config);
-
-                let clientstate: ClientState | null;
-                if (config.content) {
-                    const normalizer = new ClientStateNormalizer();
-                    normalizer.fromGoldenLayout(config);
-
-                    clientstate = normalizer.normalized;
-                } else {
-                    clientstate = new ClientState(config);
-                }
+                const clientstate = configToClientState(JSON.parse(result.config));
 
                 const session = clientstate.findSessionById(sessionid);
                 if (!session) throw {msg: `Session ${sessionid} doesn't exist in this shortlink`};
@@ -122,10 +116,7 @@ export class RouteAPI {
         this.storageHandler
             .expandId(id)
             .then(result => {
-                let config = JSON.parse(result.config);
-                if (config.sessions) {
-                    config = this.getGoldenLayoutFromClientState(new ClientState(config));
-                }
+                const config = configToGoldenLayout(JSON.parse(result.config));
                 const metadata = this.getMetaDataFromLink(req, result, config);
                 this.renderGoldenLayout(config, metadata, req, res);
                 // And finally, increment the view count
@@ -145,19 +136,13 @@ export class RouteAPI {
             });
     }
 
-    getGoldenLayoutFromClientState(state: ClientState) {
-        const goldenifier = new ClientStateGoldenifier();
-        goldenifier.fromClientState(state);
-        return goldenifier.golden;
-    }
-
     unstoredStateHandler(req: express.Request, res: express.Response, next: express.NextFunction) {
         let clientstatebase64: string | undefined;
         try {
             clientstatebase64 = unwrapString(req.params.clientstatebase64);
             const buffer = Buffer.from(clientstatebase64, 'base64');
             const state = extractJsonFromBufferAndInflateIfRequired(buffer);
-            const config = this.getGoldenLayoutFromClientState(new ClientState(state));
+            const config = configToGoldenLayout(state);
             const metadata = this.getMetaDataFromLink(req, null, config);
 
             this.renderGoldenLayout(config, metadata, req, res);
@@ -191,7 +176,7 @@ export class RouteAPI {
         req: express.Request,
         res: express.Response,
     ) {
-        const config = this.getGoldenLayoutFromClientState(clientstate);
+        const config = goldenLayoutFromClientState(clientstate);
 
         this.renderGoldenLayout(config, metadata, req, res);
     }
@@ -201,15 +186,7 @@ export class RouteAPI {
         this.storageHandler
             .expandId(id)
             .then(result => {
-                let config = JSON.parse(result.config);
-
-                if (config.content) {
-                    const normalizer = new ClientStateNormalizer();
-                    normalizer.fromGoldenLayout(config);
-                    config = normalizer.normalized;
-                } else {
-                    config = new ClientState(config);
-                }
+                const config = configToClientState(JSON.parse(result.config));
 
                 const metadata = this.getMetaDataFromLink(req, result, config);
                 this.renderClientState(config, metadata, req, res);
@@ -304,34 +281,5 @@ export class RouteAPI {
         }
 
         return metadata;
-    }
-}
-
-export function extractJsonFromBufferAndInflateIfRequired(buffer: Buffer): any {
-    const firstByte = buffer.at(0); // for uncompressed data this is probably '{'
-    const isGzipUsed = firstByte !== undefined && (firstByte & 0x0f) === 0x8; // https://datatracker.ietf.org/doc/html/rfc1950, https://datatracker.ietf.org/doc/html/rfc1950, for '{' this yields 11
-
-    let jsonString: string;
-    if (isGzipUsed) {
-        try {
-            jsonString = zlib.inflateSync(buffer).toString();
-        } catch (inflateError) {
-            logger.debug('Failed to inflate gzipped buffer, falling back to raw buffer', inflateError);
-            jsonString = buffer.toString();
-        }
-    } else {
-        jsonString = buffer.toString();
-    }
-
-    try {
-        return JSON.parse(jsonString);
-    } catch (parseError) {
-        logger.debug('Failed to parse JSON from client state', {
-            error: parseError,
-            jsonString: jsonString.substring(0, 100) + (jsonString.length > 100 ? '...' : ''),
-            bufferLength: buffer.length,
-        });
-        const errorMessage = parseError instanceof Error ? parseError.message : 'Unknown parsing error';
-        throw new Error(`Invalid JSON in client state: ${errorMessage}`);
     }
 }

--- a/lib/storage/base.ts
+++ b/lib/storage/base.ts
@@ -97,11 +97,15 @@ export function getSafeHash(inputConfig: Record<string, any>) {
     return {config, configHash};
 }
 
-function configFor(req: express.Request) {
+// Extract the state object to store from a shortener POST. The state may be a
+// ClientState ({sessions}) or a GoldenLayout ({content}), posted either bare or
+// wrapped under an optional `config` key. It is the (unwrapped) state object
+// that gets stored and later delivered via /z/ and /clientstate.
+export function configFor(req: express.Request) {
     if (req.body.config) {
         return req.body.config;
     }
-    if (req.body.sessions) {
+    if (req.body.sessions || req.body.content) {
         return req.body;
     }
     return null;

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -26,6 +26,6 @@ import {makeKeyedTypeGetter} from '../keyed-type.js';
 import * as all from './_all.js';
 
 export * from './_all.js';
-export {encodeBuffer, getSafeHash, isCleanText, StorageBase} from './base.js';
+export {configFor, encodeBuffer, getSafeHash, isCleanText, StorageBase} from './base.js';
 
 export const getStorageTypeByKey = makeKeyedTypeGetter('storage', all);

--- a/test/handlers/noscript-tests.ts
+++ b/test/handlers/noscript-tests.ts
@@ -22,6 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import zlib from 'node:zlib';
+
 import express from 'express';
 import request from 'supertest';
 import {beforeAll, describe, expect, it} from 'vitest';
@@ -78,6 +80,37 @@ describe('NoScriptHandler clientstate', () => {
             ],
         };
         const encoded = Buffer.from(JSON.stringify(clientstate)).toString('base64');
+        const response = await request(app).get(`/noscript/clientstate/${encoded}`);
+        expect(response.status).toBe(200);
+    });
+
+    it('should return 200 for GoldenLayout format in /noscript/clientstate', async () => {
+        const goldenLayout = {
+            content: [
+                {
+                    type: 'column',
+                    content: [],
+                },
+            ],
+        };
+        const encoded = Buffer.from(JSON.stringify(goldenLayout)).toString('base64');
+        const response = await request(app).get(`/noscript/clientstate/${encoded}`);
+        expect(response.status).toBe(200);
+    });
+
+    it('should return 200 for gzip-compressed clientstate', async () => {
+        const clientstate = {
+            sessions: [
+                {
+                    id: 1,
+                    language: 'c++',
+                    source: 'int main() { return 0; }',
+                    compilers: [{id: 'g121', options: ''}],
+                },
+            ],
+        };
+        const compressed = zlib.deflateSync(Buffer.from(JSON.stringify(clientstate)));
+        const encoded = compressed.toString('base64');
         const response = await request(app).get(`/noscript/clientstate/${encoded}`);
         expect(response.status).toBe(200);
     });

--- a/test/handlers/route-api-test.ts
+++ b/test/handlers/route-api-test.ts
@@ -28,9 +28,9 @@ import express from 'express';
 import request from 'supertest';
 import {beforeAll, describe, expect, it} from 'vitest';
 
-import {GoldenLayoutRootStruct} from '../../lib/clientstate-normalizer.js';
+import {extractJsonFromBufferAndInflateIfRequired, GoldenLayoutRootStruct} from '../../lib/clientstate-normalizer.js';
 import {HandlerConfig, ShortLinkMetaData} from '../../lib/handlers/handler.interfaces.js';
-import {extractJsonFromBufferAndInflateIfRequired, RouteAPI} from '../../lib/handlers/route-api.js';
+import {RouteAPI} from '../../lib/handlers/route-api.js';
 
 function possibleCompression(buffer: Buffer): boolean {
     // code used in extractJsonFromBufferAndInflateIfRequired
@@ -184,5 +184,18 @@ describe('clientStateHandler', () => {
         const corruptGzipData = Buffer.from([0x18, 0x01, 0x02, 0x03]).toString('base64');
         const response = await request(app).get(`/clientstate/${corruptGzipData}`);
         expect(response.status).toBe(400);
+    });
+    it('should return 200 for GoldenLayout format in /clientstate', async () => {
+        const goldenLayout = {
+            content: [
+                {
+                    type: 'column',
+                    content: [],
+                },
+            ],
+        };
+        const document = Buffer.from(JSON.stringify(goldenLayout), 'utf-8').toString('base64');
+        const response = await request(app).get(`/clientstate/${document}`);
+        expect(response.status).toBe(200);
     });
 });

--- a/test/storage/storage-tests.ts
+++ b/test/storage/storage-tests.ts
@@ -24,7 +24,7 @@
 
 import {describe, expect, it} from 'vitest';
 
-import {encodeBuffer, getSafeHash, isCleanText} from '../../lib/storage/index.js';
+import {configFor, encodeBuffer, getSafeHash, isCleanText} from '../../lib/storage/index.js';
 
 describe('Hash tests', () => {
     // afterEach(() => restore());
@@ -82,5 +82,27 @@ describe('Hash tests', () => {
         getSafeHash(testCase);
         expect(JSON.stringify(testCase)).toBe(before);
         expect(testCase).not.toHaveProperty('nonce');
+    });
+});
+
+describe('configFor', () => {
+    it('unwraps a config-wrapped state object', () => {
+        const state = {content: [{type: 'column', content: []}]};
+        expect(configFor({body: {config: state}} as any)).toBe(state);
+    });
+
+    it('accepts a bare ClientState', () => {
+        const body = {sessions: [{id: 1}]};
+        expect(configFor({body} as any)).toBe(body);
+    });
+
+    it('accepts a bare GoldenLayout', () => {
+        const body = {content: [{type: 'column', content: []}]};
+        expect(configFor({body} as any)).toBe(body);
+    });
+
+    it('returns null when no recognizable state is present', () => {
+        expect(configFor({body: {}} as any)).toBeNull();
+        expect(configFor({body: {something: 'else'}} as any)).toBeNull();
     });
 });


### PR DESCRIPTION
The /z/ stored-link handler already supports both ClientState (sessions-based) and GoldenLayout (content-based) JSON formats, but the /clientstate/ endpoint only accepted ClientState and always converted it to GoldenLayout using the default layout.

Extract a shared configToGoldenLayout() method that checks for a 'content' key (GoldenLayout format) and passes it through directly, or converts from ClientState otherwise.  Both storedStateHandler and unstoredStateHandler now use this method, making the two endpoints consistent in what formats they accept.

This allows /clientstate/ URLs to carry full GoldenLayout state including custom panel layouts (e.g., editor-on-top with conformance view below), which was previously only possible via stored /z/ links.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
