### PR TITLE
Add Tenstorrent SFPI RISC-V backend compiler to Compiler Explorer

### DIFF
--- a/etc/config/c++.tenstorrent.properties
+++ b/etc/config/c++.tenstorrent.properties
@@ -5,10 +5,6 @@ type=tenstorrent
 lang=c++
 env.TT_METAL_HOME=${TT_METAL_HOME}
 defaultCompileFlags=-march=rv32imf -mabi=ilp32f -O2 -c -S -fno-asynchronous-unwind-tables -fno-exceptions -fno-rtti
-includePath=${TT_METAL_HOME}/include
-includePath=${TT_METAL_HOME}/tt_metal/include
-includePath=${TT_METAL_HOME}/tt_metal/include/compute_kernel_api
-includePath=${TT_METAL_HOME}/tt_metal/include/hw
 supportsLinker=false
 syntaxHighlight=riscv
 group=Tenstorrent

--- a/etc/config/c++.tenstorrent.properties
+++ b/etc/config/c++.tenstorrent.properties
@@ -1,0 +1,20 @@
+id=riscv-tt-elf-g++-sfpi
+name=Tenstorrent SFPI (RISC-V 32-bit)
+exe=${TT_METAL_HOME}/bin/riscv-tt-elf-g++
+type=tenstorrent
+lang=c++
+env.TT_METAL_HOME=${TT_METAL_HOME}
+defaultCompileFlags=-march=rv32imf -mabi=ilp32f -O2 -c -S -fno-asynchronous-unwind-tables -fno-exceptions -fno-rtti
+includePath=${TT_METAL_HOME}/include
+includePath=${TT_METAL_HOME}/tt_metal/include
+includePath=${TT_METAL_HOME}/tt_metal/include/compute_kernel_api
+includePath=${TT_METAL_HOME}/tt_metal/include/hw
+supportsLinker=false
+syntaxHighlight=riscv
+group=Tenstorrent
+supportsCfg=true
+supportsBinary=false
+hasAssembler=true
+compileTimeoutMs=30000
+maxOutputSize=10485760
+compilationStrategy=file

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -168,6 +168,7 @@ export {SwayCompiler} from './sway.js';
 export {SwiftCompiler} from './swift.js';
 export {TableGenCompiler} from './tablegen.js';
 export {TenDRACompiler} from './tendra.js';
+export {TenstorrentCompiler} from './tenstorrent.js';
 export {TIC2000} from './tic2000.js';
 export {TinyCCompiler} from './tinyc.js';
 export {TinyGoCompiler} from './tinygo.js';

--- a/lib/compilers/index.ts
+++ b/lib/compilers/index.ts
@@ -28,3 +28,4 @@ import * as all from './_all.js';
 export * from './_all.js';
 
 export const getCompilerTypeByKey = makeKeyedTypeGetter('compiler', all);
+

--- a/lib/compilers/tenstorrent.ts
+++ b/lib/compilers/tenstorrent.ts
@@ -1,0 +1,140 @@
+/**
+ * Compiler Explorer Driver for Tenstorrent SFPI RISC-V Toolchain
+ * Patched and production-optimized for tt-metal Issue #46364
+ */
+
+import { BaseCompiler } from '../base-compiler.js';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export class TenstorrentCompiler extends BaseCompiler {
+    private ttMetalHome: string;
+    private includePaths: string[];
+
+    constructor(info: any, env: any) {
+        super(info, env);
+
+        // Detect tt-metal installation path dynamically
+        this.ttMetalHome = process.env.TT_METAL_HOME || '/opt/tt-metal';
+
+        // Build default include paths for Tenstorrent core headers
+        this.includePaths = [
+            path.join(this.ttMetalHome, 'include'),
+            path.join(this.ttMetalHome, 'tt_metal/include'),
+            path.join(this.ttMetalHome, 'tt_metal/include/compute_kernel_api'),
+            path.join(this.ttMetalHome, 'tt_metal/include/hw'),
+        ];
+    }
+
+    /**
+     * Intercepts compilation filters if needed.
+     */
+    override optionsForFilter(filters: any, outputFilename: string): string[] {
+        return [];
+    }
+
+    /**
+     * Injects custom Tenstorrent headers and enforces assembly generation layout (-S).
+     */
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: any,
+        filters?: any,
+    ): Promise<any> {
+        
+        // Ensure options array copy
+        const modifiedOptions = [...options];
+
+        // Intercept and inject required structural headers
+        for (const includePath of this.includePaths) {
+            if (fs.existsSync(includePath)) {
+                modifiedOptions.push(`-I${includePath}`);
+            }
+        }
+
+        // Ensure default 32-bit architecture matching Tensix engine specs
+        if (!modifiedOptions.some((o) => o.startsWith('-march'))) {
+            modifiedOptions.push('-march=rv32imf');
+        }
+        if (!modifiedOptions.some((o) => o.startsWith('-O'))) {
+            modifiedOptions.push('-O2');
+        }
+
+        // Enforce assembly output targets
+        if (!modifiedOptions.includes('-S')) modifiedOptions.push('-S');
+        if (!modifiedOptions.includes('-c')) modifiedOptions.push('-c');
+
+        // Determine output filename dynamically from the file context configuration
+        const outputFilename = this.getOutputFilename(path.dirname(inputFilename), '');
+
+        // Delegate execution to base compiler context
+        const result = await super.runCompiler(compiler, modifiedOptions, inputFilename, execOptions, filters);
+
+        // Process assembly file from disk if compilation succeeded
+        if (result.code === 0 && fs.existsSync(outputFilename)) {
+            const rawAsm = fs.readFileSync(outputFilename, 'utf8');
+            const processedLines = this.normalizeAssemblyOutput(rawAsm);
+            
+            // Write clean assembly back to disk
+            fs.writeFileSync(outputFilename, processedLines.map(l => l.text).join('\n'), 'utf8');
+            
+            // Update structural stdout for the web UI display response
+            result.stdout = processedLines;
+        }
+
+        return result;
+    }
+
+    /**
+     * Normalizes assembly, clears out compiler bookkeeping noise (.SFPREPLAY) and annotates vector logic.
+     */
+    private normalizeAssemblyOutput(rawAssembly: string): any[] {
+        const lines = rawAssembly.split('\n');
+        const normalized: any[] = [];
+        const seenLabels = new Set<string>();
+
+        for (let i = 0; i < lines.length; i++) {
+            let line = lines[i];
+
+            // 1. Strip SFPREPLAY directives completely
+            if (/^\s*\.SFPREPLAY\s+/.test(line)) {
+                continue;
+            }
+
+            // 2. Preserve and tag custom vector structural elements
+            if (/^\s*(v_if|v_endif|v_else)\b/.test(line)) {
+                normalized.push({ text: `${line.trimEnd()} # Tensix vector control flow` });
+                continue;
+            }
+
+            // 3. Deduplicate duplicate label compiler artifacts
+            const labelMatch = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:/);
+            if (labelMatch) {
+                const labelName = labelMatch[1];
+                if (seenLabels.has(labelName)) {
+                    continue;
+                }
+                seenLabels.add(labelName);
+            }
+
+            // 4. Content Cleanup & Metadata Annotations
+            line = line.replace(/^\s+/, '').replace(/\s+$/, '');
+            if (line.length === 0) {
+                if (normalized.length > 0 && normalized[normalized.length - 1].text !== '') {
+                    normalized.push({ text: '' });
+                }
+                continue;
+            }
+
+            if (/\b(vFloat|vInt|vInt32|vUint32)\b/.test(line)) {
+                line = `${line} # Tensix vector type`;
+            }
+
+            normalized.push({ text: line });
+        }
+
+        return normalized;
+    }
+}

--- a/lib/compilers/tenstorrent.ts
+++ b/lib/compilers/tenstorrent.ts
@@ -3,9 +3,10 @@
  * Patched and production-optimized for tt-metal Issue #46364
  */
 
-import { BaseCompiler } from '../base-compiler.js';
-import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {BaseCompiler} from '../base-compiler.js';
 
 export class TenstorrentCompiler extends BaseCompiler {
     private ttMetalHome: string;

--- a/lib/compilers/tenstorrent.ts
+++ b/lib/compilers/tenstorrent.ts
@@ -1,141 +1,52 @@
-/**
- * Compiler Explorer Driver for Tenstorrent SFPI RISC-V Toolchain
- * Patched and production-optimized for tt-metal Issue #46364
- */
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import path from 'node:path';
 
-import {BaseCompiler} from '../base-compiler.js';
+import {GCCCompiler} from './gcc.js';
 
-export class TenstorrentCompiler extends BaseCompiler {
-    private ttMetalHome: string;
-    private includePaths: string[];
-
-    constructor(info: any, env: any) {
-        super(info, env);
-
-        // Detect tt-metal installation path dynamically
-        this.ttMetalHome = process.env.TT_METAL_HOME || '/opt/tt-metal';
-
-        // Build default include paths for Tenstorrent core headers
-        this.includePaths = [
-            path.join(this.ttMetalHome, 'include'),
-            path.join(this.ttMetalHome, 'tt_metal/include'),
-            path.join(this.ttMetalHome, 'tt_metal/include/compute_kernel_api'),
-            path.join(this.ttMetalHome, 'tt_metal/include/hw'),
-        ];
+export class TenstorrentCompiler extends GCCCompiler {
+    static override get key() {
+        return 'tenstorrent';
     }
 
-    /**
-     * Intercepts compilation filters if needed.
-     */
-    override optionsForFilter(filters: any, outputFilename: string): string[] {
-        return [];
+    private getBase() {
+        const exeDir = path.dirname(this.compiler.exe);
+        return path.resolve(exeDir, '../../');
     }
 
-    /**
-     * Injects custom Tenstorrent headers and enforces assembly generation layout (-S).
-     */
-    override async runCompiler(
-        compiler: string,
-        options: string[],
-        inputFilename: string,
-        execOptions: any,
-        filters?: any,
-    ): Promise<any> {
-        
-        // Ensure options array copy
-        const modifiedOptions = [...options];
+    override optionsForFilter(filters, outputFilename: string, userOptions?: string[]) {
+        const options = super.optionsForFilter(filters, outputFilename, userOptions);
+        const base = this.getBase();
 
-        // Intercept and inject required structural headers
-        for (const includePath of this.includePaths) {
-            if (fs.existsSync(includePath)) {
-                modifiedOptions.push(`-I${includePath}`);
-            }
-        }
+        options.push(
+            `-I${path.join(base, 'include')}`,
+            `-I${path.join(base, 'tt_metal/include')}`,
+            `-I${path.join(base, 'tt_metal/include/compute_kernel_api')}`,
+            `-I${path.join(base, 'tt_metal/include/hw')}`,
+        );
 
-        // Ensure default 32-bit architecture matching Tensix engine specs
-        if (!modifiedOptions.some((o) => o.startsWith('-march'))) {
-            modifiedOptions.push('-march=rv32imf');
-        }
-        if (!modifiedOptions.some((o) => o.startsWith('-O'))) {
-            modifiedOptions.push('-O2');
-        }
-
-        // Enforce assembly output targets
-        if (!modifiedOptions.includes('-S')) modifiedOptions.push('-S');
-        if (!modifiedOptions.includes('-c')) modifiedOptions.push('-c');
-
-        // Determine output filename dynamically from the file context configuration
-        const outputFilename = this.getOutputFilename(path.dirname(inputFilename), '');
-
-        // Delegate execution to base compiler context
-        const result = await super.runCompiler(compiler, modifiedOptions, inputFilename, execOptions, filters);
-
-        // Process assembly file from disk if compilation succeeded
-        if (result.code === 0 && fs.existsSync(outputFilename)) {
-            const rawAsm = fs.readFileSync(outputFilename, 'utf8');
-            const processedLines = this.normalizeAssemblyOutput(rawAsm);
-            
-            // Write clean assembly back to disk
-            fs.writeFileSync(outputFilename, processedLines.map(l => l.text).join('\n'), 'utf8');
-            
-            // Update structural stdout for the web UI display response
-            result.stdout = processedLines;
-        }
-
-        return result;
-    }
-
-    /**
-     * Normalizes assembly, clears out compiler bookkeeping noise (.SFPREPLAY) and annotates vector logic.
-     */
-    private normalizeAssemblyOutput(rawAssembly: string): any[] {
-        const lines = rawAssembly.split('\n');
-        const normalized: any[] = [];
-        const seenLabels = new Set<string>();
-
-        for (let i = 0; i < lines.length; i++) {
-            let line = lines[i];
-
-            // 1. Strip SFPREPLAY directives completely
-            if (/^\s*\.SFPREPLAY\s+/.test(line)) {
-                continue;
-            }
-
-            // 2. Preserve and tag custom vector structural elements
-            if (/^\s*(v_if|v_endif|v_else)\b/.test(line)) {
-                normalized.push({ text: `${line.trimEnd()} # Tensix vector control flow` });
-                continue;
-            }
-
-            // 3. Deduplicate duplicate label compiler artifacts
-            const labelMatch = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:/);
-            if (labelMatch) {
-                const labelName = labelMatch[1];
-                if (seenLabels.has(labelName)) {
-                    continue;
-                }
-                seenLabels.add(labelName);
-            }
-
-            // 4. Content Cleanup & Metadata Annotations
-            line = line.replace(/^\s+/, '').replace(/\s+$/, '');
-            if (line.length === 0) {
-                if (normalized.length > 0 && normalized[normalized.length - 1].text !== '') {
-                    normalized.push({ text: '' });
-                }
-                continue;
-            }
-
-            if (/\b(vFloat|vInt|vInt32|vUint32)\b/.test(line)) {
-                line = `${line} # Tensix vector type`;
-            }
-
-            normalized.push({ text: line });
-        }
-
-        return normalized;
+        return options;
     }
 }


### PR DESCRIPTION
## Summary
Implements native Tenstorrent SFPI cross-compiler support in Compiler Explorer.

## Changes
- `lib/compilers/tenstorrent.ts`: Patched, type-safe backend compiler driver
- `etc/config/c++.tenstorrent.properties`: Compiler configuration matrix

## References
Closes #46364
Resolves tenstorrent/tt-metal#46364

## Bounty Claim
/claim https://github.com/tenstorrent/tt-metal/issues/46364