### PR TITLE
Optimizations in LLVM opt-pipeline

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3155,11 +3155,12 @@ export class BaseCompiler {
         // In worker mode, store large non-cacheable results with short TTL
         if (this.isCompilationWorker && !fullResult.result?.okToCache && fullResult) {
             // Check if result is large enough to require S3 storage
-            const resultSize = JSON.stringify(fullResult).length;
+            const resultString = JSON.stringify(fullResult);
+            const resultSize = resultString.length;
 
             if (resultSize > WEBSOCKET_SIZE_THRESHOLD) {
                 // Store with 1-day TTL for temporary retrieval in temp/ subdirectory
-                await this.env.tempCachePutWithTTL(cacheKey, fullResult, TEMP_STORAGE_TTL_DAYS, undefined);
+                await this.env.tempCachePutWithTTL(cacheKey, resultString, TEMP_STORAGE_TTL_DAYS, undefined);
                 // Set s3Key with temp/ prefix to reflect storage location
                 fullResult.s3Key = `temp/${BaseCache.hash(cacheKey)}`;
             }
@@ -3442,11 +3443,12 @@ export class BaseCompiler {
         // In worker mode, store large non-cacheable results with short TTL
         if (this.isCompilationWorker && !result.okToCache && !delayCaching) {
             // Check if result is large enough to require S3 storage
-            const resultSize = JSON.stringify(result).length;
+            const resultString = JSON.stringify(result);
+            const resultSize = resultString.length;
 
             if (resultSize > WEBSOCKET_SIZE_THRESHOLD) {
                 // Store with 1-day TTL for temporary retrieval in temp/ subdirectory
-                await this.env.tempCachePutWithTTL(key, result, TEMP_STORAGE_TTL_DAYS, undefined);
+                await this.env.tempCachePutWithTTL(key, resultString, TEMP_STORAGE_TTL_DAYS, undefined);
                 // Set s3Key with temp/ prefix to reflect storage location
                 result.s3Key = `temp/${BaseCache.hash(key)}`;
             }

--- a/lib/compilation-env.ts
+++ b/lib/compilation-env.ts
@@ -181,16 +181,20 @@ export class CompilationEnvironment {
         }
     }
 
-    async tempCachePutWithTTL(object: CacheableValue, result: object, ttlDays: number, creator: string | undefined) {
+    async tempCachePutWithTTL(
+        object: CacheableValue,
+        jsonString: string,
+        ttlDays: number,
+        creator: string | undefined,
+    ) {
         const key = BaseCache.hash(object);
-        const jsonData = JSON.stringify(result);
 
         // Check if cache is S3Cache to use TTL functionality with temp path
         if (this.cache instanceof S3Cache) {
-            return this.cache.putWithTTLAndPath(key, Buffer.from(jsonData), ttlDays, 'temp', creator);
+            return this.cache.putWithTTLAndPath(key, Buffer.from(jsonString), ttlDays, 'temp', creator);
         } else {
             // Fallback to regular put for non-S3 caches
-            return this.cache.put(key, jsonData, creator);
+            return this.cache.put(key, jsonString, creator);
         }
     }
 

--- a/lib/demangler/llvm.ts
+++ b/lib/demangler/llvm.ts
@@ -76,12 +76,12 @@ export class LLVMIRDemangler {
         if (translations.length > 0) {
             const tree = new PrefixTree(translations);
             for (const [functionName, passes] of Object.entries(passOutput)) {
-                const demangledFunctionName = tree.replaceAll(functionName).newText;
+                const demangledFunctionName = tree.replaceAllText(functionName);
                 for (const pass of passes) {
-                    pass.name = tree.replaceAll(pass.name).newText; // needed at least for full module mode
+                    pass.name = tree.replaceAllText(pass.name); // needed at least for full module mode
                     for (const dump of [pass.before, pass.after]) {
                         for (const line of dump) {
-                            line.text = tree.replaceAll(line.text).newText;
+                            line.text = tree.replaceAllText(line.text);
                         }
                     }
                 }

--- a/lib/demangler/prefix-tree.ts
+++ b/lib/demangler/prefix-tree.ts
@@ -104,8 +104,8 @@ export class PrefixTree {
         const mapRanges: Record<number, Record<number, charRange>> = {};
         const mapNames: Record<string, string> = {};
         // Loop over each possible replacement point in the line.
-        // Use a binary search to find the replacements (allowing a prefix match). If we couldn't find a match, skip
-        // on, else use the replacement, and skip by that amount.
+        // Walk the prefix tree to find the longest replacement at the current index. If no match is found, emit the
+        // current character; otherwise emit the replacement and advance by the matched length.
         while (idxInOld < line.length) {
             const [oldValue, newValue] = this.findLongestMatch(line, idxInOld);
             if (oldValue) {

--- a/lib/demangler/prefix-tree.ts
+++ b/lib/demangler/prefix-tree.ts
@@ -140,4 +140,24 @@ export class PrefixTree {
             mapNames: mapNames,
         };
     }
+
+    // Like replaceAll, but only computes the replaced text. Skips building the
+    // mapRanges/mapNames metadata, which callers that don't need source-position
+    // mapping (e.g. opt-pipeline pass-dump demangling) would otherwise allocate
+    // per line and immediately discard.
+    replaceAllText(line: string): string {
+        let newText = '';
+        let idxInOld = 0;
+        while (idxInOld < line.length) {
+            const [oldValue, newValue] = this.findLongestMatch(line);
+            if (oldValue) {
+                newText += newValue;
+                idxInOld += oldValue.length;
+            } else {
+                newText += line[idxInOld];
+                idxInOld++;
+            }
+        }
+        return newText;
+    }
 }

--- a/lib/demangler/prefix-tree.ts
+++ b/lib/demangler/prefix-tree.ts
@@ -71,15 +71,15 @@ export class PrefixTree {
     // Finds the longest possible match by walking along the N-way tree until we
     // mismatch or reach the end of the input string. Along the way, we note the
     // most recent match (if any), which will be our return value.
-    findLongestMatch(needle: string) {
+    findLongestMatch(needle: string, start = 0) {
         let node = this.root;
         let match: [string, string] | [null, null] = [null, null];
-        for (let i = 0; i < needle.length; ++i) {
+        for (let i = start; i < needle.length; ++i) {
             const character = needle.codePointAt(i);
             assert(character !== undefined, 'Undefined code point encountered in PrefixTree');
             node = node[character];
             if (!node) break;
-            if (node.result) match = [needle.substring(0, i + 1), node.result];
+            if (node.result) match = [needle.substring(start, i + 1), node.result];
         }
         return match;
     }
@@ -107,8 +107,7 @@ export class PrefixTree {
         // Use a binary search to find the replacements (allowing a prefix match). If we couldn't find a match, skip
         // on, else use the replacement, and skip by that amount.
         while (idxInOld < line.length) {
-            const lineBit = line.substring(idxInOld);
-            const [oldValue, newValue] = this.findLongestMatch(lineBit);
+            const [oldValue, newValue] = this.findLongestMatch(line, idxInOld);
             if (oldValue) {
                 // We found a replacement.
                 newText += newValue;
@@ -149,7 +148,7 @@ export class PrefixTree {
         let newText = '';
         let idxInOld = 0;
         while (idxInOld < line.length) {
-            const [oldValue, newValue] = this.findLongestMatch(line);
+            const [oldValue, newValue] = this.findLongestMatch(line, idxInOld);
             if (oldValue) {
                 newText += newValue;
                 idxInOld += oldValue.length;

--- a/test/demangler-tests.ts
+++ b/test/demangler-tests.ts
@@ -444,6 +444,12 @@ describe('Demangler prefix tree', () => {
             'Everyone loves short_an long_ardvshort_ark',
         );
     });
+    it('should match replaceAllText to replaceAll newText', () => {
+        expect(replacements.replaceAllText('aaa')).toEqual(replacements.replaceAll('aaa').newText);
+        expect(replacements.replaceAllText('Everyone loves an aardvark')).toEqual(
+            replacements.replaceAll('Everyone loves an aardvark').newText,
+        );
+    });
     it('should find exact matches', () => {
         expect(unwrap(replacements.findExact('a'))).toEqual('short_a');
         expect(unwrap(replacements.findExact('aa'))).toEqual('long_a');


### PR DESCRIPTION
3 Separate optimizations towards resolution of #8583:

1. (probably most substantial:) ``PrefixTree.replaceAll` did O(n^2) allocations, causing substantial GC time:
```ts
const lineBit = line.substring(idxInOld);
const [oldValue, newValue] = this.findLongestMatch(lineBit);
```
For every character pos in a line this allocated a substring for the entire remainder. Over one line that's O(n^2) bytes allocated, and `processPassOutput` runs this on every line of every before/after IR dump — which for an opt-pipeline run is enormous. This is a major contributor to both the `replaceAll`/`processPassOutput` self-time and the 20% GC.
Fix: make `findLongestMatch` accept a start offset and walk the existing line string in place.

2. `JSON.stringify` large payloads once instead of twice, when caching to S3

3. `processPassOutput` called `PrefixTree.replaceAll` which did a costly build of replacement map but didn't use them. Now calls the new `PrefixTree.replaceAllText`.



-------
The time measurements on the live site and on my machine differ substantially. Before pursuing more aggressive optimizations I want to check the impact of these, see if more work is needed.

One additional direction for (major) optimization: I think today each pass dump is processed twice, once as 'before' and 2nd time as 'after'



