### PR TITLE
defaulting p3850 clang to libc++

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -711,6 +711,7 @@ compiler.clang_ericwf_contracts.notification=EricWF's contracts compiler; see <a
 compiler.clang_notadragon_contracts_p3850.exe=/opt/compiler-explorer/clang-notadragon-contracts-p3850/bin/clang++
 compiler.clang_notadragon_contracts_p3850.semver=(P3850 contracts)
 compiler.clang_notadragon_contracts_p3850.notification=Experimental C++29 Contracts Implementation; see P3850, <a href="https://github.com/notadragon/llvm-project/tree/contracts-p3850" target="_blank" rel="noopener noreferrer">notadragon/llvm-project<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_notadragon_contracts_p3850.options=-stdlib=libc++
 compiler.clang_p1974.exe=/opt/compiler-explorer/clang-p1974-trunk/bin/clang++
 compiler.clang_p1974.semver=(p1974)
 compiler.clang_p1974.notification=p1974; see <a href="https://github.com/je4d/llvm-project/tree/godbolt/propconst" target="_blank" rel="noopener noreferrer">je4d/llvm-project<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Changing options for p3850 clang compilers instead of changing how it is built (this replaces https://github.com/compiler-explorer/clang-builder/pull/113).