### PR TITLE
Add gcc 14.4.0 and 15.3.0 (C and C++)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g151:g152:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk:gcc_notadragon_contracts_p3850
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g144:g151:g152:g153:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk:gcc_notadragon_contracts_p3850
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -187,10 +187,14 @@ compiler.g142.exe=/opt/compiler-explorer/gcc-14.2.0/bin/g++
 compiler.g142.semver=14.2
 compiler.g143.exe=/opt/compiler-explorer/gcc-14.3.0/bin/g++
 compiler.g143.semver=14.3
+compiler.g144.exe=/opt/compiler-explorer/gcc-14.4.0/bin/g++
+compiler.g144.semver=14.4
 compiler.g151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/g++
 compiler.g151.semver=15.1
 compiler.g152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/g++
 compiler.g152.semver=15.2
+compiler.g153.exe=/opt/compiler-explorer/gcc-15.3.0/bin/g++
+compiler.g153.semver=15.3
 compiler.g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/g++
 compiler.g161.semver=16.1
 
@@ -301,7 +305,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g151assert:g152assert:g161assert
+group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g144assert:g151assert:g152assert:g153assert:g161assert
 group.gcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.g103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/g++
@@ -342,10 +346,14 @@ compiler.g142assert.exe=/opt/compiler-explorer/gcc-assertions-14.2.0/bin/g++
 compiler.g142assert.semver=14.2 (assertions)
 compiler.g143assert.exe=/opt/compiler-explorer/gcc-assertions-14.3.0/bin/g++
 compiler.g143assert.semver=14.3 (assertions)
+compiler.g144assert.exe=/opt/compiler-explorer/gcc-assertions-14.4.0/bin/g++
+compiler.g144assert.semver=14.4 (assertions)
 compiler.g151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/g++
 compiler.g151assert.semver=15.1 (assertions)
 compiler.g152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/g++
 compiler.g152assert.semver=15.2 (assertions)
+compiler.g153assert.exe=/opt/compiler-explorer/gcc-assertions-15.3.0/bin/g++
+compiler.g153assert.semver=15.3 (assertions)
 compiler.g161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/g++
 compiler.g161assert.semver=16.1 (assertions)
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -15,7 +15,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=&cgcc86assert:cg_thephd_dev:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg151:cg152:cg161:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=&cgcc86assert:cg_thephd_dev:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg144:cg151:cg152:cg153:cg161:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -175,10 +175,14 @@ compiler.cg142.exe=/opt/compiler-explorer/gcc-14.2.0/bin/gcc
 compiler.cg142.semver=14.2
 compiler.cg143.exe=/opt/compiler-explorer/gcc-14.3.0/bin/gcc
 compiler.cg143.semver=14.3
+compiler.cg144.exe=/opt/compiler-explorer/gcc-14.4.0/bin/gcc
+compiler.cg144.semver=14.4
 compiler.cg151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gcc
 compiler.cg151.semver=15.1
 compiler.cg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 compiler.cg152.semver=15.2
+compiler.cg153.exe=/opt/compiler-explorer/gcc-15.3.0/bin/gcc
+compiler.cg153.semver=15.3
 compiler.cg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 compiler.cg161.semver=16.1
 
@@ -209,7 +213,7 @@ compiler.cg71.needsMulti=true
 compiler.cg72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg151assert:cg152assert:cg161assert
+group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg144assert:cg151assert:cg152assert:cg153assert:cg161assert
 group.cgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.cg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -250,10 +254,14 @@ compiler.cg142assert.exe=/opt/compiler-explorer/gcc-assertions-14.2.0/bin/gcc
 compiler.cg142assert.semver=14.2 (assertions)
 compiler.cg143assert.exe=/opt/compiler-explorer/gcc-assertions-14.3.0/bin/gcc
 compiler.cg143assert.semver=14.3 (assertions)
+compiler.cg144assert.exe=/opt/compiler-explorer/gcc-assertions-14.4.0/bin/gcc
+compiler.cg144assert.semver=14.4 (assertions)
 compiler.cg151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gcc
 compiler.cg151assert.semver=15.1 (assertions)
 compiler.cg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcc
 compiler.cg152assert.semver=15.2 (assertions)
+compiler.cg153assert.exe=/opt/compiler-explorer/gcc-assertions-15.3.0/bin/gcc
+compiler.cg153assert.semver=15.3 (assertions)
 compiler.cg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
 compiler.cg161assert.semver=16.1 (assertions)
 


### PR DESCRIPTION
Exposes mainline **gcc 14.4.0** and **15.3.0** (x86-64), plus their assertions variants, in the **C** and **C++** compiler dropdowns.

### Why
This is the missing "expose in the UI" half of adding these gcc versions. compiler-explorer/infra#2203 already *installs* them (the S3 artifacts are built), but without matching `.properties` entries they don't appear in CE. cc @Yashinde145 — this is the companion PR to your infra#2203; the version bump needs a change here too so the compilers actually show up.

### What
Following the existing `g152`/`g143` pattern:
- `c++.amazon.properties`: `g144`, `g153` (+ `g144assert`, `g153assert`) entries + added to `group.gcc86.compilers` / `group.gcc86assert.compilers`.
- `c.amazon.properties`: the mirrored `cg144`, `cg153` (+ assertions) entries + group lists (the shared gcc install serves both C and C++).

`test:props` passes (ran via the pre-commit hook). Only the C/C++ dropdowns are touched; other gcc-family languages (fortran/ada/d/…) track gcc separately and could be extended in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)