### PR TITLE
Downgrade Scale's CUDA to the latest supported version (13.1)

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -757,10 +757,10 @@ group.scale-nvcc-nvidia.includeFlag=-I
 group.scale-nvcc-nvidia.rpathFlag=-L
 group.scale-nvcc-nvidia.ldPath=/opt/compiler-explorer/gcc-14.1.0/lib64
 group.scale-nvcc-nvidia.objdumper=/opt/compiler-explorer/gcc-14.1.0/bin/objdump
-#Scale's nvidia backend has to rely on a CUDA install. If CUDA 13.2.0 is removed from the site, it will break scale but we can switch to another one here.
-group.scale-nvcc-nvidia.options=--compiler-bindir /opt/compiler-explorer/gcc-14.1.0/bin --cuda-path=/opt/compiler-explorer/cuda/13.2.0/
-group.scale-nvcc-nvidia.nvdisasm=/opt/compiler-explorer/cuda/13.2.0/bin/nvdisasm
-group.scale-nvcc-nvidia.ptxas=/opt/compiler-explorer/cuda/13.2.0/bin/ptxas
+#Scale's Nvidia backend relies on a CUDA install. If CUDA 13.1.0 is removed from the site, it will break scale but we can switch to another one here.
+group.scale-nvcc-nvidia.options=--compiler-bindir /opt/compiler-explorer/gcc-14.1.0/bin --cuda-path=/opt/compiler-explorer/cuda/13.1.0/
+group.scale-nvcc-nvidia.nvdisasm=/opt/compiler-explorer/cuda/13.1.0/bin/nvdisasm
+group.scale-nvcc-nvidia.ptxas=/opt/compiler-explorer/cuda/13.1.0/bin/ptxas
 
 compiler.scalenvidia171.semver=1.7.1
 compiler.scalenvidia171.exe=/opt/compiler-explorer/scale/1.7.1/llvm/bin/nvcc


### PR DESCRIPTION
Follow up of https://github.com/compiler-explorer/compiler-explorer/pull/8849

Thanks a lot for the review and merge !

I did not realize that scale/1.7.1 does not support cuda>13.1 as I was testing locally with cuda/12.8.0, see

https://godbolt.org/z/cjdvYqGbd

> nvcc: warning: CUDA version is newer than the latest supported version 13.1 [-Wunknown-cuda-version]

The fix is straightforward and included in this PR. AMD backend seems good. Sorry for the noise :)

Regards