### PR TITLE
lower engines.node version for more precise value 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,7 @@
         "webpack-manifest-plugin": "^6.0.1"
       },
       "engines": {
-        "node": ">=22.23.1"
+        "node": ">=22.22.1"
       },
       "optionalDependencies": {
         "@rollup/rollup-darwin-arm64": "^4.62.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "version": "0.0.3",
   "engines": {
-    "node": ">=22.23.1"
+    "node": ">=22.22.1"
   },
   "main": "./app.ts",
   "dependencies": {


### PR DESCRIPTION
It lowers to the exact value as limited by lint-staged package. For some reason, the value is chosen to be the current LTS value at the time of this [PR](https://github.com/compiler-explorer/compiler-explorer/pull/8885) even though the value is dictated by lint-staged package.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
