### PR TITLE
redeploy sfpi

### DIFF
--- a/etc/config/sfpi.amazon.properties
+++ b/etc/config/sfpi.amazon.properties
@@ -1,1 +1,20 @@
-compilers=
+compilers=&sfpi
+compilerType=sfpi
+defaultCompiler=sfpi755
+supportsBinary=false
+supportsExecute=false
+
+group.sfpi.compilers=sfpi755:sfpi754
+group.sfpi.groupName=SFPI
+group.sfpi.demangler=/opt/compiler-explorer/sfpi-7.55.0/compiler/bin/riscv-tt-elf-c++filt
+group.sfpi.objdumper=/opt/compiler-explorer/sfpi-7.55.0/compiler/bin/riscv-tt-elf-objdump
+group.sfpi.instructionSet=riscv64
+group.sfpi.versionFlag=--version
+group.sfpi.options=-O1
+
+compiler.sfpi755.exe=/opt/compiler-explorer/sfpi-7.55.0/compiler/bin/riscv-tt-elf-g++
+compiler.sfpi755.name=SFPI 7.55.0
+compiler.sfpi755.alias=sfpi
+
+compiler.sfpi754.exe=/opt/compiler-explorer/sfpi-7.54.0/compiler/bin/riscv-tt-elf-g++
+compiler.sfpi754.name=SFPI 7.54.0

--- a/etc/config/sfpi.amazon.properties
+++ b/etc/config/sfpi.amazon.properties
@@ -4,7 +4,7 @@ defaultCompiler=sfpi755
 supportsBinary=false
 supportsExecute=false
 
-group.sfpi.compilers=sfpi755:sfpi754
+group.sfpi.compilers=sfpi755
 group.sfpi.groupName=SFPI
 group.sfpi.demangler=/opt/compiler-explorer/sfpi-7.55.0/compiler/bin/riscv-tt-elf-c++filt
 group.sfpi.objdumper=/opt/compiler-explorer/sfpi-7.55.0/compiler/bin/riscv-tt-elf-objdump

--- a/etc/config/sfpi.amazon.properties
+++ b/etc/config/sfpi.amazon.properties
@@ -15,6 +15,3 @@ group.sfpi.options=-O1
 compiler.sfpi755.exe=/opt/compiler-explorer/sfpi-7.55.0/compiler/bin/riscv-tt-elf-g++
 compiler.sfpi755.name=SFPI 7.55.0
 compiler.sfpi755.alias=sfpi
-
-compiler.sfpi754.exe=/opt/compiler-explorer/sfpi-7.54.0/compiler/bin/riscv-tt-elf-g++
-compiler.sfpi754.name=SFPI 7.54.0


### PR DESCRIPTION
This is to undo revert regarding sfpi deployment since a fix is applied for the building of sfpi compiler

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
