### PR TITLE
Add MCST LCC (eLbrus Compiler Collections) compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&aocc:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang:&gcc-classic:&npparm
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&aocc:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang:&gcc-classic:&npparm:&e2k-lcc
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -5073,6 +5073,26 @@ compiler.npparm-trunk.exe=/opt/compiler-explorer/ncc-ng-trunk/bin/n++
 compiler.npparm-trunk.name=Norcroft ARM C++ (trunk)
 compiler.npparm-trunk.semver=(trunk)
 compiler.npparm-trunk.isNightly=true
+
+################################
+# MCST LCC (eLbrus Compiler Collection) for E2K
+group.e2k-lcc.compilers=e2k-lcc12916
+group.e2k-lcc.groupName=e2k mcst lcc
+group.e2k-lcc.baseName=e2k lcc
+group.e2k-lcc.instructionSet=e2k
+group.e2k-lcc.isSemVer=true
+group.e2k-lcc.supportsBinary=false
+group.e2k-lcc.supportsBinaryObject=false
+group.e2k-lcc.supportsExecute=false
+group.e2k-lcc.unwiseOptions=-march=native|-mtune=native
+group.e2k-lcc.objdumper=/opt/compiler-explorer/lcc-1.29.16.e2k-v4.linux-6.1/bin.toolchain/e2k-linux-objdump
+group.e2k-lcc.licenseLink=https://dev.mcst.ru/wp-content/uploads/2024/07/mit-license.pdf
+group.e2k-lcc.licenseName=MIT License
+group.e2k-lcc.licensePreamble=Copyright (c) 2024 AO "MCST"
+group.e2k-lcc.compilerCategories=mcst-lcc
+
+compiler.e2k-lcc12916.exe=/opt/compiler-explorer/lcc-1.29.16.e2k-v4.linux-6.1/bin/l++
+compiler.e2k-lcc12916.semver=1.29.16
 
 #################################
 #################################

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&caocc:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&co2cc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm
+compilers=&cgcc86:&cclang:&caocc:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&co2cc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm:&e2k-clcc
 defaultCompiler=cg161
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -4578,6 +4578,26 @@ compiler.nccarm-trunk.exe=/opt/compiler-explorer/ncc-ng-trunk/bin/ncc
 compiler.nccarm-trunk.name=Norcroft ARM C (trunk)
 compiler.nccarm-trunk.semver=(trunk)
 compiler.nccarm-trunk.isNightly=true
+
+################################
+# MCST LCC (eLbrus Compiler Collection) for E2K
+group.e2k-clcc.compilers=e2k-clcc12916
+group.e2k-clcc.groupName=e2k mcst lcc
+group.e2k-clcc.baseName=e2k lcc
+group.e2k-clcc.instructionSet=e2k
+group.e2k-clcc.isSemVer=true
+group.e2k-clcc.supportsBinary=false
+group.e2k-clcc.supportsBinaryObject=false
+group.e2k-clcc.supportsExecute=false
+group.e2k-clcc.unwiseOptions=-march=native|-mtune=native
+group.e2k-clcc.objdumper=/opt/compiler-explorer/lcc-1.29.16.e2k-v4.linux-6.1/bin.toolchain/e2k-linux-objdump
+group.e2k-clcc.licenseLink=https://dev.mcst.ru/wp-content/uploads/2024/07/mit-license.pdf
+group.e2k-clcc.licenseName=MIT License
+group.e2k-clcc.licensePreamble=Copyright (c) 2024 AO "MCST"
+group.e2k-clcc.compilerCategories=mcst-lcc
+
+compiler.e2k-clcc12916.exe=/opt/compiler-explorer/lcc-1.29.16.e2k-v4.linux-6.1/bin/lcc
+compiler.e2k-clcc12916.semver=1.29.16
 
 #################################
 #################################

--- a/lib/binaries/binary-utils.ts
+++ b/lib/binaries/binary-utils.ts
@@ -84,6 +84,9 @@ export class BinaryInfoLinux {
             case 'loongarch': {
                 return 'loongarch';
             }
+            case 'mcst elbrus': {
+                return 'e2k';
+            }
             default: {
                 logger.error(`Unknown architecture text: ${value}`);
                 return 'amd64';

--- a/lib/instructionsets.ts
+++ b/lib/instructionsets.ts
@@ -211,6 +211,10 @@ export class InstructionSets {
                 target: [],
                 path: [],
             },
+            e2k: {
+                target: ['e2k'],
+                path: [],
+            },
         };
     }
 

--- a/types/instructionsets.ts
+++ b/types/instructionsets.ts
@@ -32,6 +32,7 @@ export const InstructionSetsList = [
     'beam',
     'c6x',
     'dex',
+    'e2k',
     'ebpf',
     'evm',
     'eravm',


### PR DESCRIPTION
Second attempt for https://github.com/compiler-explorer/compiler-explorer/pull/8874

Infra PR: https://github.com/compiler-explorer/infra/pull/2211

Changes:

* A single compiler version instead of all available.
* No Fortran compilers.
* No Rust compilers.
* No binary support.
* No execution support.
* No special handling for line numbers.
* No basic clang support.
* No `/opt/mcst`.