### PR TITLE
[Mojp] simplify mojo example

### DIFF
--- a/examples/mojo/default.mojo
+++ b/examples/mojo/default.mojo
@@ -1,5 +1,3 @@
-def multiply[m: Int](n: Int) -> Int:
-    return m * n
-
-def main():
-    _ = multiply[3](5)
+@export
+def multiply(x: Int, y: Int) abi("C") -> Int:
+    return x * y


### PR DESCRIPTION
before:

```mojo
def multiply[m: Int](n: Int) -> Int:
    return m * n

def main():
    _ = multiply[3](5)

```

https://godbolt.org/z/ze4r9ecbY

after:

```mojo
@export
def multiply(x: Int, y: Int) abi("C") -> Int:
    return x * y
```

Whivh mush simpler in term of source and codegen:

https://godbolt.org/z/4Mz1hj9b5