### PR TITLE
Add SDCC 4.6.0

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4202,7 +4202,7 @@ compiler.cc65_219.options=-I/opt/compiler-explorer/6502/cc65-2.19/share/cc65/inc
 
 #################################
 # sdcc compilers
-group.sdcc.compilers=sdcc400:sdcc410:sdcc420:sdcc430:sdcc440:sdcc450
+group.sdcc.compilers=sdcc400:sdcc410:sdcc420:sdcc430:sdcc440:sdcc450:sdcc460
 group.sdcc.compilerType=sdcc
 group.sdcc.groupName=SDCC
 group.sdcc.baseName=SDCC
@@ -4223,6 +4223,8 @@ compiler.sdcc440.exe=/opt/compiler-explorer/sdcc-4.4.0/bin/sdcc
 compiler.sdcc440.semver=4.4.0
 compiler.sdcc450.exe=/opt/compiler-explorer/sdcc-4.5.0/bin/sdcc
 compiler.sdcc450.semver=4.5.0
+compiler.sdcc460.exe=/opt/compiler-explorer/sdcc-4.6.0/bin/sdcc
+compiler.sdcc460.semver=4.6.0
 
 ################################
 # Clang for eZ80,Z80,Z180


### PR DESCRIPTION
Adds SDCC 4.6.0 to the C compilers.

Closes #8891

Depends on the infra PR that installs the compiler: compiler-explorer/infra#2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)