### PR TITLE
Support source editor diffs

### DIFF
--- a/cypress/e2e/diff.cy.ts
+++ b/cypress/e2e/diff.cy.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import {serialiseState} from '../../shared/url-serialization.js';
 import {
     addCompilerFromEditor,
     assertNoConsoleOutput,
@@ -31,6 +32,7 @@ import {
     monacoEditorTextShouldContain,
     openDiffView,
     setMonacoEditorContent,
+    stubConsoleOutput,
     visitPage,
     waitForEditors,
 } from '../support/utils';
@@ -46,6 +48,125 @@ int add_variant(int a, int b) { return a + b; }
 #else
 int mul_variant(int a, int b) { return a * b; }
 #endif`;
+
+const SOURCE_A = `\
+int source_alpha() {
+    return 1;
+}`;
+
+const SOURCE_B = `\
+int source_beta() {
+    return 2;
+}`;
+
+const SOURCE_A_UPDATED = `\
+int source_alpha_updated() {
+    return 3;
+}`;
+
+const DIFF_TYPE_SOURCE = 16;
+
+function buildSourceOnlyDiffState(diffState = {}) {
+    const sourcePane = (id: number, source: string) => ({
+        type: 'component',
+        componentName: 'codeEditor',
+        componentState: {id, lang: 'c++', source},
+        isClosable: true,
+    });
+
+    const diffPane = {
+        type: 'component',
+        componentName: 'diff',
+        componentState: diffState,
+        isClosable: true,
+    };
+
+    return {
+        version: 4,
+        content: [
+            {
+                type: 'row',
+                content: [sourcePane(1, SOURCE_A), sourcePane(2, SOURCE_B), diffPane],
+            },
+        ],
+    };
+}
+
+function visitState(state: object) {
+    cy.visit(`/#${serialiseState(state)}`, {
+        onBeforeLoad: win => {
+            stubConsoleOutput(win);
+        },
+    });
+}
+
+function addSourceEditor() {
+    findPane('source').find('[data-cy="new-editor-dropdown-btn"]').click();
+    cy.get('[data-cy="new-add-editor-btn"]:visible').first().click();
+    cy.get('span.lm_title:visible')
+        .filter(':contains("source")')
+        .should($titles => {
+            expect($titles.length).to.be.at.least(2);
+        });
+}
+
+function closeSourceEditor(sourceEditorIndex: number) {
+    cy.get('span.lm_title:visible')
+        .filter(':contains("source")')
+        .eq(sourceEditorIndex)
+        .closest('.lm_tab')
+        .find('.lm_close_tab')
+        .click({force: true});
+}
+
+function selectDiffSource(side: 'lhs' | 'rhs', editorNumber: number) {
+    findPane('Diff').find(`select.diff-picker.${side} + .ts-wrapper .ts-control`).click();
+    cy.get('.ts-dropdown .option:visible')
+        .contains(new RegExp(`source #${editorNumber}`, 'i'))
+        .click();
+}
+
+function setSourceEditorContent(content: string, sourceEditorIndex: number) {
+    cy.get('span.lm_title:visible')
+        .filter(':contains("source")')
+        .eq(sourceEditorIndex)
+        .closest('.lm_item.lm_stack')
+        .find('.lm_content .monaco-editor')
+        .then($editor => {
+            cy.window().then(win => {
+                const editorElement = $editor[0];
+                const editor = win.monaco.editor
+                    .getEditors()
+                    .find(candidate => editorElement.contains(candidate.getDomNode()));
+                if (!editor) {
+                    throw new Error('source editor Monaco instance not found');
+                }
+                editor.getModel()!.setValue(content);
+            });
+        });
+}
+
+function diffShouldContain(...expected: string[]) {
+    findPane('Diff')
+        .find('.view-lines', {timeout: 10000})
+        .should($el => {
+            const text = $el.text().replaceAll('\u00a0', ' ');
+            for (const value of expected) {
+                expect(text).to.include(value);
+            }
+        });
+}
+
+function diffShouldNotContain(...unexpected: string[]) {
+    findPane('Diff')
+        .find('.view-lines', {timeout: 10000})
+        .should($el => {
+            const text = $el.text().replaceAll('\u00a0', ' ');
+            for (const value of unexpected) {
+                expect(text).to.not.include(value);
+            }
+        });
+}
 
 beforeEach(visitPage);
 
@@ -70,13 +191,23 @@ describe('Diff view', () => {
         openDiffView();
 
         const lhsPicker = () => findPane('Diff').find('select.diff-picker.lhs + .ts-wrapper .ts-control');
+        const diffTab = () => cy.get('span.lm_title:visible').filter(':contains("Diff Viewer")');
 
         lhsPicker().should('contain.text', '-O2');
+        diffTab().should('contain.text', '-O2');
+
+        findPane('Diff').find('select.difftype-picker.lhsdifftype + .ts-wrapper .ts-control').click();
+        cy.get('.ts-dropdown .option:visible').then($options => {
+            const optionTexts = $options.toArray().map(option => option.textContent?.trim());
+            expect(optionTexts).not.to.include('Source');
+        });
 
         compilerPane().find('input.options').clear().type('-O1');
 
         lhsPicker().should('contain.text', '-O1');
         lhsPicker().should('not.contain.text', '-O2');
+        diffTab().should('contain.text', '-O1');
+        diffTab().should('not.contain.text', '-O2');
     });
 
     it('should show diff content with two compiler panes', () => {
@@ -109,5 +240,82 @@ describe('Diff view', () => {
                 const hasRhs = text.includes('add_variant');
                 expect(hasLhs || hasRhs, 'diff should contain at least one variant function name').to.be.true;
             });
+    });
+
+    it('should diff source editor contents', () => {
+        waitForEditors();
+        setSourceEditorContent(SOURCE_A, 0);
+
+        addSourceEditor();
+        setSourceEditorContent(SOURCE_B, 1);
+
+        openDiffView();
+        selectDiffSource('lhs', 1);
+        selectDiffSource('rhs', 2);
+
+        diffShouldContain('source_alpha', 'source_beta');
+
+        setSourceEditorContent(SOURCE_A_UPDATED, 0);
+
+        diffShouldContain('source_alpha_updated', 'source_beta');
+    });
+
+    it('should include source editors opened after the diff view', () => {
+        waitForEditors();
+        setSourceEditorContent(SOURCE_A, 0);
+
+        openDiffView();
+        addSourceEditor();
+        setSourceEditorContent(SOURCE_B, 1);
+
+        selectDiffSource('lhs', 1);
+        selectDiffSource('rhs', 2);
+
+        diffShouldContain('source_alpha', 'source_beta');
+    });
+
+    it('should offer source editors when no compiler pane is present', () => {
+        visitState(buildSourceOnlyDiffState());
+
+        selectDiffSource('lhs', 1);
+        selectDiffSource('rhs', 2);
+
+        diffShouldContain('source_alpha', 'source_beta');
+    });
+
+    it('should clear a selected source editor when it closes', () => {
+        waitForEditors();
+        setSourceEditorContent(SOURCE_A, 0);
+        addSourceEditor();
+        setSourceEditorContent(SOURCE_B, 1);
+
+        openDiffView();
+        selectDiffSource('lhs', 1);
+        selectDiffSource('rhs', 2);
+
+        closeSourceEditor(1);
+
+        findPane('Diff')
+            .find('select.diff-picker.rhs + .ts-wrapper .ts-control')
+            .should('not.contain.text', 'source #2');
+        diffShouldContain('source_alpha');
+        diffShouldNotContain('source_beta');
+    });
+
+    it('should restore source editor selections from layout state', () => {
+        visitState(
+            buildSourceOnlyDiffState({
+                lhs: 'source_1',
+                rhs: 'source_2',
+                lhsdifftype: DIFF_TYPE_SOURCE,
+                rhsdifftype: DIFF_TYPE_SOURCE,
+            }),
+        );
+
+        findPane('Diff').find('select.diff-picker.lhs + .ts-wrapper .ts-control').should('contain.text', 'source #1');
+        findPane('Diff').find('select.diff-picker.rhs + .ts-wrapper .ts-control').should('contain.text', 'source #2');
+        findPane('Diff').find('select.difftype-picker.lhsdifftype + .ts-wrapper .ts-control').click();
+        cy.get('.ts-dropdown .option:visible').should('have.length', 1).and('contain.text', 'Source');
+        diffShouldContain('source_alpha', 'source_beta');
     });
 });

--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -79,6 +79,7 @@ export type EventMap = {
     explainViewClosed: (compilerId: number) => void;
     explainViewOpened: (compilerId: number) => void;
     displaySharingPopover: () => void;
+    editor: (editorId: number, source: string, name: string) => void;
     editorChange: (editorId: number, source: string, langId: string, compilerId?: number) => void;
     editorClose: (editorId: number) => void;
     editorDisplayFlow: (editorId: number, flow: MessageWithLocation[]) => void;

--- a/static/panes/diff.interfaces.ts
+++ b/static/panes/diff.interfaces.ts
@@ -40,6 +40,7 @@ export enum DiffType {
     ClojureMacroExpOutput = 13,
     YulOutput = 14,
     LeanCOutput = 15,
+    Source = 16,
 }
 
 export type DiffState = {

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -61,6 +61,16 @@ function decodeSelectizeValue(value: string): DiffTypeAndExtra {
     };
 }
 
+function isSourceEntryId(id: number | string | undefined): boolean {
+    return typeof id === 'string' && id.startsWith('source_');
+}
+
+function getInitialDiffType(id: number | string | undefined, difftype?: DiffType): DiffType {
+    if (isSourceEntryId(id)) return DiffType.Source;
+
+    return difftype && difftype !== DiffType.Source ? difftype : DiffType.ASM;
+}
+
 type DiffOption = {
     id: string;
     name: string;
@@ -71,6 +81,7 @@ class DiffStateObject {
     id?: number | string;
     model: monaco.editor.ITextModel;
     compiler: CompilerEntry | null;
+    source: SourceEntry | null;
     result?: CompilationResult;
     difftype: DiffType;
     extraoption?: string;
@@ -84,6 +95,7 @@ class DiffStateObject {
         this.id = id;
         this.model = model;
         this.compiler = null;
+        this.source = null;
         this.result = undefined;
         this.difftype = difftype;
         this.extraoption = extraoption;
@@ -107,6 +119,11 @@ class DiffStateObject {
     }
 
     refresh() {
+        if (this.difftype === DiffType.Source) {
+            this.model.setValue(this.source?.source ?? '');
+            return;
+        }
+
         let output: {text: string}[] = [];
         if (this.result) {
             switch (this.difftype) {
@@ -204,6 +221,7 @@ function getItemDisplayTitle(item) {
 }
 
 type CompilerEntry = {
+    kind: 'compiler';
     id: number | string;
     name: string;
     options: unknown;
@@ -211,6 +229,16 @@ type CompilerEntry = {
     treeId: number;
     compiler: CompilerInfo;
 };
+
+type SourceEntry = {
+    kind: 'source';
+    id: string;
+    editorId: number;
+    name: string;
+    source: string;
+};
+
+type DiffEntry = CompilerEntry | SourceEntry;
 
 type SelectizeType = {
     lhs: TomSelect;
@@ -221,6 +249,7 @@ type SelectizeType = {
 
 export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffState> {
     compilers: Record<string | number, CompilerEntry> = {};
+    sources: Record<string, SourceEntry> = {};
     lhs: DiffStateObject;
     rhs: DiffStateObject;
     selectize: SelectizeType;
@@ -233,13 +262,13 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         this.lhs = new DiffStateObject(
             state.lhs,
             monaco.editor.createModel('', 'asm'),
-            state.lhsdifftype || DiffType.ASM,
+            getInitialDiffType(state.lhs, state.lhsdifftype),
             state.lhsextraoption,
         );
         this.rhs = new DiffStateObject(
             state.rhs,
             monaco.editor.createModel('', 'asm'),
-            state.rhsdifftype || DiffType.ASM,
+            getInitialDiffType(state.rhs, state.rhsdifftype),
             state.rhsextraoption,
         );
         this.editor.setModel({original: this.lhs.model, modified: this.rhs.model});
@@ -300,6 +329,18 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
                 items: [],
                 render: <any>{
                     option: (item, escapeHtml) => {
+                        if (item.kind === 'source') {
+                            return (
+                                '<div>' +
+                                `<span class="compiler">${escapeHtml(item.name)}</span>` +
+                                '<ul class="meta">' +
+                                `<li class="editor">Editor #${escapeHtml(item.editorId.toString())}</li>` +
+                                '<li class="compilerId">Source</li>' +
+                                '</ul>' +
+                                '</div>'
+                            );
+                        }
+
                         const origin = item.editorId !== false ? 'Editor #' + item.editorId : 'Tree #' + item.treeId;
                         return (
                             '<div>' +
@@ -316,16 +357,14 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
                 dropdownParent: 'body',
                 plugins: ['input_autogrow'],
                 onChange: value => {
-                    if (!((value as string) in this.compilers)) return;
-                    const compiler = this.compilers[value as string];
+                    const entry = this.getDiffEntry(value as string);
+                    if (!entry) return;
                     if (picker.classList.contains('lhs')) {
-                        this.lhs.compiler = compiler;
-                        this.lhs.id = compiler.id;
+                        this.setSelectedEntry(this.lhs, this.selectize.lhsdifftype, entry);
                     } else {
-                        this.rhs.compiler = compiler;
-                        this.rhs.id = compiler.id;
+                        this.setSelectedEntry(this.rhs, this.selectize.rhsdifftype, entry);
                     }
-                    this.onDiffSelect(compiler.id);
+                    this.onDiffSelect(entry);
                 },
             });
 
@@ -341,6 +380,7 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
 
         this.eventHub.emit('findCompilers');
         this.eventHub.emit('findExecutors');
+        this.eventHub.emit('findEditors');
 
         this.eventHub.emit('requestTheme');
         this.eventHub.emit('requestSettings');
@@ -393,6 +433,66 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         return options;
     }
 
+    getDiffEntry(id: string): DiffEntry | undefined {
+        return this.compilers[id] ?? this.sources[id];
+    }
+
+    setSelectedEntry(side: DiffStateObject, difftypePicker: TomSelect, entry: DiffEntry) {
+        const idChanged = side.id !== entry.id;
+        const previousKind = side.source ? 'source' : side.compiler ? 'compiler' : undefined;
+        const kindChanged = previousKind !== entry.kind;
+        side.id = entry.id;
+        if (idChanged) {
+            side.result = undefined;
+        }
+
+        if (entry.kind === 'source') {
+            side.compiler = null;
+            side.source = entry;
+            side.difftype = DiffType.Source;
+            side.extraoption = '';
+        } else {
+            side.compiler = entry;
+            side.source = null;
+            if (side.difftype === DiffType.Source) {
+                side.difftype = DiffType.ASM;
+            }
+        }
+
+        if (idChanged || kindChanged) {
+            this.updateDiffTypeOptionsFor(side, difftypePicker);
+        }
+        side.refresh();
+    }
+
+    updateDiffTypeOptionsFor(side: DiffStateObject, difftypePicker: TomSelect) {
+        const options =
+            side.source || side.difftype === DiffType.Source
+                ? [{id: DiffType.Source.toString(), name: 'Source'}]
+                : this.getDiffableOptions();
+        difftypePicker.clearOptions();
+        difftypePicker.addOptions(options);
+        difftypePicker.setValue(
+            encodeSelectizeValue({
+                difftype: side.difftype || DiffType.ASM,
+                extraoption: side.extraoption || '',
+            }),
+            true,
+        );
+    }
+
+    clearSelectedEntry(side: DiffStateObject, difftypePicker: TomSelect, picker: TomSelect) {
+        side.id = undefined;
+        side.compiler = null;
+        side.source = null;
+        side.result = undefined;
+        side.difftype = DiffType.ASM;
+        side.extraoption = '';
+        side.model.setValue('');
+        picker.clear(true);
+        this.updateDiffTypeOptionsFor(side, difftypePicker);
+    }
+
     override getInitialHTML() {
         return $('#diff').html();
     }
@@ -410,8 +510,10 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         return '<Unimplemented>';
     }
 
-    onDiffSelect(id: number | string) {
-        this.requestResendResult(id);
+    onDiffSelect(entry: DiffEntry) {
+        if (entry.kind === 'compiler') {
+            this.requestResendResult(entry.id);
+        }
         this.updateTitle();
         this.updateState();
     }
@@ -439,9 +541,13 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
     }
 
     override registerCallbacks() {
+        this.eventHub.on('editor', this.onEditor, this);
+        this.eventHub.on('editorChange', this.onEditorChange, this);
+        this.eventHub.on('editorClose', this.onEditorClose, this);
         this.eventHub.on('executeResult', this.onExecuteResult, this);
         this.eventHub.on('executor', this.onExecutor, this);
         this.eventHub.on('executorClose', this.onExecutorClose, this);
+        this.eventHub.on('renamePane', this.onRenamePane, this);
     }
 
     requestResendResult(id: number | string) {
@@ -500,13 +606,17 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
             }
         }
 
-        const lhsoptions = this.getDiffableOptions(this.selectize.lhs, lhsextraoptions);
-        this.selectize.lhsdifftype.clearOptions();
-        this.selectize.lhsdifftype.addOptions(lhsoptions);
+        if (!this.lhs.source) {
+            const lhsoptions = this.getDiffableOptions(this.selectize.lhs, lhsextraoptions);
+            this.selectize.lhsdifftype.clearOptions();
+            this.selectize.lhsdifftype.addOptions(lhsoptions);
+        }
 
-        const rhsoptions = this.getDiffableOptions(this.selectize.rhs, rhsextraoptions);
-        this.selectize.rhsdifftype.clearOptions();
-        this.selectize.rhsdifftype.addOptions(rhsoptions);
+        if (!this.rhs.source) {
+            const rhsoptions = this.getDiffableOptions(this.selectize.rhs, rhsextraoptions);
+            this.selectize.rhsdifftype.clearOptions();
+            this.selectize.rhsdifftype.addOptions(rhsoptions);
+        }
     }
 
     override onCompiler(
@@ -519,7 +629,8 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
         if (!compiler) return;
         options = options || '';
         const name = compiler.name + ' ' + options;
-        this.compilers[id] = {
+        const compilerEntry: CompilerEntry = {
+            kind: 'compiler',
             id: id,
             name: name,
             options: options,
@@ -527,17 +638,87 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
             treeId: treeId,
             compiler: compiler,
         };
-        if (this.lhs.id === undefined) {
-            this.lhs.compiler = this.compilers[id];
-            this.lhs.id = id;
-            this.onDiffSelect(id);
+        this.compilers[id] = compilerEntry;
+
+        const lhsWasSelected = this.lhs.id === id;
+        const rhsWasSelected = this.rhs.id === id;
+        const lhsWasUnselected = this.lhs.id === undefined;
+        const rhsWasUnselected = this.rhs.id === undefined;
+        if (lhsWasSelected || lhsWasUnselected) {
+            this.setSelectedEntry(this.lhs, this.selectize.lhsdifftype, compilerEntry);
         }
-        if (this.rhs.id === undefined) {
-            this.rhs.compiler = this.compilers[id];
-            this.rhs.id = id;
-            this.onDiffSelect(id);
+        if (rhsWasSelected || rhsWasUnselected) {
+            this.setSelectedEntry(this.rhs, this.selectize.rhsdifftype, compilerEntry);
+        }
+
+        if (lhsWasUnselected || rhsWasUnselected) {
+            this.onDiffSelect(compilerEntry);
+        } else if (lhsWasSelected || rhsWasSelected) {
+            this.updateTitle();
+            this.updateState();
         }
         this.updateCompilers();
+    }
+
+    getSourceId(editorId: number): string {
+        return `source_${editorId}`;
+    }
+
+    onEditor(editorId: number, source: string, name: string) {
+        const id = this.getSourceId(editorId);
+        this.sources[id] = {
+            kind: 'source',
+            id,
+            editorId,
+            name,
+            source,
+        };
+        const entry = this.sources[id];
+
+        if (this.lhs.id === id) {
+            this.setSelectedEntry(this.lhs, this.selectize.lhsdifftype, entry);
+        }
+        if (this.rhs.id === id) {
+            this.setSelectedEntry(this.rhs, this.selectize.rhsdifftype, entry);
+        }
+
+        this.updateCompilers();
+        this.updateTitle();
+    }
+
+    onEditorChange(editorId: number, source: string) {
+        const id = this.getSourceId(editorId);
+        const entry = this.sources[id];
+        if (!entry) return;
+
+        entry.source = source;
+
+        if (this.lhs.id === id) {
+            this.lhs.refresh();
+        }
+        if (this.rhs.id === id) {
+            this.rhs.refresh();
+        }
+    }
+
+    onEditorClose(editorId: number) {
+        const id = this.getSourceId(editorId);
+        delete this.sources[id];
+
+        if (this.lhs.id === id) {
+            this.clearSelectedEntry(this.lhs, this.selectize.lhsdifftype, this.selectize.lhs);
+        }
+        if (this.rhs.id === id) {
+            this.clearSelectedEntry(this.rhs, this.selectize.rhsdifftype, this.selectize.rhs);
+        }
+
+        this.updateCompilers();
+        this.updateTitle();
+        this.updateState();
+    }
+
+    onRenamePane() {
+        this.eventHub.emit('findEditors');
     }
 
     onExecutor(id: number, compiler: CompilerInfo | null, options: string, editorId: number, treeId: number) {
@@ -560,42 +741,57 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
     override getPaneTag() {
         // this gets called during the super's constructor before lhs/rhs have been initialized
         if ((this.lhs as any) !== undefined && (this.rhs as any) !== undefined) {
-            if (this.lhs.compiler && this.rhs.compiler) {
-                return `${this.lhs.compiler.name} vs ${this.rhs.compiler.name}`;
+            const lhsName = this.lhs.compiler?.name ?? this.lhs.source?.name;
+            const rhsName = this.rhs.compiler?.name ?? this.rhs.source?.name;
+            if (lhsName && rhsName) {
+                return `${lhsName} vs ${rhsName}`;
             }
         }
         return '';
     }
 
-    updateCompilersFor(selectize: TomSelect, id: number | string) {
+    updateCompilersFor(selectize: TomSelect, id?: number | string) {
+        selectize.clear(true);
         selectize.clearOptions();
+        for (const [_, source] of Object.entries(this.sources)) {
+            const optionId = source.id.toString();
+            selectize.addOption(source);
+            selectize.updateOption(optionId, source);
+        }
         for (const [_, compiler] of Object.entries(this.compilers)) {
             const optionId = compiler.id.toString();
             selectize.addOption(compiler);
             selectize.updateOption(optionId, compiler);
         }
         selectize.refreshOptions(false);
-        const selectedId = id.toString();
-        if (selectedId in this.compilers) {
-            selectize.setValue(selectedId);
+        if (id !== undefined) {
+            const selectedId = id.toString();
+            if (this.getDiffEntry(selectedId)) {
+                selectize.setValue(selectedId, true);
+            }
         }
     }
 
     updateCompilers() {
-        if (this.lhs.id) this.updateCompilersFor(this.selectize.lhs, this.lhs.id);
-        if (this.rhs.id) this.updateCompilersFor(this.selectize.rhs, this.rhs.id);
+        this.updateCompilersFor(this.selectize.lhs, this.lhs.id);
+        this.updateCompilersFor(this.selectize.rhs, this.rhs.id);
 
-        this.selectize.lhsdifftype.setValue(
+        this.updateDiffTypeValue(this.lhs, this.selectize.lhsdifftype);
+        this.updateDiffTypeValue(this.rhs, this.selectize.rhsdifftype);
+    }
+
+    updateDiffTypeValue(side: DiffStateObject, difftypePicker: TomSelect) {
+        if (side.source || side.difftype === DiffType.Source) {
+            this.updateDiffTypeOptionsFor(side, difftypePicker);
+            return;
+        }
+
+        difftypePicker.setValue(
             encodeSelectizeValue({
-                difftype: this.lhs.difftype || DiffType.ASM,
-                extraoption: this.lhs.extraoption || '',
+                difftype: side.difftype || DiffType.ASM,
+                extraoption: side.extraoption || '',
             }),
-        );
-        this.selectize.rhsdifftype.setValue(
-            encodeSelectizeValue({
-                difftype: this.rhs.difftype || DiffType.ASM,
-                extraoption: this.rhs.extraoption || '',
-            }),
+            true,
         );
     }
 

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -345,7 +345,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     override registerCallbacks(): void {
         this.container.on('shown', this.resize, this);
         this.container.on('open', () => {
-            this.eventHub.emit('editorOpen', this.id);
+            this.sendEditor();
         });
         this.container.layoutManager.on('initialised', () => {
             // Once initialized, let everyone know what text we have.
@@ -420,6 +420,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
 
     sendEditor(): void {
         this.eventHub.emit('editorOpen', this.id);
+        this.eventHub.emit('editor', this.id, this.getSource() ?? '', this.getPaneName());
     }
 
     onMouseMove(e: editor.IEditorMouseEvent): void {
@@ -1920,6 +1921,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         this.filename = name;
         this.updateTitle();
         this.updateState();
+        this.sendEditor();
     }
 
     getFilename(): string {

--- a/views/templates/panes/diff.pug
+++ b/views/templates/panes/diff.pug
@@ -5,12 +5,12 @@
       .input-group.input-group-sm.w-100
         label.input-group-text
           | Left:&nbsp;
-        select.diff-picker.lhs(placeholder="Select compiler...")
+        select.diff-picker.lhs(placeholder="Select input...")
         select.difftype-picker.lhsdifftype(placeholder="...")
     .btn-group.btn-group-sm.flex-grow-1
       .input-group.input-group-sm.w-100
         label.input-group-text
           | Right:&nbsp;
-        select.diff-picker.rhs(placeholder="Select compiler...")
+        select.diff-picker.rhs(placeholder="Select input...")
         select.difftype-picker.rhsdifftype(placeholder="...")
   .monaco-placeholder


### PR DESCRIPTION
## Summary
- allow Diff pane selectors to include source editors alongside compiler and executor outputs
- keep source diffs live as editors change, open after Diff, close, rename, or restore from layout state
- keep the Source diff type scoped to source selections and use neutral picker placeholders

Fixes #1276

## Tests
- npm run ts-check
- npm run lint
- npm run cypress -- --spec cypress/e2e/diff.cy.ts
- npm run check-frontend-imports && npm run check-license-headers
- git commit hook: lint, ts-check, related vitest