### PR TITLE
fix: use baseOptions for clangx86trunk gcc-toolchain

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -560,7 +560,7 @@ compiler.clang2210.debugPatched=true
 
 group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3822:clang_p3951:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_p1974:clang_chrisbazley
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
-group.clangx86trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
+group.clangx86trunk.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 group.clangx86trunk.groupName=Clang x86-64
 group.clangx86trunk.instructionSet=amd64
@@ -588,7 +588,8 @@ compiler.clang_concepts.options=-std=c++2a -Xclang -fconcepts-ts -stdlib=libc++
 compiler.clang_concepts.notification=<span style="color:red"><b>WARNING</b>: Concepts support has been merged to Clang trunk: use <code>-std=c++2a</code> for the most up-to-date support</span>
 compiler.clang_p1144.exe=/opt/compiler-explorer/clang-relocatable-trunk/bin/clang++
 compiler.clang_p1144.semver=(experimental P1144)
-compiler.clang_p1144.options=--gcc-toolchain=/opt/compiler-explorer/gcc-p1144-trunk -stdlib=libc++ -g0
+compiler.clang_p1144.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-p1144-trunk
+compiler.clang_p1144.options=-stdlib=libc++ -g0
 compiler.clang_p1144.notification=Experimental __is_trivially_relocatable; see <a href="https://wg21.link/p1144" target="_blank" rel="noopener noreferrer">P1144 <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_autonsdmi.exe=/opt/compiler-explorer/clang-autonsdmi-trunk/bin/clang++
 compiler.clang_autonsdmi.semver=(experimental metaprogramming - P2632)
@@ -596,7 +597,8 @@ compiler.clang_autonsdmi.options=-std=c++2a -stdlib=libc++
 compiler.clang_autonsdmi.notification=Experimental Template Meta Programming features; see <a href="https://wg21.link/P2632" target="_blank" rel="noopener noreferrer">this C++ paper <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for more information
 compiler.clang_lifetime.exe=/opt/compiler-explorer/clang-lifetime-trunk/bin/clang++
 compiler.clang_lifetime.semver=(experimental -Wlifetime)
-compiler.clang_lifetime.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0 -Wlifetime
+compiler.clang_lifetime.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+compiler.clang_lifetime.options=-Wlifetime
 compiler.clang_lifetime.notification=Lifetime profile checker based on Herb Sutter's paper; see <a href="https://herbsutter.com/2018/09/20/lifetime-profile-v1-0-posted/" target="_blank" rel="noopener noreferrer">this blog post <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a> for more information
 compiler.clang_p2561.exe=/opt/compiler-explorer/clang-p2561-trunk/bin/clang++
 compiler.clang_p2561.semver=(experimental P2561)


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

## Problem

Compilers in the `clangx86trunk` group that set their own `options` property silently **override** the group-level `options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot`. The per-compiler value is checked first; if found, the group fallback is never reached.

This means ~18 compilers (all those with a per-compiler `options` line — e.g. `clang_hana`, `clang_bb_p2996`, `clang_p2998`, `clang_patmat`, `clang_resugar`, `clang_barry`, `clang_concepts`, etc.) fall back to the system GCC 13 instead of `gcc-snapshot`. System GCC 13's libstdc++ lacks headers like `bits/version.h`, so any user who switches these compilers to `-stdlib=libstdc++` gets:

```
fatal error: 'bits/version.h' file not found
```

Reported via: https://compiler-explorer.com/z/WcPd19b5o (hana-clang, but confirmed broken on all affected compilers).

## Fix

Move the toolchain flag from `group.clangx86trunk.options` to `group.clangx86trunk.baseOptions`. The `baseOptions` and `options` values are **concatenated** rather than one replacing the other, so per-compiler `options` no longer silently discard the toolchain.

`clang_p1144` and `clang_lifetime` intentionally use different GCC toolchains, so they get their own `baseOptions` override with the correct path. The toolchain flag is removed from their `options` entries (which now only contain the non-toolchain flags).

## Testing

Verified via CE compile API with `-v` that:
- Affected compilers (e.g. `clang_hana`) currently select `/usr/lib/gcc/x86_64-linux-gnu/13` instead of `gcc-snapshot`  
- `clang_trunk` (no per-compiler options) correctly gets `gcc-snapshot` today
- Explicitly passing `--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot` as a user flag fixes the affected compilers, confirming the root cause