### PR TITLE
Add missing Beman libraries for trunk

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5129,6 +5129,18 @@ libs.beman_any_view.versions.100.path=/opt/compiler-explorer/libs/beman_any_view
 libs.beman_any_view.versions.110.version=1.1.0
 libs.beman_any_view.versions.110.path=/opt/compiler-explorer/libs/beman_any_view/v1.1.0/include
 
+libs.beman_at_most.name=beman.at_most
+libs.beman_at_most.versions=trunk
+libs.beman_at_most.url=https://github.com/bemanproject/at_most
+libs.beman_at_most.versions.trunk.version=trunk
+libs.beman_at_most.versions.trunk.path=/opt/compiler-explorer/libs/beman_at_most/main/include
+
+libs.beman_bounds_test.name=beman.bounds_test
+libs.beman_bounds_test.versions=trunk
+libs.beman_bounds_test.url=https://github.com/bemanproject/bounds_test
+libs.beman_bounds_test.versions.trunk.version=trunk
+libs.beman_bounds_test.versions.trunk.path=/opt/compiler-explorer/libs/beman_bounds_test/main/include
+
 libs.beman_cache_latest.name=beman.cache_latest
 libs.beman_cache_latest.versions=trunk:010
 libs.beman_cache_latest.url=https://github.com/bemanproject/cache_latest
@@ -5136,6 +5148,12 @@ libs.beman_cache_latest.versions.trunk.version=trunk
 libs.beman_cache_latest.versions.trunk.path=/opt/compiler-explorer/libs/beman_cache_latest/main/include
 libs.beman_cache_latest.versions.010.version=0.1.0
 libs.beman_cache_latest.versions.010.path=/opt/compiler-explorer/libs/beman_cache_latest/v0.1.0/include
+
+libs.beman_closed_view.name=beman.closed_view
+libs.beman_closed_view.versions=trunk
+libs.beman_closed_view.url=https://github.com/bemanproject/closed_view
+libs.beman_closed_view.versions.trunk.version=trunk
+libs.beman_closed_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_closed_view/main/include
 
 libs.beman_copyable_function.name=beman.copyable_function
 libs.beman_copyable_function.versions=trunk:010
@@ -5152,6 +5170,18 @@ libs.beman_cstring_view.versions.trunk.version=trunk
 libs.beman_cstring_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_cstring_view/main/include
 libs.beman_cstring_view.versions.010.version=0.1.0
 libs.beman_cstring_view.versions.010.path=/opt/compiler-explorer/libs/beman_cstring_view/v0.1.0/include
+
+libs.beman_cycle.name=beman.cycle
+libs.beman_cycle.versions=trunk
+libs.beman_cycle.url=https://github.com/bemanproject/cycle
+libs.beman_cycle.versions.trunk.version=trunk
+libs.beman_cycle.versions.trunk.path=/opt/compiler-explorer/libs/beman_cycle/main/include
+
+libs.beman_elide.name=beman.elide
+libs.beman_elide.versions=trunk
+libs.beman_elide.url=https://github.com/bemanproject/elide
+libs.beman_elide.versions.trunk.version=trunk
+libs.beman_elide.versions.trunk.path=/opt/compiler-explorer/libs/beman_elide/main/include
 
 libs.beman_execution.name=beman.execution
 libs.beman_execution.versions=trunk
@@ -5181,6 +5211,12 @@ libs.beman_exemplar.versions.230.path=/opt/compiler-explorer/libs/beman_exemplar
 libs.beman_exemplar.versions.240.version=2.4.0
 libs.beman_exemplar.versions.240.path=/opt/compiler-explorer/libs/beman_exemplar/v2.4.0/include
 
+libs.beman_gates.name=beman.gates
+libs.beman_gates.versions=trunk
+libs.beman_gates.url=https://github.com/bemanproject/gates
+libs.beman_gates.versions.trunk.version=trunk
+libs.beman_gates.versions.trunk.path=/opt/compiler-explorer/libs/beman_gates/main/include
+
 libs.beman_indices_view.name=beman.indices_view
 libs.beman_indices_view.versions=trunk:010
 libs.beman_indices_view.url=https://github.com/bemanproject/indices_view
@@ -5189,6 +5225,12 @@ libs.beman_indices_view.versions.trunk.path=/opt/compiler-explorer/libs/beman_in
 libs.beman_indices_view.versions.010.version=0.1.0
 libs.beman_indices_view.versions.010.path=/opt/compiler-explorer/libs/beman_indices_view/v0.1.0/include
 
+libs.beman_indirect.name=beman.indirect
+libs.beman_indirect.versions=trunk
+libs.beman_indirect.url=https://github.com/bemanproject/indirect
+libs.beman_indirect.versions.trunk.version=trunk
+libs.beman_indirect.versions.trunk.path=/opt/compiler-explorer/libs/beman_indirect/main/include
+
 libs.beman_inplace_vector.name=beman.inplace_vector
 libs.beman_inplace_vector.versions=trunk:010
 libs.beman_inplace_vector.url=https://github.com/bemanproject/inplace_vector/
@@ -5196,6 +5238,12 @@ libs.beman_inplace_vector.versions.trunk.version=trunk
 libs.beman_inplace_vector.versions.trunk.path=/opt/compiler-explorer/libs/beman_inplace_vector/main/include
 libs.beman_inplace_vector.versions.010.version=0.1.0
 libs.beman_inplace_vector.versions.010.path=/opt/compiler-explorer/libs/beman_inplace_vector/v0.1.0/include
+
+libs.beman_integer_division.name=beman.integer_division
+libs.beman_integer_division.versions=trunk
+libs.beman_integer_division.url=https://github.com/bemanproject/integer_division
+libs.beman_integer_division.versions.trunk.version=trunk
+libs.beman_integer_division.versions.trunk.path=/opt/compiler-explorer/libs/beman_integer_division/main/include
 
 libs.beman_iterator_interface.name=beman.iterator_interface
 libs.beman_iterator_interface.versions=trunk:010
@@ -5235,6 +5283,12 @@ libs.beman_optional.versions.trunk.path=/opt/compiler-explorer/libs/beman_option
 libs.beman_optional.versions.100.version=1.0.0
 libs.beman_optional.versions.100.path=/opt/compiler-explorer/libs/beman_optional/v1.0.0/include
 
+libs.beman_range_searcher.name=beman.range_searcher
+libs.beman_range_searcher.versions=trunk
+libs.beman_range_searcher.url=https://github.com/bemanproject/range_searcher
+libs.beman_range_searcher.versions.trunk.version=trunk
+libs.beman_range_searcher.versions.trunk.path=/opt/compiler-explorer/libs/beman_range_searcher/main/include
+
 libs.beman_scan_view.name=beman.scan_view
 libs.beman_scan_view.versions=trunk:010
 libs.beman_scan_view.url=https://github.com/bemanproject/scan_view
@@ -5256,6 +5310,12 @@ libs.beman_span.versions=trunk
 libs.beman_span.url=https://github.com/bemanproject/span
 libs.beman_span.versions.trunk.version=trunk
 libs.beman_span.versions.trunk.path=/opt/compiler-explorer/libs/beman_span/main/include
+
+libs.beman_str_split.name=beman.str_split
+libs.beman_str_split.versions=trunk
+libs.beman_str_split.url=https://github.com/bemanproject/str_split
+libs.beman_str_split.versions.trunk.version=trunk
+libs.beman_str_split.versions.trunk.path=/opt/compiler-explorer/libs/beman_str_split/main/include
 
 libs.beman_take_before.name=beman.take_before
 libs.beman_take_before.versions=trunk:010


### PR DESCRIPTION
## Summary

- Add trunk entries for 10 missing Beman libraries in `etc/config/c++.amazon.properties`.

## Libraries (trunk)

- beman.at_most
- beman.bounds_test
- beman.closed_view
- beman.cycle
- beman.elide
- beman.gates
- beman.indirect
- beman.integer_division
- beman.range_searcher
- beman.str_split

## Tracking

- Compiler Explorer issue: https://github.com/compiler-explorer/compiler-explorer/issues/8908
- infra PR (merge first): https://github.com/compiler-explorer/infra/pull/2219

## Test plan

- [x] Merge infra PR first and wait for deployment
- [ ] Verify libraries appear in Godbolt library picker
- [ ] Smoke-compile a sample include for each library