### PR TITLE
Lint GitHub Actions workflows with actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # The admin node is registered as a self-hosted runner (see the infra repository)
+  labels:
+    - admin

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,20 @@
+name: Lint GitHub Actions workflows
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**', '.github/actionlint.yaml']
+  pull_request:
+    paths: ['.github/workflows/**', '.github/actionlint.yaml']
+
+jobs:
+  actionlint:
+    if: github.repository_owner == 'compiler-explorer'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths: ['.github/workflows/**', '.github/actionlint.yaml']
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     if: github.repository_owner == 'compiler-explorer'


### PR DESCRIPTION
Part of the actionlint rollout across CE repos (compiler-explorer/compiler-workflows#68, compiler-explorer/infra#2226). [actionlint](https://github.com/rhysd/actionlint) statically checks workflow files: schema/typos, expression type-checking against real contexts (undefined inputs/outputs/needs are errors), unknown runner labels, and shellcheck over embedded `run:` scripts.

This repo has no pre-commit framework, so it's wired as a small CI workflow that runs on any push/PR touching `.github/workflows/**`, using the pinned official docker image. `.github/actionlint.yaml` declares the self-hosted `admin` label so `runs-on: [admin]` (deploy workflows) checks correctly.

The existing ten workflows already pass with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)