### PR TITLE
Add SDCC 4.6.0

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4202,7 +4202,7 @@ compiler.cc65_219.options=-I/opt/compiler-explorer/6502/cc65-2.19/share/cc65/inc
 
 #################################
 # sdcc compilers
-group.sdcc.compilers=sdcc400:sdcc410:sdcc420:sdcc430:sdcc440:sdcc450
+group.sdcc.compilers=sdcc400:sdcc410:sdcc420:sdcc430:sdcc440:sdcc450:sdcc460
 group.sdcc.compilerType=sdcc
 group.sdcc.groupName=SDCC
 group.sdcc.baseName=SDCC
@@ -4223,6 +4223,8 @@ compiler.sdcc440.exe=/opt/compiler-explorer/sdcc-4.4.0/bin/sdcc
 compiler.sdcc440.semver=4.4.0
 compiler.sdcc450.exe=/opt/compiler-explorer/sdcc-4.5.0/bin/sdcc
 compiler.sdcc450.semver=4.5.0
+compiler.sdcc460.exe=/opt/compiler-explorer/sdcc-4.6.0/bin/sdcc
+compiler.sdcc460.semver=4.6.0
 
 ################################
 # Clang for eZ80,Z80,Z180


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds SDCC 4.6.0 to the C compiler list. Requested because 4.6.0 is the first C compiler release to support the `_Optional` type qualifier.

Follows the existing SDCC group convention exactly: appends `sdcc460` to `group.sdcc.compilers` and adds the `exe`/`semver` entries. No existing IDs changed.

Depends on the infra install PR landing first: compiler-explorer/infra#2228

Verified the 4.6.0 tarball installs via `ce_install`, `bin/sdcc --version` reports `4.6.0`, and a `_Optional int *p;` program compiles cleanly. The properties validation suite passes (`npm run test:props`, 90 tests).

🤖 Generated by LLM (Claude, via OpenClaw)