### PR TITLE
Mask temp paths by the CE marker, not the live os.tmpdir()

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,7 +24,6 @@
 
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {Buffer} from 'buffer';
@@ -94,10 +93,17 @@ export function expandTabs(line: string): string {
     });
 }
 
-function getRegexForTempdir(): RegExp {
-    const tmp = os.tmpdir();
-    return new RegExp(tmp.replaceAll('/', '\\/') + '\\/' + ce_temp_prefix + '[\\w\\d-.]*\\/');
-}
+// Matches everything up to and through a CE temp dir, `.../<ce_temp_prefix><suffix>/`.
+// We key off the ce_temp_prefix marker, NOT the live os.tmpdir(): the temp root varies
+// by host/config (macOS /var vs /private/var, an execution.tempDirRoot elsewhere) and
+// the path being masked may have been recorded under a different tmpdir than this one.
+// The marker is the only invariant — it's the same constant we create the dir with.
+// `(?:[A-Za-z]:)?` + `/` handles Windows too; `[^/\s]` confines the match to one path
+// token so an embedded `-I/tmp/<prefix>XXX/inc` still masks to `-I/app/inc`.
+// A user path that itself contains a `<ce_temp_prefix>...` segment would be masked too,
+// but that only affects displayed output (never what's compiled/executed) and needs a
+// deliberately odd dir name, so it's not worth a costlier scheme to prevent.
+const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]*/)*${ce_temp_prefix}[\\w.-]*/`);
 
 /**
  * Removes the root dir from the given filepath, so that it will match to the user's filenames used
@@ -105,14 +111,7 @@ function getRegexForTempdir(): RegExp {
  */
 export function maskRootdir(filepath: string): string {
     if (filepath) {
-        if (process.platform === 'win32') {
-            // todo: should also use temp_prefix here
-            return filepath
-                .replace(/^C:\/Users\/[\w\d-.]*\/AppData\/Local\/Temp\/compiler-explorer-compiler[\w\d-.]*\//, '/app/')
-                .replace(/^\/app\//, '');
-        }
-        const re = getRegexForTempdir();
-        return filepath.replace(re, '/app/').replace(/^\/app\//, '');
+        return filepath.replace(TEMPDIR_RE, '/app/').replace(/^\/app\//, '');
     }
     return filepath;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -93,18 +93,85 @@ export function expandTabs(line: string): string {
     });
 }
 
-// Matches everything up to and through a CE temp dir, `.../<ce_temp_prefix><suffix>/`.
-// We key off the ce_temp_prefix marker, NOT the live os.tmpdir(): the temp root varies
-// by host/config (macOS /var vs /private/var, an execution.tempDirRoot elsewhere) and
-// the path being masked may have been recorded under a different tmpdir than this one.
-// The marker is the only invariant — it's the same constant we create the dir with.
-// `(?:[A-Za-z]:)?` + `/` handles Windows too; `[^/\s]+` confines the match to one
-// non-empty path token so an embedded `-I/tmp/<prefix>XXX/inc` still masks to
-// `-I/app/inc` (real temp paths never have empty `//` segments).
-// A user path that itself contains a `<ce_temp_prefix>...` segment would be masked too,
-// but that only affects displayed output (never what's compiled/executed) and needs a
-// deliberately odd dir name, so it's not worth a costlier scheme to prevent.
-const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]+/)*${ce_temp_prefix}[\\w.-]*/`);
+function isWhitespaceChar(char: string): boolean {
+    return /\s/.test(char);
+}
+
+function isDriveLetter(char: string): boolean {
+    return /^[A-Za-z]$/.test(char);
+}
+
+function isTempdirSuffixChar(char: string): boolean {
+    return /^[\w.-]$/.test(char);
+}
+
+function findTokenStart(filepath: string, start: number): number {
+    let tokenStart = start;
+    while (tokenStart > 0 && !isWhitespaceChar(filepath[tokenStart - 1])) {
+        tokenStart--;
+    }
+    return tokenStart;
+}
+
+function findPathStart(filepath: string, tokenStart: number, markerSlashIndex: number): number {
+    const hasDrivePrefix =
+        tokenStart + 2 <= markerSlashIndex &&
+        isDriveLetter(filepath[tokenStart]) &&
+        filepath[tokenStart + 1] === ':' &&
+        filepath[tokenStart + 2] === '/';
+
+    if (hasDrivePrefix) {
+        return tokenStart;
+    }
+
+    const firstSlashInToken = filepath.indexOf('/', tokenStart);
+    if (firstSlashInToken === -1 || firstSlashInToken > markerSlashIndex) {
+        return -1;
+    }
+
+    return firstSlashInToken;
+}
+
+function findTempdirRange(filepath: string): [number, number] | undefined {
+    let searchFrom = 0;
+    while (searchFrom < filepath.length) {
+        const markerStart = filepath.indexOf(ce_temp_prefix, searchFrom);
+        if (markerStart === -1) {
+            return undefined;
+        }
+
+        const markerSlashIndex = markerStart - 1;
+        if (markerSlashIndex < 0 || filepath[markerSlashIndex] !== '/') {
+            searchFrom = markerStart + 1;
+            continue;
+        }
+
+        let tempdirSegmentEnd = markerStart + ce_temp_prefix.length;
+        let isValidSegment = true;
+        while (tempdirSegmentEnd < filepath.length && filepath[tempdirSegmentEnd] !== '/') {
+            if (!isTempdirSuffixChar(filepath[tempdirSegmentEnd])) {
+                isValidSegment = false;
+                break;
+            }
+            tempdirSegmentEnd++;
+        }
+        if (!isValidSegment || tempdirSegmentEnd >= filepath.length || filepath[tempdirSegmentEnd] !== '/') {
+            searchFrom = markerStart + 1;
+            continue;
+        }
+
+        const tokenStart = findTokenStart(filepath, markerSlashIndex);
+        const pathStart = findPathStart(filepath, tokenStart, markerSlashIndex);
+        if (pathStart === -1) {
+            searchFrom = markerStart + 1;
+            continue;
+        }
+
+        return [pathStart, tempdirSegmentEnd + 1];
+    }
+
+    return undefined;
+}
 
 /**
  * Removes the root dir from the given filepath, so that it will match to the user's filenames used
@@ -112,7 +179,12 @@ const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]+/)*${ce_temp_prefix}[\\
  */
 export function maskRootdir(filepath: string): string {
     if (filepath) {
-        return filepath.replace(TEMPDIR_RE, '/app/').replace(/^\/app\//, '');
+        const tempdirRange = findTempdirRange(filepath);
+        if (!tempdirRange) return filepath.replace(/^\/app\//, '');
+
+        const [start, end] = tempdirRange;
+        const maskedPath = filepath.slice(0, start) + '/app/' + filepath.slice(end);
+        return maskedPath.replace(/^\/app\//, '');
     }
     return filepath;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -98,12 +98,13 @@ export function expandTabs(line: string): string {
 // by host/config (macOS /var vs /private/var, an execution.tempDirRoot elsewhere) and
 // the path being masked may have been recorded under a different tmpdir than this one.
 // The marker is the only invariant — it's the same constant we create the dir with.
-// `(?:[A-Za-z]:)?` + `/` handles Windows too; `[^/\s]` confines the match to one path
-// token so an embedded `-I/tmp/<prefix>XXX/inc` still masks to `-I/app/inc`.
+// `(?:[A-Za-z]:)?` + `/` handles Windows too; `[^/\s]+` confines the match to one
+// non-empty path token so an embedded `-I/tmp/<prefix>XXX/inc` still masks to
+// `-I/app/inc` (real temp paths never have empty `//` segments).
 // A user path that itself contains a `<ce_temp_prefix>...` segment would be masked too,
 // but that only affects displayed output (never what's compiled/executed) and needs a
 // deliberately odd dir name, so it's not worth a costlier scheme to prevent.
-const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]*/)*${ce_temp_prefix}[\\w.-]*/`);
+const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]+/)*${ce_temp_prefix}[\\w.-]*/`);
 
 /**
  * Removes the root dir from the given filepath, so that it will match to the user's filenames used

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -93,100 +93,37 @@ export function expandTabs(line: string): string {
     });
 }
 
-function isWhitespaceChar(char: string): boolean {
-    return /\s/.test(char);
-}
-
-function isDriveLetter(char: string): boolean {
-    return /^[A-Za-z]$/.test(char);
-}
-
-function isTempdirSuffixChar(char: string): boolean {
-    return /^[\w.-]$/.test(char);
-}
-
-function findTokenStart(filepath: string, start: number): number {
-    let tokenStart = start;
-    while (tokenStart > 0 && !isWhitespaceChar(filepath[tokenStart - 1])) {
-        tokenStart--;
-    }
-    return tokenStart;
-}
-
-function findPathStart(filepath: string, tokenStart: number, markerSlashIndex: number): number {
-    const hasDrivePrefix =
-        tokenStart + 2 <= markerSlashIndex &&
-        isDriveLetter(filepath[tokenStart]) &&
-        filepath[tokenStart + 1] === ':' &&
-        filepath[tokenStart + 2] === '/';
-
-    if (hasDrivePrefix) {
-        return tokenStart;
-    }
-
-    const firstSlashInToken = filepath.indexOf('/', tokenStart);
-    if (firstSlashInToken === -1 || firstSlashInToken > markerSlashIndex) {
-        return -1;
-    }
-
-    return firstSlashInToken;
-}
-
-function findTempdirRange(filepath: string): [number, number] | undefined {
-    let searchFrom = 0;
-    while (searchFrom < filepath.length) {
-        const markerStart = filepath.indexOf(ce_temp_prefix, searchFrom);
-        if (markerStart === -1) {
-            return undefined;
-        }
-
-        const markerSlashIndex = markerStart - 1;
-        if (markerSlashIndex < 0 || filepath[markerSlashIndex] !== '/') {
-            searchFrom = markerStart + 1;
-            continue;
-        }
-
-        let tempdirSegmentEnd = markerStart + ce_temp_prefix.length;
-        let isValidSegment = true;
-        while (tempdirSegmentEnd < filepath.length && filepath[tempdirSegmentEnd] !== '/') {
-            if (!isTempdirSuffixChar(filepath[tempdirSegmentEnd])) {
-                isValidSegment = false;
-                break;
-            }
-            tempdirSegmentEnd++;
-        }
-        if (!isValidSegment || tempdirSegmentEnd >= filepath.length || filepath[tempdirSegmentEnd] !== '/') {
-            searchFrom = markerStart + 1;
-            continue;
-        }
-
-        const tokenStart = findTokenStart(filepath, markerSlashIndex);
-        const pathStart = findPathStart(filepath, tokenStart, markerSlashIndex);
-        if (pathStart === -1) {
-            searchFrom = markerStart + 1;
-            continue;
-        }
-
-        return [pathStart, tempdirSegmentEnd + 1];
-    }
-
-    return undefined;
-}
+// Matches everything up to and through a CE temp dir, `.../<ce_temp_prefix><suffix>/`.
+// We key off the ce_temp_prefix marker, NOT the live os.tmpdir(): the temp root varies
+// by host/config (macOS /var vs /private/var, an execution.tempDirRoot elsewhere) and
+// the path being masked may have been recorded under a different tmpdir than this one.
+// The marker is the only invariant — it's the same constant we create the dir with.
+// `(?:[A-Za-z]:)?` + `/` handles Windows too; `[^/\s]+` confines the match to one
+// non-empty path token so an embedded `-I/tmp/<prefix>XXX/inc` still masks to
+// `-I/app/inc` (real temp paths never have empty `//` segments).
+// A user path that itself contains a `<ce_temp_prefix>...` segment would be masked too,
+// but that only affects displayed output (never what's compiled/executed) and needs a
+// deliberately odd dir name, so it's not worth a costlier scheme to prevent.
+const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]+/)*${ce_temp_prefix}[\\w.-]*/`);
 
 /**
  * Removes the root dir from the given filepath, so that it will match to the user's filenames used
  *  note: will keep /app/ if instead of filepath something like '-I/tmp/path' is used
  */
 export function maskRootdir(filepath: string): string {
-    if (filepath) {
-        const tempdirRange = findTempdirRange(filepath);
-        if (!tempdirRange) return filepath.replace(/^\/app\//, '');
-
-        const [start, end] = tempdirRange;
-        const maskedPath = filepath.slice(0, start) + '/app/' + filepath.slice(end);
-        return maskedPath.replace(/^\/app\//, '');
-    }
-    return filepath;
+    // TODO: this falsy guard is load-bearing against runtime `undefined` that the types
+    // don't catch — not declared `string | undefined` callers (TS would reject those),
+    // but type holes: a JSON.parse(...) result typed `any` (base-compiler cleanup) and a
+    // Record<number,string> index that's really `undefined` when the key is missing
+    // (noUncheckedIndexedAccess is off). Tighten those two sites, then this can go.
+    if (!filepath) return filepath;
+    // TEMPDIR_RE has a repeated path-segment group that backtracks on long input, and
+    // maskRootdir runs on every output line. Gate it behind a cheap linear substring
+    // check: the regex cannot match without the marker anyway. The trailing /app/ strip
+    // is anchored (no backtracking) and must run regardless, as paths may already be
+    // /app/-rooted from an earlier mask.
+    const masked = filepath.includes(ce_temp_prefix) ? filepath.replace(TEMPDIR_RE, '/app/') : filepath;
+    return masked.replace(/^\/app\//, '');
 }
 
 export function changeExtension(filename: string, newExtension: string): string {

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -810,6 +810,17 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
 
+    it('leaves paths with invalid marker suffix chars untouched', () => {
+        expect(utils.maskRootdir('/tmp/compiler-explorer-compiler+bad/example.cpp')).toEqual(
+            '/tmp/compiler-explorer-compiler+bad/example.cpp',
+        );
+    });
+
+    it('handles long non-matching path-like inputs without altering them', () => {
+        const input = `-I/${'segment/'.repeat(4000)}not-temp/include`;
+        expect(utils.maskRootdir(input)).toEqual(input);
+    });
+
     it('passes empty input through unchanged', () => {
         expect(utils.maskRootdir('')).toEqual('');
     });

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -810,6 +810,23 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
 
+    // A bare temp dir with no trailing slash isn't masked: the marker segment must be
+    // followed by `/` (i.e. contain a file/subpath). In practice maskRootdir is only
+    // ever called on paths *inside* the temp dir, so this bare-directory form doesn't
+    // arise; asserted here to pin the boundary.
+    it('leaves a bare temp dir with no trailing slash untouched', () => {
+        expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc')).toEqual(
+            '/tmp/compiler-explorer-compiler123-4-abc',
+        );
+    });
+
+    // With a trailing slash the whole thing is the temp dir, so it masks to /app/ and
+    // the leading-/app/ strip then leaves an empty string. (Pre-existing behaviour,
+    // unchanged by this PR; also doesn't occur for real inputs, which name a file.)
+    it('masks a bare temp dir with a trailing slash to empty', () => {
+        expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc/')).toEqual('');
+    });
+
     it('leaves paths with invalid marker suffix chars untouched', () => {
         expect(utils.maskRootdir('/tmp/compiler-explorer-compiler+bad/example.cpp')).toEqual(
             '/tmp/compiler-explorer-compiler+bad/example.cpp',

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -794,9 +794,8 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir('-I/tmp/compiler-explorer-compiler123-4-abc/include')).toEqual('-I/app/include');
     });
 
-    // The path being masked was recorded when the compile ran; its leading directory
-    // need not match this process's os.tmpdir(). The distinctive ce_temp_prefix marker
-    // is what identifies a CE temp dir, so masking must not depend on the tmpdir root.
+    // The recorded path's tmpdir root need not match this process's os.tmpdir(), so
+    // masking keys off the ce_temp_prefix marker, not the root.
     it.each([
         ['/tmp', '/tmp/compiler-explorer-compilerXYZ/example.cpp'],
         ['/usr/tmp', '/usr/tmp/compiler-explorer-compilerXYZ/example.cpp'],
@@ -810,19 +809,14 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
 
-    // A bare temp dir with no trailing slash isn't masked: the marker segment must be
-    // followed by `/` (i.e. contain a file/subpath). In practice maskRootdir is only
-    // ever called on paths *inside* the temp dir, so this bare-directory form doesn't
-    // arise; asserted here to pin the boundary.
+    // The marker segment must be followed by `/`, so a bare dir with no trailing slash
+    // is left alone. (Real inputs always name a file inside the dir.)
     it('leaves a bare temp dir with no trailing slash untouched', () => {
         expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc')).toEqual(
             '/tmp/compiler-explorer-compiler123-4-abc',
         );
     });
 
-    // With a trailing slash the whole thing is the temp dir, so it masks to /app/ and
-    // the leading-/app/ strip then leaves an empty string. (Pre-existing behaviour,
-    // unchanged by this PR; also doesn't occur for real inputs, which name a file.)
     it('masks a bare temp dir with a trailing slash to empty', () => {
         expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc/')).toEqual('');
     });
@@ -838,11 +832,8 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir(input)).toEqual(input);
     });
 
-    // maskRootdir runs on whole output lines with space-separated tokens, so the regex
-    // deliberately stops at whitespace. A temp root that itself contains a space (e.g.
-    // --tmp-dir "/tmp/with space") is therefore only masked from the last space onward,
-    // not fully collapsed to the basename. This is the accepted trade-off: widening the
-    // match to cross spaces would let a single line's leading tokens be swallowed too.
+    // The regex stops at whitespace (so multi-token output lines aren't over-masked),
+    // so a temp root containing a space is only masked from the last space onward.
     it('masks only from the last space in a spaced temp root (documented limitation)', () => {
         expect(utils.maskRootdir('/tmp/with space/compiler-explorer-compilerXXX/example.cpp')).toEqual(
             '/tmp/with space/app/example.cpp',

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -821,6 +821,17 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir(input)).toEqual(input);
     });
 
+    // maskRootdir runs on whole output lines with space-separated tokens, so the regex
+    // deliberately stops at whitespace. A temp root that itself contains a space (e.g.
+    // --tmp-dir "/tmp/with space") is therefore only masked from the last space onward,
+    // not fully collapsed to the basename. This is the accepted trade-off: widening the
+    // match to cross spaces would let a single line's leading tokens be swallowed too.
+    it('masks only from the last space in a spaced temp root (documented limitation)', () => {
+        expect(utils.maskRootdir('/tmp/with space/compiler-explorer-compilerXXX/example.cpp')).toEqual(
+            '/tmp/with space/app/example.cpp',
+        );
+    });
+
     it('passes empty input through unchanged', () => {
         expect(utils.maskRootdir('')).toEqual('');
     });

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -784,3 +784,33 @@ describe('output files', async () => {
         expect(await utils.tryReadTextFile(filepath)).toEqual('hello');
     });
 });
+
+describe('maskRootdir', () => {
+    it('masks a CE temp path down to the user-facing filename', () => {
+        expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc/example.cpp')).toEqual('example.cpp');
+    });
+
+    it('keeps /app/ when the temp path is embedded (e.g. a -I include flag)', () => {
+        expect(utils.maskRootdir('-I/tmp/compiler-explorer-compiler123-4-abc/include')).toEqual('-I/app/include');
+    });
+
+    // The path being masked was recorded when the compile ran; its leading directory
+    // need not match this process's os.tmpdir(). The distinctive ce_temp_prefix marker
+    // is what identifies a CE temp dir, so masking must not depend on the tmpdir root.
+    it.each([
+        ['/tmp', '/tmp/compiler-explorer-compilerXYZ/example.cpp'],
+        ['/usr/tmp', '/usr/tmp/compiler-explorer-compilerXYZ/example.cpp'],
+        ['macOS /private/var', '/private/var/folders/ab/xyz/T/compiler-explorer-compilerXYZ/example.cpp'],
+        ['Windows', 'C:/Users/ce/AppData/Local/Temp/compiler-explorer-compilerXYZ/example.cpp'],
+    ])('masks a temp path rooted at %s regardless of the local tmpdir', (_root, input) => {
+        expect(utils.maskRootdir(input)).toEqual('example.cpp');
+    });
+
+    it('leaves non-temp paths untouched', () => {
+        expect(utils.maskRootdir('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
+    });
+
+    it('passes empty input through unchanged', () => {
+        expect(utils.maskRootdir('')).toEqual('');
+    });
+});


### PR DESCRIPTION
maskRootdir() built its strip-regex from this process's os.tmpdir(), so it only masked paths whose root matched the current tmpdir. That is fragile in two real cases:

  - The path being masked is recorded when the compile runs and need not share the masking process's tmpdir. Snapshots/fixtures that freeze /tmp/... paths only mask on hosts where os.tmpdir() is /tmp (they fail where it is e.g. /usr/tmp).
  - On macOS os.tmpdir() returns /var/folders/... while real temp paths often resolve via /private/var/folders/..., so masking silently missed.
  - A configured temp root (temp dirs created outside os.tmpdir()) was never matched at all.

Key the regex off the distinctive ce_temp_prefix marker instead, matching whatever path segments precede it. This is tmpdir-independent and unifies the Windows and non-Windows branches into one rule (also masking embedded temp paths like `-I/tmp/.../include` on Windows, which the old anchored branch missed).

Adds unit tests for maskRootdir (previously untested) covering /tmp, /usr/tmp, macOS /private/var, Windows, the -I include case, and non-temp paths left untouched.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
