### PR TITLE
Remove outdated comments/code from JavaScript example

### DIFF
--- a/examples/javascript/default.mjs
+++ b/examples/javascript/default.mjs
@@ -3,14 +3,11 @@ function square(a) {
 	return result;
 }
 
-// Collect type information on next call of function
+// Allocate feedback vector for the function and call it once to record type
+// information.
 %PrepareFunctionForOptimization(square)
-
-// Call function once to fill type information
 square(23);
 
-// Call function again to go from uninitialized -> pre-monomorphic -> monomorphic
-square(13);
+// Optimize with Turbofan.
 %OptimizeFunctionOnNextCall(square);
 square(71);
-


### PR DESCRIPTION
V8 doesn't have a "pre-monomorphic" feedback state anymore. This PR thus updates the JS example to reflect the current behavior of V8.

Some historical details about the pre-monomorphic state, if anyone is intersted:

The idea of the pre-monomorphic state was that the first time a JavaScript piece of code runs, it will see Maps (= hidden classes) that it won't see ever again because it might see objects that are still under constructions. So, the feedback was initialized with "unitialized" state, then the first time operations ran the state was migrated to "pre-monomorphic" but nothing was really collected, and the next time operations were ran we actually started collecting feedback and thus transitioning to "monomorphic" state.

However, this became obsolete when we introduced lazy feedback allocation: now, feedback vectors are lazily allocated after a function has been called a few times (or a loop in the function has looped a few times), so we don't need the pre-monomorphic state anymore and can just straight ahead to the monomorphic state.

The pre-monomorphic state stopped being used in 2019 (https://crrev.com/c/1731000).