### PR TITLE
Fix android-java dropdown menu display

### DIFF
--- a/etc/config/android-java.amazon.properties
+++ b/etc/config/android-java.amazon.properties
@@ -116,13 +116,15 @@ compiler.java-dex2oat-latest.isNightly=true
 compiler.java-dex2oat-latest.profmanPath=/opt/compiler-explorer/dex2oat-latest/x86_64/bin/profman
 
 compiler.java-dex2oat-3700.name=ART dex2oat android17-release (June 2026)
+compiler.java-dex2oat-3700.semver=37.0
 compiler.java-dex2oat-3700.artArtifactDir=/opt/compiler-explorer/dex2oat-37.0
 compiler.java-dex2oat-3700.exe=/opt/compiler-explorer/dex2oat-37.0/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3700.objdumper=/opt/compiler-explorer/dex2oat-37.0/x86_64/bin/oatdump
 compiler.java-dex2oat-3700.d8Id=java-d8-8718
 compiler.java-dex2oat-3700.profmanPath=/opt/compiler-explorer/dex2oat-37.0/x86_64/bin/profman
 
-compiler.java-dex2oat-3601.name=ART dex2oat android16-qpr2-release (Dec 2026)
+compiler.java-dex2oat-3601.name=ART dex2oat android16-qpr2-release (Dec 2025)
+compiler.java-dex2oat-3601.semver=36.1
 compiler.java-dex2oat-3601.artArtifactDir=/opt/compiler-explorer/dex2oat-36.1
 compiler.java-dex2oat-3601.exe=/opt/compiler-explorer/dex2oat-36.1/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3601.objdumper=/opt/compiler-explorer/dex2oat-36.1/x86_64/bin/oatdump
@@ -130,6 +132,7 @@ compiler.java-dex2oat-3601.d8Id=java-d8-8718
 compiler.java-dex2oat-3601.profmanPath=/opt/compiler-explorer/dex2oat-36.1/x86_64/bin/profman
 
 compiler.java-dex2oat-3600.name=ART dex2oat android16-release (May 2025)
+compiler.java-dex2oat-3600.semver=36.0
 compiler.java-dex2oat-3600.artArtifactDir=/opt/compiler-explorer/dex2oat-36.0
 compiler.java-dex2oat-3600.exe=/opt/compiler-explorer/dex2oat-36.0/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3600.objdumper=/opt/compiler-explorer/dex2oat-36.0/x86_64/bin/oatdump
@@ -137,6 +140,7 @@ compiler.java-dex2oat-3600.d8Id=java-d8-8718
 compiler.java-dex2oat-3600.profmanPath=/opt/compiler-explorer/dex2oat-36.0/x86_64/bin/profman
 
 compiler.java-dex2oat-3514.name=ART dex2oat aml_art_351410020 (Feb 2025)
+compiler.java-dex2oat-3514.semver=35.14
 compiler.java-dex2oat-3514.artArtifactDir=/opt/compiler-explorer/dex2oat-35.14
 compiler.java-dex2oat-3514.exe=/opt/compiler-explorer/dex2oat-35.14/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3514.objdumper=/opt/compiler-explorer/dex2oat-35.14/x86_64/bin/oatdump
@@ -144,6 +148,7 @@ compiler.java-dex2oat-3514.d8Id=java-d8-8718
 compiler.java-dex2oat-3514.profmanPath=/opt/compiler-explorer/dex2oat-35.14/x86_64/bin/profman
 
 compiler.java-dex2oat-3513.name=ART dex2oat aml_art_351310060 (Jan 2025)
+compiler.java-dex2oat-3513.semver=35.13
 compiler.java-dex2oat-3513.artArtifactDir=/opt/compiler-explorer/dex2oat-35.13
 compiler.java-dex2oat-3513.exe=/opt/compiler-explorer/dex2oat-35.13/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3513.objdumper=/opt/compiler-explorer/dex2oat-35.13/x86_64/bin/oatdump
@@ -151,6 +156,7 @@ compiler.java-dex2oat-3513.d8Id=java-d8-8718
 compiler.java-dex2oat-3513.profmanPath=/opt/compiler-explorer/dex2oat-35.13/x86_64/bin/profman
 
 compiler.java-dex2oat-3511.name=ART dex2oat aml_art_351110180 (Nov 2024)
+compiler.java-dex2oat-3511.semver=35.11
 compiler.java-dex2oat-3511.artArtifactDir=/opt/compiler-explorer/dex2oat-35.11
 compiler.java-dex2oat-3511.exe=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3511.objdumper=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/oatdump
@@ -158,6 +164,7 @@ compiler.java-dex2oat-3511.d8Id=java-d8-8718
 compiler.java-dex2oat-3511.profmanPath=/opt/compiler-explorer/dex2oat-35.11/x86_64/bin/profman
 
 compiler.java-dex2oat-3510.name=ART dex2oat aml_art_351011240 (Oct 2024)
+compiler.java-dex2oat-3510.semver=35.10
 compiler.java-dex2oat-3510.artArtifactDir=/opt/compiler-explorer/dex2oat-35.10
 compiler.java-dex2oat-3510.exe=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3510.objdumper=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/oatdump
@@ -165,6 +172,7 @@ compiler.java-dex2oat-3510.d8Id=java-d8-8718
 compiler.java-dex2oat-3510.profmanPath=/opt/compiler-explorer/dex2oat-35.10/x86_64/bin/profman
 
 compiler.java-dex2oat-3509.name=ART dex2oat aml_art_350913340 (Sep 2024)
+compiler.java-dex2oat-3509.semver=35.9
 compiler.java-dex2oat-3509.artArtifactDir=/opt/compiler-explorer/dex2oat-35.9
 compiler.java-dex2oat-3509.exe=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3509.objdumper=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/oatdump
@@ -172,6 +180,7 @@ compiler.java-dex2oat-3509.d8Id=java-d8-8718
 compiler.java-dex2oat-3509.profmanPath=/opt/compiler-explorer/dex2oat-35.9/x86_64/bin/profman
 
 compiler.java-dex2oat-3508.name=ART dex2oat aml_art_350820960 (Aug 2024)
+compiler.java-dex2oat-3508.semver=35.8
 compiler.java-dex2oat-3508.artArtifactDir=/opt/compiler-explorer/dex2oat-35.8
 compiler.java-dex2oat-3508.exe=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3508.objdumper=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/oatdump
@@ -179,6 +188,7 @@ compiler.java-dex2oat-3508.d8Id=java-d8-8718
 compiler.java-dex2oat-3508.profmanPath=/opt/compiler-explorer/dex2oat-35.8/x86_64/bin/profman
 
 compiler.java-dex2oat-3418.name=ART dex2oat aml_art_341810020 (Jun 2024)
+compiler.java-dex2oat-3418.semver=34.18
 compiler.java-dex2oat-3418.artArtifactDir=/opt/compiler-explorer/dex2oat-34.18
 compiler.java-dex2oat-3418.exe=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3418.objdumper=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/oatdump
@@ -186,6 +196,7 @@ compiler.java-dex2oat-3418.d8Id=java-d8-8535
 compiler.java-dex2oat-3418.profmanPath=/opt/compiler-explorer/dex2oat-34.18/x86_64/bin/profman
 
 compiler.java-dex2oat-3417.name=ART dex2oat aml_art_341711000 (May 2024)
+compiler.java-dex2oat-3417.semver=34.17
 compiler.java-dex2oat-3417.artArtifactDir=/opt/compiler-explorer/dex2oat-34.17
 compiler.java-dex2oat-3417.exe=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3417.objdumper=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/oatdump
@@ -193,6 +204,7 @@ compiler.java-dex2oat-3417.d8Id=java-d8-8535
 compiler.java-dex2oat-3417.profmanPath=/opt/compiler-explorer/dex2oat-34.17/x86_64/bin/profman
 
 compiler.java-dex2oat-3416.name=ART dex2oat aml_art_341615020 (Apr 2024)
+compiler.java-dex2oat-3416.semver=34.16
 compiler.java-dex2oat-3416.artArtifactDir=/opt/compiler-explorer/dex2oat-34.16
 compiler.java-dex2oat-3416.exe=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3416.objdumper=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/oatdump
@@ -200,6 +212,7 @@ compiler.java-dex2oat-3416.d8Id=java-d8-8337
 compiler.java-dex2oat-3416.profmanPath=/opt/compiler-explorer/dex2oat-34.16/x86_64/bin/profman
 
 compiler.java-dex2oat-3415.name=ART dex2oat aml_art_341514410 (Mar 2024)
+compiler.java-dex2oat-3415.semver=34.15
 compiler.java-dex2oat-3415.artArtifactDir=/opt/compiler-explorer/dex2oat-34.15
 compiler.java-dex2oat-3415.exe=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3415.objdumper=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/oatdump
@@ -207,6 +220,7 @@ compiler.java-dex2oat-3415.d8Id=java-d8-8337
 compiler.java-dex2oat-3415.profmanPath=/opt/compiler-explorer/dex2oat-34.15/x86_64/bin/profman
 
 compiler.java-dex2oat-3414.name=ART dex2oat aml_art_341411300 (Feb 2024)
+compiler.java-dex2oat-3414.semver=34.14
 compiler.java-dex2oat-3414.artArtifactDir=/opt/compiler-explorer/dex2oat-34.14
 compiler.java-dex2oat-3414.exe=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3414.objdumper=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/oatdump
@@ -214,6 +228,7 @@ compiler.java-dex2oat-3414.d8Id=java-d8-8337
 compiler.java-dex2oat-3414.profmanPath=/opt/compiler-explorer/dex2oat-34.14/x86_64/bin/profman
 
 compiler.java-dex2oat-3413.name=ART dex2oat aml_art_341311100 (Jan 2024)
+compiler.java-dex2oat-3413.semver=34.13
 compiler.java-dex2oat-3413.artArtifactDir=/opt/compiler-explorer/dex2oat-34.13
 compiler.java-dex2oat-3413.exe=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3413.objdumper=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/oatdump
@@ -221,6 +236,7 @@ compiler.java-dex2oat-3413.d8Id=java-d8-8337
 compiler.java-dex2oat-3413.profmanPath=/opt/compiler-explorer/dex2oat-34.13/x86_64/bin/profman
 
 compiler.java-dex2oat-3411.name=ART dex2oat aml_art_341110060 (Nov 2023)
+compiler.java-dex2oat-3411.semver=34.11
 compiler.java-dex2oat-3411.artArtifactDir=/opt/compiler-explorer/dex2oat-34.11
 compiler.java-dex2oat-3411.exe=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3411.objdumper=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/oatdump
@@ -228,6 +244,7 @@ compiler.java-dex2oat-3411.d8Id=java-d8-8242
 compiler.java-dex2oat-3411.profmanPath=/opt/compiler-explorer/dex2oat-34.11/x86_64/bin/profman
 
 compiler.java-dex2oat-3310.name=ART dex2oat aml_art_331012050 (Oct 2022)
+compiler.java-dex2oat-3310.semver=33.10
 compiler.java-dex2oat-3310.artArtifactDir=/opt/compiler-explorer/dex2oat-33.10
 compiler.java-dex2oat-3310.exe=/opt/compiler-explorer/dex2oat-33.10/x86_64/bin/dex2oat64
 compiler.java-dex2oat-3310.objdumper=/opt/compiler-explorer/dex2oat-33.10/x86_64/bin/oatdump


### PR DESCRIPTION
- `android16-qpr2-release` is Dec 2025, not Dec 2026.
- Add `semver` to order the versions properly.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
