### PR TITLE
Add clang for newer versions of ROCm

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -849,7 +849,7 @@ compiler.clang221assert.semver=22.1.0 (assertions)
 compiler.clang221assert.options=--gcc-toolchain=/opt/compiler-explorer/gcc-15.2.0
 compiler.clang221assert.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
-group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102:clang-rocm-60204:clang-rocm-60303:clang-rocm-60400:clang-rocm-70001:clang-rocm-70002:clang-rocm-70100:clang-rocm-70101:clang-rocm-70200:clang-rocm-70201:clang-rocm-70202:clang-rocm-70203:clang-rocm-70204:clang-rocm-71400
+group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102:clang-rocm-60204:clang-rocm-60303:clang-rocm-60400:clang-rocm-70001:clang-rocm-70002:clang-rocm-70100:clang-rocm-70101:clang-rocm-70200:clang-rocm-70201:clang-rocm-71400
 group.clang-rocm.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang-rocm.groupName=ROCm clang x86-64
 group.clang-rocm.instructionSet=amd64
@@ -943,18 +943,6 @@ compiler.clang-rocm-70201.exe=/opt/compiler-explorer/clang-rocm-7.2.1/bin/clang+
 compiler.clang-rocm-70201.semver=rocm-7.2.1
 compiler.clang-rocm-70201.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
 compiler.clang-rocm-70201.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
-compiler.clang-rocm-70202.exe=/opt/compiler-explorer/clang-rocm-7.2.2/bin/clang++
-compiler.clang-rocm-70202.semver=rocm-7.2.2
-compiler.clang-rocm-70202.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
-compiler.clang-rocm-70202.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
-compiler.clang-rocm-70203.exe=/opt/compiler-explorer/clang-rocm-7.2.3/bin/clang++
-compiler.clang-rocm-70203.semver=rocm-7.2.3
-compiler.clang-rocm-70203.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
-compiler.clang-rocm-70203.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
-compiler.clang-rocm-70204.exe=/opt/compiler-explorer/clang-rocm-7.2.4/bin/clang++
-compiler.clang-rocm-70204.semver=rocm-7.2.4
-compiler.clang-rocm-70204.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
-compiler.clang-rocm-70204.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 compiler.clang-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-7.14.0/bin/clang++
 compiler.clang-rocm-71400.semver=rocm-7.14.0
 compiler.clang-rocm-71400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -849,7 +849,7 @@ compiler.clang221assert.semver=22.1.0 (assertions)
 compiler.clang221assert.options=--gcc-toolchain=/opt/compiler-explorer/gcc-15.2.0
 compiler.clang221assert.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
-group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102:clang-rocm-60204:clang-rocm-60303:clang-rocm-60400:clang-rocm-70001:clang-rocm-70002:clang-rocm-70100:clang-rocm-70101:clang-rocm-70200
+group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102:clang-rocm-60204:clang-rocm-60303:clang-rocm-60400:clang-rocm-70001:clang-rocm-70002:clang-rocm-70100:clang-rocm-70101:clang-rocm-70200:clang-rocm-71400
 group.clang-rocm.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang-rocm.groupName=ROCm clang x86-64
 group.clang-rocm.instructionSet=amd64
@@ -939,6 +939,10 @@ compiler.clang-rocm-70200.exe=/opt/compiler-explorer/clang-rocm-7.2.0/bin/clang+
 compiler.clang-rocm-70200.semver=rocm-7.2.0
 compiler.clang-rocm-70200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
 compiler.clang-rocm-70200.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-7.14.0/bin/clang++
+compiler.clang-rocm-71400.semver=rocm-7.14.0
+compiler.clang-rocm-71400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang-rocm-71400.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
 ################################
 # AOCC (AMD Optimizing C/C++ Compiler)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -849,7 +849,7 @@ compiler.clang221assert.semver=22.1.0 (assertions)
 compiler.clang221assert.options=--gcc-toolchain=/opt/compiler-explorer/gcc-15.2.0
 compiler.clang221assert.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 
-group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102:clang-rocm-60204:clang-rocm-60303:clang-rocm-60400:clang-rocm-70001:clang-rocm-70002:clang-rocm-70100:clang-rocm-70101:clang-rocm-70200:clang-rocm-71400
+group.clang-rocm.compilers=clang-rocm-trunk:clang-rocm-40502:clang-rocm-50002:clang-rocm-50103:clang-rocm-50203:clang-rocm-50303:clang-rocm-50700:clang-rocm-60002:clang-rocm-60102:clang-rocm-60204:clang-rocm-60303:clang-rocm-60400:clang-rocm-70001:clang-rocm-70002:clang-rocm-70100:clang-rocm-70101:clang-rocm-70200:clang-rocm-70201:clang-rocm-70202:clang-rocm-70203:clang-rocm-70204:clang-rocm-71400
 group.clang-rocm.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang-rocm.groupName=ROCm clang x86-64
 group.clang-rocm.instructionSet=amd64
@@ -939,6 +939,22 @@ compiler.clang-rocm-70200.exe=/opt/compiler-explorer/clang-rocm-7.2.0/bin/clang+
 compiler.clang-rocm-70200.semver=rocm-7.2.0
 compiler.clang-rocm-70200.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
 compiler.clang-rocm-70200.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-70201.exe=/opt/compiler-explorer/clang-rocm-7.2.1/bin/clang++
+compiler.clang-rocm-70201.semver=rocm-7.2.1
+compiler.clang-rocm-70201.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang-rocm-70201.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-70202.exe=/opt/compiler-explorer/clang-rocm-7.2.2/bin/clang++
+compiler.clang-rocm-70202.semver=rocm-7.2.2
+compiler.clang-rocm-70202.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang-rocm-70202.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-70203.exe=/opt/compiler-explorer/clang-rocm-7.2.3/bin/clang++
+compiler.clang-rocm-70203.semver=rocm-7.2.3
+compiler.clang-rocm-70203.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang-rocm-70203.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
+compiler.clang-rocm-70204.exe=/opt/compiler-explorer/clang-rocm-7.2.4/bin/clang++
+compiler.clang-rocm-70204.semver=rocm-7.2.4
+compiler.clang-rocm-70204.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0
+compiler.clang-rocm-70204.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-linux-gnu
 compiler.clang-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-7.14.0/bin/clang++
 compiler.clang-rocm-71400.semver=rocm-7.14.0
 compiler.clang-rocm-71400.options=--gcc-toolchain=/opt/compiler-explorer/gcc-14.2.0

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -428,7 +428,7 @@ compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/13.1.0 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
 
-group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700:hipclang-rocm-60002:hipclang-rocm-60102:hipclang-trunk-rocm-60102:hipclang-staging-rocm-60102:hipclang-rocm-60204:hipclang-trunk-rocm-60204:hipclang-staging-rocm-60204:hipclang-rocm-60303:hipclang-trunk-rocm-60303:hipclang-staging-rocm-60303:hipclang-rocm-60400:hipclang-trunk-rocm-60400:hipclang-staging-rocm-60400:hipclang-rocm-70001:hipclang-trunk-rocm-70001:hipclang-staging-rocm-70001:hipclang-rocm-70002:hipclang-trunk-rocm-70002:hipclang-staging-rocm-70002:hipclang-rocm-70100:hipclang-trunk-rocm-70100:hipclang-staging-rocm-70100:hipclang-rocm-70101:hipclang-trunk-rocm-70101:hipclang-staging-rocm-70101:hipclang-rocm-70200:hipclang-trunk-rocm-70200:hipclang-staging-rocm-70200:hipclang-rocm-71400:hipclang-trunk-rocm-71400:hipclang-staging-rocm-71400
+group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700:hipclang-rocm-60002:hipclang-rocm-60102:hipclang-trunk-rocm-60102:hipclang-staging-rocm-60102:hipclang-rocm-60204:hipclang-trunk-rocm-60204:hipclang-staging-rocm-60204:hipclang-rocm-60303:hipclang-trunk-rocm-60303:hipclang-staging-rocm-60303:hipclang-rocm-60400:hipclang-trunk-rocm-60400:hipclang-staging-rocm-60400:hipclang-rocm-70001:hipclang-trunk-rocm-70001:hipclang-staging-rocm-70001:hipclang-rocm-70002:hipclang-trunk-rocm-70002:hipclang-staging-rocm-70002:hipclang-rocm-70100:hipclang-trunk-rocm-70100:hipclang-staging-rocm-70100:hipclang-rocm-70101:hipclang-trunk-rocm-70101:hipclang-staging-rocm-70101:hipclang-rocm-70200:hipclang-trunk-rocm-70200:hipclang-staging-rocm-70200:hipclang-rocm-70201:hipclang-trunk-rocm-70201:hipclang-staging-rocm-70201:hipclang-rocm-70202:hipclang-trunk-rocm-70202:hipclang-staging-rocm-70202:hipclang-rocm-70203:hipclang-trunk-rocm-70203:hipclang-staging-rocm-70203:hipclang-rocm-70204:hipclang-trunk-rocm-70204:hipclang-staging-rocm-70204:hipclang-rocm-71400:hipclang-trunk-rocm-71400:hipclang-staging-rocm-71400
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang
 group.hipclang.compilerType=clang-hip
@@ -647,6 +647,78 @@ compiler.hipclang-staging-rocm-70200.name=clang staging rocm-7.2.0
 compiler.hipclang-staging-rocm-70200.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-70200.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-70200.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.0 -include hip/hip_runtime.h
+compiler.hipclang-rocm-70201.exe=/opt/compiler-explorer/clang-rocm-7.2.1/bin/clang++
+compiler.hipclang-rocm-70201.semver=7.2.1
+compiler.hipclang-rocm-70201.name=clang rocm-7.2.1
+compiler.hipclang-rocm-70201.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.1/bin/llvm-objdump
+compiler.hipclang-rocm-70201.objdumper=/opt/compiler-explorer/clang-rocm-7.2.1/bin/llvm-objdump
+compiler.hipclang-rocm-70201.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.1 -include hip/hip_runtime.h
+compiler.hipclang-trunk-rocm-70201.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
+compiler.hipclang-trunk-rocm-70201.semver=trunk-7.2.1
+compiler.hipclang-trunk-rocm-70201.name=clang trunk rocm-7.2.1
+compiler.hipclang-trunk-rocm-70201.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70201.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70201.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.1 -include hip/hip_runtime.h
+compiler.hipclang-staging-rocm-70201.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
+compiler.hipclang-staging-rocm-70201.semver=staging-7.2.1
+compiler.hipclang-staging-rocm-70201.name=clang staging rocm-7.2.1
+compiler.hipclang-staging-rocm-70201.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70201.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70201.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.1 -include hip/hip_runtime.h
+compiler.hipclang-rocm-70202.exe=/opt/compiler-explorer/clang-rocm-7.2.2/bin/clang++
+compiler.hipclang-rocm-70202.semver=7.2.2
+compiler.hipclang-rocm-70202.name=clang rocm-7.2.2
+compiler.hipclang-rocm-70202.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.2/bin/llvm-objdump
+compiler.hipclang-rocm-70202.objdumper=/opt/compiler-explorer/clang-rocm-7.2.2/bin/llvm-objdump
+compiler.hipclang-rocm-70202.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.2 -include hip/hip_runtime.h
+compiler.hipclang-trunk-rocm-70202.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
+compiler.hipclang-trunk-rocm-70202.semver=trunk-7.2.2
+compiler.hipclang-trunk-rocm-70202.name=clang trunk rocm-7.2.2
+compiler.hipclang-trunk-rocm-70202.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70202.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70202.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.2 -include hip/hip_runtime.h
+compiler.hipclang-staging-rocm-70202.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
+compiler.hipclang-staging-rocm-70202.semver=staging-7.2.2
+compiler.hipclang-staging-rocm-70202.name=clang staging rocm-7.2.2
+compiler.hipclang-staging-rocm-70202.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70202.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70202.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.2 -include hip/hip_runtime.h
+compiler.hipclang-rocm-70203.exe=/opt/compiler-explorer/clang-rocm-7.2.3/bin/clang++
+compiler.hipclang-rocm-70203.semver=7.2.3
+compiler.hipclang-rocm-70203.name=clang rocm-7.2.3
+compiler.hipclang-rocm-70203.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.3/bin/llvm-objdump
+compiler.hipclang-rocm-70203.objdumper=/opt/compiler-explorer/clang-rocm-7.2.3/bin/llvm-objdump
+compiler.hipclang-rocm-70203.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.3 -include hip/hip_runtime.h
+compiler.hipclang-trunk-rocm-70203.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
+compiler.hipclang-trunk-rocm-70203.semver=trunk-7.2.3
+compiler.hipclang-trunk-rocm-70203.name=clang trunk rocm-7.2.3
+compiler.hipclang-trunk-rocm-70203.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70203.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70203.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.3 -include hip/hip_runtime.h
+compiler.hipclang-staging-rocm-70203.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
+compiler.hipclang-staging-rocm-70203.semver=staging-7.2.3
+compiler.hipclang-staging-rocm-70203.name=clang staging rocm-7.2.3
+compiler.hipclang-staging-rocm-70203.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70203.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70203.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.3 -include hip/hip_runtime.h
+compiler.hipclang-rocm-70204.exe=/opt/compiler-explorer/clang-rocm-7.2.4/bin/clang++
+compiler.hipclang-rocm-70204.semver=7.2.4
+compiler.hipclang-rocm-70204.name=clang rocm-7.2.4
+compiler.hipclang-rocm-70204.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.4/bin/llvm-objdump
+compiler.hipclang-rocm-70204.objdumper=/opt/compiler-explorer/clang-rocm-7.2.4/bin/llvm-objdump
+compiler.hipclang-rocm-70204.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.4 -include hip/hip_runtime.h
+compiler.hipclang-trunk-rocm-70204.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
+compiler.hipclang-trunk-rocm-70204.semver=trunk-7.2.4
+compiler.hipclang-trunk-rocm-70204.name=clang trunk rocm-7.2.4
+compiler.hipclang-trunk-rocm-70204.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70204.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-70204.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.4 -include hip/hip_runtime.h
+compiler.hipclang-staging-rocm-70204.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
+compiler.hipclang-staging-rocm-70204.semver=staging-7.2.4
+compiler.hipclang-staging-rocm-70204.name=clang staging rocm-7.2.4
+compiler.hipclang-staging-rocm-70204.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70204.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-70204.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.4 -include hip/hip_runtime.h
 compiler.hipclang-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-7.14.0/bin/clang++
 compiler.hipclang-rocm-71400.semver=7.14.0
 compiler.hipclang-rocm-71400.name=clang rocm-7.14.0

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -428,7 +428,7 @@ compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/13.1.0 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
 
-group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700:hipclang-rocm-60002:hipclang-rocm-60102:hipclang-trunk-rocm-60102:hipclang-staging-rocm-60102:hipclang-rocm-60204:hipclang-trunk-rocm-60204:hipclang-staging-rocm-60204:hipclang-rocm-60303:hipclang-trunk-rocm-60303:hipclang-staging-rocm-60303:hipclang-rocm-60400:hipclang-trunk-rocm-60400:hipclang-staging-rocm-60400:hipclang-rocm-70001:hipclang-trunk-rocm-70001:hipclang-staging-rocm-70001:hipclang-rocm-70002:hipclang-trunk-rocm-70002:hipclang-staging-rocm-70002:hipclang-rocm-70100:hipclang-trunk-rocm-70100:hipclang-staging-rocm-70100:hipclang-rocm-70101:hipclang-trunk-rocm-70101:hipclang-staging-rocm-70101:hipclang-rocm-70200:hipclang-trunk-rocm-70200:hipclang-staging-rocm-70200
+group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700:hipclang-rocm-60002:hipclang-rocm-60102:hipclang-trunk-rocm-60102:hipclang-staging-rocm-60102:hipclang-rocm-60204:hipclang-trunk-rocm-60204:hipclang-staging-rocm-60204:hipclang-rocm-60303:hipclang-trunk-rocm-60303:hipclang-staging-rocm-60303:hipclang-rocm-60400:hipclang-trunk-rocm-60400:hipclang-staging-rocm-60400:hipclang-rocm-70001:hipclang-trunk-rocm-70001:hipclang-staging-rocm-70001:hipclang-rocm-70002:hipclang-trunk-rocm-70002:hipclang-staging-rocm-70002:hipclang-rocm-70100:hipclang-trunk-rocm-70100:hipclang-staging-rocm-70100:hipclang-rocm-70101:hipclang-trunk-rocm-70101:hipclang-staging-rocm-70101:hipclang-rocm-70200:hipclang-trunk-rocm-70200:hipclang-staging-rocm-70200:hipclang-rocm-71400:hipclang-trunk-rocm-71400:hipclang-staging-rocm-71400
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang
 group.hipclang.compilerType=clang-hip
@@ -647,6 +647,24 @@ compiler.hipclang-staging-rocm-70200.name=clang staging rocm-7.2.0
 compiler.hipclang-staging-rocm-70200.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-70200.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-70200.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.0 -include hip/hip_runtime.h
+compiler.hipclang-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-7.14.0/bin/clang++
+compiler.hipclang-rocm-71400.semver=7.14.0
+compiler.hipclang-rocm-71400.name=clang rocm-7.14.0
+compiler.hipclang-rocm-71400.nvdisasm=/opt/compiler-explorer/clang-rocm-7.14.0/bin/llvm-objdump
+compiler.hipclang-rocm-71400.objdumper=/opt/compiler-explorer/clang-rocm-7.14.0/bin/llvm-objdump
+compiler.hipclang-rocm-71400.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.14.0 -include hip/hip_runtime.h
+compiler.hipclang-trunk-rocm-71400.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
+compiler.hipclang-trunk-rocm-71400.semver=trunk-7.14.0
+compiler.hipclang-trunk-rocm-71400.name=clang trunk rocm-7.14.0
+compiler.hipclang-trunk-rocm-71400.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-71400.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
+compiler.hipclang-trunk-rocm-71400.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.14.0 -include hip/hip_runtime.h
+compiler.hipclang-staging-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
+compiler.hipclang-staging-rocm-71400.semver=staging-7.14.0
+compiler.hipclang-staging-rocm-71400.name=clang staging rocm-7.14.0
+compiler.hipclang-staging-rocm-71400.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-71400.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
+compiler.hipclang-staging-rocm-71400.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.14.0 -include hip/hip_runtime.h
 
 group.nvrtc.compilers=nvrtc133:nvrtc132:nvrtc131u1:nvrtc131:nvrtc130u2:nvrtc130u1:nvrtc130:nvrtc129u1:nvrtc129:nvrtc128u1:nvrtc126u2:nvrtc126u1:nvrtc125u1:nvrtc124u1:nvrtc123u1:nvrtc122u1:nvrtc121:nvrtc120u1:nvrtc120:nvrtc118:nvrtc117u1:nvrtc117:nvrtc116u2:nvrtc116u1:nvrtc116:nvrtc115u2:nvrtc115u1:nvrtc115:nvrtc114u1:nvrtc114:nvrtc113u1:nvrtc113:nvrtc112u2:nvrtc112u1:nvrtc112:nvrtc111u1:nvrtc111:nvrtc11u1:nvrtc11
 group.nvrtc.compilerType=nvrtc

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -428,7 +428,7 @@ compiler.cltrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.cltrunk.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 compiler.cltrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot --cuda-path=/opt/compiler-explorer/cuda/13.1.0 --cuda-gpu-arch=sm_120a --cuda-device-only -Wno-unknown-cuda-version -D_ALLOW_UNSUPPORTED_LIBCPP
 
-group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700:hipclang-rocm-60002:hipclang-rocm-60102:hipclang-trunk-rocm-60102:hipclang-staging-rocm-60102:hipclang-rocm-60204:hipclang-trunk-rocm-60204:hipclang-staging-rocm-60204:hipclang-rocm-60303:hipclang-trunk-rocm-60303:hipclang-staging-rocm-60303:hipclang-rocm-60400:hipclang-trunk-rocm-60400:hipclang-staging-rocm-60400:hipclang-rocm-70001:hipclang-trunk-rocm-70001:hipclang-staging-rocm-70001:hipclang-rocm-70002:hipclang-trunk-rocm-70002:hipclang-staging-rocm-70002:hipclang-rocm-70100:hipclang-trunk-rocm-70100:hipclang-staging-rocm-70100:hipclang-rocm-70101:hipclang-trunk-rocm-70101:hipclang-staging-rocm-70101:hipclang-rocm-70200:hipclang-trunk-rocm-70200:hipclang-staging-rocm-70200:hipclang-rocm-70201:hipclang-trunk-rocm-70201:hipclang-staging-rocm-70201:hipclang-rocm-70202:hipclang-trunk-rocm-70202:hipclang-staging-rocm-70202:hipclang-rocm-70203:hipclang-trunk-rocm-70203:hipclang-staging-rocm-70203:hipclang-rocm-70204:hipclang-trunk-rocm-70204:hipclang-staging-rocm-70204:hipclang-rocm-71400:hipclang-trunk-rocm-71400:hipclang-staging-rocm-71400
+group.hipclang.compilers=hiptrunk:hipclang-rocm-40502:hipclang-rocm-50002:hipclang-rocm-50103:hipclang-rocm-50203:hipclang-rocm-50302:hipclang-rocm-50700:hipclang-rocm-60002:hipclang-rocm-60102:hipclang-trunk-rocm-60102:hipclang-staging-rocm-60102:hipclang-rocm-60204:hipclang-trunk-rocm-60204:hipclang-staging-rocm-60204:hipclang-rocm-60303:hipclang-trunk-rocm-60303:hipclang-staging-rocm-60303:hipclang-rocm-60400:hipclang-trunk-rocm-60400:hipclang-staging-rocm-60400:hipclang-rocm-70001:hipclang-trunk-rocm-70001:hipclang-staging-rocm-70001:hipclang-rocm-70002:hipclang-trunk-rocm-70002:hipclang-staging-rocm-70002:hipclang-rocm-70100:hipclang-trunk-rocm-70100:hipclang-staging-rocm-70100:hipclang-rocm-70101:hipclang-trunk-rocm-70101:hipclang-staging-rocm-70101:hipclang-rocm-70200:hipclang-trunk-rocm-70200:hipclang-staging-rocm-70200:hipclang-rocm-70201:hipclang-trunk-rocm-70201:hipclang-staging-rocm-70201:hipclang-rocm-71400:hipclang-trunk-rocm-71400:hipclang-staging-rocm-71400
 group.hipclang.isSemVer=true
 group.hipclang.baseName=clang
 group.hipclang.compilerType=clang-hip
@@ -665,60 +665,6 @@ compiler.hipclang-staging-rocm-70201.name=clang staging rocm-7.2.1
 compiler.hipclang-staging-rocm-70201.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-70201.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
 compiler.hipclang-staging-rocm-70201.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.1 -include hip/hip_runtime.h
-compiler.hipclang-rocm-70202.exe=/opt/compiler-explorer/clang-rocm-7.2.2/bin/clang++
-compiler.hipclang-rocm-70202.semver=7.2.2
-compiler.hipclang-rocm-70202.name=clang rocm-7.2.2
-compiler.hipclang-rocm-70202.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.2/bin/llvm-objdump
-compiler.hipclang-rocm-70202.objdumper=/opt/compiler-explorer/clang-rocm-7.2.2/bin/llvm-objdump
-compiler.hipclang-rocm-70202.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.2 -include hip/hip_runtime.h
-compiler.hipclang-trunk-rocm-70202.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
-compiler.hipclang-trunk-rocm-70202.semver=trunk-7.2.2
-compiler.hipclang-trunk-rocm-70202.name=clang trunk rocm-7.2.2
-compiler.hipclang-trunk-rocm-70202.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-70202.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-70202.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.2 -include hip/hip_runtime.h
-compiler.hipclang-staging-rocm-70202.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
-compiler.hipclang-staging-rocm-70202.semver=staging-7.2.2
-compiler.hipclang-staging-rocm-70202.name=clang staging rocm-7.2.2
-compiler.hipclang-staging-rocm-70202.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-70202.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-70202.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.2 -include hip/hip_runtime.h
-compiler.hipclang-rocm-70203.exe=/opt/compiler-explorer/clang-rocm-7.2.3/bin/clang++
-compiler.hipclang-rocm-70203.semver=7.2.3
-compiler.hipclang-rocm-70203.name=clang rocm-7.2.3
-compiler.hipclang-rocm-70203.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.3/bin/llvm-objdump
-compiler.hipclang-rocm-70203.objdumper=/opt/compiler-explorer/clang-rocm-7.2.3/bin/llvm-objdump
-compiler.hipclang-rocm-70203.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.3 -include hip/hip_runtime.h
-compiler.hipclang-trunk-rocm-70203.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
-compiler.hipclang-trunk-rocm-70203.semver=trunk-7.2.3
-compiler.hipclang-trunk-rocm-70203.name=clang trunk rocm-7.2.3
-compiler.hipclang-trunk-rocm-70203.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-70203.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-70203.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.3 -include hip/hip_runtime.h
-compiler.hipclang-staging-rocm-70203.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
-compiler.hipclang-staging-rocm-70203.semver=staging-7.2.3
-compiler.hipclang-staging-rocm-70203.name=clang staging rocm-7.2.3
-compiler.hipclang-staging-rocm-70203.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-70203.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-70203.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.3 -include hip/hip_runtime.h
-compiler.hipclang-rocm-70204.exe=/opt/compiler-explorer/clang-rocm-7.2.4/bin/clang++
-compiler.hipclang-rocm-70204.semver=7.2.4
-compiler.hipclang-rocm-70204.name=clang rocm-7.2.4
-compiler.hipclang-rocm-70204.nvdisasm=/opt/compiler-explorer/clang-rocm-7.2.4/bin/llvm-objdump
-compiler.hipclang-rocm-70204.objdumper=/opt/compiler-explorer/clang-rocm-7.2.4/bin/llvm-objdump
-compiler.hipclang-rocm-70204.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.4 -include hip/hip_runtime.h
-compiler.hipclang-trunk-rocm-70204.exe=/opt/compiler-explorer/clang-assertions-trunk/bin/clang++
-compiler.hipclang-trunk-rocm-70204.semver=trunk-7.2.4
-compiler.hipclang-trunk-rocm-70204.name=clang trunk rocm-7.2.4
-compiler.hipclang-trunk-rocm-70204.nvdisasm=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-70204.objdumper=/opt/compiler-explorer/clang-assertions-trunk/bin/llvm-objdump
-compiler.hipclang-trunk-rocm-70204.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.4 -include hip/hip_runtime.h
-compiler.hipclang-staging-rocm-70204.exe=/opt/compiler-explorer/clang-rocm-trunk/bin/clang++
-compiler.hipclang-staging-rocm-70204.semver=staging-7.2.4
-compiler.hipclang-staging-rocm-70204.name=clang staging rocm-7.2.4
-compiler.hipclang-staging-rocm-70204.nvdisasm=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-70204.objdumper=/opt/compiler-explorer/clang-rocm-trunk/bin/llvm-objdump
-compiler.hipclang-staging-rocm-70204.options=-x hip --cuda-device-only -O3 --rocm-path=/opt/compiler-explorer/libs/rocm/7.2.4 -include hip/hip_runtime.h
 compiler.hipclang-rocm-71400.exe=/opt/compiler-explorer/clang-rocm-7.14.0/bin/clang++
 compiler.hipclang-rocm-71400.semver=7.14.0
 compiler.hipclang-rocm-71400.name=clang rocm-7.14.0


### PR DESCRIPTION
ROCm 7.14 was officially released a few days ago: https://rocm.docs.amd.com/en/docs-7.14.0/about/release-notes.html

Depends on: https://github.com/compiler-explorer/infra/pull/2235