### PR TITLE
Add clang_p3817 compiler entry

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -558,7 +558,7 @@ compiler.clang2210.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-lin
 compiler.clang2210.debugPatched=true
 
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3822:clang_p3951:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_p1974:clang_chrisbazley
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_p1974:clang_chrisbazley
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -641,6 +641,10 @@ compiler.clang_p3412.notification=Experimental String interpolation; see <a href
 compiler.clang_p3776.exe=/opt/compiler-explorer/clang-p3776-trunk/bin/clang++
 compiler.clang_p3776.semver=(experimental P3776)
 compiler.clang_p3776.notification=Experimental trailing commas; see <a href="https://wg21.link/p3776" target="_blank" rel="noopener noreferrer">P3776<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_p3817.exe=/opt/compiler-explorer/clang-p3817-trunk/bin/clang++
+compiler.clang_p3817.semver=(experimental P3817)
+compiler.clang_p3817.options=-std=c++2c
+compiler.clang_p3817.notification=Experimental structured binding assignments; see <a href="https://github.com/regevran/llvm-project-fork/blob/p3817/P3817.md" target="_blank" rel="noopener noreferrer">P3817<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_p3822.exe=/opt/compiler-explorer/clang-p3822-trunk/bin/clang++
 compiler.clang_p3822.semver=(experimental P3822)
 compiler.clang_p3822.notification=Experimental conditional noexcept specifiers in compound requirements; see <a href="https://wg21.link/P3822" target="_blank" rel="noopener noreferrer">P3822<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
## Summary
Adds `clang_p3817` to the `clangx86trunk` group, implementing [P3817R0](https://github.com/regevran/llvm-project-fork/blob/p3817/P3817.md) ("Structured Binding Assignments") -- a `using` keyword extension to structured bindings letting an element assign to a pre-existing variable instead of declaring a new one:

```cpp
int id;
auto [using id, name] = get_record();  // id is assigned; name is declared
```

Fork: https://github.com/regevran/llvm-project-fork, branch `p3817`.

Verified locally end-to-end: cloned this repo, pointed a local compiler entry at a build of the fork's clang, and confirmed the compile+execute API works correctly for the feature (including move-vs-copy selection matching the ref-qualifier). `npm run test:props` passes against this diff.

## Companion PRs
- compiler-explorer/clang-builder#115 (build.sh case)
- compiler-explorer/compiler-workflows#69 (nightly build workflow)
- compiler-explorer/infra#2236 (install target)