### PR TITLE
Add LFortran compiler versions 0.60.0 to 0.64.0

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1229,7 +1229,7 @@ compiler.aoccflang520.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/..
 
 #################################
 # LFortran
-group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520:lfortran0530:lfortran0540:lfortran0550:lfortran0560:lfortran0570:lfortran0580:lfortran0590
+group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520:lfortran0530:lfortran0540:lfortran0550:lfortran0560:lfortran0570:lfortran0580:lfortran0590:lfortran0600:lfortran0610:lfortran0620:lfortran0630:lfortan0640:lfortranlatest
 group.lfortran.groupName=LFortran
 group.lfortran.baseName=LFortran
 group.lfortran.supportsBinary=true

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1229,7 +1229,7 @@ compiler.aoccflang520.ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/..
 
 #################################
 # LFortran
-group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520:lfortran0530:lfortran0540:lfortran0550:lfortran0560:lfortran0570:lfortran0580:lfortran0590:lfortran0600:lfortran0610:lfortran0620:lfortran0630:lfortan0640:lfortranlatest
+group.lfortran.compilers=lfortran0420:lfortran0430:lfortran0440:lfortran0450:lfortran0460:lfortran0470:lfortran0480:lfortran0490:lfortran0500:lfortran0510:lfortran0520:lfortran0530:lfortran0540:lfortran0550:lfortran0560:lfortran0570:lfortran0580:lfortran0590:lfortran0600:lfortran0610:lfortran0620:lfortran0630:lfortran0640:lfortranlatest
 group.lfortran.groupName=LFortran
 group.lfortran.baseName=LFortran
 group.lfortran.supportsBinary=true

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1292,6 +1292,25 @@ compiler.lfortran0580.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 compiler.lfortran0590.exe=/opt/compiler-explorer/lfortran/v0.59.0/bin/lfortran
 compiler.lfortran0590.semver=0.59.0
 compiler.lfortran0590.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0600.exe=/opt/compiler-explorer/lfortran/v0.60.0/bin/lfortran
+compiler.lfortran0600.semver=0.60.0
+compiler.lfortran0600.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0610.exe=/opt/compiler-explorer/lfortran/v0.61.0/bin/lfortran
+compiler.lfortran0610.semver=0.61.0
+compiler.lfortran0610.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0620.exe=/opt/compiler-explorer/lfortran/v0.62.0/bin/lfortran
+compiler.lfortran0620.semver=0.62.0
+compiler.lfortran0620.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0630.exe=/opt/compiler-explorer/lfortran/v0.63.0/bin/lfortran
+compiler.lfortran0630.semver=0.63.0
+compiler.lfortran0630.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+compiler.lfortran0640.exe=/opt/compiler-explorer/lfortran/v0.64.0/bin/lfortran
+compiler.lfortran0640.semver=0.64.0
+compiler.lfortran0640.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
+
+compiler.lfortranlatest.exe=/opt/compiler-explorer/lfortran/v0.64.0/bin/lfortran
+compiler.lfortranlatest.semver=(latest)
+compiler.lfortranlatest.clang=/opt/compiler-explorer/clang-19.1.0/bin/clang
 
 ###############################
 # GCC for ARM 64bit


### PR DESCRIPTION
Added new LFortran compiler versions and updated paths.

Depends on https://github.com/compiler-explorer/infra/pull/2238
