### PR TITLE
Cleanup gcc pass dumps from file/line info

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2004,9 +2004,9 @@ export class BaseCompiler {
                 // RTL dumps also contain brackets that must survive: [orig:N], hex operands like
                 // [0x..], branch probabilities like [5.50%], and the insn's own quoted "file":line
                 // locations (bracket-free). The forced -lineno prefixes always carry a path, so
-                // restrict the strip to brackets holding a '/' -- that keeps [orig:N] et al. while
+                // restrict the strip to brackets holding a path separator -- that keeps [orig:N] et al. while
                 // reproducing the readable no-lineno RTL dump.
-                trimmed = trimmed.replace(/\[[^[\]\n]*\/[^[\]\n]*:\d+(?::\d+)?(?: discrim \d+)?\] ?/g, '');
+                trimmed = trimmed.replace(/\[[^[\]\n]*[\/\\\\][^[\]\n]*:\d+(?::\d+)?(?: discrim \d+)?\] ?/g, '');
                 // Each insn also prints its own location as "file":line:col; the filename is the
                 // (long, temp-dir) source path repeated on every line and adds no information, so
                 // drop just the quoted path and keep the :line:col that pinskia asked to retain.

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -1967,12 +1967,15 @@ export class BaseCompiler {
      * recognisable location at all — is kept. Dumps without any `;; Function` markers (IPA
      * summaries such as cgraph) are returned whole.
      *
-     * `isRtlDump` selects the lineno handling: `-lineno` adds `[file:line]` prefixes to every
-     * GIMPLE statement, which appears in tree dumps AND in IPA passes that print GIMPLE bodies
-     * (icf, inline, sra, ...). So when the user disabled lineno but we forced it on for origin
-     * detection, those prefixes are stripped from all non-RTL dumps. RTL dumps are left untouched
-     * because they use different bracket syntax (`[orig:N]`, nested `[N [file:line]]`) that the
-     * strip regex would corrupt, and their locations come from -g rather than -lineno anyway.
+     * `isRtlDump` selects the lineno-strip regex. `-lineno` adds `[file:line]` prefixes to every
+     * GIMPLE statement; these show up in tree dumps, in IPA passes that print GIMPLE bodies (icf,
+     * inline, sra, ...), and in the GIMPLE section of RTL expand dumps (which print each gimple
+     * statement before the RTL it expands to). When the user disabled lineno but we forced it on
+     * for origin detection, those prefixes are stripped so the dump reads as it would without
+     * -lineno. RTL dumps carry extra brackets that are NOT lineno noise -- `[orig:N]`, hex operands
+     * like `[0x..]`, branch probabilities like `[5.50%]` -- so the RTL strip only removes brackets
+     * that contain a path ('/'), leaving those intact. The `"file":line:col` location each insn
+     * prints keeps its `:line:col` but loses the repeated (temp-dir) filename, which is noise.
      */
     trimGccDumpHeaderFunctions(
         content: string,
@@ -1993,11 +1996,24 @@ export class BaseCompiler {
                 : pieces.filter((piece, index) => index === 0 || !isHeaderFunction(piece));
 
         let trimmed = kept.join('');
-        if (!keepLineno && !isRtlDump) {
-            // Approximate the no-lineno output by removing the forced [file:line(:col)] prefixes
-            // from GIMPLE (tree + IPA) dumps. RTL is excluded so its [orig:N]/nested brackets are
-            // never touched.
-            trimmed = trimmed.replace(/\[[^[\]\n]*?:\d+(?::\d+)?(?: discrim \d+)?\] ?/g, '');
+        if (!keepLineno) {
+            // Approximate the no-lineno output by removing the [file:line(:col)] prefixes that
+            // -lineno forces onto GIMPLE statements (tree/IPA dumps, and the GIMPLE section of RTL
+            // expand dumps).
+            if (isRtlDump) {
+                // RTL dumps also contain brackets that must survive: [orig:N], hex operands like
+                // [0x..], branch probabilities like [5.50%], and the insn's own quoted "file":line
+                // locations (bracket-free). The forced -lineno prefixes always carry a path, so
+                // restrict the strip to brackets holding a '/' -- that keeps [orig:N] et al. while
+                // reproducing the readable no-lineno RTL dump.
+                trimmed = trimmed.replace(/\[[^[\]\n]*\/[^[\]\n]*:\d+(?::\d+)?(?: discrim \d+)?\] ?/g, '');
+                // Each insn also prints its own location as "file":line:col; the filename is the
+                // (long, temp-dir) source path repeated on every line and adds no information, so
+                // drop just the quoted path and keep the :line:col that pinskia asked to retain.
+                trimmed = trimmed.replace(/"[^"\n]*"(?=:\d)/g, '');
+            } else {
+                trimmed = trimmed.replace(/\[[^[\]\n]*?:\d+(?::\d+)?(?: discrim \d+)?\] ?/g, '');
+            }
         }
         return trimmed;
     }

--- a/test/gccdump-tests.ts
+++ b/test/gccdump-tests.ts
@@ -151,10 +151,41 @@ describe('GCC dump output processing', () => {
             expect(trimmed).toContain('[orig:117]'); // RTL brackets left intact
         });
 
-        it('does not strip brackets from RTL dumps even when lineno is disabled', () => {
-            const rtlBlock = ';; Function main (main)\n(note 1 0 3 [orig:117] "example.cpp":5)\n';
+        it('keeps non-lineno RTL brackets ([orig:N], hex, %) but drops the insn filename when lineno is disabled', () => {
+            const rtlBlock =
+                ';; Function main (main)\n' +
+                '(note 1 0 3 [orig:117] NOTE_INSN_DELETED)\n' +
+                '(insn 8 7 9 (set (reg:DI 139) (const_int -32 [0xffffffffffffffe0])) "/app/example.cpp":12:15 discrim 1 -1)\n' +
+                '  goto <bb 3>; [94.50%]\n';
             const trimmed = compiler.trimGccDumpHeaderFunctions(rtlBlock, 'example.cpp', false, true);
-            expect(trimmed).toContain('[orig:117]');
+            expect(trimmed).toContain('[orig:117]'); // not a path -> kept
+            expect(trimmed).toContain('[0xffffffffffffffe0]'); // hex operand -> kept
+            expect(trimmed).toContain('[94.50%]'); // branch probability -> kept
+            expect(trimmed).toContain(':12:15 discrim 1'); // line:col of the insn location -> kept
+            expect(trimmed).not.toContain('"/app/example.cpp"'); // redundant source filename -> dropped
+        });
+
+        it('strips forced -lineno [path:line] prefixes from RTL dumps when lineno is disabled (#8826)', () => {
+            // -fdump-rtl-expand-details prints the gimple statements it expands; -lineno prefixes
+            // each with [path:line:col], which pinskia reported made the dump hard to read.
+            const rtlBlock =
+                ';; Function main (main)\n' +
+                '  [/app/example.cpp:12:15 discrim 1] __builtin_memcpy (&v1, data_22(D), 32);\n' +
+                '  _32 = BIT_FIELD_REF <[/app/example.cpp:16:41] [/app/example.cpp:16:37] v.val[3], 16, 0>;\n' +
+                ';; [/app/example.cpp:12:15 discrim 1] __builtin_memcpy (&v1, data_22(D), 32);\n';
+            const trimmed = compiler.trimGccDumpHeaderFunctions(rtlBlock, 'example.cpp', false, true);
+            expect(trimmed).not.toContain('[/app/example.cpp:12:15 discrim 1]');
+            expect(trimmed).not.toContain('[/app/example.cpp:16:41]');
+            expect(trimmed).toContain('  __builtin_memcpy (&v1, data_22(D), 32);');
+            expect(trimmed).toContain('  _32 = BIT_FIELD_REF <v.val[3], 16, 0>;');
+            expect(trimmed).toContain(';; __builtin_memcpy (&v1, data_22(D), 32);');
+        });
+
+        it('keeps forced -lineno prefixes in RTL dumps when lineno is enabled', () => {
+            const rtlBlock =
+                ';; Function main (main)\n  [/app/example.cpp:12:15 discrim 1] __builtin_memcpy (&v1, x);\n';
+            const trimmed = compiler.trimGccDumpHeaderFunctions(rtlBlock, 'example.cpp', true, true);
+            expect(trimmed).toContain('[/app/example.cpp:12:15 discrim 1]');
         });
 
         it('strips location annotations from tree dumps when lineno is disabled', () => {


### PR DESCRIPTION
Following the review in https://github.com/compiler-explorer/compiler-explorer/pull/8826/changes/c4d8590f6a992b4478f9f08b41af2ac05bff3402#r3476267780, this PR tries to clean up file/line info from gcc dumps.

Example `expand (rtl)` output, for the default C++ source example:
```

;; Function square (_Z6squarei, funcdef_no=0, decl_uid=2861, cgraph_uid=1, symbol_order=0)


;; Generating RTL for gimple basic block 2

;; Generating RTL for gimple basic block 3


try_optimize_cfg iteration 1

Merging block 3 into block 2...
Merged blocks 2 and 3.
Merged 2 and 3 without moving.
Merging block 4 into block 2...
Merged blocks 2 and 4.
Merged 2 and 4 without moving.
Removing jump 11.
Merging block 5 into block 2...
Merged blocks 2 and 5.
Merged 2 and 5 without moving.


try_optimize_cfg iteration 2



;;
;; Full RTL generated for this function:
;;
(note 1 0 4 NOTE_INSN_DELETED)
(note 4 1 2 2 [bb 2] NOTE_INSN_BASIC_BLOCK)
(insn 2 4 3 2 (set (mem/c:SI (plus:DI (reg/f:DI 93 virtual-stack-vars)
                (const_int -4 [0xfffffffffffffffc])) [1 num+0 S4 A32])
        (reg:SI 5 di [ num ])) :2:21 -1
     (nil))
(note 3 2 6 2 NOTE_INSN_FUNCTION_BEG)
(insn 6 3 7 2 (set (reg:SI 100)
        (mem/c:SI (plus:DI (reg/f:DI 93 virtual-stack-vars)
                (const_int -4 [0xfffffffffffffffc])) [1 num+0 S4 A32])) :3:18 -1
     (nil))
(insn 7 6 10 2 (parallel [
            (set (reg:SI 98 [ _2 ])
                (mult:SI (reg:SI 100)
                    (reg:SI 100)))
            (clobber (reg:CC 17 flags))
        ]) :3:18 -1
     (nil))
(insn 10 7 14 2 (set (reg:SI 99 [ <retval> ])
        (reg:SI 98 [ _2 ])) :3:18 discrim 1 -1
     (nil))
(insn 14 10 15 2 (set (reg/i:SI 0 ax)
        (reg:SI 99 [ <retval> ])) :4:1 -1
     (nil))
(insn 15 14 0 2 (use (reg/i:SI 0 ax)) :4:1 -1
     (nil))
```