### PR TITLE
FPC: recognize AArch64 '// [n]' source-line comments

### DIFF
--- a/lib/compilers/pascal.ts
+++ b/lib/compilers/pascal.ts
@@ -296,9 +296,11 @@ export class FPCCompiler extends BaseCompiler {
     }
 
     getExtraAsmHint(asm: string, currentFileId: number) {
-        if (asm.startsWith('# [')) {
-            const bracketEndPos = asm.indexOf(']', 3);
-            let valueInBrackets = asm.substring(3, bracketEndPos);
+        // FPC's source-line comments use '# [' on x86 but '// [' on ARM/AArch64.
+        const prefixLen = asm.startsWith('# [') ? 3 : asm.startsWith('// [') ? 4 : 0;
+        if (prefixLen > 0) {
+            const bracketEndPos = asm.indexOf(']', prefixLen);
+            let valueInBrackets = asm.substring(prefixLen, bracketEndPos);
             const colonPos = valueInBrackets.indexOf(':');
             if (colonPos !== -1) {
                 valueInBrackets = valueInBrackets.substring(0, colonPos - 1);
@@ -320,9 +322,11 @@ export class FPCCompiler extends BaseCompiler {
     }
 
     tryGetFilenumber(asm: string, files: Record<string, number>) {
-        if (asm.startsWith('# [')) {
-            const bracketEndPos = asm.indexOf(']', 3);
-            let valueInBrackets = asm.substring(3, bracketEndPos);
+        // FPC's source-line comments use '# [' on x86 but '// [' on ARM/AArch64.
+        const prefixLen = asm.startsWith('# [') ? 3 : asm.startsWith('// [') ? 4 : 0;
+        if (prefixLen > 0) {
+            const bracketEndPos = asm.indexOf(']', prefixLen);
+            let valueInBrackets = asm.substring(prefixLen, bracketEndPos);
             const colonPos = valueInBrackets.indexOf(':');
             if (colonPos !== -1) {
                 valueInBrackets = valueInBrackets.substring(0, colonPos - 1);


### PR DESCRIPTION
### Problem
`FPCCompiler`'s source-line hinting (`getExtraAsmHint` / `tryGetFilenumber`) only matches the x86
assembler comment style `# [n]`. On ARM/AArch64, FPC emits `// [n]` instead, so source↔asm mapping is
silently lost for those targets (asm rows come back with no source line).

### Fix
Accept both prefixes (`# [` and `// [`) when parsing the line/file hints. No change for x86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)