### PR TITLE
Add TunnelPascal 1.9.1 to Pascal compilers

### DIFF
--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&fpc:&madpascal
+compilers=&fpc:&tunnelpascal:&madpascal
 defaultCompiler=fpc322
 
 nasmpath=/opt/compiler-explorer/nasm-2.16.01
@@ -30,6 +30,18 @@ compiler.fpc320.exe=/opt/compiler-explorer/fpc-3.2.0.x86_64-linux/bin/fpc
 compiler.fpc320.semver=3.2.0
 compiler.fpc322.exe=/opt/compiler-explorer/fpc-3.2.2.x86_64-linux/bin/fpc
 compiler.fpc322.semver=3.2.2
+
+
+group.tunnelpascal.compilers=tp191
+group.tunnelpascal.demangler=/dev/null
+group.tunnelpascal.objdumper=/opt/compiler-explorer/gcc-10.2.0/bin/objdump
+group.tunnelpascal.isSemVer=true
+group.tunnelpascal.baseName=x86-64 tunnelpascal
+group.tunnelpascal.licenseLink=https://github.com/partouf/tunnelpascal/blob/tunnel-main/LICENSE
+group.tunnelpascal.licenseName=Library GNU General Public License (Modified)
+
+compiler.tp191.exe=/opt/compiler-explorer/tunnel-pascal-1.9.1.x86_64-linux/bin/fpc
+compiler.tp191.semver=1.9.1
 
 
 group.madpascal.compilers=mptrunk


### PR DESCRIPTION
Adds [TunnelPascal](https://github.com/partouf/tunnelpascal) 1.9.1 as an x86-64 Pascal compiler, shown as **"x86-64 tunnelpascal 1.9.1"** (id `tp191`). TunnelPascal is a Free Pascal (FPC 3.3.1) fork that adds Delphi language features.

Paired with compiler-explorer/infra#2239 which installs it.

No `options` override is set: the release ships its own relocatable `fpc.cfg` that `bin/fpc` auto-loads for unit resolution, so `tp191` behaves like the existing `fpc` compilers (which also don't default to `-O2`; that lives behind `#IFDEF RELEASE` in the shared cfg).

Verified end-to-end via `--discovery-only` + a local server against the `amazon` env: `tp191` is discovered and listed by `/api/compilers/pascal`, and a compile of Delphi-specific source (inline-`if`) returns asm with exit 0, while the same source through `fpc322` fails — confirming it genuinely uses the TunnelPascal compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)