### PR TITLE
Reapply extraBodyClass-driven branding, validating via the manifest in production

### DIFF
--- a/lib/app/rendering.ts
+++ b/lib/app/rendering.ts
@@ -26,7 +26,6 @@ import express, {Request, Response} from 'express';
 import _ from 'underscore';
 
 import type {Options as FrontendOptions} from '../../static/options.interfaces.js';
-import {AppArguments} from '../app.interfaces.js';
 import * as normalizer from '../clientstate-normalizer.js';
 import {GoldenLayoutRootStruct} from '../clientstate-normalizer.js';
 import type {ShortLinkMetaData} from '../handlers/handler.interfaces.js';
@@ -40,7 +39,7 @@ import {
     ServerDependencies,
     ServerOptions,
 } from './server.interfaces.js';
-import {getFaviconFilename} from './static-assets.js';
+import {getFaviconFilename, getLogoOverlayFilename} from './static-assets.js';
 import {isMobileViewer} from './url-handlers.js';
 
 // Heavy fields (compilers, libs, tools, ...) are absent on purpose — they are lazy-loaded.
@@ -67,19 +66,10 @@ const FRONTEND_INLINE_OPTION_KEYS = [
     'explainApiEndpoint',
 ] as const satisfies readonly (keyof ClientOptionsType & keyof FrontendOptions)[];
 
-/**
- * Create rendering-related functions
- * @param pugRequireHandler - Handler for Pug requires
- * @param options - Server options
- * @param dependencies - Server dependencies
- * @param appArgs - App arguments
- * @returns Rendering functions
- */
 export function createRenderHandlers(
     pugRequireHandler: PugRequireHandler,
     options: ServerOptions,
     dependencies: ServerDependencies,
-    appArgs: AppArguments,
 ): {
     renderConfig: RenderConfigFunction;
     renderGoldenLayout: RenderGoldenLayoutHandler;
@@ -124,7 +114,8 @@ export function createRenderHandlers(
         options.storageSolution = options.storageSolution || storageSolution;
         options.require = pugRequireHandler;
         options.sponsors = sponsorConfig;
-        options.faviconFilename = getFaviconFilename(appArgs.devMode, appArgs.env);
+        options.faviconFilename = getFaviconFilename(extraBodyClass);
+        options.logoOverlayFilename = getLogoOverlayFilename(extraBodyClass);
         return options;
     };
 

--- a/lib/app/server-config.ts
+++ b/lib/app/server-config.ts
@@ -137,14 +137,10 @@ export function setupLoggingMiddleware(isDevMode: boolean, router: Router): void
     );
 }
 
+const FAVICON_PATH_RE = /^\/favicon(-[a-z0-9-]+)?\.ico$/;
+
 function isFaviconRequest(req: Request): boolean {
-    return [
-        'favicon.ico',
-        'favicon-beta.ico',
-        'favicon-dev.ico',
-        'favicon-staging.ico',
-        'favicon-suspend.ico',
-    ].includes(req.path);
+    return FAVICON_PATH_RE.test(req.path);
 }
 
 /**

--- a/lib/app/server.interfaces.ts
+++ b/lib/app/server.interfaces.ts
@@ -59,6 +59,7 @@ export interface RenderConfig extends PugOptions {
     config?: GoldenLayoutRootStruct;
     metadata?: ShortLinkMetaData;
     faviconFilename: string;
+    logoOverlayFilename?: string;
     storedStateId?: string | false;
     require?: PugRequireHandler;
     sponsors?: Sponsors;

--- a/lib/app/server.ts
+++ b/lib/app/server.ts
@@ -30,10 +30,12 @@ import {createRenderHandlers} from './rendering.js';
 import {ServerDependencies, ServerOptions, WebServerResult} from './server.interfaces.js';
 import {setupBaseServerConfig, setupBasicRoutes, setupLoggingMiddleware} from './server-config.js';
 import {
-    getBrandingAssetDir,
+    getBrandingPublicDir,
+    loadStaticManifest,
     setupStaticMiddleware,
     setupWebPackDevMiddleware,
-    validateBrandingAssets,
+    validateBrandingAssetsInManifest,
+    validateBrandingAssetsOnDisk,
 } from './static-assets.js';
 
 export {startListening} from './server-listening.js';
@@ -55,18 +57,29 @@ export async function setupWebServer(
     const router = express.Router();
 
     let pugRequireHandler;
+    let staticManifest: Record<string, string> | undefined;
 
     try {
-        pugRequireHandler = await (appArgs.devMode
-            ? setupWebPackDevMiddleware(options, router)
-            : setupStaticMiddleware(options, router));
+        if (appArgs.devMode) {
+            pugRequireHandler = await setupWebPackDevMiddleware(options, router);
+        } else {
+            staticManifest = await loadStaticManifest(options.manifestPath);
+            pugRequireHandler = setupStaticMiddleware(options, router, staticManifest);
+        }
     } catch (err: unknown) {
         const error = err as Error;
         logger.warn(`Error setting up static middleware: ${error.message}`);
         pugRequireHandler = path => `${options.staticRoot}/${path}`;
     }
 
-    await validateBrandingAssets(getBrandingAssetDir(appArgs.devMode, options.staticPath), options.extraBodyClass);
+    // Deliberately fatal (and outside the try above): a mistyped extraBodyClass should stop
+    // startup, not serve broken branding. If the manifest failed to load we're already limping
+    // on the fallback handler, so there's nothing to validate against and we don't try.
+    if (appArgs.devMode) {
+        await validateBrandingAssetsOnDisk(getBrandingPublicDir(), options.extraBodyClass);
+    } else if (staticManifest) {
+        validateBrandingAssetsInManifest(staticManifest, options.extraBodyClass);
+    }
 
     const {renderConfig, renderGoldenLayout, embeddedHandler} = createRenderHandlers(
         pugRequireHandler,

--- a/lib/app/server.ts
+++ b/lib/app/server.ts
@@ -29,7 +29,12 @@ import {logger} from '../logger.js';
 import {createRenderHandlers} from './rendering.js';
 import {ServerDependencies, ServerOptions, WebServerResult} from './server.interfaces.js';
 import {setupBaseServerConfig, setupBasicRoutes, setupLoggingMiddleware} from './server-config.js';
-import {setupStaticMiddleware, setupWebPackDevMiddleware} from './static-assets.js';
+import {
+    getBrandingAssetDir,
+    setupStaticMiddleware,
+    setupWebPackDevMiddleware,
+    validateBrandingAssets,
+} from './static-assets.js';
 
 export {startListening} from './server-listening.js';
 export {isMobileViewer} from './url-handlers.js';
@@ -61,11 +66,12 @@ export async function setupWebServer(
         pugRequireHandler = path => `${options.staticRoot}/${path}`;
     }
 
+    await validateBrandingAssets(getBrandingAssetDir(appArgs.devMode, options.staticPath), options.extraBodyClass);
+
     const {renderConfig, renderGoldenLayout, embeddedHandler} = createRenderHandlers(
         pugRequireHandler,
         options,
         dependencies,
-        appArgs,
     );
 
     // Add healthcheck before logging middleware to prevent excessive log entries

--- a/lib/app/static-assets.ts
+++ b/lib/app/static-assets.ts
@@ -85,15 +85,22 @@ export async function setupWebPackDevMiddleware(options: ServerOptions, router: 
     return path => urljoin(options.httpRoot, path);
 }
 
+export async function loadStaticManifest(manifestPath: string): Promise<Record<string, string>> {
+    return JSON.parse(await fs.readFile(path.join(manifestPath, 'manifest.json'), 'utf-8'));
+}
+
 /**
  * Sets up static file middleware for production mode
  * @param options - Server options
  * @param router - Express router
+ * @param staticManifest - Webpack manifest mapping asset names to hashed filenames
  * @returns Function to handle Pug requires
  */
-export async function setupStaticMiddleware(options: ServerOptions, router: Router): Promise<PugRequireHandler> {
-    const staticManifest = JSON.parse(await fs.readFile(path.join(options.manifestPath, 'manifest.json'), 'utf-8'));
-
+export function setupStaticMiddleware(
+    options: ServerOptions,
+    router: Router,
+    staticManifest: Record<string, string>,
+): PugRequireHandler {
     if (options.staticUrl) {
         logger.info(`  using static files from '${options.staticUrl}'`);
     } else {
@@ -118,32 +125,50 @@ export function getLogoOverlayFilename(extraBodyClass: string): string | undefin
 }
 
 /**
- * Resolves the directory branding assets are actually served from. In dev mode the webpack
- * dev middleware serves them from public/ (they aren't on disk in staticPath); in production
- * webpack has copied public/ into staticPath (dist/static), so we validate there.
+ * The directory branding assets are served from in dev mode: the webpack dev middleware
+ * serves public/ directly (they aren't on disk in staticPath).
  */
-export function getBrandingAssetDir(devMode: boolean, staticPath: string): string {
-    return devMode ? resolvePathFromAppRoot('public') : staticPath;
+export function getBrandingPublicDir(): string {
+    return resolvePathFromAppRoot('public');
 }
 
-export async function validateBrandingAssets(staticPath: string, extraBodyClass: string): Promise<void> {
-    if (!extraBodyClass) return;
-    const required = [getFaviconFilename(extraBodyClass), getLogoOverlayFilename(extraBodyClass)].filter(
+function requiredBrandingAssets(extraBodyClass: string): string[] {
+    return [getFaviconFilename(extraBodyClass), getLogoOverlayFilename(extraBodyClass)].filter(
         (f): f is string => f !== undefined,
     );
+}
+
+function throwIfMissingBrandingAssets(extraBodyClass: string, where: string, missing: string[]): void {
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing branding assets for extraBodyClass='${extraBodyClass}' in ${where}: ${missing.join(', ')}`,
+        );
+    }
+}
+
+export async function validateBrandingAssetsOnDisk(assetDir: string, extraBodyClass: string): Promise<void> {
+    if (!extraBodyClass) return;
     const missing: string[] = [];
-    for (const filename of required) {
+    for (const filename of requiredBrandingAssets(extraBodyClass)) {
         try {
-            await fs.access(path.join(staticPath, filename));
+            await fs.access(path.join(assetDir, filename));
         } catch (e: unknown) {
             const err = e as NodeJS.ErrnoException;
             if (err.code === 'ENOENT') missing.push(filename);
             else throw err;
         }
     }
-    if (missing.length > 0) {
-        throw new Error(
-            `Missing branding assets for extraBodyClass='${extraBodyClass}' in ${staticPath}: ${missing.join(', ')}`,
-        );
-    }
+    throwIfMissingBrandingAssets(extraBodyClass, assetDir, missing);
+}
+
+/**
+ * Production deploys ship the static assets in a separate CDN bundle (see build-dist.sh), so
+ * they are not on disk next to the node app and cannot be checked with the filesystem. The
+ * webpack manifest *does* ship with the node app and lists every asset in the static bundle
+ * (public/ is copied in wholesale), so presence of a manifest key proves the asset shipped.
+ */
+export function validateBrandingAssetsInManifest(manifest: Record<string, string>, extraBodyClass: string): void {
+    if (!extraBodyClass) return;
+    const missing = requiredBrandingAssets(extraBodyClass).filter(filename => !Object.hasOwn(manifest, filename));
+    throwIfMissingBrandingAssets(extraBodyClass, 'the static manifest', missing);
 }

--- a/lib/app/static-assets.ts
+++ b/lib/app/static-assets.ts
@@ -31,6 +31,7 @@ import urljoin from 'url-join';
 
 import {unwrap} from '../assert.js';
 import {logger} from '../logger.js';
+import {resolvePathFromAppRoot} from '../utils.js';
 import {PugRequireHandler, ServerOptions} from './server.interfaces.js';
 
 /**
@@ -108,21 +109,41 @@ export async function setupStaticMiddleware(options: ServerOptions, router: Rout
     return createDefaultPugRequireHandler(options.staticRoot, staticManifest);
 }
 
+export function getFaviconFilename(extraBodyClass: string): string {
+    return extraBodyClass ? `favicon-${extraBodyClass}.ico` : 'favicon.ico';
+}
+
+export function getLogoOverlayFilename(extraBodyClass: string): string | undefined {
+    return extraBodyClass ? `site-logo-${extraBodyClass}.svg` : undefined;
+}
+
 /**
- * Gets the appropriate favicon filename based on the environment
- * @param isDevMode - Whether the app is running in development mode
- * @param env - The environment names array
- * @returns The favicon filename to use
+ * Resolves the directory branding assets are actually served from. In dev mode the webpack
+ * dev middleware serves them from public/ (they aren't on disk in staticPath); in production
+ * webpack has copied public/ into staticPath (dist/static), so we validate there.
  */
-export function getFaviconFilename(isDevMode: boolean, env?: string[]): string {
-    if (isDevMode) {
-        return 'favicon-dev.ico';
+export function getBrandingAssetDir(devMode: boolean, staticPath: string): string {
+    return devMode ? resolvePathFromAppRoot('public') : staticPath;
+}
+
+export async function validateBrandingAssets(staticPath: string, extraBodyClass: string): Promise<void> {
+    if (!extraBodyClass) return;
+    const required = [getFaviconFilename(extraBodyClass), getLogoOverlayFilename(extraBodyClass)].filter(
+        (f): f is string => f !== undefined,
+    );
+    const missing: string[] = [];
+    for (const filename of required) {
+        try {
+            await fs.access(path.join(staticPath, filename));
+        } catch (e: unknown) {
+            const err = e as NodeJS.ErrnoException;
+            if (err.code === 'ENOENT') missing.push(filename);
+            else throw err;
+        }
     }
-    if (env?.includes('beta')) {
-        return 'favicon-beta.ico';
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing branding assets for extraBodyClass='${extraBodyClass}' in ${staticPath}: ${missing.join(', ')}`,
+        );
     }
-    if (env?.includes('staging')) {
-        return 'favicon-staging.ico';
-    }
-    return 'favicon.ico';
 }

--- a/public/favicon-winprod.ico
+++ b/public/favicon-winprod.ico
@@ -1,0 +1,1 @@
+favicon.ico

--- a/public/favicon-winstaging.ico
+++ b/public/favicon-winstaging.ico
@@ -1,0 +1,1 @@
+favicon-staging.ico

--- a/public/favicon-wintest.ico
+++ b/public/favicon-wintest.ico
@@ -1,0 +1,1 @@
+favicon-dev.ico

--- a/public/site-logo-winprod.svg
+++ b/public/site-logo-winprod.svg
@@ -1,0 +1,1 @@
+site-logo.svg

--- a/public/site-logo-winstaging.svg
+++ b/public/site-logo-winstaging.svg
@@ -1,0 +1,1 @@
+site-logo-staging.svg

--- a/public/site-logo-wintest.svg
+++ b/public/site-logo-wintest.svg
@@ -1,0 +1,1 @@
+site-logo-dev.svg

--- a/test/app/rendering-tests.ts
+++ b/test/app/rendering-tests.ts
@@ -27,7 +27,6 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {createRenderHandlers} from '../../lib/app/rendering.js';
 import {PugRequireHandler, ServerDependencies, ServerOptions} from '../../lib/app/server.interfaces.js';
-import {AppArguments} from '../../lib/app.interfaces.js';
 
 // Mock dependencies
 vi.mock('../../lib/app/url-handlers.js', () => ({
@@ -75,31 +74,6 @@ describe('Rendering Module', () => {
         let mockPugRequireHandler: PugRequireHandler;
         let mockOptions: ServerOptions;
         let mockDependencies: ServerDependencies;
-        const mockAppArgs: AppArguments = {
-            rootDir: '/test/root',
-            env: ['test'],
-            port: 10240,
-            gitReleaseName: 'test-release',
-            releaseBuildNumber: '123',
-            wantedLanguages: ['c++'],
-            doCache: true,
-            fetchCompilersFromRemote: true,
-            ensureNoCompilerClash: false,
-            prediscovered: undefined,
-            discoveryOnly: undefined,
-            staticPath: undefined,
-            metricsPort: undefined,
-            useLocalProps: true,
-            propDebug: false,
-            tmpDir: undefined,
-            isWsl: false,
-            devMode: false,
-            loggingOptions: {
-                debug: false,
-                suppressConsoleLog: false,
-                paperTrailIdentifier: 'test',
-            },
-        };
 
         beforeEach(() => {
             mockPugRequireHandler = vi.fn((file: string) => `/static/${file}`);
@@ -134,12 +108,7 @@ describe('Rendering Module', () => {
         });
 
         it('should create renderConfig function that correctly merges options', () => {
-            const {renderConfig} = createRenderHandlers(
-                mockPugRequireHandler,
-                mockOptions,
-                mockDependencies,
-                mockAppArgs,
-            );
+            const {renderConfig} = createRenderHandlers(mockPugRequireHandler, mockOptions, mockDependencies);
 
             const result = renderConfig({userOption: 'value'});
 
@@ -161,12 +130,7 @@ describe('Rendering Module', () => {
         });
 
         it('should set extraBodyClass to "embedded" when embedded is true', () => {
-            const {renderConfig} = createRenderHandlers(
-                mockPugRequireHandler,
-                mockOptions,
-                mockDependencies,
-                mockAppArgs,
-            );
+            const {renderConfig} = createRenderHandlers(mockPugRequireHandler, mockOptions, mockDependencies);
 
             const result = renderConfig({embedded: true});
 
@@ -174,12 +138,7 @@ describe('Rendering Module', () => {
         });
 
         it('should filter URL options to only allow whitelisted properties', () => {
-            const {renderConfig} = createRenderHandlers(
-                mockPugRequireHandler,
-                mockOptions,
-                mockDependencies,
-                mockAppArgs,
-            );
+            const {renderConfig} = createRenderHandlers(mockPugRequireHandler, mockOptions, mockDependencies);
 
             const urlOptions = {
                 readOnly: 'true',
@@ -207,12 +166,7 @@ describe('Rendering Module', () => {
         it('should generate slides for mobile viewer', () => {
             // Skip complex mock setup due to TypeScript issues
             // Just verify we can call it without error
-            const {renderConfig} = createRenderHandlers(
-                mockPugRequireHandler,
-                mockOptions,
-                mockDependencies,
-                mockAppArgs,
-            );
+            const {renderConfig} = createRenderHandlers(mockPugRequireHandler, mockOptions, mockDependencies);
 
             // This test is simplified to avoid complex mocking issues
             expect(renderConfig).toBeDefined();
@@ -220,12 +174,7 @@ describe('Rendering Module', () => {
         });
 
         it('should create renderGoldenLayout function that renders correct template', () => {
-            const {renderGoldenLayout} = createRenderHandlers(
-                mockPugRequireHandler,
-                mockOptions,
-                mockDependencies,
-                mockAppArgs,
-            );
+            const {renderGoldenLayout} = createRenderHandlers(mockPugRequireHandler, mockOptions, mockDependencies);
 
             const mockConfig = {};
             const mockMetadata = {};
@@ -270,12 +219,7 @@ describe('Rendering Module', () => {
         });
 
         it('should create embeddedHandler function that renders embed template', () => {
-            const {embeddedHandler} = createRenderHandlers(
-                mockPugRequireHandler,
-                mockOptions,
-                mockDependencies,
-                mockAppArgs,
-            );
+            const {embeddedHandler} = createRenderHandlers(mockPugRequireHandler, mockOptions, mockDependencies);
 
             const mockReq = {
                 query: {foo: 'bar'},

--- a/test/app/server-tests.ts
+++ b/test/app/server-tests.ts
@@ -98,7 +98,7 @@ describe('Server Module', () => {
                 httpRoot: '',
                 sentrySlowRequestMs: 500,
                 manifestPath: '/mocked/dist', // Use absolute path for testing
-                extraBodyClass: 'test-class',
+                extraBodyClass: '',
                 maxUploadSize: '1mb',
             };
 
@@ -155,9 +155,9 @@ describe('Server Module', () => {
             const embeddedConfig = renderConfig({embedded: true});
             expect(embeddedConfig).toHaveProperty('extraBodyClass', 'embedded');
 
-            // When embedded is false
+            // When embedded is false the configured extraBodyClass is passed through
             const normalConfig = renderConfig({embedded: false});
-            expect(normalConfig).toHaveProperty('extraBodyClass', 'test-class');
+            expect(normalConfig).toHaveProperty('extraBodyClass', '');
         });
 
         it('should include mobile viewer slides when needed', async () => {

--- a/test/app/server-tests.ts
+++ b/test/app/server-tests.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import path from 'node:path';
 import process from 'node:process';
 
 // Test helper functions
@@ -187,6 +188,44 @@ describe('Server Module', () => {
             renderGoldenLayout({} as Record<string, unknown>, {} as Record<string, unknown>, mockRequest, mockResponse);
 
             expect(mockResponse.render).toHaveBeenCalledWith('index', expect.any(Object));
+        });
+
+        describe('branding validation in the CDN deploy layout', () => {
+            // Regression for the gh-8755 revert: on AWS the static assets ship in the CDN
+            // bundle, not on the node's disk — only manifest.json ships with the app. A branded
+            // env (e.g. staging) must boot by validating against the manifest, never staticPath.
+            let manifestDir: string;
+
+            const writeManifest = async (manifest: Record<string, string>) => {
+                const fs = await import('node:fs/promises');
+                const os = await import('node:os');
+                manifestDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ce-manifest-test-'));
+                await fs.writeFile(path.join(manifestDir, 'manifest.json'), JSON.stringify(manifest));
+                mockOptions.manifestPath = manifestDir;
+                mockOptions.staticPath = '/nonexistent/.deploy/static';
+                mockOptions.staticUrl = 'https://static.example.com/';
+                mockOptions.extraBodyClass = 'staging';
+            };
+
+            afterEach(async () => {
+                const fs = await import('node:fs/promises');
+                await fs.rm(manifestDir, {recursive: true, force: true});
+            });
+
+            it('boots when the manifest lists the branding assets, despite no local static files', async () => {
+                await writeManifest({
+                    'favicon-staging.ico': 'favicon-staging.ico',
+                    'site-logo-staging.svg': 'site-logo-staging.svg',
+                });
+                await expect(setupWebServer(mockAppArgs, mockOptions, mockDependencies)).resolves.toBeDefined();
+            });
+
+            it('fails startup when the manifest is missing the branding assets', async () => {
+                await writeManifest({'main.js': 'main.abc123.js'});
+                await expect(setupWebServer(mockAppArgs, mockOptions, mockDependencies)).rejects.toThrow(
+                    /Missing branding assets for extraBodyClass='staging' in the static manifest/,
+                );
+            });
         });
     });
 });

--- a/test/app/static-assets-tests.ts
+++ b/test/app/static-assets-tests.ts
@@ -28,10 +28,11 @@ import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 
 import {
     createDefaultPugRequireHandler,
-    getBrandingAssetDir,
+    getBrandingPublicDir,
     getFaviconFilename,
     getLogoOverlayFilename,
-    validateBrandingAssets,
+    validateBrandingAssetsInManifest,
+    validateBrandingAssetsOnDisk,
 } from '../../lib/app/static-assets.js';
 import {resolvePathFromAppRoot} from '../../lib/utils.js';
 
@@ -145,7 +146,7 @@ describe('Static assets', () => {
         });
     });
 
-    describe('validateBrandingAssets', () => {
+    describe('validateBrandingAssetsOnDisk', () => {
         let tmpDir: string;
 
         beforeAll(async () => {
@@ -163,39 +164,63 @@ describe('Static assets', () => {
         });
 
         it('is a no-op when no body class is set', async () => {
-            await expect(validateBrandingAssets('/nonexistent/path', '')).resolves.toBeUndefined();
+            await expect(validateBrandingAssetsOnDisk('/nonexistent/path', '')).resolves.toBeUndefined();
         });
 
         it('passes when both assets exist', async () => {
-            await expect(validateBrandingAssets(tmpDir, 'good')).resolves.toBeUndefined();
+            await expect(validateBrandingAssetsOnDisk(tmpDir, 'good')).resolves.toBeUndefined();
         });
 
         it('throws listing every missing asset', async () => {
-            await expect(validateBrandingAssets(tmpDir, 'missing')).rejects.toThrow(/favicon-missing\.ico/);
-            await expect(validateBrandingAssets(tmpDir, 'missing')).rejects.toThrow(/site-logo-missing\.svg/);
+            await expect(validateBrandingAssetsOnDisk(tmpDir, 'missing')).rejects.toThrow(/favicon-missing\.ico/);
+            await expect(validateBrandingAssetsOnDisk(tmpDir, 'missing')).rejects.toThrow(/site-logo-missing\.svg/);
         });
 
         it('throws when only one asset is missing', async () => {
-            await expect(validateBrandingAssets(tmpDir, 'partial')).rejects.toThrow(/site-logo-partial\.svg/);
+            await expect(validateBrandingAssetsOnDisk(tmpDir, 'partial')).rejects.toThrow(/site-logo-partial\.svg/);
         });
     });
 
-    describe('getBrandingAssetDir', () => {
-        it('uses staticPath in production mode', () => {
-            expect(getBrandingAssetDir(false, '/dist/static')).toBe('/dist/static');
+    describe('validateBrandingAssetsInManifest', () => {
+        // Regression for the gh-8755 revert: production nodes don't have the static files on
+        // disk (they ship in the CDN bundle), so validation must go via the manifest, which
+        // lists everything webpack copied from public/ into that bundle.
+        const manifest = {
+            'favicon-staging.ico': 'favicon-staging.ico',
+            'site-logo-staging.svg': 'site-logo-staging.svg',
+            'favicon-partial.ico': 'favicon-partial.ico',
+        };
+
+        it('is a no-op when no body class is set', () => {
+            expect(() => validateBrandingAssetsInManifest({}, '')).not.toThrow();
         });
 
-        it('uses the public source dir in dev mode (assets are served from there, not staticPath)', () => {
+        it('passes when both assets are in the manifest', () => {
+            expect(() => validateBrandingAssetsInManifest(manifest, 'staging')).not.toThrow();
+        });
+
+        it('throws listing every missing asset', () => {
+            expect(() => validateBrandingAssetsInManifest(manifest, 'missing')).toThrow(/favicon-missing\.ico/);
+            expect(() => validateBrandingAssetsInManifest(manifest, 'missing')).toThrow(/site-logo-missing\.svg/);
+        });
+
+        it('throws when only one asset is missing', () => {
+            expect(() => validateBrandingAssetsInManifest(manifest, 'partial')).toThrow(/site-logo-partial\.svg/);
+        });
+    });
+
+    describe('getBrandingPublicDir', () => {
+        it('points at the public source dir (dev serves branding from there, not staticPath)', () => {
             // Regression: in dev the webpack middleware serves branding from public/, so validating
             // staticPath (the source dir, which has no branding assets) spuriously crashes startup.
-            expect(getBrandingAssetDir(true, '/dist/static')).toBe(resolvePathFromAppRoot('public'));
+            expect(getBrandingPublicDir()).toBe(resolvePathFromAppRoot('public'));
         });
     });
 
     describe('branding assets ship for every deployed environment', () => {
-        // Guards the dev path end-to-end: getBrandingAssetDir(devMode) points here and the real
-        // files must exist, so a missing asset or a wrong directory fails the build, not just prod.
-        const publicDir = getBrandingAssetDir(true, '/unused');
+        // Guards the dev path end-to-end: the real files must exist in public/, so a missing
+        // asset fails the build, not just a deploy. Adding an environment? Add its class here.
+        const publicDir = getBrandingPublicDir();
 
         it.each([
             'dev',
@@ -205,7 +230,7 @@ describe('Static assets', () => {
             'winstaging',
             'wintest',
         ])('has favicon + logo overlay for %s', async extraBodyClass => {
-            await expect(validateBrandingAssets(publicDir, extraBodyClass)).resolves.toBeUndefined();
+            await expect(validateBrandingAssetsOnDisk(publicDir, extraBodyClass)).resolves.toBeUndefined();
         });
     });
 });

--- a/test/app/static-assets-tests.ts
+++ b/test/app/static-assets-tests.ts
@@ -22,9 +22,18 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {describe, expect, it, vi} from 'vitest';
+import path from 'node:path';
 
-import {createDefaultPugRequireHandler, getFaviconFilename} from '../../lib/app/static-assets.js';
+import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
+
+import {
+    createDefaultPugRequireHandler,
+    getBrandingAssetDir,
+    getFaviconFilename,
+    getLogoOverlayFilename,
+    validateBrandingAssets,
+} from '../../lib/app/static-assets.js';
+import {resolvePathFromAppRoot} from '../../lib/utils.js';
 
 // Mock the logger
 vi.mock('../../lib/logger.js', () => ({
@@ -112,38 +121,91 @@ describe('Static assets', () => {
     });
 
     describe('getFaviconFilename', () => {
-        it('should prioritize dev environment over other environments', () => {
-            // Dev mode favicon should be used regardless of environment flags
-            expect(getFaviconFilename(true, [])).toContain('dev');
-            expect(getFaviconFilename(true, ['beta'])).toContain('dev');
-            expect(getFaviconFilename(true, ['staging'])).toContain('dev');
-            expect(getFaviconFilename(true, ['beta', 'staging'])).toContain('dev');
+        it('uses the default favicon when no body class is set', () => {
+            expect(getFaviconFilename('')).toBe('favicon.ico');
         });
 
-        it('should select appropriate favicon based on environment', () => {
-            // Test specific environments when not in dev mode
-            const environments = [
-                {env: ['beta'], expected: 'beta'},
-                {env: ['staging'], expected: 'staging'},
-                {env: [], expected: 'favicon.ico'},
-            ];
+        it('derives the favicon name from the body class', () => {
+            expect(getFaviconFilename('dev')).toBe('favicon-dev.ico');
+            expect(getFaviconFilename('beta')).toBe('favicon-beta.ico');
+            expect(getFaviconFilename('staging')).toBe('favicon-staging.ico');
+            expect(getFaviconFilename('anything-else')).toBe('favicon-anything-else.ico');
+        });
+    });
 
-            for (const {env, expected} of environments) {
-                const result = getFaviconFilename(false, env);
-                if (expected === 'favicon.ico') {
-                    expect(result).toBe(expected);
-                } else {
-                    expect(result).toContain(expected);
-                }
-            }
+    describe('getLogoOverlayFilename', () => {
+        it('returns undefined when no body class is set', () => {
+            expect(getLogoOverlayFilename('')).toBeUndefined();
         });
 
-        it('should handle environment arrays with mixed values', () => {
-            // When multiple environments are specified, there should be a consistent priority
-            expect(getFaviconFilename(false, ['beta', 'staging'])).toContain('beta');
-            expect(getFaviconFilename(false, ['staging', 'beta'])).toContain('beta');
-            expect(getFaviconFilename(false, ['other', 'beta'])).toContain('beta');
-            expect(getFaviconFilename(false, ['other', 'staging'])).toContain('staging');
+        it('derives the overlay filename from the body class', () => {
+            expect(getLogoOverlayFilename('dev')).toBe('site-logo-dev.svg');
+            expect(getLogoOverlayFilename('beta')).toBe('site-logo-beta.svg');
+            expect(getLogoOverlayFilename('intern')).toBe('site-logo-intern.svg');
+        });
+    });
+
+    describe('validateBrandingAssets', () => {
+        let tmpDir: string;
+
+        beforeAll(async () => {
+            const fs = await import('node:fs/promises');
+            const os = await import('node:os');
+            tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ce-branding-test-'));
+            await fs.writeFile(path.join(tmpDir, 'favicon-good.ico'), '');
+            await fs.writeFile(path.join(tmpDir, 'site-logo-good.svg'), '');
+            await fs.writeFile(path.join(tmpDir, 'favicon-partial.ico'), '');
+        });
+
+        afterAll(async () => {
+            const fs = await import('node:fs/promises');
+            await fs.rm(tmpDir, {recursive: true, force: true});
+        });
+
+        it('is a no-op when no body class is set', async () => {
+            await expect(validateBrandingAssets('/nonexistent/path', '')).resolves.toBeUndefined();
+        });
+
+        it('passes when both assets exist', async () => {
+            await expect(validateBrandingAssets(tmpDir, 'good')).resolves.toBeUndefined();
+        });
+
+        it('throws listing every missing asset', async () => {
+            await expect(validateBrandingAssets(tmpDir, 'missing')).rejects.toThrow(/favicon-missing\.ico/);
+            await expect(validateBrandingAssets(tmpDir, 'missing')).rejects.toThrow(/site-logo-missing\.svg/);
+        });
+
+        it('throws when only one asset is missing', async () => {
+            await expect(validateBrandingAssets(tmpDir, 'partial')).rejects.toThrow(/site-logo-partial\.svg/);
+        });
+    });
+
+    describe('getBrandingAssetDir', () => {
+        it('uses staticPath in production mode', () => {
+            expect(getBrandingAssetDir(false, '/dist/static')).toBe('/dist/static');
+        });
+
+        it('uses the public source dir in dev mode (assets are served from there, not staticPath)', () => {
+            // Regression: in dev the webpack middleware serves branding from public/, so validating
+            // staticPath (the source dir, which has no branding assets) spuriously crashes startup.
+            expect(getBrandingAssetDir(true, '/dist/static')).toBe(resolvePathFromAppRoot('public'));
+        });
+    });
+
+    describe('branding assets ship for every deployed environment', () => {
+        // Guards the dev path end-to-end: getBrandingAssetDir(devMode) points here and the real
+        // files must exist, so a missing asset or a wrong directory fails the build, not just prod.
+        const publicDir = getBrandingAssetDir(true, '/unused');
+
+        it.each([
+            'dev',
+            'beta',
+            'staging',
+            'winprod',
+            'winstaging',
+            'wintest',
+        ])('has favicon + logo overlay for %s', async extraBodyClass => {
+            await expect(validateBrandingAssets(publicDir, extraBodyClass)).resolves.toBeUndefined();
         });
     });
 });

--- a/views/logo.pug
+++ b/views/logo.pug
@@ -1,8 +1,4 @@
 a.navbar-brand(href=httpRoot title="Compiler Explorer", style="position: relative")
   img(src=staticRoot + "site-logo.svg" alt="Compiler Explorer logo" height="50" width="165")
-  if extraBodyClass === "beta"
-    img(src=staticRoot + "site-logo-beta.svg" alt="Compiler Explorer logo (beta)" height="50" width="165" style="position: absolute; top: 0; right: 0;")
-  else if extraBodyClass === "staging"
-    img(src=staticRoot + "site-logo-staging.svg" alt="Compiler Explorer logo (staging)" height="50" width="165" style="position: absolute; top: 0; right: 0;")
-  else if extraBodyClass === "dev"
-    img(src=staticRoot + "site-logo-dev.svg" alt="Compiler Explorer logo (dev)" height="50" width="165" style="position: absolute; top: 0; right: 0;")
+  if logoOverlayFilename
+    img(src=staticRoot + logoOverlayFilename alt="" aria-hidden="true" height="50" width="165" style="position: absolute; top: 0; right: 0;")


### PR DESCRIPTION
Reapplies #8755, which was reverted in 463e3e70f after it broke the staging deploy:

```
error: Top-level error (shutting down): Missing branding assets for extraBodyClass='staging'
in /infra/.deploy/static: favicon-staging.ico, site-logo-staging.svg
```

### What went wrong

`validateBrandingAssets` checked `staticPath` on the local filesystem. That's correct for dev and local prod runs, but AWS deploys ship **two** packages (`build-dist.sh`): the node app tarball (no `static/` at all) and the static bundle, which goes to the CDN (`staticUrl=https://static.ce-cdn.net/`). Production nodes never have the branding files on disk, so any env with `extraBodyClass` set (staging, beta, win\*) died at startup. Prod itself has an empty `extraBodyClass`, which is why the check short-circuited there and the bug only surfaced on the staging deploy.

### The fix (second commit)

The webpack manifest **does** ship with the node app, and lists every asset copied from `public/` into the static bundle. So in production, validate the derived `favicon-<class>.ico` / `site-logo-<class>.svg` names against **manifest keys** instead of the filesystem; dev keeps the on-disk check against `public/`. This preserves the fail-fast-on-typo behaviour #8755 wanted, checking the thing that actually describes what shipped to the CDN. If the manifest can't be loaded we're already on the existing warn-and-fall-back handler, so validation is skipped rather than fatal.

`setupStaticMiddleware` now takes the parsed manifest (loaded once in `setupWebServer` via new `loadStaticManifest`) instead of reading it itself.

### Verification

- Fresh **production** webpack build: all six env asset pairs (dev, beta, staging, winprod, winstaging, wintest) appear as plain-name keys in `manifest.json` (the win\* symlink placeholders are dereferenced on copy).
- Booted the built `out/dist` server code in the exact deploy layout (`staticUrl` set, nonexistent `staticPath`, `extraBodyClass=staging`): boots cleanly and renders `favicon-staging.ico` + `site-logo-staging.svg`; a mistyped class still fails startup with a clear error.
- New regression tests pin both behaviours at the `setupWebServer` level with a shipped-manifest-only layout.

⚠️ Merge timing: prod's empty `extraBodyClass` never exercises this path — the real test is the next **staging** deploy, so this should merge when someone (me) is ready to deploy staging and watch it.

cc @partouf — sorry again for the breakage; this validates against the manifest rather than expecting the CDN bundle's files on local disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)