### PR TITLE
Bump workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Update browerslist
         run: |
           git config user.name 'Compiler Explorer Bot'
@@ -18,7 +18,7 @@ jobs:
           npm run update-browserslist
           git commit -am "Automated checkin - update browsers list"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           title: '[bot] Update browsers list'
           body: |

--- a/.github/workflows/check-infra-settings-comment.yml
+++ b/.github/workflows/check-infra-settings-comment.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: infra-settings-check
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-infra-settings-comment.yml
+++ b/.github/workflows/check-infra-settings-comment.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.download.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/check-infra-settings.yml
+++ b/.github/workflows/check-infra-settings.yml
@@ -10,12 +10,12 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload check results
         if: steps.check.outputs.has_findings == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: infra-settings-check
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy-win.yml
+++ b/.github/workflows/deploy-win.yml
@@ -18,19 +18,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.buildnumber }}
       - name: Use Node.js (from .node-version)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
           cache: npm
       - name: Build distribution
         id: build_dist
         run: powershell -File etc/scripts/build-dist-win.ps1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: out/dist-bin
@@ -41,17 +41,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           check-latest: true
           cache: npm
       - name: Download the built distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: out/dist-bin

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,6 +11,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Check workflow files
         uses: docker://rhysd/actionlint:1.7.12
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -31,7 +31,7 @@ jobs:
           npm run ts-check
           python3 ./etc/scripts/test_numba_wrapper.py
           uv run --directory etc/scripts/gh_tool pytest -v
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
@@ -131,7 +131,7 @@ jobs:
           SOURCE_DIR: out/dist-bin
           DEST_DIR: dist/gh/${{ needs.build_dist.outputs.branch }}
       - name: Tag the commit
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           make prereqs
           python3 -m pip install numba
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
       - name: Run checks
         run: |
           npm run lint-check

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -8,11 +8,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           check-latest: true
@@ -40,11 +40,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Use Node.js (minimum supported, from .minimum-node-version)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .minimum-node-version
           check-latest: false
@@ -67,11 +67,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           check-latest: true
@@ -79,7 +79,7 @@ jobs:
       - name: Build distribution
         id: build_dist
         run: etc/scripts/build-dist.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: out/dist-bin
@@ -93,17 +93,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           check-latest: true
           cache: npm
       - name: Download the built distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: out/dist-bin

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           make prereqs
           python3 -m pip install numba
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
       - name: Run checks
         run: |
           npm run lint-check

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -10,9 +10,9 @@ jobs:
         browser: ['chrome']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           check-latest: true
@@ -23,10 +23,10 @@ jobs:
         uses: browser-actions/setup-firefox@v1
         if: matrix.browser == 'firefox'
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
         if: matrix.browser == 'chrome'
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           start: npm run dev -- --language c++ --no-local
           wait-on: 'http://localhost:10240'
@@ -34,7 +34,7 @@ jobs:
           config: screenshotOnRunFailure=true,video=false
           browser: ${{ matrix.browser }}
       - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -12,11 +12,11 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           check-latest: true


### PR DESCRIPTION
Every CI run currently emits "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24" runner annotations (visible on every job of the main build and the Windows build). These come from the runner at execution time, so the actionlint gate added in #8912 can't catch them: actionlint checks workflow files statically and has no knowledge of which Node runtime an action's implementation targets.

This bumps every runner-flagged action to its latest major, all of which target node24:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/setup-python | v5 | v7 |
| actions/labeler | v5 | v6 |
| actions/github-script | v7 | v9 |
| github/codeql-action | v3 | v4 |
| peter-evans/create-pull-request | v6 | v8 |
| cypress-io/github-action | v6 | v7 |
| browser-actions/setup-chrome | v1 | v2 |
| codecov/codecov-action | v5 | v7 |
| astral-sh/setup-uv | v6 | v8.3.2 (exact pin; from v8 they publish immutable releases only, no floating major tags) |

The last three rows came from iterating: this branch's own push builds run the full workflow (including the real deploy path), and scanning their annotations after each round caught what the first sweep missed — our github-script uses, codecov-action (whose v5 pins a node20 github-script by SHA internally; their v6 fixed that), and setup-uv.

codeql-action v3 additionally carries its own deprecation warning (sunset December 2026).

**Behaviour changes checked against our usage:**
- create-pull-request v7 renamed `git-token` to `branch-token` and removed the `PULL_REQUEST_NUMBER` env output: browserslist.yml uses neither.
- setup-python v7 removed the `pip-install` input: check-infra-settings.yml doesn't use it.
- github-script v9: `require('@actions/github')` no longer works inside scripts; neither of ours does that (one calls `github.rest.git.createRef`, the other requires only the core `fs` module).
- setup-uv v7/v8 removed the `server-url` input and changed the manifest-file format: we pass no inputs.
- setup-chrome v2 installs Chrome for Testing by default: fine (arguably better) for the Cypress frontend tests.
- download-artifact v8 now errors on hash mismatch by default: a fix we want.
- checkout v7 blocks fork-PR checkout under `pull_request_target`/`workflow_run` unless opted in: our only such workflows (label.yml, check-infra-settings-comment.yml) don't use checkout at all.
- codecov-action v6 is their node24 bump; v7 only rotates their signing account. Our `token`/`verbose` usage is unaffected.

**Deliberately left alone:**
- `browser-actions/setup-firefox@v1`: latest release is still v1 (1.7.x, node24).
- `wow-actions/potential-duplicates@v1`: upstream is unmaintained (last release 2022); no node24 version exists. Its warning will remain on duplicate-detection runs until we replace or drop it.
- `jakejarvis/s3-sync-action@master`: a Docker action, unaffected by the Node runtime deprecation.

**Validation:**
- actionlint 1.7.12 (the pinned CI version) passes clean.
- All PR checks green across two full rounds, including Cypress on Chrome for Testing and CodeQL v4.
- Because pushes to any branch run the real deploy job, the complete chain (dist build → download-artifact v8 → sentry → S3 sync → github-script v9 tagging → post_deploy_check on admin-node) ran green for real.
- Runner compatibility: these majors require Actions Runner >= 2.327.1; the self-hosted admin-node and ce fleet runners are all on 2.335.1 (confirmed from job logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
