### PR TITLE
Add dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Version updates for the actions used in .github/workflows. This does not
+# change security-update behaviour, and no other ecosystem (npm, pip) gets
+# version updates from this file.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # One rolled-up PR per interval instead of a PR per action.
+    groups:
+      github-actions:
+        patterns: ["*"]
+    # Don't propose a release until it has been public for a week, the window
+    # in which compromised releases tend to be caught and yanked.
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Follow-up to #8936. The action pins in `.github/workflows/` sat on node20-targeting majors for a year because nothing bumps them: the dependabot PRs this repo gets are security updates, which need no config file but don't cover action versions. Version updates only run for ecosystems listed in `.github/dependabot.yml`, which didn't exist.

This adds the minimal config, scoped to `github-actions` only:

- **Monthly** schedule, with **all bumps grouped into one PR** per interval, so the expected noise is roughly one small rolled-up PR a month.
- **7-day cooldown**: a new release isn't proposed until it has been public a week, the window in which compromised releases (tj-actions style) tend to be caught and yanked.
- No behaviour change for anything else: npm/pip version updates stay off, and security updates are unaffected.

This is also what keeps `astral-sh/setup-uv` fresh: from v8 it publishes immutable releases only (no floating major tags), so its exact pin from #8936 would otherwise rot silently. Note the deploy job already skips for `dependabot[bot]` pushes, so grouped bump PRs won't publish branch dists or create gh- tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)