### PR TITLE
npm>=12 requires `--allow-git`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ scripts:
 prereqs: $(NODE_MODULES)
 
 $(NODE_MODULES): package.json package-lock.json | node-installed
-	$(NPM) clean-install $(NPM_FLAGS)
+	$(NPM) clean-install --allow-git=root $(NPM_FLAGS)
 	@rm -rf node_modules/.cache/esm/*
 	@touch $@
 


### PR DESCRIPTION
... otherwise it won’t install CE’s `golden-layout` fork from git: https://github.com/compiler-explorer/compiler-explorer/blob/1eacae7d5b6f05aeb1cb03031f8b826336998ebc/package.json#L48

See [the release notes](https://docs.npmjs.com/cli/v12/using-npm/changelog#%EF%B8%8F-breaking-changes:~:text=allow%2Dgit%20and%20allow%2Dremote%20now%20default%20to%20%22none%22%3B%20set%20them%20to%20%22all%22%20%28or%20%22root%22%29%20to%20install%20git%20or%20user%2Dsupplied%20tarball%2DURL%20dependencies).

Unfortunately, `--allow-git` is only supported for `npm` >= 11, so if the makefile is supposed to work with older npm versions, this PR can be closed and I’ll just manually pass `NPM_FLAGS=--allow-git=root`.