### PR TITLE
[HLSL] Add DXC 1.9.2607 release

### DIFF
--- a/etc/config/hlsl.amazon.properties
+++ b/etc/config/hlsl.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&dxc:&rga:&clang:godbolt.org@443/winprod
 
-group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502:dxc_1_8_2505:dxc_1_8_2505_1:dxc_1_9_2602:dxc_1_9_2602_24:dxc_1_10_2605_2:dxc_1_10_2605_24
+group.dxc.compilers=dxc_trunk:dxc_1_6_2112:dxc_1_7_2207:dxc_1_7_2212:dxc_1_7_2308:dxc_1_8_2306:dxc_1_8_2403:dxc_1_8_2403_1:dxc_1_8_2403_2:dxc_1_8_2405:dxc_1_8_2407:dxc_1_8_2502:dxc_1_8_2505:dxc_1_8_2505_1:dxc_1_9_2602:dxc_1_9_2602_24:dxc_1_9_2607:dxc_1_10_2605_2:dxc_1_10_2605_24
 group.dxc.groupName=DXC
 group.dxc.isSemVer=true
 group.dxc.baseName=DXC
@@ -38,6 +38,8 @@ compiler.dxc_1_9_2602.exe=/opt/compiler-explorer/dxc-1.9.2602/bin/dxc
 compiler.dxc_1_9_2602.semver=1.9.2602
 compiler.dxc_1_9_2602_24.exe=/opt/compiler-explorer/dxc-1.9.2602.24/bin/dxc
 compiler.dxc_1_9_2602_24.semver=1.9.2602.24
+compiler.dxc_1_9_2607.exe=/opt/compiler-explorer/dxc-1.9.2607/bin/dxc
+compiler.dxc_1_9_2607.semver=1.9.2607
 compiler.dxc_1_10_2605_2.exe=/opt/compiler-explorer/dxc-1.10.2605.2/bin/dxc
 compiler.dxc_1_10_2605_2.semver=1.10.2605.2
 compiler.dxc_1_10_2605_24.exe=/opt/compiler-explorer/dxc-1.10.2605.24/bin/dxc


### PR DESCRIPTION
Adds the DXC `1.9.2607` release to the HLSL config. Depends on compiler-explorer/infra#2255, which builds and publishes the `dxc-1.9.2607` tarball.