### PR TITLE
Fix dex2oat class regex for later versions

### DIFF
--- a/lib/compilers/dex2oat.ts
+++ b/lib/compilers/dex2oat.ts
@@ -118,7 +118,7 @@ export class Dex2OatCompiler extends BaseCompiler {
 
         // These must be used after the output is split on newlines.
         this.compilerFilterRegex = /^compiler-filter\s=\s(.*)$/;
-        this.classRegex = /^\s*\d+:\s+L(.*);\s+\(offset=0x\w+\)\s+\(type_idx=\d+\).*$/;
+        this.classRegex = /^\s*\d+:\s+(\S+)\s+\(offset=0x\w+\)\s+\(type_idx=\d+\).*$/;
         this.methodRegex = /^\s+\d+:\s+(.*)\s+\(dex_method_idx=\d+\)$/;
         this.methodSizeRegex = /^\s+CODE:\s+\(code_offset=(0x\w+)\s+size=(\d+).*$/;
         this.insnRegex = /^\s+(0x\w+):\s+\w+\s+(.*)$/;


### PR DESCRIPTION
The output format for classes in dex2oat has changed:
- before: 0: LSquare; (offset=0x00001454) (type_idx=1)
- after:  0: Square (offset=0x00001480) (type_idx=1)

This change updates the regex to accept any non-whitespace character for the class name (LSquare; or Square). The extracted class name is only used as a key, so the presence of 'L' and ';' aren't important, as long as it's consistent

This is compatible with both older and newer dex2oat versions, and line associations + output formatting are still the same.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
