### PR TITLE
Fix C3 assembly and IR output

### DIFF
--- a/lib/compilers/c3c.ts
+++ b/lib/compilers/c3c.ts
@@ -22,15 +22,28 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import Semver from 'semver';
 
+import type {CompilationResult, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
+import * as utils from '../utils.js';
 import {asSafeVer} from '../utils.js';
+
+// c3c emits one file per module section, named after the module with `::` replaced by `.`, into the
+// `--asm-out`/`--llvm-out` directory. A file with no `module` declaration gets a module named after
+// the file. Nothing is ever written to the single output path CE expects, so we work out which files
+// belong to the user's source and join them together ourselves.
+//
+// Deliberately driven by the module declarations rather than by "every .s that isn't the standard
+// library": it is legal to declare `module std::io` in user code, in which case c3c appends to the
+// standard library's own file and a name-based exclusion would discard the user's output.
+const MODULE_DECL_RE = /^[^\S\n]*module\s+([a-zA-Z_]\w*(?:\s*::\s*[a-zA-Z_]\w*)*)/gm;
 
 export class C3Compiler extends BaseCompiler {
     static get key() {
@@ -48,10 +61,73 @@ export class C3Compiler extends BaseCompiler {
         if (Semver.gte(asSafeVer(this.compiler.semver), '0.6.8', true)) {
             options.push('--llvm-out', '.', '--asm-out', '.');
         }
+        // c3c defaults to --strip-unused=yes, tracing only from main, `@export` and `@nostrip`, so a
+        // lone uncalled function produces no output at all. That is the common case on CE, so ask for
+        // everything. Users can put --strip-unused=yes back: user options are appended after these,
+        // and c3c takes the last occurrence.
+        if (Semver.gte(asSafeVer(this.compiler.semver), '0.5.0', true)) {
+            options.push('--strip-unused=no');
+        }
         return options;
     }
 
     override getIrOutputFilename(inputFilename: string): string {
         return this.filename(path.dirname(inputFilename) + '/output.ll');
+    }
+
+    // Module names for the sections declared in the source, in declaration order, as c3c would name
+    // the files it writes. Falls back to the source's own basename, matching how c3c names the module
+    // for a file that declares none.
+    async getModuleBaseNames(inputFilename: string): Promise<string[]> {
+        let source: string;
+        try {
+            source = await fs.readFile(inputFilename, 'utf8');
+        } catch {
+            return [];
+        }
+        const names = [...source.matchAll(MODULE_DECL_RE)].map(match => match[1].replaceAll(/\s*::\s*/g, '.'));
+        // Order matters, but a module may be declared more than once in one file and each declaration
+        // appends to the same output file, so only join it in once.
+        const unique = [...new Set(names)];
+        return unique.length > 0 ? unique : [path.parse(inputFilename).name];
+    }
+
+    async joinModuleOutputs(dirPath: string, baseNames: string[], extension: string, destination: string) {
+        const parts: string[] = [];
+        for (const baseName of baseNames) {
+            const modulePath = path.join(dirPath, baseName + extension);
+            // Read everything before writing: a `module output;` would otherwise have us copy the
+            // destination onto itself.
+            if (modulePath !== destination && (await utils.fileExists(modulePath))) {
+                parts.push(await fs.readFile(modulePath, 'utf8'));
+            }
+        }
+        // Leave the destination absent when there is nothing to write, so the usual "no output"
+        // reporting still happens rather than showing an empty pane.
+        if (parts.length > 0) await fs.writeFile(destination, parts.join('\n'));
+    }
+
+    override async runCompiler(
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+        filters?: ParseFiltersAndOutputOptions,
+    ): Promise<CompilationResult> {
+        const result = await super.runCompiler(compiler, options, inputFilename, execOptions, filters);
+        if (result.code === 0) {
+            const dirPath = path.dirname(inputFilename);
+            const baseNames = await this.getModuleBaseNames(inputFilename);
+            // Both panes are fed from per-module files, and which one this invocation produced depends
+            // on whether --emit-llvm was added, so gather up whatever is there.
+            await this.joinModuleOutputs(
+                dirPath,
+                baseNames,
+                '.s',
+                this.getOutputFilename(dirPath, this.outputFilebase),
+            );
+            await this.joinModuleOutputs(dirPath, baseNames, '.ll', this.getIrOutputFilename(inputFilename));
+        }
+        return result;
     }
 }

--- a/lib/compilers/c3c.ts
+++ b/lib/compilers/c3c.ts
@@ -27,7 +27,8 @@ import path from 'node:path';
 
 import Semver from 'semver';
 
-import type {CompilationResult, ExecutionOptionsWithEnv} from '../../types/compilation/compilation.interfaces.js';
+import type {CompilationResult} from '../../types/compilation/compilation.interfaces.js';
+import type {LLVMIrBackendOptions} from '../../types/compilation/ir.interfaces.js';
 import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
 import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
 import {BaseCompiler} from '../base-compiler.js';
@@ -44,6 +45,13 @@ import {asSafeVer} from '../utils.js';
 // library": it is legal to declare `module std::io` in user code, in which case c3c appends to the
 // standard library's own file and a name-based exclusion would discard the user's output.
 const MODULE_DECL_RE = /^[^\S\n]*module\s+([a-zA-Z_]\w*(?:\s*::\s*[a-zA-Z_]\w*)*)/gm;
+
+// Raw strings and the three comment forms, blanked before looking for module declarations so that a
+// commented-out or quoted `module std::io;` doesn't have us serve up the standard library's assembly.
+const NON_CODE_RE = /`[^`]*`|<\*[\s\S]*?\*>|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g;
+
+// c3c replaces anything that isn't a word character when it derives a module name from a file name.
+const FILENAME_TO_MODULE_RE = /\W/g;
 
 export class C3Compiler extends BaseCompiler {
     static get key() {
@@ -71,63 +79,104 @@ export class C3Compiler extends BaseCompiler {
         return options;
     }
 
-    override getIrOutputFilename(inputFilename: string): string {
+    override getIrOutputFilename(
+        inputFilename: string,
+        filters?: ParseFiltersAndOutputOptions,
+        irOptions?: LLVMIrBackendOptions,
+    ): string {
         return this.filename(path.dirname(inputFilename) + '/output.ll');
     }
 
+    // The module name c3c derives for a file that declares none.
+    static moduleNameForFile(inputFilename: string): string {
+        return path.parse(inputFilename).name.replace(FILENAME_TO_MODULE_RE, '_');
+    }
+
     // Module names for the sections declared in the source, in declaration order, as c3c would name
-    // the files it writes. Falls back to the source's own basename, matching how c3c names the module
-    // for a file that declares none.
+    // the files it writes. Falls back to the name derived from the file, matching what c3c does when
+    // the source declares no module at all.
     async getModuleBaseNames(inputFilename: string): Promise<string[]> {
         let source: string;
         try {
             source = await fs.readFile(inputFilename, 'utf8');
         } catch {
-            return [];
+            return [C3Compiler.moduleNameForFile(inputFilename)];
         }
-        const names = [...source.matchAll(MODULE_DECL_RE)].map(match => match[1].replaceAll(/\s*::\s*/g, '.'));
+        // Blank out non-code, preserving newlines so the line anchors below still line up.
+        const code = source.replaceAll(NON_CODE_RE, match => match.replaceAll(/[^\n]/g, ' '));
+        const names = [...code.matchAll(MODULE_DECL_RE)].map(match => match[1].replaceAll(/\s*::\s*/g, '.'));
         // Order matters, but a module may be declared more than once in one file and each declaration
         // appends to the same output file, so only join it in once.
         const unique = [...new Set(names)];
-        return unique.length > 0 ? unique : [path.parse(inputFilename).name];
+        return unique.length > 0 ? unique : [C3Compiler.moduleNameForFile(inputFilename)];
     }
 
     async joinModuleOutputs(dirPath: string, baseNames: string[], extension: string, destination: string) {
-        const parts: string[] = [];
+        const parts: {name: string; text: string}[] = [];
         for (const baseName of baseNames) {
             const modulePath = path.join(dirPath, baseName + extension);
             // Read everything before writing: a `module output;` would otherwise have us copy the
             // destination onto itself.
             if (modulePath !== destination && (await utils.fileExists(modulePath))) {
-                parts.push(await fs.readFile(modulePath, 'utf8'));
+                parts.push({name: baseName, text: await fs.readFile(modulePath, 'utf8')});
             }
         }
         // Leave the destination absent when there is nothing to write, so the usual "no output"
         // reporting still happens rather than showing an empty pane.
-        if (parts.length > 0) await fs.writeFile(destination, parts.join('\n'));
+        if (parts.length === 0) return;
+        // One module is overwhelmingly the common case; only label the chunks when there is more than
+        // one to tell apart, so ordinary output is untouched.
+        const comment = extension === '.ll' ? ';' : '#';
+        const body =
+            parts.length === 1
+                ? parts[0].text
+                : parts.map(part => `${comment} module ${part.name}\n${part.text}`).join('\n');
+        await fs.writeFile(destination, body);
     }
 
-    override async runCompiler(
-        compiler: string,
-        options: string[],
-        inputFilename: string,
-        execOptions: ExecutionOptionsWithEnv,
-        filters?: ParseFiltersAndOutputOptions,
-    ): Promise<CompilationResult> {
-        const result = await super.runCompiler(compiler, options, inputFilename, execOptions, filters);
-        if (result.code === 0) {
-            const dirPath = path.dirname(inputFilename);
-            const baseNames = await this.getModuleBaseNames(inputFilename);
-            // Both panes are fed from per-module files, and which one this invocation produced depends
-            // on whether --emit-llvm was added, so gather up whatever is there.
-            await this.joinModuleOutputs(
-                dirPath,
-                baseNames,
-                '.s',
-                this.getOutputFilename(dirPath, this.outputFilebase),
-            );
-            await this.joinModuleOutputs(dirPath, baseNames, '.ll', this.getIrOutputFilename(inputFilename));
+    async joinModulesFor(inputFilename: string, extension: string, destination: string) {
+        await this.joinModuleOutputs(
+            path.dirname(inputFilename),
+            await this.getModuleBaseNames(inputFilename),
+            extension,
+            destination,
+        );
+    }
+
+    // Runs once, after every compiler invocation for this request has finished, and is handed the
+    // caller's own outputFilename, so there is no second writer and no need to guess the name.
+    override async postProcess(
+        result: CompilationResult,
+        outputFilename: string,
+        filters: ParseFiltersAndOutputOptions,
+        produceOptRemarks = false,
+    ) {
+        if (result.code === 0 && result.inputFilename) {
+            await this.joinModulesFor(result.inputFilename, '.s', outputFilename);
+            // checkOutputFileAndDoPostProcess sizes the output before calling us, which is before the
+            // file exists at all. Without refreshing it, super reports "<No output file>" regardless.
+            try {
+                result.asmSize = (await fs.stat(outputFilename)).size;
+            } catch {
+                // Nothing was written; leave asmSize unset so the usual reporting applies.
+            }
         }
-        return result;
+        return super.postProcess(result, outputFilename, filters, produceOptRemarks);
+    }
+
+    // The IR pane reads its own file, written by a separate --emit-llvm invocation, so it is joined
+    // here rather than in postProcess. Only that invocation writes .ll files, so the two never collide.
+    override async processIrOutput(
+        output: CompilationResult,
+        irOptions: LLVMIrBackendOptions,
+        filters: ParseFiltersAndOutputOptions,
+    ) {
+        if (output.inputFilename)
+            await this.joinModulesFor(
+                output.inputFilename,
+                '.ll',
+                this.getIrOutputFilename(output.inputFilename, filters, irOptions),
+            );
+        return super.processIrOutput(output, irOptions, filters);
     }
 }

--- a/lib/compilers/c3c.ts
+++ b/lib/compilers/c3c.ts
@@ -36,21 +36,17 @@ import {CompilationEnvironment} from '../compilation-env.js';
 import * as utils from '../utils.js';
 import {asSafeVer} from '../utils.js';
 
-// c3c emits one file per module section, named after the module with `::` replaced by `.`, into the
-// `--asm-out`/`--llvm-out` directory. A file with no `module` declaration gets a module named after
-// the file. Nothing is ever written to the single output path CE expects, so we work out which files
-// belong to the user's source and join them together ourselves.
-//
-// Deliberately driven by the module declarations rather than by "every .s that isn't the standard
-// library": it is legal to declare `module std::io` in user code, in which case c3c appends to the
-// standard library's own file and a name-based exclusion would discard the user's output.
+// c3c writes one file per module section into the `--asm-out`/`--llvm-out` directory, named after the
+// module with `::` replaced by `.`, never to the single path CE expects, so we join the user's files
+// ourselves. Driven by the declarations rather than by "any file that isn't the standard library",
+// because `module std::io;` is legal in user code and c3c then appends to the standard library's file.
 const MODULE_DECL_RE = /^[^\S\n]*module\s+([a-zA-Z_]\w*(?:\s*::\s*[a-zA-Z_]\w*)*)/gm;
 
-// Raw strings and the three comment forms, blanked before looking for module declarations so that a
-// commented-out or quoted `module std::io;` doesn't have us serve up the standard library's assembly.
+// Raw strings and the three comment forms, blanked before matching declarations so a commented-out or
+// quoted `module std::io;` doesn't have us serve up the standard library's assembly.
 const NON_CODE_RE = /`[^`]*`|<\*[\s\S]*?\*>|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g;
 
-// c3c replaces anything that isn't a word character when it derives a module name from a file name.
+// c3c replaces anything that isn't a word character when deriving a module name from a file name.
 const FILENAME_TO_MODULE_RE = /\W/g;
 
 export class C3Compiler extends BaseCompiler {
@@ -69,10 +65,9 @@ export class C3Compiler extends BaseCompiler {
         if (Semver.gte(asSafeVer(this.compiler.semver), '0.6.8', true)) {
             options.push('--llvm-out', '.', '--asm-out', '.');
         }
-        // c3c defaults to --strip-unused=yes, tracing only from main, `@export` and `@nostrip`, so a
-        // lone uncalled function produces no output at all. That is the common case on CE, so ask for
-        // everything. Users can put --strip-unused=yes back: user options are appended after these,
-        // and c3c takes the last occurrence.
+        // c3c defaults to --strip-unused=yes, tracing only from main, `@export` and `@nostrip`, so a lone
+        // uncalled function emits nothing at all: the common case on CE. User options are appended after
+        // these and c3c takes the last occurrence, so `--strip-unused=yes` still works.
         if (Semver.gte(asSafeVer(this.compiler.semver), '0.5.0', true)) {
             options.push('--strip-unused=no');
         }
@@ -92,9 +87,7 @@ export class C3Compiler extends BaseCompiler {
         return path.parse(inputFilename).name.replace(FILENAME_TO_MODULE_RE, '_');
     }
 
-    // Module names for the sections declared in the source, in declaration order, as c3c would name
-    // the files it writes. Falls back to the name derived from the file, matching what c3c does when
-    // the source declares no module at all.
+    // Module names as c3c would name its output files, in declaration order, or the derived name.
     async getModuleBaseNames(inputFilename: string): Promise<string[]> {
         let source: string;
         try {
@@ -102,11 +95,10 @@ export class C3Compiler extends BaseCompiler {
         } catch {
             return [C3Compiler.moduleNameForFile(inputFilename)];
         }
-        // Blank out non-code, preserving newlines so the line anchors below still line up.
+        // Blank non-code, preserving newlines so MODULE_DECL_RE's line anchors still line up.
         const code = source.replaceAll(NON_CODE_RE, match => match.replaceAll(/[^\n]/g, ' '));
         const names = [...code.matchAll(MODULE_DECL_RE)].map(match => match[1].replaceAll(/\s*::\s*/g, '.'));
-        // Order matters, but a module may be declared more than once in one file and each declaration
-        // appends to the same output file, so only join it in once.
+        // A module may be declared in several sections, all appending to one file: join it in once.
         const unique = [...new Set(names)];
         return unique.length > 0 ? unique : [C3Compiler.moduleNameForFile(inputFilename)];
     }
@@ -115,17 +107,14 @@ export class C3Compiler extends BaseCompiler {
         const parts: {name: string; text: string}[] = [];
         for (const baseName of baseNames) {
             const modulePath = path.join(dirPath, baseName + extension);
-            // Read everything before writing: a `module output;` would otherwise have us copy the
-            // destination onto itself.
+            // A `module output;` would otherwise have us copy the destination onto itself.
             if (modulePath !== destination && (await utils.fileExists(modulePath))) {
                 parts.push({name: baseName, text: await fs.readFile(modulePath, 'utf8')});
             }
         }
-        // Leave the destination absent when there is nothing to write, so the usual "no output"
-        // reporting still happens rather than showing an empty pane.
+        // Leave the destination absent, so the usual "no output file" reporting applies, not an empty pane.
         if (parts.length === 0) return;
-        // One module is overwhelmingly the common case; only label the chunks when there is more than
-        // one to tell apart, so ordinary output is untouched.
+        // Only label the chunks when there is more than one, so single-module output is unchanged.
         const comment = extension === '.ll' ? ';' : '#';
         const body =
             parts.length === 1
@@ -143,8 +132,8 @@ export class C3Compiler extends BaseCompiler {
         );
     }
 
-    // Runs once, after every compiler invocation for this request has finished, and is handed the
-    // caller's own outputFilename, so there is no second writer and no need to guess the name.
+    // Runs after every compiler invocation for this request has finished, handed the caller's own
+    // outputFilename, so there is no second writer and no name to guess.
     override async postProcess(
         result: CompilationResult,
         outputFilename: string,
@@ -153,19 +142,19 @@ export class C3Compiler extends BaseCompiler {
     ) {
         if (result.code === 0 && result.inputFilename) {
             await this.joinModulesFor(result.inputFilename, '.s', outputFilename);
-            // checkOutputFileAndDoPostProcess sizes the output before calling us, which is before the
-            // file exists at all. Without refreshing it, super reports "<No output file>" regardless.
+            // checkOutputFileAndDoPostProcess sizes the output before calling us, i.e. before the file
+            // exists at all. Without refreshing it, super reports "<No output file>" regardless.
             try {
                 result.asmSize = (await fs.stat(outputFilename)).size;
             } catch {
-                // Nothing was written; leave asmSize unset so the usual reporting applies.
+                // Nothing written; leave asmSize unset so the usual reporting applies.
             }
         }
         return super.postProcess(result, outputFilename, filters, produceOptRemarks);
     }
 
-    // The IR pane reads its own file, written by a separate --emit-llvm invocation, so it is joined
-    // here rather than in postProcess. Only that invocation writes .ll files, so the two never collide.
+    // The IR pane reads its own file, written by a separate --emit-llvm invocation, so join it here
+    // rather than in postProcess. Only that invocation writes .ll files, so the two never collide.
     override async processIrOutput(
         output: CompilationResult,
         irOptions: LLVMIrBackendOptions,

--- a/test/c3c-tests.ts
+++ b/test/c3c-tests.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, beforeAll, describe, expect, it} from 'vitest';
+
+import {CompilationEnvironment} from '../lib/compilation-env.js';
+import {C3Compiler} from '../lib/compilers/index.js';
+import {CompilerInfo} from '../types/compiler.interfaces.js';
+import {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
+import {makeCompilationEnvironment} from './utils.js';
+
+const languages = {
+    c3: {id: 'c3'},
+};
+
+function makeInfo(semver: string): CompilerInfo {
+    return {
+        exe: '/opt/compiler-explorer/c3-test/c3c',
+        remote: true,
+        lang: languages.c3.id,
+        semver,
+    } as unknown as CompilerInfo;
+}
+
+describe('C3 compiler', () => {
+    let env: CompilationEnvironment;
+    const dirs: string[] = [];
+
+    beforeAll(() => {
+        env = makeCompilationEnvironment({languages});
+    });
+
+    afterEach(async () => {
+        while (dirs.length > 0) await fs.rm(dirs.pop()!, {recursive: true, force: true});
+    });
+
+    async function tempDir(): Promise<string> {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ce-c3c-test-'));
+        dirs.push(dir);
+        return dir;
+    }
+
+    it('should not crash on instantiation', () => {
+        new C3Compiler(makeInfo('0.8.2'), env);
+    });
+
+    describe('module name to output file mapping', () => {
+        async function baseNamesFor(source: string, filename = 'example.c3'): Promise<string[]> {
+            const dir = await tempDir();
+            const inputFilename = path.join(dir, filename);
+            await fs.writeFile(inputFilename, source);
+            return await new C3Compiler(makeInfo('0.8.2'), env).getModuleBaseNames(inputFilename);
+        }
+
+        it('uses the module name', async () => {
+            expect(await baseNamesFor('module test;\nfn int sq(int x) { return x * x; }\n')).toEqual(['test']);
+        });
+
+        it('replaces the path separator in a nested module', async () => {
+            expect(await baseNamesFor('module foo::bar;\n')).toEqual(['foo.bar']);
+        });
+
+        it('tolerates spaces around the path separator', async () => {
+            expect(await baseNamesFor('module foo :: bar;\n')).toEqual(['foo.bar']);
+        });
+
+        it('returns every module in declaration order', async () => {
+            expect(await baseNamesFor('module alpha;\nfn void a() {}\nmodule beta;\nfn void b() {}\n')).toEqual([
+                'alpha',
+                'beta',
+            ]);
+        });
+
+        it('joins a repeated module in only once', async () => {
+            // A module may be declared in several sections; c3c appends them all to one file.
+            expect(await baseNamesFor('module alpha;\nfn void a() {}\nmodule alpha;\nfn void b() {}\n')).toEqual([
+                'alpha',
+            ]);
+        });
+
+        it('falls back to the file name when no module is declared', async () => {
+            expect(await baseNamesFor('fn int sq(int x) { return x * x; }\n')).toEqual(['example']);
+        });
+
+        it('keeps a user module that shadows a standard library name', async () => {
+            // Legal in C3: the section is appended to the standard library module's own output file,
+            // so it must not be filtered out as "not the user's code".
+            expect(await baseNamesFor('module std::io;\nfn void mine() {}\n')).toEqual(['std.io']);
+        });
+
+        it('ignores attributes after the module name', async () => {
+            expect(await baseNamesFor('module test @export;\nfn int sq(int x) { return x * x; }\n')).toEqual(['test']);
+            expect(await baseNamesFor('module test @if(env::LINUX);\n')).toEqual(['test']);
+        });
+
+        it('does not treat an indented or embedded "module" as a declaration', async () => {
+            expect(await baseNamesFor('module real;\nfn void f() { int modules = 1; }\n')).toEqual(['real']);
+        });
+    });
+
+    describe('joining per-module output', () => {
+        it('concatenates the modules that were emitted', async () => {
+            const dir = await tempDir();
+            await fs.writeFile(path.join(dir, 'alpha.s'), 'alpha asm');
+            await fs.writeFile(path.join(dir, 'beta.s'), 'beta asm');
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+            const destination = path.join(dir, 'output.s');
+
+            await compiler.joinModuleOutputs(dir, ['alpha', 'beta'], '.s', destination);
+
+            expect(await fs.readFile(destination, 'utf8')).toEqual('alpha asm\nbeta asm');
+        });
+
+        it('skips modules that produced no file', async () => {
+            const dir = await tempDir();
+            await fs.writeFile(path.join(dir, 'alpha.s'), 'alpha asm');
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+            const destination = path.join(dir, 'output.s');
+
+            await compiler.joinModuleOutputs(dir, ['alpha', 'missing'], '.s', destination);
+
+            expect(await fs.readFile(destination, 'utf8')).toEqual('alpha asm');
+        });
+
+        it('writes nothing at all when no module produced a file', async () => {
+            const dir = await tempDir();
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+            const destination = path.join(dir, 'output.s');
+
+            await compiler.joinModuleOutputs(dir, ['nothing'], '.s', destination);
+
+            // Absent rather than empty, so the usual "no output file" reporting still applies.
+            await expect(fs.access(destination)).rejects.toThrow();
+        });
+
+        it('does not copy the destination onto itself for a module named output', async () => {
+            const dir = await tempDir();
+            const destination = path.join(dir, 'output.s');
+            await fs.writeFile(destination, 'stale');
+            await fs.writeFile(path.join(dir, 'other.s'), 'real asm');
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+
+            await compiler.joinModuleOutputs(dir, ['output', 'other'], '.s', destination);
+
+            expect(await fs.readFile(destination, 'utf8')).toEqual('real asm');
+        });
+    });
+
+    describe('strip-unused default', () => {
+        const filters = {} as ParseFiltersAndOutputOptions;
+
+        it('asks for unreferenced code on versions that support it', () => {
+            const options = new C3Compiler(makeInfo('0.8.2'), env).optionsForFilter(filters, 'output.s');
+            expect(options).toContain('--strip-unused=no');
+        });
+
+        it('is not passed to versions predating the option', () => {
+            // --strip-unused arrived in 0.5.0.
+            const options = new C3Compiler(makeInfo('0.4.0'), env).optionsForFilter(filters, 'output.s');
+            expect(options).not.toContain('--strip-unused=no');
+        });
+
+        it('comes before user options so the user can override it', () => {
+            // c3c honours the last occurrence, and BaseCompiler appends user options after these.
+            const options = new C3Compiler(makeInfo('0.8.2'), env).optionsForFilter(filters, 'output.s');
+            expect(options.indexOf('--strip-unused=no')).toBeGreaterThanOrEqual(0);
+            expect(options.at(-1)).toEqual('--strip-unused=no');
+        });
+    });
+});

--- a/test/c3c-tests.ts
+++ b/test/c3c-tests.ts
@@ -109,8 +109,8 @@ describe('C3 compiler', () => {
         });
 
         it('keeps a user module that shadows a standard library name', async () => {
-            // Legal in C3: the section is appended to the standard library module's own output file,
-            // so it must not be filtered out as "not the user's code".
+            // Legal in C3: the section is appended to the standard library module's own output file, so
+            // it must not be filtered out as "not the user's code".
             expect(await baseNamesFor('module std::io;\nfn void mine() {}\n')).toEqual(['std.io']);
         });
 
@@ -255,8 +255,7 @@ describe('C3 compiler', () => {
 
         it('joins the module output and refreshes the recorded size', async () => {
             // The size is stat'd by the caller before postProcess runs, i.e. before the file exists.
-            // If it is not refreshed here, BaseCompiler reports "<No output file>" even though we
-            // just wrote one.
+            // Unrefreshed, BaseCompiler reports "<No output file>" even though we just wrote one.
             const {result, outputFilename} = await runPostProcess(async dir =>
                 fs.writeFile(path.join(dir, 'test.s'), 'the asm'),
             );

--- a/test/c3c-tests.ts
+++ b/test/c3c-tests.ts
@@ -30,6 +30,7 @@ import {afterEach, beforeAll, describe, expect, it} from 'vitest';
 
 import {CompilationEnvironment} from '../lib/compilation-env.js';
 import {C3Compiler} from '../lib/compilers/index.js';
+import {CompilationResult} from '../types/compilation/compilation.interfaces.js';
 import {CompilerInfo} from '../types/compiler.interfaces.js';
 import {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
 import {makeCompilationEnvironment} from './utils.js';
@@ -118,13 +119,64 @@ describe('C3 compiler', () => {
             expect(await baseNamesFor('module test @if(env::LINUX);\n')).toEqual(['test']);
         });
 
-        it('does not treat an indented or embedded "module" as a declaration', async () => {
+        it('handles a generic module', async () => {
+            expect(await baseNamesFor('module gen<Type>;\nfn void f() {}\n')).toEqual(['gen']);
+        });
+
+        it('accepts an indented declaration but not one embedded mid-line', async () => {
+            expect(await baseNamesFor('    module indented;\n')).toEqual(['indented']);
             expect(await baseNamesFor('module real;\nfn void f() { int modules = 1; }\n')).toEqual(['real']);
+            expect(await baseNamesFor('module real;\nimport std::io;\n')).toEqual(['real']);
+        });
+
+        it('sanitises the derived name the way c3c does', async () => {
+            // c3c turns my-file.c3 into module my_file, so the file it writes is my_file.s.
+            expect(await baseNamesFor('fn void f() {}\n', 'my-file.c3')).toEqual(['my_file']);
+        });
+
+        it('falls back to the derived name when the source cannot be read', async () => {
+            const dir = await tempDir();
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+            expect(await compiler.getModuleBaseNames(path.join(dir, 'missing.c3'))).toEqual(['missing']);
+        });
+
+        describe('ignores declarations that are not code', () => {
+            it('in a line comment', async () => {
+                expect(await baseNamesFor('module mine;\n// module std::io;\n')).toEqual(['mine']);
+            });
+
+            it('in a block comment', async () => {
+                expect(await baseNamesFor('/*\nmodule std::io;\n*/\nmodule mine;\n')).toEqual(['mine']);
+            });
+
+            it('in a doc comment', async () => {
+                expect(await baseNamesFor('<*\nmodule std::io;\n*>\nmodule mine;\n')).toEqual(['mine']);
+            });
+
+            it('in a raw string', async () => {
+                expect(await baseNamesFor('module mine;\nString s = `\nmodule std::io;\n`;\n')).toEqual(['mine']);
+            });
+
+            it('but still finds a declaration on the line after a comment', async () => {
+                // Blanking must preserve line structure, or the anchors shift.
+                expect(await baseNamesFor('/* c */\nmodule mine;\n')).toEqual(['mine']);
+            });
         });
     });
 
     describe('joining per-module output', () => {
-        it('concatenates the modules that were emitted', async () => {
+        it('passes a single module through untouched', async () => {
+            const dir = await tempDir();
+            await fs.writeFile(path.join(dir, 'alpha.s'), 'alpha asm');
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+            const destination = path.join(dir, 'output.s');
+
+            await compiler.joinModuleOutputs(dir, ['alpha'], '.s', destination);
+
+            expect(await fs.readFile(destination, 'utf8')).toEqual('alpha asm');
+        });
+
+        it('labels the chunks when several modules were emitted', async () => {
             const dir = await tempDir();
             await fs.writeFile(path.join(dir, 'alpha.s'), 'alpha asm');
             await fs.writeFile(path.join(dir, 'beta.s'), 'beta asm');
@@ -133,7 +185,21 @@ describe('C3 compiler', () => {
 
             await compiler.joinModuleOutputs(dir, ['alpha', 'beta'], '.s', destination);
 
-            expect(await fs.readFile(destination, 'utf8')).toEqual('alpha asm\nbeta asm');
+            expect(await fs.readFile(destination, 'utf8')).toEqual(
+                '# module alpha\nalpha asm\n# module beta\nbeta asm',
+            );
+        });
+
+        it('comments the labels correctly for IR', async () => {
+            const dir = await tempDir();
+            await fs.writeFile(path.join(dir, 'alpha.ll'), 'alpha ir');
+            await fs.writeFile(path.join(dir, 'beta.ll'), 'beta ir');
+            const compiler = new C3Compiler(makeInfo('0.8.2'), env);
+            const destination = path.join(dir, 'output.ll');
+
+            await compiler.joinModuleOutputs(dir, ['alpha', 'beta'], '.ll', destination);
+
+            expect(await fs.readFile(destination, 'utf8')).toEqual('; module alpha\nalpha ir\n; module beta\nbeta ir');
         });
 
         it('skips modules that produced no file', async () => {
@@ -168,6 +234,48 @@ describe('C3 compiler', () => {
             await compiler.joinModuleOutputs(dir, ['output', 'other'], '.s', destination);
 
             expect(await fs.readFile(destination, 'utf8')).toEqual('real asm');
+        });
+    });
+
+    describe('postProcess wiring', () => {
+        async function runPostProcess(setup: (dir: string) => Promise<void>, code = 0) {
+            const dir = await tempDir();
+            const inputFilename = path.join(dir, 'example.c3');
+            await fs.writeFile(inputFilename, 'module test;\nfn void f() {}\n');
+            await setup(dir);
+            const outputFilename = path.join(dir, 'output.s');
+            const result = {code, inputFilename, asm: '', stdout: [], stderr: []} as unknown as CompilationResult;
+            await new C3Compiler(makeInfo('0.8.2'), env).postProcess(
+                result,
+                outputFilename,
+                {} as ParseFiltersAndOutputOptions,
+            );
+            return {result, outputFilename};
+        }
+
+        it('joins the module output and refreshes the recorded size', async () => {
+            // The size is stat'd by the caller before postProcess runs, i.e. before the file exists.
+            // If it is not refreshed here, BaseCompiler reports "<No output file>" even though we
+            // just wrote one.
+            const {result, outputFilename} = await runPostProcess(async dir =>
+                fs.writeFile(path.join(dir, 'test.s'), 'the asm'),
+            );
+            expect(await fs.readFile(outputFilename, 'utf8')).toEqual('the asm');
+            expect(result.asmSize).toEqual('the asm'.length);
+        });
+
+        it('leaves the size unset when the compiler produced nothing', async () => {
+            const {result} = await runPostProcess(async () => {});
+            expect(result.asmSize).toBeUndefined();
+        });
+
+        it('does nothing when the compilation failed', async () => {
+            const {result, outputFilename} = await runPostProcess(
+                async dir => fs.writeFile(path.join(dir, 'test.s'), 'stale asm'),
+                1,
+            );
+            await expect(fs.access(outputFilename)).rejects.toThrow();
+            expect(result.asmSize).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
Fixes #8968.

C3 has shown `<No output file>` for assembly on every version we host, from `c3c04` through `c3c082`, and the IR pane has been returning `Internal error; unable to open output path`.

`c3c --emit-asm` writes one file per module section into the `--asm-out` directory, named after the module with `::` replaced by `.`, and a file declaring no module gets one named after the file. `optionsForFilter` never passed `outputFilename`, so nothing was ever written where `BaseCompiler` looks. The same applies to `--emit-llvm` and the IR pane.

## What this does

- Works out which files belong to the user's source from the `module` declarations, and joins them into the output path CE expects. The asm join happens in `postProcess`, which is handed the caller's own `outputFilename`; the IR join happens in `processIrOutput`.
- Passes `--strip-unused=no` on 0.5.0 and later. See the note below, this is the part most worth arguing about.

Driven by the module declarations rather than by excluding standard library names, because it is legal to write `module std::io;` in user code, in which case `c3c` appends to the standard library's own output file and a name-based exclusion would throw the user's code away.

Comments and raw strings are blanked before the declarations are matched, so a commented-out `module std::io;` doesn't cause several megabytes of standard library assembly to be served instead of the user's code.

## Performance, and a thing worth revisiting

`--strip-unused=no` is not free. `c3c` otherwise traces reachability only from `main`, `@export` and `@nostrip`, so the single commonest thing anyone does here, pasting one uncalled function, produces **no output at all**. Turning it off is what makes the fix useful rather than merely correct. But measured on c3c 0.8.2 with a one-line `fn int sq(int x) { return x * x; }`:

| flags | wall | files written |
| --- | --- | --- |
| c3c default | 0.57s | 20 |
| `--strip-unused=no` | 7.46s | 124 |
| `--strip-unused=no --emit-llvm` (IR pane open) | 10.35s | 248 |

Roughly **13x the wall time** for a trivial input. Everything lands in the per-compilation temp directory and is removed with it, so there is no disk story, but with `maxConcurrentCompiles=4` a C3 compile now occupies a queue slot around thirteen times longer than it did. C3 is low traffic so this seems an acceptable trade for output that actually appears, and it is well inside the 200s `compileTimeoutMs`, but it is a real cost and worth knowing about.

@lerno, this is the part where your input would be most valuable if you ever fancy it, no obligation at all. Is there a cheaper way to get the same result for a single-function snippet, short of disabling reachability analysis wholesale? Something scoped to the user's own module, or a way to keep the standard library from being re-emitted each time, would let us drop most of that 13x. Very happy to leave it exactly as it is otherwise.

## Notes

- Where several modules are emitted the chunks are labelled with a comment naming each module, using `#` for asm and `;` for IR. Single-module output, which is almost everything, is byte for byte unchanged. Joined multi-module IR is not valid LLVM IR as a whole, since each module brings its own header, so the IR CFG view on such a file will not be meaningful. That predates this change in the sense that the pane simply errored before.
- Generic modules emit no separate file until instantiated, so they still show no output. Not a regression, and not addressed here.
- Adds `test/c3c-tests.ts`. `C3Compiler` previously had no test coverage at all.

## Verification

Beyond the unit tests, checked end to end against a real c3c 0.8.2 using the exact option list this produces, on the previously broken input (a plain uncalled function, no `@export`): asm comes out as 185 lines containing `test.square:`, and IR contains `define i32 @test.square(i32 %0)`.

Thanks to @lerno for confirming the file naming rules on #8968 and for pointing out `--strip-unused`, which is the difference between this fixing the filenames and this actually fixing C3. Thanks also to @aliaegik and @ManuLinares for the C3 support and version bumps up to now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
