### PR TITLE
set llvmObjdumper path for zig.amazon.properties

### DIFF
--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -4,6 +4,7 @@ defaultCompiler=z0160
 # When adding a compiler here, please add it in the &zigcc and &zigcxx compiler groups too (C and C++ files, respectively)
 group.zig.compilers=ztrunk:z020:z030:z040:z050:z060:z070:z071:z080:z090:z0100:z0110:z0120:z0121:z0130:z0140:z0141:z0151:z0152:z0160
 group.zig.objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
+group.zig.llvmObjdumper=/opt/compiler-explorer/clang-trunk/bin/llvm-objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
 group.zig.compilerType=zig


### PR DESCRIPTION
Fixes`<No output: objdump returned 255>` error when compiling Zig to wasm with “Link to binary” enabled.

I think the error come from`llvm-objdump` not being resolved by `nsjail`. This change sets the explicit `llvmObjdumper` path in properties file.
