### PR TITLE
Fix stack usage view for GCC nightly

### DIFF
--- a/lib/stack-usage-transformer.ts
+++ b/lib/stack-usage-transformer.ts
@@ -43,12 +43,13 @@ export function parse(suText: string): StackUsageInfo[] {
         const pathLocName = c[0].split(':');
         const lineNumber = +pathLocName[1];
         const qualifier = c.at(-1);
+        const bytesUsed = c.at(-2);
         const su = {
             DebugLoc: {File: pathLocName[0], Line: lineNumber, Column: 0},
             Function: pathLocName.at(-1),
             Qualifier: qualifier,
-            BytesUsed: Number.parseInt(c[1], 10),
-            displayString: c[1] + ' bytes, ' + qualifier,
+            BytesUsed: Number.parseInt(bytesUsed!, 10),
+            displayString: `${bytesUsed} bytes, ${qualifier}`,
         };
         output.push(su as StackUsageInfo);
     }

--- a/test/stack-usage-transformer-test.ts
+++ b/test/stack-usage-transformer-test.ts
@@ -64,4 +64,21 @@ example.cpp:7:5:int h()\t64\tdynamic,bounded
             },
         ]);
     });
+
+    it('should work for GCC >= 17', () => {
+        const output = parse('example.cpp:2:5:int square(int)\t_Z6squarei\t16\tstatic\n');
+        expect(output).toEqual([
+            {
+                BytesUsed: 16,
+                DebugLoc: {
+                    File: 'example.cpp',
+                    Line: 2,
+                    Column: 0,
+                },
+                Function: 'int square(int)',
+                Qualifier: 'static',
+                displayString: '16 bytes, static',
+            },
+        ]);
+    });
 });


### PR DESCRIPTION
GCC nightly has changed its `-fstack-usage` output to include the mangled function name, so currently the stack usage view shows the demangled function name instead of the stack frame size, e. g. `square(int) bytes, static`; see https://godbolt.org/z/xxhWfzqha.