### PR TITLE
Fix crash in CFG generation when a conditional jump is the last instruction

### DIFF
--- a/lib/cfg/cfg-parsers/base.ts
+++ b/lib/cfg/cfg-parsers/base.ts
@@ -214,7 +214,15 @@ export class BaseCFGParser {
         const bb = arrBB[bbIdx];
         if (hasName(asmArr, bb)) return asmArr[bb.end].text;
         const newBbName = generateName(bb.nameId, bb.end);
-        arrBB[bbIdx + 1].nameId = newBbName;
+        // bbIdx can be the last canonical basic block in the function (e.g. when a
+        // conditional jump is the final instruction and there's no fallthrough block
+        // to rename). In that case there's nothing to point the "not taken" edge at,
+        // so we still return a name for the edge but skip mutating a block that
+        // doesn't exist. The layout code already ignores edges whose target isn't a
+        // real node (see graph-layout-core.ts), so this degrades gracefully.
+        if (arrBB[bbIdx + 1]) {
+            arrBB[bbIdx + 1].nameId = newBbName;
+        }
         return newBbName;
     }
 

--- a/test/cfg-cases/cfg-base.cond-jmp-last-instruction.json
+++ b/test/cfg-cases/cfg-base.cond-jmp-last-instruction.json
@@ -1,0 +1,40 @@
+{
+  "asm": [
+    {
+      "text": "main:",
+      "source": null
+    },
+    {
+      "text": "  cmp eax, 0",
+      "source": null
+    },
+    {
+      "text": "  je .L2",
+      "source": null
+    }
+  ],
+  "cfg": {
+    "main:": {
+      "nodes": [
+        {
+          "id": "main:",
+          "label": "main:\n  cmp eax, 0\n  je .L2"
+        }
+      ],
+      "edges": [
+        {
+          "from": "main:",
+          "to": ".L2:",
+          "arrows": "to",
+          "color": "green"
+        },
+        {
+          "from": "main:",
+          "to": "main:@3",
+          "arrows": "to",
+          "color": "red"
+        }
+      ]
+    }
+  }
+}

--- a/test/cfg-tests.ts
+++ b/test/cfg-tests.ts
@@ -52,6 +52,14 @@ describe('Cfg test cases', () => {
     // TODO: Consider replacing with https://github.com/vitest-dev/vitest/issues/703
     const files = fsSync.readdirSync(testcasespath);
 
+    describe('base', () => {
+        for (const filename of files.filter(x => x.includes('cfg-base'))) {
+            it(filename, async () => {
+                await DoCfgTest('', path.join(testcasespath, filename));
+            });
+        }
+    });
+
     describe('gcc', () => {
         for (const filename of files.filter(x => x.includes('gcc'))) {
             it(filename, async () => {


### PR DESCRIPTION
Fixes #6902

## What was happening
Reproducing the Clean example from the issue, the CFG pane didn't just draw
a wrong graph — it actually crashed the whole compile with:

TypeError: Cannot set properties of undefined (setting 'nameId')
    at BaseCFGParser.extractAltJmpTargetName

## Root cause
`extractAltJmpTargetName` assumes a conditional jump is never the last
instruction of a function — it always tries to write a generated name onto
"the next basic block" (`arrBB[bbIdx + 1]`). When a function's last basic
block ends in a conditional jump with no fallthrough block after it,
`arrBB[bbIdx + 1]` doesn't exist, and the code crashes trying to set a
property on `undefined`.

I couldn't get a working Clean compiler locally, so I wasn't able to
confirm Clean's exact label format, but I could reliably reproduce the
exact same crash/stack trace with 3 lines of synthetic assembly (see the
added test case) — any input that leaves a conditional jump as the final
instruction of a function hits this.

## Fix
Guard the write so it only happens when a next block actually exists. The
frontend layout code (`graph-layout-core.ts`) already tolerates edges that
point at a node ID that doesn't exist (there's an existing comment there
about exactly this: "Backend can return dest: null"), so this degrades
gracefully instead of crashing.

## Note
This fixes the crash. The original report also mentioned Clean's *labels*
getting misidentified as separate functions in the graph itself — that's
a related but separate issue (in `isFunctionEnd()`'s assumption that local
labels are dot-prefixed, GNU-`as`-style). I didn't have a way to verify
Clean's actual label format to fix that part with confidence, so I've left
it for a possible follow-up.

## Testing
Added `test/cfg-cases/cfg-base.cond-jmp-last-instruction.json` and a new
`describe('base', ...)` block in `test/cfg-tests.ts`. Confirmed it fails
with the original crash on unpatched code and passes with the fix.