### PR TITLE
Update mojo default example

### DIFF
--- a/examples/mojo/default.mojo
+++ b/examples/mojo/default.mojo
@@ -1,3 +1,3 @@
 @export
-def multiply(x: Int, y: Int) abi("C") -> Int:
-    return x * y
+def square(i: Int32) abi("C") -> Int32:
+    return i * i

--- a/examples/mojo/default.mojo
+++ b/examples/mojo/default.mojo
@@ -1,3 +1,5 @@
+# export + abi("C"): keeps square from being stripped as unused, uses C calling
+# convention (no unbound params), and gives it a clean mangled name.
 @export
 def square(i: Int32) abi("C") -> Int32:
     return i * i


### PR DESCRIPTION
Replaced the default mojo example with a `square` function to align with other examples. Added an explanatory comment on the decorator and abi effect.