### PR TITLE
Use `llvm-objdump` for Rust

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,5 +1,6 @@
 compilers=&rust:&rustgcc:&mrustc:&rustccggcc:&rustccgcranelift
-objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+objdumper=/opt/compiler-explorer/clang-22.1.0/bin/llvm-objdump
+objdumperType=llvm
 linker=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 aarch64linker=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 defaultCompiler=r1970


### PR DESCRIPTION
`rustc` supports multiple target architectures, while GNU `objdump` only supports the host arch. This breaks “Compile to binary object” and “Link to binary” when targeting an arch other than x86.

Resolves #8980.