### PR TITLE
Add gcc-ilazaric-enclosing_cast compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g144:g151:g152:g153:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcontracts-p4324-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk:gcc_notadragon_contracts_p3850
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g144:g151:g152:g153:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcontracts-p4324-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk:gcc_notadragon_contracts_p3850:gcc-ilazaric-enclosing_cast
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -304,6 +304,13 @@ compiler.gcc-thomas-healy-trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bi
 compiler.gcc-thomas-healy-trunk.semver=(Thomas Healy)
 compiler.gcc-thomas-healy-trunk.isNightly=true
 compiler.gcc-thomas-healy-trunk.notification=Thomas Healy; see <a href="https://github.com/healytpk/gcc-thomas-healy.git" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+
+compiler.gcc-ilazaric-enclosing_cast.exe=/opt/compiler-explorer/gcc-ilazaric-enclosing_cast/bin/g++
+compiler.gcc-ilazaric-enclosing_cast.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
+compiler.gcc-ilazaric-enclosing_cast.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
+compiler.gcc-ilazaric-enclosing_cast.semver=(ilazaric enclosing_cast)
+compiler.gcc-ilazaric-enclosing_cast.isNightly=true
+compiler.gcc-ilazaric-enclosing_cast.notification=Implementation of enclosing_cast from P3377; see <a href="https://github.com/ilazaric/gcc/tree/enclosing_cast" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 # Some multilib workarounds for older compilers not built quite right...
 compiler.g63.needsMulti=true


### PR DESCRIPTION
Compiler implements `std::enclosing_cast` from P3377
Paper: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3377r0.html

Associated PRs:
https://github.com/compiler-explorer/gcc-builder/pull/56
https://github.com/compiler-explorer/compiler-workflows/pull/74
https://github.com/compiler-explorer/infra/pull/2262

`make check` passes.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
