### PR TITLE
Add SystemC and QuantLib libraries

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6963,6 +6963,16 @@ libs.qt.versions.6110.version=6.11.0
 libs.qt.versions.6110.path=/app/qt/include/QtCore
 libs.qt.dependencies=pcre2-16
 
+libs.quantlib.name=QuantLib
+libs.quantlib.description=A free/open-source library for quantitative finance
+libs.quantlib.url=https://www.quantlib.org/
+libs.quantlib.packagedheaders=true
+libs.quantlib.staticliblink=QuantLib
+libs.quantlib.versions=143
+libs.quantlib.versions.143.version=1.43
+# QuantLib's public headers include boost/, so the headers come along for the ride.
+libs.quantlib.versions.143.path=/opt/compiler-explorer/libs/boost_1_84_0
+
 libs.quill.name=Quill
 libs.quill.description=C++ Low Latency Logging Library
 libs.quill.versions=611:700:721:730:750:810:820:900:1001:1020:1102:1110:1200:1210
@@ -7230,6 +7240,16 @@ libs.strong_type.versions.2.path=/opt/compiler-explorer/libs/strong_type/v2/incl
 libs.strong_type.versions.2.version=v2
 libs.strong_type.versions.1.path=/opt/compiler-explorer/libs/strong_type/v1/include
 libs.strong_type.versions.1.version=v1
+
+libs.systemc.name=SystemC
+libs.systemc.description=System-level modelling and simulation of hardware designs (IEEE 1666)
+libs.systemc.url=https://systemc.org/
+libs.systemc.packagedheaders=true
+libs.systemc.staticliblink=systemc
+libs.systemc.versions=300:301:302
+libs.systemc.versions.300.version=3.0.0
+libs.systemc.versions.301.version=3.0.1
+libs.systemc.versions.302.version=3.0.2
 
 libs.taojson.name=taoJSON
 libs.taojson.description=taoJSON is a C++ header-only JSON library that provides a generic value class, uses type traits to interoperate with C++ types, uses an events interface to convert from and to JSON, JAXN, CBOR, MsgPack and UBJSON, and much more...


### PR DESCRIPTION
Exposes SystemC (3.0.0, 3.0.1, 3.0.2) and QuantLib (1.43) in the C++ library dropdown.

Closes #8291. QuantLib was requested directly by @vickoza alongside SystemC and has no issue of its own.

Needs compiler-explorer/infra#2265 to install and build them; that PR has the build recipes and the end-to-end verification (a clocked `SC_MODULE` simulation and a Black-Scholes option price, both compiled and run against the real install trees).

Both are static libraries with `packagedheaders=true`, so the headers arrive with the conan package and no `path` is needed. The one exception is QuantLib, whose public headers include `boost/`, so its Boost include path is listed the same way `libs.hpx` does it.

Two things users will run into, both inherent to the libraries:

- SystemC 3.0 requires C++17 or newer and says so with its own `#error`, so `-std=c++17` is needed on compilers that default lower.
- `#include <ql/quantlib.hpp>` is the QuantLib mega-header and costs about 12.7s to compile; including the specific `ql/` headers instead costs about 1.9s.

`npm run test:props` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
