### PR TITLE
Enable clang-tidy for Clang-CUDA builds

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -331,6 +331,7 @@ group.cuclang.compilers=cuclang700:cuclang800:cuclang900:cuclang1000:cuclang1001
 group.cuclang.isSemVer=true
 group.cuclang.baseName=clang
 group.cuclang.compilerType=clang-cuda
+group.cuclang.supportsClangTidy=true
 # The most recent nvdisasm works for older CUDA versions
 group.cuclang.nvdisasm=/opt/compiler-explorer/cuda/13.1.0/bin/nvdisasm
 group.cuclang.objdumper=/opt/compiler-explorer/cuda/13.1.0/bin/nvdisasm
@@ -815,6 +816,19 @@ group.scale-nvcc-amd.options=--compiler-bindir /opt/compiler-explorer/gcc-14.1.0
 compiler.scaleamd171.semver=1.7.1
 compiler.scaleamd171.exe=/opt/compiler-explorer/scale/1.7.1/targets/amdgpu/bin/nvcc
 compiler.scaleamd171.llvmDisassembler=/opt/compiler-explorer/scale/1.7.1/llvm/bin/llvm-dis
+
+#################################
+#################################
+# Installed tools
+
+tools=clangtidytrunk
+
+tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
+tools.clangtidytrunk.name=clang-tidy (trunk)
+tools.clangtidytrunk.type=independent
+tools.clangtidytrunk.class=clang-tidy-tool
+tools.clangtidytrunk.includeKey=supportsClangTidy
+tools.clangtidytrunk.stdinHint=disabled
 
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172:173:174:175:176:177:178:179:180:181:182

--- a/etc/config/cuda.defaults.properties
+++ b/etc/config/cuda.defaults.properties
@@ -20,6 +20,7 @@ group.clang.compilers=cltrunkdef
 group.clang.options=--cuda-path=/opt/cuda --cuda-gpu-arch=sm_61 --cuda-device-only
 group.clang.compilerType=clang-cuda
 group.clang.nvdisasm=/opt/compiler-explorer/cuda/9.1.85/bin/nvdisasm
+group.clang.supportsClangTidy=true
 
 compiler.cltrunkdef.name=clang trunk
 compiler.cltrunkdef.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
@@ -49,4 +50,5 @@ tools.clangtidydefault.exe=/usr/bin/clang-tidy
 tools.clangtidydefault.name=clang-tidy (default)
 tools.clangtidydefault.type=independent
 tools.clangtidydefault.class=clang-tidy-tool
+tools.clangtidydefault.includeKey=supportsClangTidy
 tools.clangtidydefault.stdinHint=disabled

--- a/lib/tooling/clang-tidy-tool.ts
+++ b/lib/tooling/clang-tidy-tool.ts
@@ -43,6 +43,19 @@ export class ClangTidyTool extends BaseTool {
         this.addOptionsToToolArgs = false;
     }
 
+    override getToolExe(compilationInfo: CompilationInfo): string {
+        if (compilationInfo.compiler.compilerType !== 'clang-cuda') {
+            return super.getToolExe(compilationInfo);
+        }
+
+        const compilerPath = path.parse(compilationInfo.compiler.exe);
+        const clangTidyName = compilerPath.base.replace(/^clang(?:\+\+)?/, 'clang-tidy');
+
+        return clangTidyName === compilerPath.base
+            ? super.getToolExe(compilationInfo)
+            : path.join(compilerPath.dir, clangTidyName);
+    }
+
     override async runTool(
         compilationInfo: CompilationInfo,
         inputFilepath: string,

--- a/test/tool-tests.ts
+++ b/test/tool-tests.ts
@@ -35,6 +35,7 @@ import {
 } from '../lib/toolchain-utils.js';
 import {ToolEnv} from '../lib/tooling/base-tool.interface.js';
 import {BrontoRefactorTool} from '../lib/tooling/bronto-refactor-tool.js';
+import {ClangTidyTool} from '../lib/tooling/clang-tidy-tool.js';
 import {CompilerDropinTool} from '../lib/tooling/compiler-dropin-tool.js';
 import {CompilationInfo} from '../types/compilation/compilation.interfaces.js';
 import {ToolInfo} from '../types/tool.interfaces.js';
@@ -243,6 +244,46 @@ describe('CompilerDropInTool', () => {
             '-fno-crash-diagnostics',
             '/app/example.cpp',
         ]);
+    });
+});
+
+describe('ClangTidyTool', () => {
+    const configuredToolExe = '/opt/compiler-explorer/clang-trunk/bin/clang-tidy';
+    const tool = new ClangTidyTool({exe: configuredToolExe} as ToolInfo, {} as ToolEnv);
+
+    it('Should use clang-tidy from the selected Clang CUDA toolchain', () => {
+        const compilationInfo = {
+            compiler: {
+                compilerType: 'clang-cuda',
+                exe: '/opt/compiler-explorer/clang-20.1.0/bin/clang++',
+            },
+        } as unknown as CompilationInfo;
+
+        expect(tool.getToolExe(compilationInfo)).toBe(
+            path.join('/opt/compiler-explorer/clang-20.1.0/bin', 'clang-tidy'),
+        );
+    });
+
+    it('Should preserve a version suffix when selecting clang-tidy', () => {
+        const compilationInfo = {
+            compiler: {
+                compilerType: 'clang-cuda',
+                exe: '/usr/bin/clang++-18',
+            },
+        } as unknown as CompilationInfo;
+
+        expect(tool.getToolExe(compilationInfo)).toBe(path.join('/usr/bin', 'clang-tidy-18'));
+    });
+
+    it('Should use the configured executable for other compiler types', () => {
+        const compilationInfo = {
+            compiler: {
+                compilerType: 'clang',
+                exe: '/opt/compiler-explorer/clang-20.1.0/bin/clang++',
+            },
+        } as unknown as CompilationInfo;
+
+        expect(tool.getToolExe(compilationInfo)).toBe(configuredToolExe);
     });
 });
 


### PR DESCRIPTION
## Summary
- enable clang-tidy for Clang-CUDA compiler groups in the default and production CUDA configurations
- resolve clang-tidy from the selected Clang-CUDA toolchain while preserving version suffixes
- add focused tests for CUDA and non-CUDA executable selection

Closes #6944

## Test plan
- [x] `npm run test:props` (90 tests)
- [x] `npm run ts-check`
- [x] `cross-env SKIP_EXPENSIVE_TESTS=true npx vitest related --run` (39 tests)

## AI assistance
AI assistance was used for codebase navigation and drafting. The final diff was reviewed and the listed checks were run locally.