### PR TITLE
Add gcc 16.2.0

### DIFF
--- a/etc/config/ada.amazon.properties
+++ b/etc/config/ada.amazon.properties
@@ -1,13 +1,13 @@
 # Default settings for Ada
 compilers=&gnat:&gnatcross
-defaultCompiler=gnat161
+defaultCompiler=gnat162
 versionFlag=--version
 compilerType=ada
 
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gnat.compilers=&gnatassert:gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat124:gnat125:gnat131:gnat132:gnat133:gnat134:gnat141:gnat142:gnat143:gnat151:gnat152:gnat161:gnatsnapshot
+group.gnat.compilers=&gnatassert:gnat82:gnat95:gnat102:gnat104:gnat105:gnat111:gnat112:gnat113:gnat114:gnat121:gnat122:gnat123:gnat124:gnat125:gnat131:gnat132:gnat133:gnat134:gnat141:gnat142:gnat143:gnat151:gnat152:gnat161:gnat162:gnatsnapshot
 group.gnat.intelAsm=-masm=intel
 group.gnat.groupName=X86-64 GNAT
 group.gnat.baseName=x86-64 gnat
@@ -71,6 +71,8 @@ compiler.gnat152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gnatmake
 compiler.gnat152.semver=15.2
 compiler.gnat161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gnatmake
 compiler.gnat161.semver=16.1
+compiler.gnat162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gnatmake
+compiler.gnat162.semver=16.2
 
 compiler.gnatsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gnatmake
 compiler.gnatsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -78,7 +80,7 @@ compiler.gnatsnapshot.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
 compiler.gnatsnapshot.semver=(trunk)
 
 ## GNAT x86 build with "assertions" (--enable-checking=XXX)
-group.gnatassert.compilers=gnat104assert:gnat105assert:gnat111assert:gnat112assert:gnat113assert:gnat114assert:gnat121assert:gnat122assert:gnat123assert:gnat124assert:gnat125assert:gnat131assert:gnat132assert:gnat133assert:gnat134assert:gnat141assert:gnat142assert:gnat143assert:gnat151assert:gnat152assert:gnat161assert
+group.gnatassert.compilers=gnat104assert:gnat105assert:gnat111assert:gnat112assert:gnat113assert:gnat114assert:gnat121assert:gnat122assert:gnat123assert:gnat124assert:gnat125assert:gnat131assert:gnat132assert:gnat133assert:gnat134assert:gnat141assert:gnat142assert:gnat143assert:gnat151assert:gnat152assert:gnat161assert:gnat162assert
 group.gnatassert.groupName=GCC x86-64 (assertions)
 
 compiler.gnat104assert.exe=/opt/compiler-explorer/gcc-assertions-10.4.0/bin/gnatmake
@@ -123,6 +125,8 @@ compiler.gnat152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gnat
 compiler.gnat152assert.semver=15.2 (assertions)
 compiler.gnat161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gnatmake
 compiler.gnat161assert.semver=16.1 (assertions)
+compiler.gnat162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gnatmake
+compiler.gnat162assert.semver=16.2 (assertions)
 
 ################################
 # Cross GNAT

--- a/etc/config/algol68.amazon.properties
+++ b/etc/config/algol68.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&ga68
-defaultCompiler=ga68-g161
+defaultCompiler=ga68-g162
 
 group.ga68.compilers=&ga68-x86
 group.ga68.supportsBinary=false
@@ -10,7 +10,7 @@ group.ga68.isSemVer=true
 group.ga68.unwiseOptions=-march=native
 
 # native compiler
-group.ga68-x86.compilers=ga68-g161:ga68-snapshot
+group.ga68-x86.compilers=ga68-g161:ga68-g162:ga68-snapshot
 group.ga68-x86.groupName=x86-64 GA68
 group.ga68-x86.baseName=x86-64 GA68
 group.ga68-x86.unwiseOptions=-march=native
@@ -19,6 +19,10 @@ compiler.ga68-g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/ga68
 compiler.ga68-g161.demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
 compiler.ga68-g161.objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
 compiler.ga68-g161.semver=16.1.0
+compiler.ga68-g162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/ga68
+compiler.ga68-g162.demangler=/opt/compiler-explorer/gcc-16.2.0/bin/c++filt
+compiler.ga68-g162.objdumper=/opt/compiler-explorer/gcc-16.2.0/bin/objdump
+compiler.ga68-g162.semver=16.2.0
 
 compiler.ga68-snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/ga68
 compiler.ga68-snapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -2,7 +2,7 @@ compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&aocc:&mosclang-tru
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
-defaultCompiler=g161
+defaultCompiler=g162
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-14.2.0/bin/objdump
@@ -18,7 +18,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g144:g151:g152:g153:g161:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcontracts-p4324-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk:gcc_notadragon_contracts_p3850
+group.gcc86.compilers=&gcc86assert:g346:g404:g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g65:g71:g72:g73:g74:g75:g81:g82:g83:g84:g85:g91:g92:g93:g94:g95:g101:g102:g103:g104:g105:g111:g112:g113:g114:g115:g121:g122:g123:g124:g125:g131:g132:g133:g134:g141:g142:g143:g144:g151:g152:g153:g161:g162:gsnapshot:gcontracts-trunk:gcontract-labels-trunk:gcontracts-nonattr-trunk:gcontracts-p4324-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc_thephd_dev:gcc-static-analysis-trunk:glambda-p2034-trunk:gcontracts-base-trunk:gcontracts-gnuext-trunk:gcc-thomas-healy-trunk:gtrivial-reloc-trunk:gcc_notadragon_contracts_p3850
 group.gcc86.groupName=GCC x86-64
 group.gcc86.instructionSet=amd64
 group.gcc86.baseName=x86-64 gcc
@@ -197,6 +197,8 @@ compiler.g153.exe=/opt/compiler-explorer/gcc-15.3.0/bin/g++
 compiler.g153.semver=15.3
 compiler.g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/g++
 compiler.g161.semver=16.1
+compiler.g162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/g++
+compiler.g162.semver=16.2
 
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.gsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -311,7 +313,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g144assert:g151assert:g152assert:g153assert:g161assert
+group.gcc86assert.compilers=g103assert:g104assert:g105assert:g111assert:g112assert:g113assert:g114assert:g121assert:g122assert:g123assert:g124assert:g125assert:g131assert:g132assert:g133assert:g134assert:g141assert:g142assert:g143assert:g144assert:g151assert:g152assert:g153assert:g161assert:g162assert
 group.gcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.g103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/g++
@@ -362,6 +364,8 @@ compiler.g153assert.exe=/opt/compiler-explorer/gcc-assertions-15.3.0/bin/g++
 compiler.g153assert.semver=15.3 (assertions)
 compiler.g161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/g++
 compiler.g161assert.semver=16.1 (assertions)
+compiler.g162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/g++
+compiler.g162assert.semver=16.2 (assertions)
 
 ################################
 # Clang for x86

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,5 +1,5 @@
 compilers=&cgcc86:&cclang:&caocc:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&co2cc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm
-defaultCompiler=cg161
+defaultCompiler=cg162
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 objdumper=/opt/compiler-explorer/gcc-15.1.0/bin/objdump
@@ -15,7 +15,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=&cgcc86assert:cg_thephd_dev:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg144:cg151:cg152:cg153:cg161:cgsnapshot:cgstatic-analysis
+group.cgcc86.compilers=&cgcc86assert:cg_thephd_dev:cg346:cg404:cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg65:cg71:cg72:cg73:cg74:cg75:cg81:cg82:cg83:cg84:cg85:cg91:cg92:cg93:cg94:cg95:cg101:cg102:cg103:cg104:cg105:cg111:cg112:cg113:cg114:cg115:cg121:cg122:cg123:cg124:cg125:cg131:cg132:cg133:cg134:cg141:cg142:cg143:cg144:cg151:cg152:cg153:cg161:cg162:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.instructionSet=amd64
 group.cgcc86.isSemVer=true
@@ -185,6 +185,8 @@ compiler.cg153.exe=/opt/compiler-explorer/gcc-15.3.0/bin/gcc
 compiler.cg153.semver=15.3
 compiler.cg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 compiler.cg161.semver=16.1
+compiler.cg162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gcc
+compiler.cg162.semver=16.2
 
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -213,7 +215,7 @@ compiler.cg71.needsMulti=true
 compiler.cg72.needsMulti=true
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg144assert:cg151assert:cg152assert:cg153assert:cg161assert
+group.cgcc86assert.compilers=cg103assert:cg104assert:cg105assert:cg111assert:cg112assert:cg113assert:cg114assert:cg121assert:cg122assert:cg123assert:cg124assert:cg125assert:cg131assert:cg132assert:cg133assert:cg134assert:cg141assert:cg142assert:cg143assert:cg144assert:cg151assert:cg152assert:cg153assert:cg161assert:cg162assert
 group.cgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.cg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -264,6 +266,8 @@ compiler.cg153assert.exe=/opt/compiler-explorer/gcc-assertions-15.3.0/bin/gcc
 compiler.cg153assert.semver=15.3 (assertions)
 compiler.cg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
 compiler.cg161assert.semver=16.1 (assertions)
+compiler.cg162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gcc
+compiler.cg162assert.semver=16.2 (assertions)
 
 
 # Classic x86 compilers (32-bit only)

--- a/etc/config/cobol.amazon.properties
+++ b/etc/config/cobol.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&gnucobol:&gcccobol
 defaultCompiler=gnucobol32
-objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+objdumper=/opt/compiler-explorer/gcc-16.2.0/bin/objdump
 
 group.gnucobol.groupName=GnuCOBOL
 group.gnucobol.compilers=gnucobol32:gnucobol32rc2:gnucobol31:gnucobol22:gnucobol11
@@ -30,7 +30,7 @@ compiler.gnucobol11.licensePreamble=Copyright (c) 2012 Free Software Foundation,
 
 group.gcccobol.compilerType=gcccobol
 group.gcccobol.groupName=GCC
-group.gcccobol.compilers=&gcccobolassert:gcccobolsnapshot:gcccobol151:gcccobol152:gcccobol161:gcccoboltrunk
+group.gcccobol.compilers=&gcccobolassert:gcccobolsnapshot:gcccobol151:gcccobol152:gcccobol161:gcccobol162:gcccoboltrunk
 group.gcccobol.unwiseOptions=-march=native
 group.gcccobol.isSemVer=true
 group.gcccobol.baseName=GCC
@@ -49,12 +49,14 @@ compiler.gcccobol152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcobol
 compiler.gcccobol152.semver=15.2.0
 compiler.gcccobol161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcobol
 compiler.gcccobol161.semver=16.1.0
+compiler.gcccobol162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gcobol
+compiler.gcccobol162.semver=16.2.0
 
 compiler.gcccoboltrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcobol
 compiler.gcccoboltrunk.semver=(GCC master)
 
 ## GCC (from upstream GCC, not GCCRS github) x86 build with "assertions" (--enable-checking=XXX)
-group.gcccobolassert.compilers=gcccobol151assert:gcccobol152assert:gcccobol161assert
+group.gcccobolassert.compilers=gcccobol151assert:gcccobol152assert:gcccobol161assert:gcccobol162assert
 group.gcccobolassert.groupName=x86-64 GCC (assertions)
 
 compiler.gcccobol151assert.exe=/opt/compiler-explorer/gcc-assertions-15.1.0/bin/gcobol
@@ -64,3 +66,5 @@ compiler.gcccobol152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/
 compiler.gcccobol152assert.semver=15.2.0 (GCC assertions)
 compiler.gcccobol161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcobol
 compiler.gcccobol161assert.semver=16.1.0 (GCC assertions)
+compiler.gcccobol162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gcobol
+compiler.gcccobol162assert.semver=16.2.0 (GCC assertions)

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gdc:&ldc:&dmd:&dmd1:&gdccross
 defaultCompiler=ldc1_42
 
-group.gdc.compilers=&gdcassert:gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc124:gdc125:gdc131:gdc132:gdc133:gdc134:gdc141:gdc142:gdc143:gdc151:gdc152:gdc161:gdctrunk
+group.gdc.compilers=&gdcassert:gdc48:gdc49:gdc52:gdc92:gdc93:gdc95:gdc101:gdc102:gdc105:gdc111:gdc113:gdc114:gdc121:gdc122:gdc123:gdc124:gdc125:gdc131:gdc132:gdc133:gdc134:gdc141:gdc142:gdc143:gdc151:gdc152:gdc161:gdc162:gdctrunk
 group.gdc.groupName=GDC x86-64
 group.gdc.includeFlag=-isystem
 group.gdc.isSemVer=true
@@ -68,6 +68,8 @@ compiler.gdc152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gdc
 compiler.gdc152.semver=15.2
 compiler.gdc161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gdc
 compiler.gdc161.semver=16.1
+compiler.gdc162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gdc
+compiler.gdc162.semver=16.2
 
 compiler.gdctrunk.exe=/opt/compiler-explorer/gcc-snapshot/bin/gdc
 compiler.gdctrunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -75,7 +77,7 @@ compiler.gdctrunk.semver=(trunk)
 compiler.gdctrunk.isNightly=true
 
 ## GDC x86 build with "assertions" (--enable-checking=XXX)
-group.gdcassert.compilers=gdc105assert:gdc111assert:gdc113assert:gdc114assert:gdc121assert:gdc122assert:gdc123assert:gdc124assert:gdc125assert:gdc131assert:gdc132assert:gdc133assert:gdc134assert:gdc141assert:gdc142assert:gdc143assert:gdc151assert:gdc152assert:gdc161assert
+group.gdcassert.compilers=gdc105assert:gdc111assert:gdc113assert:gdc114assert:gdc121assert:gdc122assert:gdc123assert:gdc124assert:gdc125assert:gdc131assert:gdc132assert:gdc133assert:gdc134assert:gdc141assert:gdc142assert:gdc143assert:gdc151assert:gdc152assert:gdc161assert:gdc162assert
 group.gdcassert.groupName=GDC x86-64 (assertions)
 
 compiler.gdc105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gdc
@@ -116,6 +118,8 @@ compiler.gdc152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gdc
 compiler.gdc152assert.semver=15.2 (assertions)
 compiler.gdc161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gdc
 compiler.gdc161assert.semver=16.1 (assertions)
+compiler.gdc162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gdc
+compiler.gdc162assert.semver=16.2 (assertions)
 
 ## CROSS GDC
 group.gdccross.compilers=&gdcloongarch64:&gdcs390x:&gdcppc:&gdcppc64:&gdcppc64le:&gdcmips64:&gdcmips:&gdcmipsel:&gdcarm:&gdcarm64:&gdcriscv:&gdcriscv64:&gdchppa

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gfortran_86:&ifort:&ifx:&nvfortran_x86:&cross:&clang_llvmflang:&aocc_flang:&lfortran
-defaultCompiler=gfortran161
-demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+defaultCompiler=gfortran162
+demangler=/opt/compiler-explorer/gcc-16.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.2.0/bin/objdump
 compilerType=fortran
 
 buildenvsetup=ceconan-fortran
@@ -9,7 +9,7 @@ buildenvsetup.host=https://conan.compiler-explorer.com
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran124:gfortran125:gfortran131:gfortran132:gfortran133:gfortran134:gfortran141:gfortran142:gfortran143:gfortran151:gfortran152:gfortran161:gfortransnapshot
+group.gfortran_86.compilers=&gfortranassert:gfortran494:gfortran550:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran84:gfortran85:gfortran91:gfortran92:gfortran93:gfortran94:gfortran101:gfortran102:gfortran103:gfortran104:gfortran105:gfortran111:gfortran112:gfortran113:gfortran114:gfortran121:gfortran122:gfortran123:gfortran124:gfortran125:gfortran131:gfortran132:gfortran133:gfortran134:gfortran141:gfortran142:gfortran143:gfortran151:gfortran152:gfortran161:gfortran162:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 group.gfortran_86.isSemVer=true
 group.gfortran_86.baseName=x86-64 gfortran
@@ -92,6 +92,8 @@ compiler.gfortran152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gfortran
 compiler.gfortran152.semver=15.2
 compiler.gfortran161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gfortran
 compiler.gfortran161.semver=16.1
+compiler.gfortran162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gfortran
+compiler.gfortran162.semver=16.2
 
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -100,7 +102,7 @@ compiler.gfortransnapshot.semver=(trunk)
 compiler.gfortransnapshot.isNightly=true
 
 ## GFORTRAN x86 build with "assertions" (--enable-checking=XXX)
-group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran125assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran134assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert:gfortran152assert:gfortran161assert
+group.gfortranassert.compilers=gfortran103assert:gfortran104assert:gfortran105assert:gfortran111assert:gfortran112assert:gfortran113assert:gfortran114assert:gfortran121assert:gfortran122assert:gfortran123assert:gfortran124assert:gfortran125assert:gfortran131assert:gfortran132assert:gfortran133assert:gfortran134assert:gfortran141assert:gfortran142assert:gfortran143assert:gfortran151assert:gfortran152assert:gfortran161assert:gfortran162assert
 group.gfortranassert.groupName=GFORTRAN x86-64 (assertions)
 group.gfortranassert.compilerCategories=gfortran
 
@@ -148,6 +150,8 @@ compiler.gfortran152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/
 compiler.gfortran152assert.semver=15.2 (assertions)
 compiler.gfortran161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gfortran
 compiler.gfortran161assert.semver=16.1 (assertions)
+compiler.gfortran162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gfortran
+compiler.gfortran162assert.semver=16.2 (assertions)
 
 ###############################
 # Intel Parallel Studio XE for x86

--- a/etc/config/gimple.amazon.properties
+++ b/etc/config/gimple.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&gimplegcc86:&gimplecross:&wyrm
-defaultCompiler=gimpleg161
-demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+defaultCompiler=gimpleg162
+demangler=/opt/compiler-explorer/gcc-16.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.2.0/bin/objdump
 needsMulti=false
 compilerType=gimple
 buildenvsetup=ceconan
@@ -12,7 +12,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.gimplegcc86.compilers=&gimplegcc86assert:gimpleg91:gimpleg92:gimpleg93:gimpleg94:gimpleg95:gimpleg101:gimpleg102:gimpleg103:gimpleg104:gimpleg105:gimpleg111:gimpleg112:gimpleg113:gimpleg114:gimpleg121:gimpleg122:gimpleg123:gimpleg124:gimpleg125:gimpleg131:gimpleg132:gimpleg133:gimpleg134:gimpleg141:gimpleg142:gimpleg143:gimpleg151:gimpleg152:gimpleg161:gimplegsnapshot:gimplegstatic-analysis
+group.gimplegcc86.compilers=&gimplegcc86assert:gimpleg91:gimpleg92:gimpleg93:gimpleg94:gimpleg95:gimpleg101:gimpleg102:gimpleg103:gimpleg104:gimpleg105:gimpleg111:gimpleg112:gimpleg113:gimpleg114:gimpleg121:gimpleg122:gimpleg123:gimpleg124:gimpleg125:gimpleg131:gimpleg132:gimpleg133:gimpleg134:gimpleg141:gimpleg142:gimpleg143:gimpleg151:gimpleg152:gimpleg161:gimpleg162:gimplegsnapshot:gimplegstatic-analysis
 group.gimplegcc86.groupName=GCC x86-64
 group.gimplegcc86.instructionSet=amd64
 group.gimplegcc86.isSemVer=true
@@ -80,6 +80,8 @@ compiler.gimpleg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 compiler.gimpleg152.semver=15.2
 compiler.gimpleg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 compiler.gimpleg161.semver=16.1
+compiler.gimpleg162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gcc
+compiler.gimpleg162.semver=16.2
 
 compiler.gimplegsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.gimplegsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -96,7 +98,7 @@ compiler.gimplegstatic-analysis.options=-fanalyzer -fdiagnostics-urls=never -fdi
 compiler.gimplegstatic-analysis.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 ## GCC build with "assertions" (--enable-checking=XXX)
-group.gimplegcc86assert.compilers=gimpleg103assert:gimpleg104assert:gimpleg105assert:gimpleg111assert:gimpleg112assert:gimpleg113assert:gimpleg114assert:gimpleg121assert:gimpleg122assert:gimpleg123assert:gimpleg124assert:gimpleg125assert:gimpleg131assert:gimpleg132assert:gimpleg133assert:gimpleg134assert:gimpleg141assert:gimpleg142assert:gimpleg143assert:gimpleg151assert:gimpleg152assert:gimpleg161assert
+group.gimplegcc86assert.compilers=gimpleg103assert:gimpleg104assert:gimpleg105assert:gimpleg111assert:gimpleg112assert:gimpleg113assert:gimpleg114assert:gimpleg121assert:gimpleg122assert:gimpleg123assert:gimpleg124assert:gimpleg125assert:gimpleg131assert:gimpleg132assert:gimpleg133assert:gimpleg134assert:gimpleg141assert:gimpleg142assert:gimpleg143assert:gimpleg151assert:gimpleg152assert:gimpleg161assert:gimpleg162assert
 group.gimplegcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.gimpleg103assert.exe=/opt/compiler-explorer/gcc-assertions-10.3.0/bin/gcc
@@ -143,6 +145,8 @@ compiler.gimpleg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/g
 compiler.gimpleg152assert.semver=15.2 (assertions)
 compiler.gimpleg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
 compiler.gimpleg161assert.semver=16.1 (assertions)
+compiler.gimpleg162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gcc
+compiler.gimpleg162assert.semver=16.2 (assertions)
 
 ################################
 # GCC for AVR

--- a/etc/config/go.amazon.properties
+++ b/etc/config/go.amazon.properties
@@ -3,7 +3,7 @@ defaultCompiler=gl1260
 objdumper=/opt/compiler-explorer/gcc-13.1.0/bin/objdump
 buildenvsetup.host=https://conan.compiler-explorer.com
 
-group.gccgo.compilers=&gccgoassert:gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo124:gccgo125:gccgo131:gccgo132:gccgo133:gccgo134:gccgo141:gccgo142:gccgo143:gccgo151:gccgo152:gccgo161
+group.gccgo.compilers=&gccgoassert:gccgo494:gccgo630:gccgo720:gccgo830:gccgo930:gccgo950:gccgo102:gccgo105:gccgo111:gccgo112:gccgo113:gccgo114:gccgo121:gccgo122:gccgo123:gccgo124:gccgo125:gccgo131:gccgo132:gccgo133:gccgo134:gccgo141:gccgo142:gccgo143:gccgo151:gccgo152:gccgo161:gccgo162
 group.gccgo.isSemVer=true
 group.gccgo.baseName=x86 gccgo
 compiler.gccgo494.exe=/opt/compiler-explorer/gcc-4.9.4/bin/gccgo
@@ -62,9 +62,11 @@ compiler.gccgo152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gccgo
 compiler.gccgo152.semver=15.2
 compiler.gccgo161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gccgo
 compiler.gccgo161.semver=16.1
+compiler.gccgo162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gccgo
+compiler.gccgo162.semver=16.2
 
 ## GCC x86 build with "assertions" (--enable-checking=XXX)
-group.gccgoassert.compilers=gccgo105assert:gccgo111assert:gccgo112assert:gccgo113assert:gccgo114assert:gccgo121assert:gccgo122assert:gccgo123assert:gccgo124assert:gccgo125assert:gccgo131assert:gccgo132assert:gccgo133assert:gccgo134assert:gccgo141assert:gccgo142assert:gccgo143assert:gccgo151assert:gccgo152assert:gccgo161assert
+group.gccgoassert.compilers=gccgo105assert:gccgo111assert:gccgo112assert:gccgo113assert:gccgo114assert:gccgo121assert:gccgo122assert:gccgo123assert:gccgo124assert:gccgo125assert:gccgo131assert:gccgo132assert:gccgo133assert:gccgo134assert:gccgo141assert:gccgo142assert:gccgo143assert:gccgo151assert:gccgo152assert:gccgo161assert:gccgo162assert
 group.gccgoassert.groupName=x86 gccgo (assertions)
 
 compiler.gccgo105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gccgo
@@ -107,6 +109,8 @@ compiler.gccgo152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcc
 compiler.gccgo152assert.semver=15.2 (assertions)
 compiler.gccgo161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gccgo
 compiler.gccgo161assert.semver=16.1 (assertions)
+compiler.gccgo162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gccgo
+compiler.gccgo162assert.semver=16.2 (assertions)
 
 group.gl.compilers=&x86gl:&armgl:&mipsgl:&ppcgl:&riscvgl:&s390xgl:&wasmgl
 group.gl.versionFlag=version

--- a/etc/config/modula2.amazon.properties
+++ b/etc/config/modula2.amazon.properties
@@ -1,6 +1,6 @@
 # Default settings for modula2
 compilers=&gm2
-defaultCompiler=gm2161
+defaultCompiler=gm2162
 
 demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -15,7 +15,7 @@ needsMulti=false
 externalparser=CEAsmParser
 externalparser.exe=/usr/local/bin/asm-parser
 
-group.gm2.compilers=&gm2assert:gm2131:gm2132:gm2133:gm2134:gm2141:gm2142:gm2143:gm2151:gm2152:gm2161:gm2snapshot
+group.gm2.compilers=&gm2assert:gm2131:gm2132:gm2133:gm2134:gm2141:gm2142:gm2143:gm2151:gm2152:gm2161:gm2162:gm2snapshot
 group.gm2.compilerType=gm2
 group.gm2.instructionSet=amd64
 group.gm2.isSemVer=true
@@ -42,12 +42,14 @@ compiler.gm2152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gm2
 compiler.gm2152.semver=15.2
 compiler.gm2161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gm2
 compiler.gm2161.semver=16.1
+compiler.gm2162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gm2
+compiler.gm2162.semver=16.2
 
 compiler.gm2snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gm2
 compiler.gm2snapshot.semver=(snapshot)
 
 ## GFORTRAN x86 build with "assertions" (--enable-checking=XXX)
-group.gm2assert.compilers=gm2131assert:gm2132assert:gm2133assert:gm2134assert:gm2141assert:gm2142assert:gm2143assert:gm2151assert:gm2152assert:gm2161assert
+group.gm2assert.compilers=gm2131assert:gm2132assert:gm2133assert:gm2134assert:gm2141assert:gm2142assert:gm2143assert:gm2151assert:gm2152assert:gm2161assert:gm2162assert
 group.gm2assert.groupName=GM2 x86-64 (assertions)
 
 compiler.gm2131assert.exe=/opt/compiler-explorer/gcc-assertions-13.1.0/bin/gm2
@@ -70,3 +72,5 @@ compiler.gm2152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gm2
 compiler.gm2152assert.semver=15.2 (assertions)
 compiler.gm2161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gm2
 compiler.gm2161assert.semver=16.1 (assertions)
+compiler.gm2162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gm2
+compiler.gm2162assert.semver=16.2 (assertions)

--- a/etc/config/objc++.amazon.properties
+++ b/etc/config/objc++.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&objcppgcc86:&objcppcross
-defaultCompiler=objcppg161
-demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+defaultCompiler=objcppg162
+demangler=/opt/compiler-explorer/gcc-16.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.2.0/bin/objdump
 needsMulti=false
 
 buildenvsetup=ceconan
@@ -14,7 +14,7 @@ llvmDisassembler=/opt/compiler-explorer/clang-19.1.0/bin/llvm-dis
 
 ###############################
 # GCC for x86
-group.objcppgcc86.compilers=&objcppgcc86assert:objcppg105:objcppg114:objcppg122:objcppg123:objcppg124:objcppg125:objcppg131:objcppg132:objcppg133:objcppg134:objcppg141:objcppg142:objcppg143:objcppg151:objcppg152:objcppg161:objcppgsnapshot
+group.objcppgcc86.compilers=&objcppgcc86assert:objcppg105:objcppg114:objcppg122:objcppg123:objcppg124:objcppg125:objcppg131:objcppg132:objcppg133:objcppg134:objcppg141:objcppg142:objcppg143:objcppg151:objcppg152:objcppg161:objcppg162:objcppgsnapshot
 group.objcppgcc86.groupName=GCC x86-64
 group.objcppgcc86.instructionSet=amd64
 group.objcppgcc86.baseName=x86-64 gcc
@@ -72,6 +72,8 @@ compiler.objcppg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/g++
 compiler.objcppg152.semver=15.2
 compiler.objcppg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/g++
 compiler.objcppg161.semver=16.1
+compiler.objcppg162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/g++
+compiler.objcppg162.semver=16.2
 
 compiler.objcppgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
 compiler.objcppgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -81,7 +83,7 @@ compiler.objcppgsnapshot.isNightly=true
 
 ## OBJC++ GCC x86 build with "assertions" (--enable-checking=XXX)
 group.objcppgcc86assert.groupName=GCC x86-64 (assertions)
-group.objcppgcc86assert.compilers=objcppg105assert:objcppg114assert:objcppg122assert:objcppg123assert:objcppg124assert:objcppg125assert:objcppg131assert:objcppg132assert:objcppg133assert:objcppg134assert:objcppg141assert:objcppg142assert:objcppg143assert:objcppg151assert:objcppg152assert:objcppg161assert
+group.objcppgcc86assert.compilers=objcppg105assert:objcppg114assert:objcppg122assert:objcppg123assert:objcppg124assert:objcppg125assert:objcppg131assert:objcppg132assert:objcppg133assert:objcppg134assert:objcppg141assert:objcppg142assert:objcppg143assert:objcppg151assert:objcppg152assert:objcppg161assert:objcppg162assert
 
 compiler.objcppg105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/g++
 compiler.objcppg105assert.semver=10.5 (assertions)
@@ -129,6 +131,8 @@ compiler.objcppg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/g
 compiler.objcppg152assert.semver=15.2 (assertions)
 compiler.objcppg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/g++
 compiler.objcppg161assert.semver=16.1 (assertions)
+compiler.objcppg162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/g++
+compiler.objcppg162assert.semver=16.2 (assertions)
 
 group.objcppcross.compilers=&objcppgccs
 

--- a/etc/config/objc.amazon.properties
+++ b/etc/config/objc.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&objcgcc86:&objccross
-defaultCompiler=objcg161
-demangler=/opt/compiler-explorer/gcc-16.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/gcc-16.1.0/bin/objdump
+defaultCompiler=objcg162
+demangler=/opt/compiler-explorer/gcc-16.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-16.2.0/bin/objdump
 needsMulti=false
 
 externalparser=CEAsmParser
@@ -9,7 +9,7 @@ externalparser.exe=/usr/local/bin/asm-parser
 
 ###############################
 # GCC for x86
-group.objcgcc86.compilers=&objcgcc86assert:objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg124:objcg125:objcg131:objcg132:objcg133:objcg134:objcg141:objcg142:objcg143:objcg151:objcg152:objcg161:objcgsnapshot
+group.objcgcc86.compilers=&objcgcc86assert:objcg346:objcg404:objcg650:objcg105:objcg114:objcg122:objcg123:objcg124:objcg125:objcg131:objcg132:objcg133:objcg134:objcg141:objcg142:objcg143:objcg151:objcg152:objcg161:objcg162:objcgsnapshot
 group.objcgcc86.groupName=GCC x86-64
 group.objcgcc86.instructionSet=amd64
 group.objcgcc86.isSemVer=true
@@ -74,6 +74,8 @@ compiler.objcg152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gcc
 compiler.objcg152.semver=15.2
 compiler.objcg161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 compiler.objcg161.semver=16.1
+compiler.objcg162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gcc
+compiler.objcg162.semver=16.2
 
 compiler.objcgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.objcgsnapshot.demangler=/opt/compiler-explorer/gcc-snapshot/bin/c++filt
@@ -82,7 +84,7 @@ compiler.objcgsnapshot.semver=(trunk)
 compiler.objcgsnapshot.isNightly=true
 
 ## OBJC GCC x86 build with "assertions" (--enable-checking=XXX)
-group.objcgcc86assert.compilers=objcg105assert:objcg114assert:objcg122assert:objcg123assert:objcg124assert:objcg125assert:objcg131assert:objcg132assert:objcg133assert:objcg134assert:objcg141assert:objcg142assert:objcg143assert:objcg151assert:objcg152assert:objcg161assert
+group.objcgcc86assert.compilers=objcg105assert:objcg114assert:objcg122assert:objcg123assert:objcg124assert:objcg125assert:objcg131assert:objcg132assert:objcg133assert:objcg134assert:objcg141assert:objcg142assert:objcg143assert:objcg151assert:objcg152assert:objcg161assert:objcg162assert
 group.objcgcc86assert.groupName=GCC x86-64 (assertions)
 
 compiler.objcg105assert.exe=/opt/compiler-explorer/gcc-assertions-10.5.0/bin/gcc
@@ -131,6 +133,8 @@ compiler.objcg152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/gcc
 compiler.objcg152assert.semver=15.2 (assertions)
 compiler.objcg161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gcc
 compiler.objcg161assert.semver=16.1 (assertions)
+compiler.objcg162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gcc
+compiler.objcg162assert.semver=16.2 (assertions)
 
 ###############################
 # Cross Compilers

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&rust:&rustgcc:&mrustc:&rustccggcc:&rustccgcranelift
 objdumper=/opt/compiler-explorer/clang-22.1.0/bin/llvm-objdump
 objdumperType=llvm
-linker=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
+linker=/opt/compiler-explorer/gcc-16.2.0/bin/gcc
 aarch64linker=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 defaultCompiler=r1970
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
@@ -261,7 +261,7 @@ group.rustgcc.options=-frust-incomplete-and-experimental-compiler-do-not-use
 group.rustgcc.notification=Rust GCC Frontend - Very early snapshot
 
 # native compiler
-group.gcc86.compilers=&gccrsassert:gccrs-snapshot:gccrs-g141:gccrs-g142:gccrs-g143:gccrs-g151:gccrs-g152:gccrs-g161:gcc-snapshot
+group.gcc86.compilers=&gccrsassert:gccrs-snapshot:gccrs-g141:gccrs-g142:gccrs-g143:gccrs-g151:gccrs-g152:gccrs-g161:gccrs-g162:gcc-snapshot
 group.gcc86.groupName=x86-64 GCCRS
 group.gcc86.baseName=x86-64 GCCRS
 group.gcc86.unwiseOptions=-march=native
@@ -282,6 +282,8 @@ compiler.gccrs-g152.exe=/opt/compiler-explorer/gcc-15.2.0/bin/gccrs
 compiler.gccrs-g152.semver=15.2 (GCC)
 compiler.gccrs-g161.exe=/opt/compiler-explorer/gcc-16.1.0/bin/gccrs
 compiler.gccrs-g161.semver=16.1 (GCC)
+compiler.gccrs-g162.exe=/opt/compiler-explorer/gcc-16.2.0/bin/gccrs
+compiler.gccrs-g162.semver=16.2 (GCC)
 
 compiler.gcc-snapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gccrs
 compiler.gcc-snapshot.semver=(GCC master)
@@ -292,7 +294,7 @@ compiler.gccrs-snapshot.semver=(GCCRS master)
 compiler.gccrs-snapshot.isNightly=true
 
 ## GCC (from upstream GCC, not GCCRS github) x86 build with "assertions" (--enable-checking=XXX)
-group.gccrsassert.compilers=gccrs-g141assert:gccrs-g142assert:gccrs-g143assert:gccrs-g151assert:gccrs-g152assert:gccrs-g161assert
+group.gccrsassert.compilers=gccrs-g141assert:gccrs-g142assert:gccrs-g143assert:gccrs-g151assert:gccrs-g152assert:gccrs-g161assert:gccrs-g162assert
 group.gccrsassert.groupName=x86-64 GCC (assertions)
 
 compiler.gccrs-g141assert.exe=/opt/compiler-explorer/gcc-assertions-14.1.0/bin/gccrs
@@ -311,6 +313,8 @@ compiler.gccrs-g152assert.exe=/opt/compiler-explorer/gcc-assertions-15.2.0/bin/g
 compiler.gccrs-g152assert.semver=15.2 (GCC assertions)
 compiler.gccrs-g161assert.exe=/opt/compiler-explorer/gcc-assertions-16.1.0/bin/gccrs
 compiler.gccrs-g161assert.semver=16.1 (GCC assertions)
+compiler.gccrs-g162assert.exe=/opt/compiler-explorer/gcc-assertions-16.2.0/bin/gccrs
+compiler.gccrs-g162assert.semver=16.2 (GCC assertions)
 
 # cross compilers
 group.gcccross.compilers=&rustgccbpf


### PR DESCRIPTION
Exposes x86-64 gcc 16.2.0 (and its assertions build) across every gcc-family language, mirroring the existing 16.1.0 entries.

New compilers: `g162`/`cg162`, `gnat162`, `ga68-g162`, `gcccobol162`, `gdc162`, `gfortran162`, `gimpleg162`, `gccgo162`, `gm2162`, `objcg162`, `objcppg162`, `gccrs-g162` — each with an `assert` counterpart except `ga68`, which has no assertions build today.

16.2.0 becomes the default wherever 16.1.0 was (C, C++, Ada, Algol68, Fortran, GIMPLE, Modula-2, ObjC, ObjC++), and the "newest gcc" `demangler`/`objdumper`/`linker` paths in cobol, fortran, gimple, objc, objc++ and rust move with it.

Native only — no cross-compiler tarballs are built for 16.2.0, so the cross sections are untouched.

Depends on compiler-explorer/infra#2279 plus the S3 packages being available.

`npm run test:props` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)