### PR TITLE
Fix Rust source line highlighting with `objdump`

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -5,6 +5,8 @@ linker=/opt/compiler-explorer/gcc-16.1.0/bin/gcc
 aarch64linker=/opt/compiler-explorer/arm64/gcc-14.1.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 defaultCompiler=r1970
 demangler=/opt/compiler-explorer/demanglers/rust/bin/rustfilt
+externalparser=CEAsmParser
+externalparser.exe=/usr/local/bin/asm-parser
 
 buildenvsetup=ceconan-rust
 buildenvsetup.host=https://conan.compiler-explorer.com


### PR DESCRIPTION
#8982 broke source line highlighting for Rust with “Compile to binary object” and “Link to binary” ([example](https://godbolt.org/z/aPYGca9ME)).

While testing locally, I noticed that the JS `objdump` parser doesn’t handle `llvm-objdump`’s output format, but I assumed that the live site *always* used the external parser and not only when explicitly configured.