### PR TITLE
Support Rust in makefiles

### DIFF
--- a/docs/BuildSystems.md
+++ b/docs/BuildSystems.md
@@ -30,8 +30,8 @@ phases below have landed.
 
 The compiler to use is injected through environment variables rather than a command line:
 
-- `getCmakeBaseEnv()` sets `CXX`/`CC` (C++), `FC` (Fortran), `CUDACXX` (CUDA), `AS` (assembly), `CC` otherwise.
-- `getCompilerEnvironmentVariables()` sets `CXXFLAGS`/`FFLAGS`/`CUDAFLAGS`/`CFLAGS`.
+- `getCmakeBaseEnv()` sets `CXX`/`CC` (C++), `FC` (Fortran), `CUDACXX` (CUDA), `AS` (assembly), `RUSTC` (Rust), `CC` otherwise.
+- `getCompilerEnvironmentVariables()` sets `CXXFLAGS`/`FFLAGS`/`CUDAFLAGS`/`CFLAGS`/`RUSTFLAGS`.
 - `createCmakeExecParams()` sets `LDFLAGS` and `ldPath`.
 
 Compilers that need to deviate override `getExtraCMakeArgs()` (`win32-vc`, `llvm-mos`), `getCMakeExtToolchainParam()`
@@ -275,9 +275,9 @@ offered for **every** language: `compatibleLanguageIds: 'all'`, since a Makefile
 than being tied to a toolchain. One `make=` in the properties names the binary, as `cmake=` does.
 
 - **It is handed the environment CMake is handed**, by the same `createCmakeExecParams`: `CXX`/`CC`/`FC`/`CUDACXX`/
-  `AS` from the selected compiler, the matching `CXXFLAGS`/`CFLAGS`/`FFLAGS`/`CUDAFLAGS` carrying the user's options
-  and libraries, and `LDFLAGS`. So a recipe reading `$(CXX) $(CXXFLAGS) -o output main.cpp` compiles with what was
-  selected in the UI, which is the whole point of offering it.
+  `AS`/`RUSTC` from the selected compiler, the matching `CXXFLAGS`/`CFLAGS`/`FFLAGS`/`CUDAFLAGS`/`RUSTFLAGS` carrying
+  the user's options and libraries, and `LDFLAGS`. So a recipe reading `$(CXX) $(CXXFLAGS) -o output main.cpp`
+  compiles with what was selected in the UI, which is the whole point of offering it.
 - **`NVCC` as well, when the compiler really is nvcc.** CMake has no need of it, but a CUDA Makefile conventionally
   says `$(NVCC)`, and make has no built-in for it, so it would otherwise expand to nothing and the recipe would run
   without a compiler. Guarded on `compilerType === 'nvcc'`: clang compiles CUDA too, and naming it NVCC would be a

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -405,6 +405,8 @@ export class BaseCompiler {
             env.CUDACXX = this.compiler.exe;
         } else if (this.lang.id === 'assembly') {
             env.AS = this.compiler.exe;
+        } else if (this.lang.id === 'rust') {
+            env.RUSTC = this.compiler.exe;
         } else {
             env.CC = this.compiler.exe;
         }
@@ -2833,6 +2835,9 @@ export class BaseCompiler {
         if (this.lang.id === 'cuda') {
             return {...this.cmakeBaseEnv, CUDAFLAGS: compilerflags};
         }
+        if (this.lang.id === 'rust') {
+            return {...this.cmakeBaseEnv, RUSTFLAGS: compilerflags};
+        }
         return {...this.cmakeBaseEnv, CFLAGS: compilerflags};
     }
 
@@ -2980,6 +2985,9 @@ export class BaseCompiler {
         }
         if (this.lang.id === 'cuda') {
             return splitArguments(makeExecParams.env.CUDAFLAGS);
+        }
+        if (this.lang.id === 'rust') {
+            return splitArguments(makeExecParams.env.RUSTFLAGS);
         }
         return splitArguments(makeExecParams.env.CFLAGS);
     }


### PR DESCRIPTION
Similar to `CC` and `CFLAGS`, support `RUST` and `RUSTFLAGS` if a Rust compiler is selected.