### PR TITLE
Fix "DROPDOWN: Option boundary provided type undefined" TypeError

### DIFF
--- a/static/bootstrap-utils.ts
+++ b/static/bootstrap-utils.ts
@@ -211,6 +211,29 @@ export function getDropdownInstance(elementOrSelector: string | HTMLElement | JQ
 }
 
 /**
+ * Get the dropdown instance for an element, creating it with the given options if needed
+ *
+ * Prefer this over `data-bs-*` attributes whenever a dropdown needs non-default options.
+ * Bootstrap merges an element's data attributes on top of its defaults, so if a browser
+ * enumerates `data-bs-foo` but hands back `undefined` when reading it via `element.dataset`,
+ * the option ends up `undefined` and Bootstrap's config type check throws. An explicit
+ * config object is merged last and always wins, which makes that failure impossible.
+ *
+ * @param elementOrSelector Element or selector for the dropdown
+ * @param config Dropdown options to use if the instance does not exist yet
+ * @returns The dropdown instance, or null if the element could not be found
+ */
+export function getOrCreateDropdownInstance(
+    elementOrSelector: string | HTMLElement | JQuery,
+    config?: Partial<Dropdown.Options>,
+): Dropdown | null {
+    const element = getElement(elementOrSelector);
+    if (!element) return null;
+
+    return Dropdown.getOrCreateInstance(element, config);
+}
+
+/**
  * Show a dropdown
  * @param elementOrSelector Element or selector for the dropdown
  */

--- a/static/widgets/fontscale.ts
+++ b/static/widgets/fontscale.ts
@@ -27,6 +27,7 @@ import EventEmitter from 'events';
 import $ from 'jquery';
 import {editor} from 'monaco-editor';
 
+import * as BootstrapUtils from '../bootstrap-utils.js';
 import {options} from '../options.js';
 import {Settings} from '../settings.js';
 
@@ -39,6 +40,13 @@ function getDefaultFontScale() {
 }
 
 function makeFontSizeDropdown(elem: JQuery, obj: FontScale, buttonDropdown: JQuery) {
+    // Create the dropdown eagerly with an explicit boundary rather than relying on a
+    // data-bs-boundary attribute: the menu must escape the pane it lives in, and passing
+    // the option here keeps Bootstrap from ever type-checking an undefined boundary.
+    // 'viewport' is honoured by Popper at runtime, but @popperjs/core's Boundary type only
+    // covers 'clippingParents' and elements, hence the cast.
+    BootstrapUtils.getOrCreateDropdownInstance(buttonDropdown, {boundary: 'viewport' as unknown as Element});
+
     function onClickEvent(this: JQuery) {
         // Toggle off the selection of the others
         $(this).addClass('active').siblings().removeClass('active');

--- a/views/font-size.pug
+++ b/views/font-size.pug
@@ -1,4 +1,4 @@
 .btn-group.btn-group-sm(role="group" aria-label="Font size")
-  button.dropdown-toggle.btn.btn-light.fs-button(type="button" title="Change font size\nTip #1: You can use scroll wheel while hovering over this button\nTip #2: You can ctrl+click this button to reset to default" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-bs-flip="false" data-bs-boundary="viewport")
+  button.dropdown-toggle.btn.btn-light.fs-button(type="button" title="Change font size\nTip #1: You can use scroll wheel while hovering over this button\nTip #2: You can ctrl+click this button to reset to default" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false")
     span.fa.fa-font
   .dropdown-menu.font-size-list(aria-labelledby="fs-button")


### PR DESCRIPTION
May fix [Sentry CE-1YR](https://compiler-explorer.sentry.io/issues/7663628036?project=102028):

```
TypeError: DROPDOWN: Option "boundary" provided type "undefined" but expected type "(string|element)".
    at Config._typeCheckConfig (bootstrap/js/src/util/config.js:57:15)
    at BaseComponent._getConfig (bootstrap/js/src/base-component.js:56:10)
    at Dropdown._getConfig (bootstrap/js/src/dropdown.js:213:20)
    at new Dropdown (bootstrap/js/src/dropdown.js:95:5)
    at BaseComponent.getOrCreateInstance (bootstrap/js/src/base-component.js:66:41)
    at apply (bootstrap/js/src/dropdown.js:446:12)
```

## Where it came from

`dropdown.js:446` is Bootstrap's delegated data-API click handler
(`Dropdown.getOrCreateInstance(this).toggle()`), so this fires when a user clicks a
`[data-bs-toggle="dropdown"]` and Bootstrap lazily constructs the instance.

The font size button in `views/font-size.pug` was the only dropdown in the codebase
that supplied a `boundary` option, and it did so through a data attribute:

```pug
button.dropdown-toggle...fs-button(... data-bs-toggle="dropdown" data-bs-flip="false" data-bs-boundary="viewport")
```

Every other dropdown in `views/` sets no `boundary` at all, so they just inherit
`Dropdown.Default.boundary` and cannot produce this error. This template is
`include`d by 17 pane toolbars, which matches the volume of the issue.

## Why it threw

`BaseComponent._getConfig` builds the config as:

```js
{...this.constructor.Default, ...Manipulator.getDataAttributes(element), ...config}
```

The data attributes are spread **over** the defaults, and `config` is `{}` on the
data-API path. `getDataAttributes` does:

```js
for (const key of Object.keys(element.dataset).filter(k => k.startsWith('bs'))) {
  attributes[pureKey] = normalizeData(element.dataset[key])
}
```

`normalizeData` never returns `undefined` for a string (`"viewport"` → `"viewport"`,
`""` → `null`, `"undefined"` → `"undefined"`), and `toType(null)` reports `"null"`,
not `"undefined"`. So for the message to say `"undefined"`, `element.dataset.bsBoundary`
itself must have read back `undefined` — the key enumerated but not readable. That's a
client-side DOM quirk (old/exotic engine, or an extension/translation layer rewriting
attributes), not something we control. But because the attribute is spread over the
default, that `undefined` clobbers `'clippingParents'` and `_typeCheckConfig` throws
against `(string|element)`.

## The fix

Pass the option explicitly from JS. The explicit `config` object is spread **last**,
so `boundary` is guaranteed to be defined regardless of what `dataset` returns, which
makes the crash structurally impossible rather than merely less likely.

`data-bs-flip="false"` is also dropped — `flip` is not a Bootstrap 5 dropdown option
at all (it isn't in `DefaultType`), so it was a dead Bootstrap 4 leftover.

## Behaviour is unchanged

`boundary: 'viewport'` is still what Popper gets, so the menu keeps escaping the pane
it lives in. The `as unknown as Element` cast is needed because `@popperjs/core` types
`Boundary` as `Element | Element[] | 'clippingParents'`, even though
`getClippingRect.js` handles the `'viewport'` string at runtime.

## Verification

- `npm run lint`, `npm run ts-check` (all 5 projects), `npm test` (2610 passed) — clean.
- Dev run: `.fs-button` now carries only `data-bs-toggle`; the dropdown opens, closes on
  selection, marks the active item, and the editor font visibly resizes. No console errors.
- Confirmed the option really reaches Bootstrap with temporary instrumentation (since
  removed): the instance is created eagerly by `makeFontSizeDropdown` and bound to the live
  button, `_config.boundary === "viewport"` against a class default of `"clippingParents"`,
  and Popper's `preventOverflow` modifier receives `boundary: "viewport"`.

Marked "may fix" rather than "fixes" because the trigger is a browser-side `dataset`
quirk I could not reproduce locally — but this removes the only code path in CE that can
feed an `undefined` `boundary` into Bootstrap, so the Sentry issue should stop recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
