### PR TITLE
Kokkos: updating properties for version 5.2.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6413,7 +6413,7 @@ libs.kiwaku.versions.trunk.path=/opt/compiler-explorer/libs/kiwaku/trunk/include
 
 libs.kokkos.name=kokkos
 libs.kokkos.description=C++ Performance Portability Programming Model
-libs.kokkos.versions=4001:4100:4200:4201:4300:4301:4400:4401:4500:4501:4600:4601:4602:4700:4701:4702:4703:4704:500:501:502:510:511
+libs.kokkos.versions=4001:4100:4200:4201:4300:4301:4400:4401:4500:4501:4600:4601:4602:4700:4701:4702:4703:4704:500:501:502:510:511:520
 libs.kokkos.staticliblink=kokkoscore:kokkoscontainers:kokkossimd
 libs.kokkos.packagedheaders=true
 libs.kokkos.dependencies=dl
@@ -6441,6 +6441,7 @@ libs.kokkos.versions.501.version=5.0.1
 libs.kokkos.versions.502.version=5.0.2
 libs.kokkos.versions.510.version=5.1.0
 libs.kokkos.versions.511.version=5.1.1
+libs.kokkos.versions.520.version=5.2.0
 
 libs.kumi.name=kumi
 libs.kumi.description=C++20 Compact Tuple Library

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -1061,10 +1061,11 @@ libs.hip-amd.versions.70001.path=/opt/compiler-explorer/libs/rocm/7.0.1
 
 libs.kokkos-cuda.name=kokkos
 libs.kokkos-cuda.description=C++ Performance Portability Programming Model
-libs.kokkos-cuda.versions=4704:511
+libs.kokkos-cuda.versions=4704:511:520
 libs.kokkos-cuda.staticliblink=kokkoscore:kokkoscontainers:kokkossimd
 libs.kokkos-cuda.packagedheaders=true
 libs.kokkos-cuda.dependencies=dl
 libs.kokkos-cuda.url=https://github.com/kokkos/kokkos
 libs.kokkos-cuda.versions.4704.version=4.7.04
 libs.kokkos-cuda.versions.511.version=5.1.1
+libs.kokkos-cuda.versions.520.version=5.2.0


### PR DESCRIPTION
@JBludau 
Bumping up the versions for kokkos and kokkos-cuda after the latest release.
See [Kokkos 5.2.0](https://github.com/kokkos/kokkos/releases/tag/5.2.0) and infra PR [#2285](https://github.com/compiler-explorer/infra/pull/2285)