### PR TITLE
Redirect old browsers, not just IE11, to the noscript site

### DIFF
--- a/views/_layout.pug
+++ b/views/_layout.pug
@@ -8,9 +8,12 @@ html(lang="en")
 
     script
       | (function () {
-      |   var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+      |   // Send browsers too old to parse our bundles to the noscript site. Feature-checked rather
+      |   // than UA-sniffed, and kept ES5-safe as it must run on the browsers it is detecting.
+      |   // replaceAll is the stricter check (Chrome 85+); IE11 lacks both.
+      |   var tooOld = !window.globalThis || !String.prototype.replaceAll;
       |   var storedState = '#{storedStateId}';
-      |   if (isIE11) {
+      |   if (tooOld) {
       |     if (storedState) {
       |       location.href = '#{httpRoot}noscript/z/' + storedState;
       |     } else {

--- a/views/_layout.pug
+++ b/views/_layout.pug
@@ -8,9 +8,6 @@ html(lang="en")
 
     script
       | (function () {
-      |   // Send browsers too old to parse our bundles to the noscript site. Feature-checked rather
-      |   // than UA-sniffed, and kept ES5-safe as it must run on the browsers it is detecting.
-      |   // replaceAll is the stricter check (Chrome 85+); IE11 lacks both.
       |   var tooOld = !window.globalThis || !String.prototype.replaceAll;
       |   var storedState = '#{storedStateId}';
       |   if (tooOld) {


### PR DESCRIPTION
The inline check in `views/_layout.pug` only caught IE11, via two IE-specific globals (`MSInputMethodContext` / `documentMode`). Older non-IE browsers — Chrome 49 was the example that prompted this — sailed past it and then died parsing our bundles, leaving a blank page instead of the noscript fallback that exists for exactly this case.

This replaces the IE11 sniff with a feature check:

```js
var tooOld = !window.globalThis || !String.prototype.replaceAll;
```

Feature-detected rather than UA-sniffed, so it doesn't need a list of every old browser and doesn't get fooled by spoofed UA strings. `replaceAll` is the stricter of the two, putting the cutoff around Chrome 85 / Firefox 77 / Safari 13.1. IE11 lacks both, so this subsumes the check it replaces rather than adding alongside it. The redirect logic below is untouched, including the stored-state path to `/noscript/z/<id>`.

The script must stay ES5-parseable, since it runs on the very browsers it's detecting — hence `var` and no arrow functions.

### Caveat on the cutoff

Chrome 85 is a proxy for "can this browser parse our bundles", not a measured floor. It's set comfortably above where monaco 0.55 is believed to land, but I did not empirically verify the true minimum — the site might work below 85, or break above it. A future dependency bump could also raise the real requirement past this line, and the check would silently wave those browsers through to a blank page.

### Testing

- `npm run lint` and `npm run ts-check` clean.
- `noscript-tests.ts` and `main-tests.ts` pass.
- Rendered `_layout.pug` directly and confirmed the emitted script is valid ES5 with the comments on their own lines.

Not tested in a genuinely old browser — no existing test covers this inline script, so nothing in CI would catch a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)