### PR TITLE
[odin] fix llvm for past two versions and assembly for current version

### DIFF
--- a/lib/compilers/odin.ts
+++ b/lib/compilers/odin.ts
@@ -62,6 +62,16 @@ class OdinVersion {
             return false;
         }
     }
+
+    lte(version: OdinVersion) {
+        if (this.year < version.year) {
+            return true;
+        } else if (this.year === version.year) {
+            return this.month <= version.month;
+        } else {
+            return false;
+        }
+    }
 }
 
 export class OdinCompiler extends BaseCompiler {
@@ -124,12 +134,27 @@ export class OdinCompiler extends BaseCompiler {
         filters: ParseFiltersAndOutputOptions,
     ) {
         let newOutputFilename = outputFilename;
-        if (!filters.binary && !filters.execute) newOutputFilename = outputFilename.replace(/.s$/, '.S');
+
+        const version = new OdinVersion(this.compiler.version);
+        if (version.lte(new OdinVersion('dev-2026-07a'))) {
+            if (!filters.binary && !filters.execute) newOutputFilename = outputFilename.replace(/.s$/, '.S');
+        }
+
         return super.checkOutputFileAndDoPostProcess(asmResult, newOutputFilename, filters);
     }
 
     override getIrOutputFilename(inputFilename: string): string {
-        return this.filename(path.dirname(inputFilename) + '/output.ll');
+        const outputDir = path.dirname(inputFilename);
+        let outputFile = '/output.ll';
+
+        const version = new OdinVersion(this.compiler.version);
+        const filenameIssueStart = new OdinVersion('dev-2026-07a');
+        const filenameIssueEnd = new OdinVersion('dev-2026-08');
+        if (version.gte(filenameIssueStart) && version.lte(filenameIssueEnd)) {
+            outputFile = '/outputoutput.ll';
+        }
+
+        return outputDir + outputFile;
     }
 
     override async postProcessAsm(result, filters?: ParseFiltersAndOutputOptions) {


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
The most recent Odin versions have had an issue where the `output.ll` filename is actually duplicated to `outputoutput.ll`, resulting in the LLVM IR view not finding the file. Additionally, `dev-2026-08` fixed an output assembly naming issue that caused the `.S` extension to always be uppercase, regardless of filename. This broke the assembly view though since the filenames now no longer matched.

Both of these issues were fixed by adding explicit version checks with the corresponding correct codepaths.
