### PR TITLE
MCP: proxy compiles for remotely-hosted compilers

### DIFF
--- a/lib/mcp/tools/compile.ts
+++ b/lib/mcp/tools/compile.ts
@@ -25,7 +25,8 @@
 import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
 
-import {BypassCache} from '../../../types/compilation/compilation.interfaces.js';
+import {BypassCache, type CompilationResult} from '../../../types/compilation/compilation.interfaces.js';
+import type {Remote} from '../../../types/compiler.interfaces.js';
 import type {LanguageKey} from '../../../types/languages.interfaces.js';
 import type {ApiHandler} from '../../handlers/api.js';
 import {CompileHandler} from '../../handlers/compile.js';
@@ -35,6 +36,27 @@ import {truncateLines} from '../utils.js';
 const DEFAULT_MAX_ASM_LINES = 500;
 const DEFAULT_MAX_STDOUT_LINES = 100;
 const DEFAULT_MAX_STDERR_LINES = 100;
+
+/**
+ * Compile on the sub-server that actually hosts this compiler.
+ *
+ * Remote-hosted compilers (Windows boxes, for instance) have no executable on this node, so calling
+ * `compile()` on the local object fails when it tries to launch the compiler. `CompileHandler.handle`
+ * proxies the incoming request in that case; a tool call has no request to proxy, so post an
+ * equivalent one instead. The remote returns the same JSON shape as `compile()` returns locally.
+ */
+async function compileOnRemote(remote: Remote, body: unknown): Promise<CompilationResult> {
+    const url = `${remote.target}${remote.path}`;
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', Accept: 'application/json'},
+        body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+        throw new Error(`Status ${response.status} on POST ${url}`);
+    }
+    return (await response.json()) as CompilationResult;
+}
 
 export function registerCompileTool(server: McpServer, compileHandler: CompileHandler, apiHandler: ApiHandler): void {
     server.tool(
@@ -185,18 +207,27 @@ export function registerCompileTool(server: McpServer, compileHandler: CompileHa
                     },
                 };
 
-                const parsed = CompileHandler.parseRequestReusable(true, {}, body, baseCompiler);
-                const result = await baseCompiler.compile(
-                    parsed.source,
-                    parsed.options,
-                    parsed.backendOptions,
-                    parsed.filters,
-                    BypassCache.None,
-                    parsed.tools,
-                    parsed.executeParameters,
-                    parsed.libraries,
-                    [],
-                );
+                const remote = baseCompiler.getRemote();
+                // `CompilationResult` describes the wire shape, which is wider than what a local
+                // compile() hands back (`asm` may be a string there); the JSON a sub-server returns is
+                // the narrow one, so line up with the local branch rather than widening everything below.
+                let result: Awaited<ReturnType<typeof baseCompiler.compile>>;
+                if (remote) {
+                    result = (await compileOnRemote(remote, body)) as typeof result;
+                } else {
+                    const parsed = CompileHandler.parseRequestReusable(true, {}, body, baseCompiler);
+                    result = await baseCompiler.compile(
+                        parsed.source,
+                        parsed.options,
+                        parsed.backendOptions,
+                        parsed.filters,
+                        BypassCache.None,
+                        parsed.tools,
+                        parsed.executeParameters,
+                        parsed.libraries,
+                        [],
+                    );
+                }
 
                 const asmCap = maxAsmLines ?? DEFAULT_MAX_ASM_LINES;
                 const stdoutCap = maxStdoutLines ?? DEFAULT_MAX_STDOUT_LINES;

--- a/test/mcp/mcp-tests.ts
+++ b/test/mcp/mcp-tests.ts
@@ -807,6 +807,7 @@ describe('MCP compile tool', () => {
     ): CompileHandler {
         const fakeBaseCompiler = {
             getDefaultFilters: () => ({}),
+            getRemote: () => false,
             compile: vi.fn().mockResolvedValue({
                 code: topLevelCode,
                 asm: asm.map(text => ({text})),
@@ -966,6 +967,57 @@ describe('MCP compile tool', () => {
         const result = await toolHandlers.compile({source: 'x', language: 'wat'});
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toMatch(/No compiler specified.*language "wat"/);
+    });
+
+    it('posts to the sub-server instead of compiling locally when the compiler is remote', async () => {
+        const {fakeServer, toolHandlers} = makeFakeServer();
+        const compileHandler = makeCompileHandler(['ret']);
+        const baseCompiler = compileHandler.findCompiler('c++' as any, 'g161');
+        const compileSpy = vi.spyOn(baseCompiler!, 'compile');
+        vi.spyOn(baseCompiler!, 'getRemote').mockReturnValue({
+            target: 'https://sub.example.com',
+            path: '/api/compiler/vcpp/compile',
+            cmakePath: '/api/compiler/vcpp/cmake',
+            basePath: '/',
+        });
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({code: 0, asm: [{text: 'ret 0'}], stdout: [], stderr: []}), {
+                status: 200,
+                headers: {'Content-Type': 'application/json'},
+            }),
+        );
+        registerCompileTool(fakeServer, compileHandler, fakeApiForCompile);
+
+        const result = await toolHandlers.compile({source: 'x', language: 'c++', compiler: 'vcpp'});
+
+        expect(result.isError).toBeUndefined();
+        expect(compileSpy).not.toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        const [url, init] = fetchSpy.mock.calls[0];
+        expect(url).toBe('https://sub.example.com/api/compiler/vcpp/compile');
+        expect(init?.method).toBe('POST');
+        expect(JSON.parse(result.content[0].text).asm).toBe('ret 0');
+        fetchSpy.mockRestore();
+    });
+
+    it('surfaces a failing sub-server response as a tool error', async () => {
+        const {fakeServer, toolHandlers} = makeFakeServer();
+        const compileHandler = makeCompileHandler(['ret']);
+        const baseCompiler = compileHandler.findCompiler('c++' as any, 'g161');
+        vi.spyOn(baseCompiler!, 'getRemote').mockReturnValue({
+            target: 'https://sub.example.com',
+            path: '/api/compiler/vcpp/compile',
+            cmakePath: '/api/compiler/vcpp/cmake',
+            basePath: '/',
+        });
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', {status: 502}));
+        registerCompileTool(fakeServer, compileHandler, fakeApiForCompile);
+
+        const result = await toolHandlers.compile({source: 'x', language: 'c++', compiler: 'vcpp'});
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toMatch(/502/);
+        fetchSpy.mockRestore();
     });
 
     it('normalises a human library version (1.88.0) to its id (188) and reaches baseCompiler.compile', async () => {


### PR DESCRIPTION
cc @mattgodbolt — this is in the MCP endpoint from #8644.

## The problem

`compile` in the MCP tool calls `baseCompiler.compile()` directly, so a compiler served by a sub-server gets attempted on whichever node handled the MCP request. There's no compiler binary there to launch, so every remotely-hosted compiler fails through `/mcp`:

```
runChild():486 Launching child process failed
```

Reproducible on production right now — `vcpp_v19_51_VS18_6_x64` through `compiler-explorer.com/mcp` fails, while the same id and options through `/api/compiler/<id>/compile` works. It affects any remote, not just the Windows ones.

`CompileHandler.handle` has the branch that makes this work for REST:

```ts
const remote = compiler.getRemote();
if (remote) {
    req.url = remote.path;
    this.proxy.web(req, res, {target: remote.target, changeOrigin: true}, ...);
    return;
}
```

There's no equivalent anywhere in `lib/mcp` — `git log -S"getRemote" -- lib/mcp` is empty, so this has been the case since the endpoint landed.

## The change

Check `getRemote()` and, when it's set, POST an equivalent request to `remote.target + remote.path` rather than compiling locally. A tool call has no `req`/`res` to hand to `http-proxy`, hence an outbound `fetch` instead of the proxy. The sub-server returns the same JSON shape `compile()` returns locally, so truncation, `buildResult` and `execResult` handling below are untouched.

One wart: `result` is annotated `Awaited<ReturnType<typeof baseCompiler.compile>>` rather than `CompilationResult`, because the declared wire type has `asm?: string | ParsedAsmResultLine[]` and `truncateLines` wants the array form — typing it as `CompilationResult` doesn't compile. There's a cast on the remote branch with a comment explaining why. Happy to do this differently if you'd rather.

## Testing

Unit tests: the existing fake compiler had no `getRemote`, so it's added there; two new cases cover the remote path posting to the sub-server (and never calling `compile()` locally) and a failing sub-server response surfacing as a tool error.

Manually, against a local instance configured with the `gpu` and `winprod` remotes:

| compiler | before | after |
| --- | --- | --- |
| `vcpp_v19_51_VS18_6_x64` `/O2` | `runChild():486` | `code 0`, `lea eax, DWORD PTR [rcx+1]` |
| `vcpp_v19_51_VS18_6_x86` `/O2 /std:c++20` | — | `code 0`, `mov eax, DWORD PTR _x$[esp-4]` |
| `clang-cl2216-v19_50_VS18_2` `/O2` | — | `code 0` |

Compile errors propagate too: a deliberate typo returns `code 2` with `<source>(1): error C2065: 'nope': undeclared identifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
