### PR TITLE
Add the clang std::init and std::core_ub profile compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -575,7 +575,7 @@ compiler.clang2210.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-lin
 compiler.clang2210.debugPatched=true
 
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_p1974:clang_chrisbazley
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_profiles_init:clang_profiles_core_ub:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_p1974:clang_chrisbazley
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -669,6 +669,14 @@ compiler.clang_p3951.exe=/opt/compiler-explorer/clang-p3951-trunk/bin/clang++
 compiler.clang_p3951.semver=(template strings - P3951)
 compiler.clang_p3951.notification=Experimental P3951 Support (t"..."); see <a href="https://brevzin.github.io/cpp_proposals/3951_string_interpolation/p3951r0.html" target="_blank" rel="noopener noreferrer">P3951<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_p3951.options=-std=c++26 -freflection -fexpansion-statements -stdlib=libc++
+compiler.clang_profiles_init.exe=/opt/compiler-explorer/clang-profiles-init-trunk/bin/clang++
+compiler.clang_profiles_init.semver=(std::init profile - P4222)
+compiler.clang_profiles_init.notification=Experimental std::init profile on the P3589R2 framework; nothing is enforced until you add [[profiles::enforce(std::init)]]; above your includes. See the <a href="https://github.com/cppalliance/clang/tree/profiles-init" target="_blank" rel="noopener noreferrer">implementation notes<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_profiles_init.options=-std=c++26 -fprofiles
+compiler.clang_profiles_core_ub.exe=/opt/compiler-explorer/clang-profiles-core-ub-trunk/bin/clang++
+compiler.clang_profiles_core_ub.semver=(std::core_ub profile - P4317)
+compiler.clang_profiles_core_ub.notification=Experimental std::core_ub profile on the P3589R2 framework; nothing is checked until you add [[profiles::enforce(std::core_ub)]]; above your includes, after which violations trap. See the <a href="https://github.com/cppalliance/clang/tree/profiles-core-ub" target="_blank" rel="noopener noreferrer">implementation notes<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_profiles_core_ub.options=-std=c++26 -fprofiles
 compiler.clang_barry.exe=/opt/compiler-explorer/clang-barry-clang-trunk/bin/clang++
 compiler.clang_barry.semver=(barry prototypes)
 compiler.clang_barry.notification=Barry's various prototypes; see <a href="https://github.com/brevzin/llvm-project/tree/compiler-explorer/barry" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
Companion to https://github.com/compiler-explorer/clang-builder/pull/118, which has the background on both profiles.

Adds two entries to the x86-64 clang group:

| Dropdown | Default options |
|---|---|
| x86-64 clang (std::init profile - P4222) | `-std=c++26 -fprofiles` |
| x86-64 clang (std::core_ub profile - P4317) | `-std=c++26 -fprofiles` |

`-fprofiles` turns the framework on but enforces nothing by itself — a profile has to be asked for in the source with `[[profiles::enforce(...)]];`. Without that the compilers look identical to trunk, so each notification says as much.
