### PR TITLE
Add the aburi compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -7804,6 +7804,8 @@ libs.yaml_cpp.packagedheaders=true
 # aburi
 group.aburipp.compilers=aburi-godbolt-pp
 group.aburipp.groupName=aburi
+group.aburipp.baseName=aburi
+group.aburipp.isSemVer=true
 group.aburipp.instructionSet=amd64
 group.aburipp.compilerType=aburi
 group.aburipp.isNightly=true
@@ -7813,7 +7815,6 @@ group.aburipp.supportsExecute=false
 group.aburipp.options=-std=c++20
 
 compiler.aburi-godbolt-pp.exe=/opt/compiler-explorer/aburi-godbolt/bin/aburi
-compiler.aburi-godbolt-pp.name=aburi
 compiler.aburi-godbolt-pp.semver=(trunk)
 
 #################################

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&aocc:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang:&gcc-classic:&npparm
+compilers=&gcc86:&icc:&icx:&clang:&clangx86trunk:&clang-rocm:&aocc:&mosclang-trunk:&rvclang:&wasmclang:&loongarch-clang:&cross:&ellcc:&zapcc:&djggp:&armclang32:&armclang64:&zigcxx:&cxx6502:godbolt.org@443/gpu:godbolt.org@443/winprod:&hexagon-clang:&edg:&vast:&qnx:&z80-clang:&clad-clang:&gcc-classic:&npparm:&aburipp
 # Disabled: nvcxx_x86_cxx
 # The disabled groups are actually used in the c++.gpu.properties. One day these might exist on both servers, so I want
 # to keep them in the same place.
@@ -7799,6 +7799,22 @@ libs.yaml_cpp.versions=yaml-cpp-090
 libs.yaml_cpp.versions.yaml-cpp-090.version=yaml-cpp-0.9.0
 libs.yaml_cpp.staticliblink=yaml-cppd
 libs.yaml_cpp.packagedheaders=true
+
+################################
+# aburi
+group.aburipp.compilers=aburi-godbolt-pp
+group.aburipp.groupName=aburi
+group.aburipp.instructionSet=amd64
+group.aburipp.compilerType=aburi
+group.aburipp.isNightly=true
+group.aburipp.supportsBinary=false
+group.aburipp.supportsBinaryObject=false
+group.aburipp.supportsExecute=false
+group.aburipp.options=-std=c++20
+
+compiler.aburi-godbolt-pp.exe=/opt/compiler-explorer/aburi-godbolt/bin/aburi
+compiler.aburi-godbolt-pp.name=aburi
+compiler.aburi-godbolt-pp.semver=(trunk)
 
 #################################
 #################################

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&caocc:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&co2cc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm
+compilers=&cgcc86:&cclang:&caocc:&nvc_x86:&armcclang32:&armcclang64:&cmosclang-trunk:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86:&chibicc:&ccc:&co2cc:&z80-cclang:&z88dk:&compcert:godbolt.org@443/winprod:&movfuscator:&lc3:&upmem-clang:&cvast:&orcac:&c2rust:&nccarm:&aburi
 defaultCompiler=cg162
 # We use the llvm-trunk demangler for all c/c++ compilers, as c++filt tends to lag behind
 demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
@@ -4990,6 +4990,21 @@ libs.zlib.versions=131
 libs.zlib.packagedheaders=true
 libs.zlib.staticliblink=z
 libs.zlib.versions.131.version=1.3.1
+
+################################
+# aburi
+group.aburi.compilers=aburi-godbolt
+group.aburi.groupName=aburi
+group.aburi.instructionSet=amd64
+group.aburi.compilerType=aburi
+group.aburi.isNightly=true
+group.aburi.supportsBinary=false
+group.aburi.supportsBinaryObject=false
+group.aburi.supportsExecute=false
+
+compiler.aburi-godbolt.exe=/opt/compiler-explorer/aburi-godbolt/bin/aburi
+compiler.aburi-godbolt.name=aburi
+compiler.aburi-godbolt.semver=(trunk)
 
 #################################
 #################################

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -4995,6 +4995,8 @@ libs.zlib.versions.131.version=1.3.1
 # aburi
 group.aburi.compilers=aburi-godbolt
 group.aburi.groupName=aburi
+group.aburi.baseName=aburi
+group.aburi.isSemVer=true
 group.aburi.instructionSet=amd64
 group.aburi.compilerType=aburi
 group.aburi.isNightly=true
@@ -5003,7 +5005,6 @@ group.aburi.supportsBinaryObject=false
 group.aburi.supportsExecute=false
 
 compiler.aburi-godbolt.exe=/opt/compiler-explorer/aburi-godbolt/bin/aburi
-compiler.aburi-godbolt.name=aburi
 compiler.aburi-godbolt.semver=(trunk)
 
 #################################

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -22,6 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+export {AburiCompiler} from './aburi.js';
 export {AdaCompiler} from './ada.js';
 export {AMDRGACompiler} from './amd-rga.js';
 export {AnalysisTool} from './analysis-tool.js';

--- a/lib/compilers/aburi.ts
+++ b/lib/compilers/aburi.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2025, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import _ from 'underscore';
+
+import type {LLVMIrBackendOptions} from '../../types/compilation/ir.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {unwrap} from '../assert.js';
+import {BaseCompiler} from '../base-compiler.js';
+import * as utils from '../utils.js';
+
+export class AburiCompiler extends BaseCompiler {
+    static get key() {
+        return 'aburi';
+    }
+
+    constructor(info, env) {
+        super(info, env);
+        this.compiler.supportsIrView = true;
+        this.compiler.irArg = ['--emit-llvm'];
+    }
+
+    override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string, userOptions?: string[]) {
+        if (_.some(unwrap(userOptions), opt => opt === '--help' || opt === '-h' || opt === '-hh')) {
+            return [];
+        }
+        const options = ['-g', '-o', this.filename(outputFilename)];
+        if (!filters.binary) {
+            options.unshift('-S');
+        }
+        return options;
+    }
+
+    override filterUserOptions(userOptions: string[]) {
+        return userOptions.filter(opt => opt !== '-run');
+    }
+
+    override getIrOutputFilename(inputFilename: string): string {
+        return utils.changeExtension(inputFilename, '.ll');
+    }
+
+    override generateIR(
+        inputFilename: string,
+        options: string[],
+        irOptions: LLVMIrBackendOptions,
+        produceCfg: boolean,
+        filters: ParseFiltersAndOutputOptions,
+    ) {
+        const irPath = this.getIrOutputFilename(inputFilename);
+        const irOptions_ = options
+            .filter(opt => opt !== '-S')
+            .map(opt => {
+                if (opt === '-o') return '__OFLAG__';
+                return opt;
+            });
+        const oIdx = irOptions_.indexOf('__OFLAG__');
+        if (oIdx !== -1 && oIdx + 1 < irOptions_.length) {
+            irOptions_[oIdx] = '-o';
+            irOptions_[oIdx + 1] = irPath;
+        }
+        return super.generateIR(inputFilename, irOptions_, irOptions, produceCfg, filters);
+    }
+}


### PR DESCRIPTION
Supersedes #8872. Thanks to @likecrazy1, whose `AburiCompiler` class is taken from that PR unchanged and who is credited as co-author — the reason this is a new PR rather than an edit is that the properties needed rewriting from scratch once upstream changed direction.

@serjective has [confirmed](https://github.com/compiler-explorer/compiler-explorer/pull/8872#issuecomment-) that `godbolt` is the live branch and the pinned `atta-mills` classic version is abandoned, so this configures the nightly built from `godbolt`.

## What changed from #8872, and why

**It is not an aarch64 Darwin cross compiler any more.** The new build reports `Target: x86_64-unknown-linux-gnu`, so the group is plain `aburi` with `instructionSet=amd64` rather than "Aburi (aarch64 Apple Darwin)".

**No `--sysroot`.** This is the important one. On Linux, aburi's `resolve_effective_stdlib` treats an explicit `--sysroot` as a different root filesystem and **switches off Adinkra**, its own C++ standard library. That is exactly why the previous configuration compiled CE's header-free `square` example byte-perfectly and then failed on the first `#include`. For a Linux target aburi takes its C headers from the host root and its C++ headers from Adinkra, so it wants no sysroot at all.

**`-std=c++20` is required**, not optional — Adinkra `#error`s below C++20, so a bare C++ compile fails outright.

**Nightly shape:** `isNightly=true` and `semver=(trunk)` instead of a pinned `0.1.1`, since it now tracks a moving branch.

**Binary, binary object and execution are off.** Linking does work (I built and ran a C++ executable against the shipped artifact), but nothing has exercised those paths on the site, and they need `-L`/`-Wl,-rpath` pointing at the bundled libc++abi to link at all. Advertising a control that hard-fails is the exact trap this compiler fell into last time, so I would rather turn them on as a follow-up once someone can try them for real.

## Testing

Everything below was run against the artifact that is actually on S3 (`aburi-godbolt-20260814.tar.xz`), installed through the infra installable:

- `--version` and `--help` both exit 0 (a non-zero version command silently drops a compiler from the dropdown)
- C++ `-S` emits x86-64 assembly
- C compiles, links and runs
- `--emit-llvm` alone emits valid LLVM IR, which is what `AburiCompiler` uses for the IR view. Note it rejects `--emit-llvm` combined with `-S`, and the class already strips `-S` on that path
- `-g` is accepted, which the class always passes
- a TU using `<vector>`, `<string>` and a thrown-and-caught exception compiles, links and runs — the case the old `--sysroot` broke

`npm run test:props` (90 passed), `npm run ts-check` and `npm run lint-check` all clean.

## Merge order

This should land after, and only after, the compiler is installed:

- compiler-explorer/misc-builder#142, #143 (builder) — merged
- compiler-explorer/infra#2294 (nightly installable)
- compiler-explorer/compiler-workflows#76 (daily build)

Co-Authored-By: likecrazy1 <157763655+likecrazy1@users.noreply.github.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)