### PR TITLE
Pass --extended-lambda for kokkos-cuda

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -1079,6 +1079,9 @@ libs.kokkos-cuda.versions=4704:511:520
 libs.kokkos-cuda.staticliblink=kokkoscore:kokkoscontainers:kokkossimd
 libs.kokkos-cuda.packagedheaders=true
 libs.kokkos-cuda.dependencies=dl
+# Kokkos' own headers use __host__ __device__ lambdas, so nvcc needs this to compile
+# anything that includes Kokkos_Core.hpp, not just user code that writes a KOKKOS_LAMBDA.
+libs.kokkos-cuda.options=--extended-lambda
 libs.kokkos-cuda.url=https://github.com/kokkos/kokkos
 libs.kokkos-cuda.versions.4704.version=4.7.04
 libs.kokkos-cuda.versions.511.version=5.1.1


### PR DESCRIPTION
Compiling anything that includes `Kokkos_Core.hpp` with nvcc currently fails unless the user adds `--extended-lambda` by hand. Kokkos' own headers use `__host__ __device__` lambdas, so this affects code that never writes a `KOKKOS_LAMBDA` itself.

Verified on prod, nvcc 13.3, `-std=c++20`:

| kokkos-cuda | without the flag | with it |
|---|---|---|
| 4.7.04 | fails | |
| 5.1.1 | fails (first error in `Kokkos_CopyViews.hpp`) | |
| 5.2.0 | fails (first error in `Kokkos_CopyViews.hpp`) | compiles, exit 0 |

Note Kokkos 5.2 also requires C++20; `-std=c++17` fails earlier on `std::type_identity`.

cc @JBludau (reported in compiler-explorer/infra#2184), @lucbv (#9009), @partouf

🤖 Generated with [Claude Code](https://claude.com/claude-code)
