### PR TITLE
Pass CUDAToolkit_ROOT for cuda clang compilers

### DIFF
--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -27,6 +27,7 @@ import path from 'node:path';
 
 import _ from 'underscore';
 
+import {splitArguments} from '../../shared/common-utils.js';
 import {OptRemark} from '../../static/panes/opt-view.interfaces.js';
 import type {
     ActiveTool,
@@ -44,6 +45,7 @@ import {ArtifactType} from '../../types/tool.interfaces.js';
 import {addArtifactToResult} from '../artifact-utils.js';
 import {BaseCompiler} from '../base-compiler.js';
 import {CompilationEnvironment} from '../compilation-env.js';
+import type {ParsedRequest} from '../handlers/compile.js';
 import {AmdgpuAsmParser} from '../parsers/asm-parser-amdgpu.js';
 import {HexagonAsmParser} from '../parsers/asm-parser-hexagon.js';
 import {PTXAsmParser} from '../parsers/asm-parser-ptx.js';
@@ -297,6 +299,11 @@ export class ClangCompiler extends BaseCompiler {
     }
 }
 
+function getCudaPath(args: string[]): string | undefined {
+    const arg = args.find(arg => arg.startsWith('--cuda-path='));
+    return arg ? arg.substring('--cuda-path='.length) : undefined;
+}
+
 export class ClangCudaCompiler extends ClangCompiler {
     static override get key() {
         return 'clang-cuda';
@@ -310,6 +317,15 @@ export class ClangCudaCompiler extends ClangCompiler {
 
     override getCompilerResultLanguageId(filters?: ParseFiltersAndOutputOptions): string | undefined {
         return 'ptx';
+    }
+
+    override getExtraCMakeArgs(key: ParsedRequest): string[] {
+        // CMake locates the toolkit through nvcc, so an nvcc compiler needs no help. Clang is told
+        // where it is with --cuda-path, which CMake reads neither from the flags nor from the
+        // compiler, and it refuses to enable the CUDA language for Clang without a toolkit.
+        const args = super.getExtraCMakeArgs(key);
+        const cudaPath = getCudaPath(key.options) ?? getCudaPath(splitArguments(this.compiler.options));
+        return cudaPath ? [...args, `-DCUDAToolkit_ROOT=${cudaPath}`] : args;
     }
 
     override optionsForFilter(filters: ParseFiltersAndOutputOptions, outputFilename: string) {

--- a/test/compilers/clang-tests.ts
+++ b/test/compilers/clang-tests.ts
@@ -27,7 +27,7 @@ import path from 'node:path';
 
 import {describe, expect, it} from 'vitest';
 
-import {ClangCompiler} from '../../lib/compilers/index.js';
+import {ClangCompiler, ClangCudaCompiler} from '../../lib/compilers/index.js';
 import {makeCompilationEnvironment} from '../utils.js';
 
 describe('clang tests', () => {
@@ -152,5 +152,39 @@ Args:
                 optType: 'Analysis',
             },
         ]);
+    });
+});
+
+describe('clang-cuda cmake tests', () => {
+    const languages = {cuda: {id: 'cuda'}};
+    const makeCompiler = (options: string) =>
+        new ClangCudaCompiler(
+            {
+                exe: '/opt/compiler-explorer/clang-19.1.0/bin/clang++',
+                remote: true,
+                lang: 'cuda',
+                ldPath: [],
+                options,
+            } as any,
+            makeCompilationEnvironment({languages}),
+        );
+    const request = (options: string[] = []) => ({options}) as any;
+
+    it('names the cuda toolkit root from the compiler options', () => {
+        const compiler = makeCompiler('--cuda-path=/opt/compiler-explorer/cuda/12.5.1 --cuda-gpu-arch=sm_90');
+        expect(compiler.getExtraCMakeArgs(request())).toEqual([
+            '-DCUDAToolkit_ROOT=/opt/compiler-explorer/cuda/12.5.1',
+        ]);
+    });
+
+    it("prefers the user's cuda path over the compiler's", () => {
+        const compiler = makeCompiler('--cuda-path=/opt/compiler-explorer/cuda/12.5.1');
+        expect(compiler.getExtraCMakeArgs(request(['--cuda-path=/some/other/cuda']))).toEqual([
+            '-DCUDAToolkit_ROOT=/some/other/cuda',
+        ]);
+    });
+
+    it('adds nothing when no cuda path is given', () => {
+        expect(makeCompiler('--cuda-gpu-arch=sm_90').getExtraCMakeArgs(request())).toEqual([]);
     });
 });


### PR DESCRIPTION
CMake projects fail on every cuda clang compiler. CMake finds the toolkit through nvcc, so nvcc compilers need no help; clang is told where the toolkit is with `--cuda-path`, which CMake reads neither from the flags nor from the compiler.

Verified on prod with a minimal project, `find_package(CUDAToolkit REQUIRED)`:

| compiler | project | result |
|---|---|---|
| `nvcc133` | `project(CUDA)` | configures, `Found CUDAToolkit ... 13.3.33` |
| `cuclang1910` | `project(CUDA)` | `Compiler Clang requires the CUDA toolkit. Please set the CUDAToolkit_ROOT` |
| `cuclang1910` | `project(CXX)` | `Could not find nvcc executable in any searched paths, please set CUDAToolkit_ROOT` |

Note the CUDA-language case fails inside `CMakeCUDAFindToolkit.cmake` while enabling the language, before `find_package` gets a look in, so this isn't only about projects that call `find_package(CUDAToolkit)` themselves.

`ClangCudaCompiler.getExtraCMakeArgs` now passes the root through. The user's options are checked first so an explicit `--cuda-path` still wins, then the compiler's own.

Same root cause as compiler-explorer/infra#2304, which fixed it for our own kokkos-cuda library builds; this is the runtime half.

One thing I did not touch, in case it's a separate bug worth its own issue: `getCmakeBaseEnv` sets only `CUDACXX` for cuda-language compilers, never `CXX`. A `project(CXX)` build with `cuclang1910` selected therefore compiles with the system `/usr/bin/c++` (identified as GNU 13.3.0 on prod) rather than the selected clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)