### PR TITLE
Recompile when the options field is edited without a keystroke

### DIFF
--- a/cypress/e2e/compile.cy.ts
+++ b/cypress/e2e/compile.cy.ts
@@ -106,6 +106,18 @@ int cypress_test_inactive(void) { return 0; }
         monacoEditorTextShouldContain(compilerOutput(), 'cypress_test_active');
         monacoEditorTextShouldNotContain(compilerOutput(), 'cypress_test_inactive');
     });
+
+    it('should recompile when the options change without a keystroke', () => {
+        // Regression test for #8984: the field listened for "keyup" and "change"
+        // only, so an edit that involves no key press left the compilation stale
+        // until the field lost focus. A middle-click paste in Firefox dispatches
+        // "input" and no key event, which is what this reproduces; the same holds
+        // for drag and drop and for autofill.
+        compilerPane().find('input.options').invoke('val', '-DCYPRESS_TEST').trigger('input');
+
+        monacoEditorTextShouldContain(compilerOutput(), 'cypress_test_active');
+        monacoEditorTextShouldNotContain(compilerOutput(), 'cypress_test_inactive');
+    });
 });
 
 describe('Output filters', () => {

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -3156,7 +3156,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
             this.onOptionsChange(unwrapString($(e.target).val()));
         }, 800);
 
-        this.optionsField.on('change', optionsChange).on('keyup', optionsChange);
+        // "input" rather than "keyup": it covers every edit, including the ones that
+        // involve no keystroke at all (middle-click paste, drag and drop, autofill).
+        this.optionsField.on('change', optionsChange).on('input', optionsChange);
 
         this.mouseMoveThrottledFunction = _.throttle(this.onMouseMove.bind(this), 50);
         this.editor.onMouseMove(e => {

--- a/static/panes/conformance-view.ts
+++ b/static/panes/conformance-view.ts
@@ -228,7 +228,7 @@ export class Conformance extends Pane<ConformanceViewState> {
             .find('.conformance-options')
             .val(config.options)
             .on('change', onOptionsChange)
-            .on('keyup', onOptionsChange);
+            .on('input', onOptionsChange);
 
         newSelector.find('.close-compiler').on('click', () => {
             this.removeCompilerPicker(newCompilerEntry);

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -978,11 +978,11 @@ export class Executor extends Pane<ExecutorState> {
             this.onExecStdinChange($(e.target).val() as string);
         }, 800);
 
-        this.optionsField.on('change', optionsChange).on('keyup', optionsChange);
+        this.optionsField.on('change', optionsChange).on('input', optionsChange);
 
-        this.execArgsField.on('change', execArgsChange).on('keyup', execArgsChange);
+        this.execArgsField.on('change', execArgsChange).on('input', execArgsChange);
 
-        this.execStdinField.on('change', execStdinChange).on('keyup', execStdinChange);
+        this.execStdinField.on('change', execStdinChange).on('input', execStdinChange);
 
         // Dismiss the popover on escape.
         $(document).on('keyup.editable', e => {

--- a/static/panes/tool.ts
+++ b/static/panes/tool.ts
@@ -207,13 +207,13 @@ export class Tool extends MonacoPane<monaco.editor.IStandaloneCodeEditor, ToolSt
             this.eventHub.emit('toolSettingsChange', this.compilerInfo.compilerId);
         }, 800);
 
-        this.optionsField.on('change', optionsChange).on('keyup', optionsChange);
+        this.optionsField.on('change', optionsChange).on('input', optionsChange);
 
         if (state.args) {
             this.optionsField.val(state.args);
         }
 
-        this.localStdinField.on('change', optionsChange).on('keyup', optionsChange);
+        this.localStdinField.on('change', optionsChange).on('input', optionsChange);
 
         if (state.stdin) {
             if (!this.monacoStdin) {


### PR DESCRIPTION
Closes #8984.

### What happens

The compiler options field binds its debounced handler to two events:

```ts
this.optionsField.on('change', optionsChange).on('keyup', optionsChange);
```

`keyup` covers typing and Ctrl+V, since both end with a key release. It does not cover an edit made with no key at all. A middle-click paste in Firefox sets the value and dispatches `input`, so nothing runs until the field loses focus and `change` fires. That is #8984: the text lands in the box, the compilation stays stale, and a link shared at that moment carries the old options. Drag and drop into the field and autofill behave the same way.

### The fix

Bind `input` in place of `keyup`. It fires for every user edit of the value, keyboard ones included, so typing and Ctrl+V work exactly as before. It also stops firing for arrow keys and modifiers, which never changed the value but did wake the debounce.

`change` stays bound, so the programmatic `optionsField.change()` in the "add argument" button path is unaffected.

The same pair was used for six other fields that take the same kinds of edit: the executor's options, execution arguments and stdin, the tool pane's options and stdin, and the conformance view's options. They are changed too, since leaving them on `keyup` would keep the same symptom in the executor's options box. Happy to cut this back to the compiler pane alone if you would rather review the rest separately.

### Tests

A case was added to the `Compiler options` block that already exists in `cypress/e2e/compile.cy.ts`, next to the `-DCYPRESS_TEST` one. It sets the value and fires `input` with no keyboard event, which is what a middle-click paste produces.

Measured both ways against a local instance, restarting the server each time so the served bundle matched the source:

- with the change: 15 passing
- with only the four source files reverted: 14 passing, and the new case fails with `expected 'cypress_test_inactive(): ...' to include 'cypress_test_active'`

`npm run check` is green: type checks, biome over 825 files, the frontend import and license header scripts, and 121 test files.

### What I could not test

An actual middle-click paste. I am on Windows, which has no primary selection to paste from, so the test dispatches the `input` event that the Firefox paste produces rather than performing the paste itself. The Chromium half of the report, where nothing is pasted at all, is browser behaviour and is not addressed here.
