### PR TITLE
Key LibsWidget consistently, so the conformance view keeps its libraries

### DIFF
--- a/static/tests/widgets/libs-widget-tests.ts
+++ b/static/tests/widgets/libs-widget-tests.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {describe, expect, it} from 'vitest';
+
+import type {CompilerInfo} from '../../../types/compiler.interfaces.js';
+import {DEFAULT_COMPILER_KEY, toCompilerKey} from '../../widgets/libs-widget.js';
+
+const fakeCompiler = {id: 'g142', name: 'x86-64 gcc 14.2'} as unknown as CompilerInfo;
+
+describe('LibsWidget compiler key', () => {
+    it('reads the id off a compiler object, as the compiler and executor panes pass', () => {
+        expect(toCompilerKey(fakeCompiler)).toBe('g142');
+    });
+
+    it('takes an id string as-is, as the conformance view passes', () => {
+        expect(toCompilerKey('g142|clang1500')).toBe('g142|clang1500');
+    });
+
+    it('agrees with itself across the two call shapes for the same compiler', () => {
+        expect(toCompilerKey('g142')).toBe(toCompilerKey(fakeCompiler));
+    });
+
+    it('falls back to the default key for every empty shape', () => {
+        expect(toCompilerKey(undefined)).toBe(DEFAULT_COMPILER_KEY);
+        expect(toCompilerKey(null)).toBe(DEFAULT_COMPILER_KEY);
+        expect(toCompilerKey('')).toBe(DEFAULT_COMPILER_KEY);
+    });
+
+    it('never yields undefined, which is what keyed the conformance view into a dead bucket', () => {
+        for (const shape of [fakeCompiler, 'g142|clang1500', '', null, undefined]) {
+            expect(typeof toCompilerKey(shape)).toBe('string');
+        }
+    });
+});

--- a/static/widgets/libs-widget.ts
+++ b/static/widgets/libs-widget.ts
@@ -25,6 +25,7 @@
 import $ from 'jquery';
 
 import {unwrapString} from '../../shared/assert.js';
+import type {CompilerInfo} from '../../types/compiler.interfaces.js';
 import * as BootstrapUtils from '../bootstrap-utils.js';
 import {localStorage} from '../local.js';
 import {Library, LibraryVersion} from '../options.interfaces.js';
@@ -36,7 +37,25 @@ import {Alert} from './alert.js';
 import {Lib, WidgetState} from './libs-widget.interfaces.js';
 
 const FAV_LIBS_STORE_KEY = 'favlibs';
-const c_default_compiler_non_id = '_default_';
+
+/** The bucket libs land in when no compiler is selected yet. */
+export const DEFAULT_COMPILER_KEY = '_default_';
+
+/**
+ * The key `availableLibs` is bucketed by.
+ *
+ * Two call shapes reach this widget. The compiler and executor panes own one
+ * compiler each and pass the `CompilerInfo`. The conformance view tracks
+ * several at once and passes their ids joined with `|`, because the libraries
+ * it offers are the intersection across all of them. `setNewLangId` already
+ * took the string form while the constructor only read `.id`, so a widget
+ * built from a string keyed itself on `undefined` and then silently re-keyed
+ * the first time a compiler changed, orphaning every lib recorded until then.
+ */
+export function toCompilerKey(compiler: CompilerInfo | string | null | undefined): string {
+    const id = typeof compiler === 'string' ? compiler : compiler?.id;
+    return id === undefined || id === '' ? DEFAULT_COMPILER_KEY : id;
+}
 
 export type CompilerLibs = Record<string, Library>;
 type LangLibs = Record<string, CompilerLibs>;
@@ -103,7 +122,7 @@ class LibraryAnnotations {
 }
 
 async function getCompilerName(compilerId: string, langId: string): Promise<string> {
-    if (compilerId === c_default_compiler_non_id) {
+    if (compilerId === DEFAULT_COMPILER_KEY) {
         return 'compiler';
     }
 
@@ -161,18 +180,16 @@ export class LibsWidget {
 
     constructor(
         langId: string,
-        compiler: any,
+        compiler: CompilerInfo | string | null | undefined,
         dropdownButton: JQuery,
         state: WidgetState,
         onChangeCallback: () => void,
         possibleLibs: CompilerLibs,
     ) {
         this.dropdownButton = dropdownButton;
-        if (compiler) {
-            this.currentCompilerId = compiler.id;
+        this.currentCompilerId = toCompilerKey(compiler);
+        if (compiler && typeof compiler !== 'string') {
             this.currentCompilerName = compiler.name ?? '';
-        } else {
-            this.currentCompilerId = c_default_compiler_non_id;
         }
         this.currentLangId = langId;
         this.domRoot = $('#library-selection').clone(true);
@@ -656,7 +673,7 @@ export class LibsWidget {
         }
 
         if (!(this.currentCompilerId in this.availableLibs[this.currentLangId])) {
-            if (this.currentCompilerId === '_default_') {
+            if (this.currentCompilerId === DEFAULT_COMPILER_KEY) {
                 const allLibs = await libsService.getLibsForLang(this.currentLangId);
                 this.availableLibs[this.currentLangId][this.currentCompilerId] = $.extend(true, {}, allLibs);
             } else {
@@ -676,13 +693,8 @@ export class LibsWidget {
 
         this.currentLangId = langId;
 
-        if (compilerId) {
-            this.currentCompilerId = compilerId;
-            this.currentCompilerName = (await getCompilerName(compilerId, langId)) || compilerId;
-        } else {
-            this.currentCompilerId = '_default_';
-            this.currentCompilerName = '';
-        }
+        this.currentCompilerId = toCompilerKey(compilerId);
+        this.currentCompilerName = compilerId ? (await getCompilerName(compilerId, langId)) || compilerId : '';
 
         // Clear the dom Root so it gets rebuilt with the new language libraries
         await this.updateAvailableLibs(possibleLibs, isLangChanged);


### PR DESCRIPTION
Fixes #9007.

`LibsWidget` buckets `availableLibs` by compiler id, and it had two disagreeing ways of deciding that key.

The constructor read `compiler.id`. `setNewLangId` took a plain id string. The compiler and executor panes pass a `CompilerInfo`, so they matched the constructor. The conformance view passes `compilerIds.join('|')`, because the libraries it offers are the intersection across every compiler in the pane, so it matched `setNewLangId` instead. The parameter was typed `any`, so nothing complained.

Reading `.id` off a string gives `undefined`. So a conformance view restored from a link:

1. builds the widget with the joined id and keys itself on `undefined`,
2. loads the saved libs into `availableLibs[langId][undefined]`,
3. gets a real compiler-change event once the picker resolves, which calls `updateLibraries` and then `setNewLangId` with the same joined string,
4. is now keyed on `"g142|clang1500"`, where nothing was ever recorded.

`listUsedLibs` reads the new bucket, finds nothing, and the libraries are gone. Re-adding one through the green button writes it into the new bucket, which is why that workaround sticks, exactly as the reporter describes.

Both paths now go through one `toCompilerKey`, so the key cannot change shape mid-life. The parameter is typed instead of `any`, which is what let the two conventions coexist.

One deliberate behavior change beyond the bug: a compiler whose `id` is the empty string now falls into `_default_` from the constructor too. `setNewLangId` already treated it that way through its falsy check, so this makes the two agree rather than inventing a third rule.

The local `c_default_compiler_non_id` becomes the exported `DEFAULT_COMPILER_KEY`, and the two places that spelled the same value as a bare `'_default_'` literal now use it. Same value throughout, one name.

## What I ran

`npm run check` passes: ts-check on both projects, biome over 826 files, frontend imports, license headers, and the test run.

New test file `static/tests/widgets/libs-widget-tests.ts`, 5 cases over `toCompilerKey`, covering both call shapes, that they agree for the same compiler, every empty shape landing on the default, and that no shape can yield a non-string. All 5 fail before the change and pass after.

The one failure in the suite, `test/build-systems-tests.ts > Maven build system > builds Kotlin ...`, also fails on a clean `main` on my machine. It is a symlink `realpath` comparison and I am on Windows.

I did not reproduce the symptom in a browser: I cannot run the server locally, since it needs at least one compiler on POSIX paths. The chain above is read off the code and pinned by the unit test at the point where the two conventions met. If you would rather see a test that drives the whole widget through construct then `setNewLangId`, say so and I will add it.
