### PR TITLE
Fix blank right-hand pane in tree shortlink layouts

### DIFF
--- a/lib/clientstate-normalizer.ts
+++ b/lib/clientstate-normalizer.ts
@@ -779,9 +779,10 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
         };
     }
 
-    newEmptyColumn(): BasicGoldenLayoutStruct {
+    newEmptyColumn(width?: number): BasicGoldenLayoutStruct {
         return {
             type: 'column',
+            width: width,
             content: [],
         };
     }
@@ -1105,15 +1106,17 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
         let contentRow;
         let extraRow;
 
+        // A stack may only ever hold components; putting a row in one renders as a blank, untitled tab.
         if (leaveSomeSpace) {
             contentRow = this.newEmptyRow(50);
             extraRow = this.newEmptyRow(50);
             rightSide = this.newEmptyColumn();
-            rightSide.content.push(contentRow, extraRow);
         } else {
-            rightSide = this.newEmptyStack(40);
             contentRow = this.newEmptyRow(100);
+            rightSide = this.newEmptyColumn(40);
         }
+        rightSide.content.push(contentRow);
+        if (extraRow) rightSide.content.push(extraRow);
 
         let idxCompiler = 0;
         for (const compiler of firstTree.compilers) {
@@ -1128,10 +1131,16 @@ export class ClientStateGoldenifier extends GoldenLayoutComponents {
             idxCompiler++;
         }
 
-        rightSide.content.push(contentRow);
+        for (const executor of firstTree.executors) {
+            contentRow.content.push(this.createExecutorComponentForTree(firstTree, executor));
+        }
 
         assert(this.golden.content);
-        this.golden.content[0].content.push(leftSide, middle, rightSide);
+        this.golden.content[0].content.push(leftSide, middle);
+        // With nothing to put on the right, adding it anyway just reserves a blank slice of the screen.
+        if (contentRow.content.length > 0 || extraRow) {
+            this.golden.content[0].content.push(rightSide);
+        }
 
         return extraRow;
     }

--- a/test/state/tree-executor-only.json
+++ b/test/state/tree-executor-only.json
@@ -1,0 +1,115 @@
+{
+    "sessions": [
+        {
+            "id": 1,
+            "language": "cmake",
+            "source": "add_executable(output main.cpp)\n",
+            "conformanceview": false,
+            "compilers": [],
+            "executors": [],
+            "filename": "CMakeLists.txt"
+        },
+        {
+            "id": 2,
+            "language": "c++",
+            "source": "int apply() { return 0; }\n",
+            "conformanceview": false,
+            "compilers": [],
+            "executors": [],
+            "filename": "plugin.cpp"
+        },
+        {
+            "id": 3,
+            "language": "c++",
+            "source": "int main() {}\n",
+            "conformanceview": false,
+            "compilers": [],
+            "executors": [],
+            "filename": "main.cpp"
+        }
+    ],
+    "trees": [
+        {
+            "id": 1,
+            "cmakeArgs": "",
+            "customOutputFilename": "output",
+            "isCMakeProject": true,
+            "buildSystem": "cmake",
+            "compilerLanguageId": "c++",
+            "files": [
+                {
+                    "isIncluded": true,
+                    "isOpen": true,
+                    "isMainSource": true,
+                    "filename": "CMakeLists.txt",
+                    "content": "add_executable(output main.cpp)\n",
+                    "editorId": 1,
+                    "langId": "c++"
+                },
+                {
+                    "isIncluded": true,
+                    "isOpen": false,
+                    "isMainSource": false,
+                    "filename": "config.h",
+                    "content": "#pragma once\n",
+                    "editorId": -1,
+                    "langId": "c++"
+                },
+                {
+                    "isIncluded": true,
+                    "isOpen": true,
+                    "isMainSource": false,
+                    "filename": "plugin.cpp",
+                    "content": "int apply() { return 0; }\n",
+                    "editorId": 2,
+                    "langId": "c++"
+                },
+                {
+                    "isIncluded": true,
+                    "isOpen": true,
+                    "isMainSource": false,
+                    "filename": "main.cpp",
+                    "content": "int main() {}\n",
+                    "editorId": 3,
+                    "langId": "c++"
+                }
+            ],
+            "newFileId": 5,
+            "compilers": [],
+            "executors": [
+                {
+                    "compilerVisible": true,
+                    "compilerOutputVisible": true,
+                    "arguments": "",
+                    "argumentsVisible": false,
+                    "stdin": "",
+                    "stdinVisible": false,
+                    "compiler": {
+                        "id": "clang2110",
+                        "options": "-Wno-invalid-offsetof",
+                        "filters": {
+                            "binary": false,
+                            "binaryObject": false,
+                            "commentOnly": true,
+                            "demangle": true,
+                            "directives": true,
+                            "execute": false,
+                            "intel": true,
+                            "labels": true,
+                            "libraryCode": false,
+                            "trim": false,
+                            "debugCalls": false
+                        },
+                        "libs": [],
+                        "specialoutputs": [],
+                        "tools": [],
+                        "overrides": []
+                    },
+                    "wrap": false,
+                    "runtimeTools": [],
+                    "overrides": []
+                }
+            ]
+        }
+    ]
+}

--- a/test/state/tree.goldenified.json
+++ b/test/state/tree.goldenified.json
@@ -158,7 +158,7 @@
           ]
         },
         {
-          "type": "stack",
+          "type": "column",
           "width": 40,
           "content": [
             {

--- a/test/statenormalisation-tests.ts
+++ b/test/statenormalisation-tests.ts
@@ -204,6 +204,79 @@ describe('Trees', () => {
         expect(normalized).toEqual(resultdata);
     });
 
+    // A stack may only hold components; anything else renders as a blank, untitled tab.
+    function expectNoNestedStacks(golden: any) {
+        const check = (item: any) => {
+            if (item.type === 'stack') {
+                for (const child of item.content ?? []) {
+                    expect(child.type).toEqual('component');
+                }
+            }
+            for (const child of item.content ?? []) check(child);
+        };
+        check({content: golden.content});
+    }
+
+    function componentNamesOf(golden: any): string[] {
+        const names: string[] = [];
+        const collect = (item: any) => {
+            if (item.componentName) names.push(item.componentName);
+            for (const child of item.content ?? []) collect(child);
+        };
+        collect({content: golden.content});
+        return names;
+    }
+
+    // https://godbolt.org/z/59q8GYa5z: a CMake tree whose only pane is an executor, with no
+    // editor-attached compilers or executors either. The right hand pane came out empty.
+    function goldenifyExecutorOnlyTree(mutate?: (state: ClientState) => void) {
+        const jsonStr = fs.readFileSync('test/state/tree-executor-only.json', {encoding: 'utf8'});
+        const state = new ClientState(JSON.parse(jsonStr));
+        expect(state.trees.length).toEqual(1);
+        mutate?.(state);
+
+        const gl = new ClientStateGoldenifier();
+        gl.fromClientState(state);
+
+        const golden = JSON.parse(JSON.stringify(gl.golden));
+        expectNoNestedStacks(golden);
+        return golden;
+    }
+
+    it('ClientState to GL with only a tree executor', () => {
+        const golden = goldenifyExecutorOnlyTree(state => {
+            expect(state.trees[0].compilers.length).toEqual(0);
+            expect(state.trees[0].executors.length).toEqual(1);
+        });
+
+        expect(componentNamesOf(golden)).toContain('executor');
+    });
+
+    it('ClientState to GL with only a tree compiler', () => {
+        const treeJson = fs.readFileSync('test/state/tree.json', {encoding: 'utf8'});
+        const treeCompiler = new ClientState(JSON.parse(treeJson)).trees[0].compilers[0];
+
+        const golden = goldenifyExecutorOnlyTree(state => {
+            state.trees[0].compilers = [treeCompiler];
+            state.trees[0].executors = [];
+        });
+
+        const names = componentNamesOf(golden);
+        expect(names).toContain('compiler');
+        expect(names).not.toContain('executor');
+    });
+
+    it('ClientState to GL with neither tree compilers nor executors', () => {
+        const golden = goldenifyExecutorOnlyTree(state => {
+            state.trees[0].compilers = [];
+            state.trees[0].executors = [];
+        });
+
+        // Nothing to show on the right, so no empty pane should be reserved for it.
+        expect(componentNamesOf(golden)).toEqual(['tree', 'codeEditor', 'codeEditor', 'codeEditor']);
+        expect(golden.content[0].content.length).toEqual(2);
+    });
+
     it('ClientState to Mobile GL', () => {
         const jsonStr = fs.readFileSync('test/state/tree-mobile.json', {encoding: 'utf8'});
         const state = new ClientState(JSON.parse(jsonStr));


### PR DESCRIPTION
Reported via https://godbolt.org/z/59q8GYa5z — a CMake tree whose only pane is an executor. The right hand side rendered as an empty black box.

The layout is generated server-side by `ClientStateGoldenifier.treeLayoutFromClientstate`, which had three problems:

1. **Tree executors were never laid out at all.** Only `firstTree.compilers` was iterated; `createExecutorComponentForTree` was reachable solely from the presentation-mode path. This is what left the reported link's pane empty.
2. **The right hand side was a `stack` holding a `row`.** A GoldenLayout stack may only contain components, so the row showed up as a blank, untitled tab. It's now a `column` in both branches. This one affected *every* tree shortlink without editor-attached compilers or executors, including the existing `tree.goldenified.json` fixture.
3. **`contentRow` was pushed twice** in the `leaveSomeSpace` branch — once alongside `extraRow`, once at the end — duplicating the tree compiler pane.

Additionally, when a tree has neither compilers nor executors the right hand side is now skipped entirely rather than reserving a dead 40% of the screen for an empty row.

## Tests

New fixture `test/state/tree-executor-only.json` (the reported link's state, sources trimmed) plus three cases covering the tree shapes: executor-only, compiler-only, and neither. They assert that no stack holds a non-component child, and that the expected components reach the layout.

`tree.goldenified.json` needed a one-line update for the `stack` → `column` change.

## Verification

- `npm run lint`, `npm run ts-check` clean
- Full suite: 2628 passed, 1 skipped
- All three tree shapes loaded in a local dev server and checked in the browser: the executor pane now renders titled "Executor x86-64 clang 21.1.0 (C++, Tree #1)" with its compiler picker; the compiler-only case shows compiler + output with no phantom tab; the empty case fills the width with tree + editors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)