### PR TITLE
Add TileLang as a compile-only language

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -444,6 +444,13 @@
           - 'etc/config/tablegen.*.properties'
           - 'static/modes/tablegen-mode.ts'
 
+'lang-tilelang':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/compilers/tilelang.ts'
+          - 'etc/config/tilelang.*.properties'
+          - 'etc/scripts/tilelang_wrapper.py'
+
 'lang-toit':
   - changed-files:
       - any-glob-to-any-file:

--- a/etc/config/tilelang.defaults.properties
+++ b/etc/config/tilelang.defaults.properties
@@ -1,0 +1,17 @@
+compilers=&tilelang
+defaultCompiler=tilelang_0113
+compilerType=tilelang
+interpreted=true
+supportsBinary=false
+supportsBinaryObject=false
+supportsExecute=false
+needsMulti=false
+isSemVer=true
+notification=Experimental TileLang compile-only support. Default target is CPU C (no GPU). CUDA is later.
+
+group.tilelang.compilers=tilelang_0113
+group.tilelang.groupName=TileLang
+
+compiler.tilelang_0113.name=TileLang 0.1.13
+compiler.tilelang_0113.exe=/opt/compiler-explorer/tilelang/v0.1.13/bin/python3
+compiler.tilelang_0113.semver=0.1.13

--- a/etc/scripts/tilelang_wrapper.py
+++ b/etc/scripts/tilelang_wrapper.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, Compiler Explorer Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Compiler Explorer wrapper for TileLang compile-only output.
+
+CE invokes::
+
+    python3 -I tilelang_wrapper.py --output_file out.s example.py
+
+This forwards to the official CLI (default ``--target c``)::
+
+    python3 -I -m tilelang.tools.compile_only --output_file out.s example.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="TileLang Compiler Explorer wrapper")
+    parser.add_argument("input_file", type=Path, help="Path to the input Python file")
+    parser.add_argument(
+        "--output_file",
+        type=Path,
+        required=True,
+        help="Path to the output kernel source",
+    )
+    parser.add_argument(
+        "--target",
+        default="c",
+        help="Explicit tilelang target (default: c). CUDA is later.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        from tilelang.tools.compile_only import cli_main
+    except ModuleNotFoundError as exc:
+        print(
+            "tilelang compile-only error: tilelang is not importable. "
+            "Use a Python with tilelang installed. "
+            f"Missing module: {exc.name}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return cli_main(
+        [
+            str(args.input_file),
+            "--output_file",
+            str(args.output_file),
+            "--target",
+            args.target,
+        ]
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/tilelang/default.py
+++ b/examples/tilelang/default.py
@@ -1,0 +1,14 @@
+import tilelang
+import tilelang.language as T
+
+
+@tilelang.jit
+def add(A, B):
+    N = 64
+    A: T.Tensor((N,), T.float16)
+    B: T.Tensor((N,), T.float16)
+    C = T.empty((N,), T.float16)
+    with T.Kernel(1, threads=64):
+        for i in T.Parallel(N):
+            C[i] = A[i] + B[i]
+    return C

--- a/lib/compilers/_all.ts
+++ b/lib/compilers/_all.ts
@@ -174,6 +174,7 @@ export {SwiftCompiler} from './swift.js';
 export {TableGenCompiler} from './tablegen.js';
 export {TenDRACompiler} from './tendra.js';
 export {TIC2000} from './tic2000.js';
+export {TileLangCompiler} from './tilelang.js';
 export {TinyCCompiler} from './tinyc.js';
 export {TinyGoCompiler} from './tinygo.js';
 export {ToitCompiler} from './toit.js';

--- a/lib/compilers/tilelang.ts
+++ b/lib/compilers/tilelang.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import type {PreliminaryCompilerInfo} from '../../types/compiler.interfaces.js';
+import type {ParseFiltersAndOutputOptions} from '../../types/features/filters.interfaces.js';
+import {BaseCompiler} from '../base-compiler.js';
+import {CompilationEnvironment} from '../compilation-env.js';
+import {resolvePathFromAppRoot} from '../utils.js';
+import {BaseParser} from './argument-parsers.js';
+
+export class TileLangCompiler extends BaseCompiler {
+    private compilerWrapperPath: string;
+
+    static get key() {
+        return 'tilelang';
+    }
+
+    constructor(compilerInfo: PreliminaryCompilerInfo, env: CompilationEnvironment) {
+        super(compilerInfo, env);
+        this.compilerWrapperPath =
+            this.compilerProps('compilerWrapper', '') ||
+            resolvePathFromAppRoot('etc', 'scripts', 'tilelang_wrapper.py');
+    }
+
+    override getCompilerResultLanguageId(_filters?: ParseFiltersAndOutputOptions): string | undefined {
+        // Default compile-only target is CPU C (D7). CUDA-in-CE is later.
+        return 'nc';
+    }
+
+    override optionsForFilter(_filters: ParseFiltersAndOutputOptions, outputFilename: string): string[] {
+        // Wrapper contract: python3 -I tilelang_wrapper.py --output_file out.s example.py
+        return ['-I', this.compilerWrapperPath, '--output_file', outputFilename];
+    }
+
+    override getArgumentParserClass() {
+        return BaseParser;
+    }
+
+    override getDefaultFilters() {
+        return {
+            intel: false,
+            commentOnly: false,
+            directives: false,
+            labels: false,
+            optOutput: true,
+            binary: false,
+            execute: false,
+            demangle: false,
+            libraryCode: false,
+            trim: false,
+            binaryObject: false,
+            debugCalls: false,
+        };
+    }
+}

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -1030,6 +1030,17 @@ const definitions: Record<LanguageKey, LanguageDefinition> = {
         previewFilter: null,
         monacoDisassembly: null,
     },
+    tilelang: {
+        name: 'TileLang',
+        monaco: 'python',
+        extensions: ['.py'],
+        alias: ['tile-lang'],
+        logoFilename: null,
+        logoFilenameDark: null,
+        formatter: null,
+        previewFilter: null,
+        monacoDisassembly: 'nc',
+    },
     toit: {
         name: 'Toit',
         monaco: 'toit',

--- a/types/languages.interfaces.ts
+++ b/types/languages.interfaces.ts
@@ -112,6 +112,7 @@ export type LanguageKey =
     | 'sway'
     | 'swift'
     | 'tablegen'
+    | 'tilelang'
     | 'toit'
     | 'triton'
     | 'typescript'


### PR DESCRIPTION
Compile-only TileLang. Followed the Triton/Helion wrapper; it calls `tilelang.tools.compile_only`.

tilelang: https://github.com/tile-ai/tilelang/pull/3045
infra: https://github.com/compiler-explorer/infra/pull/2307
