### PR TITLE
Add Compiler Explorer to the official MCP Registry

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -28,6 +28,30 @@ For Claude Code on the command line:
 claude mcp add --transport http compiler-explorer https://godbolt.org/mcp
 ```
 
+## Registry listing
+
+The server is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io)
+as `io.github.compiler-explorer/compiler-explorer`. The registry stores *metadata* only — it
+records where the endpoint lives, not what is running behind it — so publishing is deliberately
+not part of a deploy. Nothing here changes when the site updates.
+
+The published record is [`server.json`](../server.json) in the repository root. Re-publish only
+when that file changes:
+
+1. Edit `server.json` and bump its `version`. Published versions are immutable and the registry
+   rejects a repeat of one that already exists. It versions the metadata record, and has nothing
+   to do with CE's `gh-NNNNN` build numbers.
+2. Install [`mcp-publisher`](https://github.com/modelcontextprotocol/registry/releases) and run:
+
+   ```sh
+   mcp-publisher login github   # requires Owner/admin on the compiler-explorer org
+   mcp-publisher validate
+   mcp-publisher publish
+   ```
+
+The `io.github.compiler-explorer/*` namespace is granted by GitHub org ownership, so no DNS
+records or domain proofs are involved.
+
 ## Tools
 
 Successful responses are JSON in a single `text` content block. Error responses set

--- a/server.json
+++ b/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.compiler-explorer/compiler-explorer",
+  "title": "Compiler Explorer",
+  "description": "Compile code with thousands of compilers, inspect the assembly, and share godbolt.org links",
+  "version": "1.0.0",
+  "websiteUrl": "https://godbolt.org/",
+  "repository": {
+    "url": "https://github.com/compiler-explorer/compiler-explorer",
+    "source": "github",
+    "id": "4414698"
+  },
+  "icons": [
+    {
+      "src": "https://static.ce-cdn.net/site-logo.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": ["any"]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://godbolt.org/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Lists CE's public MCP endpoint (`https://godbolt.org/mcp`) in the [official MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.compiler-explorer/compiler-explorer`.

### What's here

- `server.json` — the registry record. Validated with `mcp-publisher validate` against the live registry.
- `docs/MCP.md` — a "Registry listing" section covering how and when to re-publish.

### Notes for review

**Publishing is deliberately not wired to a deploy.** The registry stores metadata only — it records where the endpoint is, not what's running behind it. Nothing in the record changes when the site updates, and the registry rejects a repeat of an existing version, so a publish on every deploy would simply fail. `server.json`'s `version` identifies the *metadata record*; it's unrelated to `gh-NNNNN` build numbers. Re-publish by hand on the rare occasion the file changes (documented in `docs/MCP.md`). No CI workflow, and no infra changes.

**The namespace comes from GitHub org ownership**, not DNS — `io.github.compiler-explorer/*` is granted to Owners/admins of the org, so no TXT records or `.well-known` files are involved. It was chosen over `org.godbolt/*` because the GitHub identity has exactly one name, sidestepping the godbolt.org / compiler-explorer.com question.

**`name` is the one field that can't be changed later.** The URL, description and icon all live in a versioned record and can be updated by bumping the version and re-publishing — worth a second look at that line specifically.

Not yet published — that needs a `mcp-publisher login github` device-code auth from an org admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)