### PR TITLE
Add library dispenso

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5941,6 +5941,14 @@ libs.dawjson.versions.trunk.path=/opt/compiler-explorer/libs/dawjson/trunk/inclu
 libs.dawjson.versions.2911.version=2.9.11
 libs.dawjson.versions.2911.path=/opt/compiler-explorer/libs/dawjson/v2.9.11/include
 
+libs.dispenso.name=dispenso
+libs.dispenso.description=High-performance concurrency: thread pools, parallel loops, futures, task graphs, and concurrent containers
+libs.dispenso.url=https://github.com/facebookincubator/dispenso
+libs.dispenso.packagedheaders=true
+libs.dispenso.staticliblink=dispenso
+libs.dispenso.versions=162
+libs.dispenso.versions.162.version=1.6.2
+
 libs.dlib.name=dlib
 libs.dlib.description=Machine learning algorithms and tools
 libs.dlib.versions=197:199:1910:trunk


### PR DESCRIPTION
Companion to compiler-explorer/infra#2309, which adds the build recipe. This is
the properties half that makes the library selectable.

[dispenso](https://github.com/facebookincubator/dispenso) is a C++ library for
parallel programming — thread pools, `parallel_for`, futures, task graphs and
concurrent containers. MIT licensed, C++14 baseline, C++20 supported. I'm one of
its maintainers.

Adding v1.6.1. dispenso is a compiled library rather than header-only, so this
uses `staticliblink` alongside `packagedheaders=true`; the recipe builds it with
`lib_type: static`, so the two agree. No `.path=` entries, since the install
prefix contains exactly `include/` and `lib/` and `packagedheaders` derives the
include path from the package. I modelled the block on `kokkos`, which is the
closest existing entry structurally.

No `dependencies` are needed: on Linux a consumer linking only `-ldispenso`,
with no `-pthread`, compiles and runs correctly — glibc 2.34 folds libpthread
into libc — and the 32-bit build links without `-latomic`. Both were checked
directly rather than assumed. The recipe PR has the full verification detail.

I could not run `npm run test:props` locally (no suitable node on the machine I
have). Instead I lifted the regexes and rules out of `lib/properties-validator.ts`
and replicated its checks over the modified file, comparing before against
after: +7 keys, and zero newly introduced duplicate keys, empty list elements,
malformed lines, or orphaned lib versions in either direction. That is a
replication rather than the real test, so CI is the authority here.

Once dispenso is building and selectable I'd like to follow up with a
`libs.dispenso.examples=` shortlink, the same way `libs.tbb.examples` works.
