### PR TITLE
Keep the /app/ prefix in the compilation options shown to the user

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2094,7 +2094,10 @@ export class BaseCompiler {
     protected maskPathsInArgumentsForUser(args: string[]): string[] {
         const maskedArgs: string[] = [];
         for (const arg of args) {
-            maskedArgs.push(utils.maskRootdir(arg));
+            // Keep the `/app/` prefix: these are shown as the command line the compiler
+            // ran, and dropping it made the source file look relative while the compiler
+            // was given an absolute path.
+            maskedArgs.push(utils.maskRootdirKeepingAppPrefix(arg));
         }
         return maskedArgs;
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -129,6 +129,9 @@ export function maskRootdirKeepingAppPrefix(filepath: string): string {
  *  note: will keep /app/ if instead of filepath something like '-I/tmp/path' is used
  */
 export function maskRootdir(filepath: string): string {
+    // Same load-bearing guard as the function above: it hands a falsy argument straight
+    // back, so an undefined that slipped through a type hole must not reach the strip.
+    if (!filepath) return filepath;
     // The trailing /app/ strip is anchored (no backtracking) and must run regardless, as
     // paths may already be /app/-rooted from an earlier mask.
     return maskRootdirKeepingAppPrefix(filepath).replace(/^\/app\//, '');

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -107,23 +107,31 @@ export function expandTabs(line: string): string {
 const TEMPDIR_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]+/)*${ce_temp_prefix}[\\w.-]*/`);
 
 /**
- * Removes the root dir from the given filepath, so that it will match to the user's filenames used
- *  note: will keep /app/ if instead of filepath something like '-I/tmp/path' is used
+ * Rewrites a CE temp dir down to `/app/`, and stops there. That is the path the compiler
+ * is really given, and what `__FILE__` and friends expand to, so anything that shows the
+ * user a command line has to keep the prefix. Use maskRootdir() for output lines instead.
  */
-export function maskRootdir(filepath: string): string {
+export function maskRootdirKeepingAppPrefix(filepath: string): string {
     // TODO: this falsy guard is load-bearing against runtime `undefined` that the types
     // don't catch — not declared `string | undefined` callers (TS would reject those),
     // but type holes: a JSON.parse(...) result typed `any` (base-compiler cleanup) and a
     // Record<number,string> index that's really `undefined` when the key is missing
     // (noUncheckedIndexedAccess is off). Tighten those two sites, then this can go.
     if (!filepath) return filepath;
-    // TEMPDIR_RE has a repeated path-segment group that backtracks on long input, and
-    // maskRootdir runs on every output line. Gate it behind a cheap linear substring
-    // check: the regex cannot match without the marker anyway. The trailing /app/ strip
-    // is anchored (no backtracking) and must run regardless, as paths may already be
-    // /app/-rooted from an earlier mask.
-    const masked = filepath.includes(ce_temp_prefix) ? filepath.replace(TEMPDIR_RE, '/app/') : filepath;
-    return masked.replace(/^\/app\//, '');
+    // TEMPDIR_RE has a repeated path-segment group that backtracks on long input, and this
+    // runs on every output line. Gate it behind a cheap linear substring check: the regex
+    // cannot match without the marker anyway.
+    return filepath.includes(ce_temp_prefix) ? filepath.replace(TEMPDIR_RE, '/app/') : filepath;
+}
+
+/**
+ * Removes the root dir from the given filepath, so that it will match to the user's filenames used
+ *  note: will keep /app/ if instead of filepath something like '-I/tmp/path' is used
+ */
+export function maskRootdir(filepath: string): string {
+    // The trailing /app/ strip is anchored (no backtracking) and must run regardless, as
+    // paths may already be /app/-rooted from an earlier mask.
+    return maskRootdirKeepingAppPrefix(filepath).replace(/^\/app\//, '');
 }
 
 export function changeExtension(filename: string, newExtension: string): string {

--- a/test/base-compiler-tests.ts
+++ b/test/base-compiler-tests.ts
@@ -70,6 +70,17 @@ describe('Basic compiler invariants', () => {
         expect(compiler.optOutputRequested(['please', "don't", 'recognize'])).toBe(false);
     });
 
+    it('should keep /app/ on the arguments it reports to the user', () => {
+        expect(
+            compiler['maskPathsInArgumentsForUser']([
+                '-O3',
+                '-o',
+                '/tmp/compiler-explorer-compiler123-4-abc/output.s',
+                '/tmp/compiler-explorer-compiler123-4-abc/example.cpp',
+            ]),
+        ).toEqual(['-O3', '-o', '/app/output.s', '/app/example.cpp']);
+    });
+
     it('should skip version check if forced to', async () => {
         const newConfig: Partial<CompilerInfo> = {...info, explicitVersion: '123'};
         const forcedVersionCompiler = new BaseCompiler(newConfig as CompilerInfo, ce);

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -827,6 +827,13 @@ describe('maskRootdir', () => {
         expect(utils.maskRootdir('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
 
+    // Callers reach here through type holes that hand over an undefined, which is what the
+    // falsy guard is for. Both entry points have to survive it, not just one.
+    it.each([undefined, null, ''])('hands %p straight back', input => {
+        expect(utils.maskRootdir(input as unknown as string)).toEqual(input);
+        expect(utils.maskRootdirKeepingAppPrefix(input as unknown as string)).toEqual(input);
+    });
+
     // The marker segment must be followed by `/`, so a bare dir with no trailing slash
     // is left alone. (Real inputs always name a file inside the dir.)
     it('leaves a bare temp dir with no trailing slash untouched', () => {

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -785,6 +785,24 @@ describe('output files', async () => {
     });
 });
 
+describe('maskRootdirKeepingAppPrefix', () => {
+    it('keeps the /app/ prefix, which is the path the compiler is given', () => {
+        expect(utils.maskRootdirKeepingAppPrefix('/tmp/compiler-explorer-compiler123-4-abc/example.cpp')).toEqual(
+            '/app/example.cpp',
+        );
+    });
+
+    it('masks an embedded temp path the same way maskRootdir does', () => {
+        expect(utils.maskRootdirKeepingAppPrefix('-I/tmp/compiler-explorer-compiler123-4-abc/include')).toEqual(
+            '-I/app/include',
+        );
+    });
+
+    it('leaves non-temp paths untouched', () => {
+        expect(utils.maskRootdirKeepingAppPrefix('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
+    });
+});
+
 describe('maskRootdir', () => {
     it('masks a CE temp path down to the user-facing filename', () => {
         expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc/example.cpp')).toEqual('example.cpp');


### PR DESCRIPTION
Fixes #8648.

`maskRootdir` strips a leading `/app/`, so the "All compilation options" popup shows the source as `example.cpp` while the compiler is handed `/app/example.cpp`. The same line already shows `-I/app/include` and `-o/app/output.s`, because those keep the prefix, so today it is inconsistent with itself.

Checked against production before touching anything, compiling `const char* f = __FILE__;`:

```
compilationOptions: ['-g', '-o', 'output.s', '-masm=intel', '-fno-verbose-asm', '-S', '-fdiagnostics-color=always', '-O0', 'example.cpp']
asm:                .string "/app/example.cpp"
```

That is what makes it worth fixing rather than cosmetic: `__FILE__` in C, `file!()` in Rust and anything else that echoes the input path give the user a value the popup contradicts.

The change adds `maskRootdirKeepingAppPrefix` and uses it in `maskPathsInArgumentsForUser`, which is the only caller feeding that popup. Output lines keep going through `maskRootdir`, so diagnostics are untouched.

`npm run check` passes here except for the Maven Kotlin test, which fails the same way on a clean checkout on this machine (symlink realpath on Windows).

One part of the issue I did not fix: the `/nosym/tmp/compiler-explorer-.../example.rs` path reported on the first compilation. `maskRootdir` handles that shape correctly when I feed it directly, so it looks like a result that never reaches the masking, and I could not reproduce it.
