### PR TITLE
Remove temp directories per request instead of leaving them to the sweep

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -444,6 +444,16 @@ export class BaseCompiler {
         return await temp.mkdir(utils.ce_temp_prefix, options);
     }
 
+    /**
+     * Remove a temporary directory this compiler is finished with, rather than leaving it for the sweep: that only
+     * runs when the queue is idle, which a busy server seldom is. Safe to call more than once, and on a directory
+     * that is already gone. Compilers that delay cleanup keep everything for the sweep.
+     */
+    async removeTempDir(dirPath: string) {
+        if (this.delayCleanupTemp) return;
+        await fs.rm(dirPath, {recursive: true, force: true}).catch(() => {});
+    }
+
     optOutputRequested(options: string[]) {
         return options.includes('-fsave-optimization-record');
     }
@@ -492,45 +502,47 @@ export class BaseCompiler {
             options.customCwd = await this.newTempDir({hold: true});
         }
 
-        const key = this.getCompilerCacheKey(compiler, args, optionsForCache);
-        const hash = BaseCache.hash(key);
+        try {
+            const key = this.getCompilerCacheKey(compiler, args, optionsForCache);
+            const hash = BaseCache.hash(key);
 
-        let result = await this.env.compilerCacheGet(key);
-        if (result) {
-            if (exec.hasNsjailPermissionsIssue(result)) {
-                logger.info(`Throwing out faulty cached result with nsjail permissions issue for ${compiler}`);
-                result = undefined;
+            let result = await this.env.compilerCacheGet(key);
+            if (result) {
+                if (exec.hasNsjailPermissionsIssue(result)) {
+                    logger.info(`Throwing out faulty cached result with nsjail permissions issue for ${compiler}`);
+                    result = undefined;
+                }
+            }
+
+            if (!result && this.env.willBeInCacheSoon(hash)) {
+                result = await this.env.enqueue(async () => {
+                    return await this.env.compilerCacheGet(key);
+                });
+            }
+
+            if (!result) {
+                this.env.setCachingInProgress(hash);
+                result = await this.env.enqueue(async () => {
+                    const res = await this.exec(compiler, args, options);
+                    if (res.okToCache) {
+                        try {
+                            await this.env.compilerCachePut(key, res, undefined);
+                        } catch (e) {
+                            logger.info('Uncaught exception caching compilation results', e);
+                        }
+                    }
+                    this.env.clearCachingInProgress(hash);
+                    return res;
+                });
+            }
+
+            return result;
+        } finally {
+            if (options.createAndUseTempDir) {
+                temp.release(options.customCwd!);
+                fs.rm(options.customCwd!, {recursive: true, force: true}).catch(() => {});
             }
         }
-
-        if (!result && this.env.willBeInCacheSoon(hash)) {
-            result = await this.env.enqueue(async () => {
-                return await this.env.compilerCacheGet(key);
-            });
-        }
-
-        if (!result) {
-            this.env.setCachingInProgress(hash);
-            result = await this.env.enqueue(async () => {
-                const res = await this.exec(compiler, args, options);
-                if (res.okToCache) {
-                    try {
-                        await this.env.compilerCachePut(key, res, undefined);
-                    } catch (e) {
-                        logger.info('Uncaught exception caching compilation results', e);
-                    }
-                }
-                this.env.clearCachingInProgress(hash);
-                return res;
-            });
-        }
-
-        if (options.createAndUseTempDir) {
-            temp.release(options.customCwd!);
-            fs.rm(options.customCwd!, {recursive: true, force: true}).catch(() => {});
-        }
-
-        return result;
     }
 
     protected getExtraPaths(): string[] {
@@ -2217,7 +2229,23 @@ export class BaseCompiler {
         executablePackageHash: string,
     ): Promise<BuildResult> {
         const dirPath = await this.newTempDir();
+        try {
+            const buildResult = await this.getOrBuildExecutableIn(key, bypassCache, executablePackageHash, dirPath);
+            // However the build went, the directory is the caller's from here: it runs what is in it, and removes it.
+            if (!buildResult.dirPath) buildResult.dirPath = dirPath;
+            return buildResult;
+        } catch (e) {
+            await this.removeTempDir(dirPath);
+            throw e;
+        }
+    }
 
+    private async getOrBuildExecutableIn(
+        key: CacheKey,
+        bypassCache: BypassCache,
+        executablePackageHash: string,
+        dirPath: string,
+    ): Promise<BuildResult> {
         if (!bypassCompilationCache(bypassCache)) {
             const buildResult = await this.loadPackageWithExecutable(key, executablePackageHash, dirPath);
             if (buildResult) return buildResult;
@@ -2240,10 +2268,6 @@ export class BaseCompiler {
         await this.storePackageWithExecutable(executablePackageHash, dirPath, buildResult);
         const packageStoreEnd = process.hrtime.bigint();
         buildResult.packageStoreTime = utils.deltaTimeNanoToMili(packageStoreStart, packageStoreEnd);
-
-        if (!buildResult.dirPath) {
-            buildResult.dirPath = dirPath;
-        }
 
         return buildResult;
     }
@@ -2375,32 +2399,36 @@ export class BaseCompiler {
     async handleInterpreting(key: CacheKey, executeParameters: ExecutableExecutionOptions): Promise<CompilationResult> {
         const source = key.source;
         const dirPath = await this.newTempDir();
-        const outputFilename = this.getExecutableFilename(dirPath, this.outputFilebase);
+        try {
+            const outputFilename = this.getExecutableFilename(dirPath, this.outputFilebase);
 
-        // cant use this.writeAllFiles here because outputFilename is used as the file to execute
-        //  instead of inputFilename
+            // cant use this.writeAllFiles here because outputFilename is used as the file to execute
+            //  instead of inputFilename
 
-        await fs.writeFile(outputFilename, source);
-        if (key.files && key.files.length > 0) {
-            await this.writeMultipleFiles(key.files, dirPath);
+            await fs.writeFile(outputFilename, source);
+            if (key.files && key.files.length > 0) {
+                await this.writeMultipleFiles(key.files, dirPath);
+            }
+
+            this.fixExecuteParametersForInterpreting(executeParameters, outputFilename);
+
+            const result = await this.runExecutable(this.compiler.exe, executeParameters, dirPath);
+            return {
+                ...result,
+                didExecute: true,
+                buildResult: {
+                    code: 0,
+                    timedOut: false,
+                    stdout: [],
+                    stderr: [],
+                    downloads: [],
+                    executableFilename: outputFilename,
+                    compilationOptions: [],
+                },
+            };
+        } finally {
+            await this.removeTempDir(dirPath);
         }
-
-        this.fixExecuteParametersForInterpreting(executeParameters, outputFilename);
-
-        const result = await this.runExecutable(this.compiler.exe, executeParameters, dirPath);
-        return {
-            ...result,
-            didExecute: true,
-            buildResult: {
-                code: 0,
-                timedOut: false,
-                stdout: [],
-                stderr: [],
-                downloads: [],
-                executableFilename: outputFilename,
-                compilationOptions: [],
-            },
-        };
     }
 
     async doExecution(
@@ -2415,6 +2443,22 @@ export class BaseCompiler {
         const executablePackageHash = this.env.getExecutableHash(key);
 
         const buildResult = await this.getOrBuildExecutable(key, bypassCache, executablePackageHash);
+        try {
+            return await this.executeBuildResult(key, executeParameters, executablePackageHash, buildResult);
+        } catch (e) {
+            // On success the build directory goes back inside the result for the caller to remove once it has
+            // finished with it; a failure here is the last chance to remove it.
+            if (buildResult.dirPath) await this.removeTempDir(buildResult.dirPath);
+            throw e;
+        }
+    }
+
+    private async executeBuildResult(
+        key: CacheKey,
+        executeParameters: ExecutableExecutionOptions,
+        executablePackageHash: string,
+        buildResult: BuildResult,
+    ): Promise<CompilationResult> {
         if (buildResult.code !== 0) {
             return {
                 code: -1,
@@ -2819,9 +2863,7 @@ export class BaseCompiler {
     }
 
     async doTempfolderCleanup(buildResult: BuildResult | CompilationResult) {
-        if (buildResult.dirPath && !this.delayCleanupTemp) {
-            await fs.rm(buildResult.dirPath, {recursive: true, force: true}).catch(() => {});
-        }
+        if (buildResult.dirPath) await this.removeTempDir(buildResult.dirPath);
         buildResult.dirPath = undefined;
     }
 
@@ -3060,50 +3102,65 @@ export class BaseCompiler {
                 async () => {
                     compilationQueueTimeHistogram.observe((performance.now() - queueTime) / 1000);
 
-                    const build = await this.prepareProjectBuild(
-                        buildSystem,
-                        parsedRequest,
-                        files,
-                        libsAndOptions,
-                        toolchainPath,
-                        cacheKey,
-                        executablePackageHash,
-                    );
-                    const {dirPath, outputFilename} = build;
-
-                    let fullResult: CompilationResult | undefined;
-                    if (packaged) {
-                        // Falls through to building it if the package turns out not to be usable.
-                        const cached: CompilationResult | false = await this.unpackExecutablePackage(
-                            packaged,
+                    const dirPath = await this.newTempDir();
+                    try {
+                        const build = await this.prepareProjectBuild(
+                            buildSystem,
+                            parsedRequest,
+                            files,
+                            libsAndOptions,
+                            toolchainPath,
                             cacheKey,
                             executablePackageHash,
                             dirPath,
                         );
-                        if (cached) {
-                            cached.retreivedFromCache = true;
-                            cached.s3Key = BaseCache.hash(cacheKey);
+                        const {outputFilename} = build;
 
-                            delete cached.inputFilename;
-                            delete cached.dirPath;
-                            cached.executableFilename = outputFilename;
-                            fullResult = cached;
+                        let fullResult: CompilationResult | undefined;
+                        if (packaged) {
+                            // Falls through to building it if the package turns out not to be usable.
+                            const cached: CompilationResult | false = await this.unpackExecutablePackage(
+                                packaged,
+                                cacheKey,
+                                executablePackageHash,
+                                dirPath,
+                            );
+                            if (cached) {
+                                cached.retreivedFromCache = true;
+                                cached.s3Key = BaseCache.hash(cacheKey);
+
+                                delete cached.inputFilename;
+                                delete cached.dirPath;
+                                cached.executableFilename = outputFilename;
+                                fullResult = cached;
+                            }
                         }
+                        if (!fullResult) fullResult = await this.runProjectBuild(build, parsedRequest);
+
+                        // Where the post-processing finds what was built, whichever way it got here: a package
+                        // carries the path of the directory it was made in, not the one it was unpacked into.
+                        if (fullResult.result) fullResult.result.dirPath = dirPath;
+                        if (doExecute) await this.executeProjectArtifact(build, fullResult);
+
+                        return await this.finishProjectBuild(
+                            build,
+                            fullResult,
+                            parsedRequest,
+                            libsAndOptions,
+                            bypassCache,
+                        );
+                    } finally {
+                        // Only once everything is done with it: the executable was run from it, and the tools and
+                        // post-processing in finishProjectBuild read from it.
+                        await this.removeTempDir(dirPath);
                     }
-                    if (!fullResult) fullResult = await this.runProjectBuild(build, parsedRequest);
-
-                    // Wanted by the cleanup at the end whether or not there is anything to run.
-                    if (fullResult.result) fullResult.result.dirPath = dirPath;
-                    if (doExecute) await this.executeProjectArtifact(build, fullResult);
-
-                    return await this.finishProjectBuild(build, fullResult, parsedRequest, libsAndOptions, bypassCache);
                 },
                 {abandonIfStale: !packaged},
             ),
         );
     }
 
-    /** Where a project build happens and what it is building, worked out before any of it starts. */
+    /** What a project build is building and how, worked out before any of it starts in the directory given. */
     private async prepareProjectBuild(
         buildSystem: BuildSystemDriver,
         parsedRequest: ParsedRequest,
@@ -3112,9 +3169,8 @@ export class BaseCompiler {
         toolchainPath: string | undefined,
         cacheKey: CmakeCacheKey,
         executablePackageHash: string,
+        dirPath: string,
     ): Promise<ProjectBuild> {
-        const dirPath = await this.newTempDir();
-
         // todo: executeOptions.env should be set??
         const executeOptions: ExecutableExecutionOptions = {
             args: parsedRequest.executeParameters.args || [],
@@ -3364,13 +3420,9 @@ export class BaseCompiler {
             buildContext.buildPath,
         );
 
+        // The directory itself is removed by buildProject once this returns; only the paths go from the result.
+        delete fullResult.dirPath;
         if (fullResult.result) delete fullResult.result.dirPath;
-
-        // Cleanup temp directory after execution is complete
-        await this.doTempfolderCleanup(fullResult);
-        if (fullResult.result) {
-            await this.doTempfolderCleanup(fullResult.result);
-        }
 
         this.cleanupResult(fullResult);
         fullResult.s3Key = BaseCache.hash(cacheKey);
@@ -3500,39 +3552,44 @@ export class BaseCompiler {
                     }
 
                     const dirPath = await this.newTempDir();
-
-                    let writeSummary;
                     try {
-                        writeSummary = await this.writeAllFiles(dirPath, source, files);
-                    } catch (e) {
-                        return this.handleUserError(e, dirPath);
+                        let writeSummary;
+                        try {
+                            writeSummary = await this.writeAllFiles(dirPath, source, files);
+                        } catch (e) {
+                            return this.handleUserError(e, dirPath);
+                        }
+                        const inputFilename = writeSummary.inputFilename;
+
+                        const [result, optOutput, stackUsageOutput] = await this.doCompilation(
+                            inputFilename,
+                            dirPath,
+                            key,
+                            options,
+                            filters,
+                            backendOptions,
+                            libraries,
+                            tools,
+                        );
+
+                        return await this.afterCompilation(
+                            result,
+                            doExecute!,
+                            key,
+                            executeOptions,
+                            tools,
+                            backendOptions,
+                            filters,
+                            options,
+                            optOutput,
+                            stackUsageOutput,
+                            bypassCache,
+                        );
+                    } finally {
+                        // Ordinarily already gone, afterCompilation having removed it once everything that reads
+                        // from it was done; this catches the paths that return or throw before that.
+                        await this.removeTempDir(dirPath);
                     }
-                    const inputFilename = writeSummary.inputFilename;
-
-                    const [result, optOutput, stackUsageOutput] = await this.doCompilation(
-                        inputFilename,
-                        dirPath,
-                        key,
-                        options,
-                        filters,
-                        backendOptions,
-                        libraries,
-                        tools,
-                    );
-
-                    return await this.afterCompilation(
-                        result,
-                        doExecute!,
-                        key,
-                        executeOptions,
-                        tools,
-                        backendOptions,
-                        filters,
-                        options,
-                        optOutput,
-                        stackUsageOutput,
-                        bypassCache,
-                    );
                 })();
                 compilationTimeHistogram.observe((performance.now() - start) / 1000);
                 return res;

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -454,6 +454,20 @@ export class BaseCompiler {
         await fs.rm(dirPath, {recursive: true, force: true}).catch(() => {});
     }
 
+    /**
+     * Run `fn` in a fresh temporary directory that is removed once it returns or throws. For work that is done with
+     * its directory by the time it answers; anything that hands the directory on (see getOrBuildExecutable) cannot
+     * use this.
+     */
+    async withTempDir<T>(fn: (dirPath: string) => Promise<T>): Promise<T> {
+        const dirPath = await this.newTempDir();
+        try {
+            return await fn(dirPath);
+        } finally {
+            await this.removeTempDir(dirPath);
+        }
+    }
+
     optOutputRequested(options: string[]) {
         return options.includes('-fsave-optimization-record');
     }
@@ -2398,8 +2412,7 @@ export class BaseCompiler {
 
     async handleInterpreting(key: CacheKey, executeParameters: ExecutableExecutionOptions): Promise<CompilationResult> {
         const source = key.source;
-        const dirPath = await this.newTempDir();
-        try {
+        return await this.withTempDir(async dirPath => {
             const outputFilename = this.getExecutableFilename(dirPath, this.outputFilebase);
 
             // cant use this.writeAllFiles here because outputFilename is used as the file to execute
@@ -2426,9 +2439,7 @@ export class BaseCompiler {
                     compilationOptions: [],
                 },
             };
-        } finally {
-            await this.removeTempDir(dirPath);
-        }
+        });
     }
 
     async doExecution(
@@ -2441,13 +2452,26 @@ export class BaseCompiler {
         }
 
         const executablePackageHash = this.env.getExecutableHash(key);
+        return await this.withBuiltExecutable(key, bypassCache, executablePackageHash, buildResult =>
+            this.executeBuildResult(key, executeParameters, executablePackageHash, buildResult),
+        );
+    }
 
+    /**
+     * Build (or fetch) the executable for `key` and hand it to `fn` to run. The result `fn` returns carries the
+     * build directory for the caller to remove once it has finished with it (see doTempfolderCleanup); if `fn`
+     * throws instead, this is the last chance to remove it.
+     */
+    protected async withBuiltExecutable(
+        key: CacheKey,
+        bypassCache: BypassCache,
+        executablePackageHash: string,
+        fn: (buildResult: BuildResult) => Promise<CompilationResult>,
+    ): Promise<CompilationResult> {
         const buildResult = await this.getOrBuildExecutable(key, bypassCache, executablePackageHash);
         try {
-            return await this.executeBuildResult(key, executeParameters, executablePackageHash, buildResult);
+            return await fn(buildResult);
         } catch (e) {
-            // On success the build directory goes back inside the result for the caller to remove once it has
-            // finished with it; a failure here is the last chance to remove it.
             if (buildResult.dirPath) await this.removeTempDir(buildResult.dirPath);
             throw e;
         }
@@ -3102,8 +3126,9 @@ export class BaseCompiler {
                 async () => {
                     compilationQueueTimeHistogram.observe((performance.now() - queueTime) / 1000);
 
-                    const dirPath = await this.newTempDir();
-                    try {
+                    // Removed only once everything is done with it: the executable is run from it, and the tools
+                    // and post-processing in finishProjectBuild read from it.
+                    return await this.withTempDir(async dirPath => {
                         const build = await this.prepareProjectBuild(
                             buildSystem,
                             parsedRequest,
@@ -3149,11 +3174,7 @@ export class BaseCompiler {
                             libsAndOptions,
                             bypassCache,
                         );
-                    } finally {
-                        // Only once everything is done with it: the executable was run from it, and the tools and
-                        // post-processing in finishProjectBuild read from it.
-                        await this.removeTempDir(dirPath);
-                    }
+                    });
                 },
                 {abandonIfStale: !packaged},
             ),
@@ -3551,8 +3572,9 @@ export class BaseCompiler {
                         return execResult;
                     }
 
-                    const dirPath = await this.newTempDir();
-                    try {
+                    // Ordinarily gone before this returns, afterCompilation having removed it once everything that
+                    // reads from it was done; withTempDir catches the paths that return or throw before that.
+                    return await this.withTempDir(async dirPath => {
                         let writeSummary;
                         try {
                             writeSummary = await this.writeAllFiles(dirPath, source, files);
@@ -3585,11 +3607,7 @@ export class BaseCompiler {
                             stackUsageOutput,
                             bypassCache,
                         );
-                    } finally {
-                        // Ordinarily already gone, afterCompilation having removed it once everything that reads
-                        // from it was done; this catches the paths that return or throw before that.
-                        await this.removeTempDir(dirPath);
-                    }
+                    });
                 })();
                 compilationTimeHistogram.observe((performance.now() - start) / 1000);
                 return res;

--- a/lib/compilers/cerberus.ts
+++ b/lib/compilers/cerberus.ts
@@ -91,30 +91,31 @@ export class CerberusCompiler extends BaseCompiler {
 
     override async handleInterpreting(key: CacheKey, executeParameters: ExecutableExecutionOptions) {
         const executionPackageHash = this.env.getExecutableHash(key);
-        const compileResult = await this.getOrBuildExecutable(key, BypassCache.None, executionPackageHash);
-        assert(compileResult.dirPath !== undefined);
-        if (compileResult.code === 0) {
-            executeParameters.args = [
-                '--exec',
-                this.getOutputFilename(compileResult.dirPath),
-                '--',
-                ...executeParameters.args,
-            ];
-            const result = await this.runExecutable(this.compiler.exe, executeParameters, compileResult.dirPath);
+        return await this.withBuiltExecutable(key, BypassCache.None, executionPackageHash, async compileResult => {
+            assert(compileResult.dirPath !== undefined);
+            if (compileResult.code === 0) {
+                executeParameters.args = [
+                    '--exec',
+                    this.getOutputFilename(compileResult.dirPath),
+                    '--',
+                    ...executeParameters.args,
+                ];
+                const result = await this.runExecutable(this.compiler.exe, executeParameters, compileResult.dirPath);
+                return {
+                    ...result,
+                    didExecute: true,
+                    buildResult: compileResult,
+                };
+            }
             return {
-                ...result,
-                didExecute: true,
+                stdout: compileResult.stdout,
+                stderr: compileResult.stderr,
+                code: compileResult.code,
+                didExecute: false,
                 buildResult: compileResult,
+                timedOut: false,
             };
-        }
-        return {
-            stdout: compileResult.stdout,
-            stderr: compileResult.stderr,
-            code: compileResult.code,
-            didExecute: false,
-            buildResult: compileResult,
-            timedOut: false,
-        };
+        });
     }
 
     override async processAsm(result): Promise<ParsedAsmResult> {

--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -187,6 +187,7 @@ export class ClangCompiler extends BaseCompiler {
         stackUsageOutput: StackUsageInfo[] | undefined,
         bypassCache: BypassCache,
         customBuildPath?: string,
+        delayCaching?: boolean,
     ) {
         const compilationInfo = this.getCompilationInfo(key, result, customBuildPath);
 
@@ -207,6 +208,7 @@ export class ClangCompiler extends BaseCompiler {
             stackUsageOutput,
             bypassCache,
             customBuildPath,
+            delayCaching,
         );
     }
 

--- a/lib/compilers/dosbox-compiler.ts
+++ b/lib/compilers/dosbox-compiler.ts
@@ -143,19 +143,23 @@ export class DosboxCompiler extends BaseCompiler {
 
         execOptions.env = this.getDosboxEnv();
 
-        if (!execOptions.customCwd) {
-            execOptions.customCwd = await this.newTempDir();
+        // A directory made here is nobody else's to read from once this returns, so it can go then.
+        const ownTempDir = execOptions.customCwd ? undefined : await this.newTempDir();
+        if (ownTempDir) execOptions.customCwd = ownTempDir;
+
+        try {
+            const tempDir = execOptions.customCwd;
+            const fullArgs = this.getDosboxArgs(tempDir, args);
+
+            const result = await exec.executeDirect(this.dosbox, fullArgs, execOptions);
+
+            const stdoutFilename = path.join(tempDir, 'STDOUT.TXT');
+            result.stdout = await fs.readFile(stdoutFilename, 'utf-8');
+
+            return result;
+        } finally {
+            if (ownTempDir) await this.removeTempDir(ownTempDir);
         }
-
-        const tempDir = execOptions.customCwd;
-        const fullArgs = this.getDosboxArgs(tempDir, args);
-
-        const result = await exec.executeDirect(this.dosbox, fullArgs, execOptions);
-
-        const stdoutFilename = path.join(tempDir, 'STDOUT.TXT');
-        result.stdout = await fs.readFile(stdoutFilename, 'utf-8');
-
-        return result;
     }
 
     public override async runCompiler(

--- a/lib/compilers/dosbox-compiler.ts
+++ b/lib/compilers/dosbox-compiler.ts
@@ -143,23 +143,15 @@ export class DosboxCompiler extends BaseCompiler {
 
         execOptions.env = this.getDosboxEnv();
 
-        // A directory made here is nobody else's to read from once this returns, so it can go then.
-        const ownTempDir = execOptions.customCwd ? undefined : await this.newTempDir();
-        if (ownTempDir) execOptions.customCwd = ownTempDir;
+        if (execOptions.customCwd) return await this.runDosbox(execOptions.customCwd, args, execOptions);
+        // A directory made here is nobody else's to read from once this returns.
+        return await this.withTempDir(tempDir => this.runDosbox(tempDir, args, {...execOptions, customCwd: tempDir}));
+    }
 
-        try {
-            const tempDir = execOptions.customCwd;
-            const fullArgs = this.getDosboxArgs(tempDir, args);
-
-            const result = await exec.executeDirect(this.dosbox, fullArgs, execOptions);
-
-            const stdoutFilename = path.join(tempDir, 'STDOUT.TXT');
-            result.stdout = await fs.readFile(stdoutFilename, 'utf-8');
-
-            return result;
-        } finally {
-            if (ownTempDir) await this.removeTempDir(ownTempDir);
-        }
+    private async runDosbox(tempDir: string, args: string[], execOptions: ExecutionOptionsWithEnv) {
+        const result = await exec.executeDirect(this.dosbox, this.getDosboxArgs(tempDir, args), execOptions);
+        result.stdout = await fs.readFile(path.join(tempDir, 'STDOUT.TXT'), 'utf-8');
+        return result;
     }
 
     public override async runCompiler(

--- a/lib/compilers/java.ts
+++ b/lib/compilers/java.ts
@@ -180,39 +180,40 @@ export class JavaCompiler extends BaseCompiler implements SimpleOutputFilenameCo
         executeParameters: ExecutableExecutionOptions,
     ): Promise<CompilationResult> {
         const executionPackageHash = this.env.getExecutableHash(key);
-        const compileResult = await this.getOrBuildExecutable(key, BypassCache.None, executionPackageHash);
-        if (compileResult.code === 0) {
-            const extraXXFlags: string[] = [];
-            if (Semver.gte(utils.asSafeVer(this.compiler.semver), '11.0.0', true)) {
-                extraXXFlags.push('-XX:-UseDynamicNumberOfCompilerThreads');
+        return await this.withBuiltExecutable(key, BypassCache.None, executionPackageHash, async compileResult => {
+            if (compileResult.code === 0) {
+                const extraXXFlags: string[] = [];
+                if (Semver.gte(utils.asSafeVer(this.compiler.semver), '11.0.0', true)) {
+                    extraXXFlags.push('-XX:-UseDynamicNumberOfCompilerThreads');
+                }
+                assert(compileResult.dirPath !== undefined);
+                executeParameters.args = [
+                    '-Xss136K', // Reduce thread stack size
+                    '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
+                    '-XX:-UseDynamicNumberOfGCThreads',
+                    '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
+                    ...extraXXFlags,
+                    await this.getMainClassName(compileResult.dirPath),
+                    '-cp',
+                    compileResult.dirPath,
+                    ...executeParameters.args,
+                ];
+                const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
+                return {
+                    ...result,
+                    didExecute: true,
+                    buildResult: compileResult,
+                };
             }
-            assert(compileResult.dirPath !== undefined);
-            executeParameters.args = [
-                '-Xss136K', // Reduce thread stack size
-                '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
-                '-XX:-UseDynamicNumberOfGCThreads',
-                '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
-                ...extraXXFlags,
-                await this.getMainClassName(compileResult.dirPath),
-                '-cp',
-                compileResult.dirPath,
-                ...executeParameters.args,
-            ];
-            const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
             return {
-                ...result,
-                didExecute: true,
+                stdout: compileResult.stdout,
+                stderr: compileResult.stderr,
+                code: compileResult.code,
+                didExecute: false,
                 buildResult: compileResult,
+                timedOut: false,
             };
-        }
-        return {
-            stdout: compileResult.stdout,
-            stderr: compileResult.stderr,
-            code: compileResult.code,
-            didExecute: false,
-            buildResult: compileResult,
-            timedOut: false,
-        };
+        });
     }
 
     async getMainClassName(dirPath: string) {

--- a/lib/compilers/kotlin.ts
+++ b/lib/compilers/kotlin.ts
@@ -142,40 +142,46 @@ export class KotlinCompiler extends JavaCompiler implements SimpleOutputFilename
             options: ['-include-runtime', '-d', 'example.jar'],
         };
         const executablePackageHash = this.env.getExecutableHash(key);
-        const compileResult = await this.getOrBuildExecutable(alteredKey, BypassCache.None, executablePackageHash);
-        assert(compileResult.dirPath !== undefined);
-        if (compileResult.code !== 0) {
-            return {
-                stdout: compileResult.stdout,
-                stderr: compileResult.stderr,
-                code: compileResult.code,
-                didExecute: false,
-                buildResult: compileResult,
-                timedOut: false,
-            };
-        }
+        return await this.withBuiltExecutable(
+            alteredKey,
+            BypassCache.None,
+            executablePackageHash,
+            async compileResult => {
+                assert(compileResult.dirPath !== undefined);
+                if (compileResult.code !== 0) {
+                    return {
+                        stdout: compileResult.stdout,
+                        stderr: compileResult.stderr,
+                        code: compileResult.code,
+                        didExecute: false,
+                        buildResult: compileResult,
+                        timedOut: false,
+                    };
+                }
 
-        executeParameters.args = [
-            '-Xss136K', // Reduce thread stack size
-            '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
-            '-XX:-UseDynamicNumberOfCompilerThreads',
-            '-XX:-UseDynamicNumberOfGCThreads',
-            '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
-            '-cp',
-            compileResult.dirPath,
-            '-jar',
-            'example.jar',
-            // -jar <jar> has to be the last java parameter, otherwise it will use
-            // our java parameters as program parameters
-            ...executeParameters.args,
-        ];
+                executeParameters.args = [
+                    '-Xss136K', // Reduce thread stack size
+                    '-XX:CICompilerCount=2', // Reduce JIT compilation threads. 2 is minimum
+                    '-XX:-UseDynamicNumberOfCompilerThreads',
+                    '-XX:-UseDynamicNumberOfGCThreads',
+                    '-XX:+UseSerialGC', // Disable parallell/concurrent garbage collector
+                    '-cp',
+                    compileResult.dirPath,
+                    '-jar',
+                    'example.jar',
+                    // -jar <jar> has to be the last java parameter, otherwise it will use
+                    // our java parameters as program parameters
+                    ...executeParameters.args,
+                ];
 
-        const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
-        return {
-            ...result,
-            didExecute: true,
-            buildResult: compileResult,
-        };
+                const result = await this.runExecutable(this.javaRuntime, executeParameters, compileResult.dirPath);
+                return {
+                    ...result,
+                    didExecute: true,
+                    buildResult: compileResult,
+                };
+            },
+        );
     }
 
     override getArgumentParserClass() {

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -189,30 +189,33 @@ export class RacketCompiler extends BaseCompiler {
     ): Promise<OptPipelineOutput | undefined> {
         // Use a separate directory so this is not affected by the main
         // compilation (which races in parallel)
-        const pipelineDir = await this.newTempDir();
-        let output: CompilationResult;
-        let compileStart: number;
-        let compileEnd: number;
-        try {
-            const inputFile = this.filename(inputFilename);
-            const pipelineFile = path.join(pipelineDir, path.basename(inputFile));
-            await fs.copyFile(inputFile, pipelineFile);
+        return await this.withTempDir(pipelineDir =>
+            this.generateOptPipelineIn(pipelineDir, inputFilename, options, filters, optPipelineOptions),
+        );
+    }
 
-            const execOptions = this.getDefaultExecOptions();
-            execOptions.maxOutput = 1024 * 1024 * 1024;
+    private async generateOptPipelineIn(
+        pipelineDir: string,
+        inputFilename: string,
+        options: string[],
+        filters: ParseFiltersAndOutputOptions,
+        optPipelineOptions: OptPipelineBackendOptions,
+    ): Promise<OptPipelineOutput | undefined> {
+        const inputFile = this.filename(inputFilename);
+        const pipelineFile = path.join(pipelineDir, path.basename(inputFile));
+        await fs.copyFile(inputFile, pipelineFile);
 
-            // Dump various optimisation passes during compilation
-            execOptions.env['PLT_LINKLET_SHOW_CP0'] = '1';
-            execOptions.env['PLT_LINKLET_SHOW_PASSES'] = 'all';
-            execOptions.env['PLT_LINKLET_SHOW_ASSEMBLY'] = '1';
+        const execOptions = this.getDefaultExecOptions();
+        execOptions.maxOutput = 1024 * 1024 * 1024;
 
-            compileStart = performance.now();
-            output = await this.runCompiler(this.compiler.exe, options, pipelineFile, execOptions);
-            compileEnd = performance.now();
-        } finally {
-            // Everything wanted from here on is in the output; the files are not.
-            await this.removeTempDir(pipelineDir);
-        }
+        // Dump various optimisation passes during compilation
+        execOptions.env['PLT_LINKLET_SHOW_CP0'] = '1';
+        execOptions.env['PLT_LINKLET_SHOW_PASSES'] = 'all';
+        execOptions.env['PLT_LINKLET_SHOW_ASSEMBLY'] = '1';
+
+        const compileStart = performance.now();
+        const output = await this.runCompiler(this.compiler.exe, options, pipelineFile, execOptions);
+        const compileEnd = performance.now();
 
         if (output.timedOut) {
             return {

--- a/lib/compilers/racket.ts
+++ b/lib/compilers/racket.ts
@@ -190,21 +190,29 @@ export class RacketCompiler extends BaseCompiler {
         // Use a separate directory so this is not affected by the main
         // compilation (which races in parallel)
         const pipelineDir = await this.newTempDir();
-        const inputFile = this.filename(inputFilename);
-        const pipelineFile = path.join(pipelineDir, path.basename(inputFile));
-        await fs.copyFile(inputFile, pipelineFile);
+        let output: CompilationResult;
+        let compileStart: number;
+        let compileEnd: number;
+        try {
+            const inputFile = this.filename(inputFilename);
+            const pipelineFile = path.join(pipelineDir, path.basename(inputFile));
+            await fs.copyFile(inputFile, pipelineFile);
 
-        const execOptions = this.getDefaultExecOptions();
-        execOptions.maxOutput = 1024 * 1024 * 1024;
+            const execOptions = this.getDefaultExecOptions();
+            execOptions.maxOutput = 1024 * 1024 * 1024;
 
-        // Dump various optimisation passes during compilation
-        execOptions.env['PLT_LINKLET_SHOW_CP0'] = '1';
-        execOptions.env['PLT_LINKLET_SHOW_PASSES'] = 'all';
-        execOptions.env['PLT_LINKLET_SHOW_ASSEMBLY'] = '1';
+            // Dump various optimisation passes during compilation
+            execOptions.env['PLT_LINKLET_SHOW_CP0'] = '1';
+            execOptions.env['PLT_LINKLET_SHOW_PASSES'] = 'all';
+            execOptions.env['PLT_LINKLET_SHOW_ASSEMBLY'] = '1';
 
-        const compileStart = performance.now();
-        const output = await this.runCompiler(this.compiler.exe, options, pipelineFile, execOptions);
-        const compileEnd = performance.now();
+            compileStart = performance.now();
+            output = await this.runCompiler(this.compiler.exe, options, pipelineFile, execOptions);
+            compileEnd = performance.now();
+        } finally {
+            // Everything wanted from here on is in the output; the files are not.
+            await this.removeTempDir(pipelineDir);
+        }
 
         if (output.timedOut) {
             return {

--- a/lib/compilers/sway.ts
+++ b/lib/compilers/sway.ts
@@ -122,14 +122,10 @@ export class SwayCompiler extends BaseCompiler {
         execOptions: ExecutionOptionsWithEnv,
         filters?: Partial<ParseFiltersAndOutputOptions>,
     ): Promise<CompilationResult> {
-        // Make a temp directory for a forc project
-        const projectDir = await this.newTempDir();
-        try {
-            return await this.buildForcProject(projectDir, compiler, options, inputFilename, execOptions, filters);
-        } finally {
-            // Everything the result needs has been read out of it by now.
-            await this.removeTempDir(projectDir);
-        }
+        // Everything the result needs is read out of the forc project directory before this returns.
+        return await this.withTempDir(projectDir =>
+            this.buildForcProject(projectDir, compiler, options, inputFilename, execOptions, filters),
+        );
     }
 
     private async buildForcProject(

--- a/lib/compilers/sway.ts
+++ b/lib/compilers/sway.ts
@@ -124,7 +124,22 @@ export class SwayCompiler extends BaseCompiler {
     ): Promise<CompilationResult> {
         // Make a temp directory for a forc project
         const projectDir = await this.newTempDir();
+        try {
+            return await this.buildForcProject(projectDir, compiler, options, inputFilename, execOptions, filters);
+        } finally {
+            // Everything the result needs has been read out of it by now.
+            await this.removeTempDir(projectDir);
+        }
+    }
 
+    private async buildForcProject(
+        projectDir: string,
+        compiler: string,
+        options: string[],
+        inputFilename: string,
+        execOptions: ExecutionOptionsWithEnv,
+        filters?: Partial<ParseFiltersAndOutputOptions>,
+    ): Promise<CompilationResult> {
         const {symbolsPath} = await setupForcProject(projectDir, inputFilename, this.std);
 
         // Run `forc build`
@@ -220,7 +235,6 @@ export class SwayCompiler extends BaseCompiler {
             inputFilename,
             execTime: buildResult.execTime,
             okToCache: true,
-            dirPath: projectDir,
             irOutput:
                 irLines.length > 0
                     ? {

--- a/lib/execution/base-execution-env.ts
+++ b/lib/execution/base-execution-env.ts
@@ -131,6 +131,11 @@ export class LocalExecutionEnvironment implements IExecutionEnvironment {
         this.buildResult = await this.loadPackageWithExecutable(hash, this.dirPath);
     }
 
+    async cleanup(): Promise<void> {
+        if (this.dirPath === 'not initialized') return;
+        await fs.rm(this.dirPath, {recursive: true, force: true}).catch(() => {});
+    }
+
     protected getDefaultExecOptions(params: ExecutionParams): ExecutionOptionsWithEnv {
         const env: Record<string, string> = {};
         env.PATH = '';

--- a/lib/execution/base-execution-env.ts
+++ b/lib/execution/base-execution-env.ts
@@ -54,7 +54,7 @@ import {ExecutablePackageCacheMiss, IExecutionEnvironment} from './execution-env
 
 export class LocalExecutionEnvironment implements IExecutionEnvironment {
     protected packager: Packager;
-    protected dirPath: string;
+    protected dirPath: string | undefined;
     protected buildResult: BuildResult | undefined;
     protected environment: CompilationEnvironment;
     protected timeoutMs: number;
@@ -77,7 +77,6 @@ export class LocalExecutionEnvironment implements IExecutionEnvironment {
         this.sandboxType = execProps('sandboxType', 'none');
 
         this.packager = new Packager();
-        this.dirPath = 'not initialized';
     }
 
     protected async executableGet(hash: string, destinationFolder: string) {
@@ -132,7 +131,7 @@ export class LocalExecutionEnvironment implements IExecutionEnvironment {
     }
 
     async cleanup(): Promise<void> {
-        if (this.dirPath === 'not initialized') return;
+        if (!this.dirPath) return;
         await fs.rm(this.dirPath, {recursive: true, force: true}).catch(() => {});
     }
 
@@ -176,7 +175,7 @@ export class LocalExecutionEnvironment implements IExecutionEnvironment {
 
     async execute(params: ExecutionParams): Promise<BasicExecutionResult> {
         assert(this.buildResult);
-        assert(this.dirPath !== 'not initialized');
+        assert(this.dirPath);
 
         const execExecutableOptions: ExecutableExecutionOptions = {
             args: typeof params.args === 'string' ? splitArguments(params.args) : params.args || [],

--- a/lib/execution/execution-env.interfaces.ts
+++ b/lib/execution/execution-env.interfaces.ts
@@ -28,7 +28,6 @@ import {BasicExecutionResult, ExecutableExecutionOptions} from '../../types/exec
 export interface IExecutionEnvironment {
     downloadExecutablePackage(hash: string): Promise<void>;
     execute(params: ExecutionParams): Promise<BasicExecutionResult>;
-    /** Remove whatever downloadExecutablePackage put on disk. Harmless when nothing was downloaded. */
     cleanup(): Promise<void>;
     execBinary(
         executable: string,

--- a/lib/execution/execution-env.interfaces.ts
+++ b/lib/execution/execution-env.interfaces.ts
@@ -28,6 +28,8 @@ import {BasicExecutionResult, ExecutableExecutionOptions} from '../../types/exec
 export interface IExecutionEnvironment {
     downloadExecutablePackage(hash: string): Promise<void>;
     execute(params: ExecutionParams): Promise<BasicExecutionResult>;
+    /** Remove whatever downloadExecutablePackage put on disk. Harmless when nothing was downloaded. */
+    cleanup(): Promise<void>;
     execBinary(
         executable: string,
         executeParameters: ExecutableExecutionOptions,

--- a/lib/execution/remote-execution-env.ts
+++ b/lib/execution/remote-execution-env.ts
@@ -57,6 +57,8 @@ export class RemoteExecutionEnvironment implements IExecutionEnvironment {
         throw new Error('Method not implemented.');
     }
 
+    async cleanup(): Promise<void> {}
+
     private async queueRemoteExecution(params: ExecutionParams) {
         await this.execQueue.push(this.triple, {
             guid: this.guid,

--- a/lib/execution/sqs-execution-queue.ts
+++ b/lib/execution/sqs-execution-queue.ts
@@ -159,8 +159,9 @@ async function doOneExecution(
     const msg = await queue.pop();
     if (msg?.guid) {
         const startTime = Date.now();
-        const executor = new LocalExecutionEnvironment(compilationEnvironment);
+        let executor: LocalExecutionEnvironment | undefined;
         try {
+            executor = new LocalExecutionEnvironment(compilationEnvironment);
             await executor.downloadExecutablePackage(msg.hash);
             const result = await executor.execute(msg.params);
 
@@ -190,7 +191,7 @@ async function doOneExecution(
                 duration,
             );
         } finally {
-            await executor.cleanup();
+            await executor?.cleanup();
         }
     }
 }

--- a/lib/execution/sqs-execution-queue.ts
+++ b/lib/execution/sqs-execution-queue.ts
@@ -159,8 +159,8 @@ async function doOneExecution(
     const msg = await queue.pop();
     if (msg?.guid) {
         const startTime = Date.now();
+        const executor = new LocalExecutionEnvironment(compilationEnvironment);
         try {
-            const executor = new LocalExecutionEnvironment(compilationEnvironment);
             await executor.downloadExecutablePackage(msg.hash);
             const result = await executor.execute(msg.params);
 
@@ -189,6 +189,8 @@ async function doOneExecution(
                 },
                 duration,
             );
+        } finally {
+            await executor.cleanup();
         }
     }
 }

--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -382,8 +382,9 @@ export class ApiHandler {
             return;
         }
 
-        const env: IExecutionEnvironment = new LocalExecutionEnvironment(this.compilationEnvironment);
+        let env: IExecutionEnvironment | undefined;
         try {
+            env = new LocalExecutionEnvironment(this.compilationEnvironment);
             await env.downloadExecutablePackage(unwrapString(req.params.hash));
             const execResult = await env.execute(req.body.ExecutionParams);
             logger.debug('execResult', execResult);
@@ -392,7 +393,7 @@ export class ApiHandler {
             logger.error(e);
             next({statusCode: 500, message: 'Internal error'});
         } finally {
-            await env.cleanup();
+            await env?.cleanup();
         }
     }
 

--- a/lib/handlers/api.ts
+++ b/lib/handlers/api.ts
@@ -382,8 +382,8 @@ export class ApiHandler {
             return;
         }
 
+        const env: IExecutionEnvironment = new LocalExecutionEnvironment(this.compilationEnvironment);
         try {
-            const env: IExecutionEnvironment = new LocalExecutionEnvironment(this.compilationEnvironment);
             await env.downloadExecutablePackage(unwrapString(req.params.hash));
             const execResult = await env.execute(req.body.ExecutionParams);
             logger.debug('execResult', execResult);
@@ -391,6 +391,8 @@ export class ApiHandler {
         } catch (e) {
             logger.error(e);
             next({statusCode: 500, message: 'Internal error'});
+        } finally {
+            await env.cleanup();
         }
     }
 

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -90,6 +90,20 @@ function initialise(compilerEnv: CompilationEnvironment) {
             this.set(temp.getStats().numRemoved);
         },
     });
+    new Gauge({
+        name: 'ce_compilation_temp_dirs_already_gone',
+        help: 'Total number of temporary directories the temp system found already removed by their owner',
+        async collect() {
+            this.set(temp.getStats().numAlreadyGone);
+        },
+    });
+    new Gauge({
+        name: 'ce_compilation_temp_dirs_held',
+        help: 'Number of temporary directories currently held by something using them',
+        async collect() {
+            this.set(temp.getStats().numHeld);
+        },
+    });
     const tempDirsBusy = new Counter({
         name: 'ce_compilation_temp_dirs_busy',
         help: 'Total number of times the temp dir system was busy',

--- a/test/base-compiler-temp-dir-tests.ts
+++ b/test/base-compiler-temp-dir-tests.ts
@@ -253,6 +253,31 @@ describe('Per-request temp directory cleanup', () => {
 
             expect(await utils.dirExists(dirs[0])).toBe(false);
         });
+
+        // Java, Kotlin and Cerberus run the built executable themselves from handleInterpreting, through this.
+        it('removes the build directory when what withBuiltExecutable runs throws', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'buildExecutableInFolder').mockResolvedValue({
+                code: 0,
+                okToCache: true,
+                stdout: [],
+                stderr: [],
+                timedOut: false,
+                downloads: [],
+                executableFilename: '',
+                compilationOptions: [],
+            });
+            vi.spyOn(compiler, 'storePackageWithExecutable').mockResolvedValue();
+
+            await expect(
+                (compiler as any).withBuiltExecutable(key(), BypassCache.Compilation, 'hash', async () => {
+                    throw new Error('no main class');
+                }),
+            ).rejects.toThrow('no main class');
+
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
     });
 
     describe('buildProject()', () => {

--- a/test/base-compiler-temp-dir-tests.ts
+++ b/test/base-compiler-temp-dir-tests.ts
@@ -1,0 +1,354 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {BaseCompiler} from '../lib/base-compiler.js';
+import {CompilationEnvironment} from '../lib/compilation-env.js';
+import {LocalExecutionEnvironment} from '../lib/execution/base-execution-env.js';
+import * as utils from '../lib/utils.js';
+import {BypassCache, CompilationResult} from '../types/compilation/compilation.interfaces.js';
+import {BasicExecutionResult} from '../types/execution/execution.interfaces.js';
+import {makeCompilationEnvironment, makeFakeCompilerInfo} from './utils.js';
+
+const languages = {'c++': {id: 'c++'}, javascript: {id: 'javascript'}};
+
+const executedFine: BasicExecutionResult = {
+    code: 0,
+    okToCache: true,
+    filenameTransform: x => x,
+    stdout: [],
+    stderr: [],
+    execTime: 1,
+    timedOut: false,
+};
+
+function compiledResult(dirPath: string): CompilationResult {
+    return {code: 0, okToCache: false, stdout: [], stderr: [], asm: '', timedOut: false, dirPath};
+}
+
+/** The directories a compiler made, in the order it made them, so a test can check what became of each. */
+function trackTempDirs(compiler: BaseCompiler): string[] {
+    const made: string[] = [];
+    const original = compiler.newTempDir.bind(compiler);
+    vi.spyOn(compiler, 'newTempDir').mockImplementation(async options => {
+        const dir = await original(options);
+        made.push(dir);
+        return dir;
+    });
+    return made;
+}
+
+// Each flow here makes a temporary directory, and is expected to have removed it by the time it answers: the sweep
+// that would otherwise reclaim it only runs when the queue is idle.
+describe('Per-request temp directory cleanup', () => {
+    let ce: CompilationEnvironment;
+    let compiler: BaseCompiler;
+
+    beforeEach(() => {
+        ce = makeCompilationEnvironment({languages, doCache: false});
+        compiler = new BaseCompiler(
+            makeFakeCompilerInfo({
+                exe: 'fake-compiler',
+                lang: 'c++',
+                ldPath: [],
+                libPath: [],
+                supportsBinary: true,
+                supportsExecute: true,
+            }),
+            ce,
+        );
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    describe('compile()', () => {
+        const compileSource = () => compiler.compile('int main() {}', [], {}, {}, BypassCache.None, [], {}, [], []);
+
+        it('removes the directory when writing the source fails', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler as any, 'writeAllFiles').mockRejectedValue(new Error('disk full'));
+
+            const result = await compileSource();
+
+            expect(result.code).toBe(-1);
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+
+        it('removes the directory when compilation throws', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'doCompilation').mockRejectedValue(new Error('compiler fell over'));
+
+            await expect(compileSource()).rejects.toThrow('compiler fell over');
+
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+
+        it('removes the directory after a successful compilation', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'doCompilation').mockImplementation(async (_input, dirPath) => [
+                compiledResult(dirPath),
+                [],
+                [],
+            ]);
+
+            const result = await compileSource();
+
+            expect(result.code).toBe(0);
+            expect(result.dirPath).toBeUndefined();
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+    });
+
+    describe('handleInterpreting()', () => {
+        it('removes the directory it ran the source from', async () => {
+            const dirs = trackTempDirs(compiler);
+            let ranFrom: string | undefined;
+            vi.spyOn(compiler, 'runExecutable').mockImplementation(async (_exe, _params, homeDir) => {
+                ranFrom = homeDir;
+                expect(await utils.dirExists(homeDir)).toBe(true);
+                return executedFine;
+            });
+
+            const key = compiler.getCacheKey('print(1)', [], {}, {}, [], [], []);
+            const result = await compiler.handleInterpreting(key, {args: [], stdin: '', ldPath: [], env: {}});
+
+            expect(result.didExecute).toBe(true);
+            expect(ranFrom).toBe(dirs[0]);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+
+        it('removes the directory even when running the source throws', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'runExecutable').mockRejectedValue(new Error('no interpreter'));
+
+            const key = compiler.getCacheKey('print(1)', [], {}, {}, [], [], []);
+            await expect(compiler.handleInterpreting(key, {args: [], stdin: '', ldPath: [], env: {}})).rejects.toThrow(
+                'no interpreter',
+            );
+
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+    });
+
+    describe('getOrBuildExecutable()', () => {
+        const executeParameters = () => ({args: [], stdin: '', ldPath: [], env: {}});
+        const key = () => compiler.getCacheKey('int main() {}', [], {}, {}, [], [], []);
+
+        it('hands back the directory of a failed build so the caller can remove it', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'buildExecutableInFolder').mockResolvedValue({
+                code: 1,
+                okToCache: false,
+                stdout: [],
+                stderr: [{text: 'nope'}],
+                timedOut: false,
+                downloads: [],
+                executableFilename: '',
+                compilationOptions: [],
+            });
+
+            const buildResult = await compiler.getOrBuildExecutable(key(), BypassCache.Compilation, 'hash');
+
+            expect(buildResult.code).toBe(1);
+            expect(buildResult.dirPath).toBe(dirs[0]);
+            expect(await utils.dirExists(dirs[0])).toBe(true);
+        });
+
+        it('removes the directory when the build throws past the user error handler', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'buildExecutableInFolder').mockImplementation(async (_key, dirPath) => ({
+                code: 0,
+                okToCache: true,
+                stdout: [],
+                stderr: [],
+                timedOut: false,
+                downloads: [],
+                executableFilename: `${dirPath}/output.s`,
+                compilationOptions: [],
+            }));
+            vi.spyOn(compiler, 'storePackageWithExecutable').mockRejectedValue(new Error('no cache'));
+
+            await expect(compiler.getOrBuildExecutable(key(), BypassCache.Compilation, 'hash')).rejects.toThrow(
+                'no cache',
+            );
+
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+
+        it('leaves a failed build for compile() to remove once it has reported it', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'buildExecutableInFolder').mockResolvedValue({
+                code: 1,
+                okToCache: false,
+                stdout: [],
+                stderr: [{text: 'nope'}],
+                timedOut: false,
+                downloads: [],
+                executableFilename: '',
+                compilationOptions: [],
+            });
+
+            const result = await compiler.compile(
+                'int main() {}',
+                [],
+                {executorRequest: true},
+                {},
+                BypassCache.Compilation,
+                [],
+                executeParameters(),
+                [],
+                [],
+            );
+
+            expect(result.didExecute).toBe(false);
+            expect(result.buildResult?.dirPath).toBeUndefined();
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+
+        it('removes the build directory when running the executable throws', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler, 'buildExecutableInFolder').mockImplementation(async (_key, dirPath) => ({
+                code: 0,
+                okToCache: true,
+                stdout: [],
+                stderr: [],
+                timedOut: false,
+                downloads: [],
+                executableFilename: `${dirPath}/output.s`,
+                compilationOptions: [],
+            }));
+            vi.spyOn(compiler, 'storePackageWithExecutable').mockResolvedValue();
+            vi.spyOn(utils, 'fileExists').mockResolvedValue(true);
+            vi.spyOn(compiler, 'runExecutable').mockRejectedValue(new Error('sandbox missing'));
+
+            await expect(compiler.doExecution(key(), executeParameters(), BypassCache.Compilation)).rejects.toThrow(
+                'sandbox missing',
+            );
+
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+    });
+
+    describe('buildProject()', () => {
+        const parsedRequest = () => ({
+            source: 'cmake_minimum_required(VERSION 3.5)',
+            options: [],
+            backendOptions: {},
+            filters: {},
+            bypassCache: BypassCache.Compilation,
+            tools: [],
+            executeParameters: {args: [], stdin: ''},
+            libraries: [],
+        });
+        const files = [{filename: 'main.cpp', contents: 'int main() {}'}];
+
+        it('removes the project directory once the build has been post-processed', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler as any, 'runProjectBuild').mockImplementation(async (build: any) => {
+                expect(await utils.dirExists(build.dirPath)).toBe(true);
+                return {
+                    code: 0,
+                    timedOut: false,
+                    stdout: [],
+                    stderr: [],
+                    buildsteps: [],
+                    result: compiledResult(build.dirPath),
+                };
+            });
+
+            const result = await compiler.cmake(files, parsedRequest(), BypassCache.Compilation);
+
+            expect(result.code).toBe(0);
+            expect(result.dirPath).toBeUndefined();
+            expect(result.result?.dirPath).toBeUndefined();
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+
+        it('removes the project directory when the build throws', async () => {
+            const dirs = trackTempDirs(compiler);
+            vi.spyOn(compiler as any, 'runProjectBuild').mockRejectedValue(new Error('cmake exploded'));
+
+            await expect(compiler.cmake(files, parsedRequest(), BypassCache.Compilation)).rejects.toThrow(
+                'cmake exploded',
+            );
+
+            expect(dirs).toHaveLength(1);
+            expect(await utils.dirExists(dirs[0])).toBe(false);
+        });
+    });
+
+    describe('execCompilerCached()', () => {
+        it('releases and removes the scratch directory when the compiler throws', async () => {
+            const dirs = trackTempDirs(compiler);
+            (compiler as any).mtime = new Date();
+            vi.spyOn(compiler, 'exec').mockRejectedValue(new Error('cannot spawn'));
+
+            await expect(
+                compiler.execCompilerCached('fake-compiler', ['--version'], {
+                    ...compiler.getDefaultExecOptions(),
+                    createAndUseTempDir: true,
+                }),
+            ).rejects.toThrow('cannot spawn');
+
+            expect(dirs).toHaveLength(1);
+            await vi.waitFor(async () => expect(await utils.dirExists(dirs[0])).toBe(false));
+        });
+    });
+});
+
+describe('LocalExecutionEnvironment cleanup', () => {
+    let ce: CompilationEnvironment;
+
+    beforeEach(() => {
+        ce = makeCompilationEnvironment({languages, doCache: false});
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    it('removes what it downloaded', async () => {
+        const env = new LocalExecutionEnvironment(ce);
+        let downloadedTo: string | undefined;
+        vi.spyOn(env as any, 'loadPackageWithExecutable').mockImplementation(async (_hash, dirPath) => {
+            downloadedTo = dirPath as string;
+            return {code: 0, executableFilename: 'a.out'};
+        });
+
+        await env.downloadExecutablePackage('hash');
+        expect(await utils.dirExists(downloadedTo!)).toBe(true);
+
+        await env.cleanup();
+        expect(await utils.dirExists(downloadedTo!)).toBe(false);
+    });
+
+    it('is harmless before anything was downloaded', async () => {
+        const env = new LocalExecutionEnvironment(ce);
+        await expect(env.cleanup()).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
Makes per-request temp-dir removal the norm, so that only genuine failures are left for the periodic queue-idle sweep in `lib/handlers/compile.ts` (which stays as the safety net, unchanged). Context: compiler-explorer/infra#2310.

### What leaked, and why

| Path | Why it escaped |
|---|---|
| Project builds (cmake/cargo/make/maven), `lib/base-compiler.ts` `finishProjectBuild` | `delete fullResult.result.dirPath` ran *before* `doTempfolderCleanup(fullResult)` / `(fullResult.result)`, so both were no-ops; `afterCompilation` is called with `delayCaching=true` which skips its own cleanup. Regressed in #8174. Every project build leaked its directory. |
| Interpreted languages, `handleInterpreting` | The directory was never put in the returned `buildResult`, so the callers' `doTempfolderCleanup` had nothing to remove. |
| `compile()` | `handleUserError` returned without cleanup; any throw from `doCompilation`/`afterCompilation` leaked. |
| `getOrBuildExecutable` | A failed build (`code !== 0`) returned without `dirPath` (only set on success), so the callers' cleanup no-op'd. Kotlin's `handleInterpreting` asserts on `dirPath` before checking the code, so a failed Kotlin build also threw. A throw after the directory was made leaked it. |
| `doExecution` | A throw after the build (e.g. from `runExecutable`) leaked the build directory. |
| `execCompilerCached` with `createAndUseTempDir` | A throw skipped both `temp.release` and the `rm`. |
| `LocalExecutionEnvironment.downloadExecutablePackage` | The directory was never removed, by either caller (`sqs-execution-queue.ts`, `handlers/api.ts`). |
| racket `generateOptPipeline`, sway `runCompiler`, dosbox `exec` | Scratch directories made and never removed. |

Also: `ClangCompiler.afterCompilation` dropped the `delayCaching` parameter, so clang cmake builds were cleaned up and cached as if they were single-file compilations (cleaning the dir *inside* afterCompilation, and caching the inner result separately under the cmake key). Passes it through now.

### What changed

- `BaseCompiler.removeTempDir(dir)`: idempotent `fs.rm` that respects `delayCleanupTemp`; `doTempfolderCleanup` uses it.
- `buildProject` makes the directory and removes it in a `finally` around the enqueued job, after `executeProjectArtifact` and `finishProjectBuild` (tools, post-processing, caching) are done with it. `prepareProjectBuild` takes the directory instead of making it. `finishProjectBuild` only strips the paths from the result.
- `compile()`: `finally` around the per-request directory (ordinarily already gone via `afterCompilation`; this catches the return/throw paths).
- `handleInterpreting`: `finally`.
- `getOrBuildExecutable`: every returned `BuildResult` carries `dirPath`, so the existing caller cleanup works for failed builds too; a throw removes the directory. `doExecution` removes the build directory if anything after the build throws.
- `execCompilerCached`: release + rm in a `finally`.
- `IExecutionEnvironment.cleanup()`; `LocalExecutionEnvironment` removes its download dir, `RemoteExecutionEnvironment` no-op; both callers call it in a `finally`.
- racket/sway/dosbox: `finally` around their scratch dirs.
- Metrics: `ce_compilation_temp_dirs_already_gone` (dirs the sweep found already removed by their owner, i.e. per-request removals) and `ce_compilation_temp_dirs_held`, next to the existing `_created`/`_removed`.

### Deliberately left as follow-ups

- `LocalExecutionEnvironment.execBinary` has `return this.execBinaryMaybeWrapped(...)` inside a try/catch without `await`, so rejections bypass the catch. Not touched here (the new `doExecution` catch covers the temp dir); worth a separate look.
- cmake results are `cachePut` (in `afterCmakeCompilation`) before `finishProjectBuild` strips `result.dirPath`, so the cached value carries the (now removed) path. Pre-existing and harmless, but untidy.
- `handleUserError` results still carry `dirPath` in the response body (pre-existing).

### Testing

- New `test/base-compiler-temp-dir-tests.ts` (14 tests) covering each path above: the dir is gone after the call (or, for `getOrBuildExecutable` failures, is handed back for the caller to remove). All 13 new behavioural tests fail against `main` and pass here.
- `npm run ts-check`, `npm run lint`, `npm run test` (full): 2642 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


