### PR TITLE
Keep inline asm directives when filtering directives

### DIFF
--- a/lib/parsers/asm-parser.ts
+++ b/lib/parsers/asm-parser.ts
@@ -143,6 +143,13 @@ export class AsmParser extends AsmRegex implements IAsmParser {
                 // We're defining data that's being used somewhere.
                 return false;
             }
+            // Between #APP and #NO_APP the directives are the user's own inline asm, and
+            // dropping them changes what the block assembles to: `.rept 5` / `.endr` around
+            // a `nop` collapses to a single `nop`. Only the source-location markers the
+            // compiler interleaves in there are ours to drop.
+            if (this.parsingState.isInCustomAssembly() && !this.sourceLineHandler.isSourceLocationDirective(line)) {
+                return false;
+            }
             // .inst generates an opcode, so does not count as a directive, nor does an alias definition that's used.
             if (
                 this.directive.test(line) &&

--- a/lib/parsers/source-line-handler.ts
+++ b/lib/parsers/source-line-handler.ts
@@ -137,6 +137,21 @@ export class SourceLineHandler {
         }
     }
 
+    /**
+     * Whether the line is one of the source-location directives this handler consumes,
+     * rather than something the compiler was asked to assemble.
+     */
+    isSourceLocationDirective(line: string): boolean {
+        return (
+            this.sourceTag.test(line) ||
+            this.sourceD2Tag.test(line) ||
+            this.sourceCVTag.test(line) ||
+            this.source6502Dbg.test(line) ||
+            this.source6502DbgEnd.test(line) ||
+            this.sourceStab.test(line)
+        );
+    }
+
     processSourceLine(
         line: string,
         context: SourceHandlerContext,

--- a/test/asm-parser-tests.ts
+++ b/test/asm-parser-tests.ts
@@ -59,6 +59,52 @@ describe('AsmParser comment filtering', () => {
     });
 });
 
+describe('AsmParser directive filtering', () => {
+    const parser = new AsmParser();
+    // GCC wraps inline asm in #APP/#NO_APP and interleaves its own .loc markers there.
+    const inlineAsm = `square(int):
+	pushq	%rbp
+#APP
+# 3 "/app/example.cpp" 1
+	.rept 5
+nop
+.endr
+# 0 "" 2
+	.loc 1 4 5 view .LVU3
+#NO_APP
+	movl	%edi, %eax
+	.loc 1 5 1
+	popq	%rbp
+	ret`;
+
+    it('should keep inline asm directives when filtering directives', () => {
+        const result = parser.processAsm(inlineAsm, {directives: true});
+        const lines = result.asm.map(line => line.text.trim());
+        expect(lines).toContain('.rept 5');
+        expect(lines).toContain('.endr');
+    });
+
+    it('should still drop source location markers inside an inline asm block', () => {
+        const result = parser.processAsm(inlineAsm, {directives: true});
+        const lines = result.asm.map(line => line.text.trim());
+        expect(lines.some(line => line.startsWith('.loc'))).toBe(false);
+    });
+
+    it('should keep filtering directives once the inline asm block has ended', () => {
+        const result = parser.processAsm(
+            `#APP
+	.rept 5
+#NO_APP
+	.p2align 4
+	ret`,
+            {directives: true},
+        );
+        const lines = result.asm.map(line => line.text.trim());
+        expect(lines).toContain('.rept 5');
+        expect(lines).not.toContain('.p2align 4');
+    });
+});
+
 describe('PTXAsmParser tests', () => {
     const parser = new PTXAsmParser();
 

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.comments.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.comments.json
@@ -8,6 +8,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -84,6 +94,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -467,11 +482,11 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 37,
-    "_ZL15__fatDeviceText": 61,
-    "_ZL24__sti____cudaRegisterAllv": 39,
-    "_ZL26__cudaUnregisterBinaryUtilv": 19,
-    "fatbinData": 2,
-    "main": 27
+    ".LC0": 40,
+    "_ZL15__fatDeviceText": 64,
+    "_ZL24__sti____cudaRegisterAllv": 42,
+    "_ZL26__cudaUnregisterBinaryUtilv": 22,
+    "fatbinData": 4,
+    "main": 30
   }
 }

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.json
@@ -13,6 +13,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -89,6 +99,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -477,11 +492,11 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 39,
-    "_ZL15__fatDeviceText": 63,
-    "_ZL24__sti____cudaRegisterAllv": 41,
-    "_ZL26__cudaUnregisterBinaryUtilv": 21,
-    "fatbinData": 3,
-    "main": 29
+    ".LC0": 42,
+    "_ZL15__fatDeviceText": 66,
+    "_ZL24__sti____cudaRegisterAllv": 44,
+    "_ZL26__cudaUnregisterBinaryUtilv": 24,
+    "fatbinData": 5,
+    "main": 32
   }
 }

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.json
@@ -3,6 +3,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -79,6 +89,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -432,11 +447,11 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 32,
-    "_ZL15__fatDeviceText": 54,
-    "_ZL24__sti____cudaRegisterAllv": 34,
-    "_ZL26__cudaUnregisterBinaryUtilv": 18,
-    "fatbinData": 1,
-    "main": 24
+    ".LC0": 35,
+    "_ZL15__fatDeviceText": 57,
+    "_ZL24__sti____cudaRegisterAllv": 37,
+    "_ZL26__cudaUnregisterBinaryUtilv": 21,
+    "fatbinData": 3,
+    "main": 27
   }
 }

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.dontMaskFilenames.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.dontMaskFilenames.json
@@ -3,6 +3,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -79,6 +89,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -408,10 +423,10 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 26,
-    "_ZL15__fatDeviceText": 48,
-    "_ZL24__sti____cudaRegisterAllv": 28,
-    "fatbinData": 1,
-    "main": 18
+    ".LC0": 29,
+    "_ZL15__fatDeviceText": 51,
+    "_ZL24__sti____cudaRegisterAllv": 31,
+    "fatbinData": 3,
+    "main": 21
   }
 }

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.comments.library.json
@@ -3,6 +3,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -79,6 +89,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -382,10 +397,10 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 26,
-    "_ZL15__fatDeviceText": 48,
-    "_ZL24__sti____cudaRegisterAllv": 28,
-    "fatbinData": 1,
-    "main": 18
+    ".LC0": 29,
+    "_ZL15__fatDeviceText": 51,
+    "_ZL24__sti____cudaRegisterAllv": 31,
+    "fatbinData": 3,
+    "main": 21
   }
 }

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.labels.json
@@ -8,6 +8,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -84,6 +94,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -442,11 +457,11 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 34,
-    "_ZL15__fatDeviceText": 56,
-    "_ZL24__sti____cudaRegisterAllv": 36,
-    "_ZL26__cudaUnregisterBinaryUtilv": 20,
-    "fatbinData": 2,
-    "main": 26
+    ".LC0": 37,
+    "_ZL15__fatDeviceText": 59,
+    "_ZL24__sti____cudaRegisterAllv": 39,
+    "_ZL26__cudaUnregisterBinaryUtilv": 23,
+    "fatbinData": 4,
+    "main": 29
   }
 }

--- a/test/filters-cases/nvcc-x86-host-example.asm.directives.library.json
+++ b/test/filters-cases/nvcc-x86-host-example.asm.directives.library.json
@@ -13,6 +13,16 @@
     {
       "labels": [],
       "source": null,
+      "text": "        .section .nv_fatbin, \"a\""
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".align 8"
+    },
+    {
+      "labels": [],
+      "source": null,
       "text": "fatbinData:"
     },
     {
@@ -89,6 +99,11 @@
       "labels": [],
       "source": null,
       "text": ".quad 0x652e7466752e766e,0x766e2e007972746e,0x5a5f006f666e692e,0x5065726175717336"
+    },
+    {
+      "labels": [],
+      "source": null,
+      "text": ".text"
     },
     {
       "labels": [],
@@ -427,11 +442,11 @@
     }
   ],
   "labelDefinitions": {
-    ".LC0": 33,
-    "_ZL15__fatDeviceText": 57,
-    "_ZL24__sti____cudaRegisterAllv": 35,
-    "_ZL26__cudaUnregisterBinaryUtilv": 21,
-    "fatbinData": 3,
-    "main": 23
+    ".LC0": 36,
+    "_ZL15__fatDeviceText": 60,
+    "_ZL24__sti____cudaRegisterAllv": 38,
+    "_ZL26__cudaUnregisterBinaryUtilv": 24,
+    "fatbinData": 5,
+    "main": 26
   }
 }


### PR DESCRIPTION
Fixes #8964.

Directive filtering runs over the whole listing, including the region between `#APP` and `#NO_APP`. That region is the user's own inline asm, so filtering it changes what the block says. For the case in the issue:

```cpp
int square(int num) {
    asm(".rept 5\nnop\n.endr");
    return num * num;
}
```

`.rept 5` and `.endr` go away and a single `nop` is left, which reads as one instruction where the source asks for five.

The parser already tracks the region: `updateParsingState` calls `enterCustomAssembly` on `#APP` and `exitCustomAssembly` on `#NO_APP`, and `isInCustomAssembly()` was being used only to fix label indentation. `shouldSkipDirective` now consults it too.

### What still gets dropped

Not everything in the block is the user's. GCC interleaves its own line markers, as @Alcaro pointed out on the issue:

```
#APP
# 3 "/app/example.cpp" 1
	.rept 5
nop
.endr
# 0 "" 2
	.loc 1 4 5 view .LVU3
# /app/example.cpp:4:     return num * num;
	.loc 1 4 18 is_stmt 0 view .LVU4
#NO_APP
```

So the rule is narrower than "skip filtering inside the block": inside it, a directive is dropped only when it is a source-location marker. That set is not a new list, it is the one `SourceLineHandler` already consumes to build the source mapping (`.loc`, `.d2line`, `.cv_loc`, `.dbg line`, `.stabn`), exposed as `isSourceLocationDirective`. Anything the handler does not claim is text the compiler was asked to assemble, and it stays.

The `#` lines above are comments and are unaffected, they still go with the comment filter.

### The changed snapshots

`nvcc-x86-host-example` gains three lines: `.section .nv_fatbin, "a"`, `.align 8` and `.text`, all inside its `#APP` block. The hundreds of `.quad` lines in that block were already surviving the directive filter, because `fatbinData:` sets `prevLabel` and `dataDefn` lines under a used label are kept, so this is three lines added to output that was already showing the blob, not the blob becoming visible. `NvccCompiler.removeNvccFatbinaryBlob` is what actually hides it, and it is unaffected.

No other case in `filters-cases` moves. `bug-577_gcc` and `bug-577_clang` have `#APP` blocks with no directives in them.

### Tests

Three in `test/asm-parser-tests.ts`: the directives survive, the `.loc` markers inside the same block still do not, and filtering resumes after `#NO_APP`. The first and third fail on `main`. I ran the full suite in `node:22-bookworm`, since `filter-tests.ts` returns early on Windows: 2631 passed.
