### PR TITLE
Store S3 cache objects as STANDARD rather than reduced redundancy

### DIFF
--- a/lib/cache/s3.ts
+++ b/lib/cache/s3.ts
@@ -24,8 +24,6 @@
 
 import {Buffer} from 'buffer';
 
-import {StorageClass} from '@aws-sdk/client-s3';
-
 import type {GetResult} from '../../types/cache.interfaces.js';
 import {logger} from '../logger.js';
 import type {S3HandlerOptions} from '../s3-handler.interfaces.js';
@@ -74,7 +72,6 @@ export class S3Cache extends BaseCache {
     override async putInternal(key: string, value: Buffer, creator?: string): Promise<void> {
         const options: S3HandlerOptions = {
             metadata: creator ? {CreatedBy: creator} : {},
-            redundancy: StorageClass.REDUCED_REDUNDANCY,
         };
         try {
             await this.s3.put(key, value, this.path, options);
@@ -87,7 +84,6 @@ export class S3Cache extends BaseCache {
         const expiresDate = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
         const options: S3HandlerOptions = {
             metadata: creator ? {CreatedBy: creator} : {},
-            redundancy: StorageClass.REDUCED_REDUNDANCY,
             expires: expiresDate,
         };
         try {
@@ -107,7 +103,6 @@ export class S3Cache extends BaseCache {
         const expiresDate = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
         const options: S3HandlerOptions = {
             metadata: creator ? {CreatedBy: creator} : {},
-            redundancy: StorageClass.REDUCED_REDUNDANCY,
             expires: expiresDate,
         };
         try {

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -22,7 +22,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {StorageClass} from '@aws-sdk/client-s3';
 import {createMs, ms} from 'enhanced-ms';
 
 import {FiledataPair} from '../types/compilation/compilation.interfaces.js';
@@ -148,9 +147,7 @@ class StatsNoter implements IStatsNoter {
             // async write to S3
             const key = makeKey(new Date(Date.now()));
             this._s3
-                .put(key, Buffer.from(toFlush.map(x => JSON.stringify(x)).join('\n')), this._path, {
-                    redundancy: StorageClass.REDUCED_REDUNDANCY,
-                })
+                .put(key, Buffer.from(toFlush.map(x => JSON.stringify(x)).join('\n')), this._path, {})
                 .then(() => {})
                 .catch(e => {
                     logger.warn(`Caught exception trying to log compilations to ${key}: ${e}`);

--- a/test/cache-tests.ts
+++ b/test/cache-tests.ts
@@ -205,6 +205,15 @@ describe('S3 tests', () => {
         expect(err.toString()).toEqual('Error: Some s3 error');
     });
 
+    it('should store objects as STANDARD', async () => {
+        const cache = new S3Cache('test', 'test.bucket', 'cache', 'uk-north-1');
+        await cache.put('a key', 'a value', 'bob');
+        await cache.putWithTTL('a ttl key', Buffer.from('a value'), 1, 'bob');
+        await cache.putWithTTLAndPath('a prefixed key', Buffer.from('a value'), 1, 'prefix', 'bob');
+        const puts = mockS3.commandCalls(PutObjectCommand);
+        expect(puts.map(put => put.args[0].input.StorageClass)).toEqual(['STANDARD', 'STANDARD', 'STANDARD']);
+    });
+
     // BE VERY CAREFUL - the below can be used with sufficient permissions to test on prod (With mocks off)...
     // basicTests(() => new S3Cache(''test', storage.godbolt.org', 'cache', 'us-east-1'));
 });

--- a/test/stats-test.ts
+++ b/test/stats-test.ts
@@ -22,9 +22,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import {describe, expect, it} from 'vitest';
+import {PutObjectCommand, S3} from '@aws-sdk/client-s3';
+import {mockClient} from 'aws-sdk-client-mock';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-import {filterCompilerOptions, KnownBuildMethod, makeSafe} from '../lib/stats.js';
+import {ParsedRequest} from '../lib/handlers/compile.js';
+import {createStatsNoter, filterCompilerOptions, KnownBuildMethod, makeSafe} from '../lib/stats.js';
 import {getHash} from '../lib/utils.js';
 import {ParseFiltersAndOutputOptions} from '../types/features/filters.interfaces.js';
 
@@ -101,6 +104,33 @@ describe('Stats', () => {
         expect(filterCompilerOptions(['-moo', 'foo', '/moo'])).toEqual(['-moo', '/moo']);
         expect(filterCompilerOptions(['-Dsecret=1234', '/Dsecret'])).toEqual([]);
         expect(filterCompilerOptions(['-ithings', '/Ithings'])).toEqual([]);
+    });
+
+    describe('S3 flushing', () => {
+        const mockS3 = mockClient(S3);
+        const request = {
+            source: '',
+            options: [],
+            backendOptions: {},
+            filters: {} as ParseFiltersAndOutputOptions,
+            bypassCache: 0,
+            tools: [],
+            executeParameters: {},
+            libraries: [],
+        } as unknown as ParsedRequest;
+
+        beforeEach(() => {
+            mockS3.reset();
+            mockS3.on(PutObjectCommand).resolves({});
+        });
+
+        it('should store compilation records as STANDARD', async () => {
+            const noter = createStatsNoter(() => 'S3(test.bucket,compile-stats,uk-north-1,1ms)');
+            noter.noteCompilation('g130', request, [], KnownBuildMethod.Compile);
+            await vi.waitUntil(() => mockS3.commandCalls(PutObjectCommand).length > 0);
+            const puts = mockS3.commandCalls(PutObjectCommand);
+            expect(puts.map(put => put.args[0].input.StorageClass)).toEqual(['STANDARD']);
+        });
     });
 
     it('should sanitize some duplications', () => {


### PR DESCRIPTION
Drops the `redundancy` option from the three `S3Cache` put paths. `S3Bucket.put` already falls back to `STANDARD` when nothing is passed (`lib/s3-handler.ts:77`), so the deletion is the whole fix.

One thing beyond what the issue lists: `lib/stats.ts` asks for the same class when it flushes compilation records, and that is the only other caller in the tree. Those records are not reconstructible the way a cache entry is, so the lower durability costs something there and buys nothing. I moved it across in the same commit rather than leaving a single RRS write behind, but say the word and I will pull it back out into its own PR.

For the regression guard I added a case per file, both asserting the `StorageClass` that reaches the mocked `PutObjectCommand`: `test/cache-tests.ts` covers `put`, `putWithTTL` and `putWithTTLAndPath`, and `test/stats-test.ts` covers the flush. Reverting either source file turns the matching test red with `REDUCED_REDUNDANCY` instead of `STANDARD`.

Verified in a `node:22-bookworm` container, which is where my node_modules live: full suite 2630 passed, 1 skipped across 122 files, plus `npm run ts-check` and `biome check` clean. Committed through the normal pre-commit hook.
