### PR TITLE
Add C++ library anyxx v0.7.0

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -7817,6 +7817,12 @@ group.aburipp.options=-std=c++20
 compiler.aburi-godbolt-pp.exe=/opt/compiler-explorer/aburi-godbolt/bin/aburi
 compiler.aburi-godbolt-pp.semver=(trunk)
 
+libs.anyxx.name=anyxx
+libs.anyxx.url=https://github.com/bitfactory-software/anyxx
+libs.anyxx.versions=070
+libs.anyxx.versions.070.path=/opt/compiler-explorer/libs/anyxx/0.7.0/include
+libs.anyxx.versions.070.version=0.7.0
+
 #################################
 #################################
 # Installed tools


### PR DESCRIPTION
This PR adds the C++ library **anyxx** version 0.7.0 to Compiler Explorer.

- GitHub URL: https://github.com/bitfactory-software/anyxx
- Library Type: header-only

~Related PR: https://github.com/compiler-explorer/infra/pull/2317~

Related PR: https://github.com/compiler-explorer/infra/pull/2326

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_