### PR TITLE
Avoid redundant serialisation work in the startup tail

### DIFF
--- a/lib/app/compiler-changes.ts
+++ b/lib/app/compiler-changes.ts
@@ -33,6 +33,16 @@ import {ClientOptionsHandler} from '../options-handler.js';
 import {PropertyGetter} from '../properties.interfaces.js';
 import {getHash} from '../utils.js';
 
+/**
+ * Setup handling of compiler changes and periodic rescanning
+ * @param initialCompilers - The initial set of compilers
+ * @param clientOptionsHandler - Client options handler
+ * @param routeApi - Route API instance
+ * @param languages - Available languages
+ * @param ceProps - CE properties
+ * @param compilerFinder - Compiler finder instance
+ * @param appArgs - Application arguments
+ */
 export async function setupCompilerChangeHandling(
     initialCompilers: CompilerInfo[],
     clientOptionsHandler: ClientOptionsHandler,
@@ -46,11 +56,12 @@ export async function setupCompilerChangeHandling(
     const rescanEnabled = !!rescanCompilerSecs && !appArgs.prediscovered;
     let prevCompilersHash: string | undefined;
 
+    /**
+     * Handle compiler change events
+     * @param compilers - New set of compilers
+     */
     async function onCompilerChange(compilers: CompilerInfo[]) {
         if (rescanEnabled) {
-            // Compare by content hash so no-op rescans are skipped without
-            // retaining a full serialised copy of every compiler, which for a
-            // production-sized set runs to tens of megabytes.
             const compilersHash = getHash(compilers);
             if (prevCompilersHash === compilersHash) {
                 return;

--- a/lib/app/compiler-changes.ts
+++ b/lib/app/compiler-changes.ts
@@ -31,17 +31,8 @@ import {RouteAPI} from '../handlers/route-api.js';
 import {logger} from '../logger.js';
 import {ClientOptionsHandler} from '../options-handler.js';
 import {PropertyGetter} from '../properties.interfaces.js';
+import {getHash} from '../utils.js';
 
-/**
- * Setup handling of compiler changes and periodic rescanning
- * @param initialCompilers - The initial set of compilers
- * @param clientOptionsHandler - Client options handler
- * @param routeApi - Route API instance
- * @param languages - Available languages
- * @param ceProps - CE properties
- * @param compilerFinder - Compiler finder instance
- * @param appArgs - Application arguments
- */
 export async function setupCompilerChangeHandling(
     initialCompilers: CompilerInfo[],
     clientOptionsHandler: ClientOptionsHandler,
@@ -51,20 +42,23 @@ export async function setupCompilerChangeHandling(
     compilerFinder: CompilerFinder,
     appArgs: AppArguments,
 ): Promise<void> {
-    let prevCompilers = '';
+    const rescanCompilerSecs = ceProps('rescanCompilerSecs', 0);
+    const rescanEnabled = !!rescanCompilerSecs && !appArgs.prediscovered;
+    let prevCompilersHash: string | undefined;
 
-    /**
-     * Handle compiler change events
-     * @param compilers - New set of compilers
-     */
     async function onCompilerChange(compilers: CompilerInfo[]) {
-        const compilersAsJson = JSON.stringify(compilers);
-        if (prevCompilers === compilersAsJson) {
-            return;
+        if (rescanEnabled) {
+            // Compare by content hash so no-op rescans are skipped without
+            // retaining a full serialised copy of every compiler, which for a
+            // production-sized set runs to tens of megabytes.
+            const compilersHash = getHash(compilers);
+            if (prevCompilersHash === compilersHash) {
+                return;
+            }
+            prevCompilersHash = compilersHash;
         }
         logger.info(`Compiler scan count: ${compilers.length}`);
         logger.debug('Compilers:', compilers);
-        prevCompilers = compilersAsJson;
         await clientOptionsHandler.setCompilers(compilers);
         const apiHandler = unwrap(routeApi.apiHandler);
         apiHandler.setCompilers(compilers);
@@ -72,12 +66,9 @@ export async function setupCompilerChangeHandling(
         apiHandler.setOptions(clientOptionsHandler);
     }
 
-    // Set initial compilers
     await onCompilerChange(initialCompilers);
 
-    // Set up compiler rescanning if configured
-    const rescanCompilerSecs = ceProps('rescanCompilerSecs', 0);
-    if (rescanCompilerSecs && !appArgs.prediscovered) {
+    if (rescanEnabled) {
         logger.info(`Rescanning compilers every ${rescanCompilerSecs} secs`);
         setInterval(
             () => compilerFinder.find().then(result => onCompilerChange(result.compilers)),

--- a/lib/options-handler.ts
+++ b/lib/options-handler.ts
@@ -229,10 +229,10 @@ export class ClientOptionsHandler implements ClientOptionsSource {
             explainApiEndpoint: ceProps('explainApiEndpoint', ''),
             pageloadUrl: ceProps('pageloadUrl', ''),
         };
-        // Will be immediately replaced with actual values
+        // Replaced with real values by the first setCompilers() call, which
+        // always happens before the server starts listening.
         this.optionsJSON = '';
         this.optionsHash = '';
-        this._updateOptionsHash();
     }
 
     parseTools(baseTools: Record<string, string>) {

--- a/test/app/compiler-changes-tests.ts
+++ b/test/app/compiler-changes-tests.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {setupCompilerChangeHandling} from '../../lib/app/compiler-changes.js';
+import {AppArguments} from '../../lib/app.interfaces.js';
+import {CompilerFinder} from '../../lib/compiler-finder.js';
+import {RouteAPI} from '../../lib/handlers/route-api.js';
+import {logger} from '../../lib/logger.js';
+import {ClientOptionsHandler} from '../../lib/options-handler.js';
+import * as properties from '../../lib/properties.js';
+import {CompilerInfo} from '../../types/compiler.interfaces.js';
+import {Language, LanguageKey} from '../../types/languages.interfaces.js';
+
+describe('compiler-changes module', () => {
+    const languages = {fake: {id: 'fake'}} as unknown as Record<LanguageKey, Language>;
+    const initialCompilers = [{id: 'gcc', name: 'GCC', lang: 'c++'}] as unknown as CompilerInfo[];
+
+    let clientOptionsHandler: ClientOptionsHandler;
+    let apiHandler: {
+        setCompilers: ReturnType<typeof vi.fn>;
+        setLanguages: ReturnType<typeof vi.fn>;
+        setOptions: ReturnType<typeof vi.fn>;
+    };
+    let routeApi: RouteAPI;
+    let compilerFinder: CompilerFinder;
+
+    beforeEach(() => {
+        vi.spyOn(logger, 'info').mockImplementation(() => logger);
+        vi.spyOn(logger, 'debug').mockImplementation(() => logger);
+        clientOptionsHandler = {setCompilers: vi.fn().mockResolvedValue(undefined)} as unknown as ClientOptionsHandler;
+        apiHandler = {setCompilers: vi.fn(), setLanguages: vi.fn(), setOptions: vi.fn()};
+        routeApi = {apiHandler} as unknown as RouteAPI;
+        compilerFinder = {find: vi.fn()} as unknown as CompilerFinder;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    function setup(props: Record<string, any>, appArgs?: Partial<AppArguments>) {
+        return setupCompilerChangeHandling(
+            initialCompilers,
+            clientOptionsHandler,
+            routeApi,
+            languages,
+            properties.fakeProps(props),
+            compilerFinder,
+            appArgs as AppArguments,
+        );
+    }
+
+    it('should apply the initial compiler set', async () => {
+        await setup({});
+
+        expect(clientOptionsHandler.setCompilers).toHaveBeenCalledWith(initialCompilers);
+        expect(apiHandler.setCompilers).toHaveBeenCalledWith(initialCompilers);
+        expect(apiHandler.setLanguages).toHaveBeenCalledWith(languages);
+        expect(apiHandler.setOptions).toHaveBeenCalledWith(clientOptionsHandler);
+    });
+
+    it('should not rescan when compilers were prediscovered', async () => {
+        vi.useFakeTimers();
+        await setup({rescanCompilerSecs: 1}, {prediscovered: 'compilers.json'});
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(compilerFinder.find).not.toHaveBeenCalled();
+    });
+
+    it('should not reapply an unchanged compiler set on rescan', async () => {
+        vi.useFakeTimers();
+        vi.mocked(compilerFinder.find).mockResolvedValue({compilers: [...initialCompilers], foundClash: false});
+        await setup({rescanCompilerSecs: 1}, {});
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(compilerFinder.find).toHaveBeenCalledTimes(1);
+        expect(clientOptionsHandler.setCompilers).toHaveBeenCalledTimes(1);
+        expect(apiHandler.setCompilers).toHaveBeenCalledTimes(1);
+    });
+
+    it('should apply a changed compiler set on rescan', async () => {
+        vi.useFakeTimers();
+        const newCompilers = [{id: 'clang', name: 'Clang', lang: 'c++'}] as unknown as CompilerInfo[];
+        vi.mocked(compilerFinder.find).mockResolvedValue({compilers: newCompilers, foundClash: false});
+        await setup({rescanCompilerSecs: 1}, {});
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(clientOptionsHandler.setCompilers).toHaveBeenCalledTimes(2);
+        expect(clientOptionsHandler.setCompilers).toHaveBeenLastCalledWith(newCompilers);
+        expect(apiHandler.setCompilers).toHaveBeenLastCalledWith(newCompilers);
+    });
+});

--- a/test/options-handler.ts
+++ b/test/options-handler.ts
@@ -383,6 +383,15 @@ describe('Options handler', () => {
         });
         optionsHandler.setCompilers([]);
     });
+    it('should only compute the options hash once compilers are set', async () => {
+        const handler = new ClientOptionsHandler([], compilerProps, {env: ['dev']} as unknown as AppArguments);
+        expect(handler.getHash()).toEqual('');
+        expect(handler.getJSON()).toEqual('');
+
+        await handler.setCompilers([]);
+        expect(handler.getHash()).not.toEqual('');
+        expect(JSON.parse(handler.getJSON())).toHaveProperty('compilers', []);
+    });
     it('should get static libraries', () => {
         const libs = optionsHandler.parseLibraries({fake: optionsProps.libs});
         const compilerInfo = fakeCompilerInfo('g82', 'c++', 'cpp', '8.2', true);


### PR DESCRIPTION
Profiling a production startup (2026-08-20, 6232 compilers) showed two avoidable CPU costs in the last couple of seconds of startup:

- `setupCompilerChangeHandling`'s `onCompilerChange` ran `JSON.stringify` over all 6232 compiler objects purely to detect whether the compiler set had changed since the last discovery. The serialised form is comparable in scale to the 74MB discovery JSON, and it was computed (and retained in memory) even in production, where rescanning is disabled (`rescanCompilerSecs` unset / `--prediscovered`) and so the comparison can never trigger.
- The `OPTIONS HASH` log line appeared twice per startup: `ClientOptionsHandler`'s constructor eagerly serialised and hashed the options blob, only for the result to be immediately discarded and recomputed by the first `setCompilers()` call.

Changes:

- `lib/app/compiler-changes.ts`: only do change detection when rescanning is actually enabled, and compare a SHA-256 content hash instead of retaining the full serialised compiler list. In production the initial set is now applied with no serialisation at all; with rescanning enabled, behaviour is unchanged (identical rescans are skipped, changed sets applied) while dropping the tens-of-megabytes retained string.
- `lib/options-handler.ts`: drop the constructor's `_updateOptionsHash()` call. The hash/JSON are computed exactly once at startup by the first `setCompilers()`, which always runs before the server starts listening.

Tests: new `test/app/compiler-changes-tests.ts` covering initial application, no rescan when prediscovered, unchanged rescans skipped, and changed rescans applied; plus an options-handler test pinning that the hash is only computed once compilers are set. `ts-check`, `lint`, and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)