### PR TITLE
Load possible-argument stats off the startup critical path

### DIFF
--- a/lib/app/compiler-discovery.ts
+++ b/lib/app/compiler-discovery.ts
@@ -115,6 +115,9 @@ export async function handleDiscoveryOnlyMode(
     initialCompilers: Partial<CompilerInfo>[],
     compilerFinder: CompilerFinder,
 ) {
+    // Possible-argument stats load in the background after setCompilers; wait for them
+    // here so the saved discovery file still includes them.
+    await compilerFinder.compileHandler.possibleArgumentsLoaded();
     for (const compiler of initialCompilers) {
         if (compiler.buildenvsetup && compiler.buildenvsetup.id === '') delete compiler.buildenvsetup;
 

--- a/lib/handlers/compile.ts
+++ b/lib/handlers/compile.ts
@@ -136,6 +136,9 @@ export class CompileHandler implements ICompileHandler {
     private readonly awsProps: PropertyGetter;
     private readonly appArgs: AppArguments | undefined;
     private clientOptions: ClientOptionsType | null = null;
+    // Serialises background loads of possible-argument stats so repeated setCompilers
+    // calls (e.g. compiler rescans) never stack concurrent S3 fan-outs.
+    private possibleArgumentsLoad: Promise<void> = Promise.resolve();
     private readonly compileCounter = new Counter({
         name: 'ce_compilations_total',
         help: 'Number of compilations',
@@ -336,18 +339,46 @@ export class CompileHandler implements ICompileHandler {
             }
 
             logger.info('Compilers created: ' + compilersCreated);
-            if (this.awsProps) {
-                logger.info('Fetching possible arguments from storage');
-                await Promise.all(
-                    createdCompilers.map(compiler => compiler.possibleArguments.loadFromStorage(this.awsProps)),
-                );
-            }
             this.compilersById = compilersById;
+            this.loadPossibleArgumentsInBackground(createdCompilers);
             return createdCompilers.map(compiler => compiler.getInfo());
         } catch (err) {
             logger.error('Exception while processing compilers:', err);
             return [];
         }
+    }
+
+    private loadPossibleArgumentsInBackground(compilers: BaseCompiler[]): void {
+        this.possibleArgumentsLoad = this.possibleArgumentsLoad.then(() => this.loadPossibleArguments(compilers));
+    }
+
+    // The stats only feed popular-argument ranking, so they're deliberately loaded off the
+    // startup critical path; the server can begin serving before they arrive.
+    private async loadPossibleArguments(compilers: BaseCompiler[]): Promise<void> {
+        logger.info(`Fetching possible arguments from storage for ${compilers.length} compilers`);
+        const startTime = performance.now();
+        let failedCount = 0;
+        await Promise.all(
+            compilers.map(async compiler => {
+                try {
+                    await compiler.possibleArguments.loadFromStorage(this.awsProps);
+                } catch (err) {
+                    failedCount++;
+                    logger.debug(`Failed to load possible arguments for ${compiler.getInfo().id}:`, err);
+                }
+            }),
+        );
+        const durationMs = Math.round(performance.now() - startTime);
+        const message = `Loaded possible arguments for ${compilers.length - failedCount} compilers in ${durationMs}ms`;
+        if (failedCount > 0) {
+            logger.warn(`${message} (${failedCount} failed)`);
+        } else {
+            logger.info(message);
+        }
+    }
+
+    possibleArgumentsLoaded(): Promise<void> {
+        return this.possibleArgumentsLoad;
     }
 
     setPossibleToolchains(toolchains: CompilerOverrideOptions) {

--- a/test/app/compiler-discovery-tests.ts
+++ b/test/app/compiler-discovery-tests.ts
@@ -156,6 +156,7 @@ describe('compiler-discovery module', () => {
         const mockCompilerFinder = {
             compileHandler: {
                 findCompiler: vi.fn().mockReturnValue(mockCompilerInstance),
+                possibleArgumentsLoaded: vi.fn().mockResolvedValue(undefined),
             },
         } as unknown as CompilerFinder;
 

--- a/test/handlers/compile-tests.ts
+++ b/test/handlers/compile-tests.ts
@@ -24,12 +24,13 @@
 
 import express, {Express} from 'express';
 import request from 'supertest';
-import {beforeAll, describe, expect, it} from 'vitest';
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 
+import {CompilerArguments} from '../../lib/compiler-arguments.js';
 import {CompileHandler, SetTestMode} from '../../lib/handlers/compile.js';
 import {fakeProps} from '../../lib/properties.js';
 import {ActiveTool, BypassCache, LegacyCompatibleActiveTool} from '../../types/compilation/compilation.interfaces.js';
-import {makeCompilationEnvironment} from '../utils.js';
+import {makeCompilationEnvironment, makeFakeCompilerInfo} from '../utils.js';
 
 SetTestMode();
 
@@ -481,6 +482,61 @@ describe('Compiler tests', () => {
             await setFakeCompilers();
             const res = await makeFakeJson('a', 'b');
             expect(res.body.asm).toEqual([{text: 'LANG B but A'}]);
+        });
+    });
+
+    describe('Possible arguments background loading', () => {
+        beforeEach(async () => {
+            // Flush any load kicked off by earlier tests before mocking loadFromStorage.
+            await compileHandler.possibleArgumentsLoaded();
+        });
+
+        afterEach(async () => {
+            await compileHandler.possibleArgumentsLoaded();
+            vi.restoreAllMocks();
+        });
+
+        function fakeCompiler(id: string) {
+            return makeFakeCompilerInfo({compilerType: 'fake-for-test', id, lang: 'a' as any, exe: 'fake'});
+        }
+
+        it('does not block setCompilers on storage loads', async () => {
+            let resolveLoad: () => void = () => {};
+            const loadSpy = vi
+                .spyOn(CompilerArguments.prototype, 'loadFromStorage')
+                .mockReturnValue(new Promise<void>(resolve => (resolveLoad = resolve)));
+            const compilers = await compileHandler.setCompilers([fakeCompiler('one')], null);
+            expect(compilers).toHaveLength(1);
+            await vi.waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(1));
+            resolveLoad();
+            await compileHandler.possibleArgumentsLoaded();
+        });
+
+        it('keeps other compilers when one storage load fails', async () => {
+            const loadSpy = vi
+                .spyOn(CompilerArguments.prototype, 'loadFromStorage')
+                .mockRejectedValueOnce(new Error('S3 exploded'))
+                .mockResolvedValue(undefined);
+            const compilers = await compileHandler.setCompilers([fakeCompiler('one'), fakeCompiler('two')], null);
+            expect(compilers).toHaveLength(2);
+            await expect(compileHandler.possibleArgumentsLoaded()).resolves.toBeUndefined();
+            expect(loadSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('serialises loads across repeated setCompilers calls', async () => {
+            const resolvers: (() => void)[] = [];
+            const loadSpy = vi
+                .spyOn(CompilerArguments.prototype, 'loadFromStorage')
+                .mockImplementation(() => new Promise<void>(resolve => resolvers.push(resolve)));
+            await compileHandler.setCompilers([fakeCompiler('one')], null);
+            await compileHandler.setCompilers([fakeCompiler('one')], null);
+            // Only the first batch's load should start until it completes.
+            await vi.waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(1));
+            expect(loadSpy).toHaveBeenCalledTimes(1);
+            resolvers.shift()!();
+            await vi.waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(2));
+            resolvers.shift()!();
+            await compileHandler.possibleArgumentsLoaded();
         });
     });
 });


### PR DESCRIPTION
### Problem

On prod x86 (6232 compilers), startup spends ~8s warm / ~11s cold in `Fetching possible arguments from storage` — of a 20.5s warm / 38s cold total startup. `CompileHandler.setCompilers` awaited a `Promise.all` doing one S3 GET per compiler; the AWS SDK logged "socket usage at capacity=50 and 6182 additional requests are enqueued". All of this blocked the app from listening, even though the stats only feed popular-argument ranking (`/api/popularArguments`) and compilers work fine without them.

### What changed

- `setCompilers` no longer awaits the per-compiler `loadFromStorage` fan-out. Compilers are installed and the server can start serving immediately; the stats load in the background and fill in as they arrive.
- Each compiler's load failure is caught individually and a summary is logged (count loaded/failed, duration). A single S3 error can no longer reject the whole `Promise.all` and lose every compiler, which mitigates the failure mode in #6689.
- Repeated `setCompilers` calls (compiler rescans) chain onto any in-flight load, so refreshes serialise instead of stacking unbounded concurrent S3 fan-outs. Within one load the SDK's 50-socket agent queues requests exactly as before — no new concurrency cap.
- Discovery-only mode (`--discoveryOnly`) awaits the background load before writing the cache file, so its output still includes the argument stats.

### How tested

- New unit tests in `test/handlers/compile-tests.ts`: `setCompilers` resolves while loads are still pending; one failing load doesn't affect other compilers or reject; repeated `setCompilers` calls serialise their loads.
- `npm run ts-check`, `npm run lint-check` and the full `npm run test` suite (2631 passed) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
