### PR TITLE
Fix: overrides dropped

### DIFF
--- a/static/compiler-shared.interfaces.ts
+++ b/static/compiler-shared.interfaces.ts
@@ -28,7 +28,7 @@ import type {CompilerState} from './panes/compiler.interfaces.js';
 import type {ExecutorState} from './panes/executor.interfaces.js';
 
 export interface ICompilerShared {
-    updateState(state: CompilerState | ExecutorState): void;
+    updateState(state: CompilerState | ExecutorState): Promise<void>;
     getOverrides(): ConfiguredOverrides | undefined;
     getRuntimeTools(): ConfiguredRuntimeTools | undefined;
 }

--- a/static/compiler-shared.ts
+++ b/static/compiler-shared.ts
@@ -51,15 +51,15 @@ export class CompilerShared implements ICompilerShared {
         return this.runtimeToolsWidget?.get();
     }
 
-    public updateState(state: CompilerState | ExecutorState) {
-        this.overridesWidget.setCompiler(state.compiler, state.lang);
+    public async updateState(state: CompilerState | ExecutorState): Promise<void> {
+        await this.overridesWidget.setCompiler(state.compiler, state.lang);
 
         if (state.overrides) {
             this.overridesWidget.set(state.overrides);
         }
 
         if (this.runtimeToolsWidget) {
-            this.runtimeToolsWidget.setCompiler(state.compiler, state.lang);
+            await this.runtimeToolsWidget.setCompiler(state.compiler, state.lang);
             if (state.runtimeTools) {
                 this.runtimeToolsWidget.set(state.runtimeTools);
             } else {

--- a/static/compiler-shared.ts
+++ b/static/compiler-shared.ts
@@ -58,29 +58,28 @@ export class CompilerShared implements ICompilerShared {
         this.pendingUpdate = controller;
         const {signal} = controller;
 
-        await this.overridesWidget.setCompiler(state.compiler, state.lang, signal);
-
-        if (signal.aborted) {
-            return;
-        }
-
+        // Apply the configuration before awaiting the compiler list, so that a re-entrant
+        // updateState() (e.g. a pane opening during layout init) reads it back instead of
+        // an empty widget.
         if (state.overrides) {
             this.overridesWidget.set(state.overrides);
         }
 
         if (this.runtimeToolsWidget) {
-            await this.runtimeToolsWidget.setCompiler(state.compiler, state.lang, signal);
-
-            if (signal.aborted) {
-                return;
-            }
-
             if (state.runtimeTools) {
                 this.runtimeToolsWidget.set(state.runtimeTools);
             } else {
                 this.runtimeToolsWidget.setDefaults();
             }
         }
+
+        await this.overridesWidget.setCompiler(state.compiler, state.lang, signal);
+
+        if (signal.aborted) {
+            return;
+        }
+
+        await this.runtimeToolsWidget?.setCompiler(state.compiler, state.lang, signal);
     }
 
     private initButtons(onChange: () => void) {

--- a/static/compiler-shared.ts
+++ b/static/compiler-shared.ts
@@ -36,6 +36,7 @@ export class CompilerShared implements ICompilerShared {
     private overridesWidget: CompilerOverridesWidget;
     private runtimeToolsButton: JQuery<HTMLElement>;
     private runtimeToolsWidget?: RuntimeToolsWidget;
+    private pendingUpdate?: AbortController;
 
     constructor(domRoot: JQuery, onChange: () => void) {
         this.domRoot = domRoot;
@@ -52,14 +53,28 @@ export class CompilerShared implements ICompilerShared {
     }
 
     public async updateState(state: CompilerState | ExecutorState): Promise<void> {
-        await this.overridesWidget.setCompiler(state.compiler, state.lang);
+        this.pendingUpdate?.abort();
+        const controller = new AbortController();
+        this.pendingUpdate = controller;
+        const {signal} = controller;
+
+        await this.overridesWidget.setCompiler(state.compiler, state.lang, signal);
+
+        if (signal.aborted) {
+            return;
+        }
 
         if (state.overrides) {
             this.overridesWidget.set(state.overrides);
         }
 
         if (this.runtimeToolsWidget) {
-            await this.runtimeToolsWidget.setCompiler(state.compiler, state.lang);
+            await this.runtimeToolsWidget.setCompiler(state.compiler, state.lang, signal);
+
+            if (signal.aborted) {
+                return;
+            }
+
             if (state.runtimeTools) {
                 this.runtimeToolsWidget.set(state.runtimeTools);
             } else {

--- a/static/tests/compiler-shared-tests.ts
+++ b/static/tests/compiler-shared-tests.ts
@@ -142,6 +142,16 @@ describe('CompilerShared override restoration', () => {
         expect(shared.getOverrides()).toEqual(urlOverrides);
     });
 
+    it('seeds the compiler defaults when the state has no overrides', async () => {
+        vi.mocked(compilersService.getCompilersForLang).mockResolvedValue({r1970: rustc1970});
+
+        const shared = new CompilerShared(makeDomRoot(), () => {});
+
+        await shared.updateState({compiler: 'r1970', lang: 'rust'} as any);
+
+        expect(shared.getOverrides()).toEqual([{name: 'edition', value: '2024'}]);
+    });
+
     it('keeps the URL overrides when the pane echoes its state back', async () => {
         vi.mocked(compilersService.getCompilersForLang).mockResolvedValue({r1970: rustc1970});
 

--- a/static/tests/compiler-shared-tests.ts
+++ b/static/tests/compiler-shared-tests.ts
@@ -156,6 +156,32 @@ describe('CompilerShared override restoration', () => {
         expect(shared.getOverrides()).toEqual(urlOverrides);
     });
 
+    it('keeps the URL overrides when the pane echoes its state back before the compiler list arrives', async () => {
+        let resolveRust!: (value: Record<string, CompilerInfo>) => void;
+
+        const rustPromise = new Promise<Record<string, CompilerInfo>>(resolve => {
+            resolveRust = resolve;
+        });
+
+        vi.mocked(compilersService.getCompilersForLang).mockReturnValue(rustPromise);
+
+        const state = deserialiseState(urlHash);
+        const componentState = findComponent(state.content, 'compiler').componentState;
+        const shared = new CompilerShared(makeDomRoot(), () => {});
+
+        const first = shared.updateState(componentState);
+
+        // A pane opening during layout init (e.g. the flags view) makes the compiler pane
+        // echo getCurrentState() back synchronously, while the compiler list is still loading.
+        const second = shared.updateState({...componentState, overrides: shared.getOverrides()});
+
+        resolveRust({r1970: rustc1970});
+
+        await Promise.all([first, second]);
+
+        expect(shared.getOverrides()).toEqual(urlOverrides);
+    });
+
     it('ignores a stale compiler-list fetch that resolves after a newer call', async () => {
         let resolveRust!: (value: Record<string, CompilerInfo>) => void;
 

--- a/static/tests/compiler-shared-tests.ts
+++ b/static/tests/compiler-shared-tests.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import $ from 'jquery';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {CompilerOverrideType} from '../../types/compilation/compiler-overrides.interfaces.js';
+import type {CompilerInfo} from '../../types/compiler.interfaces.js';
+import {CompilerShared} from '../compiler-shared.js';
+import {compilersService} from '../services/compilers.service.js';
+import {deserialiseState} from '../url.js';
+
+vi.mock('../services/compilers.service.js', () => ({
+    compilersService: {
+        getCompilersForLang: vi.fn(),
+    },
+}));
+
+// Fragment of a link whose overrides (edition, arch) were dropped on load.
+// See PR#9047
+// Reduced to the row -> stack -> compiler-component skeleton with only the componentState fields the widget path reads.
+const urlHash =
+    "g:!((g:!((g:!((h:compiler,i:(compiler:r1970,lang:rust,overrides:!((name:edition,value:'2021'),(name:arch,value:aarch64-unknown-linux-musl))),l:'5')),l:'4')),l:'2')),version:4";
+
+const rustc1970 = {
+    id: 'r1970',
+    lang: 'rust',
+    possibleOverrides: [
+        {
+            type: 'options',
+            name: CompilerOverrideType.edition,
+            display_title: 'Edition',
+            description: '',
+            flags: ['--edition', '<value>'],
+            values: [
+                {name: '2015', value: '2015'},
+                {name: '2018', value: '2018'},
+                {name: '2021', value: '2021'},
+                {name: '2024', value: '2024'},
+            ],
+            default: '2024',
+        },
+        {
+            type: 'options',
+            name: CompilerOverrideType.arch,
+            display_title: 'Architecture',
+            description: '',
+            flags: ['--target=<value>'],
+            values: [
+                {name: 'x86_64-unknown-linux-gnu', value: 'x86_64-unknown-linux-gnu'},
+                {name: 'aarch64-unknown-linux-musl', value: 'aarch64-unknown-linux-musl'},
+            ],
+        },
+    ],
+} as unknown as CompilerInfo;
+
+const gcc152 = {
+    id: 'g152',
+    lang: 'c++',
+    possibleOverrides: [
+        {
+            type: 'options',
+            name: CompilerOverrideType.stdver,
+            display_title: 'Std version',
+            description: '',
+            flags: ['-std=<value>'],
+            values: [{name: 'c++17', value: 'c++17'}],
+        },
+    ],
+} as unknown as CompilerInfo;
+
+const urlOverrides = [
+    {name: 'edition', value: '2021'},
+    {name: 'arch', value: 'aarch64-unknown-linux-musl'},
+];
+
+function findComponent(content: any[], name: string): any {
+    for (const item of content) {
+        if (item.componentName === name) {
+            return item;
+        }
+
+        if (item.content && Array.isArray(item.content)) {
+            const found = findComponent(item.content, name);
+
+            if (found) {
+                return found;
+            }
+        }
+    }
+    return null;
+}
+
+function makeDomRoot(): JQuery {
+    return $('<div><button class="btn show-overrides"></button></div>');
+}
+
+describe('CompilerShared override restoration', () => {
+    beforeEach(() => {
+        vi.mocked(compilersService.getCompilersForLang).mockReset();
+    });
+
+    it('deserialises the overrides from the URL fragment', () => {
+        const state = deserialiseState(urlHash);
+        const compiler = findComponent(state.content, 'compiler');
+
+        expect(compiler.componentState.compiler).toBe('r1970');
+        expect(compiler.componentState.lang).toBe('rust');
+        expect(compiler.componentState.overrides).toEqual(urlOverrides);
+    });
+
+    it('applies the URL overrides instead of the compiler defaults', async () => {
+        vi.mocked(compilersService.getCompilersForLang).mockResolvedValue({r1970: rustc1970});
+
+        const state = deserialiseState(urlHash);
+        const componentState = findComponent(state.content, 'compiler').componentState;
+        const shared = new CompilerShared(makeDomRoot(), () => {});
+
+        await shared.updateState(componentState);
+
+        expect(shared.getOverrides()).toEqual(urlOverrides);
+    });
+
+    it('keeps the URL overrides when the pane echoes its state back', async () => {
+        vi.mocked(compilersService.getCompilersForLang).mockResolvedValue({r1970: rustc1970});
+
+        const state = deserialiseState(urlHash);
+        const componentState = findComponent(state.content, 'compiler').componentState;
+        const shared = new CompilerShared(makeDomRoot(), () => {});
+
+        await shared.updateState(componentState);
+
+        await shared.updateState({...componentState, overrides: shared.getOverrides()});
+
+        expect(shared.getOverrides()).toEqual(urlOverrides);
+    });
+
+    it('ignores a stale compiler-list fetch that resolves after a newer call', async () => {
+        let resolveRust!: (value: Record<string, CompilerInfo>) => void;
+
+        const rustPromise = new Promise<Record<string, CompilerInfo>>(resolve => {
+            resolveRust = resolve;
+        });
+
+        vi.mocked(compilersService.getCompilersForLang).mockImplementation(lang =>
+            lang === 'rust' ? rustPromise : Promise.resolve({g152: gcc152}),
+        );
+
+        const shared = new CompilerShared(makeDomRoot(), () => {});
+
+        const stale = shared.updateState({
+            compiler: 'r1970',
+            lang: 'rust',
+            overrides: [{name: 'edition', value: '2018'}],
+        } as any);
+
+        const fresh = shared.updateState({
+            compiler: 'g152',
+            lang: 'c++',
+            overrides: [{name: 'stdver', value: 'c++17'}],
+        } as any);
+
+        await fresh;
+
+        resolveRust({r1970: rustc1970});
+
+        await stale;
+
+        expect(shared.getOverrides()).toEqual([{name: 'stdver', value: 'c++17'}]);
+    });
+});

--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -408,9 +408,13 @@ export class CompilerOverridesWidget {
         this.updateButton();
     }
 
-    async setCompiler(compilerId: string, languageId?: string) {
+    async setCompiler(compilerId: string, languageId?: string, signal?: AbortSignal) {
         if (languageId) {
             const compilers = await compilersService.getCompilersForLang(languageId);
+
+            if (signal?.aborted) {
+                return;
+            }
             this.compiler = compilers[compilerId];
         } else {
             this.compiler = undefined;

--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -192,7 +192,7 @@ export class CompilerOverridesWidget {
                         'The value of this override is not compatible with the current compiler.',
                     );
                 } else if (
-                    current_overrides?.find(ov => {
+                    current_overrides.find(ov => {
                         return ov.name !== CompilerOverrideType.env && ov.name === fave.name && ov.value === fave.value;
                     })
                 ) {
@@ -383,17 +383,27 @@ export class CompilerOverridesWidget {
     }
 
     set(configured: ConfiguredOverrides) {
-        this.configured = [];
+        this.configured = this.filterForCompiler(configured);
+        this.updateButton();
+    }
 
-        // Only keep the overrides that apply to this compiler. Set the overrides to the their
-        // defaults if they are not configured.
-        for (const ov of this.compiler?.possibleOverrides ?? []) {
+    // Only keep the overrides that apply to this compiler. Set the overrides to their
+    // defaults if they are not configured. Without a compiler the applicable overrides are
+    // unknown, so we keep the configuration as-is. setCompiler() re-filters once it resolves.
+    private filterForCompiler(configured: ConfiguredOverrides): ConfiguredOverrides {
+        if (!this.compiler) {
+            return configured;
+        }
+
+        const filtered: ConfiguredOverrides = [];
+
+        for (const ov of this.compiler.possibleOverrides ?? []) {
             if (ov.name === CompilerOverrideType.env) continue;
             const config = configured.find(config => config.name === ov.name);
             if (config) {
-                this.configured.push(config);
+                filtered.push(config);
             } else if (!this.dirtyOverrides.has(ov.name) && ov.default) {
-                this.configured.push({
+                filtered.push({
                     name: ov.name,
                     value: ov.default,
                 });
@@ -402,10 +412,10 @@ export class CompilerOverridesWidget {
 
         const config = configured.find(config => config.name === CompilerOverrideType.env);
         if (config) {
-            this.configured.push(config);
+            filtered.push(config);
         }
 
-        this.updateButton();
+        return filtered;
     }
 
     async setCompiler(compilerId: string, languageId?: string, signal?: AbortSignal) {
@@ -419,13 +429,13 @@ export class CompilerOverridesWidget {
         } else {
             this.compiler = undefined;
         }
+
+        this.configured = this.filterForCompiler(this.configured);
+        this.updateButton();
     }
 
-    get(): ConfiguredOverrides | undefined {
-        if (this.compiler) {
-            return this.configured;
-        }
-        return undefined;
+    get(): ConfiguredOverrides {
+        return this.configured;
     }
 
     private getFavorites(): FavOverrides {
@@ -438,7 +448,7 @@ export class CompilerOverridesWidget {
 
     private updateButton() {
         const selected = this.get();
-        if (selected && selected.length > 0) {
+        if (selected.length > 0) {
             this.dropdownButton
                 .addClass('btn-success')
                 .removeClass('btn-light')

--- a/static/widgets/compiler-overrides.ts
+++ b/static/widgets/compiler-overrides.ts
@@ -418,11 +418,11 @@ export class CompilerOverridesWidget {
         return filtered;
     }
 
-    async setCompiler(compilerId: string, languageId?: string, signal?: AbortSignal) {
+    async setCompiler(compilerId: string, languageId: string | undefined, signal: AbortSignal) {
         if (languageId) {
             const compilers = await compilersService.getCompilersForLang(languageId);
 
-            if (signal?.aborted) {
+            if (signal.aborted) {
                 return;
             }
             this.compiler = compilers[compilerId];

--- a/static/widgets/runtime-tools.ts
+++ b/static/widgets/runtime-tools.ts
@@ -350,9 +350,13 @@ export class RuntimeToolsWidget {
         this.updateButton();
     }
 
-    async setCompiler(compilerId: string, languageId?: string) {
+    async setCompiler(compilerId: string, languageId?: string, signal?: AbortSignal) {
         if (languageId) {
             const compilers = await compilersService.getCompilersForLang(languageId);
+
+            if (signal?.aborted) {
+                return;
+            }
             this.compiler = compilers[compilerId];
         } else {
             this.compiler = undefined;

--- a/static/widgets/runtime-tools.ts
+++ b/static/widgets/runtime-tools.ts
@@ -350,11 +350,11 @@ export class RuntimeToolsWidget {
         this.updateButton();
     }
 
-    async setCompiler(compilerId: string, languageId?: string, signal?: AbortSignal) {
+    async setCompiler(compilerId: string, languageId: string | undefined, signal: AbortSignal) {
         if (languageId) {
             const compilers = await compilersService.getCompilersForLang(languageId);
 
-            if (signal?.aborted) {
+            if (signal.aborted) {
                 return;
             }
             this.compiler = compilers[compilerId];

--- a/static/widgets/runtime-tools.ts
+++ b/static/widgets/runtime-tools.ts
@@ -363,11 +363,8 @@ export class RuntimeToolsWidget {
         }
     }
 
-    get(): ConfiguredRuntimeTools | undefined {
-        if (this.compiler) {
-            return this.configured;
-        }
-        return undefined;
+    get(): ConfiguredRuntimeTools {
+        return this.configured;
     }
 
     private getFavorites(): FavRuntimeTools {
@@ -380,7 +377,7 @@ export class RuntimeToolsWidget {
 
     private updateButton() {
         const selected = this.get();
-        if (selected && selected.length > 0) {
+        if (selected.length > 0) {
             this.dropdownButton
                 .addClass('btn-success')
                 .removeClass('btn-light')


### PR DESCRIPTION
(in Biome this bug would've been noticed by `lint/nursery/noFloatingPromises`, I didn't want to turn that on as it is in nursery).

Opening a link with compiler overrides loads the defaults instead.

E.g. a Rust link saved with edition 2021 & an arch comes up as 2024, arch unset.

Repro: [link with edition 2021 + musl arch](https://rust.godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,source:'pub+fn+main()+%7B%0A++++println!!(%22Hello,+world!!%22)%3B%0A%7D'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1970,lang:rust,libs:!(),options:'',overrides:!((name:edition,value:'2021'),(name:arch,value:x86_64-unknown-linux-musl)),source:1),l:'5',n:'0',o:'+rustc+1.97.0+(Editor+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

The overrides here are discarded:

<img width="1237" height="1035" alt="image" src="https://github.com/user-attachments/assets/d9c671a0-725b-472e-b1f1-145f6e876db2" />

Since #8549 `setCompiler` is async. `updateState` never awaited it, so the overrides from the link were validated against a compiler that wasn't loaded yet and all thrown away and later state updates then refilled the empty list with the defaults. Runtime tools have the same race.

Review feedback: State without an overrides key gets the compiler defaults seeded into the widget (edition: 2024 for recent rustc). This is existing behavior. This PR merely moves the it to a different location. I pushed a test for it to make sure we understand how the behavior works (even if it is not the behavior we want).