### PR TITLE
Report where a temporary result was actually stored

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3382,10 +3382,13 @@ export class BaseCompiler {
             const resultSize = resultString.length;
 
             if (resultSize > WEBSOCKET_SIZE_THRESHOLD) {
-                // Store with 1-day TTL for temporary retrieval in temp/ subdirectory
-                await this.env.tempCachePutWithTTL(cacheKey, resultString, TEMP_STORAGE_TTL_DAYS, undefined);
-                // Set s3Key with temp/ prefix to reflect storage location
-                fullResult.s3Key = `temp/${BaseCache.hash(cacheKey)}`;
+                // Too big for the websocket: hand the reader an out-of-band key instead
+                fullResult.s3Key = await this.env.tempCachePutWithTTL(
+                    cacheKey,
+                    resultString,
+                    TEMP_STORAGE_TTL_DAYS,
+                    undefined,
+                );
             }
         }
 
@@ -3654,10 +3657,8 @@ export class BaseCompiler {
             const resultSize = resultString.length;
 
             if (resultSize > WEBSOCKET_SIZE_THRESHOLD) {
-                // Store with 1-day TTL for temporary retrieval in temp/ subdirectory
-                await this.env.tempCachePutWithTTL(key, resultString, TEMP_STORAGE_TTL_DAYS, undefined);
-                // Set s3Key with temp/ prefix to reflect storage location
-                result.s3Key = `temp/${BaseCache.hash(key)}`;
+                // Too big for the websocket: hand the reader an out-of-band key instead
+                result.s3Key = await this.env.tempCachePutWithTTL(key, resultString, TEMP_STORAGE_TTL_DAYS, undefined);
             }
         }
 

--- a/lib/compilation-env.ts
+++ b/lib/compilation-env.ts
@@ -181,21 +181,23 @@ export class CompilationEnvironment {
         }
     }
 
+    // Returns the key the value was stored under, relative to the cache's own path.
     async tempCachePutWithTTL(
         object: CacheableValue,
         jsonString: string,
         ttlDays: number,
         creator: string | undefined,
-    ) {
+    ): Promise<string> {
         const key = BaseCache.hash(object);
 
         // Check if cache is S3Cache to use TTL functionality with temp path
         if (this.cache instanceof S3Cache) {
-            return this.cache.putWithTTLAndPath(key, Buffer.from(jsonString), ttlDays, 'temp', creator);
-        } else {
-            // Fallback to regular put for non-S3 caches
-            return this.cache.put(key, jsonString, creator);
+            await this.cache.putWithTTLAndPath(key, Buffer.from(jsonString), ttlDays, 'temp', creator);
+            return `temp/${key}`;
         }
+        // Fallback to regular put for non-S3 caches
+        await this.cache.put(key, jsonString, creator);
+        return key;
     }
 
     getExecutableHash(object: CacheableValue): string {

--- a/test/compilation-env-tests.ts
+++ b/test/compilation-env-tests.ts
@@ -24,7 +24,9 @@
 
 import './utils.js';
 
-import {beforeAll, describe, expect, it} from 'vitest';
+import {PutObjectCommand, S3} from '@aws-sdk/client-s3';
+import {mockClient} from 'aws-sdk-client-mock';
+import {beforeAll, beforeEach, describe, expect, it} from 'vitest';
 
 import {CompilationEnvironment} from '../lib/compilation-env.js';
 import {CompilationQueue} from '../lib/compilation-queue.js';
@@ -81,5 +83,44 @@ describe('Compilation environment', () => {
         const ce = new CompilationEnvironment(compilerProps, fakeProps({}), compilationQueue, new FormattingService());
         expect(ce.findBadOptions(['-O3', '-flto'])).toEqual([]);
         expect(ce.findBadOptions(['-O3', '-plugin'])).toEqual(['-plugin']);
+    });
+});
+
+describe('Temporary result storage', () => {
+    const mockS3 = mockClient(S3);
+    let compilationQueue: CompilationQueue;
+    let writtenKeys: string[];
+
+    beforeEach(() => {
+        compilationQueue = new CompilationQueue(1, 1000, 1000);
+        writtenKeys = [];
+        mockS3.reset();
+        mockS3.on(PutObjectCommand, {Bucket: 'test.bucket'}).callsFake(params => {
+            writtenKeys.push(params.Key);
+            return {};
+        });
+    });
+
+    function envForCacheConfig(cacheConfig: string) {
+        return new CompilationEnvironment(
+            new CompilerProps({}, fakeProps({...props, cacheConfig})),
+            fakeProps({}),
+            compilationQueue,
+            new FormattingService(),
+        );
+    }
+
+    // The deployed configuration is layered, so the cache is a MultiCache and never an S3Cache.
+    it('Reports the key it actually wrote to for a layered cache', async () => {
+        const ce = envForCacheConfig('InMemory(25);S3(test.bucket,cache,uk-north-1)');
+        const s3Key = await ce.tempCachePutWithTTL('some-key', '{"big": "result"}', 1, undefined);
+        expect(writtenKeys).toEqual([`cache/${s3Key}`]);
+    });
+
+    it('Reports the temp path when the cache is a bare S3 cache', async () => {
+        const ce = envForCacheConfig('S3(test.bucket,cache,uk-north-1)');
+        const s3Key = await ce.tempCachePutWithTTL('some-key', '{"big": "result"}', 1, undefined);
+        expect(s3Key).toMatch(/^temp\//);
+        expect(writtenKeys).toEqual([`cache/${s3Key}`]);
     });
 });


### PR DESCRIPTION
Fixes #9015.

Both halves check out. `cacheConfig` in `compiler-explorer.amazon.properties:11` is `InMemory(25);S3(storage.godbolt.org,cache,us-east-1)`, and `createInternal` returns a `MultiCache` for any config with a `;` in it, so `this.cache instanceof S3Cache` is false, the fallback `put` runs, and the object lands at `cache/<hash>`. At the other end, `fetchResultFromS3` in ce-router builds its `Key` as `prefix + s3Key` with `COMPILATION_RESULTS_PREFIX` defaulting to `cache/`, so a reported `temp/<hash>` sends it looking in `cache/temp/<hash>`.

I left the write where it is and fixed the reporting instead. `tempCachePutWithTTL` now returns the key it used, and both call sites in `base-compiler.ts` take `s3Key` from that rather than composing one of their own. A bare `S3Cache` still goes through `putWithTTLAndPath` and gets `temp/<hash>` back, which is right for it, since that method writes under `${this.path}/temp`.

Your second point, the fallback landing on the same key `cacheGet` reads, is untouched here. That one changes what an instance can serve rather than where a reader looks, so I would rather not fold it into this diff. I will open it separately if you want it.

The tests are in `test/compilation-env-tests.ts` and go through `createCacheFromConfig` as your note asks: one case on the layered production string, one on a bare `S3(...)`. Both assert that the key handed back names the object that reached the mocked `PutObjectCommand`. They sit at the storage layer rather than at the compiler, which is as close to the mismatch as I could get without standing up a worker compile; the call sites no longer have a key of their own to get wrong.

Green on the full suite (122 files, 2630 passed, 1 skipped) and through the pre-commit hook, both run in a Linux container since that is where my `node_modules` are built.
