### PR TITLE
Add the C++ Alliance P4324 minimal contracts clang

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -575,7 +575,7 @@ compiler.clang2210.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-lin
 compiler.clang2210.debugPatched=true
 
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_profiles_init:clang_profiles_core_ub:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_p1974:clang_chrisbazley
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_profiles_init:clang_profiles_core_ub:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_cppa_p4324:clang_p1974:clang_chrisbazley
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -751,6 +751,10 @@ compiler.clang_notadragon_contracts_p3850.exe=/opt/compiler-explorer/clang-notad
 compiler.clang_notadragon_contracts_p3850.semver=(P3850 contracts)
 compiler.clang_notadragon_contracts_p3850.notification=Experimental C++29 Contracts Implementation; see P3850, <a href="https://github.com/notadragon/llvm-project/tree/contracts-p3850" target="_blank" rel="noopener noreferrer">notadragon/llvm-project<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_notadragon_contracts_p3850.options=-stdlib=libc++
+compiler.clang_cppa_p4324.exe=/opt/compiler-explorer/clang-cppa-contracts-p4324/bin/clang++
+compiler.clang_cppa_p4324.semver=(P4324 contracts)
+compiler.clang_cppa_p4324.notification=Experimental Minimal Contracts; see <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4324r0.html" target="_blank" rel="noopener noreferrer">P4324R0<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.clang_cppa_p4324.options=-fcontracts -stdlib=libc++
 compiler.clang_p1974.exe=/opt/compiler-explorer/clang-p1974-trunk/bin/clang++
 compiler.clang_p1974.semver=(p1974)
 compiler.clang_p1974.notification=p1974; see <a href="https://github.com/je4d/llvm-project/tree/godbolt/propconst" target="_blank" rel="noopener noreferrer">je4d/llvm-project<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>


### PR DESCRIPTION
Adds the C++ Alliance's clang fork implementing [P4324R0 (minimal contracts)](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4324r0.html) to the C++ compiler list.

This is the last piece of a chain whose other parts are already merged:

| Repo | PR | What it does |
|---|---|---|
| clang-builder | compiler-explorer/clang-builder#121 | build recipe for `cppa-contracts-p4324` |
| infra | compiler-explorer/infra#2320 | nightly installable |
| compiler-workflows | compiler-explorer/compiler-workflows#79 | daily rebuild, gated on branch activity |

### Why both options

`options=-fcontracts -stdlib=libc++` is load-bearing, not decoration:

- **`-fcontracts`**: without it the `pre` / `post` / `contract_assert` syntax does not parse, so the compiler cannot demonstrate the thing it exists to demonstrate. It parses under the fork's default `-std`, so users do not have to pass `-std=c++2c` themselves.
- **`-stdlib=libc++`**: the violation handler `__handle_contract_violation_v3` is only defined in this fork's own libc++. Against the default libstdc++ the code compiles but fails to link, so anything using Execute would break. This matches the sibling `clang_notadragon_contracts_p3850`, which sets the same flag for the same reason. `group.clangx86trunk.ldPath` already covers the fork's lib dirs, so the runtime library resolves at execution time.

### Verification

Test-installed the actual S3 artifact (`clang-cppa-contracts-p4324-20260821.tar.xz`) with `ce_install --dest`, rather than eyeballing the config:

- `1 packages installed OK, 0 skipped, 0 failed`; `check_exe` passes.
- `clang version 24.0.0git (https://github.com/cppalliance/clang c0d0594f6...)`, matching the head of the `p4324` branch.
- `ldd` shows only system libraries, so nothing is missing from the tarball.
- A program with `pre` / `contract_assert` that `#include`s real headers compiles, links and runs; violating the precondition aborts with `bad.cpp:2: pre(i >= 0) failed`.

`npm run test:props` passes.

/cc @cor3ntin
