### PR TITLE
Split experimental clang forks into their own dropdown group

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -575,7 +575,7 @@ compiler.clang2210.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-lin
 compiler.clang2210.debugPatched=true
 
 
-group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_profiles_init:clang_profiles_core_ub:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_clangir:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_cppa_p4324:clang_p1974:clang_chrisbazley
+group.clangx86trunk.compilers=clang_trunk:clang_assertions_trunk:clang_clangir:&clangx86experimental
 group.clangx86trunk.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clangx86trunk.baseOptions=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot
 group.clangx86trunk.objdumper=/opt/compiler-explorer/gcc-snapshot/bin/objdump
@@ -594,6 +594,9 @@ group.clangx86trunk.ldPath=${exePath}/../lib|${exePath}/../lib/x86_64-unknown-li
 group.clangx86trunk.compilerCategories=clang
 group.clangx86trunk.demangler=/opt/compiler-explorer/clang-trunk/bin/llvm-cxxfilt
 group.clangx86trunk.debugPatched=true
+
+group.clangx86experimental.compilers=clang_concepts:clang_p1144:clang_autonsdmi:clang_p2561:clang_bb_p2996:clang_p2998:clang_p3039:clang_p3068:clang_p3309:clang_p3334:clang_p3367:clang_p3372:clang_p3385:clang_p3412:clang_p3776:clang_p3817:clang_p3822:clang_p3951:clang_profiles_init:clang_profiles_core_ub:clang_barry:clang_implicit_constexpr:clang_hana:clang_lifetime:clang_p1061:clang_parmexpr:clang_patmat:clang_embed:clang_dang:clang_thephd_dev:clang_reflection:clang_variadic_friends:clang_widberg:clang_resugar:clang_dascandy_contracts:clang_ericwf_contracts:clang_notadragon_contracts_p3850:clang_cppa_p4324:clang_p1974:clang_chrisbazley
+group.clangx86experimental.groupName=Clang x86-64 (experimental forks)
 
 compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.clang_trunk.semver=(trunk)


### PR DESCRIPTION
The **Clang x86-64** section currently mixes upstream `llvm/llvm-project` builds in with 40 third-party forks, so there is no way to tell at a glance which entries are actually upstream clang. Several people in the clang community have raised this as the number of experimental forks has grown.

This splits them:

- **Clang x86-64** keeps the upstream builds: `clang_trunk`, `clang_assertions_trunk`, and `clang_clangir`.
- **Clang x86-64 (experimental forks)** gets the other 40.

`clang_clangir` is deliberately on the upstream side: since compiler-explorer/clang-builder#111 it builds from `llvm/llvm-project` main with `-DCLANG_ENABLE_CIR=ON`, because ClangIR has been upstreamed. It is a build flag, not a fork.

### Why this is only four lines

`clangx86experimental` is nested inside `clangx86trunk` rather than being a new top-level group, so it inherits every other `group.clangx86trunk.*` property (`baseName`, `ldPath`, `isNightly`, `compilerType`, the `supports*` flags and the rest). `compiler-finder.ts` passes the enclosing group's resolver as the fallback when it expands a `&group` reference, and returns the innermost group id for `group`, which is what the picker keys its sections off.

This is exactly what `clangx86assert` already does inside `group.clang` to render its own "Clang x86-64 (assertions)" section, so the mechanism is already in production.

### Compatibility

Only the dropdown label changes. Compiler ids, `name` and `baseName` are all untouched, so **existing links and bookmarks keep working** and no compiler is renamed.

`npm run test:props` passes.

/cc @cor3ntin
