### PR TITLE
Allow `stdin` for Rust Miri tool

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1383,7 +1383,6 @@ tools.miri.exe=/opt/compiler-explorer/rust-miri-nightly/bin/miri
 tools.miri.options=--sysroot=/opt/compiler-explorer/rust-miri-nightly/miri-sysroot --color=always
 tools.miri.type=independent
 tools.miri.class=miri-tool
-tools.miri.stdinHint=disabled
 
 tools.ldd.name=ldd
 tools.ldd.exe=/usr/bin/ldd


### PR DESCRIPTION
Miri is an interpreter, so it makes sense to allow `stdin` just like in an execution pane.