### PR TITLE
Replace exact string comparison with semver comparison for tool excludes

### DIFF
--- a/docs/AddingATool.md
+++ b/docs/AddingATool.md
@@ -27,8 +27,9 @@ The `type` of the tool represents the stage in which the tool will run:
 - independent - when running a tool on sourcecode
 - postcompilation - when running a tool on the assembly or a binary
 
-The `exclude` property is to indicate which compilers are proven to be incompatible with the tool. You can supply the
-full id of the compiler, or a partial id (for example 'arm' to exclude all arm compilers).
+The `exclude` property is to indicate which compilers are proven to be incompatible with the tool. Values of the form
+`group<semver` are interpreted as excluding compilers from group `group` that have a SemVer less than the given
+`semver`. All other values will exclude any compiler whose ID contains the value as a substring.
 
 The `class` of the tool says which javascript class is needed to run the tool and process its output. The folder
 _lib/tooling_ is used for these classes.

--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1376,7 +1376,7 @@ tools.clippy.stdinHint=disabled
 tools.clippy.includeKey=supportsClippy
 # clippy is supported for Rust >= 1.29
 # https://github.com/compiler-explorer/compiler-explorer/pull/7477#pullrequestreview-2662514775
-tools.clippy.exclude=r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190$:r180$:r170$:r160$:r150$:r140$:r130$:r120$:r110$:r100$
+tools.clippy.exclude=rust<1.29.0
 
 tools.miri.name=Miri nightly
 tools.miri.exe=/opt/compiler-explorer/rust-miri-nightly/bin/miri

--- a/lib/tooling/base-tool.ts
+++ b/lib/tooling/base-tool.ts
@@ -25,6 +25,7 @@
 import path from 'node:path';
 
 import PromClient from 'prom-client';
+import {SemVer} from 'semver';
 import _ from 'underscore';
 
 import {CompilationInfo, ExecutionOptions} from '../../types/compilation/compilation.interfaces.js';
@@ -85,8 +86,17 @@ export class BaseTool implements ITool {
 
         return (
             this.tool.exclude.find(excl => {
-                if (excl.endsWith('$')) {
-                    return compilerId === excl.substring(0, excl.length - 1);
+                if (excl.includes('<')) {
+                    const [group, version] = excl.split('<');
+                    try {
+                        return (
+                            compilerProps('group') === group &&
+                            !compilerProps('isNightly') &&
+                            new SemVer(compilerProps<string>('semver')).compare(version) < 0
+                        );
+                    } catch {
+                        return false;
+                    }
                 }
                 return compilerId.includes(excl);
             }) !== undefined


### PR DESCRIPTION
The existing `clippy` excludes would need to be changed for Rust 1.100’s release anyways (to all use `$` as e. g. `r1100` would match `r11000`), and additionally a semver comparison is simpler for exclude lists that exclude a larger number of versions, e. g. if someone were to add `llvm-cov` as a tool, which is only available in Rust >= 1.49.