### PR TITLE
Mask temp paths on the compilation cache-hit path

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3635,8 +3635,6 @@ export class BaseCompiler {
             ];
         }
 
-        // Mask before caching, not after: whatever we store here is served verbatim on a
-        // cache hit, which never gets a chance to clean it up.
         this.cleanupResult(result);
 
         if (result.okToCache && !delayCaching) {

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3466,6 +3466,13 @@ export class BaseCompiler {
                 result.retreivedFromCacheTime = utils.deltaTimeNanoToMili(cacheRetrieveTimeStart, cacheRetrieveTimeEnd);
                 result.retreivedFromCache = true;
                 result.s3Key = BaseCache.hash(key);
+                // cachePut() stores the result *before* cleanupResult() masks it, so what
+                // comes back out still has the temp dir of whichever compilation happened to
+                // populate the entry. Mask on the way out too, or a cache hit shows a
+                // different command line to the cold compile of the same input. Safe to
+                // repeat: maskRootdirKeepingAppPrefix() only rewrites paths still carrying
+                // the temp prefix, so re-masking an already-masked result is a no-op.
+                this.cleanupResult(result);
                 if (doExecute) {
                     const queueTime = performance.now();
                     result.execResult = await this.env.enqueue(

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3466,12 +3466,8 @@ export class BaseCompiler {
                 result.retreivedFromCacheTime = utils.deltaTimeNanoToMili(cacheRetrieveTimeStart, cacheRetrieveTimeEnd);
                 result.retreivedFromCache = true;
                 result.s3Key = BaseCache.hash(key);
-                // cachePut() stores the result *before* cleanupResult() masks it, so what
-                // comes back out still has the temp dir of whichever compilation happened to
-                // populate the entry. Mask on the way out too, or a cache hit shows a
-                // different command line to the cold compile of the same input. Safe to
-                // repeat: maskRootdirKeepingAppPrefix() only rewrites paths still carrying
-                // the temp prefix, so re-masking an already-masked result is a no-op.
+                // We cache before masking, so cached results still hold a temp dir. Masking
+                // is idempotent, so it's safe to redo here.
                 this.cleanupResult(result);
                 if (doExecute) {
                     const queueTime = performance.now();

--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3466,9 +3466,6 @@ export class BaseCompiler {
                 result.retreivedFromCacheTime = utils.deltaTimeNanoToMili(cacheRetrieveTimeStart, cacheRetrieveTimeEnd);
                 result.retreivedFromCache = true;
                 result.s3Key = BaseCache.hash(key);
-                // We cache before masking, so cached results still hold a temp dir. Masking
-                // is idempotent, so it's safe to redo here.
-                this.cleanupResult(result);
                 if (doExecute) {
                     const queueTime = performance.now();
                     result.execResult = await this.env.enqueue(
@@ -3638,6 +3635,10 @@ export class BaseCompiler {
             ];
         }
 
+        // Mask before caching, not after: whatever we store here is served verbatim on a
+        // cache hit, which never gets a chance to clean it up.
+        this.cleanupResult(result);
+
         if (result.okToCache && !delayCaching) {
             await this.env.cachePut(key, result, undefined);
         }
@@ -3650,7 +3651,6 @@ export class BaseCompiler {
             }
         }
 
-        this.cleanupResult(result);
         result.s3Key = BaseCache.hash(key);
 
         // In worker mode, store large non-cacheable results with short TTL

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -801,15 +801,6 @@ describe('maskRootdirKeepingAppPrefix', () => {
     it('leaves non-temp paths untouched', () => {
         expect(utils.maskRootdirKeepingAppPrefix('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
-
-    it('is idempotent, so masking an already-masked path is a no-op', () => {
-        // Load-bearing for base-compiler's cache-hit path, which masks results that may
-        // already have been masked before being cached.
-        const once = utils.maskRootdirKeepingAppPrefix('/tmp/compiler-explorer-compiler123-4-abc/example.cpp');
-        expect(utils.maskRootdirKeepingAppPrefix(once)).toEqual(once);
-        const embedded = utils.maskRootdirKeepingAppPrefix('-I/tmp/compiler-explorer-compiler123-4-abc/include');
-        expect(utils.maskRootdirKeepingAppPrefix(embedded)).toEqual(embedded);
-    });
 });
 
 describe('maskRootdir', () => {

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -801,6 +801,15 @@ describe('maskRootdirKeepingAppPrefix', () => {
     it('leaves non-temp paths untouched', () => {
         expect(utils.maskRootdirKeepingAppPrefix('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
+
+    it('is idempotent, so masking an already-masked path is a no-op', () => {
+        // Load-bearing for base-compiler's cache-hit path, which masks results that may
+        // already have been masked before being cached.
+        const once = utils.maskRootdirKeepingAppPrefix('/tmp/compiler-explorer-compiler123-4-abc/example.cpp');
+        expect(utils.maskRootdirKeepingAppPrefix(once)).toEqual(once);
+        const embedded = utils.maskRootdirKeepingAppPrefix('-I/tmp/compiler-explorer-compiler123-4-abc/include');
+        expect(utils.maskRootdirKeepingAppPrefix(embedded)).toEqual(embedded);
+    });
 });
 
 describe('maskRootdir', () => {

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -801,6 +801,13 @@ describe('maskRootdirKeepingAppPrefix', () => {
     it('leaves non-temp paths untouched', () => {
         expect(utils.maskRootdirKeepingAppPrefix('/usr/include/stdio.h')).toEqual('/usr/include/stdio.h');
     });
+
+    it('is idempotent, so masking an already-masked path is a no-op', () => {
+        const once = utils.maskRootdirKeepingAppPrefix('/tmp/compiler-explorer-compiler123-4-abc/example.cpp');
+        expect(utils.maskRootdirKeepingAppPrefix(once)).toEqual(once);
+        const embedded = utils.maskRootdirKeepingAppPrefix('-I/tmp/compiler-explorer-compiler123-4-abc/include');
+        expect(utils.maskRootdirKeepingAppPrefix(embedded)).toEqual(embedded);
+    });
 });
 
 describe('maskRootdir', () => {


### PR DESCRIPTION
### The bug

`cachePut()` stores the compilation result **before** `cleanupResult()` masks it, and the cache-hit path returns the stored value directly. So we cache an unmasked result, and every subsequent hit serves it verbatim.

### What you see

The compilation-options popover shows a different command line for a warm compile than for a cold one of the same input, naming a temp dir that belonged to an unrelated earlier request:

```
cold:  -o output.s ... example.cpp
warm:  -o /tmp/compiler-explorer-compilerAbC123/output.s ... /tmp/compiler-explorer-compilerAbC123/example.cpp
```

`inputFilename` gets the same treatment, since `cleanupResult()` masks both.

Cosmetic rather than a disclosure problem: the temp dir name isn't sensitive. The reason it's worth fixing is that it means the masking added in #9033 only ever takes effect on cold compiles, so on a warm instance most users see the unmasked form.

### The fix

Move `cleanupResult()` above `cachePut()`, so what we store is what we'd have shown. One statement, no new call site.

Nothing between the two positions reads the fields being masked: the intervening block only touches `result.execResult` and its `buildResult`.

### Scope

This covers the main compilation cache path. Two other `cachePut()` call sites exist, and I have **not** verified them here: the execution cache, and the cmake `fullResult` path (which caches with `delayCaching` and whose inner `fullResult.result.compilationOptions` isn't reached by `cleanupResult()` anyway, since that only masks top level). Worth a look separately.

Also still unmasked on every path: `irOutput.compilationOptions` and `optPipelineOutput.compilationOptions`. Being handled as part of the review of #8960, which adds the panes that surface them.

### On existing cache entries

No migration concern. Cache entries live under `cache/` in `storage.godbolt.org`, which has a lifecycle rule expiring them after 1 day (`terraform/s3.tf`, "Remove cached items"), so anything cached unmasked before this ships ages out by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
