### PR TITLE
Re-render the difftype dropdown when its options are rebuilt

### DIFF
--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -61,6 +61,13 @@ function decodeSelectizeValue(value: string): DiffTypeAndExtra {
     };
 }
 
+function replaceOptions(picker: TomSelect, options: any[]): void {
+    picker.clearOptions();
+    picker.addOptions(options);
+    // addOptions() doesn't re-render an open dropdown, leaving the user staring at an empty list.
+    if (picker.isOpen) picker.refreshOptions(false);
+}
+
 function isSourceEntryId(id: number | string | undefined): boolean {
     return typeof id === 'string' && id.startsWith('source_');
 }
@@ -475,8 +482,7 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
             side.source || side.difftype === DiffType.Source
                 ? [{id: DiffType.Source.toString(), name: 'Source'}]
                 : this.getDiffableOptions();
-        difftypePicker.clearOptions();
-        difftypePicker.addOptions(options);
+        replaceOptions(difftypePicker, options);
         difftypePicker.setValue(
             encodeSelectizeValue({
                 difftype: side.difftype || DiffType.ASM,
@@ -613,14 +619,12 @@ export class Diff extends MonacoPane<monaco.editor.IStandaloneDiffEditor, DiffSt
 
         if (!this.lhs.source) {
             const lhsoptions = this.getDiffableOptions(this.selectize.lhs, lhsextraoptions);
-            this.selectize.lhsdifftype.clearOptions();
-            this.selectize.lhsdifftype.addOptions(lhsoptions);
+            replaceOptions(this.selectize.lhsdifftype, lhsoptions);
         }
 
         if (!this.rhs.source) {
             const rhsoptions = this.getDiffableOptions(this.selectize.rhs, rhsextraoptions);
-            this.selectize.rhsdifftype.clearOptions();
-            this.selectize.rhsdifftype.addOptions(rhsoptions);
+            replaceOptions(this.selectize.rhsdifftype, rhsoptions);
         }
     }
 


### PR DESCRIPTION
Fixes #9056. Fixes #9045.

### The bug, which is real for users and not just for CI

TomSelect's `addOptions()` does not re-render a dropdown that is already open. `static/panes/diff.ts` rebuilds the difftype options whenever a compile result lands:

```ts
this.selectize.lhsdifftype.clearOptions();
this.selectize.lhsdifftype.addOptions(lhsoptions);
```

`clearOptions()` strips the rendered `.option` nodes, and nothing puts them back. So if you have the difftype picker open when a compile response arrives, **the list empties under you** and stays empty until you close and reopen it.

### The fix

Route the three rebuild sites through a helper that re-renders when the picker is open.

`refreshOptions(false)` is deliberate: in tom-select both the open and the close branches are gated on that argument (`if (triggerDropdown && !self.isOpen)` / `if (triggerDropdown && self.isOpen)`), so passing `false` leaves the dropdown's open/closed state alone and only re-renders the list. The `isOpen` guard keeps the common closed case from doing render work on every compile.

### Why this also fixes the flaky test

#9056 worked out the mechanism: `diff.cy.ts` types `-O2` into the options field, which debounce-triggers a recompile, then clicks the difftype picker without waiting for it to settle. If the response lands in the window between the click and the assertion, the dropdown is emptied and `.ts-dropdown .option:visible` finds nothing.

Fixing the pane rather than adding a wait to the test means the user-facing bug goes away too, rather than just being hidden from CI.

### On verification

I can't prove this deterministically: it's a race, so a green cypress run isn't evidence either way, and the same run passes on `main` most of the time. What I have checked is the mechanism end to end, in particular that `refreshOptions(false)` re-renders without touching open/closed state. Worth a maintainer sanity-check of that reasoning rather than trusting a green tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)