### PR TITLE
Unify the TomSelect repaint workaround in one place

### DIFF
--- a/static/panes/cfg-view.ts
+++ b/static/panes/cfg-view.ts
@@ -43,6 +43,7 @@ import * as BootstrapUtils from '../bootstrap-utils.js';
 import {GraphLayoutCore} from '../graph-layout-core.js';
 import {Hub} from '../hub.js';
 import * as MonacoConfig from '../monaco-config.js';
+import {replaceOptions} from '../tom-select-utils.js';
 import * as utils from '../utils.js';
 import {Toggles} from '../widgets/toggles.js';
 import {CfgState} from './cfg-view.interfaces.js';
@@ -333,25 +334,18 @@ export class Cfg extends Pane<CfgState> {
     override onCompileResult(compilerId: number, compiler: CompilerInfo, result: CompilationResult) {
         if (this.compilerInfo.compilerId !== compilerId) return;
         this.functionSelector.clear(true);
-        this.functionSelector.clearOptions();
         const cfg = this.state.isircfg ? result.irOutput?.cfg : result.cfg;
         if (cfg) {
             this.results = cfg;
             this.contentsAreIr = !!this.state.isircfg || !!result.compilationOptions?.includes('-emit-llvm');
             let selectedFunction: string | null = this.state.selectedFunction;
             const keys = Object.keys(cfg);
-            if (keys.length === 0) {
-                this.functionSelector.addOption({
-                    title: '<No functions available>',
-                    value: '<No functions available>',
-                });
-            }
-            for (const fn of keys) {
-                this.functionSelector.addOption({
-                    title: fn,
-                    value: fn,
-                });
-            }
+            replaceOptions(
+                this.functionSelector,
+                keys.length === 0
+                    ? [{title: '<No functions available>', value: '<No functions available>'}]
+                    : keys.map(fn => ({title: fn, value: fn})),
+            );
             if (keys.length > 0) {
                 if (selectedFunction === '' || !(selectedFunction !== null && selectedFunction in cfg)) {
                     selectedFunction = keys[0];
@@ -365,6 +359,7 @@ export class Cfg extends Pane<CfgState> {
             this.selectFunction(selectedFunction);
         } else {
             // this case can be fallen into with a blank input file
+            replaceOptions(this.functionSelector, []);
             this.selectFunction(null);
         }
     }

--- a/static/panes/diff.ts
+++ b/static/panes/diff.ts
@@ -31,6 +31,7 @@ import {CompilationResult} from '../../types/compilation/compilation.interfaces.
 import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {Hub} from '../hub.js';
+import {replaceOptions} from '../tom-select-utils.js';
 import {DiffState, DiffType} from './diff.interfaces.js';
 import {MonacoPaneState} from './pane.interfaces.js';
 import {MonacoPane} from './pane.js';
@@ -59,13 +60,6 @@ function decodeSelectizeValue(value: string): DiffTypeAndExtra {
         difftype: Number.parseInt(value, 10),
         extraoption: '',
     };
-}
-
-function replaceOptions(picker: TomSelect, options: any[]): void {
-    picker.clearOptions();
-    picker.addOptions(options);
-    // addOptions() doesn't re-render an open dropdown, leaving the user staring at an empty list.
-    if (picker.isOpen) picker.refreshOptions(false);
 }
 
 function isSourceEntryId(id: number | string | undefined): boolean {

--- a/static/panes/gccdump-view.ts
+++ b/static/panes/gccdump-view.ts
@@ -34,6 +34,7 @@ import {CompilationResult, GccDumpOutput} from '../../types/compilation/compilat
 import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import {Hub} from '../hub.js';
 import * as monacoConfig from '../monaco-config.js';
+import {replaceOptions} from '../tom-select-utils.js';
 import {Toggles} from '../widgets/toggles.js';
 import {GccDumpFiltersState, GccDumpViewSelectedPass, GccDumpViewState} from './gccdump-view.interfaces.js';
 import {MonacoPaneState, PaneState} from './pane.interfaces.js';
@@ -372,20 +373,15 @@ but nothing was dumped. Possible causes are:
         // Pass `() => false` so EVERY option is dropped: TomSelect's default clearOptions filter
         // keeps options belonging to the currently-selected item, which would otherwise leave a
         // stale pass (e.g. a Tree pass after Tree dumps are unchecked) in the drop-down.
-        selectize.clearOptions(() => false);
-
-        for (const p of passes) {
-            selectize.addOption(p);
-        }
+        replaceOptions(selectize, passes, () => false);
 
         if (gccDumpOutput?.selectedPass?.name) {
             selectize.addItem(gccDumpOutput.selectedPass.name, true);
             this.eventHub.emit('gccDumpPassSelected', this.compilerInfo.compilerId, gccDumpOutput.selectedPass, false);
         } else selectize.clear(true);
 
-        // Re-render the drop-down from the new option set. clearOptions()/addOption() only mark
-        // the rendered content stale; neither they nor a later open() actually repaint it, so
-        // without this the drop-down can keep showing the previous pass list.
+        // addItem() above goes through refreshItems(), which re-marks the drop-down stale, so
+        // the repaint replaceOptions() already did is no longer enough on that path.
         selectize.refreshOptions(false);
 
         this.inhibitPassSelect = false;

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -42,6 +42,7 @@ import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import {Hub} from '../hub.js';
 import {extendConfig} from '../monaco-config.js';
 import {SentryCapture} from '../sentry.js';
+import {replaceOptions} from '../tom-select-utils.js';
 import * as utils from '../utils.js';
 import {Toggles} from '../widgets/toggles.js';
 import {OptPipelineViewState} from './opt-pipeline.interfaces.js';
@@ -365,20 +366,13 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
         //const groups = Object.keys(result);
         let selectedGroup = this.state.selectedGroup; // one of the .clear calls below will end up resetting this
         this.groupSelector.clear();
-        this.groupSelector.clearOptions();
         const keys = Object.keys(results);
-        if (keys.length === 0) {
-            this.groupSelector.addOption({
-                title: '<No groups available>',
-                value: '<No groups available>',
-            });
-        }
-        for (const fn of keys) {
-            this.groupSelector.addOption({
-                title: fn,
-                value: fn,
-            });
-        }
+        replaceOptions(
+            this.groupSelector,
+            keys.length === 0
+                ? [{title: '<No groups available>', value: '<No groups available>'}]
+                : keys.map(fn => ({title: fn, value: fn})),
+        );
         this.passesList.empty();
         if (keys.length > 0) {
             if (selectedGroup === '' || !(selectedGroup in results)) {

--- a/static/tom-select-utils.ts
+++ b/static/tom-select-utils.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import TomSelect from 'tom-select';
+import type {TomClearFilter, TomOption} from 'tom-select/dist/esm/types/core.js';
+
+/**
+ * Replace a picker's entire option set and repaint the drop-down.
+ *
+ * `clearOptions()` and `addOption()` only mark the rendered content stale; neither they nor
+ * a later `open()` repaint it. Only tom-select's focus and input handlers call
+ * `refreshOptions()`, so a drop-down that is open, or that is reopened without first losing
+ * focus, keeps showing the previous option list until something forces a re-render.
+ *
+ * `refreshOptions(false)` is what forces it: tom-select gates both its open and its close
+ * branch on that argument, so passing `false` re-renders the list while leaving the
+ * drop-down's open/closed state alone.
+ *
+ * @param picker the tom-select instance to update
+ * @param options the new option set
+ * @param clearFilter passed through to `clearOptions()`. Return true to keep an option.
+ *   Pass `() => false` to drop every option, including those belonging to the current
+ *   selection, which tom-select's default filter would otherwise keep.
+ */
+export function replaceOptions(picker: TomSelect, options: TomOption[], clearFilter?: TomClearFilter): void {
+    picker.clearOptions(clearFilter);
+    picker.addOptions(options);
+    picker.refreshOptions(false);
+}


### PR DESCRIPTION
Follow-up to #9058, answering your question there: yes, other TomSelects suffer the same fate.

### The underlying behaviour

`clearOptions()` and `addOption()` only mark a tom-select drop-down's rendered content stale. Nothing repaints it. `open()` does not, and only the focus and input handlers call `refreshOptions()`. So a drop-down that is open, **or that is reopened without first losing focus**, keeps showing the previous option list.

### It had already been solved twice

| Pane | Selector | Rebuilt from | Repaint before this PR |
|---|---|---|---|
| `gccdump-view` | pass list | compile result | yes |
| `diff` | difftype | compile result | yes, as of #9058 |
| `cfg-view` | function selector | `onCompileResult` | **no** |
| `opt-pipeline` | group selector | `updateResults` | **no** |

`gccdump-view` even carried a comment describing the exact mechanism. It just never made it to the other panes, so #9058 was the third independent rediscovery.

This moves it into `static/tom-select-utils.ts` as `replaceOptions()` and routes all four sites through it, so the next pane that rebuilds a picker gets the repaint for free instead of finding out the hard way.

### This also corrects #9058

That PR guarded the refresh on `picker.isOpen`. **That was wrong.** A drop-down can be closed while the control still has focus, and reopening it in that state does not repaint, so the stale list survives. `gccdump-view` had it right by refreshing unconditionally, and the shared helper now does the same.

### Two subtleties worth checking in review

- **`gccdump-view` keeps a trailing `refreshOptions()`.** Its `addItem()` after the rebuild goes through `refreshItems()`, which re-marks the content stale, so the repaint done inside `replaceOptions()` no longer covers that path. Verified in the tom-select source rather than assumed.
- **`cfg-view` cleared its options before deciding whether it had a cfg at all.** Folding the clear into `replaceOptions()` would have left the previous functions listed when a compile yields no cfg (a blank input file, for instance), so the no-cfg path now empties the picker explicitly.

### Verification

`ts-check`, biome and the frontend unit tests pass. As with #9058 the user-visible symptom is a race, so I can't demonstrate it deterministically; what I've checked is the mechanism in tom-select's own source, in particular that `refreshOptions(false)` gates both its open and close branches on that argument and so leaves the drop-down's state alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)