### PR TITLE
Add a runnable dispenso example

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -5953,6 +5953,7 @@ libs.dispenso.description=High-performance concurrency: thread pools, parallel l
 libs.dispenso.url=https://github.com/facebookincubator/dispenso
 libs.dispenso.packagedheaders=true
 libs.dispenso.staticliblink=dispenso
+libs.dispenso.examples=W116zME61
 libs.dispenso.versions=162
 libs.dispenso.versions.162.version=1.6.2
 


### PR DESCRIPTION
Adds an example to the dispenso library entry so it is reachable from the
Libraries UI rather than only via a link.

The example compares the default `kStatic` chunking against `kAdaptive` on a
workload whose per-element cost grows 64x across the range, with a serial
baseline for reference: https://godbolt.org/z/W116zME61

It prints a note that the timings should be disregarded on Compiler Explorer.
The sandbox has very few cores, so any of the three can come out ahead on a
given run; the example is there to read and run, not to measure.

Verified it builds clean under `-Wall -Wextra` and runs correctly against
dispenso 1.6.2.