### PR TITLE
Remove GCC cobol snapshot

### DIFF
--- a/etc/config/cobol.amazon.properties
+++ b/etc/config/cobol.amazon.properties
@@ -30,7 +30,7 @@ compiler.gnucobol11.licensePreamble=Copyright (c) 2012 Free Software Foundation,
 
 group.gcccobol.compilerType=gcccobol
 group.gcccobol.groupName=GCC
-group.gcccobol.compilers=&gcccobolassert:gcccobolsnapshot:gcccobol151:gcccobol152:gcccobol161:gcccobol162:gcccoboltrunk
+group.gcccobol.compilers=&gcccobolassert:gcccobol151:gcccobol152:gcccobol161:gcccobol162:gcccoboltrunk
 group.gcccobol.unwiseOptions=-march=native
 group.gcccobol.isSemVer=true
 group.gcccobol.baseName=GCC
@@ -38,9 +38,6 @@ group.gcccobol.intelAsm=-masm=intel
 group.gcccobol.licenseLink=https://gcc.gnu.org/onlinedocs/gcc/Copying.html
 group.gcccobol.licenseName=GNU General Public License
 group.gcccobol.licensePreamble=Copyright (c) 2025 Free Software Foundation, Inc. <a href="https://fsf.org/" target="_blank">https://fsf.org/</a>
-
-compiler.gcccobolsnapshot.exe=/opt/compiler-explorer/cobol/gcc-cobol-master/bin/gcobol
-compiler.gcccobolsnapshot.semver=(cobol+master)
 
 compiler.gcccobol151.exe=/opt/compiler-explorer/gcc-15.1.0/bin/gcobol
 compiler.gcccobol151.semver=15.1.0


### PR DESCRIPTION
GCC Cobol is upstream first and GCC trunk already enables it. As per the author, it's very rare that the dedicated repository is more up to date than gcc's upstream.

Refs https://github.com/compiler-explorer/gcc-builder/issues/57
