### PR TITLE
docs: fix typo publically -> publicly

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ encourage users to promptly report security vulnerabilities they find.
 If the issue can be reported without revealing exploitable specifics, please file
 [an issue](https://github.com/compiler-explorer/compiler-explorer/issues/new/choose) as a bug.
 
-Please email matt@godbolt.org with specifics, or if the bug can't be reported publically without leaving an obvious
+Please email matt@godbolt.org with specifics, or if the bug can't be reported publicly without leaving an obvious
 exploit in the public eye.
 
 We expect to get back within a day or two. If you don't hear from us, please do ping us again, or reach out to us on the


### PR DESCRIPTION
One-word typo fix in `SECURITY.md:11`.
