### PR TITLE
Fix/update the default for `Cargo.toml`

### DIFF
--- a/examples/cargo/default.toml
+++ b/examples/cargo/default.toml
@@ -1,11 +1,8 @@
 [package]
 name = "output"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
-# Crates cannot be downloaded here, so [dependencies] will not resolve.
-# Pick the crate you want in the Libraries pane instead and leave it out of
-# this file: it is handed to rustc directly, so `use rand::Rng;` just works.
-[[bin]]
-name = "output.s"
-path = "example.rs"
+# Crates cannot be downloaded here, so only `path` [dependencies] are possible.
+# They can instead be selected via the Libraries pane and are passed to rustc
+# directly without needing to be mentioned here.


### PR DESCRIPTION
The default should use the newest `edition`.

Also, `.` is not allowed in crate names. I removed the `[[bin]]` section because the default (look for the binary crate in `src/main.rs` and the library crate in `src/lib.rs`) works well and is familiar to cargo users.

Thirdly, I rewrote the explanation for why normal `[ dependencies]` don’t work to explicitly point out that `path` dependencies work fine.