### PR TITLE
fix: propagate libPath to Cargo IDE execution

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -3122,7 +3122,7 @@ export class BaseCompiler {
         const executeOptions: ExecutableExecutionOptions = {
             args: parsedRequest.executeParameters.args || [],
             stdin: parsedRequest.executeParameters.stdin || '',
-            ldPath: this.getSharedLibraryPathsAsLdLibraryPaths(parsedRequest.libraries, dirPath),
+            ldPath: this.getSharedLibraryPathsAsLdLibraryPathsForExecution(cacheKey, dirPath),
             runtimeTools: parsedRequest.executeParameters?.runtimeTools || [],
             env: {},
         };

--- a/test/build-systems-tests.ts
+++ b/test/build-systems-tests.ts
@@ -477,6 +477,26 @@ describe('Cargo build system', () => {
         expect(plan.steps[0].execParams.customCwd).toEqual(ctx.dirPath);
     });
 
+    it('passes the compiler library path to Cargo project execution', async () => {
+        const env = makeRustEnv();
+        const compiler = makeRustCompiler(env, {libPath: ['/opt/rust/lib']});
+        const request = makeParsedRequest();
+        const cacheKey = compiler.getBuildProjectCacheKey(cargoBuildSystem, request, []);
+        vi.spyOn(compiler, 'newTempDir').mockResolvedValue('/tmp/ce-cargo-execution');
+
+        const build = await (compiler as any).prepareProjectBuild(
+            cargoBuildSystem,
+            request,
+            [],
+            {libraries: [], options: []},
+            undefined,
+            cacheKey,
+            'unused-package-hash',
+        );
+
+        expect(build.executeOptions.ldPath).toContain('/opt/rust/lib');
+    });
+
     it('passes the user arguments to cargo, and compiler options through RUSTFLAGS', async () => {
         const env = makeRustEnv();
         const compiler = makeRustCompiler(env);


### PR DESCRIPTION
Fixes #9067

Use the existing project-execution library-path plumbing when preparing build-system execution options. This makes Cargo IDE runs include the configured compiler `libPath`, while preserving existing behavior when no library path is configured.

Validation:
- `npm run ts-check`
- `npm run lint-check`
- `npm run test -- --run test/build-systems-tests.ts` (76 passed)
- `npm run test-min` (1910 passed, 743 skipped)