### PR TITLE
Surface RazorForge 0.3.0 and 0.4.0

### DIFF
--- a/etc/config/razorforge.amazon.properties
+++ b/etc/config/razorforge.amazon.properties
@@ -1,10 +1,10 @@
 compilers=&razorforge
 compilerType=razorforge
-defaultCompiler=razorforge020
+defaultCompiler=razorforge040
 supportsBinary=false
 supportsBinaryObject=false
 supportsExecute=false
-group.razorforge.compilers=razorforge010:razorforge011:razorforge020
+group.razorforge.compilers=razorforge010:razorforge011:razorforge020:razorforge030:razorforge040
 group.razorforge.isSemVer=true
 group.razorforge.baseName=razorforge
 
@@ -14,3 +14,7 @@ compiler.razorforge011.semver=0.1.1
 compiler.razorforge011.exe=/opt/compiler-explorer/razorforge-0.1.1/RazorForge
 compiler.razorforge020.semver=0.2.0
 compiler.razorforge020.exe=/opt/compiler-explorer/razorforge-0.2.0/RazorForge
+compiler.razorforge030.semver=0.3.0
+compiler.razorforge030.exe=/opt/compiler-explorer/razorforge-0.3.0/RazorForge
+compiler.razorforge040.semver=0.4.0
+compiler.razorforge040.exe=/opt/compiler-explorer/razorforge-0.4.0/RazorForge


### PR DESCRIPTION
Adds RazorForge 0.3.0 and 0.4.0 to `group.razorforge.compilers` and bumps `defaultCompiler` to 0.4.0.

0.3.0 was already installable via the infra tarball target but was never added to the group list, so it never surfaced in production (as noted in a recent review). This adds it alongside the new 0.4.0.

Pairs with compiler-explorer/infra#2336, which adds the 0.4.0 tarball target.