### PR TITLE
Use `dumb-init` to correctly show signals raised during execution

### DIFF
--- a/etc/nsjail/user-execution.cfg
+++ b/etc/nsjail/user-execution.cfg
@@ -225,6 +225,12 @@ mount {
     fstype: "tmpfs"
 }
 
+mount {
+    src: "/usr/local/bin/dumb-init"
+    dst: "/usr/local/bin/dumb-init"
+    is_bind: true
+}
+
 # TODO: this is commented out per @apmorton's advice for now:
 # kafel (the library nsjail uses) doesn't correctly handle non-native syscall architectures currently
 # so if you compile/run a 32bit binary and apply a seccomp policy it incorrectly matches 32bit syscall numbers against

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -293,7 +293,7 @@ export function getNsJailOptions(
     delete options.env;
 
     return {
-        args: jailingOptions.concat(['--', command]).concat(args),
+        args: jailingOptions.concat(['--', '/usr/local/bin/dumb-init', command]).concat(args),
         options,
         filenameTransform,
     };

--- a/test/exec-tests.ts
+++ b/test/exec-tests.ts
@@ -181,6 +181,7 @@ describe('Execution tests', async () => {
                 exec.getNsJailCfgFilePath('sandbox'),
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 '/path/to/compiler',
                 '1',
                 '2',
@@ -215,6 +216,7 @@ describe('Execution tests', async () => {
                 '/some/custom/cwd:/app',
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 './exec',
                 '/app/file',
                 '/not/custom/file',
@@ -298,6 +300,7 @@ describe('Execution tests', async () => {
                 '/tmp/hellow:/app',
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 './output.s',
             ]);
         });
@@ -317,6 +320,7 @@ describe('Execution tests', async () => {
                 '/tmp/hellow:/app',
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 './output.s',
             ]);
         });
@@ -337,6 +341,7 @@ describe('Execution tests', async () => {
                 '--env=SOME_DOTNET_THING=/app/dotnet',
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 './output.s',
             ]);
         });
@@ -358,6 +363,7 @@ describe('Execution tests', async () => {
                 '--env=CXX_FLAGS=-L/usr/lib -L/app/curl/lib -L/app/fmt/lib',
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 './output.s',
             ]);
         });
@@ -379,6 +385,7 @@ describe('Execution tests', async () => {
                 '--env=LD_LIBRARY_PATH=' + ['/usr/lib', '/app/lib'].join(path.delimiter),
                 '--env=HOME=/app',
                 '--',
+                '/usr/local/bin/dumb-init',
                 './output.s',
             ]);
         });
@@ -399,6 +406,7 @@ describe('Execution tests', async () => {
                     '/tmp/hellow:/app',
                     '--env=HOME=/app',
                     '--',
+                    '/usr/local/bin/dumb-init',
                     'subdir/output.s',
                 ]);
             }
@@ -423,6 +431,7 @@ describe('Execution tests', async () => {
                     '/tmp/hellow:/app',
                     '--env=HOME=/app',
                     '--',
+                    '/usr/local/bin/dumb-init',
                     '/opt/compiler-explorer/cmake/bin/cmake',
                     '..',
                 ]);
@@ -461,6 +470,7 @@ describe('Execution tests', async () => {
                     '/tmp/hellow:/app',
                     '--env=HOME=/app',
                     '--',
+                    '/usr/local/bin/dumb-init',
                     '/opt/compiler-explorer/compiler/bin/g++',
                     '-c',
                     '-S',


### PR DESCRIPTION
From `dumb-init`’s [docs](https://github.com/Yelp/dumb-init/blob/master/README.md):

> Lightweight containers have popularized the idea of running a single process or service without normal init systems like [systemd](https://wiki.freedesktop.org/www/Software/systemd/) or [sysvinit](https://wiki.archlinux.org/index.php/SysVinit). However, omitting an init system often leads to incorrect handling of processes and signals [...]
> 
> `dumb-init` [...] immediately spawns your command as a child process, taking care to properly handle and forward signals as they are received.

Thanks to @ecatmur for the analysis [here](https://github.com/compiler-explorer/compiler-explorer/issues/5224#issuecomment-1617111007) with the explanation that the user process acts as init in the jail.

Resolves #5224. Resolves #8924.

This depends on https://github.com/compiler-explorer/infra/pull/2339 to install a `dumb-init` fork that is patched to print a message when the child terminates with a signal. Because `dumb-init` itself does *not* exit with a signal, this patch to CE’s `nsjail` will become obsolete: https://github.com/compiler-explorer/nsjail/commit/8fbbe18d44a1753619e1ba2675d1e76685f25535