### PR TITLE
Fix parsing supported `flang` options

### DIFF
--- a/lib/compilers/argument-parsers.ts
+++ b/lib/compilers/argument-parsers.ts
@@ -1115,6 +1115,14 @@ export class GccFortranParser extends GCCParser {
 }
 
 export class FlangParser extends ClangParser {
+    override getHiddenHelpOptions(): string[] {
+        return ['-mllvm', '--help-list-hidden', '-x', 'f95', '/dev/null', '-c'];
+    }
+
+    override getStdVersHelpOptions(): string[] {
+        return ['-std=f9999999', '-x', 'f95', '/dev/null', '-c'];
+    }
+
     override async setCompilerSettingsFromOptions(options: Record<string, Argument>) {
         await super.setCompilerSettingsFromOptions(options);
 


### PR DESCRIPTION
`flang` does not support `-xc++`, so pass `-xf95` instead.

Resolves #9081.