### PR TITLE
Fix the executor's "All compilation options" popover

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -2528,6 +2528,8 @@ export class BaseCompiler {
 
         const result = await this.doExecution(key, executeParameters, bypassCache);
 
+        this.cleanupResult(result);
+
         if (!bypassExecutionCache(bypassCache)) {
             await this.env.cachePut(execKey, result, undefined);
         }
@@ -3737,6 +3739,9 @@ export class BaseCompiler {
         if (result.inputFilename) {
             result.inputFilename = utils.maskRootdir(result.inputFilename);
         }
+
+        if (result.buildResult) this.cleanupResult(result.buildResult);
+        if (result.result) this.cleanupResult(result.result);
     }
 
     postCompilationPreCacheHook(result: CompilationResult): CompilationResult {

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -726,7 +726,8 @@ export class Executor extends Pane<ExecutorState> {
         }
         this.compileTimeLabel.text(timeLabelText);
 
-        this.setCompilationOptionsPopover(result.buildResult ? result.buildResult.compilationOptions.join(' ') : '');
+        const compilationOptions = result.buildResult?.compilationOptions ?? result.result?.compilationOptions;
+        this.setCompilationOptionsPopover(compilationOptions?.join(' ') ?? null);
 
         if (this.currentLangId) {
             const languages = languagesService.getLanguagesOrFail();

--- a/test/base-compiler-tests.ts
+++ b/test/base-compiler-tests.ts
@@ -34,6 +34,7 @@ import {RustCompiler} from '../lib/compilers/rust.js';
 import {Win32Compiler} from '../lib/compilers/win32.js';
 import * as props from '../lib/properties.js';
 import {splitArguments} from '../shared/common-utils.js';
+import {CompilationResult} from '../types/compilation/compilation.interfaces.js';
 import {CompilerOverrideType, ConfiguredOverrides} from '../types/compilation/compiler-overrides.interfaces.js';
 import {CompilerInfo} from '../types/compiler.interfaces.js';
 import {SelectedLibraryVersion} from '../types/libraries/libraries.interfaces.js';
@@ -79,6 +80,33 @@ describe('Basic compiler invariants', () => {
                 '/tmp/compiler-explorer-compiler123-4-abc/example.cpp',
             ]),
         ).toEqual(['-O3', '-o', '/app/output.s', '/app/example.cpp']);
+    });
+
+    it('should mask the options of nested results the user is shown', () => {
+        const empty = {code: 0, timedOut: false, stdout: [], stderr: []};
+        const tmp = '/tmp/compiler-explorer-compiler123-4-abc';
+        const result: CompilationResult = {
+            ...empty,
+            compilationOptions: [`${tmp}/example.cpp`],
+            buildResult: {
+                ...empty,
+                downloads: [],
+                executableFilename: `${tmp}/output.s`,
+                compilationOptions: ['-O3', `${tmp}/example.cpp`],
+            },
+            result: {
+                ...empty,
+                compilationOptions: ['-DFOO', `${tmp}/main.cpp`],
+                inputFilename: `${tmp}/main.cpp`,
+            },
+        };
+
+        compiler.cleanupResult(result);
+
+        expect(result.compilationOptions).toEqual(['/app/example.cpp']);
+        expect(result.buildResult?.compilationOptions).toEqual(['-O3', '/app/example.cpp']);
+        expect(result.result?.compilationOptions).toEqual(['-DFOO', '/app/main.cpp']);
+        expect(result.result?.inputFilename).toEqual('main.cpp');
     });
 
     it('should skip version check if forced to', async () => {


### PR DESCRIPTION
Fixes #9088.

Two separate problems that both surface in the executor's "All compilation options" popover.

### Masking

An executor request returns from `compile()` through the `executorRequest` branch, which never reaches `afterCompilation` — so `cleanupResult()` was never called on that path at all, and the popover showed the raw temp dir:

```
-g -o /tmp/compiler-explorer-compilervVkv5C/output.s ... /tmp/compiler-explorer-compilervVkv5C/example.cpp
```

Masking now happens in `handleExecution()`, before the `cachePut`, so a cold build, an execution-cache hit and a package-cache hit all render identically. `cleanupResult()` also recurses, because what the executor actually displays is `buildResult.compilationOptions`, not the top-level options — neither change does anything without the other.

It has to happen on the way out rather than at build time: `storePackageWithExecutable()` serialises the package before any masking, and `loadPackageWithExecutable()` rebuilds `inputFilename` as a fresh temp path *after* unpacking. So a request that compiles nothing and just pulls the executable from S3 still needs masking applied to what it returns.

### Availability

The project/CMake path produces no `buildResult` at all; it reports what it compiled with on the inner `result`. The popover read `result.buildResult.compilationOptions`, got `undefined`, and rendered "No options in use" — while the compiler pane right above it showed the full line, because it reads `result.result ?? result`. Fixed client-side by falling back to that field; the data was already being sent, it was just being read from the wrong place.

### Verification

Against a local dev server, and the CMake shape checked against production:

| Case | Before | After |
|---|---|---|
| Single-file executor, cold build | `/tmp/compiler-explorer-compiler*/example.cpp` | `/app/example.cpp` |
| Single-file executor, executable from package cache | unmasked | `/app/example.cpp`, `inputFilename: example.cpp` |
| CMake executor | "No options in use" | `-fdiagnostics-color=always -std=c++20 -O3 -flto -isystem/opt/...` |

The package-cache case was exercised with two requests sharing a build key but differing in execute args, so the second skipped the execution cache and went through `loadPackageWithExecutable` (confirmed by `packageDownloadAndUnzipTime` in the response).

I also verified the masking call is load-bearing by disabling just that line with the recursion left in place — the options come back unmasked, since nothing else on that path calls `cleanupResult`.

`npm test` (2653 passed), `ts-check` and `lint` all clean. New unit test covers the nested masking.

### Note on the cache

Masking happens on write, matching the approach in #9057, so what is stored equals what is shown. Execution-cache entries written before this deploy keep their unmasked options until they turn over.

Found while testing #8960, which touches neither the executor nor the CMake path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168db5wLwZMU9TtcbN9ZD6v
