### PR TITLE
Fix the timing widget failing to open on cached executor results

### DIFF
--- a/static/widgets/timing-info-widget.ts
+++ b/static/widgets/timing-info-widget.ts
@@ -92,7 +92,7 @@ function initializeChartDataFromResult(compileResult: CompilationResult, totalTi
         }
 
         if (compileResult.packageDownloadAndUnzipTime) {
-            pushTimingInfo(data, 'Download binary from cache', unwrap(compileResult.execTime));
+            pushTimingInfo(data, 'Download binary from cache', compileResult.packageDownloadAndUnzipTime);
         }
 
         if (compileResult.execResult?.execTime) {


### PR DESCRIPTION
### The bug

Opening the Timing dialog from an executor pane throws, and the dialog never appears:

```
Uncaught Error: Unwrap failed
    at unwrap (assert.ts:77:9)
    at initializeChartDataFromResult (timing-info-widget.ts:95)
    at Object.displayCompilationTiming (timing-info-widget.ts:211)
    at HTMLButtonElement.<anonymous> (executor.ts:943)
```

The culprit is guarded on one field but unwraps another:

```ts
if (compileResult.packageDownloadAndUnzipTime) {
    pushTimingInfo(data, 'Download binary from cache', unwrap(compileResult.execTime));
}
```

One typo, two problems:

- Results from the project/CMake executor path carry no top-level `execTime` — the execution time lives on `execResult` — so `unwrap` throws and the whole dialog fails to open.
- Where it did not throw, the "Download binary from cache" bar was charting execution time rather than the download time its label describes.

### The fix

Use the field the guard already checked, which is also the one the label names. No `unwrap` is needed, since the guard narrows the type:

```ts
pushTimingInfo(data, 'Download binary from cache', compileResult.packageDownloadAndUnzipTime);
```

### Repro

1. Templates → C++ Cmake
2. Click the timing icon in the Executor pane's bottom bar
3. Before: nothing opens, `Unwrap failed` in the console. After: the chart renders.

Verified locally on a CMake tree executor; `ts-check` and `lint` clean.

### Not fixed here

The same shape exists a few lines down, and I could not reproduce it, so I have left it alone:

```ts
if (compileResult.didExecute) {
    if (compileResult.execResult?.execTime) { ... }
    else pushTimingInfo(data, 'Execution', unwrap(compileResult.execTime));
}
```

`execResult?.execTime` is a truthiness check, so a program fast enough to report `execTime: 0` falls into the `else`, where a CMake executor result has no top-level `execTime` to unwrap. Happy to harden it here if you would rather not leave it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168db5wLwZMU9TtcbN9ZD6v
