### PR TITLE
Show the build steps of a project build

### DIFF
--- a/lib/base-compiler.ts
+++ b/lib/base-compiler.ts
@@ -30,7 +30,7 @@ import * as PromClient from 'prom-client';
 import _ from 'underscore';
 import {parseAllDocuments} from 'yaml';
 
-import {splitArguments, unique} from '../shared/common-utils.js';
+import {maskRootdirsInText, splitArguments, unique} from '../shared/common-utils.js';
 import {OptRemark} from '../static/panes/opt-view.interfaces.js';
 import {PPOptions} from '../static/panes/pp-view.interfaces.js';
 import {ParsedAsmResult, ParsedAsmResultLine} from '../types/asmresult/asmresult.interfaces.js';
@@ -2923,6 +2923,24 @@ export class BaseCompiler {
         };
     }
 
+    // Environment that describes the machine CE happens to be running on rather than the build itself, so it is
+    // noise to the user and its contents depend on `environmentPassThrough`. LD_LIBRARY_PATH is deliberately not
+    // here: CE points it at the libraries it set up for this build, so it is part of explaining the build.
+    static readonly buildStepEnvNotShown = new Set(['PATH', 'HOME']);
+
+    buildStepEnvForUser(execParams: ExecutionOptions): Record<string, string> | undefined {
+        if (!execParams.env) return undefined;
+        // ldPath, not env, is where LD_LIBRARY_PATH really comes from: exec() overwrites any inherited value with
+        // it before spawning (and passes it to the jail the same way), so that is what the step actually ran with.
+        const env = {...execParams.env};
+        if (execParams.ldPath?.length) env.LD_LIBRARY_PATH = execParams.ldPath.join(path.delimiter);
+        return Object.fromEntries(
+            Object.entries(env)
+                .filter(([key, value]) => value && !BaseCompiler.buildStepEnvNotShown.has(key))
+                .map(([key, value]) => [key, maskRootdirsInText(value)]),
+        );
+    }
+
     async doBuildstepAndAddToResult(
         result: CompilationResult,
         name: string,
@@ -2934,6 +2952,8 @@ export class BaseCompiler {
             ...(await this.doBuildstep(command, args, execParams)),
             compilationOptions: args,
             step: name,
+            command: maskRootdirsInText(command),
+            env: this.buildStepEnvForUser(execParams),
         };
         logger.debug(name);
         assert(result.buildsteps);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -39,7 +39,7 @@ import {BasicExecutionResult, UnprocessedExecResult} from '../types/execution/ex
 import {LanguageKey} from '../types/languages.interfaces.js';
 import type {Fix, ResultLine} from '../types/resultline/resultline.interfaces.js';
 
-export {ce_temp_prefix, maskRootdirKeepingAppPrefix} from '../shared/common-utils.js';
+export {ce_temp_prefix, maskRootdirKeepingAppPrefix, maskRootdirsInText} from '../shared/common-utils.js';
 
 const tabsRe = /\t/g;
 const lineRe = /\r?\n/;

--- a/shared/common-utils.ts
+++ b/shared/common-utils.ts
@@ -247,3 +247,18 @@ export function maskRootdirKeepingAppPrefix(filepath: string): string {
     // cannot match without the marker anyway.
     return filepath.includes(ce_temp_prefix) ? filepath.replace(TEMPDIR_RE, '/app/') : filepath;
 }
+
+// As TEMPDIR_RE, but global, and the trailing slash is optional so a bare temp dir counts as a path. Both
+// differences only matter for free-form text: an argv entry holds one path and the temp dir is always the
+// prefix of a file within it, neither of which holds for something like `-L/tmp/<prefix>X -Wl,-rpath,...`.
+const TEMPDIR_TEXT_RE = new RegExp(`(?:[A-Za-z]:)?/(?:[^/\\s]+/)*${ce_temp_prefix}[\\w.-]*(/?)`, 'g');
+
+/**
+ * Rewrites every CE temp dir in a string that may hold several paths — an environment value such as
+ * LDFLAGS, rather than a single argument. Use maskRootdirKeepingAppPrefix() for one path on its own.
+ */
+export function maskRootdirsInText(text: string): string {
+    if (!text) return text;
+    // Same cheap guard as above: the regex cannot match without the marker, and it backtracks on long input.
+    return text.includes(ce_temp_prefix) ? text.replace(TEMPDIR_TEXT_RE, '/app$1') : text;
+}

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -61,6 +61,7 @@ import {toolsService} from '../services/tools.service.js';
 import {SiteSettings} from '../settings.js';
 import * as utils from '../utils.js';
 import {Alert} from '../widgets/alert.js';
+import {displayBuildSteps} from '../widgets/build-steps-widget.js';
 import {CompilationOptions} from '../widgets/compilation-options.js';
 import {CompilerPicker} from '../widgets/compiler-picker.js';
 import {WidgetState} from '../widgets/libs-widget.interfaces.js';
@@ -217,6 +218,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     private initialOptionsFieldPlacehoder: JQuery<HTMLElement>;
     private fullCompilerName: JQuery<HTMLElement>;
     private fullTimingInfo: JQuery<HTMLElement>;
+    private buildStepsInfo: JQuery<HTMLElement>;
     private compilerLicenseButton: JQuery<HTMLElement>;
     private filterBinaryButton: JQuery<HTMLButtonElement>;
     private filterBinaryTitle: JQuery<HTMLElement>;
@@ -1821,6 +1823,9 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         wasRealReply: boolean,
         timeTaken: number,
     ) {
+        // Only project builds run build steps; in single-file mode the button would open an empty dialog.
+        this.buildStepsInfo.toggleClass('d-none', !result.buildsteps?.length);
+
         // Delete trailing empty lines
         if (Array.isArray(result.asm)) {
             const indexToDiscard = _.findLastIndex(result.asm, line => {
@@ -2588,6 +2593,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         this.initialOptionsFieldPlacehoder = this.optionsField.prop('placeholder');
         this.fullCompilerName = this.domRoot.find('.full-compiler-name');
         this.fullTimingInfo = this.domRoot.find('.full-timing-info');
+        this.buildStepsInfo = this.domRoot.find('.build-steps-info');
         this.compilerLicenseButton = this.domRoot.find('.compiler-license');
 
         this.initFilterButtons();
@@ -3130,6 +3136,10 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
         this.fullTimingInfo.off('click').on('click', () => {
             TimingWidget.displayCompilationTiming(this.lastResult, this.lastTimeTaken);
+        });
+
+        this.buildStepsInfo.off('click').on('click', () => {
+            displayBuildSteps(this.lastResult?.buildsteps ?? []);
         });
 
         const optionsChange = _.debounce(e => {

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -52,6 +52,7 @@ import {languagesService} from '../services/languages.service.js';
 import {Settings, SiteSettings} from '../settings.js';
 import * as utils from '../utils.js';
 import {Alert} from '../widgets/alert.js';
+import {displayBuildSteps} from '../widgets/build-steps-widget.js';
 import {CompilerPicker} from '../widgets/compiler-picker.js';
 import {CompilerVersionInfo, setCompilerVersionPopoverForPane} from '../widgets/compiler-version-info.js';
 import {FontScale} from '../widgets/fontscale.js';
@@ -111,6 +112,7 @@ export class Executor extends Pane<ExecutorState> {
     private prependOptions: JQuery<HTMLElement>;
     private fullCompilerName: JQuery<HTMLElement>;
     private fullTimingInfo: JQuery<HTMLElement>;
+    private buildStepsInfo: JQuery<HTMLElement>;
     private libsButton: JQuery<HTMLElement>;
     private compileTimeLabel: JQuery<HTMLElement>;
     private shortCompilerName: JQuery<HTMLElement>;
@@ -660,6 +662,9 @@ export class Executor extends Pane<ExecutorState> {
         wasRealReply: boolean,
         timeTaken: number,
     ): void {
+        // Only project builds run build steps; in single-file mode the button would open an empty dialog.
+        this.buildStepsInfo.toggleClass('d-none', !result.buildsteps?.length);
+
         this.clearPreviousOutput();
         const compileStdout = this.getBuildStdoutFromResult(result);
         const compileStderr = this.getBuildStderrFromResult(result);
@@ -804,6 +809,7 @@ export class Executor extends Pane<ExecutorState> {
         this.prependOptions = this.domRoot.find('.prepend-options');
         this.fullCompilerName = this.domRoot.find('.full-compiler-name');
         this.fullTimingInfo = this.domRoot.find('.full-timing-info');
+        this.buildStepsInfo = this.domRoot.find('.build-steps-info');
         this.setCompilationOptionsPopover(this.compiler?.options ?? null);
 
         this.compileTimeLabel = this.domRoot.find('.compile-time');
@@ -939,6 +945,10 @@ export class Executor extends Pane<ExecutorState> {
 
         this.fullTimingInfo.off('click').on('click', () => {
             TimingWidget.displayCompilationTiming(this.lastResult, this.lastTimeTaken);
+        });
+
+        this.buildStepsInfo.off('click').on('click', () => {
+            displayBuildSteps(this.lastResult?.buildsteps ?? []);
         });
     }
 

--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -654,6 +654,70 @@ input.vim-check {
     max-width: 460px;
 }
 
+.build-step {
+    margin-bottom: 1rem;
+}
+
+.build-step:last-child {
+    margin-bottom: 0;
+}
+
+.build-step-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.build-step-name {
+    font-weight: bold;
+}
+
+.build-step-time {
+    margin-left: auto;
+    opacity: 0.7;
+}
+
+// The command line is the thing people came to copy, so let it wrap rather than scroll out of reach.
+.build-step-command {
+    font-family: monospace;
+    white-space: pre-wrap;
+    word-break: break-all;
+    margin: 0.25rem 0;
+    padding: 0.4rem;
+    background: rgba(127, 127, 127, 0.12);
+    border-radius: 4px;
+}
+
+.build-step-env {
+    font-family: monospace;
+    margin-top: 0.25rem;
+    width: 100%;
+    table-layout: fixed;
+}
+
+// table-layout: fixed takes the column widths from the first row, so the key column needs a real
+// width here — a shrink-to-fit `width: 1px` would give it literally one pixel.
+.build-step-env-key {
+    vertical-align: top;
+    padding-right: 0.75rem;
+    width: 12em;
+    word-break: break-all;
+}
+
+.build-step-env-value {
+    word-break: break-all;
+}
+
+// Modals here size to their content, and a build command line is long enough to fill the screen.
+// Cap this one and let the command line and env values wrap inside it instead.
+#build-steps {
+    .modal-dialog,
+    .modal-content {
+        width: min(900px, 100%);
+        max-width: min(900px, 100%);
+    }
+}
+
 .navbar-nav a.nav-link {
     font-size: 14px;
     border-radius: 5px;

--- a/static/widgets/build-steps-widget.ts
+++ b/static/widgets/build-steps-widget.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import $ from 'jquery';
+
+import {BuildStep} from '../../types/compilation/compilation.interfaces.js';
+import * as BootstrapUtils from '../bootstrap-utils.js';
+import {CompilationStatusCode} from '../compiler-service.interfaces.js';
+import {CompilerService} from '../compiler-service.js';
+
+// Quotes only what a shell would need it quoted for, so the common case stays readable and the
+// line can still be pasted into a terminal as-is.
+function shellQuote(arg: string): string {
+    return /^[\w.,:=@%+/-]*$/.test(arg) ? arg : `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+function commandLineOf(step: BuildStep): string {
+    return [step.command, ...step.compilationOptions]
+        .filter(Boolean)
+        .map(arg => shellQuote(arg!))
+        .join(' ');
+}
+
+function renderEnv(env: Record<string, string>): JQuery<HTMLElement> {
+    const table = $('<table/>').addClass('build-step-env');
+    for (const key of Object.keys(env).sort()) {
+        const row = $('<tr/>');
+        row.append($('<td/>').addClass('build-step-env-key').text(key));
+        row.append($('<td/>').addClass('build-step-env-value').text(env[key]));
+        table.append(row);
+    }
+    return table;
+}
+
+function renderStep(step: BuildStep): JQuery<HTMLElement> {
+    const container = $('<div/>').addClass('build-step');
+
+    const header = $('<div/>').addClass('build-step-header');
+    const icon = $('<span/>').addClass('status-icon');
+    // Same status language as everywhere else, so the step that failed is the one wearing the red cross.
+    // Judged on the exit code alone rather than via calculateStatusIcon: that treats any output at all as a
+    // warning, which suits a compiler but not a build tool, since cmake narrates its progress on stdout and
+    // would leave every successful step looking orange.
+    const code = step.code === 0 ? CompilationStatusCode.OK : CompilationStatusCode.WITH_ERRORS;
+    CompilerService.handleCompilationStatus(null, icon, {code, compilerOut: step.code});
+    header.append(icon);
+    header.append($('<span/>').addClass('build-step-name').text(step.step));
+    if (step.execTime) header.append($('<span/>').addClass('build-step-time').text(`${step.execTime}ms`));
+    container.append(header);
+
+    container.append($('<pre/>').addClass('build-step-command').text(commandLineOf(step)));
+
+    const env = step.env;
+    if (env && Object.keys(env).length > 0) {
+        const details = $('<details/>').addClass('build-step-env-details');
+        details.append($('<summary/>').text(`Environment (${Object.keys(env).length})`));
+        details.append(renderEnv(env));
+        container.append(details);
+    }
+
+    return container;
+}
+
+export function displayBuildSteps(buildsteps: BuildStep[]): void {
+    const modal = $('#build-steps');
+    const body = modal.find('.build-steps-body');
+    body.empty();
+
+    if (buildsteps.length === 0) {
+        body.append($('<p/>').text('This compilation ran no build steps.'));
+    } else {
+        for (const step of buildsteps) body.append(renderStep(step));
+    }
+
+    BootstrapUtils.showModal(modal);
+}

--- a/test/utils-tests.ts
+++ b/test/utils-tests.ts
@@ -810,6 +810,42 @@ describe('maskRootdirKeepingAppPrefix', () => {
     });
 });
 
+describe('maskRootdirsInText', () => {
+    const tmp = '/tmp/compiler-explorer-compiler123-4-abc';
+
+    it('masks every temp path, not just the first', () => {
+        expect(utils.maskRootdirsInText(`-I${tmp}/include -I${tmp}/other/include`)).toEqual(
+            '-I/app/include -I/app/other/include',
+        );
+    });
+
+    it('masks a bare temp dir with no trailing slash, as -L and -rpath produce', () => {
+        expect(utils.maskRootdirsInText(`-L${tmp}`)).toEqual('-L/app');
+    });
+
+    // The value that motivated this: a single env var holding four temp paths in two shapes.
+    it('masks a realistic LDFLAGS value completely', () => {
+        expect(
+            utils.maskRootdirsInText(`-L${tmp} -Wl,-rpath,${tmp} -Wl,-rpath,${tmp}/fmt/lib -L${tmp}/fmt/lib`),
+        ).toEqual('-L/app -Wl,-rpath,/app -Wl,-rpath,/app/fmt/lib -L/app/fmt/lib');
+    });
+
+    it('leaves text with no temp paths untouched', () => {
+        expect(utils.maskRootdirsInText('-L/opt/compiler-explorer/gcc-15.2.0/lib64')).toEqual(
+            '-L/opt/compiler-explorer/gcc-15.2.0/lib64',
+        );
+    });
+
+    it('is idempotent', () => {
+        const once = utils.maskRootdirsInText(`-L${tmp} -I${tmp}/include`);
+        expect(utils.maskRootdirsInText(once)).toEqual(once);
+    });
+
+    it.each([undefined, null, ''])('hands %p straight back', input => {
+        expect(utils.maskRootdirsInText(input as unknown as string)).toEqual(input);
+    });
+});
+
 describe('maskRootdir', () => {
     it('masks a CE temp path down to the user-facing filename', () => {
         expect(utils.maskRootdir('/tmp/compiler-explorer-compiler123-4-abc/example.cpp')).toEqual('example.cpp');

--- a/types/compilation/compilation.interfaces.ts
+++ b/types/compilation/compilation.interfaces.ts
@@ -302,6 +302,8 @@ export type Arch = 'x86' | 'x86_64' | null;
 export type BuildStep = BasicExecutionResult & {
     compilationOptions: string[];
     step: string;
+    command?: string;
+    env?: Record<string, string>;
 };
 
 export type CompilationInfo = CacheKey &

--- a/views/popups/_all.pug
+++ b/views/popups/_all.pug
@@ -29,6 +29,8 @@ include runtimetools-selection
 
 include timing
 
+include build-steps
+
 include jsbeebemu
 
 include jsspeccyemu

--- a/views/popups/build-steps.pug
+++ b/views/popups/build-steps.pug
@@ -1,0 +1,10 @@
+#build-steps.modal.fade.gl_keep(tabindex="-1" role="dialog")
+  .modal-dialog.modal-lg
+    .modal-content
+      .modal-header
+        h5.modal-title Build steps
+        button.btn-close(type="button" data-bs-dismiss="modal" aria-hidden="true" aria-label="Close")
+      .modal-body
+        .build-steps-body
+      .modal-footer
+        button.btn.btn-outline-primary(type="button" data-bs-dismiss="modal") Close

--- a/views/templates/panes/compiler.pug
+++ b/views/templates/panes/compiler.pug
@@ -100,5 +100,7 @@ mixin newPaneButton(classId, text, title, icon)
       span.compile-info.me-1(title="Compilation info" aria-label="Compilation information")
       button.btn.btn-sm.btn-light.full-timing-info(data-trigger="click" style="cursor: pointer;" role="button" aria-label="Show full timing information")
         span.fas.fa-chart-bar
+      button.btn.btn-sm.btn-light.build-steps-info.d-none(data-trigger="click" style="cursor: pointer;" role="button" title="Build steps" aria-label="Show build steps")
+        span.fas.fa-gears
       button.btn.btn-sm.btn-light.compiler-license(data-trigger="click" style="cursor: pointer;" role="button" aria-label="View compiler license")
         span Compiler License

--- a/views/templates/panes/executor.pug
+++ b/views/templates/panes/executor.pug
@@ -64,3 +64,4 @@
     button.btn.btn-sm.btn-light.fas.fa-info.full-compiler-name(data-trigger="click" style="cursor: pointer;" role="button" aria-label="Show compiler info")
     span.compile-time(title="Compilation time (Result size)" aria-label="Compilation time and result size")
     button.btn.btn-sm.btn-light.fas.fa-chart-bar.full-timing-info(data-trigger="click" style="cursor: pointer;" role="button" aria-label="Show full timing information")
+    button.btn.btn-sm.btn-light.fas.fa-gears.build-steps-info.d-none(data-trigger="click" style="cursor: pointer;" role="button" title="Build steps" aria-label="Show build steps")


### PR DESCRIPTION
Draft — the feature works end to end, but I would like a look at the wire-size and masking decisions before this is called finished.

### What it does

A CMake build runs `cmake` and then the build tool, and until now nothing in the UI said what those invocations were. The compiler pane's "All compilation options" popover reports the per-file compile line; the build system's own steps were invisible. When a project build fails in the configure step, there was no way to see what ran.

A `fa-gears` button now sits next to the timing button in the compiler and executor bottom bars, shown only when the result has build steps, and opens:

```
Build steps
────────────────────────────────────────────────────────────────
✓ cmake                                                    489ms
  /opt/compiler-explorer/cmake/bin/cmake \
    -DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/…/gcc-15.2.0 \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
  ▼ Environment (8)
      AR               /opt/compiler-explorer/gcc-15.2.0/bin/ar
      CXX              /opt/compiler-explorer/gcc-15.2.0/bin/g++
      CXXFLAGS         -fdiagnostics-color=always -std=c++20 -O3 -flto -isystem…
      LDFLAGS          -L/app -Wl,-rpath,/app -Wl,-rpath,…/lib64 …
      LD_LIBRARY_PATH  /app
✓ build                                                   1417ms
  /opt/compiler-explorer/cmake/bin/cmake --build .
  ▶ Environment (7)
```

### Server

Each `BuildStep` already carried its arguments and exit code. Two fields were missing:

- **`command`** — `doBuildstepAndAddToResult` received the binary but only stored the arguments, so `--build .` could not be shown as a cmake invocation.
- **`env`** — what the step actually ran with. Filled at the single point every build system funnels through, so this is not per-build-system work.

`LD_LIBRARY_PATH` is taken from `ldPath`, not from `env`. `exec()` overwrites any inherited value with `options.ldPath` before spawning (and passes it to the jail the same way), so `env.LD_LIBRARY_PATH` is the server's own — empty in practice. This is also why the two CMake steps legitimately differ: the configure step gets `ldPath = [dirPath]` from `createCmakeExecParams`, the build step does not. `PATH` and `HOME` are excluded as host state rather than anything about the build, and empty values are dropped.

### Masking needed a second entry point

`maskRootdirKeepingAppPrefix()` is built for argv, where a string holds one path and the temp dir is always the prefix of a file inside it. Neither holds for an env value:

```
-L/tmp/…X -Wl,-rpath,/tmp/…X -Wl,-rpath,/tmp/…X/fmt/lib -L/tmp/…X/fmt/lib
  ->  -L/tmp/…X -Wl,-rpath,/tmp/…X -Wl,-rpath,/app/fmt/lib -L/tmp/…X/fmt/lib
```

One of four, because the regex is not global and requires a trailing slash. `maskRootdirsInText()` is global and treats a bare temp dir as a path; the argv entry point is deliberately untouched, so the behaviour tuned in #9033/#8920 does not move. Six unit tests cover it, including that exact LDFLAGS value.

Verified against a live build: no temp paths survive in any step's command or env.

### UI notes

- **Modal, not popover.** A command line plus its environment is more than a popover holds, and one that dismisses on outside mouseup is awkward to copy from — and copying that cmake line is the point.
- **Status from the exit code alone.** `calculateStatusIcon()` treats any stdout/stderr as a warning, which suits a compiler but paints every successful cmake step orange, since cmake narrates its progress.
- Capped at 900px: CE modals size to `max-content`, and a build command line otherwise stretches them across the screen.

### Wire cost

The fields add ~1.2 KB raw per project build, on project builds only — single-file compiles have no `buildsteps`. Responses are gzipped (`compression()` in server-config), and the two steps' envs are nearly identical, so it compresses well:

| | base | with | added |
|---|---|---|---|
| executor, `skipAsm` | 3.3 KB raw / 1.5 KB gzip | 4.5 / 1.6 | +1,199 raw, **+157 gzip** |
| compiler pane, real build with asm | 883 KB raw / 68.6 KB gzip | 884 / 68.7 | +1,199 raw, **+177 gzip** |

The cache is the larger cost: the full result is stored, so +1.2 KB raw per cached project build.

### Open questions

1. **Wire/cache cost acceptable?** Most env keys are identical across steps; a shared base plus per-step deltas would roughly halve the raw cost. I judged that not worth the complexity for ~600 raw / ~80 gzipped bytes, but it is a real lever.
2. **Full path for `command`?** It shows `/opt/compiler-explorer/cmake/bin/cmake` on production. I kept it for consistency with `CC`/`CXX`/`LD` in the same dialog, and because it makes `--build .` legible as a cmake invocation. A basename with the full path on hover is the cheap alternative.
3. **Build steps are masked at construction**, not in `cleanupResult`. That is arguably better — it precedes caching — but it does mean two masking sites for build data.

Cached results predate these fields, so a cache hit shows arguments without the command prefix and no environment section until the cache turns over.

`npm test` (2660 passed), `ts-check` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168db5wLwZMU9TtcbN9ZD6v
