### PR TITLE
Update C++ standard version for pattern matching

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -706,7 +706,7 @@ compiler.clang_parmexpr.options=-std=c++2a -stdlib=libc++
 compiler.clang_parmexpr.notification=Experimental Parametric Expressions; see <a href="https://github.com/ricejasonf/parametric_expressions/blob/master/d1221.md" target="_blank" rel="noopener noreferrer">P1221<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_patmat.exe=/opt/compiler-explorer/clang-patmat-trunk/bin/clang++
 compiler.clang_patmat.semver=(pattern matching - P2688)
-compiler.clang_patmat.options=-std=c++2c -stdlib=libc++ -fpattern-matching
+compiler.clang_patmat.options=-std=c++2d -stdlib=libc++ -fpattern-matching
 compiler.clang_patmat.notification=Experimental Pattern Matching; see <a href="https://wg21.link/p2688" target="_blank" rel="noopener noreferrer">P2688 <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_embed.exe=/opt/compiler-explorer/clang-embed-trunk/bin/clang++
 compiler.clang_embed.semver=(std::embed)


### PR DESCRIPTION
Pattern matching (P2688R5) did not make C++26. As such, it is now targeting C++29.