### PR TITLE
Remove unused class toggling from 🧾 icon in compiler output button

### DIFF
--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -405,17 +405,7 @@ export class CompilerService {
         return '#FF6645';
     }
 
-    public static handleCompilationStatus(
-        statusLabel: JQuery | null,
-        statusIcon: JQuery | null,
-        status: CompilationStatus,
-    ) {
-        if (statusLabel != null) {
-            statusLabel
-                .toggleClass('error', status.code === CompilationStatusCode.WITH_ERRORS)
-                .toggleClass('warning', status.code === CompilationStatusCode.WITH_WARNINGS);
-        }
-
+    public static handleCompilationStatus(statusIcon: JQuery | null, status: CompilationStatus) {
         if (statusIcon != null) {
             statusIcon
                 .removeClass()

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -46,7 +46,6 @@ import {getAssemblyDocumentation} from '../api/api.js';
 import * as BootstrapUtils from '../bootstrap-utils.js';
 import * as codeLensHandler from '../codelens-handler.js';
 import * as colour from '../colour.js';
-import {CompilationStatus} from '../compiler-service.interfaces.js';
 import {CompilerService} from '../compiler-service.js';
 import {COMPILER_COMPONENT_NAME, ComponentConfig, NewToolSettings} from '../components.interfaces.js';
 import * as Components from '../components.js';
@@ -245,7 +244,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
     private noBinaryFiltersButtons: JQuery<HTMLButtonElement>;
     private shortCompilerName: JQuery<HTMLElement>;
     private bottomBar: JQuery<HTMLElement>;
-    private statusLabel: JQuery<HTMLElement>;
     private libsWidget: LibsWidget | null;
     private isLabelCtxKey: monaco.editor.IContextKey<boolean>;
     private revealJumpStackHasElementsCtxKey: monaco.editor.IContextKey<boolean>;
@@ -1926,8 +1924,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
         this.updateButtons();
 
-        this.handleCompilationStatus(CompilerService.calculateStatusIcon(result));
-
         this.checkForHints(result);
 
         this.offerFilesIfPossible(result);
@@ -2602,7 +2598,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
 
         this.topBar = this.domRoot.find('.top-bar');
         this.bottomBar = this.domRoot.find('.bottom-bar');
-        this.statusLabel = this.domRoot.find('.status-text');
 
         this.hideable = this.domRoot.find('.hideable');
 
@@ -3754,10 +3749,6 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 dismissTime: 5000,
             });
         }
-    }
-
-    handleCompilationStatus(status: CompilationStatus): void {
-        CompilerService.handleCompilationStatus(this.statusLabel, null, status);
     }
 
     onLanguageChange(editorId: number | boolean, newLangId: LanguageKey, treeId?: number | boolean): void {

--- a/static/panes/conformance-view.ts
+++ b/static/panes/conformance-view.ts
@@ -457,7 +457,7 @@ export class Conformance extends Pane<ConformanceViewState> {
     }
 
     handleStatusIcon(statusIcon: JQuery<HTMLElement> | null, status: CompilationStatus): void {
-        CompilerService.handleCompilationStatus(null, statusIcon, status);
+        CompilerService.handleCompilationStatus(statusIcon, status);
     }
 
     currentState(): ConformanceViewState {

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -44,7 +44,6 @@ import {
     CompilationStatusCode,
     CompilationStatus as CompilerServiceCompilationStatus,
 } from '../compiler-service.interfaces.js';
-import {CompilerService} from '../compiler-service.js';
 import {ICompilerShared} from '../compiler-shared.interfaces.js';
 import {CompilerShared} from '../compiler-shared.js';
 import {SourceAndFiles} from '../download-service.js';
@@ -118,7 +117,6 @@ export class Executor extends Pane<ExecutorState> {
     private compileTimeLabel: JQuery<HTMLElement>;
     private shortCompilerName: JQuery<HTMLElement>;
     private bottomBar: JQuery<HTMLElement>;
-    private statusLabel: JQuery<HTMLElement>;
     private statusIcon: JQuery<HTMLElement> | null;
     private panelCompilation: JQuery<HTMLElement>;
     private panelArgs: JQuery<HTMLElement>;
@@ -845,7 +843,6 @@ export class Executor extends Pane<ExecutorState> {
 
         this.topBar = this.domRoot.find('.top-bar');
         this.bottomBar = this.domRoot.find('.bottom-bar');
-        this.statusLabel = this.domRoot.find('.status-text');
 
         this.hideable = this.domRoot.find('.hideable');
         this.statusIcon = this.domRoot.find('.status-icon');
@@ -1268,9 +1265,6 @@ export class Executor extends Pane<ExecutorState> {
 
     // TODO: Duplicate with compiler-service.ts?
     handleCompilationStatus(status: CompilationStatus): void {
-        // We want to do some custom styles for the icon, so we don't pass it here and instead do it later
-        CompilerService.handleCompilationStatus(this.statusLabel, null, {compilerOut: 0, ...status});
-
         if (this.statusIcon != null) {
             this.statusIcon
                 .removeClass()

--- a/static/widgets/compilation-options.ts
+++ b/static/widgets/compilation-options.ts
@@ -73,7 +73,7 @@ export class CompilationOptions<P extends Pane<object>> {
     private onCompiling(compilerId: number, compiler: CompilerInfo): void {
         if (this.compilerInfo.compilerId !== compilerId) return;
         // Display the spinner
-        CompilerService.handleCompilationStatus(null, this.statusIcon, {
+        CompilerService.handleCompilationStatus(this.statusIcon, {
             code: CompilationStatusCode.COMPILING,
             compilerOut: 0,
         });
@@ -85,7 +85,6 @@ export class CompilationOptions<P extends Pane<object>> {
         const wasCmake = result.result ? (result.buildsteps?.some(step => step.step === 'cmake') ?? false) : false;
         const stepResult = this.getResult(result);
         CompilerService.handleCompilationStatus(
-            null,
             this.statusIcon,
             CompilerService.calculateStatusIcon(stepResult ?? result),
         );

--- a/views/templates/panes/compiler.pug
+++ b/views/templates/panes/compiler.pug
@@ -84,7 +84,7 @@ mixin newPaneButton(classId, text, title, icon)
           button.btn.btn-sm.btn-light.clear-cache(title="Clear cache & recompile" aria-label="Clear cache and recompile")
             span.fas.fa-redo
           button.btn.btn-sm.btn-light.opens-singleton-pane.output-btn(data-cy="new-output-pane-btn" aria-label="Show compiler output")
-            span.fas.fa-receipt.status-text
+            span.fas.fa-receipt
             | &nbsp;Output
             span.output-count(aria-live="polite")
               | &nbsp;(


### PR DESCRIPTION
The little 🧾 icon left of “Output” in the compiler pane gets a `warning` or `error` CSS class when there are errors or warnings in the compiler output. However, there are no mentions of either class in any of the (S)CSS files.

The intended behaviour (turning the icon yellow or red) is now subsumed by the compilation options icon, so this PR removes the class toggling code.