### PR TITLE
Add an "Open in ABI Explorer" button to the editor

### DIFF
--- a/public/abiexplorer.svg
+++ b/public/abiexplorer.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <defs>
+    <pattern id="abi-logo-hatch" width="2.5" height="2.5" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="2.5" stroke="#000" stroke-opacity=".8" stroke-width="1.6"/>
+    </pattern>
+    <clipPath id="abi-logo-pad"><rect x="6" y="3" width="9" height="10" rx="2"/></clipPath>
+  </defs>
+  <rect class="abi-logo-pri" x="1" y="3" width="4" height="10" rx="1.5" fill="#1cc296"/>
+  <rect class="abi-logo-sec" x="6" y="3" width="9" height="10" rx="2" fill="#626262"/>
+  <rect x="6" y="3" width="9" height="10" fill="url(#abi-logo-hatch)" clip-path="url(#abi-logo-pad)"/>
+</svg>

--- a/static/abi-explorer.ts
+++ b/static/abi-explorer.ts
@@ -54,6 +54,15 @@ export const ABI_EXPLORER_URL = 'https://abiexplorer.org/';
 /** What ABI Explorer lays out for when the link does not say. */
 export const ABI_EXPLORER_DEFAULT_TRIPLE = 'x86_64-unknown-linux-gnu';
 
+/**
+ * The ABI Hylo lays types out for.
+ *
+ * A name rather than a choice: its compiler describes exactly one, so ABI
+ * Explorer hides the target selector for Hylo and lays out for this whatever
+ * the link says.
+ */
+export const ABI_EXPLORER_HYLO_TRIPLE = 'hylo';
+
 /** Their validation of the `t` field: anything else is replaced by the default triple. */
 const TRIPLE_RE = /^[\w.-]{1,64}$/;
 
@@ -174,7 +183,7 @@ interface Wire {
 }
 
 function toWire(state: AbiExplorerState): Wire {
-    const triple = state.triple ?? ABI_EXPLORER_DEFAULT_TRIPLE;
+    const triple = state.triple ?? defaultTripleFor(state.lang);
     return {
         v: 2,
         s: state.source,
@@ -192,12 +201,19 @@ function toWire(state: AbiExplorerState): Wire {
     };
 }
 
+/** The target a language lays out for when the caller does not name one. */
+function defaultTripleFor(lang: AbiExplorerLanguage): string {
+    return lang === 'hylo' ? ABI_EXPLORER_HYLO_TRIPLE : ABI_EXPLORER_DEFAULT_TRIPLE;
+}
+
 /**
  * The ABI Explorer language for one of our language ids, or null for a language
  * it cannot lay out — which is also the answer to "should the button be shown?".
+ *
+ * Our ids for the three it knows are its own, so this is a membership test.
  */
 export function abiExplorerLanguageFor(languageId: string | undefined): AbiExplorerLanguage | null {
-    return languageId === 'c' || languageId === 'c++' ? languageId : null;
+    return languageId === 'c' || languageId === 'c++' || languageId === 'hylo' ? languageId : null;
 }
 
 /**

--- a/static/abi-explorer.ts
+++ b/static/abi-explorer.ts
@@ -1,0 +1,278 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Links to ABI Explorer (https://abiexplorer.org/), which runs clang in the
+// browser and shows how a record is laid out for a given target.
+//
+// A whole ABI Explorer session lives in the URL fragment, so a link is built
+// entirely on the client: there is no API to call, and the source never leaves
+// the browser. Two encodings exist, and the site reads both:
+//
+//     #2.<base64url(deflate-raw(json))>   what it writes itself
+//     #<base64url(json)>                  the original, still accepted
+//
+// The JSON uses short keys (see `Wire`). ABI Explorer validates every field on
+// the way in and silently substitutes its own default for anything it does not
+// recognise, so an unknown standard or triple opens the page on defaults rather
+// than failing. The format lives in src/core/url-state.ts of
+// https://github.com/tothambrus11/abi-explorer-2.
+//
+// The fragment is read once, when the page loads: a link must therefore be
+// opened in a fresh tab, not by rewriting the hash of one already showing
+// ABI Explorer.
+
+/** The languages ABI Explorer lays out. Its ids happen to match ours for C and C++. */
+export type AbiExplorerLanguage = 'c' | 'c++' | 'hylo';
+/** `-fpack-struct=N`, as ABI Explorer spells it; the empty string is the target default. */
+export type AbiExplorerPack = '' | '1' | '2' | '4' | '8' | '16';
+/** One record at a time behind a tab bar, or all of them stacked. */
+export type AbiExplorerView = 'tabs' | 'stack';
+
+export const ABI_EXPLORER_URL = 'https://abiexplorer.org/';
+
+/** What ABI Explorer lays out for when the link does not say. */
+export const ABI_EXPLORER_DEFAULT_TRIPLE = 'x86_64-unknown-linux-gnu';
+
+/** Their validation of the `t` field: anything else is replaced by the default triple. */
+const TRIPLE_RE = /^[\w.-]{1,64}$/;
+
+/** Their cap on the free-form flag string. */
+const MAX_EXTRA_FLAGS = 500;
+
+/** Standards the selector offers for C; anything else falls back to their newest. */
+export const ABI_EXPLORER_C_STANDARDS: readonly string[] = [
+    'c89',
+    'gnu89',
+    'c99',
+    'gnu99',
+    'c11',
+    'gnu11',
+    'c17',
+    'gnu17',
+    'c23',
+    'gnu23',
+];
+
+/** Standards the selector offers for C++. */
+export const ABI_EXPLORER_CXX_STANDARDS: readonly string[] = [
+    'c++03',
+    'gnu++03',
+    'c++11',
+    'gnu++11',
+    'c++14',
+    'gnu++14',
+    'c++17',
+    'gnu++17',
+    'c++20',
+    'gnu++20',
+    'c++23',
+    'gnu++23',
+    'c++26',
+    'gnu++26',
+];
+
+/**
+ * Draft spellings and older names for the standards above.
+ *
+ * Users write `-std=c++2b` as readily as `-std=c++23`, and ABI Explorer lists
+ * only the released name, so the draft ones are folded onto it here rather than
+ * dropped.
+ */
+const STD_ALIASES: Record<string, string> = {
+    c90: 'c89',
+    gnu90: 'gnu89',
+    c9x: 'c99',
+    gnu9x: 'gnu99',
+    c1x: 'c11',
+    gnu1x: 'gnu11',
+    c18: 'c17',
+    gnu18: 'gnu17',
+    c2x: 'c23',
+    gnu2x: 'gnu23',
+    'c++0x': 'c++11',
+    'gnu++0x': 'gnu++11',
+    'c++1y': 'c++14',
+    'gnu++1y': 'gnu++14',
+    'c++1z': 'c++17',
+    'gnu++1z': 'gnu++17',
+    'c++2a': 'c++20',
+    'gnu++2a': 'gnu++20',
+    'c++2b': 'c++23',
+    'gnu++2b': 'gnu++23',
+    'c++2c': 'c++26',
+    'gnu++2c': 'gnu++26',
+};
+
+/**
+ * An ABI Explorer session, in our own spelling.
+ *
+ * Everything but the source and the language is optional: an omitted field
+ * means "whatever ABI Explorer starts on", which is also what it does with a
+ * value it rejects. That is what lets a caller fill in only the parts it knows
+ * about, and what will let the target and the layout options below be derived
+ * from the compiler's architecture and settings later on.
+ */
+export interface AbiExplorerState {
+    source: string;
+    lang: AbiExplorerLanguage;
+    /** A standard from the lists above; see `normalizeAbiExplorerStd`. */
+    std?: string;
+    /** The target to lay out for. Any triple clang accepts, not just the listed ones. */
+    triple?: string;
+    pack?: AbiExplorerPack;
+    msBitfields?: boolean;
+    shortEnums?: boolean;
+    shortWchar?: boolean;
+    warnPadded?: boolean;
+    /**
+     * Extra clang flags. ABI Explorer allows only flags that change layout
+     * (`-f…`, `-m…`, `-W…`, `-D`, `-U`, `-O…`, absolute `-I`/`-isystem`, …) and
+     * drops the rest, `-target` among them: the target is `triple`.
+     */
+    extraFlags?: string;
+    /** Record to open on, by ABI Explorer's own key; null means it chooses. */
+    selectedRecord?: string | null;
+    view?: AbiExplorerView;
+}
+
+/** The state as it goes into the fragment: short keys, because each byte is a character of the link. */
+interface Wire {
+    v: number;
+    s: string;
+    l: AbiExplorerLanguage;
+    std: string;
+    t: string;
+    p: AbiExplorerPack;
+    mb: number;
+    se: number;
+    sw: number;
+    wp: number;
+    x: string;
+    r: string | null;
+    vw: AbiExplorerView;
+}
+
+function toWire(state: AbiExplorerState): Wire {
+    const triple = state.triple ?? ABI_EXPLORER_DEFAULT_TRIPLE;
+    return {
+        v: 2,
+        s: state.source,
+        l: state.lang,
+        std: normalizeAbiExplorerStd(state.lang, state.std ?? ''),
+        t: TRIPLE_RE.test(triple) ? triple : ABI_EXPLORER_DEFAULT_TRIPLE,
+        p: state.pack ?? '',
+        mb: state.msBitfields ? 1 : 0,
+        se: state.shortEnums ? 1 : 0,
+        sw: state.shortWchar ? 1 : 0,
+        wp: state.warnPadded ? 1 : 0,
+        x: (state.extraFlags ?? '').slice(0, MAX_EXTRA_FLAGS),
+        r: state.selectedRecord ?? null,
+        vw: state.view ?? 'tabs',
+    };
+}
+
+/**
+ * The ABI Explorer language for one of our language ids, or null for a language
+ * it cannot lay out — which is also the answer to "should the button be shown?".
+ */
+export function abiExplorerLanguageFor(languageId: string | undefined): AbiExplorerLanguage | null {
+    return languageId === 'c' || languageId === 'c++' ? languageId : null;
+}
+
+/**
+ * The standard ABI Explorer would name for this one, or the empty string when
+ * there is none, which leaves it on its own default.
+ *
+ * Accepts the flag as written (`-std=gnu++2b`) or just its value, and folds
+ * draft spellings onto the released name.
+ */
+export function normalizeAbiExplorerStd(lang: AbiExplorerLanguage, std: string): string {
+    // Hylo has had one release and no standards to choose between.
+    if (lang === 'hylo') return '';
+    const value = std
+        .trim()
+        .replace(/^-std=/, '')
+        .toLowerCase();
+    if (!value) return '';
+    const canonical = STD_ALIASES[value] ?? value;
+    const known = lang === 'c++' ? ABI_EXPLORER_CXX_STANDARDS : ABI_EXPLORER_C_STANDARDS;
+    return known.includes(canonical) ? canonical : '';
+}
+
+/** base64url: base64 with the URL-safe alphabet and no padding, so a link stays a link. */
+function base64Url(bytes: Uint8Array): string {
+    // Chunked, because spreading a long source into `fromCharCode` overflows the stack.
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 0x8000) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+    }
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function deflateRaw(bytes: Uint8Array): Promise<Uint8Array> {
+    const stream = new Blob([bytes as BlobPart]).stream().pipeThrough(new CompressionStream('deflate-raw'));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function encodeUncompressed(wire: Wire): string {
+    return base64Url(new TextEncoder().encode(JSON.stringify({...wire, v: 1})));
+}
+
+/**
+ * Encodes a session into a fragment value, without the leading '#'.
+ *
+ * Compressed where the browser can compress, which matters because the fragment
+ * carries the whole source; the uncompressed encoding is the fallback, and
+ * ABI Explorer reads both.
+ */
+export async function encodeAbiExplorerFragment(state: AbiExplorerState): Promise<string> {
+    const wire = toWire(state);
+    if (typeof CompressionStream !== 'undefined') {
+        try {
+            const json = new TextEncoder().encode(JSON.stringify(wire));
+            return `2.${base64Url(await deflateRaw(json))}`;
+        } catch {
+            // Fall through to the uncompressed encoding below.
+        }
+    }
+    return encodeUncompressed(wire);
+}
+
+/**
+ * The same fragment, uncompressed, for a caller that cannot wait: a link on a
+ * button has to be right at the moment it is clicked.
+ */
+export function encodeAbiExplorerFragmentSync(state: AbiExplorerState): string {
+    return encodeUncompressed(toWire(state));
+}
+
+/** A link that opens ABI Explorer on this session. */
+export async function getAbiExplorerUrl(state: AbiExplorerState): Promise<string> {
+    return `${ABI_EXPLORER_URL}#${await encodeAbiExplorerFragment(state)}`;
+}
+
+/** As `getAbiExplorerUrl`, without waiting, and so without the compression. */
+export function getAbiExplorerUrlSync(state: AbiExplorerState): string {
+    return `${ABI_EXPLORER_URL}#${encodeAbiExplorerFragmentSync(state)}`;
+}

--- a/static/abi-explorer.ts
+++ b/static/abi-explorer.ts
@@ -227,18 +227,33 @@ const TARGETS: Record<string, {triple?: string; arch: RegExp}> = {
     sparc: {arch: /^sparc/},
 };
 
-/** clang names the target it defaults to in its version banner. */
+/** The target CE aims a compiler at, in the flags its configuration gives it. */
+const CONFIGURED_TARGET_RE = /(?:^|\s)--?target[=\s]\s*(\S+)/;
+
+/** The target a compiler was built to default to, as its version banner reports it. */
 const VERSION_TARGET_RE = /^Target:\s*(\S+)/m;
 
 /**
  * The triple to lay out for, from what CE knows about a compiler without
- * compiling anything: the instruction set it reports, and its version banner.
+ * compiling anything.
  *
- * clang names its default target exactly, which is worth more than an
- * instruction set — but only where the two agree. A clang built for x86-64 and
- * aimed elsewhere by flags baked into its CE configuration still prints the
- * host in its banner, and there the instruction set is right and the banner is
- * not.
+ * In order of what each source actually claims:
+ *
+ * 1. The `-target` in the compiler's configured flags. Every clang is a cross
+ *    compiler, so CE's fleet is largely one clang binary entered many times
+ *    with a different target each time; this flag is the entry's whole point
+ *    and the only exact statement of it.
+ * 2. Failing that, the target the binary defaults to, from its banner. This
+ *    means something only when nothing above overrode it — for a distributed
+ *    cross toolchain like MinGW's clang it is the real answer, and for a
+ *    host clang it is the host.
+ * 3. Failing that, a default for the instruction set CE reports.
+ *
+ * Each candidate must agree with that instruction set to be believed, since
+ * the instruction set is CE's own conclusion about the compiler. A bare
+ * architecture (`wasm32`) is passed over for the mapped triple: clang and ABI
+ * Explorer both take it, but the fuller spelling is the one ABI Explorer's
+ * target list names.
  *
  * Undefined where nothing is known well enough to say, which leaves the link
  * on ABI Explorer's own default.
@@ -246,11 +261,16 @@ const VERSION_TARGET_RE = /^Target:\s*(\S+)/m;
 export function abiExplorerTripleFor(
     instructionSet: string | null | undefined,
     fullVersion?: string,
+    compilerOptions?: string,
 ): string | undefined {
     const known = instructionSet ? TARGETS[instructionSet] : undefined;
     if (!known) return undefined;
+    const believable = (target: string | undefined): target is string =>
+        !!target && target.includes('-') && known.arch.test(target);
+    const configured = compilerOptions ? CONFIGURED_TARGET_RE.exec(compilerOptions)?.[1] : undefined;
+    if (believable(configured)) return configured;
     const printed = fullVersion ? VERSION_TARGET_RE.exec(fullVersion)?.[1] : undefined;
-    if (printed && known.arch.test(printed)) return printed;
+    if (believable(printed)) return printed;
     return known.triple;
 }
 

--- a/static/abi-explorer.ts
+++ b/static/abi-explorer.ts
@@ -201,6 +201,59 @@ function toWire(state: AbiExplorerState): Wire {
     };
 }
 
+/**
+ * Targets we are confident about, by the instruction set CE reports.
+ *
+ * `triple` is what to lay out for when nothing more exact is known. The
+ * entries without one are instruction sets that cover several ABIs at once —
+ * 32- and 64-bit, big- and little-endian — where picking a default would be a
+ * coin toss. `arch` matches the architecture an exact triple starts with, and
+ * is what decides whether that triple and this instruction set are describing
+ * the same machine.
+ */
+const TARGETS: Record<string, {triple?: string; arch: RegExp}> = {
+    amd64: {triple: 'x86_64-unknown-linux-gnu', arch: /^(x86_64|amd64)/},
+    x86: {triple: 'i386-unknown-linux-gnu', arch: /^(i[3-6]86|x86)$/},
+    aarch64: {triple: 'aarch64-unknown-linux-gnu', arch: /^(aarch64|arm64)/},
+    arm32: {triple: 'arm-unknown-linux-gnueabihf', arch: /^(arm|thumb)(?!64)/},
+    riscv32: {triple: 'riscv32-unknown-elf', arch: /^riscv32/},
+    riscv64: {triple: 'riscv64-unknown-linux-gnu', arch: /^riscv64/},
+    s390x: {triple: 's390x-unknown-linux-gnu', arch: /^s390x/},
+    loongarch: {triple: 'loongarch64-unknown-linux-gnu', arch: /^loongarch/},
+    wasm32: {triple: 'wasm32-unknown-unknown', arch: /^wasm32/},
+    wasm64: {triple: 'wasm64-unknown-unknown', arch: /^wasm64/},
+    powerpc: {arch: /^(powerpc|ppc)/},
+    mips: {arch: /^mips/},
+    sparc: {arch: /^sparc/},
+};
+
+/** clang names the target it defaults to in its version banner. */
+const VERSION_TARGET_RE = /^Target:\s*(\S+)/m;
+
+/**
+ * The triple to lay out for, from what CE knows about a compiler without
+ * compiling anything: the instruction set it reports, and its version banner.
+ *
+ * clang names its default target exactly, which is worth more than an
+ * instruction set — but only where the two agree. A clang built for x86-64 and
+ * aimed elsewhere by flags baked into its CE configuration still prints the
+ * host in its banner, and there the instruction set is right and the banner is
+ * not.
+ *
+ * Undefined where nothing is known well enough to say, which leaves the link
+ * on ABI Explorer's own default.
+ */
+export function abiExplorerTripleFor(
+    instructionSet: string | null | undefined,
+    fullVersion?: string,
+): string | undefined {
+    const known = instructionSet ? TARGETS[instructionSet] : undefined;
+    if (!known) return undefined;
+    const printed = fullVersion ? VERSION_TARGET_RE.exec(fullVersion)?.[1] : undefined;
+    if (printed && known.arch.test(printed)) return printed;
+    return known.triple;
+}
+
 /** The target a language lays out for when the caller does not name one. */
 function defaultTripleFor(lang: AbiExplorerLanguage): string {
     return lang === 'hylo' ? ABI_EXPLORER_HYLO_TRIPLE : ABI_EXPLORER_DEFAULT_TRIPLE;

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -717,7 +717,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                 this.cppInsightsButton.hide();
                 this.quickBenchButton.hide();
             }
-            // ABI Explorer lays out C as well as C++.
+            // ABI Explorer lays out C and Hylo as well as C++.
             if (abiExplorerLanguageFor(this.currentLanguage?.id)) {
                 this.abiExplorerButton.show();
             } else {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -31,6 +31,13 @@ import * as monacoVim from 'monaco-vim';
 import TomSelect from 'tom-select';
 import _ from 'underscore';
 
+import {
+    type AbiExplorerState,
+    abiExplorerLanguageFor,
+    getAbiExplorerUrl,
+    getAbiExplorerUrlSync,
+    normalizeAbiExplorerStd,
+} from '../abi-explorer.js';
 import * as BootstrapUtils from '../bootstrap-utils.js';
 import * as colour from '../colour.js';
 import * as Components from '../components.js';
@@ -109,6 +116,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     private conformanceViewerButton: JQuery<HTMLElement>;
     private cppInsightsButton: JQuery<HTMLElement>;
     private quickBenchButton: JQuery<HTMLElement>;
+    private abiExplorerButton: JQuery<HTMLElement>;
     private languageInfoButton: JQuery;
     private nothingCtrlSSince?: number;
     private nothingCtrlSTimes?: number;
@@ -643,6 +651,11 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             this.quickBenchButton.on('mousedown', () => {
                 this.updateOpenInQuickBench();
             });
+
+            this.abiExplorerButton = this.domRoot.find('.open-in-abiexplorer');
+            this.abiExplorerButton.on('mousedown', () => {
+                this.updateOpenInAbiExplorer();
+            });
         }
 
         this.currentCursorPosition = this.domRoot.find('.currentCursorPosition');
@@ -703,6 +716,12 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
             } else {
                 this.cppInsightsButton.hide();
                 this.quickBenchButton.hide();
+            }
+            // ABI Explorer lays out C as well as C++.
+            if (abiExplorerLanguageFor(this.currentLanguage?.id)) {
+                this.abiExplorerButton.show();
+            } else {
+                this.abiExplorerButton.hide();
             }
         }
 
@@ -889,6 +908,35 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
                 Buffer.from(this.asciiEncodeJsonText(JSON.stringify(quickBenchState))).toString('base64');
             this.quickBenchButton.attr('href', link);
         }
+    }
+
+    /**
+     * Point the ABI Explorer button at what the editor currently holds.
+     *
+     * Only the source and the language standard so far: the target triple and
+     * the layout options ABI Explorer offers (packing, -fshort-enums, and the
+     * rest) are meant to follow from the compiler's architecture and settings,
+     * which this does not read yet. Everything it does not set opens on ABI
+     * Explorer's own defaults.
+     */
+    updateOpenInAbiExplorer(): void {
+        if (!options.thirdPartyIntegrationEnabled) return;
+        const lang = abiExplorerLanguageFor(this.currentLanguage?.id);
+        if (!lang) return;
+
+        let std = '';
+        for (const compiler of this.getCompilerStates()) {
+            const match = /-std=(\S+)/.exec(compiler.options ?? '');
+            const normalized = match ? normalizeAbiExplorerStd(lang, match[1]) : '';
+            if (normalized) std = normalized;
+        }
+
+        const state: AbiExplorerState = {source: this.getSource() ?? '', lang, std};
+        // This runs on mousedown, the last event before the link is followed, so
+        // the href has to be right now: set the uncompressed form immediately,
+        // and upgrade it to the shorter compressed one once that is ready.
+        this.abiExplorerButton.attr('href', getAbiExplorerUrlSync(state));
+        getAbiExplorerUrl(state).then(url => this.abiExplorerButton.attr('href', url));
     }
 
     changeLanguage(newLang: string): void {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -982,7 +982,7 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
         const info = await this.hub.compilerService
             .findCompiler(this.currentLanguage?.id ?? '', states[0].compiler)
             .catch(() => null);
-        return info ? abiExplorerTripleFor(info.instructionSet, info.fullVersion) : undefined;
+        return info ? abiExplorerTripleFor(info.instructionSet, info.fullVersion, info.options) : undefined;
     }
 
     changeLanguage(newLang: string): void {

--- a/static/panes/editor.ts
+++ b/static/panes/editor.ts
@@ -32,8 +32,10 @@ import TomSelect from 'tom-select';
 import _ from 'underscore';
 
 import {
+    type AbiExplorerLanguage,
     type AbiExplorerState,
     abiExplorerLanguageFor,
+    abiExplorerTripleFor,
     getAbiExplorerUrl,
     getAbiExplorerUrlSync,
     normalizeAbiExplorerStd,
@@ -58,6 +60,7 @@ import {assert, unwrap} from '../../shared/assert.js';
 import {getBuildSystemByManifestFilename, isManifestLanguageId} from '../../shared/build-systems.js';
 import {escapeHTML, isString} from '../../shared/common-utils.js';
 import {CompilationResult} from '../../types/compilation/compilation.interfaces.js';
+import {CompilerOverrideType} from '../../types/compilation/compiler-overrides.interfaces.js';
 import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import {Language, LanguageKey} from '../../types/languages.interfaces.js';
 import {MessageWithLocation, ResultLine} from '../../types/resultline/resultline.interfaces.js';
@@ -913,30 +916,73 @@ export class Editor extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Edit
     /**
      * Point the ABI Explorer button at what the editor currently holds.
      *
-     * Only the source and the language standard so far: the target triple and
-     * the layout options ABI Explorer offers (packing, -fshort-enums, and the
-     * rest) are meant to follow from the compiler's architecture and settings,
-     * which this does not read yet. Everything it does not set opens on ABI
-     * Explorer's own defaults.
+     * Best effort, deliberately. An editor can have any number of compilers on
+     * it, so which one a reader means by "this code's layout" is a question
+     * with no answer here; the link is a starting point, and ABI Explorer puts
+     * the language, standard and target in plain controls at the top of its
+     * page, a click from whatever we guessed wrong.
      */
     updateOpenInAbiExplorer(): void {
         if (!options.thirdPartyIntegrationEnabled) return;
         const lang = abiExplorerLanguageFor(this.currentLanguage?.id);
         if (!lang) return;
 
-        let std = '';
-        for (const compiler of this.getCompilerStates()) {
-            const match = /-std=(\S+)/.exec(compiler.options ?? '');
-            const normalized = match ? normalizeAbiExplorerStd(lang, match[1]) : '';
-            if (normalized) std = normalized;
-        }
-
-        const state: AbiExplorerState = {source: this.getSource() ?? '', lang, std};
+        const states = this.getCompilerStates();
+        const state: AbiExplorerState = {
+            source: this.getSource() ?? '',
+            lang,
+            std: this.abiExplorerStd(lang, states),
+        };
         // This runs on mousedown, the last event before the link is followed, so
-        // the href has to be right now: set the uncompressed form immediately,
-        // and upgrade it to the shorter compressed one once that is ready.
+        // the href has to be right now: the uncompressed link goes on at once,
+        // and the compressed one — carrying the target, which costs a compiler
+        // lookup — replaces it as soon as both are ready.
         this.abiExplorerButton.attr('href', getAbiExplorerUrlSync(state));
-        getAbiExplorerUrl(state).then(url => this.abiExplorerButton.attr('href', url));
+        void this.abiExplorerTriple(states)
+            .then(triple => getAbiExplorerUrl(triple ? {...state, triple} : state))
+            .then(url => this.abiExplorerButton.attr('href', url));
+    }
+
+    /**
+     * The standard to lay out with: the last one an attached compiler names,
+     * whether typed as a flag or picked from its overrides.
+     *
+     * The override wins over the flag box on the same compiler, being the more
+     * explicit choice of the two. Which compiler wins when several are attached
+     * is arbitrary, as it is for the other two integrations here.
+     */
+    private abiExplorerStd(lang: AbiExplorerLanguage, states: any[]): string {
+        let std = '';
+        for (const state of states) {
+            const typed = /-std=(\S+)/.exec(state.options ?? '')?.[1];
+            const picked = (state.overrides ?? []).find(
+                (ov: {name: string; value?: string}) => ov.name === CompilerOverrideType.stdver,
+            )?.value;
+            for (const candidate of [typed, picked]) {
+                const normalized = candidate ? normalizeAbiExplorerStd(lang, candidate) : '';
+                if (normalized) std = normalized;
+            }
+        }
+        return std;
+    }
+
+    /**
+     * The target to lay out for, or undefined to leave ABI Explorer on its own.
+     *
+     * Only where exactly one compiler is attached. With several there is no
+     * saying which target was meant, and every one of them is a machine whose
+     * layout differs from the others, so the honest answer is to name none.
+     *
+     * Read off the compiler itself rather than its flags: for most of CE's
+     * cross compilers the target is which binary runs, and appears in no
+     * argument.
+     */
+    private async abiExplorerTriple(states: any[]): Promise<string | undefined> {
+        if (states.length !== 1) return undefined;
+        const info = await this.hub.compilerService
+            .findCompiler(this.currentLanguage?.id ?? '', states[0].compiler)
+            .catch(() => null);
+        return info ? abiExplorerTripleFor(info.instructionSet, info.fullVersion) : undefined;
     }
 
     changeLanguage(newLang: string): void {

--- a/static/styles/explorer.scss
+++ b/static/styles/explorer.scss
@@ -774,7 +774,8 @@ li.lm_tab.lm_active {
 }
 
 .open-in-cppinsights *,
-.open-in-quickbench * {
+.open-in-quickbench *,
+.open-in-abiexplorer * {
     vertical-align: middle;
 }
 

--- a/static/styles/themes/dark-theme.scss
+++ b/static/styles/themes/dark-theme.scss
@@ -196,6 +196,10 @@ textarea.form-control {
     fill: #e2e2e2 !important;
 }
 
+.abi-logo-sec {
+    fill: #8a8a8a !important;
+}
+
 .currentCursorPosition {
     color: #17a2b8;
     background-color: rgba(49, 54, 60, 0.85);

--- a/static/styles/themes/one-dark-theme.scss
+++ b/static/styles/themes/one-dark-theme.scss
@@ -243,6 +243,10 @@ textarea.form-control {
     fill: #e2e2e2 !important;
 }
 
+.abi-logo-sec {
+    fill: #8a8a8a !important;
+}
+
 .currentCursorPosition {
     color: #eee;
     background-color: color.adjust($dark, $alpha: 0.8);

--- a/views/templates/panes/codeEditor.pug
+++ b/views/templates/panes/codeEditor.pug
@@ -29,6 +29,9 @@ mixin newPaneButton(classId, text, title, label, icon)
         a.btn.btn-sm.btn-light.open-in-quickbench(href="http://quick-bench.com/" target="_blank" title="Open in Quick-bench" aria-label="Open in Quick-bench")
           img(height="16" width="16" src=staticRoot + "quickbench.svg" alt="Quick-bench logo")
           span.hideable Quick-bench
+        a.btn.btn-sm.btn-light.open-in-abiexplorer(href="https://abiexplorer.org/" target="_blank" title="Open in ABI Explorer" aria-label="Open in ABI Explorer")
+          img(height="16" width="16" src=staticRoot + "abiexplorer.svg" alt="ABI Explorer logo")
+          span.hideable ABI Explorer
     .btn-group.btn-group-sm.mx-auto
       button.btn.btn-sm.btn-outline-info.ctrlSNothing(disabled=true style="display: none")
         span.fas.fa-smile


### PR DESCRIPTION
Adds an **Open in ABI Explorer** button to the editor toolbar, beside CppInsights and Quick-bench.

[ABI Explorer](https://abiexplorer.org/) ([tothambrus11/abi-explorer-2](https://github.com/tothambrus11/abi-explorer-2)) runs clang in the browser and shows how a record is laid out for a given target — sizeof/alignof, field offsets, and where the padding goes. cc @tothambrus11, in case any of the below is wrong or you would rather we did it differently.

## How the link works

ABI Explorer keeps its whole session in the URL fragment, so there is no API to call: the link is built entirely on the client and the source never leaves the browser. Two encodings exist and the site reads both (`src/core/url-state.ts` upstream):

```
https://abiexplorer.org/#2.<base64url(deflate-raw(json))>   what it writes itself
https://abiexplorer.org/#<base64url(json)>                  the original, still accepted
```

`static/abi-explorer.ts` is the whole of it: short-keyed wire format, both encodings, and a `normalizeAbiExplorerStd` that folds draft spellings (`-std=gnu++2b`) onto the names ABI Explorer lists (`gnu++23`). Every field is validated on their side, and an unrecognised value leaves them on their own default, so a link is never half-restored.

The href is set on `mousedown`, the last event before the link is followed. Compression is async, so the handler sets the uncompressed link synchronously — correct at the instant of the click — and upgrades it to the shorter compressed one when that resolves.

## What it sends today

The source, the language, the standard, and — where it can say — the target.

All three languages ABI Explorer knows are covered: **C, C++ and Hylo**. Our language ids for them are already the ones it uses, so the button shows for C and Hylo, where CppInsights and Quick-bench do not. Hylo has one ABI and no standards to choose between, so its links name the target `hylo` and carry no standard; ABI Explorer hides both selectors for it.

The standard comes from the compiler pane's `-std=` or from its `stdver` override, whichever is set — the override being an explicit choice that never appears in the flags box, and which 1095 of the 1197 C++ compilers offer.

## On the target, and what a link can know

The target is read off the **compiler**, not off the flags box, in this order:

1. **The `-target` in the compiler's configured flags.** Every clang is a cross compiler, so CE's fleet is largely one clang binary entered many times with a different target each time; that flag is the entry's whole point and the only exact statement of it.
2. **The target the binary defaults to**, from its version banner. Meaningful only when nothing above overrode it — for a distributed cross toolchain like MinGW's clang it is the real answer; for a host clang it is just the host.
3. **A default for the instruction set CE reports**, as the floor.

Each candidate has to agree with that instruction set to be believed, since the instruction set is CE's own conclusion about the compiler.

Nothing here reads the user's flags. For most of CE's cross compilers the target is *which binary runs* and appears in no argument at all — `armg1410` compiles with `['-g','-o',…,'-O1','example.cpp']` and nothing in there says ARM.

A link names no target when several compilers are attached to the editor: there is no answering which one the reader meant, and unlike a standard, every target is a different machine. Nor for instruction sets ABI Explorer has no target for (avr, z80, 6502…), nor where only the coarse hint is available for something spanning several ABIs (the GCC mips, powerpc and sparc entries). Across the 1197 C++ compilers on godbolt.org, 837 get a named target and the rest open on ABI Explorer's default.

**This is best effort by construction, and that is fine here.** An editor can carry any number of compilers and executors, so some of the guessing is irreducible. What makes it safe is that ABI Explorer puts the language, standard and target in plain controls at the top of its page: a wrong guess is one click from right, not a silently wrong answer.

Left for anyone who wants it:

- [ ] **ABI-changing flags** — `-m32`, `-mabi=`, `-mfloat-abi=`, a user's own `--target=` — which change the layout without changing the compiler. These are only accurately known *after* a compilation, from `CompilationResult.compilationOptions`, the merged argv the server actually ran; anything reconstructed client-side from the flags box is a prediction that drifts from `prepareArguments`. The editor pane does not subscribe to `compileResult` today.
- [ ] **`extraFlags` passthrough** for the rest of what ABI Explorer allowlists (`-f…`, `-m…`, `-W…`, `-D`/`-U`, `-O…`, absolute `-I`/`-isystem`, `-Xclang -f…`). Note `-target` is *not* on that list — the triple has to travel in its own field.
- [ ] **Triples for the GCC mips, powerpc and sparc entries**, which need width and endianness from something other than `instructionSet`. Their clang counterparts already resolve, since the configured target names both.

## Notes

- `public/abiexplorer.svg` is adapted from ABI Explorer's own site icon, classed `abi-logo-pri`/`abi-logo-sec` to match the existing `cppi-logo-*`/`qb-logo-*` convention, with the dark-theme fills alongside theirs. It needs a static asset deploy like any new `public/` file.
- Behind `thirdPartyIntegrationEnabled`, like the other two buttons.

## Testing

Ran locally against a dev instance: clicking the button in a C++ editor produced a link that opens ABI Explorer with the editor's exact source, C++ selected, and `c++20` picked up from the compiler's `-std=c++20 -O3 -flto`. Both encodings verified end-to-end on the live site, as were a Hylo link and one carrying an AArch64 target.

Target resolution was checked against all 1197 C++ compilers from `/api/compilers`. `armv8-full-clang-trunk` — a host clang whose banner reads `Target: x86_64-unknown-linux-gnu` — resolves to `aarch64-linux-gnu` from its configured flags. `armv7-clang1000` resolves to `arm-linux-gnueabi`, where the instruction set alone would have said `gnueabihf`: soft float against hard, a real difference in what gets laid out. MinGW and clang-cl pick up `x86_64-w64-windows-gnu` and `x86_64-pc-windows-msvc` from their banners, having no configured target to override them.

Light theme not checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUKb6LjSf9n471RNQyBKtY