### PR TITLE
Use `CompilationOptions` widget for executor pane

### DIFF
--- a/static/compiler-service.interfaces.ts
+++ b/static/compiler-service.interfaces.ts
@@ -34,4 +34,5 @@ export enum CompilationStatusCode {
 export interface CompilationStatus {
     code: CompilationStatusCode;
     compilerOut: number | undefined;
+    didExecute?: boolean;
 }

--- a/static/compiler-service.ts
+++ b/static/compiler-service.ts
@@ -371,26 +371,42 @@ export class CompilerService {
     }
 
     private static getAriaLabel(status: CompilationStatus) {
-        if (status.code === CompilationStatusCode.UNKNOWN) return 'Unknown';
-        // Compiling...
-        if (status.code === CompilationStatusCode.COMPILING) return 'Compiling';
-        if (status.compilerOut === 0) {
+        const compilationResult = (() => {
+            if (status.code === CompilationStatusCode.UNKNOWN) return 'Unknown';
+            // Compiling...
+            if (status.code === CompilationStatusCode.COMPILING) return 'Compiling';
+            if (status.compilerOut === 0) {
+                // StdErr.length > 0
+                if (status.code === CompilationStatusCode.WITH_ERRORS) return 'Compilation succeeded with errors';
+                // StdOut.length > 0
+                if (status.code === CompilationStatusCode.WITH_WARNINGS) return 'Compilation succeeded with warnings';
+                return 'Compilation succeeded';
+            }
             // StdErr.length > 0
-            if (status.code === CompilationStatusCode.WITH_ERRORS) return 'Compilation succeeded with errors';
+            if (status.code === CompilationStatusCode.WITH_ERRORS) return 'Compilation failed with errors';
             // StdOut.length > 0
-            if (status.code === CompilationStatusCode.WITH_WARNINGS) return 'Compilation succeeded with warnings';
-            return 'Compilation succeeded';
-        }
-        // StdErr.length > 0
-        if (status.code === CompilationStatusCode.WITH_ERRORS) return 'Compilation failed with errors';
-        // StdOut.length > 0
-        if (status.code === CompilationStatusCode.WITH_WARNINGS) return 'Compilation failed with warnings';
-        return 'Compilation failed';
+            if (status.code === CompilationStatusCode.WITH_WARNINGS) return 'Compilation failed with warnings';
+            return 'Compilation failed';
+        })();
+        const executionResult = (() => {
+            switch (status.didExecute) {
+                case undefined:
+                    return '';
+                case true:
+                    return '; execution successful';
+                case false:
+                    return '; execution failed';
+            }
+        })();
+        return `${compilationResult}${executionResult}`;
     }
 
     private static getColor(status: CompilationStatus) {
         // Compiling...
         if (status.code === CompilationStatusCode.COMPILING) return '#888888';
+        if (status.didExecute !== undefined) {
+            return status.didExecute ? '#12BB12' : '#FF1212';
+        }
         if (status.compilerOut === 0) {
             // StdErr.length > 0
             if (status.code === CompilationStatusCode.WITH_ERRORS) return '#FF6645';
@@ -413,13 +429,21 @@ export class CompilerService {
                 .css('color', CompilerService.getColor(status))
                 .toggle(status.code !== CompilationStatusCode.NONE)
                 .attr('aria-label', CompilerService.getAriaLabel(status))
-                .toggleClass('fa-spinner fa-spin', status.code === CompilationStatusCode.COMPILING)
-                .toggleClass('fa-times-circle', status.code === CompilationStatusCode.WITH_ERRORS)
-                .toggleClass('fa-circle-question', status.code === CompilationStatusCode.UNKNOWN)
-                .toggleClass(
-                    'fa-check-circle',
-                    status.code === CompilationStatusCode.OK || status.code === CompilationStatusCode.WITH_WARNINGS,
-                );
+                .toggleClass('fa-spinner fa-spin', status.code === CompilationStatusCode.COMPILING);
+            let error, unknown, okay;
+            if (status.didExecute === undefined) {
+                error = status.code === CompilationStatusCode.WITH_ERRORS;
+                unknown = status.code === CompilationStatusCode.UNKNOWN;
+                okay = status.code === CompilationStatusCode.OK || status.code === CompilationStatusCode.WITH_WARNINGS;
+            } else {
+                error = status.code !== CompilationStatusCode.COMPILING && !status.didExecute;
+                unknown = false;
+                okay = status.code !== CompilationStatusCode.COMPILING && status.didExecute;
+            }
+            statusIcon
+                .toggleClass('fa-times-circle', error)
+                .toggleClass('fa-circle-question', unknown)
+                .toggleClass('fa-check-circle', okay);
         }
     }
 

--- a/static/event-map.ts
+++ b/static/event-map.ts
@@ -72,6 +72,7 @@ export type EventMap = {
     // Right now nothing emits this event, but it might be useful at some point so we keep it
     compilerSetDecorations: (compilerId: number, lineNums: number[], revealLine: boolean, column?: number) => void;
     compiling: (compilerId: number, compiler: CompilerInfo) => void;
+    executeCompiling: (executorId: number, compiler: CompilerInfo) => void;
     conformanceViewClose: (editorId: number) => void;
     conformanceViewOpen: (editorId: number) => void;
     copyShortLinkToClip: () => void;

--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -343,12 +343,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
         this.initCallbacks();
         // Handle initial settings
         this.onSettingsChange(this.settings);
-        new CompilationOptions(
-            this,
-            this.domRoot.find('.prepend-options'),
-            result => result.result ?? result,
-            this.filters,
-        );
+        new CompilationOptions(this, this.id, result => result.result ?? result, this.filters);
 
         this.postInit(state);
     }

--- a/static/panes/executor.ts
+++ b/static/panes/executor.ts
@@ -40,10 +40,6 @@ import {ResultLine} from '../../types/resultline/resultline.interfaces.js';
 import {Filter as AnsiToHtml} from '../ansi-to-html.js';
 import {ArtifactHandler} from '../artifact-handler.js';
 import * as BootstrapUtils from '../bootstrap-utils.js';
-import {
-    CompilationStatusCode,
-    CompilationStatus as CompilerServiceCompilationStatus,
-} from '../compiler-service.interfaces.js';
 import {ICompilerShared} from '../compiler-shared.interfaces.js';
 import {CompilerShared} from '../compiler-shared.js';
 import {SourceAndFiles} from '../download-service.js';
@@ -54,6 +50,7 @@ import {languagesService} from '../services/languages.service.js';
 import {Settings, SiteSettings} from '../settings.js';
 import * as utils from '../utils.js';
 import {Alert} from '../widgets/alert.js';
+import {ExecutionCompilationOptions} from '../widgets/compilation-options.js';
 import {CompilerPicker} from '../widgets/compiler-picker.js';
 import {CompilerVersionInfo, setCompilerVersionPopoverForPane} from '../widgets/compiler-version-info.js';
 import {FontScale} from '../widgets/fontscale.js';
@@ -65,10 +62,6 @@ import {LangInfo} from './compiler-request.interfaces.js';
 import {ExecutorState} from './executor.interfaces.js';
 import {PaneState} from './pane.interfaces.js';
 import {Pane} from './pane.js';
-
-type CompilationStatus = Omit<CompilerServiceCompilationStatus, 'compilerOut'> & {
-    didExecute?: boolean;
-};
 
 function makeAnsiToHtml(color?: string): AnsiToHtml {
     return new AnsiToHtml({
@@ -110,14 +103,12 @@ export class Executor extends Pane<ExecutorState> {
     private optionsField: JQuery<HTMLElement>;
     private execArgsField: JQuery<HTMLElement>;
     private execStdinField: JQuery<HTMLElement>;
-    private prependOptions: JQuery<HTMLElement>;
     private fullCompilerName: JQuery<HTMLElement>;
     private fullTimingInfo: JQuery<HTMLElement>;
     private libsButton: JQuery<HTMLElement>;
     private compileTimeLabel: JQuery<HTMLElement>;
     private shortCompilerName: JQuery<HTMLElement>;
     private bottomBar: JQuery<HTMLElement>;
-    private statusIcon: JQuery<HTMLElement> | null;
     private panelCompilation: JQuery<HTMLElement>;
     private panelArgs: JQuery<HTMLElement>;
     private panelStdin: JQuery<HTMLElement>;
@@ -172,6 +163,7 @@ export class Executor extends Pane<ExecutorState> {
         this.initCallbacks();
         // Handle initial settings
         this.onSettingsChange(this.settings);
+        new ExecutionCompilationOptions(this, this.id, result => result.buildResult ?? result.result);
 
         this.postInit(state);
     }
@@ -444,9 +436,9 @@ export class Executor extends Pane<ExecutorState> {
             this.nextBuildRequest = {buildSystem, request};
             return;
         }
-        // this.eventHub.emit('compiling', this.id, this.compiler);
-        // Display the spinner
-        this.handleCompilationStatus({code: CompilationStatusCode.COMPILING});
+        if (this.compiler) {
+            this.eventHub.emit('executeCompiling', this.id, this.compiler);
+        }
         this.pendingBuildRequestSentAt = Date.now();
         // After a short delay, give the user some indication that we're working on their
         // compilation.
@@ -479,9 +471,9 @@ export class Executor extends Pane<ExecutorState> {
             this.nextRequest = request;
             return;
         }
-        // this.eventHub.emit('compiling', this.id, this.compiler);
-        // Display the spinner
-        this.handleCompilationStatus({code: CompilationStatusCode.COMPILING});
+        if (this.compiler) {
+            this.eventHub.emit('executeCompiling', this.id, this.compiler);
+        }
         this.pendingRequestSentAt = Date.now();
         // After a short delay, give the user some indication that we're working on their
         // compilation.
@@ -718,7 +710,6 @@ export class Executor extends Pane<ExecutorState> {
             }
         }
 
-        this.handleCompilationStatus({code: CompilationStatusCode.OK, didExecute: result.didExecute});
         let timeLabelText = '';
         if (cached) {
             timeLabelText = ' - cached';
@@ -726,9 +717,6 @@ export class Executor extends Pane<ExecutorState> {
             timeLabelText = ' - ' + timeTaken + 'ms';
         }
         this.compileTimeLabel.text(timeLabelText);
-
-        const compilationOptions = result.buildResult?.compilationOptions ?? result.result?.compilationOptions;
-        this.setCompilationOptionsPopover(compilationOptions?.join(' ') ?? null);
 
         if (this.currentLangId) {
             const languages = languagesService.getLanguagesOrFail();
@@ -803,10 +791,8 @@ export class Executor extends Pane<ExecutorState> {
         this.optionsField = this.domRoot.find('.compilation-options');
         this.execArgsField = this.domRoot.find('.execution-arguments');
         this.execStdinField = this.domRoot.find('.execution-stdin');
-        this.prependOptions = this.domRoot.find('.prepend-options');
         this.fullCompilerName = this.domRoot.find('.full-compiler-name');
         this.fullTimingInfo = this.domRoot.find('.full-timing-info');
-        this.setCompilationOptionsPopover(this.compiler?.options ?? null);
 
         this.compileTimeLabel = this.domRoot.find('.compile-time');
         this.libsButton = this.domRoot.find('.btn.show-libs');
@@ -815,15 +801,6 @@ export class Executor extends Pane<ExecutorState> {
         // the popover or on any alert
         $(document).on('mouseup', e => {
             const target = $(e.target);
-            if (
-                !target.is(this.prependOptions) &&
-                this.prependOptions.has(target as any).length === 0 &&
-                target.closest('.popover').length === 0
-            ) {
-                const popover = BootstrapUtils.getPopoverInstance(this.prependOptions);
-                if (popover) popover.hide();
-            }
-
             if (
                 !target.is(this.fullCompilerName) &&
                 this.fullCompilerName.has(target as any).length === 0 &&
@@ -845,7 +822,6 @@ export class Executor extends Pane<ExecutorState> {
         this.bottomBar = this.domRoot.find('.bottom-bar');
 
         this.hideable = this.domRoot.find('.hideable');
-        this.statusIcon = this.domRoot.find('.status-icon');
 
         this.panelCompilation = this.domRoot.find('.panel-compilation');
         this.panelArgs = this.domRoot.find('.panel-args');
@@ -1088,7 +1064,6 @@ export class Executor extends Pane<ExecutorState> {
                     dismissTime: 5000,
                 });
             }
-            this.prependOptions.data('content', this.compiler.options);
         }
         this.sendExecutor();
     }
@@ -1223,59 +1198,12 @@ export class Executor extends Pane<ExecutorState> {
         );
     }
 
-    setCompilationOptionsPopover(content: string | null) {
-        // Dispose of existing popover
-        const existingPopover = BootstrapUtils.getPopoverInstance(this.prependOptions);
-        if (existingPopover) existingPopover.dispose();
-
-        // Initialize new popover
-        BootstrapUtils.initPopover(this.prependOptions, {
-            content: content || 'No options in use',
-            template:
-                '<div class="popover' +
-                (content ? ' compiler-options-popover' : '') +
-                '" role="tooltip"><div class="arrow"></div>' +
-                '<h3 class="popover-header"></h3><div class="popover-body"></div></div>',
-        });
-    }
-
     setCompilerVersionPopover(version?: CompilerVersionInfo, notification?: string, compilerId?: string) {
         setCompilerVersionPopoverForPane(this, version, notification, compilerId);
     }
 
     override onSettingsChange(newSettings: SiteSettings): void {
         this.settings = _.clone(newSettings);
-    }
-
-    private ariaLabel(status: CompilationStatus): string {
-        // Compiling...
-        if (status.code === CompilationStatusCode.COMPILING) return 'Compiling';
-        if (status.didExecute) {
-            return 'Program compiled & executed';
-        }
-        return 'Program could not be executed';
-    }
-
-    private color(status: CompilationStatus) {
-        // Compiling...
-        if (status.code === CompilationStatusCode.COMPILING) return '#888888';
-        if (status.didExecute) return '#12BB12';
-        return '#FF1212';
-    }
-
-    // TODO: Duplicate with compiler-service.ts?
-    handleCompilationStatus(status: CompilationStatus): void {
-        if (this.statusIcon != null) {
-            this.statusIcon
-                .removeClass()
-                .addClass('status-icon fas')
-                .css('color', this.color(status))
-                .toggle(status.code !== CompilationStatusCode.NONE)
-                .attr('aria-label', this.ariaLabel(status))
-                .toggleClass('fa-spinner fa-spin', status.code === CompilationStatusCode.COMPILING)
-                .toggleClass('fa-times-circle', status.code !== CompilationStatusCode.COMPILING && !status.didExecute)
-                .toggleClass('fa-check-circle', status.code !== CompilationStatusCode.COMPILING && status.didExecute);
-        }
     }
 
     async updateLibraries(): Promise<void> {

--- a/static/panes/ir-view.ts
+++ b/static/panes/ir-view.ts
@@ -80,7 +80,7 @@ export class Ir extends MonacoPane<monaco.editor.IStandaloneCodeEditor, IrState>
 
     constructor(hub: Hub, container: Container, state: IrState & MonacoPaneState) {
         super(hub, container, state);
-        new CompilationOptions(this, this.domRoot.find('.prepend-options'), result => result.irOutput);
+        new CompilationOptions(this, this.compilerInfo.compilerId, result => result.irOutput);
         if (state.irOutput) {
             this.showIrResults(state.irOutput ?? []);
         }

--- a/static/panes/opt-pipeline.ts
+++ b/static/panes/opt-pipeline.ts
@@ -85,7 +85,7 @@ export class OptPipeline extends MonacoPane<monaco.editor.IStandaloneDiffEditor,
 
     constructor(hub: Hub, container: Container, state: OptPipelineViewState & MonacoPaneState) {
         super(hub, container, state);
-        new CompilationOptions(this, this.domRoot.find('.prepend-options'), result => result.optPipelineOutput);
+        new CompilationOptions(this, this.compilerInfo.compilerId, result => result.optPipelineOutput);
         this.groupName = this.domRoot.find('.opt-group-name');
         this.updateGroupName();
         this.passesColumn = this.domRoot.find('.passes-column');

--- a/static/widgets/compilation-options.ts
+++ b/static/widgets/compilation-options.ts
@@ -31,7 +31,6 @@ import {CompilerInfo} from '../../types/compiler.interfaces.js';
 import * as BootstrapUtils from '../bootstrap-utils.js';
 import {CompilationStatusCode} from '../compiler-service.interfaces.js';
 import {CompilerService} from '../compiler-service.js';
-import {PaneCompilerState} from '../panes/pane.interfaces.js';
 import {Pane} from '../panes/pane.js';
 import {Toggles} from './toggles.js';
 
@@ -39,15 +38,17 @@ type GetResult = (result: CompilationResult) => Pick<CompilationResult, 'code' |
 
 export class CompilationOptions<P extends Pane<object>> {
     private readonly parent: P;
+    private readonly parentId: number;
     private readonly prependOptions: JQuery<HTMLElement>;
     private readonly statusIcon: JQuery<HTMLElement>;
     private readonly getResult: GetResult;
     private readonly filters?: Toggles;
 
-    constructor(pane: P, prependOptions: JQuery<HTMLElement>, getResult: GetResult, filters?: Toggles) {
+    constructor(pane: P, parentId: number, getResult: GetResult, filters?: Toggles) {
         this.parent = pane;
-        this.prependOptions = prependOptions;
-        this.statusIcon = prependOptions.find('.status-icon');
+        this.parentId = parentId;
+        this.prependOptions = pane.domRoot.find('.prepend-options');
+        this.statusIcon = this.prependOptions.find('.status-icon');
         this.getResult = getResult;
         this.filters = filters;
 
@@ -66,12 +67,8 @@ export class CompilationOptions<P extends Pane<object>> {
         });
     }
 
-    private get compilerInfo(): PaneCompilerState {
-        return this.parent.compilerInfo;
-    }
-
     private onCompiling(compilerId: number, compiler: CompilerInfo): void {
-        if (this.compilerInfo.compilerId !== compilerId) return;
+        if (this.parentId !== compilerId) return;
         // Display the spinner
         CompilerService.handleCompilationStatus(this.statusIcon, {
             code: CompilationStatusCode.COMPILING,
@@ -80,7 +77,7 @@ export class CompilationOptions<P extends Pane<object>> {
     }
 
     private onCompileResult(compilerId: number, compiler: CompilerInfo, result: CompilationResult): void {
-        if (this.compilerInfo.compilerId !== compilerId) return;
+        if (this.parentId !== compilerId) return;
 
         const wasCmake = result.result ? (result.buildsteps?.some(step => step.step === 'cmake') ?? false) : false;
         const stepResult = this.getResult(result);

--- a/static/widgets/compilation-options.ts
+++ b/static/widgets/compilation-options.ts
@@ -36,8 +36,8 @@ import {Toggles} from './toggles.js';
 
 type GetResult = (result: CompilationResult) => Pick<CompilationResult, 'code' | 'compilationOptions'> | undefined;
 
-export class CompilationOptions<P extends Pane<object>> {
-    private readonly parent: P;
+abstract class BaseCompilationOptions<P extends Pane<object>> {
+    protected readonly parent: P;
     private readonly parentId: number;
     private readonly prependOptions: JQuery<HTMLElement>;
     private readonly statusIcon: JQuery<HTMLElement>;
@@ -51,9 +51,7 @@ export class CompilationOptions<P extends Pane<object>> {
         this.statusIcon = this.prependOptions.find('.status-icon');
         this.getResult = getResult;
         this.filters = filters;
-
-        pane.eventHub.on('compiling', this.onCompiling.bind(this));
-        pane.eventHub.on('compileResult', this.onCompileResult.bind(this));
+        this.initCallbacks();
 
         $(document).on('mouseup', e => {
             const target = $(e.target);
@@ -67,7 +65,9 @@ export class CompilationOptions<P extends Pane<object>> {
         });
     }
 
-    private onCompiling(compilerId: number, compiler: CompilerInfo): void {
+    protected initCallbacks(): void {}
+
+    protected onCompiling(compilerId: number, compiler: CompilerInfo): void {
         if (this.parentId !== compilerId) return;
         // Display the spinner
         CompilerService.handleCompilationStatus(this.statusIcon, {
@@ -76,15 +76,28 @@ export class CompilationOptions<P extends Pane<object>> {
         });
     }
 
-    private onCompileResult(compilerId: number, compiler: CompilerInfo, result: CompilationResult): void {
+    protected onCompileResult(compilerId: number, compiler: CompilerInfo, result: CompilationResult): void {
+        this.handleResult(compilerId, compiler, result);
+    }
+
+    protected onExecuteResult(compilerId: number, compiler: CompilerInfo, result: CompilationResult): void {
+        this.handleResult(compilerId, compiler, result, result.didExecute);
+    }
+
+    private handleResult(
+        compilerId: number,
+        compiler: CompilerInfo,
+        result: CompilationResult,
+        didExecute?: boolean,
+    ): void {
         if (this.parentId !== compilerId) return;
 
         const wasCmake = result.result ? (result.buildsteps?.some(step => step.step === 'cmake') ?? false) : false;
         const stepResult = this.getResult(result);
-        CompilerService.handleCompilationStatus(
-            this.statusIcon,
-            CompilerService.calculateStatusIcon(stepResult ?? result),
-        );
+        CompilerService.handleCompilationStatus(this.statusIcon, {
+            didExecute,
+            ...CompilerService.calculateStatusIcon(stepResult ?? result),
+        });
         const options = (stepResult?.compilationOptions ?? []).map(maskRootdirKeepingAppPrefix);
         this.setCompilationOptionsPopover(options.join(' '), this.checkForUnwiseArguments(compiler, options, wasCmake));
     }
@@ -150,5 +163,21 @@ export class CompilationOptions<P extends Pane<object>> {
         }
 
         return warnings;
+    }
+}
+
+export class CompilationOptions<P extends Pane<object>> extends BaseCompilationOptions<P> {
+    protected override initCallbacks(): void {
+        super.initCallbacks();
+        this.parent.eventHub.on('compiling', this.onCompiling.bind(this));
+        this.parent.eventHub.on('compileResult', this.onCompileResult.bind(this));
+    }
+}
+
+export class ExecutionCompilationOptions<P extends Pane<object>> extends BaseCompilationOptions<P> {
+    protected override initCallbacks(): void {
+        super.initCallbacks();
+        this.parent.eventHub.on('executeCompiling', this.onCompiling.bind(this));
+        this.parent.eventHub.on('executeResult', this.onExecuteResult.bind(this));
     }
 }

--- a/views/templates/panes/executor.pug
+++ b/views/templates/panes/executor.pug
@@ -34,8 +34,7 @@
         button.btn.btn-sm.btn-light.input-group-text.picker-popout-button(data-trigger="click" style="cursor: pointer;" role="button" title="Compiler picker popout")
           span
             i.fa-solid.fa-arrow-up-right-from-square
-        button.btn.btn-sm.btn-light.input-group-text.prepend-options(data-trigger="click" style="cursor: pointer;" role="button" title="All compilation options")
-          span.btn.btn-sm.btn-light.status-icon
+        include ../widgets/compilation-options
         label.visually-hidden(for="compilation-options") Compiler options for execution
         input.compilation-options.form-control#compilation-options(type="text" placeholder="Compiler options..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-label="Compiler options for execution")
         // TODO: Maybe enable this in the future?


### PR DESCRIPTION
The `Executor` pane (1) does not have a `compilerInfo.compilerId` set and (2) its `id` overlaps with the `compilerInfo.compilerId`s of other panes.

The first commit refactors the `CompilationOptions` widget to explicitly receive its `parent`’s `id` to work around (1).

(2) is addressed by introducing two `BaseCompilationOptions` subclasses for compilation-like and execution-like panes that listen to disjunct sets of events (because e. g. the `Executor` pane cannot emit `compiling` events because there can be `Compiler` panes with the same `id`).