### PR TITLE
fix(compiler): disable color decorators for assembly output

### DIFF
--- a/static/panes/compiler.ts
+++ b/static/panes/compiler.ts
@@ -418,6 +418,7 @@ export class Compiler extends MonacoPane<monaco.editor.IStandaloneCodeEditor, Co
                 {
                     readOnly: true,
                     language: 'asm',
+                    colorDecorators: false,
                     glyphMargin: !options.embedded,
                     guides: {
                         bracketPairs: false,

--- a/static/tests/panes/compiler-tests.ts
+++ b/static/tests/panes/compiler-tests.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import * as monaco from 'monaco-editor';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {Compiler} from '../../panes/compiler.js';
+
+describe('Compiler output editor', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('does not enable color decorators for assembly output', () => {
+        const createEditor = vi
+            .spyOn(monaco.editor, 'create')
+            .mockImplementation(() => ({}) as monaco.editor.IStandaloneCodeEditor);
+        const compiler = Object.create(Compiler.prototype) as Compiler;
+
+        compiler.createEditor(document.createElement('div'));
+
+        expect(createEditor).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                colorDecorators: false,
+                language: 'asm',
+                readOnly: true,
+            }),
+        );
+    });
+});


### PR DESCRIPTION
## Problem

Fixes #9080. The compiler output pane uses Monaco's default color decorators, so assembly constants such as `#308` and `#8` are shown with misleading color selector squares in Arm/AArch64 output.

## Root cause and solution

Monaco enables `colorDecorators` by default. The read-only assembly output editor did not override that general-purpose editor setting. The compiler output configuration now disables color decorators for the `asm` editor only.

## Tests

- `make check`
- `npm run check-frontend-imports`
- `npm run check-license-headers`
- `npm run webpack`

The focused frontend regression test verifies the exact editor options passed by `Compiler.createEditor()`. All checks passed; webpack retained only the repository's existing CSS-order and asset-size warnings.

The change is limited to the compiler output pane and does not affect source editors or other Monaco panes.
