### PR TITLE
.NET: Respect environment variable overrides

### DIFF
--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -581,9 +581,7 @@ do()
         const programDllPath = path.join(programOutputPath, 'CompilerExplorer.dll');
         const envVarFileContents = [
             'DOTNET_EnableWriteXorExecute=0',
-            ...Object.entries(execOptions.env)
-                .filter(([key]) => key.startsWith('DOTNET_'))
-                .map(([key, value]) => `${key}=${value}`),
+            ...Object.entries(execOptions.env).map(([key, value]) => `${key}=${value}`),
         ];
         const isIlDasm = this.compiler.group === 'dotnetildasm';
         const isIlSpy = this.compiler.group === 'dotnetilspy';

--- a/lib/compilers/dotnet.ts
+++ b/lib/compilers/dotnet.ts
@@ -579,7 +579,12 @@ do()
         const programDir = path.dirname(inputFilename);
         const programOutputPath = path.join(programDir, 'bin', this.buildConfig, compilerInfo.targetFramework);
         const programDllPath = path.join(programOutputPath, 'CompilerExplorer.dll');
-        const envVarFileContents = ['DOTNET_EnableWriteXorExecute=0'];
+        const envVarFileContents = [
+            'DOTNET_EnableWriteXorExecute=0',
+            ...Object.entries(execOptions.env)
+                .filter(([key]) => key.startsWith('DOTNET_'))
+                .map(([key, value]) => `${key}=${value}`),
+        ];
         const isIlDasm = this.compiler.group === 'dotnetildasm';
         const isIlSpy = this.compiler.group === 'dotnetilspy';
         const isCoreRun = this.compiler.group === 'dotnetcoreclr';


### PR DESCRIPTION
Respect environment variable overrides, appending them into the corerun environment variable file.