### PR TITLE
Add MicroPython v1.28.0 and v1.29.0.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -177,3 +177,4 @@ From oldest to newest contributor, we would like to thank:
 - [Sirui Mu](https://github.com/Lancern)
 - [Connor Simms](https://github.com/connorsimms)
 - [Macsen Casaus](https://github.com/macsencasaus)
+- [Anson Mansfield](https://github.com/AJMansfield)

--- a/etc/config/python.amazon.properties
+++ b/etc/config/python.amazon.properties
@@ -88,7 +88,7 @@ group.micropython.instructionSet=mpy
 group.micropython.objdumperType=plain
 group.micropython.objdumper=cat
 group.micropython.externalparser=plain
-group.micropython.externalparser.exe=/opt/compiler-explorer/micropython-1.27.0/tools/mpy-tool.py
+group.micropython.externalparser.exe=/opt/compiler-explorer/micropython-1.28.0/tools/mpy-tool.py
 group.micropython.externalparser.args=--disassemble|--json
 group.micropython.supportsMpyTool=true
 group.micropython.supportsExecute=true
@@ -97,7 +97,7 @@ group.micropython.emulated=true
 group.micropython.options="-march=host"
 
 group.micropython.compilerType=micropython
-group.micropython.compilers=micropython1200:micropython1210:micropython1220:micropython1221:micropython1222:micropython1230:micropython1240:micropython1241:micropython1250:micropython1260:micropython1261:micropython1270:micropython-preview
+group.micropython.compilers=micropython1200:micropython1210:micropython1220:micropython1221:micropython1222:micropython1230:micropython1240:micropython1241:micropython1250:micropython1260:micropython1261:micropython1270:micropython1280:micropython-preview
 group.micropython.isSemVer=true
 compiler.micropython1200.semver=1.20.0
 compiler.micropython1200.exe=/opt/compiler-explorer/micropython-1.20.0/bin/mpy-cross
@@ -136,7 +136,10 @@ compiler.micropython1261.executionWrapper=/opt/compiler-explorer/micropython-1.2
 compiler.micropython1270.semver=1.27.0
 compiler.micropython1270.exe=/opt/compiler-explorer/micropython-1.27.0/bin/mpy-cross
 compiler.micropython1270.executionWrapper=/opt/compiler-explorer/micropython-1.27.0/bin/micropython
-compiler.micropython-preview.semver=1.28.0-preview
+compiler.micropython1280.semver=1.28.0
+compiler.micropython1280.exe=/opt/compiler-explorer/micropython-1.28.0/bin/mpy-cross
+compiler.micropython1280.executionWrapper=/opt/compiler-explorer/micropython-1.28.0/bin/micropython
+compiler.micropython-preview.semver=1.29.0-preview
 compiler.micropython-preview.exe=/opt/compiler-explorer/micropython-preview/bin/mpy-cross
 compiler.micropython-preview.executionWrapper=/opt/compiler-explorer/micropython-preview/bin/micropython
 compiler.micropython-preview.isNightly=true
@@ -145,7 +148,7 @@ compiler.micropython-preview.isNightly=true
 tools=mpy-tool-hexdump:mpy-tool-freeze
 
 tools.mpy-tool-hexdump.name=Hexdump
-tools.mpy-tool-hexdump.exe=/opt/compiler-explorer/micropython-1.27.0/tools/mpy-tool.py
+tools.mpy-tool-hexdump.exe=/opt/compiler-explorer/micropython-1.28.0/tools/mpy-tool.py
 tools.mpy-tool-hexdump.options=--hexdump
 tools.mpy-tool-hexdump.type=postcompilation
 tools.mpy-tool-hexdump.class=strings-tool
@@ -154,7 +157,7 @@ tools.mpy-tool-hexdump.includeKey=supportsMpyTool
 tools.mpy-tool-hexdump.stdinHint=disabled
 
 tools.mpy-tool-freeze.name=Freeze
-tools.mpy-tool-freeze.exe=/opt/compiler-explorer/micropython-1.27.0/tools/mpy-tool.py
+tools.mpy-tool-freeze.exe=/opt/compiler-explorer/micropython-1.28.0/tools/mpy-tool.py
 tools.mpy-tool-freeze.options=--freeze
 tools.mpy-tool-freeze.type=postcompilation
 tools.mpy-tool-freeze.class=strings-tool

--- a/etc/config/python.amazon.properties
+++ b/etc/config/python.amazon.properties
@@ -88,7 +88,7 @@ group.micropython.instructionSet=mpy
 group.micropython.objdumperType=plain
 group.micropython.objdumper=cat
 group.micropython.externalparser=plain
-group.micropython.externalparser.exe=/opt/compiler-explorer/micropython-1.28.0/tools/mpy-tool.py
+group.micropython.externalparser.exe=/opt/compiler-explorer/micropython-1.29.0/tools/mpy-tool.py
 group.micropython.externalparser.args=--disassemble|--json
 group.micropython.supportsMpyTool=true
 group.micropython.supportsExecute=true
@@ -97,7 +97,7 @@ group.micropython.emulated=true
 group.micropython.options="-march=host"
 
 group.micropython.compilerType=micropython
-group.micropython.compilers=micropython1200:micropython1210:micropython1220:micropython1221:micropython1222:micropython1230:micropython1240:micropython1241:micropython1250:micropython1260:micropython1261:micropython1270:micropython1280:micropython-preview
+group.micropython.compilers=micropython1200:micropython1210:micropython1220:micropython1221:micropython1222:micropython1230:micropython1240:micropython1241:micropython1250:micropython1260:micropython1261:micropython1270:micropython1280:micropython1290:micropython-preview
 group.micropython.isSemVer=true
 compiler.micropython1200.semver=1.20.0
 compiler.micropython1200.exe=/opt/compiler-explorer/micropython-1.20.0/bin/mpy-cross
@@ -139,7 +139,10 @@ compiler.micropython1270.executionWrapper=/opt/compiler-explorer/micropython-1.2
 compiler.micropython1280.semver=1.28.0
 compiler.micropython1280.exe=/opt/compiler-explorer/micropython-1.28.0/bin/mpy-cross
 compiler.micropython1280.executionWrapper=/opt/compiler-explorer/micropython-1.28.0/bin/micropython
-compiler.micropython-preview.semver=1.29.0-preview
+compiler.micropython1290.semver=1.29.0
+compiler.micropython1290.exe=/opt/compiler-explorer/micropython-1.29.0/bin/mpy-cross
+compiler.micropython1290.executionWrapper=/opt/compiler-explorer/micropython-1.29.0/bin/micropython
+compiler.micropython-preview.semver=1.30.0-preview
 compiler.micropython-preview.exe=/opt/compiler-explorer/micropython-preview/bin/mpy-cross
 compiler.micropython-preview.executionWrapper=/opt/compiler-explorer/micropython-preview/bin/micropython
 compiler.micropython-preview.isNightly=true
@@ -148,7 +151,7 @@ compiler.micropython-preview.isNightly=true
 tools=mpy-tool-hexdump:mpy-tool-freeze
 
 tools.mpy-tool-hexdump.name=Hexdump
-tools.mpy-tool-hexdump.exe=/opt/compiler-explorer/micropython-1.28.0/tools/mpy-tool.py
+tools.mpy-tool-hexdump.exe=/opt/compiler-explorer/micropython-1.29.0/tools/mpy-tool.py
 tools.mpy-tool-hexdump.options=--hexdump
 tools.mpy-tool-hexdump.type=postcompilation
 tools.mpy-tool-hexdump.class=strings-tool
@@ -157,7 +160,7 @@ tools.mpy-tool-hexdump.includeKey=supportsMpyTool
 tools.mpy-tool-hexdump.stdinHint=disabled
 
 tools.mpy-tool-freeze.name=Freeze
-tools.mpy-tool-freeze.exe=/opt/compiler-explorer/micropython-1.28.0/tools/mpy-tool.py
+tools.mpy-tool-freeze.exe=/opt/compiler-explorer/micropython-1.29.0/tools/mpy-tool.py
 tools.mpy-tool-freeze.options=--freeze
 tools.mpy-tool-freeze.type=postcompilation
 tools.mpy-tool-freeze.class=strings-tool


### PR DESCRIPTION
- Pending https://github.com/compiler-explorer/infra/pull/2348
- Add release MicroPython [v1.28.0](https://github.com/micropython/micropython/releases/tag/v1.28.0) from a few months ago.
- Add release MicroPython [v1.29.0](https://github.com/micropython/micropython/releases/tag/v1.29.0) from 2 weeks ago.
- Use `mpy-tool.py` provided by v1.29.0 over v1.27.0.
- Update preview name to v1.30.0-preview.
- Add myself to CONTRIBUTORS.md (see also #8256)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
